### PR TITLE
fix(ext/node): fix TLS peer certificate multi-value fields, issuer chain, and EC curve names

### DIFF
--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -3504,7 +3504,7 @@ fn build_server_config(
   let key_str = get_js_string(scope, context, "key");
   let no_server_cert = cert_str.is_none() && key_str.is_none();
 
-  let (certs, private_key) = if no_server_cert {
+  let (mut certs, private_key) = if no_server_cert {
     (Vec::new(), None)
   } else {
     let cert_str = cert_str?;
@@ -3520,6 +3520,42 @@ fn build_server_config(
     .flatten()?;
     (certs, Some(private_key))
   };
+
+  // OpenSSL auto-chains: when `ca` certs are provided, it includes them in
+  // the certificate chain sent during the handshake so that clients receive
+  // the full chain (leaf + intermediates + root).  This is needed for
+  // getPeerCertificate(true) to return the issuer chain.
+  {
+    let ca_key = v8::String::new(scope, "ca").unwrap();
+    if let Some(ca_val) = context.get(scope, ca_key.into()) {
+      let mut ca_pems: Vec<Vec<u8>> = Vec::new();
+      if let Ok(arr) = v8::Local::<v8::Array>::try_from(ca_val) {
+        for i in 0..arr.length() {
+          if let Some(v) = arr.get_index(scope, i)
+            && let Some(s) = v.to_string(scope)
+          {
+            ca_pems.push(s.to_rust_string_lossy(scope).into_bytes());
+          }
+        }
+      } else if !ca_val.is_undefined()
+        && !ca_val.is_null()
+        && let Some(s) = ca_val.to_string(scope)
+      {
+        ca_pems.push(s.to_rust_string_lossy(scope).into_bytes());
+      }
+      for pem in &ca_pems {
+        let normalized = normalize_pem_headers(pem);
+        let reader = &mut std::io::BufReader::new(std::io::Cursor::new(
+          normalized.as_ref(),
+        ));
+        for parsed in rustls_pemfile::certs(reader) {
+          if let Ok(cert) = parsed {
+            certs.push(cert);
+          }
+        }
+      }
+    }
+  }
 
   let request_cert = get_js_bool(scope, context, "requestCert", false);
   let reject_unauthorized =

--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -3548,11 +3548,7 @@ fn build_server_config(
         let reader = &mut std::io::BufReader::new(std::io::Cursor::new(
           normalized.as_ref(),
         ));
-        for parsed in rustls_pemfile::certs(reader) {
-          if let Ok(cert) = parsed {
-            certs.push(cert);
-          }
-        }
+        certs.extend(rustls_pemfile::certs(reader).flatten());
       }
     }
   }

--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -124,6 +124,13 @@ function buildPeerLegacyCertificate(handle) {
       current.issuerCertificate = issuer;
       current = issuer;
     }
+    // Self-signed root: issuerCertificate points to itself (matches Node.js)
+    if (
+      current.subject && current.issuer &&
+      JSON.stringify(current.subject) === JSON.stringify(current.issuer)
+    ) {
+      current.issuerCertificate = current;
+    }
   }
 
   return translatePeerCertificate(cert) || {};

--- a/ext/node_crypto/x509.rs
+++ b/ext/node_crypto/x509.rs
@@ -27,23 +27,55 @@ enum CertificateSources {
   Pem(pem::Pem),
 }
 
+/// A certificate field value that may have one or multiple values.
+/// Serializes as a plain string when there is exactly one value,
+/// or as an array of strings when there are multiple (matching Node.js behavior).
+#[derive(Default)]
+struct StringOrArray(Vec<String>);
+
+impl StringOrArray {
+  fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+
+  fn push(&mut self, value: String) {
+    self.0.push(value);
+  }
+}
+
+impl serde::Serialize for StringOrArray {
+  fn serialize<S: serde::Serializer>(
+    &self,
+    serializer: S,
+  ) -> Result<S::Ok, S::Error> {
+    if self.0.len() == 1 {
+      serializer.serialize_str(&self.0[0])
+    } else {
+      self.0.serialize(serializer)
+    }
+  }
+}
+
 #[derive(serde::Serialize, Default)]
 #[serde(rename_all = "UPPERCASE")]
 struct SubjectOrIssuer {
-  #[serde(skip_serializing_if = "Option::is_none")]
-  c: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  st: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  l: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  o: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  ou: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  cn: Option<String>,
-  #[serde(rename = "emailAddress", skip_serializing_if = "Option::is_none")]
-  email_address: Option<String>,
+  #[serde(skip_serializing_if = "StringOrArray::is_empty")]
+  c: StringOrArray,
+  #[serde(skip_serializing_if = "StringOrArray::is_empty")]
+  st: StringOrArray,
+  #[serde(skip_serializing_if = "StringOrArray::is_empty")]
+  l: StringOrArray,
+  #[serde(skip_serializing_if = "StringOrArray::is_empty")]
+  o: StringOrArray,
+  #[serde(skip_serializing_if = "StringOrArray::is_empty")]
+  ou: StringOrArray,
+  #[serde(skip_serializing_if = "StringOrArray::is_empty")]
+  cn: StringOrArray,
+  #[serde(
+    rename = "emailAddress",
+    skip_serializing_if = "StringOrArray::is_empty"
+  )]
+  email_address: StringOrArray,
 }
 
 #[derive(serde::Serialize)]
@@ -381,25 +413,25 @@ fn extract_subject_or_issuer(name: &X509Name) -> SubjectOrIssuer {
       {
         match attr.attr_type() {
           oid if oid == &x509_parser::oid_registry::OID_X509_COUNTRY_NAME => {
-            result.c = Some(value_str);
+            result.c.push(value_str);
           }
           oid if oid == &x509_parser::oid_registry::OID_X509_STATE_OR_PROVINCE_NAME => {
-            result.st = Some(value_str);
+            result.st.push(value_str);
           }
           oid if oid == &x509_parser::oid_registry::OID_X509_LOCALITY_NAME => {
-            result.l = Some(value_str);
+            result.l.push(value_str);
           }
           oid if oid == &x509_parser::oid_registry::OID_X509_ORGANIZATION_NAME => {
-            result.o = Some(value_str);
+            result.o.push(value_str);
           }
           oid if oid == &x509_parser::oid_registry::OID_X509_ORGANIZATIONAL_UNIT => {
-            result.ou = Some(value_str);
+            result.ou.push(value_str);
           }
           oid if oid == &x509_parser::oid_registry::OID_X509_COMMON_NAME => {
-            result.cn = Some(value_str);
+            result.cn.push(value_str);
           }
           oid if oid == &x509_parser::oid_registry::OID_PKCS9_EMAIL_ADDRESS => {
-            result.email_address = Some(value_str);
+            result.email_address.push(value_str);
           }
           _ => {}
         }
@@ -585,25 +617,27 @@ fn extract_key_info(spki: &x509_parser::x509::SubjectPublicKeyInfo) -> KeyInfo {
         const ID_SECP384R1: &[u8] = &oid!(raw 1.3.132.0.34);
         const ID_SECP521R1: &[u8] = &oid!(raw 1.3.132.0.35);
 
+        // Use OpenSSL short names for asn1Curve and NIST names for
+        // nistCurve to match Node.js behavior.
         match curve_oid.as_bytes() {
           ID_SECP224R1 => {
-            asn1_curve = Some("1.3.132.0.33".to_string());
-            nist_curve = Some("secp224r1".to_string());
+            asn1_curve = Some("secp224r1".to_string());
+            nist_curve = Some("P-224".to_string());
             bits = Some(224);
           }
           ID_SECP256R1 => {
-            asn1_curve = Some("1.2.840.10045.3.1.7".to_string());
-            nist_curve = Some("secp256r1".to_string());
+            asn1_curve = Some("prime256v1".to_string());
+            nist_curve = Some("P-256".to_string());
             bits = Some(256);
           }
           ID_SECP384R1 => {
-            asn1_curve = Some("1.3.132.0.34".to_string());
-            nist_curve = Some("secp384r1".to_string());
+            asn1_curve = Some("secp384r1".to_string());
+            nist_curve = Some("P-384".to_string());
             bits = Some(384);
           }
           ID_SECP521R1 => {
-            asn1_curve = Some("1.3.132.0.35".to_string());
-            nist_curve = Some("secp521r1".to_string());
+            asn1_curve = Some("secp521r1".to_string());
+            nist_curve = Some("P-521".to_string());
             bits = Some(521);
           }
           _ => {

--- a/ext/node_crypto/x509.rs
+++ b/ext/node_crypto/x509.rs
@@ -30,7 +30,7 @@ enum CertificateSources {
 /// A certificate field value that may have one or multiple values.
 /// Serializes as a plain string when there is exactly one value,
 /// or as an array of strings when there are multiple (matching Node.js behavior).
-#[derive(Default)]
+#[derive(Default, Debug, PartialEq, Eq)]
 struct StringOrArray(Vec<String>);
 
 impl StringOrArray {
@@ -1360,11 +1360,11 @@ r6C3V5F4Z9y8o8i9E4j5V8O5Q7Y8Z4W8n7R8B8l8H8L4P4F8r8c8A4v3O4g8L8S6
 
     let result = extract_subject_or_issuer(cert_inner.subject());
 
-    assert_eq!(result.cn, Some("CN".to_string()));
-    assert_eq!(result.c, None);
-    assert_eq!(result.st, None);
-    assert_eq!(result.l, None);
-    assert_eq!(result.o, None);
-    assert_eq!(result.ou, None);
+    assert_eq!(result.cn, StringOrArray(vec!["CN".to_string()]));
+    assert!(result.c.is_empty());
+    assert!(result.st.is_empty());
+    assert!(result.l.is_empty());
+    assert!(result.o.is_empty());
+    assert!(result.ou.is_empty());
   }
 }

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3285,6 +3285,8 @@
     "parallel/test-tls-over-http-tunnel.js": {},
     "parallel/test-tls-pause.js": {},
     "parallel/test-tls-peer-certificate-encoding.js": {},
+    "parallel/test-tls-peer-certificate-multi-keys.js": {},
+    "parallel/test-tls-peer-certificate.js": {},
     "parallel/test-tls-psk-server.js": {},
     "parallel/test-tls-reduced-SECLEVEL-in-cipher.js": {},
     "parallel/test-tls-request-timeout.js": {},


### PR DESCRIPTION
## Summary

- Support multi-value X.509 certificate fields (e.g. multiple OU entries) by serializing as a string for single values and an array for multiple, matching Node.js behavior
- Include CA certs in the server's TLS handshake chain (OpenSSL auto-chain behavior) so `getPeerCertificate(true)` returns the full issuer chain with self-signed root circular reference
- Fix EC curve names: use OpenSSL short names for `asn1Curve` (`prime256v1` not OID) and NIST names for `nistCurve` (`P-256` not `secp256r1`)
- Enable `test-tls-peer-certificate.js` and `test-tls-peer-certificate-multi-keys.js` in node compat tests

## Details

### Multi-value certificate fields (`ext/node_crypto/x509.rs`)

`SubjectOrIssuer` fields were `Option<String>`, so when a certificate had multiple values for the same key (e.g. two OU entries), only the last was kept. Introduced a `StringOrArray` type that accumulates values and serializes as a plain string (single value) or array (multiple values), matching Node.js.

### Issuer certificate chain (`ext/node/ops/tls_wrap.rs`, `ext/node/polyfills/_tls_wrap.js`)

`getPeerCertificate(true)` wasn't returning the issuer chain because:
1. The server only sent its leaf cert — rustls's `peer_certificates()` returns only what the peer sent. Fixed by appending CA certs from the `ca` option to the server's cert chain in `build_server_config`, replicating OpenSSL's auto-chain behavior.
2. Self-signed root CAs didn't have `issuerCertificate` pointing to themselves. Added the circular reference check in `buildPeerLegacyCertificate`.

### EC curve names (`ext/node_crypto/x509.rs`)

`asn1Curve` was returning raw OIDs (e.g. `1.2.840.10045.3.1.7`) instead of OpenSSL short names (`prime256v1`). `nistCurve` was returning `secp256r1` instead of `P-256`. Fixed to match Node.js/OpenSSL naming conventions.

## Test plan

- [x] `./x test-compat test-tls-peer-certificate.js` passes
- [x] `./x test-compat test-tls-peer-certificate-multi-keys.js` passes