### PR TITLE
perf(ext/node): true writev on tcp sockets for node:http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,6 +2815,7 @@ dependencies = [
  "rustls-tokio-stream",
  "rustls-webpki 0.103.13",
  "serde",
+ "smallvec",
  "socket2 0.5.5",
  "sys_traits",
  "thiserror 2.0.12",

--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -59,6 +59,7 @@ rustls-tokio-stream.workspace = true
 # `rustls::CertificateError::Other` payloads to `webpki::Error`.
 rustls-webpki = "0.103"
 serde.workspace = true
+smallvec.workspace = true
 socket2.workspace = true
 sys_traits = { workspace = true, features = ["real", "winapi", "libc"] }
 thiserror.workspace = true

--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -1350,12 +1350,18 @@ impl LibUvStreamWrap {
     // through `Vec::spare_capacity_mut` each time.
     let mut string_storage: Vec<u8> = if string_size > 0 {
       let mut v = Vec::with_capacity(string_size);
+      #[allow(
+        clippy::uninit_vec,
+        reason = "encoders fully fill `string_size` bytes before any read"
+      )]
       // SAFETY: we reserved `string_size` bytes; the encoders write
       // into this range before we expose any slice. `set_len` here
       // claims the full capacity so `as_mut_ptr().add(offset)` is
       // valid for arbitrary `offset < string_size`. Bytes may be
       // uninit at this point, but we never read before writing.
-      unsafe { v.set_len(string_size) };
+      unsafe {
+        v.set_len(string_size)
+      };
       v
     } else {
       Vec::new()

--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -1046,6 +1046,29 @@ fn encode_string_into_uninit(
     }
     StringEncoding::Ucs2 => {
       let len_chars = string.length();
+      // V8's `write_v2` writes native-endian u16, which on
+      // little-endian targets is identical to UTF-16LE bytes — Node's
+      // 'ucs2' encoding. On the BE path (no current Deno target) we
+      // fall through to the temp-buffer + byte-swap path. Direct
+      // write requires the destination be u16-aligned and have room
+      // for `len_chars` u16 elements.
+      #[cfg(target_endian = "little")]
+      {
+        let dst_ptr = out.as_mut_ptr();
+        if dst_ptr.align_offset(std::mem::align_of::<u16>()) == 0
+          && out.len() >= len_chars * 2
+        {
+          // SAFETY: `dst_ptr` is u16-aligned and points at
+          // `len_chars * 2` writable bytes = `len_chars` writable
+          // u16 slots. `MaybeUninit<u8>` and `u16` have compatible
+          // representations modulo alignment, which we've verified.
+          let dst: &mut [u16] = unsafe {
+            std::slice::from_raw_parts_mut(dst_ptr as *mut u16, len_chars)
+          };
+          string.write_v2(scope, 0, dst, v8::WriteFlags::empty());
+          return len_chars * 2;
+        }
+      }
       let mut tmp = vec![0u16; len_chars];
       string.write_v2(scope, 0, &mut tmp, v8::WriteFlags::empty());
       for (i, &ch) in tmp.iter().enumerate() {
@@ -1338,35 +1361,25 @@ impl LibUvStreamWrap {
       }
     }
 
-    // Single owned `Vec<u8>` for the concat of all encoded strings.
-    // Functional shape mirrors Node's `NewBackingStore(storage_size)`
-    // at stream_base.cc:247 but stays outside V8 entirely — no
-    // persistent handles, no GC-visible ArrayBuffer objects, just a
-    // heap allocation.
+    // Single owned `Box<[MaybeUninit<u8>]>` for the concat of all
+    // encoded strings. Functional shape mirrors Node's
+    // `NewBackingStore(storage_size)` at stream_base.cc:247 but stays
+    // outside V8 entirely — no persistent handles, no GC-visible
+    // ArrayBuffer objects, just a heap allocation.
     //
-    // Allocate-with-capacity-then-set-len so the pointer is stable
-    // (no realloc during encode) and we can hand raw `&mut
-    // [MaybeUninit<u8>]` windows to the encoders without going
-    // through `Vec::spare_capacity_mut` each time.
-    let mut string_storage: Vec<u8> = if string_size > 0 {
-      let mut v = Vec::with_capacity(string_size);
-      #[allow(
-        clippy::uninit_vec,
-        reason = "encoders fully fill `string_size` bytes before any read"
-      )]
-      // SAFETY: we reserved `string_size` bytes; the encoders write
-      // into this range before we expose any slice. `set_len` here
-      // claims the full capacity so `as_mut_ptr().add(offset)` is
-      // valid for arbitrary `offset < string_size`. Bytes may be
-      // uninit at this point, but we never read before writing.
-      unsafe {
-        v.set_len(string_size)
+    // Typed as `MaybeUninit<u8>` so the "bytes may be uninit until an
+    // encoder fills them" contract is enforced by the type system.
+    // Encoders take `&mut [MaybeUninit<u8>]` windows; iovec base
+    // pointers cast through `*mut u8` and only reference written
+    // sub-ranges.
+    let mut string_storage: Box<[std::mem::MaybeUninit<u8>]> =
+      if string_size > 0 {
+        Box::new_uninit_slice(string_size)
+      } else {
+        Box::new_uninit_slice(0)
       };
-      v
-    } else {
-      Vec::new()
-    };
-    let string_storage_ptr: *mut u8 = string_storage.as_mut_ptr();
+    let string_storage_ptr: *mut std::mem::MaybeUninit<u8> =
+      string_storage.as_mut_ptr();
 
     let mut iovecs: smallvec::SmallVec<[uv_buf_t; 16]> =
       smallvec::SmallVec::new();
@@ -1410,11 +1423,10 @@ impl LibUvStreamWrap {
           continue;
         }
         // SAFETY: string_storage_ptr is non-null (string_size > 0) and
-        // points at a `string_size`-byte buffer (stack or cage-backed).
+        // points at a `string_size`-byte buffer.
         let dst_slice = unsafe {
           std::slice::from_raw_parts_mut(
-            string_storage_ptr.add(str_offset)
-              as *mut std::mem::MaybeUninit<u8>,
+            string_storage_ptr.add(str_offset),
             remaining,
           )
         };
@@ -1490,22 +1502,30 @@ impl LibUvStreamWrap {
     }
 
     // Partial drain: slice iovecs in place, matching libuv's
-    // DoTryWrite pointer advance (stream_wrap.cc:370-382).
+    // DoTryWrite pointer advance (stream_wrap.cc:370-382). Pre-count
+    // fully-consumed iovecs and the partial head offset, then `drain`
+    // the consumed prefix in a single shift — avoids the O(n²) cost of
+    // `remove(0)` in a loop, which matters at large iovec counts (e.g.
+    // chunked-encoding responses approaching `IOV_MAX`).
     if sync_written > 0 {
       let mut remaining = sync_written;
-      while remaining > 0 && !iovecs.is_empty() {
-        let head_len = iovecs[0].len;
+      let mut consumed = 0;
+      while remaining > 0 && consumed < iovecs.len() {
+        let head_len = iovecs[consumed].len;
         if remaining >= head_len {
           remaining -= head_len;
-          iovecs.remove(0);
+          consumed += 1;
         } else {
           // SAFETY: sliced within bounds.
-          iovecs[0].base = unsafe {
-            (iovecs[0].base as *mut u8).add(remaining) as *mut c_char
+          iovecs[consumed].base = unsafe {
+            (iovecs[consumed].base as *mut u8).add(remaining) as *mut c_char
           };
-          iovecs[0].len = head_len - remaining;
+          iovecs[consumed].len = head_len - remaining;
           remaining = 0;
         }
+      }
+      if consumed > 0 {
+        iovecs.drain(0..consumed);
       }
     }
 
@@ -1513,7 +1533,8 @@ impl LibUvStreamWrap {
     // state. Buffer chunks are retained JS-side via `req.buffer =
     // data`, so `owned_buffers` only holds the string storage (or
     // nothing at all if this writev was Buffers-only).
-    let mut owned: smallvec::SmallVec<[Vec<u8>; 1]> = smallvec::SmallVec::new();
+    let mut owned: smallvec::SmallVec<[Box<[std::mem::MaybeUninit<u8>]>; 1]> =
+      smallvec::SmallVec::new();
     if !string_storage.is_empty() {
       owned.push(string_storage);
     }
@@ -1774,7 +1795,7 @@ impl LibUvStreamWrap {
     scope: &mut v8::PinScope,
     stream: *mut uv_stream_t,
     iovecs: smallvec::SmallVec<[uv_buf_t; 16]>,
-    owned_buffers: smallvec::SmallVec<[Vec<u8>; 1]>,
+    owned_buffers: smallvec::SmallVec<[Box<[std::mem::MaybeUninit<u8>]>; 1]>,
     total_bytes: usize,
     req_wrap_obj: v8::Local<v8::Object>,
     state_array: v8::Local<v8::Int32Array>,

--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -997,6 +997,67 @@ fn encode_string_to_vec(
   }
 }
 
+/// Upper bound on the encoded byte length of `string` under `encoding`.
+/// Mirrors Node's `StringBytes::StorageSize`. For UTF-8 this is the
+/// exact length; for UCS-2 it's length() * 2; for Latin1/ASCII it's
+/// length(). Used as the pre-allocation size for the shared backing
+/// store that holds all encoded strings in a writev call.
+fn encoded_storage_size(
+  scope: &mut v8::PinScope,
+  string: v8::Local<v8::String>,
+  encoding: &StringEncoding,
+) -> usize {
+  match encoding {
+    StringEncoding::Utf8 => string.utf8_length(scope),
+    StringEncoding::Latin1 | StringEncoding::Ascii => string.length(),
+    StringEncoding::Ucs2 => string.length() * 2,
+  }
+}
+
+/// Encode `string` directly into pre-allocated uninit storage. Returns
+/// the number of bytes written. The storage is typically a window
+/// inside a V8 `BackingStore` that will be held alive by the write
+/// request's retention list.
+fn encode_string_into_uninit(
+  scope: &mut v8::PinScope,
+  string: v8::Local<v8::String>,
+  encoding: StringEncoding,
+  out: &mut [std::mem::MaybeUninit<u8>],
+) -> usize {
+  match encoding {
+    StringEncoding::Utf8 => {
+      let len = string.utf8_length(scope);
+      string.write_utf8_uninit_v2(
+        scope,
+        &mut out[..len],
+        v8::WriteFlags::kReplaceInvalidUtf8,
+        None,
+      )
+    }
+    StringEncoding::Latin1 | StringEncoding::Ascii => {
+      let len = string.length();
+      string.write_one_byte_uninit_v2(
+        scope,
+        0,
+        &mut out[..len],
+        v8::WriteFlags::empty(),
+      );
+      len
+    }
+    StringEncoding::Ucs2 => {
+      let len_chars = string.length();
+      let mut tmp = vec![0u16; len_chars];
+      string.write_v2(scope, 0, &mut tmp, v8::WriteFlags::empty());
+      for (i, &ch) in tmp.iter().enumerate() {
+        let bytes = ch.to_le_bytes();
+        out[i * 2] = std::mem::MaybeUninit::new(bytes[0]);
+        out[i * 2 + 1] = std::mem::MaybeUninit::new(bytes[1]);
+      }
+      len_chars * 2
+    }
+  }
+}
+
 #[op2(base, inherit = HandleWrap)]
 impl LibUvStreamWrap {
   /// Called by JS immediately after construction to store the JS object
@@ -1177,6 +1238,7 @@ impl LibUvStreamWrap {
         stream_handle,
         stream_base_state: v8::Global::new(scope, state_array),
         bytes: byte_length,
+        owned_buffers: smallvec::SmallVec::new(),
       }),
     );
     let req_ptr = Box::into_raw(req);
@@ -1234,85 +1296,137 @@ impl LibUvStreamWrap {
     let state_global = &op_state.borrow::<StreamBaseState>().array;
     let state_array = v8::Local::new(scope, state_global);
 
-    // Pre-pass: sum per-chunk upper-bound sizes so the concat Vec is
-    // allocated once with sufficient capacity — no growth reallocs as
-    // chunks are appended. For Uint8Arrays the byte length is exact;
-    // for strings we use `length() * 3` which upper-bounds utf-8
-    // output (a single UTF-16 code unit encodes to ≤ 3 bytes). This
-    // replaces an unallocated `Vec::new()` that previously incurred
-    // ~2-3 growth allocations per writev call on the HTTP
-    // chunked-encoding path.
+    // Scatter-gather writev matching Node's StreamBase::Writev
+    // (src/stream_base.cc:180).
+    //
+    // Retention strategy (matches Node):
+    //   - Buffer chunks: iovec points directly at the ArrayBuffer
+    //     backing store; NO per-chunk retention. JS side keeps chunks
+    //     alive via `req.buffer = data` on the WriteWrap (see
+    //     stream_base_commons.js `writevGeneric`).
+    //   - String chunks: encode into stack storage first. Only
+    //     allocate a V8 BackingStore if we have to go async, and
+    //     only size it to the unwritten tail. Matches Node's stack
+    //     storage optimization in WriteString and its single-alloc
+    //     `ArrayBuffer::NewBackingStore` for the string storage.
     let array_len = chunks.length();
-    let (iter_count, stride): (u32, u32) = if all_buffers {
+    let (count, stride): (u32, u32) = if all_buffers {
       (array_len, 1)
     } else {
       (array_len / 2, 2)
     };
-    let mut total_est: usize = 0;
-    for i in 0..iter_count {
-      let Some(chunk) = chunks.get_index(scope, i * stride) else {
-        continue;
-      };
-      if let Ok(buf) = TryInto::<v8::Local<v8::Uint8Array>>::try_into(chunk) {
-        total_est += buf.byte_length();
-      } else if let Ok(s) = TryInto::<v8::Local<v8::String>>::try_into(chunk) {
-        total_est += s.length() * 3;
-      }
-    }
-    let mut data = Vec::with_capacity(total_est);
 
-    if all_buffers {
-      for i in 0..array_len {
-        let Some(chunk) = chunks.get_index(scope, i) else {
-          continue;
-        };
-        if let Ok(buf) = TryInto::<v8::Local<v8::Uint8Array>>::try_into(chunk) {
-          let byte_len = buf.byte_length();
-          if byte_len > 0 {
-            let byte_off = buf.byte_offset();
-            let ab = buf.buffer(scope).unwrap();
-            let ptr = ab.data().unwrap().as_ptr() as *const u8;
-            // SAFETY: ptr points to the backing store of the ArrayBuffer; byte_off + byte_len is within bounds as guaranteed by the Uint8Array view.
-            let slice = unsafe {
-              std::slice::from_raw_parts(ptr.add(byte_off), byte_len)
-            };
-            data.extend_from_slice(slice);
-          }
-        }
-      }
-    } else {
-      let count = array_len / 2;
+    // Pre-pass: compute string storage size. Buffer chunks contribute
+    // zero since they're zero-copied.
+    let mut string_size: usize = 0;
+    if !all_buffers {
       for i in 0..count {
         let Some(chunk) = chunks.get_index(scope, i * 2) else {
           continue;
         };
-        if let Ok(buf) = TryInto::<v8::Local<v8::Uint8Array>>::try_into(chunk) {
-          let byte_len = buf.byte_length();
-          if byte_len > 0 {
-            let byte_off = buf.byte_offset();
-            let ab = buf.buffer(scope).unwrap();
-            let ptr = ab.data().unwrap().as_ptr() as *const u8;
-            // SAFETY: ptr points to the backing store of the ArrayBuffer; byte_off + byte_len is within bounds as guaranteed by the Uint8Array view.
-            let slice = unsafe {
-              std::slice::from_raw_parts(ptr.add(byte_off), byte_len)
-            };
-            data.extend_from_slice(slice);
-          }
-        } else if let Ok(s) = TryInto::<v8::Local<v8::String>>::try_into(chunk)
-        {
+        if TryInto::<v8::Local<v8::Uint8Array>>::try_into(chunk).is_ok() {
+          continue;
+        }
+        if let Ok(s) = TryInto::<v8::Local<v8::String>>::try_into(chunk) {
           let enc = chunks
             .get_index(scope, i * 2 + 1)
             .and_then(|v| TryInto::<v8::Local<v8::String>>::try_into(v).ok())
             .map(|e| parse_encoding_no_alloc(scope, e))
             .unwrap_or(StringEncoding::Utf8);
-          encode_string_to_vec(scope, s, enc, &mut data);
+          string_size += encoded_storage_size(scope, s, &enc);
         }
       }
     }
 
-    let total_bytes = data.len();
+    // Single owned `Vec<u8>` for the concat of all encoded strings.
+    // Functional shape mirrors Node's `NewBackingStore(storage_size)`
+    // at stream_base.cc:247 but stays outside V8 entirely — no
+    // persistent handles, no GC-visible ArrayBuffer objects, just a
+    // heap allocation.
+    //
+    // Allocate-with-capacity-then-set-len so the pointer is stable
+    // (no realloc during encode) and we can hand raw `&mut
+    // [MaybeUninit<u8>]` windows to the encoders without going
+    // through `Vec::spare_capacity_mut` each time.
+    let mut string_storage: Vec<u8> = if string_size > 0 {
+      let mut v = Vec::with_capacity(string_size);
+      // SAFETY: we reserved `string_size` bytes; the encoders write
+      // into this range before we expose any slice. `set_len` here
+      // claims the full capacity so `as_mut_ptr().add(offset)` is
+      // valid for arbitrary `offset < string_size`. Bytes may be
+      // uninit at this point, but we never read before writing.
+      unsafe { v.set_len(string_size) };
+      v
+    } else {
+      Vec::new()
+    };
+    let string_storage_ptr: *mut u8 = string_storage.as_mut_ptr();
 
-    // Track bytes_written
+    let mut iovecs: smallvec::SmallVec<[uv_buf_t; 16]> =
+      smallvec::SmallVec::new();
+    let mut str_offset: usize = 0;
+
+    for i in 0..count {
+      let Some(chunk) = chunks.get_index(scope, i * stride) else {
+        continue;
+      };
+      if let Ok(buf) = TryInto::<v8::Local<v8::Uint8Array>>::try_into(chunk) {
+        let byte_len = buf.byte_length();
+        if byte_len == 0 {
+          continue;
+        }
+        let byte_off = buf.byte_offset();
+        let ab = buf.buffer(scope).unwrap();
+        let Some(data_ptr) = ab.data() else {
+          continue;
+        };
+        // SAFETY: data_ptr is the ArrayBuffer backing store start;
+        // the Uint8Array view guarantees byte_off + byte_len is
+        // within the allocation. JS retains the chunk via
+        // `req.buffer = data` on the write request — we don't need
+        // our own retention.
+        let base = unsafe {
+          (data_ptr.as_ptr() as *mut u8).add(byte_off) as *mut c_char
+        };
+        iovecs.push(uv_buf_t {
+          base,
+          len: byte_len,
+        });
+      } else if let Ok(s) = TryInto::<v8::Local<v8::String>>::try_into(chunk) {
+        // Only reached in !all_buffers path.
+        let enc = chunks
+          .get_index(scope, i * 2 + 1)
+          .and_then(|v| TryInto::<v8::Local<v8::String>>::try_into(v).ok())
+          .map(|e| parse_encoding_no_alloc(scope, e))
+          .unwrap_or(StringEncoding::Utf8);
+        let remaining = string_size.saturating_sub(str_offset);
+        if remaining == 0 {
+          continue;
+        }
+        // SAFETY: string_storage_ptr is non-null (string_size > 0) and
+        // points at a `string_size`-byte buffer (stack or cage-backed).
+        let dst_slice = unsafe {
+          std::slice::from_raw_parts_mut(
+            string_storage_ptr.add(str_offset)
+              as *mut std::mem::MaybeUninit<u8>,
+            remaining,
+          )
+        };
+        let written = encode_string_into_uninit(scope, s, enc, dst_slice);
+        if written > 0 {
+          // SAFETY: we wrote `written` bytes starting at str_offset.
+          let base =
+            unsafe { string_storage_ptr.add(str_offset) as *mut c_char };
+          iovecs.push(uv_buf_t {
+            base,
+            len: written,
+          });
+        }
+        str_offset += written;
+      }
+    }
+
+    let total_bytes: usize = iovecs.iter().map(|b| b.len).sum();
     self
       .bytes_written
       .set(self.bytes_written.get() + total_bytes as u64);
@@ -1331,7 +1445,85 @@ impl LibUvStreamWrap {
       return 0;
     }
 
-    self.do_write(scope, stream, data, total_bytes, req_wrap_obj, state_array)
+    // Sync scatter-gather try-write. Mirrors Node's
+    // StreamBase::Write → DoTryWrite pre-async path. When this fully
+    // drains (common for small HTTP responses) we skip the async
+    // request entirely — zero heap allocations.
+    let (sync_written, fully_drained) = {
+      let slices: smallvec::SmallVec<[std::io::IoSlice; 16]> = iovecs
+        .iter()
+        .map(|b| {
+          // SAFETY: iovec bases point at live memory for `len` bytes.
+          unsafe {
+            std::io::IoSlice::new(std::slice::from_raw_parts(
+              b.base as *const u8,
+              b.len,
+            ))
+          }
+        })
+        .collect();
+      // SAFETY: stream is a valid non-null uv_stream_t.
+      let rc = unsafe { uv_compat::uv_try_writev(stream, &slices) };
+      if rc >= 0 {
+        let n = rc as usize;
+        (n, n == total_bytes)
+      } else {
+        (0, false)
+      }
+    };
+
+    if fully_drained {
+      state_array.set_index(
+        scope,
+        StreamBaseStateFields::BytesWritten as u32,
+        v8::Number::new(scope, total_bytes as f64).into(),
+      );
+      state_array.set_index(
+        scope,
+        StreamBaseStateFields::LastWriteWasAsync as u32,
+        v8::Integer::new(scope, 0).into(),
+      );
+      return 0;
+    }
+
+    // Partial drain: slice iovecs in place, matching libuv's
+    // DoTryWrite pointer advance (stream_wrap.cc:370-382).
+    if sync_written > 0 {
+      let mut remaining = sync_written;
+      while remaining > 0 && !iovecs.is_empty() {
+        let head_len = iovecs[0].len;
+        if remaining >= head_len {
+          remaining -= head_len;
+          iovecs.remove(0);
+        } else {
+          // SAFETY: sliced within bounds.
+          iovecs[0].base = unsafe {
+            (iovecs[0].base as *mut u8).add(remaining) as *mut c_char
+          };
+          iovecs[0].len = head_len - remaining;
+          remaining = 0;
+        }
+      }
+    }
+
+    // Own the string concat buffer on the async request's callback
+    // state. Buffer chunks are retained JS-side via `req.buffer =
+    // data`, so `owned_buffers` only holds the string storage (or
+    // nothing at all if this writev was Buffers-only).
+    let mut owned: smallvec::SmallVec<[Vec<u8>; 1]> = smallvec::SmallVec::new();
+    if !string_storage.is_empty() {
+      owned.push(string_storage);
+    }
+
+    self.do_writev_async(
+      scope,
+      stream,
+      iovecs,
+      owned,
+      total_bytes,
+      req_wrap_obj,
+      state_array,
+    )
   }
 
   #[fast]
@@ -1516,6 +1708,7 @@ impl LibUvStreamWrap {
         stream_handle,
         stream_base_state: v8::Global::new(scope, state_array),
         bytes: total_bytes,
+        owned_buffers: smallvec::SmallVec::new(),
       }),
     );
     let req_ptr = Box::into_raw(req);
@@ -1547,6 +1740,92 @@ impl LibUvStreamWrap {
         .borrow_mut()
         .take(req_data);
       // SAFETY: uv_write failed so the callback will never fire; reclaim the request.
+      unsafe {
+        drop(Box::from_raw(req_ptr));
+      }
+      return err;
+    }
+
+    state_array.set_index(
+      scope,
+      StreamBaseStateFields::BytesWritten as u32,
+      v8::Number::new(scope, total_bytes as f64).into(),
+    );
+    state_array.set_index(
+      scope,
+      StreamBaseStateFields::LastWriteWasAsync as u32,
+      v8::Integer::new(scope, 1).into(),
+    );
+
+    0
+  }
+
+  /// Queue an iovec-based async write. The `iovecs` point at memory
+  /// kept alive either JS-side (for Buffer chunks attached to
+  /// `req.buffer`) or by `owned_buffers` on the request's callback
+  /// state (for the encoded-strings concat buffer). Mirrors Node's
+  /// `LibuvStreamWrap::DoWrite(req_wrap, bufs, count, ...)`
+  /// (stream_wrap.cc:391) — no intermediate concat.
+  fn do_writev_async(
+    &self,
+    scope: &mut v8::PinScope,
+    stream: *mut uv_stream_t,
+    iovecs: smallvec::SmallVec<[uv_buf_t; 16]>,
+    owned_buffers: smallvec::SmallVec<[Vec<u8>; 1]>,
+    total_bytes: usize,
+    req_wrap_obj: v8::Local<v8::Object>,
+    state_array: v8::Local<v8::Int32Array>,
+  ) -> i32 {
+    let stream_handle = self
+      .js_handle_global(scope)
+      .unwrap_or_else(|| v8::Global::new(scope, v8::Object::new(scope)));
+    let mut req = Box::new(uv_compat::new_write());
+    req.data = self.handle_data.request_callbacks.borrow_mut().insert(
+      RequestCallbackState::Write(WriteRequestCallbackState {
+        // SAFETY: scope is a valid PinScope for the current isolate.
+        isolate: unsafe { scope.as_raw_isolate_ptr() },
+        req_wrap_obj: v8::Global::new(scope, req_wrap_obj),
+        stream_handle,
+        stream_base_state: v8::Global::new(scope, state_array),
+        bytes: total_bytes,
+        owned_buffers,
+      }),
+    );
+    let req_ptr = Box::into_raw(req);
+
+    // Narrow iovec SmallVec to the queue's inline capacity (4). Node
+    // uses `MaybeStackBuffer<uv_buf_t, 16>` for the caller stack and
+    // libuv's queue stores the array pointer directly; we use a 4-
+    // element inline here because most calls have few chunks.
+    let queue_bufs: smallvec::SmallVec<[uv_buf_t; 4]> =
+      iovecs.into_iter().collect();
+
+    // SAFETY: req_ptr is a valid uv_write_t; stream is a valid
+    // initialized stream handle; each iovec points at memory retained
+    // via `retention` on the callback state, which stays alive until
+    // `after_uv_write` runs.
+    let err = unsafe {
+      uv_compat::uv_writev_owned(
+        req_ptr,
+        stream,
+        queue_bufs,
+        Some(after_uv_write),
+      )
+    };
+
+    if err != 0 {
+      // SAFETY: `req_ptr` is still owned locally because `uv_writev_owned` failed synchronously.
+      let req_data = unsafe { (*req_ptr).data };
+      // SAFETY: `req_ptr` is valid and the callback will never observe this request after the synchronous failure.
+      unsafe {
+        (*req_ptr).data = std::ptr::null_mut();
+      }
+      let _ = self
+        .handle_data
+        .request_callbacks
+        .borrow_mut()
+        .take(req_data);
+      // SAFETY: uv_writev_owned failed so the callback will never fire; reclaim.
       unsafe {
         drop(Box::from_raw(req_ptr));
       }

--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -1417,10 +1417,7 @@ impl LibUvStreamWrap {
           // SAFETY: we wrote `written` bytes starting at str_offset.
           let base =
             unsafe { string_storage_ptr.add(str_offset) as *mut c_char };
-          iovecs.push(uv_buf_t {
-            base,
-            len: written,
-          });
+          iovecs.push(uv_buf_t { base, len: written });
         }
         str_offset += written;
       }

--- a/ext/node/ops/stream_wrap_state.rs
+++ b/ext/node/ops/stream_wrap_state.rs
@@ -136,6 +136,19 @@ pub(crate) struct WriteRequestCallbackState {
   pub stream_handle: v8::Global<v8::Object>,
   pub stream_base_state: v8::Global<v8::Int32Array>,
   pub bytes: usize,
+  /// Owned byte buffers that back the write's iovecs (specifically,
+  /// the encoded-strings concat buffer for mixed `writev` calls).
+  /// Kept alive by this field until the request is taken from the
+  /// registry in `after_uv_write`; dropped there, which releases the
+  /// memory via the system allocator. Buffer-chunk iovecs don't go
+  /// here — they're retained JS-side via `req.buffer = data` in
+  /// `writevGeneric` (matches Node's StreamBase behavior, which
+  /// doesn't retain chunks on the WriteWrap either).
+  #[allow(
+    dead_code,
+    reason = "retention anchor; read via Drop when the request completes"
+  )]
+  pub owned_buffers: smallvec::SmallVec<[Vec<u8>; 1]>,
 }
 
 pub(crate) struct ShutdownRequestCallbackState {

--- a/ext/node/ops/stream_wrap_state.rs
+++ b/ext/node/ops/stream_wrap_state.rs
@@ -144,11 +144,17 @@ pub(crate) struct WriteRequestCallbackState {
   /// here — they're retained JS-side via `req.buffer = data` in
   /// `writevGeneric` (matches Node's StreamBase behavior, which
   /// doesn't retain chunks on the WriteWrap either).
+  ///
+  /// Typed as `Box<[MaybeUninit<u8>]>` rather than `Vec<u8>` because
+  /// the encoders only fill the windows referenced by iovecs — bytes
+  /// outside those windows may be uninitialized. Storing as
+  /// `MaybeUninit` makes that fact part of the type so a future
+  /// refactor can't accidentally `&buf[..]` into uninit memory.
   #[allow(
     dead_code,
     reason = "retention anchor; read via Drop when the request completes"
   )]
-  pub owned_buffers: smallvec::SmallVec<[Vec<u8>; 1]>,
+  pub owned_buffers: smallvec::SmallVec<[Box<[std::mem::MaybeUninit<u8>]>; 1]>,
 }
 
 pub(crate) struct ShutdownRequestCallbackState {

--- a/ext/node/polyfills/_http_outgoing.ts
+++ b/ext/node/polyfills/_http_outgoing.ts
@@ -811,6 +811,10 @@ Object.defineProperties(
           // Transfer-Encoding are removed by the user.
           // See: test/parallel/test-http-remove-header-stays-removed.js
           debug("Both Content-Length and Transfer-Encoding are removed");
+
+          // We can't keep alive in this case, because with no header info the body
+          // is defined as all data until the connection is closed.
+          this._last = true;
         }
       }
 

--- a/libs/core/uv_compat/pipe.rs
+++ b/libs/core/uv_compat/pipe.rs
@@ -1069,7 +1069,21 @@ pub(crate) unsafe fn poll_pipe_handle(
         continue;
       }
       // Try writing to whichever pipe type we have.
-      let remaining = &pw.data[pw.offset..];
+      let remaining: &[u8] = if let Some(ref iov) = pw.iovecs {
+        // SAFETY: caller retention keeps iovec memory valid.
+        let s = iov.head_slice();
+        if s.is_empty() {
+          let pw = (*pipe_ptr).internal_write_queue.pop_front().unwrap();
+          any_work = true;
+          if let Some(cb) = pw.cb {
+            cb(pw.req, 0);
+          }
+          continue;
+        }
+        s
+      } else {
+        &pw.data[pw.offset..]
+      };
       use std::io::Write;
       use std::os::windows::io::FromRawHandle;
       // Register write-readiness with the reactor so the waker fires
@@ -1098,8 +1112,14 @@ pub(crate) unsafe fn poll_pipe_handle(
         Ok(n) => {
           any_work = true;
           let pw = (*pipe_ptr).internal_write_queue.front_mut().unwrap();
-          pw.offset += n;
-          if pw.offset >= pw.data.len() {
+          let drained = if let Some(ref mut iov) = pw.iovecs {
+            iov.advance(n);
+            iov.is_empty()
+          } else {
+            pw.offset += n;
+            pw.offset >= pw.data.len()
+          };
+          if drained {
             let pw = (*pipe_ptr).internal_write_queue.pop_front().unwrap();
             if let Some(cb) = pw.cb {
               cb(pw.req, 0);
@@ -1399,7 +1419,24 @@ pub(crate) unsafe fn poll_pipe_handle(
         }
         continue;
       }
-      let remaining = &pw.data[pw.offset..];
+      // When iovecs are set, walk them one head-at-a-time; otherwise
+      // use the legacy single-buf `data`/`offset` view.
+      let remaining: &[u8] = if let Some(ref iov) = pw.iovecs {
+        // SAFETY: caller retention keeps iovec memory valid.
+        let s = iov.head_slice();
+        if s.is_empty() {
+          // Fully drained — pop and fire callback.
+          let pw = (*pipe_ptr).internal_write_queue.pop_front().unwrap();
+          any_work = true;
+          if let Some(cb) = pw.cb {
+            cb(pw.req, 0);
+          }
+          continue;
+        }
+        s
+      } else {
+        &pw.data[pw.offset..]
+      };
       // Prefer AsyncFd for proper readiness tracking, then UnixStream,
       // then fall back to raw libc::write.
       let write_result = if let Some(ref afd) = (*pipe_ptr).internal_async_fd {
@@ -1462,8 +1499,14 @@ pub(crate) unsafe fn poll_pipe_handle(
         Ok(n) => {
           any_work = true;
           let pw = (*pipe_ptr).internal_write_queue.front_mut().unwrap();
-          pw.offset += n;
-          if pw.offset >= pw.data.len() {
+          let drained = if let Some(ref mut iov) = pw.iovecs {
+            iov.advance(n);
+            iov.is_empty()
+          } else {
+            pw.offset += n;
+            pw.offset >= pw.data.len()
+          };
+          if drained {
             let pw = (*pipe_ptr).internal_write_queue.pop_front().unwrap();
             if let Some(cb) = pw.cb {
               cb(pw.req, 0);

--- a/libs/core/uv_compat/stream.rs
+++ b/libs/core/uv_compat/stream.rs
@@ -238,6 +238,90 @@ pub unsafe fn uv_stream_set_blocking(
 /// ### Safety
 /// `handle` must be a valid pointer to an initialized stream handle
 /// (`uv_tcp_t`, `uv_tty_t`, or `uv_pipe_t`, cast as `uv_stream_t`).
+/// Scatter-gather try_write. Mirrors libuv's
+/// `uv_try_write(stream, bufs, nbufs)`: attempts a non-blocking vectored
+/// write and returns the number of bytes written, `UV_EAGAIN` when the
+/// socket would block, or a negative error code. Preferred over
+/// `uv_try_write` for stream_wrap's `writev` op because iovecs can
+/// point at V8 `ArrayBuffer` backing stores with no concat copy.
+///
+/// TCP uses tokio's `try_write_vectored` for true `writev(2)`; pipes
+/// and TTYs fall back to iterating single-buf `try_write_{pipe,tty}`
+/// since their internals already copy into owned queues.
+///
+/// ### Safety
+/// `handle` must be a valid pointer to an initialized stream handle
+/// (`uv_tcp_t`, `uv_tty_t`, or `uv_pipe_t`, cast as `uv_stream_t`).
+/// Each `IoSlice` must reference memory valid for the duration of
+/// this call.
+pub unsafe fn uv_try_writev(
+  handle: *mut uv_stream_t,
+  bufs: &[std::io::IoSlice<'_>],
+) -> i32 {
+  // SAFETY: caller guarantees handle is valid.
+  let handle_type = unsafe { (*handle).r#type };
+  unsafe {
+    if handle_type == uv_handle_type::UV_TTY {
+      // TTY has no native writev path; iterate. Stop on partial to
+      // match libuv's short-write semantics on writev.
+      let mut total = 0i32;
+      for buf in bufs {
+        let rc = super::tty::try_write_tty(handle, buf);
+        if rc < 0 {
+          if total > 0 {
+            return total;
+          }
+          return rc;
+        }
+        total = total.saturating_add(rc);
+        if (rc as usize) != buf.len() {
+          return total;
+        }
+      }
+      return total;
+    }
+    if handle_type == uv_handle_type::UV_NAMED_PIPE {
+      let mut total = 0i32;
+      for buf in bufs {
+        let rc = super::pipe::try_write_pipe(
+          handle as *mut super::pipe::uv_pipe_t,
+          buf,
+        );
+        if rc < 0 {
+          if total > 0 {
+            return total;
+          }
+          return rc;
+        }
+        total = total.saturating_add(rc);
+        if (rc as usize) != buf.len() {
+          return total;
+        }
+      }
+      return total;
+    }
+  }
+  // SAFETY: Caller guarantees handle is a valid, initialized uv_tcp_t.
+  let tcp_ref = unsafe { &mut *(handle as *mut uv_tcp_t) };
+
+  if tcp_ref.internal_connect.is_some()
+    || !tcp_ref.internal_write_queue.is_empty()
+  {
+    return UV_EAGAIN;
+  }
+
+  let stream = match tcp_ref.internal_stream.as_ref() {
+    Some(s) => s,
+    None => return UV_EBADF,
+  };
+
+  match stream.try_write_vectored(bufs) {
+    Ok(n) => n as i32,
+    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => UV_EAGAIN,
+    Err(_) => UV_EPIPE,
+  }
+}
+
 pub unsafe fn uv_try_write(handle: *mut uv_stream_t, data: &[u8]) -> i32 {
   // Dispatch by handle type; `uv_tcp_t`, `uv_pipe_t`, and `uv_tty_t` have
   // different struct layouts, so the TCP path below must only be taken
@@ -344,6 +428,98 @@ pub unsafe fn uv_write_owned_tcp(
   }
 }
 
+/// Queue a scatter-gather async write with caller-owned retention.
+/// The iovecs in `bufs` may point at memory not owned by uv_compat
+/// (e.g. V8 `ArrayBuffer` backing stores retained on the JS side);
+/// the caller must ensure that memory stays valid until `cb` fires.
+///
+/// Mirrors libuv's `uv_write(req, stream, bufs, nbufs, cb)` with the
+/// key difference that our write queue preserves the iovec layout
+/// across drain calls, allowing true scatter-gather writes on TCP
+/// without ever concatenating into a single buffer.
+///
+/// ### Safety
+/// `req` must be valid until the callback fires. `handle` must be an
+/// initialized stream handle. Each iovec's `base` pointer must remain
+/// valid and readable for its `len` until the callback fires.
+pub unsafe fn uv_writev_owned(
+  req: *mut uv_write_t,
+  handle: *mut uv_stream_t,
+  bufs: smallvec::SmallVec<[uv_buf_t; 4]>,
+  cb: Option<uv_write_cb>,
+) -> c_int {
+  use super::tcp::IovecCursor;
+  use super::tcp::WritePending;
+  // SAFETY: caller contract.
+  unsafe {
+    (*req).handle = handle;
+    match (*handle).r#type {
+      uv_handle_type::UV_TCP => {
+        let tcp = handle as *mut uv_tcp_t;
+        if (*tcp).internal_stream.is_none() {
+          return UV_EBADF;
+        }
+        // Try sync drain first to match uv__write's inline write-loop.
+        // Callback still fires asynchronously (deferred) if everything
+        // drains — we mark status=Some(0) so the poll loop fires it.
+        let mut iov = IovecCursor::new(bufs);
+        if (*tcp).internal_write_queue.is_empty()
+          && let Some(ref stream) = (*tcp).internal_stream
+        {
+          loop {
+            if iov.is_empty() {
+              break;
+            }
+            let write_result = {
+              let mut slices: smallvec::SmallVec<[std::io::IoSlice; 16]> =
+                smallvec::SmallVec::new();
+              iov.io_slices(&mut slices);
+              if slices.is_empty() {
+                break;
+              }
+              stream.try_write_vectored(&slices)
+            };
+            match write_result {
+              Ok(0) => break,
+              Ok(n) => iov.advance(n),
+              Err(_) => break,
+            }
+          }
+        }
+        (*tcp).internal_write_queue.push_back(WritePending {
+          req,
+          data: Vec::new(),
+          offset: 0,
+          iovecs: Some(iov),
+          cb,
+          status: None,
+        });
+        (*tcp).flags |= UV_HANDLE_ACTIVE;
+        let inner = get_inner((*tcp).loop_);
+        let mut handles = inner.tcp_handles.borrow_mut();
+        if !handles.iter().any(|&h| std::ptr::eq(h, tcp)) {
+          handles.push(tcp);
+        }
+        if let Some(w) = (*tcp).internal_waker.as_ref() {
+          w.mark_ready();
+        }
+        0
+      }
+      _ => {
+        // Pipes/TTYs internally copy; go through the regular
+        // `uv_write` buf-vector dispatch.
+        let raw_bufs: smallvec::SmallVec<[uv_buf_t; 4]> = bufs;
+        let nbufs = raw_bufs.len() as u32;
+        let rc = uv_write(req, handle, raw_bufs.as_ptr(), nbufs, cb);
+        // Keep raw_bufs alive through the call; `uv_write` collects
+        // into its own owned Vec, so the iovec array can drop now.
+        drop(raw_bufs);
+        rc
+      }
+    }
+  }
+}
+
 /// Polymorphic counterpart to `uv_write_owned_tcp` that dispatches on
 /// the runtime stream type. Callers (e.g. the stream_wrap `writev` op)
 /// hold a `*mut uv_stream_t` that may back a TCP, pipe, or TTY handle;
@@ -418,6 +594,7 @@ unsafe fn uv_write_owned_impl(
       req,
       data: write_data,
       offset,
+      iovecs: None,
       cb,
       status: None,
     });
@@ -684,6 +861,7 @@ unsafe fn write_pipe(
       req,
       data: write_data,
       offset,
+      iovecs: None,
       cb,
       status,
     });

--- a/libs/core/uv_compat/stream.rs
+++ b/libs/core/uv_compat/stream.rs
@@ -9,7 +9,6 @@ use super::UV_EALREADY;
 use super::UV_EBADF;
 use super::UV_EINVAL;
 use super::UV_ENOTCONN;
-use super::UV_EPIPE;
 use super::UV_HANDLE_ACTIVE;
 use super::UV_HANDLE_CLOSING;
 use super::get_inner;
@@ -318,7 +317,7 @@ pub unsafe fn uv_try_writev(
   match stream.try_write_vectored(bufs) {
     Ok(n) => n as i32,
     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => UV_EAGAIN,
-    Err(_) => UV_EPIPE,
+    Err(ref e) => super::io_error_to_uv(e),
   }
 }
 
@@ -361,7 +360,7 @@ pub unsafe fn uv_try_write(handle: *mut uv_stream_t, data: &[u8]) -> i32 {
   match stream.try_write(data) {
     Ok(n) => n as i32,
     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => UV_EAGAIN,
-    Err(_) => UV_EPIPE,
+    Err(ref e) => super::io_error_to_uv(e),
   }
 }
 

--- a/libs/core/uv_compat/stream.rs
+++ b/libs/core/uv_compat/stream.rs
@@ -322,6 +322,10 @@ pub unsafe fn uv_try_writev(
   }
 }
 
+/// ### Safety
+/// `handle` must be a valid pointer to an initialized stream handle
+/// (`uv_tcp_t`, `uv_tty_t`, or `uv_pipe_t`, cast as `uv_stream_t`).
+/// `data` must reference memory valid for the duration of this call.
 pub unsafe fn uv_try_write(handle: *mut uv_stream_t, data: &[u8]) -> i32 {
   // Dispatch by handle type; `uv_tcp_t`, `uv_pipe_t`, and `uv_tty_t` have
   // different struct layouts, so the TCP path below must only be taken

--- a/libs/core/uv_compat/tcp.rs
+++ b/libs/core/uv_compat/tcp.rs
@@ -152,12 +152,124 @@ pub(crate) struct WritePending {
   pub(crate) req: *mut uv_write_t,
   pub(crate) data: Vec<u8>,
   pub(crate) offset: usize,
+  /// When `Some`, iovecs take precedence over `data`/`offset` for the
+  /// write drain. Retention for the memory pointed to by these iovecs
+  /// is the caller's responsibility (typically `stream_wrap` retains
+  /// `v8::Global<v8::ArrayBuffer>` refs on the write request's
+  /// callback state so the memory stays alive until the callback).
+  /// `data` is kept empty in this mode.
+  pub(crate) iovecs: Option<IovecCursor>,
   pub(crate) cb: Option<uv_write_cb>,
   /// Pre-determined completion status. When `Some`, the write is already
   /// complete and the callback should be fired with this status without
   /// attempting any I/O. This is used to defer synchronous write
   /// completions to the event loop, preventing re-entrancy issues.
   pub(crate) status: Option<c_int>,
+}
+
+/// Cursor over a scatter-gather write: a list of iovecs plus a byte
+/// offset into the first one (entries past the first are always full).
+/// Mirrors libuv's `uv__write`'s queue entry which carries `(bufs,
+/// nbufs, write_index)` through the drain loop.
+pub(crate) struct IovecCursor {
+  pub(crate) bufs: smallvec::SmallVec<[uv_buf_t; 4]>,
+  /// Byte offset into `bufs[0]` for the next write. Entries 1.. are
+  /// always consumed whole.
+  pub(crate) head_off: usize,
+}
+
+impl IovecCursor {
+  pub(crate) fn new(bufs: smallvec::SmallVec<[uv_buf_t; 4]>) -> Self {
+    Self { bufs, head_off: 0 }
+  }
+
+  /// Unwritten slice at the head of the iovec list. Callers that can't
+  /// do true scatter-gather (pipes/TTY) use this to walk one iovec at a
+  /// time while still preserving zero-copy semantics.
+  ///
+  /// # Safety
+  /// The memory pointed to by the head iovec must be valid for reads.
+  pub(crate) unsafe fn head_slice(&self) -> &[u8] {
+    if self.bufs.is_empty() {
+      return &[];
+    }
+    // SAFETY: caller guarantees iovec memory is valid.
+    unsafe {
+      let head = &self.bufs[0];
+      if head.len <= self.head_off || head.base.is_null() {
+        return &[];
+      }
+      std::slice::from_raw_parts(
+        (head.base as *const u8).add(self.head_off),
+        head.len - self.head_off,
+      )
+    }
+  }
+
+  /// Total unwritten bytes across all iovecs.
+  #[allow(dead_code, reason = "public helper for external iovec consumers")]
+  pub(crate) fn remaining(&self) -> usize {
+    if self.bufs.is_empty() {
+      return 0;
+    }
+    let first = self.bufs[0].len.saturating_sub(self.head_off);
+    first + self.bufs[1..].iter().map(|b| b.len).sum::<usize>()
+  }
+
+  pub(crate) fn is_empty(&self) -> bool {
+    self.bufs.is_empty()
+      || (self.bufs.len() == 1 && self.head_off >= self.bufs[0].len)
+  }
+
+  /// Advance the cursor by `n` bytes written. Drops bufs fully consumed
+  /// from the front; slices the partially-written head in place.
+  /// Mirrors the pointer advance loop in libuv's `DoTryWrite`.
+  pub(crate) fn advance(&mut self, mut n: usize) {
+    while n > 0 && !self.bufs.is_empty() {
+      let avail = self.bufs[0].len.saturating_sub(self.head_off);
+      if n >= avail {
+        n -= avail;
+        self.bufs.remove(0);
+        self.head_off = 0;
+      } else {
+        self.head_off += n;
+        n = 0;
+      }
+    }
+  }
+
+  /// Build `IoSlice`s for the unwritten window, appending to `out`.
+  /// Lifetimes borrow from `self`; pointers must remain valid (caller
+  /// guarantees retention).
+  ///
+  /// # Safety
+  /// The memory pointed to by each iovec's `base` must be valid and
+  /// readable for its `len`.
+  pub(crate) unsafe fn io_slices<'a>(
+    &'a self,
+    out: &mut smallvec::SmallVec<[std::io::IoSlice<'a>; 16]>,
+  ) {
+    if self.bufs.is_empty() {
+      return;
+    }
+    // SAFETY: caller guarantees iovecs point to valid readable memory.
+    unsafe {
+      let head = &self.bufs[0];
+      if head.len > self.head_off {
+        let base = (head.base as *const u8).add(self.head_off);
+        let len = head.len - self.head_off;
+        out.push(std::io::IoSlice::new(std::slice::from_raw_parts(base, len)));
+      }
+      for buf in &self.bufs[1..] {
+        if !buf.base.is_null() && buf.len > 0 {
+          out.push(std::io::IoSlice::new(std::slice::from_raw_parts(
+            buf.base as *const u8,
+            buf.len,
+          )));
+        }
+      }
+    }
+  }
 }
 
 /// Pending shutdown request, deferred until the write queue drains.
@@ -1106,21 +1218,65 @@ pub(crate) unsafe fn poll_tcp_handle(
           let pw = (*tcp_ptr).internal_write_queue.front_mut().unwrap();
           let mut done = false;
           let mut error = false;
-          loop {
-            if pw.offset >= pw.data.len() {
-              done = true;
-              break;
+          if let Some(ref mut iov) = pw.iovecs {
+            // Scatter-gather write. Loop until drained, WouldBlock, or
+            // error — mirrors uv__write's write-all-the-bytes-you-can
+            // inner loop.
+            loop {
+              if iov.is_empty() {
+                done = true;
+                break;
+              }
+              // Scope the IoSlice borrow so we can advance `iov`
+              // afterwards.
+              let write_result = {
+                let mut slices: smallvec::SmallVec<[std::io::IoSlice; 16]> =
+                  smallvec::SmallVec::new();
+                // SAFETY: iovec memory is kept alive by caller retention.
+                iov.io_slices(&mut slices);
+                if slices.is_empty() {
+                  None
+                } else {
+                  Some(stream.try_write_vectored(&slices))
+                }
+              };
+              match write_result {
+                None => {
+                  done = true;
+                  break;
+                }
+                Some(Ok(0)) => break,
+                Some(Ok(n)) => {
+                  iov.advance(n);
+                }
+                Some(Err(ref e))
+                  if e.kind() == std::io::ErrorKind::WouldBlock =>
+                {
+                  break;
+                }
+                Some(Err(_)) => {
+                  error = true;
+                  break;
+                }
+              }
             }
-            match stream.try_write(&pw.data[pw.offset..]) {
-              Ok(n) => {
-                pw.offset += n;
-              }
-              Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+          } else {
+            loop {
+              if pw.offset >= pw.data.len() {
+                done = true;
                 break;
               }
-              Err(_) => {
-                error = true;
-                break;
+              match stream.try_write(&pw.data[pw.offset..]) {
+                Ok(n) => {
+                  pw.offset += n;
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                  break;
+                }
+                Err(_) => {
+                  error = true;
+                  break;
+                }
               }
             }
           }

--- a/libs/core/uv_compat/tcp.rs
+++ b/libs/core/uv_compat/tcp.rs
@@ -167,20 +167,31 @@ pub(crate) struct WritePending {
   pub(crate) status: Option<c_int>,
 }
 
-/// Cursor over a scatter-gather write: a list of iovecs plus a byte
-/// offset into the first one (entries past the first are always full).
-/// Mirrors libuv's `uv__write`'s queue entry which carries `(bufs,
-/// nbufs, write_index)` through the drain loop.
+/// Cursor over a scatter-gather write: a list of iovecs plus a head
+/// index and byte offset into the head entry (entries past the head
+/// are always full). Mirrors libuv's `uv__write`'s queue entry which
+/// carries `(bufs, nbufs, write_index)` through the drain loop.
+///
+/// `head_index` lets `advance` run in O(1) per consumed iovec instead
+/// of shifting the tail; matters at high iovec counts (`IOV_MAX` is
+/// 1024 on Linux, reachable via chunked-encoding responses).
 pub(crate) struct IovecCursor {
   pub(crate) bufs: smallvec::SmallVec<[uv_buf_t; 4]>,
-  /// Byte offset into `bufs[0]` for the next write. Entries 1.. are
-  /// always consumed whole.
+  /// Index of the head entry. Entries `< head_index` are consumed and
+  /// must not be read.
+  pub(crate) head_index: usize,
+  /// Byte offset into `bufs[head_index]` for the next write. Entries
+  /// `> head_index` are always consumed whole.
   pub(crate) head_off: usize,
 }
 
 impl IovecCursor {
   pub(crate) fn new(bufs: smallvec::SmallVec<[uv_buf_t; 4]>) -> Self {
-    Self { bufs, head_off: 0 }
+    Self {
+      bufs,
+      head_index: 0,
+      head_off: 0,
+    }
   }
 
   /// Unwritten slice at the head of the iovec list. Callers that can't
@@ -190,12 +201,12 @@ impl IovecCursor {
   /// # Safety
   /// The memory pointed to by the head iovec must be valid for reads.
   pub(crate) unsafe fn head_slice(&self) -> &[u8] {
-    if self.bufs.is_empty() {
+    if self.head_index >= self.bufs.len() {
       return &[];
     }
     // SAFETY: caller guarantees iovec memory is valid.
     unsafe {
-      let head = &self.bufs[0];
+      let head = &self.bufs[self.head_index];
       if head.len <= self.head_off || head.base.is_null() {
         return &[];
       }
@@ -209,27 +220,34 @@ impl IovecCursor {
   /// Total unwritten bytes across all iovecs.
   #[allow(dead_code, reason = "public helper for external iovec consumers")]
   pub(crate) fn remaining(&self) -> usize {
-    if self.bufs.is_empty() {
+    if self.head_index >= self.bufs.len() {
       return 0;
     }
-    let first = self.bufs[0].len.saturating_sub(self.head_off);
-    first + self.bufs[1..].iter().map(|b| b.len).sum::<usize>()
+    let first = self.bufs[self.head_index].len.saturating_sub(self.head_off);
+    first
+      + self.bufs[self.head_index + 1..]
+        .iter()
+        .map(|b| b.len)
+        .sum::<usize>()
   }
 
   pub(crate) fn is_empty(&self) -> bool {
-    self.bufs.is_empty()
-      || (self.bufs.len() == 1 && self.head_off >= self.bufs[0].len)
+    self.head_index >= self.bufs.len()
+      || (self.head_index == self.bufs.len() - 1
+        && self.head_off >= self.bufs[self.head_index].len)
   }
 
-  /// Advance the cursor by `n` bytes written. Drops bufs fully consumed
-  /// from the front; slices the partially-written head in place.
-  /// Mirrors the pointer advance loop in libuv's `DoTryWrite`.
+  /// Advance the cursor by `n` bytes written. Skips over bufs fully
+  /// consumed from the front by bumping `head_index`; updates the
+  /// partial-write offset for the head entry. O(consumed entries),
+  /// no tail shift. Mirrors the pointer advance loop in libuv's
+  /// `DoTryWrite`.
   pub(crate) fn advance(&mut self, mut n: usize) {
-    while n > 0 && !self.bufs.is_empty() {
-      let avail = self.bufs[0].len.saturating_sub(self.head_off);
+    while n > 0 && self.head_index < self.bufs.len() {
+      let avail = self.bufs[self.head_index].len.saturating_sub(self.head_off);
       if n >= avail {
         n -= avail;
-        self.bufs.remove(0);
+        self.head_index += 1;
         self.head_off = 0;
       } else {
         self.head_off += n;
@@ -249,18 +267,18 @@ impl IovecCursor {
     &'a self,
     out: &mut smallvec::SmallVec<[std::io::IoSlice<'a>; 16]>,
   ) {
-    if self.bufs.is_empty() {
+    if self.head_index >= self.bufs.len() {
       return;
     }
     // SAFETY: caller guarantees iovecs point to valid readable memory.
     unsafe {
-      let head = &self.bufs[0];
+      let head = &self.bufs[self.head_index];
       if head.len > self.head_off {
         let base = (head.base as *const u8).add(self.head_off);
         let len = head.len - self.head_off;
         out.push(std::io::IoSlice::new(std::slice::from_raw_parts(base, len)));
       }
-      for buf in &self.bufs[1..] {
+      for buf in &self.bufs[self.head_index + 1..] {
         if !buf.base.is_null() && buf.len > 0 {
           out.push(std::io::IoSlice::new(std::slice::from_raw_parts(
             buf.base as *const u8,

--- a/libs/core/uv_compat/tty.rs
+++ b/libs/core/uv_compat/tty.rs
@@ -1850,6 +1850,7 @@ pub(crate) unsafe fn write_tty(
         req,
         data,
         offset: 0,
+        iovecs: None,
         cb,
         status: None,
       });
@@ -1872,6 +1873,7 @@ pub(crate) unsafe fn write_tty(
                   req,
                   data: Vec::new(),
                   offset: 0,
+                  iovecs: None,
                   cb,
                   status: Some(0),
                 });
@@ -1884,6 +1886,7 @@ pub(crate) unsafe fn write_tty(
                 req,
                 data: data[offset..].to_vec(),
                 offset: 0,
+                iovecs: None,
                 cb,
                 status: None,
               });
@@ -1895,6 +1898,7 @@ pub(crate) unsafe fn write_tty(
                 req,
                 data: Vec::new(),
                 offset: 0,
+                iovecs: None,
                 cb,
                 status: Some(UV_EPIPE),
               });
@@ -1908,6 +1912,7 @@ pub(crate) unsafe fn write_tty(
         req,
         data: Vec::new(),
         offset: 0,
+        iovecs: None,
         cb,
         status: Some(0),
       });
@@ -1922,6 +1927,7 @@ pub(crate) unsafe fn write_tty(
         req,
         data: Vec::new(),
         offset: 0,
+        iovecs: None,
         cb,
         status: Some(0),
       });
@@ -1939,6 +1945,7 @@ pub(crate) unsafe fn write_tty(
               req,
               data: Vec::new(),
               offset: 0,
+              iovecs: None,
               cb,
               status: Some(0),
             });
@@ -1951,6 +1958,7 @@ pub(crate) unsafe fn write_tty(
             req,
             data: data[offset..].to_vec(),
             offset: 0,
+            iovecs: None,
             cb,
             status: None,
           });
@@ -1962,6 +1970,7 @@ pub(crate) unsafe fn write_tty(
             req,
             data: Vec::new(),
             offset: 0,
+            iovecs: None,
             cb,
             status: Some(UV_EPIPE),
           });
@@ -2487,19 +2496,48 @@ pub(crate) unsafe fn poll_tty_handle(
           let pw = (*tty_ptr).internal_write_queue.front_mut().unwrap();
           let mut done = false;
           let mut error = false;
-          loop {
-            if pw.offset >= pw.data.len() {
-              done = true;
-              break;
-            }
-            match tty_try_write(tty_ptr, &pw.data[pw.offset..]) {
-              Ok(n) => pw.offset += n,
-              Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+          if let Some(ref mut iov) = pw.iovecs {
+            // TTY has no native writev — iterate across iovecs calling
+            // single-buffer try_write.
+            loop {
+              if iov.is_empty() {
+                done = true;
                 break;
               }
-              Err(_) => {
-                error = true;
+              let (head_base, head_len) = {
+                let first = &iov.bufs[0];
+                (first.base, first.len - iov.head_off)
+              };
+              let slice = std::slice::from_raw_parts(
+                (head_base as *const u8).add(iov.head_off),
+                head_len,
+              );
+              match tty_try_write(tty_ptr, slice) {
+                Ok(n) => iov.advance(n),
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                  break;
+                }
+                Err(_) => {
+                  error = true;
+                  break;
+                }
+              }
+            }
+          } else {
+            loop {
+              if pw.offset >= pw.data.len() {
+                done = true;
                 break;
+              }
+              match tty_try_write(tty_ptr, &pw.data[pw.offset..]) {
+                Ok(n) => pw.offset += n,
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                  break;
+                }
+                Err(_) => {
+                  error = true;
+                  break;
+                }
               }
             }
           }

--- a/libs/core/uv_compat/tty.rs
+++ b/libs/core/uv_compat/tty.rs
@@ -2505,7 +2505,7 @@ pub(crate) unsafe fn poll_tty_handle(
                 break;
               }
               let (head_base, head_len) = {
-                let first = &iov.bufs[0];
+                let first = &iov.bufs[iov.head_index];
                 (first.base, first.len - iov.head_off)
               };
               let slice = std::slice::from_raw_parts(


### PR DESCRIPTION
Roughly 11% improvement in throughput for node:http server hello world.

before
```bash
❮ oha http://127.0.0.1:8000 --disable-compression -n 1m -c 128
Summary:
  Success rate: 100.00%
  Total:        12801.0954 ms
  Slowest:      102.0594 ms
  Fastest:      0.0250 ms
  Average:      1.6359 ms
  Requests/sec: 78118.3149
```

after
```bash
/v/f/n/5/T/tmp.ymoaIQT8mz                           12s
❮ oha http://127.0.0.1:8000 --disable-compression -n 1m -c 128
Summary:
  Success rate: 100.00%
  Total:        11507.3875 ms
  Slowest:      53.1333 ms
  Fastest:      0.0314 ms
  Average:      1.4704 ms
  Requests/sec: 86900.6978
```