### PR TITLE
fix(upgrade): improve logging for PR/branch artifact downloads

### DIFF
--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -10,6 +10,7 @@ use std::ops::Sub;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -735,6 +736,7 @@ fn upgrade_from_pr(
           "--dir",
           &download_dir.to_string_lossy(),
         ])
+        .stderr(Stdio::inherit())
         .output()
         .context("failed to run `gh run download`")?;
 
@@ -746,6 +748,8 @@ fn upgrade_from_pr(
         );
         downloaded = true;
         break;
+      } else {
+        log::info!("{}", colors::gray("not found"));
       }
     }
     if downloaded {
@@ -905,6 +909,7 @@ fn upgrade_from_branch(
           "--dir",
           &download_dir.to_string_lossy(),
         ])
+        .stderr(Stdio::inherit())
         .output()
         .context("failed to run `gh run download`")?;
 
@@ -916,6 +921,8 @@ fn upgrade_from_branch(
         );
         downloaded = true;
         break;
+      } else {
+        log::info!("{}", colors::gray("not found"));
       }
     }
     if downloaded {

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -632,6 +632,7 @@ fn upgrade_from_pr(
       "-q",
       r#"[.title, .state, .headRefName, .headRefOid] | @tsv"#,
     ])
+    .stderr(Stdio::inherit())
     .output()
     .context("failed to run `gh pr view`")?;
 
@@ -689,6 +690,7 @@ fn upgrade_from_pr(
         "-q",
         &jq_filter,
       ])
+      .stderr(Stdio::inherit())
       .output()
       .context("failed to query CI runs by branch")?;
 
@@ -863,6 +865,7 @@ fn upgrade_from_branch(
       "-q",
       ".[].databaseId",
     ])
+    .stderr(Stdio::inherit())
     .output()
     .context("failed to query CI runs")?;
 


### PR DESCRIPTION
## Summary
- Print "not found" when moving to the next artifact/run, so it's clear the
  process isn't stuck
- Inherit stderr from `gh run download` so download progress is visible
  (previously all output was captured and discarded, making it look like a hang)

## Test plan
- `deno upgrade pr <number>` with a valid PR — should show `gh` download
  progress and "not found" for skipped artifacts
- `deno upgrade pr <number>` with an invalid/expired PR — should show "not
  found" for each attempt before the final error