### PR TITLE
fix(ext/node): use queueMicrotask in fs.close to avoid sanitizer false-positive

### DIFF
--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -1271,7 +1271,12 @@ function close(
     callback = makeCallback(callback);
   }
 
-  setTimeout(() => {
+  // Defer to a microtask rather than a JS `setTimeout(0)`. Both make the
+  // callback asynchronous, but a real timer trips Deno's test sanitizer as a
+  // leaked timeout when a test ends before the timer fires. Node.js' libuv
+  // libc-backed `close` is invisible to userland timer queues; a microtask
+  // matches that more closely.
+  queueMicrotask(() => {
     let error = null;
     try {
       op_node_fs_close(fd);
@@ -1281,7 +1286,7 @@ function close(
         : new Error("[non-error thrown]");
     }
     callback(error);
-  }, 0);
+  });
 }
 
 function closeSync(fd: number) {

--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -189,6 +189,7 @@ const {
   TypedArrayPrototypeSet,
   TypedArrayPrototypeSubarray,
   Uint8Array,
+  queueMicrotask,
 } = primordials;
 
 const {

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -25,6 +25,7 @@ import {
   closeSync,
   constants,
   copyFileSync,
+  createReadStream,
   createWriteStream,
   existsSync,
   fchmod,
@@ -1211,6 +1212,28 @@ Deno.test({
     closeSync(rid), Deno.errors.BadResource;
   });
   await Deno.remove(tempFile);
+});
+
+// Regression test for https://github.com/denoland/deno/issues/33712
+// `fs.close` used to defer via `setTimeout(0)`, which Deno's test sanitizer
+// flagged as a leaked timer when a stream auto-closed at end-of-stream.
+// `createReadStream(...).on("end", ...)` triggers exactly that path.
+Deno.test({
+  name: "[node/fs.close] createReadStream auto-close doesn't leak a timer",
+  async fn() {
+    const tempFile = await Deno.makeTempFile();
+    try {
+      await Deno.writeTextFile(tempFile, "hello");
+      await new Promise<void>((resolve, reject) => {
+        const stream = createReadStream(tempFile);
+        stream.on("data", () => {});
+        stream.on("end", () => resolve());
+        stream.on("error", reject);
+      });
+    } finally {
+      await Deno.remove(tempFile);
+    }
+  },
 });
 
 // ==========


### PR DESCRIPTION
## Summary

The `node:fs.close` polyfill deferred the underlying `op_node_fs_close` via `setTimeout(() => {...}, 0)`. Because that's a real JS timer, any test that uses Node-shim file streams (`fs.createReadStream`, `fs.WriteStream`, or libraries built on them like Express's `res.sendFile` via `send`) trips Deno's test sanitizer with a leaked-timer report whenever the stream auto-closes after the test ends.

The `setTimeout(0)` is just a way to make `fs.close` asynchronous (since `op_node_fs_close` is sync). Replacing it with `queueMicrotask` keeps the asynchronous semantics but isn't observed as a leaked timer by the sanitizer, matching Node.js' libuv-backed `fs.close`, which is invisible to userland timer queues either.

Closes #33712.

## Test plan

- [x] New `[node/fs.close] createReadStream auto-close doesn't leak a timer` test in `tests/unit_node/fs_test.ts` exercises the issue's reproduction (createReadStream + on("end")) — passes locally
- [x] Existing `[node/fs.close]` and `[node/fs.closeSync]` tests still pass
- [x] Issue's repro (`deno test --trace-leaks`) now passes