### PR TITLE
perf(core): cap V8 platform thread pool to 4 threads

### DIFF
--- a/libs/core/runtime/setup.rs
+++ b/libs/core/runtime/setup.rs
@@ -180,8 +180,22 @@ fn v8_init(
   let v8_platform = v8_platform.unwrap_or_else(|| {
     let unprotected =
       cfg!(any(test, feature = "unsafe_use_unprotected_platform"));
-    v8::new_custom_platform(0, false, unprotected, DenoPlatformImpl)
-      .make_shared()
+    // Cap V8 platform thread pool to 4 threads (like Node.js).
+    // Using all available cores (the default when 0 is passed) wastes
+    // memory for workloads that rarely use background V8 tasks.
+    let thread_pool_size = std::cmp::min(
+      std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(4),
+      4,
+    );
+    v8::new_custom_platform(
+      thread_pool_size,
+      false,
+      unprotected,
+      DenoPlatformImpl,
+    )
+    .make_shared()
   });
   v8::V8::initialize_platform(v8_platform.clone());
   v8::V8::initialize();


### PR DESCRIPTION
## Summary

- Cap the V8 platform thread pool size to `min(available_parallelism, 4)` instead of using all available cores (the default when `thread_pool_size=0` is passed)
- Node.js uses the same cap of 4 V8 worker threads regardless of core count
- These background threads are used for V8 internal tasks (e.g. concurrent GC, compilation) and having 10+ of them for a simple script is wasteful

## Measurements

On a 10-core macOS arm64 machine (release build, idle script):

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| V8 worker threads | 10 | 4 | -6 |
| Total threads | 14 | 8 | -6 |
| Physical footprint | 24.8 MB | 23.5 MB | **-1.3 MB** |
| Peak RSS | 54.3 MB | 53.4 MB | **-0.9 MB** |

## Test plan

- [x] `deno run` of simple scripts works correctly
- [x] Verified thread count via `sample` / `vmmap` on macOS
- [ ] CI passes