### PR TITLE
fix(console): don't trigger proxy get trap for nodejs.util.inspect.custom

### DIFF
--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -565,15 +565,18 @@ function formatValue(
       return String(value[privateCustomInspect](inspect, ctx));
     } else {
       // Access the symbol directly instead of using `ReflectHas` (the `in`
-      // operator). Proxies may override `has` to hide symbols while still
-      // exposing them via `get` (e.g. nodejs-polars DataFrames). Node.js
-      // also accesses the symbol directly. Use try-catch because the
-      // Proxy's `get` trap may throw.
+      // operator). Non-proxy objects may override `has` to hide symbols
+      // while still exposing them via `get` (e.g. nodejs-polars
+      // DataFrames). For actual JS Proxy objects, access the unwrapped
+      // target to avoid triggering the proxy's get trap which may cause
+      // side effects (e.g. grammy API proxies). This matches Node.js
+      // which unwraps proxies before this check.
+      const inspectTarget = proxyDetails ? proxyDetails[0] : value;
       let maybeCustom;
       try {
-        maybeCustom = value[nodeCustomInspectSymbol];
+        maybeCustom = inspectTarget[nodeCustomInspectSymbol];
       } catch {
-        // ignore - the proxy's get trap threw
+        // ignore
       }
       if (
         typeof maybeCustom === "function" &&

--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -548,15 +548,21 @@ function formatValue(
 
   // Provide a hook for user-specified inspect functions.
   // Check that value is an object with an inspect function on it.
+  // For Proxy objects, look up custom inspect symbols on the unwrapped
+  // target (via core.getProxyDetails) to avoid triggering the proxy's
+  // get/has traps which may cause side effects (e.g. grammy API proxies
+  // return functions for any property access). This matches Node.js
+  // behavior. The call itself still uses `value` (the proxy) as `this`.
   if (ctx.customInspect) {
+    const inspectTarget = proxyDetails ? proxyDetails[0] : value;
     if (
-      ReflectHas(value, customInspect) &&
-      typeof value[customInspect] === "function"
+      ReflectHas(inspectTarget, customInspect) &&
+      typeof inspectTarget[customInspect] === "function"
     ) {
       return String(value[customInspect](inspect, ctx));
     } else if (
-      ReflectHas(value, privateCustomInspect) &&
-      typeof value[privateCustomInspect] === "function"
+      ReflectHas(inspectTarget, privateCustomInspect) &&
+      typeof inspectTarget[privateCustomInspect] === "function"
     ) {
       // TODO(nayeemrmn): `inspect` is passed as an argument because custom
       // inspect implementations in `extensions` need it, but may not have access
@@ -564,14 +570,6 @@ function formatValue(
       // namespace is always enabled.
       return String(value[privateCustomInspect](inspect, ctx));
     } else {
-      // Access the symbol directly instead of using `ReflectHas` (the `in`
-      // operator). Non-proxy objects may override `has` to hide symbols
-      // while still exposing them via `get` (e.g. nodejs-polars
-      // DataFrames). For actual JS Proxy objects, access the unwrapped
-      // target to avoid triggering the proxy's get trap which may cause
-      // side effects (e.g. grammy API proxies). This matches Node.js
-      // which unwraps proxies before this check.
-      const inspectTarget = proxyDetails ? proxyDetails[0] : value;
       let maybeCustom;
       try {
         maybeCustom = inspectTarget[nodeCustomInspectSymbol];

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -2675,3 +2675,27 @@ Deno.test(function inspectEscapeSequencesFalse() {
     '"foo\nbar"',
   );
 });
+
+Deno.test(function inspectProxyDoesNotTriggerGetTrap() {
+  // Regression test for https://github.com/denoland/deno/issues/33719
+  // Proxies that return functions for any property access (e.g. grammy API
+  // client) should not have their get trap triggered for
+  // Symbol(nodejs.util.inspect.custom) during inspection.
+  const accessed: PropertyKey[] = [];
+  const proxy = new Proxy({}, {
+    get(_target, prop) {
+      accessed.push(prop);
+      return () => {};
+    },
+  });
+
+  accessed.length = 0;
+  Deno.inspect(proxy);
+
+  const inspectSymbol = Symbol.for("nodejs.util.inspect.custom");
+  assertEquals(
+    accessed.filter((p) => p === inspectSymbol).length,
+    0,
+    "Deno.inspect should not trigger proxy get trap for nodejs.util.inspect.custom",
+  );
+});

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -2679,10 +2679,14 @@ Deno.test(function inspectEscapeSequencesFalse() {
 Deno.test(function inspectProxyDoesNotTriggerGetTrap() {
   // Regression test for https://github.com/denoland/deno/issues/33719
   // Proxies that return functions for any property access (e.g. grammy API
-  // client) should not have their get trap triggered for
-  // Symbol(nodejs.util.inspect.custom) during inspection.
+  // client) should not have their get/has traps triggered for custom inspect
+  // symbols during inspection.
   const accessed: PropertyKey[] = [];
   const proxy = new Proxy({}, {
+    has(_target, prop) {
+      accessed.push(prop);
+      return false;
+    },
     get(_target, prop) {
       accessed.push(prop);
       return () => {};
@@ -2692,10 +2696,16 @@ Deno.test(function inspectProxyDoesNotTriggerGetTrap() {
   accessed.length = 0;
   Deno.inspect(proxy);
 
-  const inspectSymbol = Symbol.for("nodejs.util.inspect.custom");
-  assertEquals(
-    accessed.filter((p) => p === inspectSymbol).length,
-    0,
-    "Deno.inspect should not trigger proxy get trap for nodejs.util.inspect.custom",
-  );
+  const inspectSymbols = [
+    Symbol.for("nodejs.util.inspect.custom"),
+    Symbol.for("Deno.customInspect"),
+    Symbol.for("Deno.privateCustomInspect"),
+  ];
+  for (const sym of inspectSymbols) {
+    assertEquals(
+      accessed.filter((p) => p === sym).length,
+      0,
+      `Deno.inspect should not trigger proxy traps for ${String(sym)}`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

- When inspecting a JS `Proxy` object, access `Symbol.for("nodejs.util.inspect.custom")` on the unwrapped proxy target (via `core.getProxyDetails`) instead of the proxy itself
- This prevents triggering the proxy's `get` trap, which can cause side effects — e.g. grammy API proxies that return functions for any property access, leading to `TypeError: Cannot convert a Symbol value to a string`
- Matches Node.js behavior which unwraps proxies before checking for custom inspect symbols
- Non-proxy objects (e.g. nodejs-polars DataFrames using V8 interceptors) are unaffected since `proxyDetails` is null for them

Closes #33719

## Test plan

- [x] Added unit test that verifies `Deno.inspect` does not trigger a proxy's `get` trap for `Symbol.for("nodejs.util.inspect.custom")`
- [x] All existing console tests pass