### PR TITLE
fix(cli): surface V8 typed-array OOM as clean error instead of panic

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -595,9 +595,33 @@ fn setup_panic_hook() {
   }));
 
   fn error_handler(file: &str, line: i32, message: &str) {
+    // Some V8 CHECKs are reachable from user JS (e.g. requesting an
+    // ArrayBuffer/TypedArray larger than the per-isolate sanity limit on
+    // chunk allocation, or external memory accounting overflow). V8 aborts
+    // before it has a chance to throw RangeError, so the process dies with
+    // a CHECK fail. These are not Deno bugs; surface them as a clean OOM
+    // exit instead of asking the user to file a bug report.
+    if message.contains("change_in_bytes < kMaxReasonableBytes")
+      || message.contains("kMaxReasonableBytes")
+    {
+      exit_with_oom("requested allocation exceeds maximum supported size");
+    }
     // Override C++ abort with a rust panic, so we
     // get our message above and a nice backtrace.
     panic!("Fatal error in {file}:{line}: {message}");
+  }
+
+  #[allow(clippy::print_stderr, reason = "fatal exit")]
+  fn exit_with_oom(detail: &str) -> ! {
+    eprintln!("\n============================================================");
+    eprintln!("error: V8 out of memory: {detail}.");
+    eprintln!();
+    eprintln!("Hint: this is usually caused by allocating an ArrayBuffer or");
+    eprintln!("TypedArray that is too large (e.g. `new Float64Array(10e9)`).");
+    eprintln!();
+    eprintln!("Platform: {} {}", env::consts::OS, env::consts::ARCH);
+    eprintln!("Version: {}", deno_lib::version::DENO_VERSION_INFO.deno);
+    deno_runtime::exit(1);
   }
 
   deno_core::v8::V8::set_fatal_error_handler(error_handler);

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -614,7 +614,7 @@ fn setup_panic_hook() {
   #[allow(clippy::print_stderr, reason = "fatal exit")]
   fn exit_with_oom(detail: &str) -> ! {
     eprintln!("\n============================================================");
-    eprintln!("error: V8 out of memory: {detail}.");
+    eprintln!("error: V8 fatal error: {detail}.");
     eprintln!();
     eprintln!("Hint: this is usually caused by allocating an ArrayBuffer or");
     eprintln!("TypedArray that is too large (e.g. `new Float64Array(10e9)`).");


### PR DESCRIPTION
Closes #33747.

`new Float64Array(10e9)` (and similar oversized ArrayBuffer/TypedArray
allocations) trip a V8 CHECK before V8 has a chance to throw RangeError:

```
Fatal error in :0: Check failed: change_in_bytes < kMaxReasonableBytes.
```

The fatal-error handler in `cli/lib.rs` then converts the CHECK into a
Rust panic, presenting it as a Deno bug worth reporting. It is not, the
allocation request was simply too large.

This recognises the OOM-style CHECK message in the existing fatal-error
handler and exits cleanly with a friendly message and exit code 1,
following the precedent established in #32856 for the worker-thread
`Check failed: Start()` CHECK.

Throwing JS from a fatal handler is unsafe (V8 invariants are already
broken at that point), so the only correct action is a clean exit.

### Before

```
$ deno -e 'new Float64Array(10e9)'
============================================================
Deno has panicked. This is a bug in Deno. Please report this
at https://github.com/denoland/deno/issues/new.
...
thread 'main' panicked at cli/lib.rs:566:5:
Fatal error in :0: Check failed: change_in_bytes < kMaxReasonableBytes.
```

### After

```
$ deno -e 'new Float64Array(10e9)'
============================================================
error: V8 out of memory: requested allocation exceeds maximum supported size.

Hint: this is usually caused by allocating an ArrayBuffer or
TypedArray that is too large (e.g. `new Float64Array(10e9)`).

Platform: macos aarch64
Version: 2.7.14
```