### PR TITLE
perf: lazy-load WebSocket and WebCrypto JS modules

### DIFF
--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -124,7 +124,7 @@ deno_core::extension!(deno_crypto,
     ed25519::op_crypto_export_pkcs8_ed25519,
     ed25519::op_crypto_jwk_x_ed25519,
   ],
-  esm = [ "00_crypto.js" ],
+  lazy_loaded_esm = [ "00_crypto.js" ],
   options = {
     maybe_seed: Option<u64>,
   },

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -72,16 +72,6 @@ import {
 } from "ext:deno_fetch/23_request.js";
 import { AbortController } from "ext:deno_web/03_abort_signal.js";
 import {
-  _eventLoop,
-  _idleTimeoutDuration,
-  _idleTimeoutTimeout,
-  _protocol,
-  _readyState,
-  _rid,
-  _role,
-  _serverHandleIdleTimeout,
-} from "ext:deno_websocket/01_websocket.js";
-import {
   getReadableStreamResourceBacking,
   readableStreamForRid,
   ReadableStreamPrototype,

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -43,18 +43,9 @@ import {
   fromInnerRequest,
   newInnerRequest,
 } from "ext:deno_fetch/23_request.js";
-import {
-  _eventLoop,
-  _idleTimeoutDuration,
-  _idleTimeoutTimeout,
-  _protocol,
-  _readyState,
-  _rid,
-  _role,
-  _serverHandleIdleTimeout,
-  SERVER,
-  WebSocket,
-} from "ext:deno_websocket/01_websocket.js";
+const loadWebSocket = core.createLazyLoader(
+  "ext:deno_websocket/01_websocket.js",
+);
 import {
   getReadableStreamResourceBacking,
   readableStreamClose,
@@ -358,6 +349,17 @@ function createRespondWith(
 
       const ws = resp[_ws];
       if (ws) {
+        const {
+          _eventLoop,
+          _idleTimeoutDuration,
+          _idleTimeoutTimeout,
+          _protocol,
+          _readyState,
+          _rid,
+          _role,
+          _serverHandleIdleTimeout,
+          SERVER,
+        } = loadWebSocket();
         const wsRid = await op_http_upgrade_websocket(
           readStreamRid,
         );
@@ -366,7 +368,7 @@ function createRespondWith(
 
         httpConn.close();
 
-        ws[_readyState] = WebSocket.OPEN;
+        ws[_readyState] = 1; // WebSocket.OPEN
         ws[_role] = SERVER;
         const event = new Event("open");
         ws.dispatchEvent(event);

--- a/ext/http/02_websocket.ts
+++ b/ext/http/02_websocket.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { internals, primordials } from "ext:core/mod.js";
+import { core, internals, primordials } from "ext:core/mod.js";
 import { op_http_websocket_accept_header } from "ext:core/ops";
 const {
   ArrayPrototypeIncludes,
@@ -18,19 +18,10 @@ import {
   newInnerResponse,
 } from "ext:deno_fetch/23_response.js";
 import { setEventTargetData } from "ext:deno_web/02_event.js";
-import {
-  _eventLoop,
-  _idleTimeoutDuration,
-  _idleTimeoutTimeout,
-  _protocol,
-  _readyState,
-  _rid,
-  _role,
-  _serverHandleIdleTimeout,
-  createWebSocketBranded,
-  SERVER,
-  WebSocket,
-} from "ext:deno_websocket/01_websocket.js";
+
+const loadWebSocket = core.createLazyLoader(
+  "ext:deno_websocket/01_websocket.js",
+);
 
 const _ws = Symbol("[[associated_ws]]");
 
@@ -87,6 +78,19 @@ function upgradeWebSocket(request, options = { __proto__: null }) {
       );
     }
   }
+
+  const {
+    _eventLoop,
+    _idleTimeoutDuration,
+    _idleTimeoutTimeout,
+    _readyState,
+    _rid,
+    _role,
+    _serverHandleIdleTimeout,
+    createWebSocketBranded,
+    SERVER,
+    WebSocket,
+  } = loadWebSocket();
 
   const socket = createWebSocketBranded(WebSocket);
   setEventTargetData(socket);

--- a/ext/node/polyfills/crypto.ts
+++ b/ext/node/polyfills/crypto.ts
@@ -167,10 +167,37 @@ import type {
 import { normalizeEncoding } from "ext:deno_node/internal/util.mjs";
 import { isArrayBufferView } from "ext:deno_node/internal/util/types.ts";
 import { validateString } from "ext:deno_node/internal/validators.mjs";
-import { crypto as webcrypto } from "ext:deno_crypto/00_crypto.js";
+import { core } from "ext:core/mod.js";
 import { deprecate } from "node:util";
 
-const subtle = webcrypto.subtle;
+const loadCrypto = core.createLazyLoader("ext:deno_crypto/00_crypto.js");
+
+// Lazy proxies so that `import { webcrypto } from "node:crypto"` works
+// without eagerly evaluating ext:deno_crypto at snapshot time.
+// deno-lint-ignore no-explicit-any
+function createLazyProxy(target: () => any) {
+  // deno-lint-ignore no-explicit-any
+  return new Proxy({} as any, {
+    get(_, prop) {
+      const value = Reflect.get(target(), prop);
+      if (typeof value === "function") {
+        return value.bind(target());
+      }
+      return value;
+    },
+    has(_, prop) {
+      return Reflect.has(target(), prop);
+    },
+    ownKeys() {
+      return Reflect.ownKeys(target());
+    },
+    getOwnPropertyDescriptor(_, prop) {
+      return Reflect.getOwnPropertyDescriptor(target(), prop);
+    },
+  });
+}
+export const webcrypto = createLazyProxy(() => loadCrypto().crypto);
+export const subtle = createLazyProxy(() => loadCrypto().crypto.subtle);
 const fipsForced = getOptionValue("--force-fips");
 
 const Hash = deprecate(
@@ -675,10 +702,8 @@ export {
   setFips,
   Sign,
   sign,
-  subtle,
   timingSafeEqual,
   Verify,
   verify,
-  webcrypto,
   X509Certificate,
 };

--- a/ext/node/polyfills/internal/crypto/keys.ts
+++ b/ext/node/polyfills/internal/crypto/keys.ts
@@ -35,10 +35,8 @@ import {
   op_node_key_type,
 } from "ext:core/ops";
 
-import {
-  cryptoKeyExportNodeKeyMaterial,
-  importCryptoKeySync,
-} from "ext:deno_crypto/00_crypto.js";
+import { core } from "ext:core/mod.js";
+const loadCrypto = core.createLazyLoader("ext:deno_crypto/00_crypto.js");
 
 import { kHandle } from "ext:deno_node/internal/crypto/constants.ts";
 import { isStringOrBuffer } from "ext:deno_node/internal/crypto/cipher.ts";
@@ -215,7 +213,7 @@ export class KeyObject {
     if (!isCryptoKey(key)) {
       throw new ERR_INVALID_ARG_TYPE("key", "CryptoKey", key);
     }
-    const { type, data } = cryptoKeyExportNodeKeyMaterial(key);
+    const { type, data } = loadCrypto().cryptoKeyExportNodeKeyMaterial(key);
     if (type === "secret") {
       const handle = op_node_create_secret_key(data);
       return new SecretKeyObject(handle);
@@ -869,7 +867,13 @@ export class SecretKeyObject extends KeyObject {
       }
     }
 
-    return importCryptoKeySync("raw", rawData, algorithm, extractable, usages);
+    return loadCrypto().importCryptoKeySync(
+      "raw",
+      rawData,
+      algorithm,
+      extractable,
+      usages,
+    );
   }
 
   export(options?: { format?: "buffer" | "jwk" }): Buffer | JsonWebKey {
@@ -938,7 +942,7 @@ export class PrivateKeyObject extends AsymmetricKeyObject {
     const pkcs8Data = Buffer.from(
       op_node_export_private_key_der(this[kHandle], "pkcs8"),
     );
-    return importCryptoKeySync(
+    return loadCrypto().importCryptoKeySync(
       "pkcs8",
       pkcs8Data,
       algorithm,
@@ -993,7 +997,7 @@ export class PublicKeyObject extends AsymmetricKeyObject {
     const spkiData = Buffer.from(
       op_node_export_public_key_der(this[kHandle], "spki"),
     );
-    return importCryptoKeySync(
+    return loadCrypto().importCryptoKeySync(
       "spki",
       spkiData,
       algorithm,

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -866,7 +866,7 @@ deno_core::extension!(
     op_ws_send_ping,
     op_ws_get_buffered_amount,
   ],
-  esm = ["01_websocket.js", "02_websocketstream.js"],
+  lazy_loaded_esm = ["01_websocket.js", "02_websocketstream.js"],
 );
 
 // Needed so hyper can use non Send futures

--- a/runtime/js/98_global_scope_shared.js
+++ b/runtime/js/98_global_scope_shared.js
@@ -10,14 +10,11 @@ import * as caches from "ext:deno_cache/01_cache.js";
 import * as compression from "ext:deno_web/14_compression.js";
 import * as worker from "ext:runtime/11_workers.js";
 import * as performance from "ext:deno_web/15_performance.js";
-import * as crypto from "ext:deno_crypto/00_crypto.js";
 import * as url from "ext:deno_web/00_url.js";
 import * as urlPattern from "ext:deno_web/01_urlpattern.js";
 import * as headers from "ext:deno_fetch/20_headers.js";
 import * as streams from "ext:deno_web/06_streams.js";
 import * as fileReader from "ext:deno_web/10_filereader.js";
-import * as webSocket from "ext:deno_websocket/01_websocket.js";
-import * as webSocketStream from "ext:deno_websocket/02_websocketstream.js";
 import * as broadcastChannel from "ext:deno_web/01_broadcast_channel.js";
 import * as file from "ext:deno_web/09_file.js";
 import * as formData from "ext:deno_fetch/21_formdata.js";
@@ -48,7 +45,14 @@ import * as webgpuSurface from "ext:deno_webgpu/02_surface.js";
 import { unstableIds } from "ext:runtime/90_deno_ns.js";
 
 const loadImage = core.createLazyLoader("ext:deno_image/01_image.js");
+const loadCrypto = core.createLazyLoader("ext:deno_crypto/00_crypto.js");
 const loadGeometry = core.createLazyLoader("ext:deno_web/geometry.js");
+const loadWebSocket = core.createLazyLoader(
+  "ext:deno_websocket/01_websocket.js",
+);
+const loadWebSocketStream = core.createLazyLoader(
+  "ext:deno_websocket/02_websocketstream.js",
+);
 const loadWebTransport = core.createLazyLoader("ext:deno_web/webtransport.js");
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
@@ -65,7 +69,10 @@ const windowOrWorkerGlobalScope = {
   CountQueuingStrategy: core.propNonEnumerable(
     streams.CountQueuingStrategy,
   ),
-  CryptoKey: core.propNonEnumerable(crypto.CryptoKey),
+  CryptoKey: core.propNonEnumerableLazyLoaded(
+    (crypto) => crypto.CryptoKey,
+    loadCrypto,
+  ),
   CustomEvent: core.propNonEnumerable(event.CustomEvent),
   DecompressionStream: core.propNonEnumerable(compression.DecompressionStream),
   DOMException: core.propNonEnumerable(DOMException),
@@ -135,7 +142,10 @@ const windowOrWorkerGlobalScope = {
   URL: core.propNonEnumerable(url.URL),
   URLPattern: core.propNonEnumerable(urlPattern.URLPattern),
   URLSearchParams: core.propNonEnumerable(url.URLSearchParams),
-  WebSocket: core.propNonEnumerable(webSocket.WebSocket),
+  WebSocket: core.propNonEnumerableLazyLoaded(
+    (ws) => ws.WebSocket,
+    loadWebSocket,
+  ),
   MessageChannel: core.propNonEnumerable(messagePort.MessageChannel),
   MessagePort: core.propNonEnumerable(messagePort.MessagePort),
   Worker: core.propNonEnumerable(worker.Worker),
@@ -179,9 +189,19 @@ const windowOrWorkerGlobalScope = {
   console: core.propNonEnumerable(
     new console.Console((msg, level) => core.print(msg, level > 1)),
   ),
-  crypto: core.propReadOnly(crypto.crypto),
-  Crypto: core.propNonEnumerable(crypto.Crypto),
-  SubtleCrypto: core.propNonEnumerable(crypto.SubtleCrypto),
+  crypto: {
+    enumerable: true,
+    configurable: true,
+    get: () => loadCrypto().crypto,
+  },
+  Crypto: core.propNonEnumerableLazyLoaded(
+    (crypto) => crypto.Crypto,
+    loadCrypto,
+  ),
+  SubtleCrypto: core.propNonEnumerableLazyLoaded(
+    (crypto) => crypto.SubtleCrypto,
+    loadCrypto,
+  ),
   fetch: core.propWritable(fetch.fetch),
   EventSource: core.propWritable(eventSource.EventSource),
   performance: core.propWritable(performance.performance),
@@ -350,8 +370,14 @@ const windowOrWorkerGlobalScope = {
 
 const unstableForWindowOrWorkerGlobalScope = { __proto__: null };
 unstableForWindowOrWorkerGlobalScope[unstableIds.net] = {
-  WebSocketStream: core.propNonEnumerable(webSocketStream.WebSocketStream),
-  WebSocketError: core.propNonEnumerable(webSocketStream.WebSocketError),
+  WebSocketStream: core.propNonEnumerableLazyLoaded(
+    (wss) => wss.WebSocketStream,
+    loadWebSocketStream,
+  ),
+  WebSocketError: core.propNonEnumerableLazyLoaded(
+    (wss) => wss.WebSocketError,
+    loadWebSocketStream,
+  ),
   WebTransport: core.propNonEnumerableLazyLoaded(
     (wt) => wt.WebTransport,
     loadWebTransport,


### PR DESCRIPTION
## Summary

Defer evaluation of `ext/websocket` and `ext/crypto` JS during snapshot creation by moving them to `lazy_loaded_esm`.

**WebSocket (~36 KB source):**
- Move `01_websocket.js` and `02_websocketstream.js` to `lazy_loaded_esm`
- `WebSocket`/`WebSocketStream`/`WebSocketError` globals use `propNonEnumerableLazyLoaded`
- `ext/http` modules use `core.createLazyLoader` and destructure on first call to `upgradeWebSocket`/`respondWith`
- Remove dead import block from `00_serve.ts`

**WebCrypto (~153 KB source):**
- Move `00_crypto.js` to `lazy_loaded_esm`
- `crypto`/`Crypto`/`SubtleCrypto`/`CryptoKey` globals use lazy loaders
- `ext/node` crypto polyfills use `core.createLazyLoader` instead of direct import
- `webcrypto`/`subtle` named exports use lazy `Proxy` wrappers to preserve `import { webcrypto } from "node:crypto"` compat

**Snapshot size decreased by ~178 KB** (measured on same main commit, debug build).

## Test plan

- [x] `deno eval "console.log(crypto.randomUUID())"` works
- [x] `deno eval "console.log(typeof WebSocket)"` returns `function`
- [x] `import { webcrypto } from "node:crypto"` works (named export via Proxy)
- [x] `import { subtle } from "node:crypto"` works
- [x] `require("node:crypto").webcrypto` works (default export getter)
- [x] `require("node:crypto").createHash(...)` works
- [ ] CI passes