### PR TITLE
perf(ext): convert ext/kv and ext/webgpu JS sources to lazy-loaded scripts

### DIFF
--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -1,10 +1,12 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
+// deno-fmt-ignore-file
 
-import { core, primordials } from "ext:core/mod.js";
+(function () {
+const { core, internals, primordials } = globalThis.__bootstrap;
 const {
   isPromise,
 } = core;
-import {
+const {
   op_kv_atomic_write,
   op_kv_database_open,
   op_kv_dequeue_next_message,
@@ -13,7 +15,7 @@ import {
   op_kv_snapshot_read,
   op_kv_watch,
   op_kv_watch_next,
-} from "ext:core/ops";
+} = core.ops;
 const {
   ArrayFrom,
   ArrayPrototypeJoin,
@@ -325,7 +327,7 @@ class Kv {
           const _res = isPromise(result) ? (await result) : result;
           success = true;
         } catch (error) {
-          import.meta.log("error", "Exception in queue handler", error);
+          internals.log("error", "Exception in queue handler", error);
         } finally {
           const promise: Promise<void> = op_kv_finish_dequeued_message(
             handleId,
@@ -950,4 +952,5 @@ async function doAtomicWriteInPlace(
   );
 }
 
-export { AtomicOperation, Kv, KvListIterator, KvU64, openKv };
+return { AtomicOperation, Kv, KvListIterator, KvU64, openKv };
+})()

--- a/ext/kv/lib.rs
+++ b/ext/kv/lib.rs
@@ -76,7 +76,7 @@ deno_core::extension!(deno_kv,
     op_kv_watch<DBH>,
     op_kv_watch_next,
   ],
-  esm = [ "01_db.ts" ],
+  lazy_loaded_js = [ "01_db.ts" ],
   options = {
     handler: DBH,
     config: KvConfig,

--- a/ext/webgpu/00_init.js
+++ b/ext/webgpu/00_init.js
@@ -1,7 +1,10 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
+// deno-fmt-ignore-file
 
-import { core } from "ext:core/mod.js";
+(function () {
+const { core } = globalThis.__bootstrap;
 
 const loadWebGPU = core.createLazyLoader("ext:deno_webgpu/01_webgpu.js");
 
-export { loadWebGPU };
+return { loadWebGPU };
+})()

--- a/ext/webgpu/lib.rs
+++ b/ext/webgpu/lib.rs
@@ -111,8 +111,8 @@ deno_core::extension!(
     texture::GPUExternalTexture,
     canvas::GPUCanvasContext,
   ],
-  esm = ["00_init.js"],
   lazy_loaded_esm = ["01_webgpu.js"],
+  lazy_loaded_js = ["00_init.js"],
 );
 
 #[op2]

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -27,12 +27,12 @@ import * as fsEvents from "ext:runtime/40_fs_events.js";
 const process = core.loadExtScript("ext:deno_process/40_process.js");
 const signals = core.loadExtScript("ext:deno_os/40_signals.js");
 import * as tty from "ext:runtime/40_tty.js";
-import * as kv from "ext:deno_kv/01_db.ts";
+const kv = core.loadExtScript("ext:deno_kv/01_db.ts");
 const cron = core.loadExtScript("ext:deno_cron/01_cron.ts");
 const surface = core.loadExtScript("ext:deno_canvas/02_surface.js");
 const telemetry = core.loadExtScript("ext:deno_telemetry/telemetry.ts");
 import { unstableIds } from "ext:deno_features/flags.js";
-import { loadWebGPU } from "ext:deno_webgpu/00_init.js";
+const { loadWebGPU } = core.loadExtScript("ext:deno_webgpu/00_init.js");
 import { bundle } from "ext:deno_bundle_runtime/bundle.ts";
 
 const { ObjectDefineProperties, Float64Array } = primordials;

--- a/runtime/js/98_global_scope_shared.js
+++ b/runtime/js/98_global_scope_shared.js
@@ -43,7 +43,7 @@ import {
   setInterval as nodeSetInterval,
   setTimeout as nodeSetTimeout,
 } from "node:timers";
-import { loadWebGPU } from "ext:deno_webgpu/00_init.js";
+const { loadWebGPU } = core.loadExtScript("ext:deno_webgpu/00_init.js");
 import { unstableIds } from "ext:runtime/90_deno_ns.js";
 
 const loadImage = core.createLazyLoader("ext:deno_image/01_image.js");

--- a/runtime/js/98_global_scope_window.js
+++ b/runtime/js/98_global_scope_window.js
@@ -22,7 +22,7 @@ const globalInterfaces = core.loadExtScript(
 );
 const webStorage = core.loadExtScript("ext:deno_webstorage/01_webstorage.js");
 import * as prompt from "ext:runtime/41_prompt.js";
-import { loadWebGPU } from "ext:deno_webgpu/00_init.js";
+const { loadWebGPU } = core.loadExtScript("ext:deno_webgpu/00_init.js");
 
 /**
  * @param {string} arch

--- a/runtime/js/98_global_scope_worker.js
+++ b/runtime/js/98_global_scope_worker.js
@@ -20,7 +20,7 @@ const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
 const globalInterfaces = core.loadExtScript(
   "ext:deno_web/04_global_interfaces.js",
 );
-import { loadWebGPU } from "ext:deno_webgpu/00_init.js";
+const { loadWebGPU } = core.loadExtScript("ext:deno_webgpu/00_init.js");
 
 /**
  * @param {string} arch


### PR DESCRIPTION
## Summary

- Convert `ext/kv/01_db.ts` from ESM to IIFE-wrapped lazy-loaded script (`lazy_loaded_js`)
- Convert `ext/webgpu/00_init.js` from ESM to IIFE-wrapped lazy-loaded script (`lazy_loaded_js`)
- Update all consumers (`runtime/js/90_deno_ns.js`, `runtime/js/98_global_scope_shared.js`, `runtime/js/98_global_scope_window.js`, `runtime/js/98_global_scope_worker.js`) to use `core.loadExtScript()` instead of ESM imports
- Replace `import.meta.log` call with `internals.log` in `01_db.ts`

Follows the same pattern established in #33778, #33780, #33784, #33800, #33801, and #33817.

## Test plan

- [x] `cargo check` passes
- [ ] CI passes (existing spec/unit tests cover ext/kv and ext/webgpu functionality)