### PR TITLE
fix(node): allow nested package.json main to resolve within package root

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -389,12 +389,33 @@ function tryPackage(requestPath, exts, isMain, originalPath) {
   }
 
   const filename = pathResolve(requestPath, pkg);
+
+  // Dynamically find the actual package root
+  let packageRoot = requestPath;
+  let current = requestPath;
+
+  while (true) {
+    const parent = pathDirname(current);
+    if (parent === current) break;
+
+    // Stop traversing upward if we hit a node_modules boundary
+    const basename = op_require_path_basename(parent);
+    if (basename === "node_modules") break;
+
+    // If a parent directory also has package.json, we consider it the new root
+    if (stat(pathResolve(parent, "package.json")) === 0) {
+      packageRoot = parent;
+    }
+
+    current = parent;
+  }
+
   // Ensure the resolved main path doesn't escape the package directory
   // via path traversal (e.g. "main": "../../secret.json")
   if (
-    !StringPrototypeStartsWith(filename, requestPath + "/") &&
-    !StringPrototypeStartsWith(filename, requestPath + "\\") &&
-    filename !== requestPath
+    !StringPrototypeStartsWith(filename, packageRoot + "/") &&
+    !StringPrototypeStartsWith(filename, packageRoot + "\\") &&
+    filename !== packageRoot
   ) {
     const err = new Error(
       `Cannot find module '${filename}'. ` +

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -406,7 +406,9 @@ function tryPackage(requestPath, exts, isMain, originalPath) {
       // - node_modules/<pkg>/...  -> root = node_modules/<pkg>
       // - node_modules/@scope/<pkg>/... -> root = node_modules/@scope/<pkg>
       const rel = requestPath.slice(current.length + 1);
-      const sep = rel.indexOf("/") !== -1 ? "/" : "\\";
+      // Detect separator from the node_modules path itself, not from
+      // rel which may be a single component with no separator at all.
+      const sep = current.indexOf("\\") !== -1 ? "\\" : "/";
       const parts = StringPrototypeSplit(rel, sep);
       if (
         parts.length > 0 && StringPrototypeStartsWith(parts[0], "@") &&

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -390,23 +390,31 @@ function tryPackage(requestPath, exts, isMain, originalPath) {
 
   const filename = pathResolve(requestPath, pkg);
 
-  // Dynamically find the actual package root
+  // Find the package root: if the package.json is inside a node_modules
+  // directory, the root is the package folder directly under node_modules
+  // (e.g. node_modules/pkg/ or node_modules/@scope/pkg/). This allows
+  // nested package.json files (subpath exports) to have "main" fields that
+  // reference sibling directories within the same package.
   let packageRoot = requestPath;
   let current = requestPath;
-
   while (true) {
     const parent = pathDirname(current);
     if (parent === current) break;
-
-    // Stop traversing upward if we hit a node_modules boundary
-    const basename = op_require_path_basename(parent);
-    if (basename === "node_modules") break;
-
-    // If a parent directory also has package.json, we consider it the new root
-    if (stat(pathResolve(parent, "package.json")) === 0) {
-      packageRoot = parent;
+    const basename = op_require_path_basename(current);
+    if (basename === "node_modules") {
+      // current is the node_modules dir, so requestPath is either:
+      // - node_modules/<pkg>/...  -> root = node_modules/<pkg>
+      // - node_modules/@scope/<pkg>/... -> root = node_modules/@scope/<pkg>
+      const rel = requestPath.slice(current.length + 1);
+      const sep = rel.indexOf("/") !== -1 ? "/" : "\\";
+      const parts = StringPrototypeSplit(rel, sep);
+      if (parts.length > 0 && StringPrototypeStartsWith(parts[0], "@") && parts.length > 1) {
+        packageRoot = current + sep + parts[0] + sep + parts[1];
+      } else if (parts.length > 0) {
+        packageRoot = current + sep + parts[0];
+      }
+      break;
     }
-
     current = parent;
   }
 

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -408,7 +408,10 @@ function tryPackage(requestPath, exts, isMain, originalPath) {
       const rel = requestPath.slice(current.length + 1);
       const sep = rel.indexOf("/") !== -1 ? "/" : "\\";
       const parts = StringPrototypeSplit(rel, sep);
-      if (parts.length > 0 && StringPrototypeStartsWith(parts[0], "@") && parts.length > 1) {
+      if (
+        parts.length > 0 && StringPrototypeStartsWith(parts[0], "@") &&
+        parts.length > 1
+      ) {
         packageRoot = current + sep + parts[0] + sep + parts[1];
       } else if (parts.length > 0) {
         packageRoot = current + sep + parts[0];

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -62,6 +62,7 @@ const {
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
+  StringPrototypeLastIndexOf,
   StringPrototypeMatch,
   StringPrototypeSlice,
   StringPrototypeSplit,
@@ -368,6 +369,38 @@ function updateChildren(parent, child, scan) {
   }
 }
 
+// Given a path inside a node_modules tree, find the package root by
+// locating the last "node_modules" path component and taking the next
+// segment (or two for scoped packages). Returns null if no node_modules
+// component is found.
+function findPackageRootFromNodeModules(filepath) {
+  // Find the last occurrence of /node_modules/ or \node_modules\ in the path
+  let nmIdx = -1;
+  let sep = "/";
+  const fwdIdx = StringPrototypeLastIndexOf(filepath, "/node_modules/");
+  const bwdIdx = StringPrototypeLastIndexOf(filepath, "\\node_modules\\");
+  if (fwdIdx !== -1 && fwdIdx > bwdIdx) {
+    nmIdx = fwdIdx;
+    sep = "/";
+  } else if (bwdIdx !== -1) {
+    nmIdx = bwdIdx;
+    sep = "\\";
+  }
+  if (nmIdx === -1) return null;
+
+  const afterNm = nmIdx + sep.length + "node_modules".length + sep.length;
+  const rest = StringPrototypeSlice(filepath, afterNm);
+  const parts = StringPrototypeSplit(rest, sep);
+  if (parts.length === 0 || parts[0] === "") return null;
+
+  if (StringPrototypeStartsWith(parts[0], "@") && parts.length > 1) {
+    // Scoped package: @scope/name
+    return StringPrototypeSlice(filepath, 0, afterNm) + parts[0] + sep +
+      parts[1];
+  }
+  return StringPrototypeSlice(filepath, 0, afterNm) + parts[0];
+}
+
 function tryFile(requestPath, _isMain) {
   const rc = stat(requestPath);
   if (rc !== 0) return;
@@ -390,38 +423,12 @@ function tryPackage(requestPath, exts, isMain, originalPath) {
 
   const filename = pathResolve(requestPath, pkg);
 
-  // Find the package root: if the package.json is inside a node_modules
-  // directory, the root is the package folder directly under node_modules
-  // (e.g. node_modules/pkg/ or node_modules/@scope/pkg/). This allows
-  // nested package.json files (subpath exports) to have "main" fields that
-  // reference sibling directories within the same package.
-  let packageRoot = requestPath;
-  let current = requestPath;
-  while (true) {
-    const parent = pathDirname(current);
-    if (parent === current) break;
-    const basename = op_require_path_basename(current);
-    if (basename === "node_modules") {
-      // current is the node_modules dir, so requestPath is either:
-      // - node_modules/<pkg>/...  -> root = node_modules/<pkg>
-      // - node_modules/@scope/<pkg>/... -> root = node_modules/@scope/<pkg>
-      const rel = requestPath.slice(current.length + 1);
-      // Detect separator from the node_modules path itself, not from
-      // rel which may be a single component with no separator at all.
-      const sep = current.indexOf("\\") !== -1 ? "\\" : "/";
-      const parts = StringPrototypeSplit(rel, sep);
-      if (
-        parts.length > 0 && StringPrototypeStartsWith(parts[0], "@") &&
-        parts.length > 1
-      ) {
-        packageRoot = current + sep + parts[0] + sep + parts[1];
-      } else if (parts.length > 0) {
-        packageRoot = current + sep + parts[0];
-      }
-      break;
-    }
-    current = parent;
-  }
+  // Find the package root for the path traversal check. For nested
+  // package.json files inside node_modules (e.g. pkg/sub/package.json with
+  // "main": "../cjs/sub.js"), we allow resolving up to the package root
+  // (node_modules/pkg/) rather than restricting to the nested directory.
+  const packageRoot = findPackageRootFromNodeModules(requestPath) ??
+    requestPath;
 
   // Ensure the resolved main path doesn't escape the package directory
   // via path traversal (e.g. "main": "../../secret.json")

--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -2009,10 +2009,11 @@ impl<
       let mut current = package_path.to_path_buf();
 
       while let Some(parent) = current.parent() {
-        if let Some(file_name) = parent.file_name() {
-          if file_name == "node_modules" {
-            break;
-          }
+        if parent
+          .file_name()
+          .is_some_and(|name| name == "node_modules")
+        {
+          break;
         }
 
         let p = parent.join("package.json");

--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -2754,31 +2754,38 @@ fn is_pe(data: &[u8]) -> bool {
 }
 
 /// Given a path inside a `node_modules` tree, find the package root by
-/// locating the `node_modules` path component and taking the next segment
-/// (or two for scoped packages like `@scope/pkg`). Returns `None` if no
-/// `node_modules` component is found, in which case the caller should
-/// fall back to the package.json's own directory.
+/// locating the last `node_modules` path component and taking the next
+/// segment (or two for scoped packages like `@scope/pkg`). Uses the last
+/// occurrence to handle nested node_modules trees correctly. Returns
+/// `None` if no `node_modules` component is found, in which case the
+/// caller should fall back to the package.json's own directory.
 fn find_package_root_from_node_modules(path: &Path) -> Option<PathBuf> {
-  let mut components = path.components().peekable();
-  let mut prefix = PathBuf::new();
-  while let Some(c) = components.next() {
-    prefix.push(c);
-    if c.as_os_str() == "node_modules" {
-      // Next component is the package name (or scope).
-      let first = components.next()?;
-      let first_str = first.as_os_str().to_string_lossy();
-      if first_str.starts_with('@') {
-        // Scoped package: @scope/name
-        let second = components.next()?;
-        prefix.push(first);
-        prefix.push(second);
-      } else {
-        prefix.push(first);
-      }
-      return Some(prefix);
-    }
+  let components: Vec<_> = path.components().collect();
+  // Find the last node_modules component
+  let nm_idx = components
+    .iter()
+    .rposition(|c| c.as_os_str() == "node_modules")?;
+  // Need at least one component after node_modules for the package name
+  if nm_idx + 1 >= components.len() {
+    return None;
   }
-  None
+  let mut prefix = PathBuf::new();
+  for c in &components[..=nm_idx] {
+    prefix.push(c);
+  }
+  let first = &components[nm_idx + 1];
+  let first_str = first.as_os_str().to_string_lossy();
+  if first_str.starts_with('@') {
+    // Scoped package: @scope/name - need two components
+    if nm_idx + 2 >= components.len() {
+      return None;
+    }
+    prefix.push(first);
+    prefix.push(&components[nm_idx + 2]);
+  } else {
+    prefix.push(first);
+  }
+  Some(prefix)
 }
 
 #[cfg(test)]

--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -2004,10 +2004,30 @@ impl<
 
     if let Some(main) = maybe_main.as_deref() {
       let package_path = package_json.path.parent().unwrap();
+
+      let mut package_root = package_path.to_path_buf();
+      let mut current = package_path.to_path_buf();
+
+      while let Some(parent) = current.parent() {
+        if let Some(file_name) = parent.file_name() {
+          if file_name == "node_modules" {
+            break;
+          }
+        }
+
+        let p = parent.join("package.json");
+        if self.sys.is_file(Cow::Borrowed(&p)) {
+          package_root = parent.to_path_buf();
+        }
+
+        current = parent.to_path_buf();
+      }
+
       let guess = package_path.join(main).clean();
+
       // Ensure the resolved main path doesn't escape the package
       // directory via path traversal (e.g. "main": "../../../secret.json")
-      if !guess.starts_with(package_path) {
+      if !guess.starts_with(&package_root) {
         return Err(
           ModuleNotFoundError {
             specifier: UrlOrPath::Path(guess),
@@ -2017,6 +2037,7 @@ impl<
           .into(),
         );
       }
+
       if self.sys.is_file(Cow::Borrowed(&guess)) {
         return Ok(self.maybe_resolve_types(
           LocalUrlOrPath::Path(LocalPath {
@@ -2050,7 +2071,7 @@ impl<
       };
       for ending in endings {
         let guess = package_path.join(format!("{main}{ending}")).clean();
-        if guess.starts_with(package_path)
+        if guess.starts_with(&package_root)
           && self.sys.is_file(Cow::Borrowed(&guess))
         {
           // TODO(bartlomieju): emitLegacyIndexDeprecation()

--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -2011,9 +2011,8 @@ impl<
       // node_modules/@scope/pkg/). This allows nested package.json files
       // (subpath exports) to have "main" fields that reference sibling
       // directories within the same package.
-      let package_root =
-        find_package_root_from_node_modules(package_path)
-          .unwrap_or_else(|| package_path.to_path_buf());
+      let package_root = find_package_root_from_node_modules(package_path)
+        .unwrap_or_else(|| package_path.to_path_buf());
 
       let guess = package_path.join(main).clean();
 

--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -2005,24 +2005,15 @@ impl<
     if let Some(main) = maybe_main.as_deref() {
       let package_path = package_json.path.parent().unwrap();
 
-      let mut package_root = package_path.to_path_buf();
-      let mut current = package_path.to_path_buf();
-
-      while let Some(parent) = current.parent() {
-        if parent
-          .file_name()
-          .is_some_and(|name| name == "node_modules")
-        {
-          break;
-        }
-
-        let p = parent.join("package.json");
-        if self.sys.is_file(Cow::Borrowed(&p)) {
-          package_root = parent.to_path_buf();
-        }
-
-        current = parent.to_path_buf();
-      }
+      // Find the package root: if the package.json is inside a
+      // node_modules directory, the root is the package folder directly
+      // under node_modules (e.g. node_modules/pkg/ or
+      // node_modules/@scope/pkg/). This allows nested package.json files
+      // (subpath exports) to have "main" fields that reference sibling
+      // directories within the same package.
+      let package_root =
+        find_package_root_from_node_modules(package_path)
+          .unwrap_or_else(|| package_path.to_path_buf());
 
       let guess = package_path.join(main).clean();
 
@@ -2761,6 +2752,34 @@ fn is_pe(data: &[u8]) -> bool {
   }
   let magic = u16::from_le_bytes([data[0], data[1]]);
   magic == 0x5a4d
+}
+
+/// Given a path inside a `node_modules` tree, find the package root by
+/// locating the `node_modules` path component and taking the next segment
+/// (or two for scoped packages like `@scope/pkg`). Returns `None` if no
+/// `node_modules` component is found, in which case the caller should
+/// fall back to the package.json's own directory.
+fn find_package_root_from_node_modules(path: &Path) -> Option<PathBuf> {
+  let mut components = path.components().peekable();
+  let mut prefix = PathBuf::new();
+  while let Some(c) = components.next() {
+    prefix.push(c);
+    if c.as_os_str() == "node_modules" {
+      // Next component is the package name (or scope).
+      let first = components.next()?;
+      let first_str = first.as_os_str().to_string_lossy();
+      if first_str.starts_with('@') {
+        // Scoped package: @scope/name
+        let second = components.next()?;
+        prefix.push(first);
+        prefix.push(second);
+      } else {
+        prefix.push(first);
+      }
+      return Some(prefix);
+    }
+  }
+  None
 }
 
 #[cfg(test)]

--- a/tests/specs/npm/byonm_main_path_traversal/__test__.jsonc
+++ b/tests/specs/npm/byonm_main_path_traversal/__test__.jsonc
@@ -9,6 +9,11 @@
       "args": "run main.mjs",
       "output": "main_esm.out",
       "exitCode": 1
+    },
+    "main_nested_package_cjs": {
+      "args": "run main_nested.cjs",
+      "output": "main_nested.out",
+      "exitCode": 0
     }
   }
 }

--- a/tests/specs/npm/byonm_main_path_traversal/__test__.jsonc
+++ b/tests/specs/npm/byonm_main_path_traversal/__test__.jsonc
@@ -14,6 +14,11 @@
       "args": "run main_nested.cjs",
       "output": "main_nested.out",
       "exitCode": 0
+    },
+    "main_nested_escape_cjs": {
+      "args": "run main_nested_escape.cjs",
+      "output": "main_nested_escape.out",
+      "exitCode": 1
     }
   }
 }

--- a/tests/specs/npm/byonm_main_path_traversal/main_nested.cjs
+++ b/tests/specs/npm/byonm_main_path_traversal/main_nested.cjs
@@ -1,0 +1,2 @@
+const sub = require("nested-pkg/sub");
+console.log("SUCCESS:", sub);

--- a/tests/specs/npm/byonm_main_path_traversal/main_nested.out
+++ b/tests/specs/npm/byonm_main_path_traversal/main_nested.out
@@ -1,0 +1,1 @@
+SUCCESS: works

--- a/tests/specs/npm/byonm_main_path_traversal/main_nested_escape.cjs
+++ b/tests/specs/npm/byonm_main_path_traversal/main_nested_escape.cjs
@@ -1,0 +1,2 @@
+const sub = require("nested-pkg/evil-sub");
+console.log("ERROR: should not have loaded:", JSON.stringify(sub));

--- a/tests/specs/npm/byonm_main_path_traversal/main_nested_escape.out
+++ b/tests/specs/npm/byonm_main_path_traversal/main_nested_escape.out
@@ -1,0 +1,4 @@
+error: Uncaught (in promise) Error: Cannot find module '[WILDCARD]secret.json'. Please verify that the package.json has a valid "main" entry
+const sub = require("nested-pkg/evil-sub");
+[WILDCARD]
+    at [WILDCARD]main_nested_escape.cjs:1:[WILDCARD]

--- a/tests/specs/npm/byonm_main_path_traversal/node_modules/nested-pkg/cjs/sub.js
+++ b/tests/specs/npm/byonm_main_path_traversal/node_modules/nested-pkg/cjs/sub.js
@@ -1,0 +1,1 @@
+module.exports = "works";

--- a/tests/specs/npm/byonm_main_path_traversal/node_modules/nested-pkg/evil-sub/package.json
+++ b/tests/specs/npm/byonm_main_path_traversal/node_modules/nested-pkg/evil-sub/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nested-pkg/evil-sub",
+  "private": true,
+  "main": "../../../secret.json"
+}

--- a/tests/specs/npm/byonm_main_path_traversal/node_modules/nested-pkg/package.json
+++ b/tests/specs/npm/byonm_main_path_traversal/node_modules/nested-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nested-pkg",
+  "version": "1.0.0",
+  "main": "./cjs/index.js"
+}

--- a/tests/specs/npm/byonm_main_path_traversal/node_modules/nested-pkg/sub/package.json
+++ b/tests/specs/npm/byonm_main_path_traversal/node_modules/nested-pkg/sub/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nested-pkg/sub",
+  "private": true,
+  "main": "../cjs/sub.js"
+}


### PR DESCRIPTION
Closes #33766
Supersedes #33767

Credit to @mhrstmnn for identifying the issue and the initial fix attempt
in #33767, including the test cases.

The path traversal check from #33170 was too strict: it used the
directory of the nested `package.json` as the boundary, which broke the
common pattern of nested `package.json` files with `"main"` pointing to
sibling directories (e.g. `sub/package.json` with `"main": "../cjs/sub.js"`).

This PR fixes both the JS (`01_require.js`) and Rust (`resolution.rs`)
code paths to detect the actual package root within `node_modules` and
use that as the boundary instead.

Changes from the original #33767:
- **JS**: Replaced the `pathDirname` walk-up loop (which threw "Path
  doesn't have a parent" for packages in the global npm cache) with a
  string-based `findPackageRootFromNodeModules` using `lastIndexOf`
- **Rust**: Fixed `find_package_root_from_node_modules` to use
  `rposition` (last `node_modules` component) for correctness with
  nested `node_modules` trees