### PR TITLE
feat(compile): support WebCache API/LocalStorage API

### DIFF
--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -1075,6 +1075,27 @@ pub async fn run(
     }
     checker
   });
+  let (storage_key_resolver, origin_data_folder_path) =
+    match metadata.location.as_ref() {
+      Some(location) => {
+        let deno_dir = deno_resolver::cache::DenoDir::new(
+          sys_traits::impls::RealSys,
+          deno_cache_dir::resolve_deno_dir(
+            &sys_traits::impls::RealSys,
+            deno_cache_dir::ResolveDenoDirOptions {
+              maybe_initial_cwd: None,
+              maybe_custom_root: None,
+            },
+          )?
+          .into_owned(),
+        );
+        (
+          StorageKeyResolver::from_flag(location),
+          Some(deno_dir.compile_origin_data_folder_path()),
+        )
+      }
+      None => (StorageKeyResolver::empty(), None),
+    };
   let lib_main_worker_options = LibMainWorkerOptions {
     argv: metadata.argv,
     log_level: WorkerLogLevel::Info,
@@ -1095,7 +1116,7 @@ pub async fn run(
     node_debug: std::env::var("NODE_DEBUG").ok(),
     node_cluster_unique_id: std::env::var("NODE_UNIQUE_ID").ok(),
     node_cluster_sched_policy: std::env::var("NODE_CLUSTER_SCHED_POLICY").ok(),
-    origin_data_folder_path: None,
+    origin_data_folder_path,
     seed: metadata.seed,
     unsafely_ignore_certificate_errors: metadata
       .unsafely_ignore_certificate_errors,
@@ -1123,7 +1144,7 @@ pub async fn run(
     create_npm_process_state_provider(&npm_resolver),
     pkg_json_resolver,
     root_cert_store_provider,
-    StorageKeyResolver::empty(),
+    storage_key_resolver,
     sys.clone(),
     lib_main_worker_options,
     Default::default(),

--- a/libs/resolver/cache/deno_dir.rs
+++ b/libs/resolver/cache/deno_dir.rs
@@ -140,6 +140,11 @@ impl<TSys: DiskCacheSys> DenoDir<TSys> {
     self.root.join("location_data")
   }
 
+  /// Path to the origin data folder used by `deno compile` binaries.
+  pub fn compile_origin_data_folder_path(&self) -> PathBuf {
+    self.root.join("origin_data")
+  }
+
   /// File used for the upgrade checker.
   pub fn upgrade_check_file_path(&self) -> PathBuf {
     self.root.join("latest.txt")

--- a/tests/specs/compile/storage_apis/__test__.jsonc
+++ b/tests/specs/compile/storage_apis/__test__.jsonc
@@ -1,0 +1,31 @@
+{
+  "tempDir": true,
+  "tests": {
+    "with_location": {
+      "steps": [
+        {
+          "if": "unix",
+          "args": "compile --location https://example.com/main --output main main.ts",
+          "output": "[WILDCARD]"
+        },
+        {
+          "if": "unix",
+          "commandName": "main",
+          "args": [],
+          "output": "A\nB\n"
+        },
+        {
+          "if": "windows",
+          "args": "compile --location https://example.com/main --output main.exe main.ts",
+          "output": "[WILDCARD]"
+        },
+        {
+          "if": "windows",
+          "commandName": "./main.exe",
+          "args": [],
+          "output": "A\nB\n"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/compile/storage_apis/main.ts
+++ b/tests/specs/compile/storage_apis/main.ts
@@ -1,0 +1,11 @@
+localStorage.setItem("a", "A");
+console.log(localStorage.getItem("a"));
+
+const cache = await caches.open("v1");
+await cache.put(
+  new Request("https://example.com/b"),
+  new Response("B"),
+);
+const res = await cache.match(new Request("https://example.com/b"));
+if (!res) throw new Error("unreachable: cache entry was just set");
+console.log(await res.text());


### PR DESCRIPTION
<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

No LLM was used
-->
Fixes: https://github.com/denoland/deno/issues/18889 (I mean, it is closed, but the underlying issue was not solved yet - cache was not enabled for compiled binaries)

Note that for testing this it is not enough to build deno from this branch, denort is downloaded from the internet during `deno compile` execution, and it gets weird. I'm also not how automate testing of this thing, the only test overriding denort seems to store denort binary in the repo (?): https://github.com/denoland/deno/blob/2d7722227068aff1a4dbfb53c85c6dff93b5ad18/tests/specs/compile/cross_compile_intel_mac/denort_intel

deno compile `--location` is required to be specified for those features to work

CacheStorage is located at the same path as standard deno: `$TMPDIR/deno_cache/$HASHED_ORIGIN/`
It is not persisted, same as in deno, because of comments regarding storage quota management (should we care about that for compile?)

LocalStorage is located at `$HOME/.cache/deno/origin_data/$HASHED_ORIGIN/local_storage`
(Compared to original deno, I respected this comment: `TODO(@crowlKats): change to origin_data for 2.0`, as we should care more for compiled binaries, I think? And we don't care about backwards compat here as compile was not supporting LocalStorage before)
But I think we should instead have human-readable directory name here instead of origin hash? Should it be derived from location, or it would be better to be specified explicitly?

Initially I have planned to implement cache storage in the same directory as local_storage, but found out a discussion is required here, so I dropped it half way, since I'm not sure about the design, this PR is an invitation to this discussion, I'll implement whatever is decided, as I just would like to have web cache api available directly.

For my current use-cases, I do not care about CacheStorage persistence, the current implementation is good enough for me for long-running backend services.

Cc: @sigmaSd (as a workaround author) @tugrulates (As someone who was also interested in this feature)