### PR TITLE
fix(ext/node): TLSSocket.setServername throws typed errors

### DIFF
--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -27,6 +27,7 @@ import {
   ERR_INVALID_ARG_VALUE,
   ERR_TLS_CERT_ALTNAME_INVALID,
   ERR_TLS_REQUIRED_SERVER_NAME,
+  ERR_TLS_SNI_FROM_SERVER,
 } from "ext:deno_node/internal/errors.ts";
 import { debuglog } from "ext:deno_node/internal/util/debuglog.ts";
 import {
@@ -686,10 +687,10 @@ TLSSocket.prototype._start = function () {
 
 TLSSocket.prototype.setServername = function (name) {
   if (typeof name !== "string") {
-    throw new TypeError("Server name must be a string");
+    throw new ERR_INVALID_ARG_TYPE("name", "string", name);
   }
   if (this._tlsOptions?.isServer) {
-    throw new Error("Cannot set servername on a server socket");
+    throw new ERR_TLS_SNI_FROM_SERVER();
   }
   this._handle?.setServername(name);
 };

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -303,6 +303,25 @@ Deno.test("TLSSocket can construct without options", () => {
   new tls.TLSSocket(new stream.PassThrough() as any);
 });
 
+// Regression test for https://github.com/denoland/deno/issues/33743
+// `setServername` must throw with Node's `code` property set, not a plain
+// `TypeError`/`Error`.
+Deno.test("TLSSocket.setServername - throws ERR_INVALID_ARG_TYPE for non-string", () => {
+  // deno-lint-ignore no-explicit-any
+  const sock: any = new tls.TLSSocket(new stream.PassThrough() as any);
+  const err = assertThrows(() => sock.setServername(123), TypeError);
+  assertEquals((err as { code?: string }).code, "ERR_INVALID_ARG_TYPE");
+});
+
+Deno.test("TLSSocket.setServername - throws ERR_TLS_SNI_FROM_SERVER on server-side socket", () => {
+  // deno-lint-ignore no-explicit-any
+  const sock: any = new tls.TLSSocket(new stream.PassThrough() as any, {
+    isServer: true,
+  });
+  const err = assertThrows(() => sock.setServername("example.com"));
+  assertEquals((err as { code?: string }).code, "ERR_TLS_SNI_FROM_SERVER");
+});
+
 Deno.test("tls.connect() throws InvalidData when there's error in certificate", async () => {
   // Uses execCode to avoid `--unsafely-ignore-certificate-errors` option applied
   const [status, output] = await execCode(`


### PR DESCRIPTION
## Summary

`TLSSocket.prototype.setServername` in `ext/node/polyfills/_tls_wrap.js` threw plain `TypeError`/`Error` without the `code` property that Node.js attaches. User code and Node test suites that branch on `err.code` couldn't distinguish these errors.

Replace with the existing `ERR_INVALID_ARG_TYPE` and `ERR_TLS_SNI_FROM_SERVER` Node-compat error classes from `internal/errors.ts` (the latter was already defined there but unused).

Closes #33743.

## Test plan

- [x] New `TLSSocket.setServername - throws ERR_INVALID_ARG_TYPE for non-string` test in `tests/unit_node/tls_test.ts` asserts `err.name === "TypeError"` and `err.code === "ERR_INVALID_ARG_TYPE"`
- [x] New `TLSSocket.setServername - throws ERR_TLS_SNI_FROM_SERVER on server-side socket` test asserts `err.code === "ERR_TLS_SNI_FROM_SERVER"`
- [x] Both pass locally