### PR TITLE
fix(libs/ops/op2): reject calling cppgc constructors without `new`

### DIFF
--- a/libs/core_testing/unit/resource_test.ts
+++ b/libs/core_testing/unit/resource_test.ts
@@ -189,3 +189,26 @@ test(function testFastProtoMethod() {
     obj.withScopeFast(); // trigger fast call
   }
 });
+
+// Regression test for op2 constructors being callable without `new`.
+// `DOMPoint()` used to bind into globalThis; `DOMPoint.call(proxy)` could
+// segfault. Construct-call enforcement at the slow-path entry rejects both.
+test(function testCppgcConstructorRequiresNew() {
+  let err1;
+  try {
+    // @ts-expect-error invoking constructor without `new`
+    DOMPoint();
+  } catch (e) {
+    err1 = e;
+  }
+  assert(err1 instanceof TypeError, `expected TypeError, got ${err1}`);
+
+  let err2;
+  try {
+    // @ts-expect-error invoking constructor without `new`
+    DOMPoint.call(new Proxy({}, {}));
+  } catch (e) {
+    err2 = e;
+  }
+  assert(err2 instanceof TypeError, `expected TypeError, got ${err2}`);
+});

--- a/libs/ops/op2/dispatch_slow.rs
+++ b/libs/ops/op2/dispatch_slow.rs
@@ -164,6 +164,12 @@ pub(crate) fn generate_dispatch_slow(
     quote!()
   };
 
+  let with_construct_call_check = if generator_state.use_this_cppgc {
+    with_construct_call_check(generator_state)
+  } else {
+    quote!()
+  };
+
   let with_self = if generator_state.needs_self {
     with_self(generator_state, &signature.ret_val)
   } else {
@@ -185,6 +191,7 @@ pub(crate) fn generate_dispatch_slow(
       #with_scope
       #with_retval
       #with_args
+      #with_construct_call_check
       #with_validate
       #with_required_check
       #with_opctx
@@ -292,6 +299,26 @@ pub(crate) fn with_required_check(
         #required,
         #arguments_lit,
         #fn_args.length() - #async_offset
+      );
+      let msg = deno_core::v8::String::new(&mut #scope, &msg).unwrap();
+      let exception = deno_core::v8::Exception::type_error(&mut #scope, msg.into());
+      #scope.throw_exception(exception);
+      return 1;
+    })
+  )
+}
+
+pub(crate) fn with_construct_call_check(
+  generator_state: &mut GeneratorState,
+) -> TokenStream {
+  generator_state.needs_scope = true;
+  generator_state.needs_args = true;
+  let prefix = format!("Failed to construct '{}'", generator_state.self_ty);
+  gs_quote!(generator_state(fn_args, scope) =>
+    (if !#fn_args.is_construct_call() {
+      let msg = format!(
+        "{}: Please use the 'new' operator, this constructor cannot be called as a function.",
+        #prefix,
       );
       let msg = deno_core::v8::String::new(&mut #scope, &msg).unwrap();
       let exception = deno_core::v8::Exception::type_error(&mut #scope, msg.into());

--- a/libs/ops/op2/test_cases/sync/object_wrap.out
+++ b/libs/ops/op2/test_cases/sync/object_wrap.out
@@ -63,6 +63,19 @@ impl Foo {
                 let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
                     info,
                 );
+                if !args.is_construct_call() {
+                    let msg = format!(
+                        "{}: Please use the 'new' operator, this constructor cannot be called as a function.",
+                        "Failed to construct 'Foo'",
+                    );
+                    let msg = deno_core::v8::String::new(&mut scope, &msg).unwrap();
+                    let exception = deno_core::v8::Exception::type_error(
+                        &mut scope,
+                        msg.into(),
+                    );
+                    scope.throw_exception(exception);
+                    return 1;
+                }
                 let result = {
                     let arg0 = args.get(0usize as i32);
                     let arg0 = if arg0.is_null_or_undefined() {


### PR DESCRIPTION
## Summary

`#[op2(constructor)]` cppgc-wrapped constructors (`DOMPoint`, etc.) used to skip any check that they were called with `new`. Two consequences from #33663:

1. `DOMPoint()` (no `new`) silently wrapped into `args.this()`, returning `globalThis`/`Window` instead of throwing.
2. `DOMPoint.call(new Proxy({}, {}))` reached `cppgc::wrap_object` with a non-Object receiver and **segfaulted**.

This is a memory-safety bug — JS code can crash the runtime with one well-formed call.

The fix: in the op2 macro's slow-path generator (`libs/ops/op2/dispatch_slow.rs`), emit a `!args.is_construct_call()` guard at the top of `slow_function_impl` whenever `use_this_cppgc` is set. If the call isn't a construct call, throw a `TypeError` with the standard "Please use the 'new' operator" message before any wrap_object runs.

The slow path is the only entry for cppgc constructors (V8 doesn't take fast-api callbacks for `new` calls), so the slow-path check is sufficient.

Closes #33663.

## Test plan

- [x] New `testCppgcConstructorRequiresNew` test in `libs/core_testing/unit/resource_test.ts` covers both `DOMPoint()` and `DOMPoint.call(proxy)` — both throw `TypeError` instead of returning `Window`/segfaulting
- [x] `cargo test -p deno_core_testing resource_test` passes
- [x] `cargo test -p deno_ops test_proc_macro_sync_op2__test_cases__sync__object_wrap_rs` passes (snapshot updated)
- [x] `cargo clippy -p deno_ops --no-deps -- -D warnings` clean