### PR TITLE
fix(ext/node): implement missing node:test APIs

### DIFF
--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -21,7 +21,6 @@ const {
   SafeArrayIterator,
   SafeMap,
   SafePromiseAll,
-  SafePromisePrototypeFinally,
   String,
   Symbol,
   SymbolFor,

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -331,6 +331,10 @@ let currentSuite: TestSuite | null = null;
 class TestSuite {
   #denoTestContext: Deno.TestContext;
   steps: Promise<boolean>[] = [];
+  beforeAllHooks: (() => void | Promise<void>)[] = [];
+  afterAllHooks: (() => void | Promise<void>)[] = [];
+  beforeEachHooks: (() => void | Promise<void>)[] = [];
+  afterEachHooks: (() => void | Promise<void>)[] = [];
 
   constructor(t: Deno.TestContext) {
     this.#denoTestContext = t;
@@ -338,6 +342,8 @@ class TestSuite {
 
   addTest(name, options, fn, overrides) {
     const prepared = prepareOptions(name, options, fn, overrides);
+    const beforeEach = this.beforeEachHooks;
+    const afterEach = this.afterEachHooks;
     const step = this.#denoTestContext.step({
       name: prepared.name,
       fn: async (denoTestContext) => {
@@ -347,6 +353,9 @@ class TestSuite {
           prepared.name,
         );
         try {
+          for (const hook of new SafeArrayIterator(beforeEach)) {
+            await hook();
+          }
           const result = await prepared.fn(newNodeTextContext);
           newNodeTextContext._checkPlan();
           return result;
@@ -355,6 +364,10 @@ class TestSuite {
             return undefined;
           } else {
             throw err;
+          }
+        } finally {
+          for (const hook of new SafeArrayIterator(afterEach)) {
+            await hook();
           }
         }
       },
@@ -492,7 +505,7 @@ function prepareDenoTest(name, options, fn, overrides) {
 }
 
 function wrapSuiteFn(fn, resolve) {
-  return function (t) {
+  return async function (t) {
     const prevSuite = currentSuite;
     const suite = currentSuite = new TestSuite(t);
     try {
@@ -500,10 +513,21 @@ function wrapSuiteFn(fn, resolve) {
     } finally {
       currentSuite = prevSuite;
     }
-    return SafePromisePrototypeFinally(SafePromiseAll(suite.steps), () => {
-      activeNodeTests--;
-      resolve();
-    });
+    try {
+      for (const hook of new SafeArrayIterator(suite.beforeAllHooks)) {
+        await hook();
+      }
+      await SafePromiseAll(suite.steps);
+    } finally {
+      try {
+        for (const hook of new SafeArrayIterator(suite.afterAllHooks)) {
+          await hook();
+        }
+      } finally {
+        activeNodeTests--;
+        resolve();
+      }
+    }
   };
 }
 
@@ -574,20 +598,48 @@ suite.only = function only(name, options, fn) {
 export const it = test;
 export const describe = suite;
 
-export function before() {
-  notImplemented("test.before");
+export function before(fn, _options) {
+  if (typeof fn !== "function") {
+    throw new TypeError("before() requires a function argument");
+  }
+  if (currentSuite) {
+    ArrayPrototypePush(currentSuite.beforeAllHooks, fn);
+    return;
+  }
+  notImplemented("test.before (module-level, outside suite)");
 }
 
-export function after() {
-  notImplemented("test.after");
+export function after(fn, _options) {
+  if (typeof fn !== "function") {
+    throw new TypeError("after() requires a function argument");
+  }
+  if (currentSuite) {
+    ArrayPrototypePush(currentSuite.afterAllHooks, fn);
+    return;
+  }
+  notImplemented("test.after (module-level, outside suite)");
 }
 
-export function beforeEach() {
-  notImplemented("test.beforeEach");
+export function beforeEach(fn, _options) {
+  if (typeof fn !== "function") {
+    throw new TypeError("beforeEach() requires a function argument");
+  }
+  if (currentSuite) {
+    ArrayPrototypePush(currentSuite.beforeEachHooks, fn);
+    return;
+  }
+  notImplemented("test.beforeEach (module-level, outside suite)");
 }
 
-export function afterEach() {
-  notImplemented("test.afterEach");
+export function afterEach(fn, _options) {
+  if (typeof fn !== "function") {
+    throw new TypeError("afterEach() requires a function argument");
+  }
+  if (currentSuite) {
+    ArrayPrototypePush(currentSuite.afterEachHooks, fn);
+    return;
+  }
+  notImplemented("test.afterEach (module-level, outside suite)");
 }
 
 test.it = test;

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -20,7 +20,6 @@ const {
   ReflectApply,
   SafeArrayIterator,
   SafeMap,
-  SafePromiseAll,
   String,
   Symbol,
   SymbolFor,
@@ -353,9 +352,18 @@ class NodeTestContext {
 
 let currentSuite: TestSuite | null = null;
 
+// Entries are step definitions collected during the suite body. Steps are
+// not created via t.step() until the suite executes, so that before/after
+// hooks run at the correct time.
+interface SuiteEntry {
+  name: string;
+  fn: (t: Deno.TestContext) => Promise<void> | void;
+  ignore: boolean;
+}
+
 class TestSuite {
   #denoTestContext: Deno.TestContext;
-  steps: Promise<boolean>[] = [];
+  entries: SuiteEntry[] = [];
   beforeAllHooks: (() => void | Promise<void>)[] = [];
   afterAllHooks: (() => void | Promise<void>)[] = [];
   beforeEachHooks: (() => void | Promise<void>)[] = [];
@@ -369,7 +377,7 @@ class TestSuite {
     const prepared = prepareOptions(name, options, fn, overrides);
     const beforeEach = this.beforeEachHooks;
     const afterEach = this.afterEachHooks;
-    const step = this.#denoTestContext.step({
+    ArrayPrototypePush(this.entries, {
       name: prepared.name,
       fn: async (denoTestContext) => {
         const newNodeTextContext = new NodeTestContext(
@@ -397,27 +405,32 @@ class TestSuite {
         }
       },
       ignore: !!prepared.options.todo || !!prepared.options.skip,
-      sanitizeExit: false,
-      sanitizeOps: false,
-      sanitizeResources: false,
     });
-    ArrayPrototypePush(this.steps, step);
   }
 
   addSuite(name, options, fn, overrides) {
     const prepared = prepareOptions(name, options, fn, overrides);
     // deno-lint-ignore prefer-primordials
     const { promise, resolve } = Promise.withResolvers();
-    const step = this.#denoTestContext.step({
+    ArrayPrototypePush(this.entries, {
       name: prepared.name,
       fn: wrapSuiteFn(prepared.fn, resolve),
       ignore: !!prepared.options.todo || !!prepared.options.skip,
-      sanitizeExit: false,
-      sanitizeOps: false,
-      sanitizeResources: false,
     });
-    ArrayPrototypePush(this.steps, step);
     return promise;
+  }
+
+  async execute() {
+    for (const entry of new SafeArrayIterator(this.entries)) {
+      await this.#denoTestContext.step({
+        name: entry.name,
+        fn: entry.fn,
+        ignore: entry.ignore,
+        sanitizeExit: false,
+        sanitizeOps: false,
+        sanitizeResources: false,
+      });
+    }
   }
 }
 
@@ -542,7 +555,7 @@ function wrapSuiteFn(fn, resolve) {
       for (const hook of new SafeArrayIterator(suite.beforeAllHooks)) {
         await hook();
       }
-      await SafePromiseAll(suite.steps);
+      await suite.execute();
     } finally {
       try {
         for (const hook of new SafeArrayIterator(suite.afterAllHooks)) {

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -150,10 +150,17 @@ class NodeTestContext {
   #beforeHooks: (() => void)[] = [];
   #parent: NodeTestContext | undefined;
   #skipped = false;
+  #name: string;
+  #abortController: AbortController = new AbortController();
 
-  constructor(t: Deno.TestContext, parent: NodeTestContext | undefined) {
+  constructor(
+    t: Deno.TestContext,
+    parent: NodeTestContext | undefined,
+    name: string,
+  ) {
     this.#denoContext = t;
     this.#parent = parent;
+    this.#name = name;
   }
 
   get [skippedSymbol]() {
@@ -165,13 +172,18 @@ class NodeTestContext {
   }
 
   get signal() {
-    notImplemented("test.TestContext.signal");
-    return null;
+    return this.#abortController.signal;
   }
 
   get name() {
-    notImplemented("test.TestContext.name");
-    return null;
+    return this.#name;
+  }
+
+  get fullName() {
+    if (this.#parent) {
+      return this.#parent.fullName + " > " + this.#name;
+    }
+    return this.#name;
   }
 
   diagnostic(message) {
@@ -219,6 +231,7 @@ class NodeTestContext {
           const newNodeTextContext = new NodeTestContext(
             denoTestContext,
             parentContext,
+            prepared.name,
           );
           try {
             await before();
@@ -283,6 +296,7 @@ class TestSuite {
         const newNodeTextContext = new NodeTestContext(
           denoTestContext,
           undefined,
+          prepared.name,
         );
         try {
           return await prepared.fn(newNodeTextContext);
@@ -348,9 +362,9 @@ function prepareOptions(name, options, fn, overrides) {
   return { fn, options: finalOptions, name };
 }
 
-function wrapTestFn(fn, resolve) {
+function wrapTestFn(fn, resolve, name) {
   return async function (t) {
-    const nodeTestContext = new NodeTestContext(t, undefined);
+    const nodeTestContext = new NodeTestContext(t, undefined, name);
     try {
       if (fn.length >= 2) {
         // Callback-style test
@@ -414,7 +428,7 @@ function prepareDenoTest(name, options, fn, overrides) {
 
   const denoTestOptions = {
     name: prepared.name,
-    fn: wrapTestFn(prepared.fn, resolve),
+    fn: wrapTestFn(prepared.fn, resolve, prepared.name),
     only: prepared.options.only,
     ignore: !!prepared.options.todo || !!prepared.options.skip,
     sanitizeOnly: false,

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -260,6 +260,9 @@ class NodeTestContext {
 
   test(name, options, fn) {
     const prepared = prepareOptions(name, options, fn, {});
+    // Subtests count toward the parent's plan (Node counts both
+    // assertions and subtests).
+    if (this.#plan) this.#plan.increment();
     // deno-lint-ignore no-this-alias
     const parentContext = this;
     const after = async () => {

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -144,6 +144,27 @@ function noop() {}
 
 const skippedSymbol = Symbol("skipped");
 
+class TestPlan {
+  #expected: number;
+  #actual: number = 0;
+
+  constructor(count: number) {
+    this.#expected = count;
+  }
+
+  increment() {
+    this.#actual++;
+  }
+
+  check() {
+    if (this.#actual !== this.#expected) {
+      throw new Error(
+        `plan expected ${this.#expected} assertion(s) but received ${this.#actual}`,
+      );
+    }
+  }
+}
+
 class NodeTestContext {
   #denoContext: Deno.TestContext;
   #afterHooks: (() => void)[] = [];
@@ -152,6 +173,8 @@ class NodeTestContext {
   #skipped = false;
   #name: string;
   #abortController: AbortController = new AbortController();
+  #plan: TestPlan | undefined;
+  #planAssert: Record<string, unknown> | undefined;
 
   constructor(
     t: Deno.TestContext,
@@ -168,7 +191,31 @@ class NodeTestContext {
   }
 
   get assert() {
+    if (this.#plan) {
+      if (!this.#planAssert) {
+        const plan = this.#plan;
+        const base = getAssertObject();
+        const wrapped = { __proto__: null };
+        ArrayPrototypeForEach(methodsToCopy, (method) => {
+          wrapped[method] = function (...args) {
+            plan.increment();
+            return ReflectApply(base[method], this, args);
+          };
+        });
+        this.#planAssert = wrapped;
+      }
+      return this.#planAssert;
+    }
     return getAssertObject();
+  }
+
+  plan(count: number) {
+    validateInteger(count, "count", 1);
+    this.#plan = new TestPlan(count);
+  }
+
+  _checkPlan() {
+    if (this.#plan) this.#plan.check();
   }
 
   get signal() {
@@ -236,6 +283,7 @@ class NodeTestContext {
           try {
             await before();
             await prepared.fn(newNodeTextContext);
+            newNodeTextContext._checkPlan();
             await after();
           } catch (err) {
             if (!newNodeTextContext[skippedSymbol]) {
@@ -299,7 +347,9 @@ class TestSuite {
           prepared.name,
         );
         try {
-          return await prepared.fn(newNodeTextContext);
+          const result = await prepared.fn(newNodeTextContext);
+          newNodeTextContext._checkPlan();
+          return result;
         } catch (err) {
           if (newNodeTextContext[skippedSymbol]) {
             return undefined;
@@ -404,6 +454,7 @@ function wrapTestFn(fn, resolve, name) {
         // Promise-style or sync test
         await ReflectApply(fn, nodeTestContext, [nodeTestContext]);
       }
+      nodeTestContext._checkPlan();
     } catch (err) {
       if (!nodeTestContext[skippedSymbol]) {
         throw sanitizeThrowValue(err);

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -175,6 +175,8 @@ class NodeTestContext {
   #abortController: AbortController = new AbortController();
   #plan: TestPlan | undefined;
   #planAssert: Record<string, unknown> | undefined;
+  #beforeEachHooks: (() => void | Promise<void>)[] = [];
+  #afterEachHooks: (() => void | Promise<void>)[] = [];
 
   constructor(
     t: Deno.TestContext,
@@ -282,6 +284,13 @@ class NodeTestContext {
           );
           try {
             await before();
+            for (
+              const hook of new SafeArrayIterator(
+                parentContext.#beforeEachHooks,
+              )
+            ) {
+              await hook();
+            }
             await prepared.fn(newNodeTextContext);
             newNodeTextContext._checkPlan();
             await after();
@@ -292,6 +301,14 @@ class NodeTestContext {
             try {
               await after();
             } catch { /* ignore, test is already failing */ }
+          } finally {
+            for (
+              const hook of new SafeArrayIterator(
+                parentContext.#afterEachHooks,
+              )
+            ) {
+              await hook();
+            }
           }
         },
         ignore: !!prepared.options.todo || !!prepared.options.skip,
@@ -317,12 +334,18 @@ class NodeTestContext {
     ArrayPrototypePush(this.#afterHooks, fn);
   }
 
-  beforeEach(_fn, _options) {
-    notImplemented("test.TestContext.beforeEach");
+  beforeEach(fn, _options) {
+    if (typeof fn !== "function") {
+      throw new TypeError("beforeEach() requires a function");
+    }
+    ArrayPrototypePush(this.#beforeEachHooks, fn);
   }
 
-  afterEach(_fn, _options) {
-    notImplemented("test.TestContext.afterEach");
+  afterEach(fn, _options) {
+    if (typeof fn !== "function") {
+      throw new TypeError("afterEach() requires a function");
+    }
+    ArrayPrototypePush(this.#afterEachHooks, fn);
   }
 }
 

--- a/tests/specs/node/node_test_context/__test__.jsonc
+++ b/tests/specs/node/node_test_context/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test test.js",
+  "output": "test.out",
+  "exitCode": 1
+}

--- a/tests/specs/node/node_test_context/test.js
+++ b/tests/specs/node/node_test_context/test.js
@@ -1,7 +1,14 @@
 // deno-lint-ignore-file
 
 import assert from "node:assert";
-import test, { describe, it, before, after, beforeEach, afterEach } from "node:test";
+import test, {
+  after,
+  afterEach,
+  before,
+  beforeEach,
+  describe,
+  it,
+} from "node:test";
 
 // --- t.name ---
 test("t.name returns the test name", (t) => {

--- a/tests/specs/node/node_test_context/test.js
+++ b/tests/specs/node/node_test_context/test.js
@@ -1,0 +1,89 @@
+// deno-lint-ignore-file
+
+import assert from "node:assert";
+import test, { describe, it, before, after, beforeEach, afterEach } from "node:test";
+
+// --- t.name ---
+test("t.name returns the test name", (t) => {
+  assert.strictEqual(t.name, "t.name returns the test name");
+});
+
+// --- t.fullName ---
+test("t.fullName with nested tests", async (t) => {
+  await t.test("child", async (t) => {
+    assert.strictEqual(t.name, "child");
+    assert.strictEqual(
+      t.fullName,
+      "t.fullName with nested tests > child",
+    );
+    await t.test("grandchild", (t) => {
+      assert.strictEqual(
+        t.fullName,
+        "t.fullName with nested tests > child > grandchild",
+      );
+    });
+  });
+});
+
+// --- t.signal ---
+test("t.signal is an AbortSignal", (t) => {
+  assert.ok(t.signal instanceof AbortSignal);
+  assert.strictEqual(t.signal.aborted, false);
+});
+
+// --- t.plan with assertions ---
+test("t.plan with assertions passes", (t) => {
+  t.plan(2);
+  t.assert.ok(true);
+  t.assert.strictEqual(1, 1);
+});
+
+// --- t.plan with subtests ---
+test("t.plan with subtests passes", async (t) => {
+  t.plan(2);
+  await t.test("sub 1", () => {});
+  await t.test("sub 2", () => {});
+});
+
+// --- t.plan failure (count mismatch) ---
+test("t.plan fails on count mismatch", (t) => {
+  t.plan(2);
+  t.assert.ok(true);
+  // only 1 of 2 expected -- should fail at _checkPlan()
+});
+
+// --- suite-level hooks ---
+describe("suite with hooks", () => {
+  let count = 0;
+
+  before(() => {
+    count = 0;
+  });
+
+  beforeEach(() => {
+    count++;
+  });
+
+  afterEach(() => {});
+
+  after(() => {
+    assert.strictEqual(count, 2);
+  });
+
+  it("hook test 1", () => {});
+  it("hook test 2", () => {});
+});
+
+// --- t.beforeEach / t.afterEach ---
+test("t.beforeEach and t.afterEach", async (t) => {
+  let count = 0;
+  t.beforeEach(() => {
+    count++;
+  });
+  t.afterEach(() => {});
+
+  await t.test("sub 1", () => {});
+  await t.test("sub 2", () => {});
+
+  assert.strictEqual(count, 2);
+});

--- a/tests/specs/node/node_test_context/test.out
+++ b/tests/specs/node/node_test_context/test.out
@@ -1,0 +1,26 @@
+running 8 tests from ./test.js
+t.name returns the test name ... ok ([WILDLINE])
+t.fullName with nested tests ...
+  child ...
+    grandchild ... ok ([WILDLINE])
+  child ... ok ([WILDLINE])
+t.fullName with nested tests ... ok ([WILDLINE])
+t.signal is an AbortSignal ... ok ([WILDLINE])
+t.plan with assertions passes ... ok ([WILDLINE])
+t.plan with subtests passes ...
+  sub 1 ... ok ([WILDLINE])
+  sub 2 ... ok ([WILDLINE])
+t.plan with subtests passes ... ok ([WILDLINE])
+t.plan fails on count mismatch ... FAILED ([WILDLINE])
+suite with hooks ...
+  hook test 1 ... ok ([WILDLINE])
+  hook test 2 ... ok ([WILDLINE])
+suite with hooks ... ok ([WILDLINE])
+t.beforeEach and t.afterEach ...
+  sub 1 ... ok ([WILDLINE])
+  sub 2 ... ok ([WILDLINE])
+t.beforeEach and t.afterEach ... ok ([WILDLINE])
+[WILDCARD] ERRORS [WILDCARD] FAILURES [WILDCARD]
+FAILED | 7 passed (8 steps) | 1 failed ([WILDLINE])
+
+error: Test failed

--- a/tests/specs/node/node_test_module/test.out
+++ b/tests/specs/node/node_test_module/test.out
@@ -57,8 +57,8 @@ suite ...
   test 1 ... ok ([WILDLINE])
   test 2 ... FAILED ([WILDLINE])
   sub suite 1 ...
-    nested test 2 ... FAILED ([WILDLINE])
     nested test 1 ... ok ([WILDLINE])
+    nested test 2 ... FAILED ([WILDLINE])
   sub suite 1 ... FAILED (due to 1 failed step) ([WILDLINE])
   sub suite 2 ...
     nested test 1 ... FAILED ([WILDLINE])


### PR DESCRIPTION
## Summary

Incremental improvements to the `node:test` polyfill, implementing several previously-stubbed APIs:

- **`t.name`, `t.fullName`, `t.signal`** - were throwing `notImplemented`, now return the test name, full parent chain, and an `AbortSignal`
- **`t.plan(count)`** - assertion planning with count verification at test completion
- **Suite-level hooks** - `before()`/`after()`/`beforeEach()`/`afterEach()` now work inside `describe`/`suite` blocks
- **`t.beforeEach()` / `t.afterEach()`** - per-subtest hooks on `TestContext`

## Test plan

- [ ] Existing `node_test_module` spec test still passes
- [ ] No regressions in other node compat tests