### PR TITLE
feat(ext/node): implement module.registerHooks() API for CommonJS

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -915,13 +915,35 @@ Module._load = function (request, parent, isMain) {
           importAttributes: { __proto__: null },
         };
         insideLoadHook = true;
+        let result;
         try {
-          executeLoadHookChain(filename, context);
+          result = executeLoadHookChain(filename, context);
         } finally {
           insideLoadHook = false;
         }
-        // Always load builtins normally regardless of hook result;
-        // hooks can observe but not replace builtin source.
+        // If the hook changed the format away from "builtin", use the
+        // hook-provided source instead of loading the native module.
+        // This matches Node.js behavior where hooks can replace builtins
+        // by returning a different format (e.g. "commonjs").
+        if (
+          result != null && result.format &&
+          result.format !== "builtin" && result.source != null
+        ) {
+          const mod = new Module(filename, parent);
+          Module._cache[filename] = mod;
+          const source = typeof result.source === "string"
+            ? result.source
+            : (utf8Decoder ??= new TextDecoder()).decode(result.source);
+          if (result.format === "commonjs") {
+            mod._compile(source, filename, "commonjs");
+          } else if (result.format === "json") {
+            mod.exports = JSONParse(stripBOM(source));
+          } else {
+            mod._compile(source, filename);
+          }
+          mod.loaded = true;
+          return mod.exports;
+        }
       }
     }
 

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -1029,7 +1029,14 @@ Module._resolveFilename = function (
     const result = executeResolveHookChain(request, context, parent, isMain);
     if (result != null && result.url != null) {
       if (StringPrototypeStartsWith(result.url, "file://")) {
-        return url.fileURLToPath(result.url);
+        try {
+          return url.fileURLToPath(result.url);
+        } catch {
+          // Virtual file:// URLs may not have valid OS paths (e.g.
+          // file:///virtual.js on Windows). Return the URL as-is and
+          // let the load hook handle it.
+          return result.url;
+        }
       }
       // node: and other schemes returned as-is
       return result.url;

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -344,9 +344,9 @@ let patched = false;
 
 // module.registerHooks() infrastructure
 const hookEntries = [];
-let nextHookId = 0;
 let insideResolveHook = false;
 let insideLoadHook = false;
+let utf8Decoder;
 
 function executeResolveHookChain(specifier, context, parent, isMain) {
   // Collect resolve hooks from hookEntries in LIFO order
@@ -436,17 +436,12 @@ function executeLoadHookChain(fileUrl, context) {
       if (StringPrototypeStartsWith(loadUrl, "node:")) {
         return { source: null, format: "builtin", shortCircuit: true };
       }
-      let source;
-      try {
-        const filePath = StringPrototypeStartsWith(loadUrl, "file://")
-          ? url.fileURLToPath(loadUrl)
-          : loadUrl;
-        source = op_require_read_file(filePath);
-      } catch {
-        source = undefined;
-      }
+      const filePath = StringPrototypeStartsWith(loadUrl, "file://")
+        ? url.fileURLToPath(loadUrl)
+        : loadUrl;
+      const source = op_require_read_file(filePath);
       return {
-        source: source ?? "",
+        source,
         format: currentContext?.format ?? undefined,
         shortCircuit: true,
       };
@@ -1289,7 +1284,7 @@ Module.prototype.load = function (filename) {
           this._compile(
             typeof result.source === "string"
               ? result.source
-              : new TextDecoder().decode(result.source),
+              : (utf8Decoder ??= new TextDecoder()).decode(result.source),
             this.filename,
             "commonjs",
           );
@@ -1299,7 +1294,7 @@ Module.prototype.load = function (filename) {
               stripBOM(
                 typeof result.source === "string"
                   ? result.source
-                  : new TextDecoder().decode(result.source),
+                  : (utf8Decoder ??= new TextDecoder()).decode(result.source),
               ),
             );
           } catch (err) {
@@ -1307,10 +1302,10 @@ Module.prototype.load = function (filename) {
             throw err;
           }
         } else {
-          // Auto-detect format: try CJS, fall back to ESM
+          // Default to CJS when format is unspecified
           const source = typeof result.source === "string"
             ? result.source
-            : new TextDecoder().decode(result.source);
+            : (utf8Decoder ??= new TextDecoder()).decode(result.source);
           this._compile(source, this.filename);
         }
         this.loaded = true;
@@ -1802,11 +1797,19 @@ Module.findSourceMap = findSourceMap;
  * @returns {{ deregister: () => void }}
  */
 export function registerHooks(hooks) {
-  const entry = {
-    resolve: typeof hooks.resolve === "function" ? hooks.resolve : null,
-    load: typeof hooks.load === "function" ? hooks.load : null,
-    id: nextHookId++,
-  };
+  if (typeof hooks !== "object" || hooks === null) {
+    throw new internalErrors.ERR_INVALID_ARG_TYPE("hooks", "object", hooks);
+  }
+  const resolve = typeof hooks.resolve === "function" ? hooks.resolve : null;
+  const load = typeof hooks.load === "function" ? hooks.load : null;
+  if (resolve === null && load === null) {
+    throw new internalErrors.ERR_INVALID_ARG_VALUE(
+      "hooks",
+      hooks,
+      "must contain at least one of 'resolve' or 'load'",
+    );
+  }
+  const entry = { resolve, load };
   ArrayPrototypePush(hookEntries, entry);
   return {
     deregister() {

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -348,7 +348,7 @@ let nextHookId = 0;
 let insideResolveHook = false;
 let insideLoadHook = false;
 
-function executeResolveHookChain(specifier, context) {
+function executeResolveHookChain(specifier, context, parent, isMain) {
   // Collect resolve hooks from hookEntries in LIFO order
   const resolveHooks = [];
   for (let i = hookEntries.length - 1; i >= 0; i--) {
@@ -379,7 +379,7 @@ function executeResolveHookChain(specifier, context) {
         if (nativeModuleCanBeRequiredByUsers(spec)) {
           return { url: "node:" + spec, shortCircuit: true };
         }
-        const resolved = Module._resolveFilename(spec, null, false);
+        const resolved = Module._resolveFilename(spec, parent, isMain);
         let resolvedUrl;
         if (StringPrototypeStartsWith(resolved, "node:")) {
           resolvedUrl = resolved;
@@ -1026,7 +1026,7 @@ Module._resolveFilename = function (
       importAttributes: { __proto__: null },
       parentURL,
     };
-    const result = executeResolveHookChain(request, context);
+    const result = executeResolveHookChain(request, context, parent, isMain);
     if (result != null && result.url != null) {
       if (StringPrototypeStartsWith(result.url, "file://")) {
         return url.fileURLToPath(result.url);

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -1257,9 +1257,18 @@ Module.prototype.load = function (filename) {
   // Run load hooks if registered
   if (hasLoadHooks) {
     {
-      const fileUrl = StringPrototypeStartsWith(this.filename, "node:")
-        ? this.filename
-        : url.pathToFileURL(this.filename).href;
+      let fileUrl;
+      if (StringPrototypeStartsWith(this.filename, "node:")) {
+        fileUrl = this.filename;
+      } else if (
+        StringPrototypeStartsWith(this.filename, "file://") ||
+        StringPrototypeIncludes(this.filename, "://")
+      ) {
+        // Already a URL (e.g. from a resolve hook returning a virtual URL)
+        fileUrl = this.filename;
+      } else {
+        fileUrl = url.pathToFileURL(this.filename).href;
+      }
       const context = {
         format: undefined,
         conditions: ["node", "require"],

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -359,12 +359,14 @@ function executeResolveHookChain(specifier, context) {
   if (resolveHooks.length === 0) return null;
 
   let index = 0;
+  // Running context accumulates changes across the chain
+  let currentContext = context;
 
   function nextResolve(spec, ctx) {
-    // Merge context: if ctx provided, merge with original context
-    const mergedContext = ctx !== undefined && ctx !== null
-      ? { ...context, ...ctx }
-      : context;
+    // If ctx provided, merge into running context
+    if (ctx !== undefined && ctx !== null) {
+      currentContext = { ...currentContext, ...ctx };
+    }
 
     if (index >= resolveHooks.length) {
       // Default resolve: use Module._resolveFilename
@@ -390,7 +392,21 @@ function executeResolveHookChain(specifier, context) {
       }
     }
     const hook = resolveHooks[index++];
-    return hook(spec, mergedContext, nextResolve);
+    let nextCalled = false;
+    const wrappedNext = (s, c) => {
+      nextCalled = true;
+      return nextResolve(s, c);
+    };
+    const result = hook(spec, currentContext, wrappedNext);
+    if (!nextCalled && !result?.shortCircuit) {
+      throw new internalErrors.ERR_INVALID_RETURN_PROPERTY_VALUE(
+        "true",
+        "resolve",
+        "shortCircuit",
+        result?.shortCircuit,
+      );
+    }
+    return result;
   }
 
   return nextResolve(specifier, context);
@@ -407,8 +423,13 @@ function executeLoadHookChain(fileUrl, context) {
   if (loadHooks.length === 0) return null;
 
   let index = 0;
+  let currentContext = context;
 
   function nextLoad(loadUrl, ctx) {
+    if (ctx !== undefined && ctx !== null) {
+      currentContext = { ...currentContext, ...ctx };
+    }
+
     if (index >= loadHooks.length) {
       // Default load: read file from disk
       // For builtins, return null source
@@ -426,12 +447,26 @@ function executeLoadHookChain(fileUrl, context) {
       }
       return {
         source: source ?? "",
-        format: ctx?.format ?? undefined,
+        format: currentContext?.format ?? undefined,
         shortCircuit: true,
       };
     }
     const hook = loadHooks[index++];
-    return hook(loadUrl, ctx ?? context, nextLoad);
+    let nextCalled = false;
+    const wrappedNext = (u, c) => {
+      nextCalled = true;
+      return nextLoad(u, c);
+    };
+    const result = hook(loadUrl, currentContext, wrappedNext);
+    if (!nextCalled && !result?.shortCircuit) {
+      throw new internalErrors.ERR_INVALID_RETURN_PROPERTY_VALUE(
+        "true",
+        "load",
+        "shortCircuit",
+        result?.shortCircuit,
+      );
+    }
+    return result;
   }
 
   return nextLoad(fileUrl, context);

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -342,6 +342,101 @@ let hasInspectBrk = false;
 let usesLocalNodeModulesDir = false;
 let patched = false;
 
+// module.registerHooks() infrastructure
+const hookEntries = [];
+let nextHookId = 0;
+let insideResolveHook = false;
+let insideLoadHook = false;
+
+function executeResolveHookChain(specifier, context) {
+  // Collect resolve hooks from hookEntries in LIFO order
+  const resolveHooks = [];
+  for (let i = hookEntries.length - 1; i >= 0; i--) {
+    if (hookEntries[i].resolve !== null) {
+      ArrayPrototypePush(resolveHooks, hookEntries[i].resolve);
+    }
+  }
+  if (resolveHooks.length === 0) return null;
+
+  let index = 0;
+
+  function nextResolve(spec, ctx) {
+    // Merge context: if ctx provided, merge with original context
+    const mergedContext = ctx !== undefined && ctx !== null
+      ? { ...context, ...ctx }
+      : context;
+
+    if (index >= resolveHooks.length) {
+      // Default resolve: use Module._resolveFilename
+      insideResolveHook = true;
+      try {
+        // Handle node: builtins
+        if (StringPrototypeStartsWith(spec, "node:")) {
+          return { url: spec, shortCircuit: true };
+        }
+        if (nativeModuleCanBeRequiredByUsers(spec)) {
+          return { url: "node:" + spec, shortCircuit: true };
+        }
+        const resolved = Module._resolveFilename(spec, null, false);
+        let resolvedUrl;
+        if (StringPrototypeStartsWith(resolved, "node:")) {
+          resolvedUrl = resolved;
+        } else {
+          resolvedUrl = url.pathToFileURL(resolved).href;
+        }
+        return { url: resolvedUrl, shortCircuit: true };
+      } finally {
+        insideResolveHook = false;
+      }
+    }
+    const hook = resolveHooks[index++];
+    return hook(spec, mergedContext, nextResolve);
+  }
+
+  return nextResolve(specifier, context);
+}
+
+function executeLoadHookChain(fileUrl, context) {
+  // Collect load hooks from hookEntries in LIFO order
+  const loadHooks = [];
+  for (let i = hookEntries.length - 1; i >= 0; i--) {
+    if (hookEntries[i].load !== null) {
+      ArrayPrototypePush(loadHooks, hookEntries[i].load);
+    }
+  }
+  if (loadHooks.length === 0) return null;
+
+  let index = 0;
+
+  function nextLoad(loadUrl, ctx) {
+    if (index >= loadHooks.length) {
+      // Default load: read file from disk
+      // For builtins, return null source
+      if (StringPrototypeStartsWith(loadUrl, "node:")) {
+        return { source: null, format: "builtin", shortCircuit: true };
+      }
+      let source;
+      try {
+        const filePath = StringPrototypeStartsWith(loadUrl, "file://")
+          ? url.fileURLToPath(loadUrl)
+          : loadUrl;
+        source = op_require_read_file(filePath);
+      } catch {
+        source = undefined;
+      }
+      return {
+        source: source ?? "",
+        format: ctx?.format ?? undefined,
+        shortCircuit: true,
+      };
+    }
+    const hook = loadHooks[index++];
+    return hook(loadUrl, ctx ?? context, nextLoad);
+  }
+
+  return nextLoad(fileUrl, context);
+}
+
 function stat(filename) {
   if (statCache !== null) {
     const result = statCache.get(filename);
@@ -774,6 +869,32 @@ Module._load = function (request, parent, isMain) {
     // Slice 'node:' prefix
     const id = StringPrototypeSlice(filename, 5);
 
+    // Run load hooks for builtins if registered
+    if (hookEntries.length > 0 && !insideLoadHook) {
+      let hasLoadHook = false;
+      for (let i = 0; i < hookEntries.length; i++) {
+        if (hookEntries[i].load !== null) {
+          hasLoadHook = true;
+          break;
+        }
+      }
+      if (hasLoadHook) {
+        const context = {
+          format: "builtin",
+          conditions: ["node", "require"],
+          importAttributes: { __proto__: null },
+        };
+        insideLoadHook = true;
+        try {
+          executeLoadHookChain(filename, context);
+        } finally {
+          insideLoadHook = false;
+        }
+        // Always load builtins normally regardless of hook result;
+        // hooks can observe but not replace builtin source.
+      }
+    }
+
     const module = loadNativeModule(id, id);
     if (!module) {
       // TODO:
@@ -858,6 +979,26 @@ Module._resolveFilename = function (
       "string",
       request,
     );
+  }
+
+  // Run resolve hooks if registered (and not already inside a hook)
+  if (hookEntries.length > 0 && !insideResolveHook) {
+    const parentURL = parent?.filename
+      ? url.pathToFileURL(parent.filename).href
+      : undefined;
+    const context = {
+      conditions: ["node", "require"],
+      importAttributes: { __proto__: null },
+      parentURL,
+    };
+    const result = executeResolveHookChain(request, context);
+    if (result != null && result.url != null) {
+      if (StringPrototypeStartsWith(result.url, "file://")) {
+        return url.fileURLToPath(result.url);
+      }
+      // node: and other schemes returned as-is
+      return result.url;
+    }
   }
 
   if (nativeModuleCanBeRequiredByUsers(request)) {
@@ -1049,8 +1190,84 @@ Module.prototype.load = function (filename) {
 
   // Canonicalize the path so it's not pointing to the symlinked directory
   // in `node_modules` directory of the referrer.
-  this.filename = op_require_real_path(filename);
+  // When load hooks are active, the file may not exist on disk (virtual
+  // modules), so we fall back to the original filename.
+  let hasLoadHooks = false;
+  if (hookEntries.length > 0 && !insideLoadHook) {
+    for (let i = 0; i < hookEntries.length; i++) {
+      if (hookEntries[i].load !== null) {
+        hasLoadHooks = true;
+        break;
+      }
+    }
+  }
+  if (hasLoadHooks) {
+    try {
+      this.filename = op_require_real_path(filename);
+    } catch {
+      this.filename = filename;
+    }
+  } else {
+    this.filename = op_require_real_path(filename);
+  }
   this.paths = Module._nodeModulePaths(pathDirname(this.filename));
+
+  // Run load hooks if registered
+  if (hasLoadHooks) {
+    {
+      const fileUrl = StringPrototypeStartsWith(this.filename, "node:")
+        ? this.filename
+        : url.pathToFileURL(this.filename).href;
+      const context = {
+        format: undefined,
+        conditions: ["node", "require"],
+        importAttributes: { __proto__: null },
+      };
+      insideLoadHook = true;
+      let result;
+      try {
+        result = executeLoadHookChain(fileUrl, context);
+      } finally {
+        insideLoadHook = false;
+      }
+      if (result != null && result.source != null) {
+        const format = result.format;
+        if (format === "module") {
+          loadESMFromCJS(this, this.filename, result.source);
+        } else if (format === "commonjs") {
+          this._compile(
+            typeof result.source === "string"
+              ? result.source
+              : new TextDecoder().decode(result.source),
+            this.filename,
+            "commonjs",
+          );
+        } else if (format === "json") {
+          try {
+            this.exports = JSONParse(
+              stripBOM(
+                typeof result.source === "string"
+                  ? result.source
+                  : new TextDecoder().decode(result.source),
+              ),
+            );
+          } catch (err) {
+            err.message = this.filename + ": " + err.message;
+            throw err;
+          }
+        } else {
+          // Auto-detect format: try CJS, fall back to ESM
+          const source = typeof result.source === "string"
+            ? result.source
+            : new TextDecoder().decode(result.source);
+          this._compile(source, this.filename);
+        }
+        this.loaded = true;
+        return;
+      }
+    }
+  }
+
   const extension = findLongestRegisteredExtension(filename);
   Module._extensions[extension](this, this.filename);
   this.loaded = true;
@@ -1527,6 +1744,30 @@ export function findSourceMap(_path) {
 }
 
 Module.findSourceMap = findSourceMap;
+
+/**
+ * Register synchronous module loader hooks.
+ * @param {{ resolve?: Function, load?: Function }} hooks
+ * @returns {{ deregister: () => void }}
+ */
+export function registerHooks(hooks) {
+  const entry = {
+    resolve: typeof hooks.resolve === "function" ? hooks.resolve : null,
+    load: typeof hooks.load === "function" ? hooks.load : null,
+    id: nextHookId++,
+  };
+  ArrayPrototypePush(hookEntries, entry);
+  return {
+    deregister() {
+      const idx = ArrayPrototypeIndexOf(hookEntries, entry);
+      if (idx !== -1) {
+        ArrayPrototypeSplice(hookEntries, idx, 1);
+      }
+    },
+  };
+}
+
+Module.registerHooks = registerHooks;
 
 /**
  * @param {string | URL} _specifier

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -94,6 +94,9 @@
       "ignore": true,
       "reason": "Node.js snapshot/heap profiling features (--build-snapshot, --heap-prof, --heapsnapshot-near-heap-limit) are not implemented in Deno"
     },
+    "module-hooks/test-module-hooks-load-context-optional.js": {},
+    "module-hooks/test-module-hooks-load-short-circuit.js": {},
+    "module-hooks/test-module-hooks-resolve-short-circuit.js": {},
     "parallel/test-abort-controller-any-timeout.js": {},
     "parallel/test-abortcontroller-internal.js": {
       "ignore": true,

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -94,9 +94,13 @@
       "ignore": true,
       "reason": "Node.js snapshot/heap profiling features (--build-snapshot, --heap-prof, --heapsnapshot-near-heap-limit) are not implemented in Deno"
     },
+    "module-hooks/test-module-hooks-load-context-merged.js": {},
     "module-hooks/test-module-hooks-load-context-optional.js": {},
     "module-hooks/test-module-hooks-load-short-circuit.js": {},
+    "module-hooks/test-module-hooks-load-short-circuit-required-middle.js": {},
+    "module-hooks/test-module-hooks-load-short-circuit-required-start.js": {},
     "module-hooks/test-module-hooks-resolve-short-circuit.js": {},
+    "module-hooks/test-module-hooks-resolve-short-circuit-required-middle.js": {},
     "parallel/test-abort-controller-any-timeout.js": {},
     "parallel/test-abortcontroller-internal.js": {
       "ignore": true,

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -99,8 +99,11 @@
     "module-hooks/test-module-hooks-load-short-circuit.js": {},
     "module-hooks/test-module-hooks-load-short-circuit-required-middle.js": {},
     "module-hooks/test-module-hooks-load-short-circuit-required-start.js": {},
+    "module-hooks/test-module-hooks-resolve-context-merged.js": {},
+    "module-hooks/test-module-hooks-resolve-context-optional.js": {},
     "module-hooks/test-module-hooks-resolve-short-circuit.js": {},
     "module-hooks/test-module-hooks-resolve-short-circuit-required-middle.js": {},
+    "module-hooks/test-module-hooks-resolve-short-circuit-required-start.js": {},
     "parallel/test-abort-controller-any-timeout.js": {},
     "parallel/test-abortcontroller-internal.js": {
       "ignore": true,

--- a/tests/specs/node/module_register_hooks/__test__.jsonc
+++ b/tests/specs/node/module_register_hooks/__test__.jsonc
@@ -1,0 +1,20 @@
+{
+  "tests": {
+    "resolve_hook": {
+      "args": "run -A main_resolve.cjs",
+      "output": "main_resolve.out"
+    },
+    "load_hook": {
+      "args": "run -A main_load.cjs",
+      "output": "main_load.out"
+    },
+    "chained_hooks": {
+      "args": "run -A main_chained.cjs",
+      "output": "main_chained.out"
+    },
+    "deregister": {
+      "args": "run -A main_deregister.cjs",
+      "output": "main_deregister.out"
+    }
+  }
+}

--- a/tests/specs/node/module_register_hooks/__test__.jsonc
+++ b/tests/specs/node/module_register_hooks/__test__.jsonc
@@ -15,6 +15,10 @@
     "deregister": {
       "args": "run -A main_deregister.cjs",
       "output": "main_deregister.out"
+    },
+    "builtin_override": {
+      "args": "run -A main_builtin_override.cjs",
+      "output": "main_builtin_override.out"
     }
   }
 }

--- a/tests/specs/node/module_register_hooks/main_builtin_override.cjs
+++ b/tests/specs/node/module_register_hooks/main_builtin_override.cjs
@@ -1,0 +1,22 @@
+const assert = require("assert");
+const { registerHooks } = require("module");
+
+// Test load hook that overrides a builtin module by changing
+// the format from "builtin" to "commonjs" with custom source.
+const hook = registerHooks({
+  load(url, context, nextLoad) {
+    if (url === "node:util" && context.format === "builtin") {
+      return {
+        source: "module.exports = { customUtil: true }",
+        format: "commonjs",
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+
+const util = require("node:util");
+assert.strictEqual(util.customUtil, true);
+assert.strictEqual(util.inspect, undefined);
+console.log("builtin override works");

--- a/tests/specs/node/module_register_hooks/main_builtin_override.out
+++ b/tests/specs/node/module_register_hooks/main_builtin_override.out
@@ -1,0 +1,1 @@
+builtin override works

--- a/tests/specs/node/module_register_hooks/main_chained.cjs
+++ b/tests/specs/node/module_register_hooks/main_chained.cjs
@@ -1,0 +1,39 @@
+const assert = require("assert");
+const { registerHooks } = require("module");
+
+// Test LIFO chaining: hook2 runs first, then hook1 via nextLoad
+const hook1 = registerHooks({
+  load(url, context, nextLoad) {
+    const result = nextLoad(url, context);
+    if (url.includes("empty.js")) {
+      assert.strictEqual(result.source, "");
+      return {
+        source: 'exports.value = "from hook1"',
+        format: "commonjs",
+      };
+    }
+    return result;
+  },
+});
+
+const hook2 = registerHooks({
+  load(url, context, nextLoad) {
+    const result = nextLoad(url, context);
+    if (url.includes("empty.js")) {
+      // hook2 runs first (LIFO), nextLoad gives hook1's result
+      assert.strictEqual(result.source, 'exports.value = "from hook1"');
+      return {
+        source: 'exports.value = "from hook2"',
+        format: "commonjs",
+      };
+    }
+    return result;
+  },
+});
+
+const mod = require("./empty.js");
+assert.strictEqual(mod.value, "from hook2");
+console.log("chained hooks work");
+
+hook1.deregister();
+hook2.deregister();

--- a/tests/specs/node/module_register_hooks/main_chained.out
+++ b/tests/specs/node/module_register_hooks/main_chained.out
@@ -1,0 +1,1 @@
+chained hooks work

--- a/tests/specs/node/module_register_hooks/main_deregister.cjs
+++ b/tests/specs/node/module_register_hooks/main_deregister.cjs
@@ -1,0 +1,29 @@
+const assert = require("assert");
+const { registerHooks } = require("module");
+
+// Test that deregister removes hooks
+const hook = registerHooks({
+  load(url, context, nextLoad) {
+    if (url.includes("empty.js")) {
+      return {
+        source: 'module.exports = "hooked"',
+        format: "commonjs",
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+
+// First require uses hook
+const result1 = require("./empty.js");
+assert.strictEqual(result1, "hooked");
+
+// Deregister and clear cache
+hook.deregister();
+delete require.cache[require.resolve("./empty.js")];
+
+// Second require should not use hook
+const result2 = require("./empty.js");
+assert.notStrictEqual(result2, "hooked");
+console.log("deregister works");

--- a/tests/specs/node/module_register_hooks/main_deregister.out
+++ b/tests/specs/node/module_register_hooks/main_deregister.out
@@ -1,0 +1,1 @@
+deregister works

--- a/tests/specs/node/module_register_hooks/main_load.cjs
+++ b/tests/specs/node/module_register_hooks/main_load.cjs
@@ -1,0 +1,22 @@
+const assert = require("assert");
+const { registerHooks } = require("module");
+
+// Test load hook that transforms source
+const hook = registerHooks({
+  load(url, context, nextLoad) {
+    if (url.includes("empty.js")) {
+      return {
+        source: 'module.exports = "modified"',
+        format: "commonjs",
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+
+const result = require("./empty.js");
+assert.strictEqual(result, "modified");
+console.log("load hook works");
+
+hook.deregister();

--- a/tests/specs/node/module_register_hooks/main_load.out
+++ b/tests/specs/node/module_register_hooks/main_load.out
@@ -1,0 +1,1 @@
+load hook works

--- a/tests/specs/node/module_register_hooks/main_resolve.cjs
+++ b/tests/specs/node/module_register_hooks/main_resolve.cjs
@@ -1,0 +1,28 @@
+const assert = require("assert");
+const { registerHooks } = require("module");
+
+// Test resolve hook with short-circuit
+const hook = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === "virtual-module") {
+      return { url: "file:///virtual.js", shortCircuit: true };
+    }
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    if (url === "file:///virtual.js") {
+      return {
+        source: 'module.exports = "hello from virtual"',
+        format: "commonjs",
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+
+const result = require("virtual-module");
+assert.strictEqual(result, "hello from virtual");
+console.log("resolve hook works");
+
+hook.deregister();

--- a/tests/specs/node/module_register_hooks/main_resolve.out
+++ b/tests/specs/node/module_register_hooks/main_resolve.out
@@ -1,0 +1,1 @@
+resolve hook works


### PR DESCRIPTION
## Summary

Implements the Node.js `module.registerHooks()` API for synchronous module
loader hooks. This is the recommended replacement for the deprecated
`module.register()` API (DEP0205).

- **Resolve hooks**: intercept module resolution with custom specifier mapping,
  virtual modules, and passthrough via `nextResolve`
- **Load hooks**: intercept module loading with custom source code and format,
  passthrough via `nextLoad`
- **LIFO hook chaining**: last registered hook runs first, `nextResolve`/`nextLoad`
  delegates to the previous hook in the chain
- **`shortCircuit` validation**: hooks that don't call `next*` must set
  `shortCircuit: true`, matching Node.js behavior (`ERR_INVALID_RETURN_PROPERTY_VALUE`)
- **Context merging**: custom properties on context accumulate across the hook chain
- **`deregister()`**: clean removal of registered hooks
- **Builtin module interception**: `node:*` modules pass through hooks with
  `{ source: null, format: 'builtin' }`

Currently supports CJS `require()` only. ESM `import()` hook support requires
changes to the Rust module loader (`CliModuleLoader`) and will follow separately.

Towards #31045, #31665, #29350, #23201, #31323, #20625, #28126, #30538