### PR TITLE
perf(ext/fs): convert ext/fs JS source to lazy-loaded script

### DIFF
--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -1,12 +1,14 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
+// deno-fmt-ignore-file
 
-import { core, primordials } from "ext:core/mod.js";
+(function () {
+const { core, primordials } = globalThis.__bootstrap;
 const {
   isDate,
   internalRidSymbol,
   createCancelHandle,
 } = core;
-import {
+const {
   op_fs_chdir,
   op_fs_chmod_async,
   op_fs_chmod_sync,
@@ -71,7 +73,7 @@ import {
   op_fs_write_file_async,
   op_fs_write_file_sync,
   op_set_raw,
-} from "ext:core/ops";
+} = core.ops;
 const {
   ArrayPrototypeFilter,
   Date,
@@ -917,7 +919,7 @@ function writeTextFile(
   }
 }
 
-export {
+return {
   chdir,
   chmod,
   chmodSync,
@@ -969,3 +971,4 @@ export {
   writeTextFile,
   writeTextFileSync,
 };
+})()

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -97,7 +97,7 @@ deno_core::extension!(deno_fs,
     op_fs_futime_async,
 
   ],
-  esm = [ "30_fs.js" ],
+  lazy_loaded_js = [ "30_fs.js" ],
   options = {
     fs: FileSystemRc,
   },

--- a/ext/node/polyfills/_process/process.ts
+++ b/ext/node/polyfills/_process/process.ts
@@ -24,7 +24,7 @@ const { build, createLazyLoader } = core;
 
 import { nextTick as _nextTick } from "ext:deno_node/_next_tick.ts";
 import { _exiting } from "ext:deno_node/_process/exiting.ts";
-import * as fs from "ext:deno_fs/30_fs.js";
+const fs = core.loadExtScript("ext:deno_fs/30_fs.js");
 import {
   denoErrorToNodeError,
   ERR_INVALID_ARG_TYPE,

--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -33,7 +33,7 @@ const {
   SymbolFor,
 } = primordials;
 
-import { FsFile } from "ext:deno_fs/30_fs.js";
+const { FsFile } = core.loadExtScript("ext:deno_fs/30_fs.js");
 const { readAll } = core.loadExtScript("ext:deno_io/12_io.js");
 const { assert, pathFromURL } = core.loadExtScript("ext:deno_web/00_infra.js");
 const { packageData } = core.loadExtScript("ext:deno_fetch/22_body.js");

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -21,7 +21,7 @@ import * as errors from "ext:runtime/01_errors.js";
 import * as version from "ext:runtime/01_version.ts";
 import * as permissions from "ext:runtime/10_permissions.js";
 const io = core.loadExtScript("ext:deno_io/12_io.js");
-import * as fs from "ext:deno_fs/30_fs.js";
+const fs = core.loadExtScript("ext:deno_fs/30_fs.js");
 const os = core.loadExtScript("ext:deno_os/30_os.js");
 import * as fsEvents from "ext:runtime/40_fs_events.js";
 import * as process from "ext:deno_process/40_process.js";


### PR DESCRIPTION
Follow-up to #33784. Converts `ext/fs/30_fs.js` from ESM to
IIFE-wrapped lazy-loaded script (`lazy_loaded_js`), eliminating ESM
module resolution overhead.

Updates three consumers to use `core.loadExtScript()`:
- `ext/process/40_process.js` (`FsFile` import)
- `ext/node/polyfills/_process/process.ts` (`fs` namespace import)
- `runtime/js/90_deno_ns.js` (`fs` namespace import)

No cross-extension blockers -- `30_fs.js` already uses
`core.loadExtScript()` for its `ext:deno_io` and `ext:deno_web`
dependencies (converted in #33798).