### PR TITLE
perf(ext/webstorage): lazy-load 01_webstorage.js

### DIFF
--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -41,7 +41,7 @@ deno_core::extension!(deno_webstorage,
   objects = [
     Storage
   ],
-  esm = [ "01_webstorage.js" ],
+  lazy_loaded_esm = [ "01_webstorage.js" ],
   options = {
       origin_storage_dir: Option<PathBuf>
   },

--- a/runtime/js/98_global_scope_window.js
+++ b/runtime/js/98_global_scope_window.js
@@ -18,9 +18,12 @@ import * as location from "ext:deno_web/12_location.js";
 import * as console from "ext:deno_web/01_console.js";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 import * as globalInterfaces from "ext:deno_web/04_global_interfaces.js";
-import * as webStorage from "ext:deno_webstorage/01_webstorage.js";
 import * as prompt from "ext:runtime/41_prompt.js";
 import { loadWebGPU } from "ext:deno_webgpu/00_init.js";
+
+const loadWebStorage = core.createLazyLoader(
+  "ext:deno_webstorage/01_webstorage.js",
+);
 
 /**
  * @param {string} arch
@@ -172,9 +175,12 @@ const mainRuntimeGlobalProperties = {
   alert: core.propWritable(prompt.alert),
   confirm: core.propWritable(prompt.confirm),
   prompt: core.propWritable(prompt.prompt),
-  localStorage: core.propGetterOnly(webStorage.localStorage),
-  sessionStorage: core.propGetterOnly(webStorage.sessionStorage),
-  Storage: core.propNonEnumerable(webStorage.Storage),
+  localStorage: core.propGetterOnly(() => loadWebStorage().localStorage()),
+  sessionStorage: core.propGetterOnly(() => loadWebStorage().sessionStorage()),
+  Storage: core.propNonEnumerableLazyLoaded(
+    (ws) => ws.Storage,
+    loadWebStorage,
+  ),
 };
 
 export { mainRuntimeGlobalProperties, memoizeLazy };


### PR DESCRIPTION
## Summary
- Switch `ext/webstorage/01_webstorage.js` from eager `esm` to `lazy_loaded_esm`, matching the pattern used by `ext/image/01_image.js` and `ext/webgpu/01_webgpu.js`.
- Wire `Storage`, and the `localStorage` / `sessionStorage` getters through `createLazyLoader` / `propNonEnumerableLazyLoaded` in `runtime/js/98_global_scope_window.js` so the webstorage module is only initialized on first use.

## Test plan
- [x] `cargo build --bin deno`
- [x] Smoke test with `--location` exercising `sessionStorage.setItem` / `getItem` / `length` / `removeItem` and `localStorage.setItem` / `getItem` / `clear` — all return expected values