### PR TITLE
chore: bump dprint-plugin-typescript to 0.96.0, remove deno-fmt-ignore-file

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -1,6 +1,7 @@
 {
   "typescript": {
-    "deno": true
+    "deno": true,
+    "functionExpression.flatIife": true
   },
   "markdown": {
     "deno": true
@@ -85,7 +86,7 @@
     "tests/specs/run/error_syntax_empty_trailing_line/error_syntax_empty_trailing_line.mjs"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.95.15.wasm",
+    "https://plugins.dprint.dev/typescript-0.96.0.wasm",
     "https://plugins.dprint.dev/json-0.21.3.wasm",
     "https://plugins.dprint.dev/markdown-0.21.1.wasm",
     "https://plugins.dprint.dev/toml-0.7.0.wasm",

--- a/ext/cache/01_cache.js
+++ b/ext/cache/01_cache.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -340,6 +339,5 @@ function cacheStorage() {
   return cacheStorageStorage;
 }
 
-
 return { Cache, CacheStorage, cacheStorage };
-})()
+})();

--- a/ext/canvas/02_surface.js
+++ b/ext/canvas/02_surface.js
@@ -1,8 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core } = globalThis.__bootstrap;
 const { UnsafeWindowSurface } = core.ops;
 return { UnsafeWindowSurface };
-})()
+})();

--- a/ext/cron/01_cron.ts
+++ b/ext/cron/01_cron.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -174,7 +173,9 @@ function cron(
       if (otelState.TRACING_ENABLED) {
         let activeContext = ContextManager.active();
         if (r.traceparent) {
-          for (const propagator of new SafeArrayIterator(otelState.PROPAGATORS)) {
+          for (
+            const propagator of new SafeArrayIterator(otelState.PROPAGATORS)
+          ) {
             activeContext = propagator.extract(activeContext, {}, {
               get(_carrier, key) {
                 if (key === "traceparent") return r.traceparent;
@@ -227,4 +228,4 @@ internals.formatToCronSchedule = formatToCronSchedule;
 internals.parseScheduleToString = parseScheduleToString;
 
 return { cron, formatToCronSchedule, parseScheduleToString };
-})()
+})();

--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials, internals } = globalThis.__bootstrap;
@@ -6122,4 +6121,4 @@ return {
   importCryptoKeySync,
   SubtleCrypto,
 };
-})()
+})();

--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -533,4 +532,4 @@ return {
   headersEntries,
   headersFromHeaderList,
 };
-})()
+})();

--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -554,4 +553,4 @@ return {
   formDataToBlob,
   parseFormData,
 };
-})()
+})();

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -573,4 +572,4 @@ webidl.converters["BodyInit_DOMString?"] = webidl.createNullableConverter(
 );
 
 return { extractBody, InnerBody, mixinBody, packageData };
-})()
+})();

--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -126,4 +125,4 @@ class HttpClient {
 const HttpClientPrototype = HttpClient.prototype;
 
 return { createHttpClient, HttpClient, HttpClientPrototype };
-})()
+})();

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -25,7 +24,9 @@ const { HTTP_TOKEN_CODE_POINT_RE } = core.loadExtScript(
   "ext:deno_web/00_infra.js",
 );
 const { URL } = core.loadExtScript("ext:deno_web/00_url.js");
-const { extractBody, mixinBody } = core.loadExtScript("ext:deno_fetch/22_body.js");
+const { extractBody, mixinBody } = core.loadExtScript(
+  "ext:deno_fetch/22_body.js",
+);
 const { getLocationHref } = core.loadExtScript("ext:deno_web/12_location.js");
 const { extractMimeType } = core.loadExtScript("ext:deno_web/01_mimesniff.js");
 const { blobFromObjectUrl } = core.loadExtScript("ext:deno_web/09_file.js");
@@ -36,7 +37,9 @@ const {
   headerListFromHeaders,
   headersFromHeaderList,
 } = core.loadExtScript("ext:deno_fetch/20_headers.js");
-const { HttpClientPrototype } = core.loadExtScript("ext:deno_fetch/22_http_client.js");
+const { HttpClientPrototype } = core.loadExtScript(
+  "ext:deno_fetch/22_http_client.js",
+);
 const {
   createDependentAbortSignal,
   newSignal,
@@ -640,4 +643,4 @@ return {
   RequestPrototype,
   toInnerRequest,
 };
-})()
+})();

--- a/ext/fetch/23_response.js
+++ b/ext/fetch/23_response.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -13,7 +12,9 @@ const {
   regexMatcher,
   serializeJSValueToJSONString,
 } = core.loadExtScript("ext:deno_web/00_infra.js");
-const { extractBody, mixinBody } = core.loadExtScript("ext:deno_fetch/22_body.js");
+const { extractBody, mixinBody } = core.loadExtScript(
+  "ext:deno_fetch/22_body.js",
+);
 const { getLocationHref } = core.loadExtScript("ext:deno_web/12_location.js");
 const { extractMimeType } = core.loadExtScript("ext:deno_web/01_mimesniff.js");
 const { URL } = core.loadExtScript("ext:deno_web/00_url.js");
@@ -525,4 +526,4 @@ return {
   ResponsePrototype,
   toInnerResponse,
 };
-})()
+})();

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -39,8 +38,12 @@ const {
   ReadableStreamPrototype,
   resourceForReadableStream,
 } = core.loadExtScript("ext:deno_web/06_streams.js");
-const { extractBody, InnerBody } = core.loadExtScript("ext:deno_fetch/22_body.js");
-const { processUrlList, Request, toInnerRequest } = core.loadExtScript("ext:deno_fetch/23_request.js");
+const { extractBody, InnerBody } = core.loadExtScript(
+  "ext:deno_fetch/22_body.js",
+);
+const { processUrlList, Request, toInnerRequest } = core.loadExtScript(
+  "ext:deno_fetch/23_request.js",
+);
 const {
   abortedNetworkError,
   fromInnerResponse,
@@ -366,7 +369,9 @@ function fetch(input, init = { __proto__: null }) {
 
       if (span) {
         const context = ContextManager.active();
-        for (const propagator of new SafeArrayIterator(__telemetry.PROPAGATORS)) {
+        for (
+          const propagator of new SafeArrayIterator(__telemetry.PROPAGATORS)
+        ) {
           propagator.inject(context, requestObject.headers, {
             set(carrier, key, value) {
               carrier.append(key, value);
@@ -462,12 +467,12 @@ function fetch(input, init = { __proto__: null }) {
         }
       });
       return (async function fetch() {
-        try {
-          await opPromise;
-          return result;
-        } finally {
-          span?.end();
-        }
+      try {
+        await opPromise;
+        return result;
+      } finally {
+        span?.end();
+      }
       })();
     }
     // We need to end the span when the promise settles.
@@ -597,4 +602,4 @@ function handleWasmStreaming(source, rid) {
 }
 
 return { fetch, handleWasmStreaming, mainFetch };
-})()
+})();

--- a/ext/fetch/27_eventsource.js
+++ b/ext/fetch/27_eventsource.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -409,4 +408,4 @@ webidl.converters.EventSourceInit = webidl.createDictionaryConverter(
 );
 
 return { EventSource, TextLineStream };
-})()
+})();

--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -579,4 +578,4 @@ return {
   UnsafePointer,
   UnsafePointerView,
 };
-})()
+})();

--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -971,4 +970,4 @@ return {
   writeTextFile,
   writeTextFileSync,
 };
-})()
+})();

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -1219,4 +1218,4 @@ return {
   upgradeHttpRaw,
   upgradeHttpRawConnect,
 };
-})()
+})();

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -404,4 +403,4 @@ function serveHttp(conn) {
 }
 
 return { HttpConn, serveHttp };
-})()
+})();

--- a/ext/http/02_websocket.ts
+++ b/ext/http/02_websocket.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -301,4 +300,4 @@ internals.buildCaseInsensitiveCommaValueFinder =
   buildCaseInsensitiveCommaValueFinder;
 
 return { _ws, upgradeWebSocket };
-})()
+})();

--- a/ext/io/12_io.js
+++ b/ext/io/12_io.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 // Interfaces 100% copied from Go.
 // Documentation liberally lifted from them too.
@@ -268,4 +267,4 @@ return {
   write,
   writeSync,
 };
-})()
+})();

--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -953,4 +952,4 @@ async function doAtomicWriteInPlace(
 }
 
 return { AtomicOperation, Kv, KvListIterator, KvU64, openKv };
-})()
+})();

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -761,4 +760,4 @@ return {
   validatePort,
   VsockConn,
 };
-})()
+})();

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -25,7 +24,9 @@ const {
   SymbolFor,
 } = primordials;
 
-const { Conn, Listener, validatePort } = core.loadExtScript("ext:deno_net/01_net.js");
+const { Conn, Listener, validatePort } = core.loadExtScript(
+  "ext:deno_net/01_net.js",
+);
 
 const _getPeerCertificate = Symbol("getPeerCertificate");
 
@@ -267,4 +268,4 @@ return {
   TlsConn,
   TlsListener,
 };
-})()
+})();

--- a/ext/node/polyfills/_util/os.ts
+++ b/ext/node/polyfills/_util/os.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core } = globalThis.__bootstrap;
@@ -21,4 +20,4 @@ const isLinux = osType === "linux" || osType === "android";
 const isMacOS = osType === "darwin";
 
 return { osType, isAndroid, isWindows, isLinux, isMacOS };
-})()
+})();

--- a/ext/node/polyfills/_utils.ts
+++ b/ext/node/polyfills/_utils.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -20,7 +19,9 @@ const { TextDecoder, TextEncoder } = core.loadExtScript(
 );
 const { errorMap } = core.loadExtScript("ext:deno_node/internal_binding/uv.ts");
 const { codes } = core.loadExtScript("ext:deno_node/internal/error_codes.ts");
-const { ERR_NOT_IMPLEMENTED } = core.loadExtScript("ext:deno_node/internal/errors.ts");
+const { ERR_NOT_IMPLEMENTED } = core.loadExtScript(
+  "ext:deno_node/internal/errors.ts",
+);
 const { validateNumber } = core.loadExtScript(
   "ext:deno_node/internal/validators.mjs",
 );
@@ -187,4 +188,4 @@ return {
   getSystemErrorName,
   getSystemErrorMessage,
 };
-})()
+})();

--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -2202,15 +2202,15 @@ function blitBuffer(src, dst, offset, byteLength = Infinity) {
 }
 
 const hexSliceLookupTable = function () {
-  const alphabet = "0123456789abcdef";
-  const table = [];
-  for (let i = 0; i < 16; ++i) {
-    const i16 = i * 16;
-    for (let j = 0; j < 16; ++j) {
-      table[i16 + j] = alphabet[i] + alphabet[j];
-    }
+const alphabet = "0123456789abcdef";
+const table = [];
+for (let i = 0; i < 16; ++i) {
+  const i16 = i * 16;
+  for (let j = 0; j < 16; ++j) {
+    table[i16 + j] = alphabet[i] + alphabet[j];
   }
-  return table;
+}
+return table;
 }();
 
 export function readUInt48LE(buf, offset = 0) {

--- a/ext/node/polyfills/internal/crypto/_keys.ts
+++ b/ext/node/polyfills/internal/crypto/_keys.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 // This file is here because to break a circular dependency between streams and
 // crypto.
@@ -9,7 +8,9 @@
 
 (function () {
 const { core } = globalThis.__bootstrap;
-const { kKeyObject } = core.loadExtScript("ext:deno_node/internal/crypto/constants.ts");
+const { kKeyObject } = core.loadExtScript(
+  "ext:deno_node/internal/crypto/constants.ts",
+);
 
 const kKeyType = Symbol("kKeyType");
 
@@ -26,4 +27,4 @@ function isCryptoKey(obj) {
 }
 
 return { kKeyType, isKeyObject, isCryptoKey };
-})()
+})();

--- a/ext/node/polyfills/internal/crypto/constants.ts
+++ b/ext/node/polyfills/internal/crypto/constants.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
-// deno-fmt-ignore-file
 
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
@@ -14,4 +13,4 @@ const kKeyObject = Symbol("kKeyObject");
 internals.kKeyObject = kKeyObject;
 
 return { kHandle, kKeyObject };
-})()
+})();

--- a/ext/node/polyfills/internal/error_codes.ts
+++ b/ext/node/polyfills/internal/error_codes.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 // Lazily initializes the error classes in this object.
 // This trick is necessary for avoiding circular dendencies between
@@ -9,4 +8,4 @@
 const codes: Record<string, any> = {};
 
 return { codes };
-})()
+})();

--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // Copyright Node.js contributors. All rights reserved. MIT License.
-// deno-fmt-ignore-file
 
 /** NOT IMPLEMENTED
  * ERR_MANIFEST_ASSERT_INTEGRITY
@@ -64,7 +63,9 @@ const {
   URIError,
   URIErrorPrototype,
 } = primordials;
-const { format, inspect } = core.loadExtScript("ext:deno_node/internal/util/inspect.mjs");
+const { format, inspect } = core.loadExtScript(
+  "ext:deno_node/internal/util/inspect.mjs",
+);
 const { codes } = core.loadExtScript("ext:deno_node/internal/error_codes.ts");
 const {
   codeMap,
@@ -73,7 +74,9 @@ const {
   UV_EBADF,
 } = core.loadExtScript("ext:deno_node/internal_binding/uv.ts");
 const { isWindows } = core.loadExtScript("ext:deno_node/_util/os.ts");
-const { os: osConstants } = core.loadExtScript("ext:deno_node/internal_binding/constants.ts");
+const { os: osConstants } = core.loadExtScript(
+  "ext:deno_node/internal_binding/constants.ts",
+);
 const { hideStackFrames } = core.loadExtScript(
   "ext:deno_node/internal/hide_stack_frames.ts",
 );
@@ -82,7 +85,8 @@ const { hideStackFrames } = core.loadExtScript(
 let _getSystemErrorName;
 function getSystemErrorName(code) {
   if (!_getSystemErrorName) {
-    _getSystemErrorName = core.loadExtScript("ext:deno_node/_utils.ts").getSystemErrorName;
+    _getSystemErrorName =
+      core.loadExtScript("ext:deno_node/_utils.ts").getSystemErrorName;
   }
   return _getSystemErrorName(code);
 }
@@ -442,8 +446,7 @@ class NodeError extends NodeErrorAbstraction {
   }
 }
 
-class NodeSyntaxError extends NodeErrorAbstraction
-  implements SyntaxError {
+class NodeSyntaxError extends NodeErrorAbstraction implements SyntaxError {
   constructor(code: string, message: string) {
     super(SyntaxError.prototype.name, code, message);
     ObjectSetPrototypeOf(this, SyntaxErrorPrototype);
@@ -1173,8 +1176,7 @@ class ERR_DOMAIN_CALLBACK_NOT_AVAILABLE extends NodeError {
   }
 }
 
-class ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE
-  extends NodeError {
+class ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE extends NodeError {
   constructor() {
     super(
       "ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE",
@@ -1977,8 +1979,7 @@ class ERR_QUICSOCKET_DESTROYED extends NodeError {
     );
   }
 }
-class ERR_QUICSOCKET_INVALID_STATELESS_RESET_SECRET_LENGTH
-  extends NodeError {
+class ERR_QUICSOCKET_INVALID_STATELESS_RESET_SECRET_LENGTH extends NodeError {
   constructor() {
     super(
       "ERR_QUICSOCKET_INVALID_STATELESS_RESET_SECRET_LENGTH",
@@ -3744,4 +3745,4 @@ return {
     uvExceptionWithHostPort,
   },
 };
-})()
+})();

--- a/ext/node/polyfills/internal/errors/error_source.ts
+++ b/ext/node/polyfills/internal/errors/error_source.ts
@@ -1,10 +1,9 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // Copyright Node.js contributors. All rights reserved. MIT License.
-// deno-fmt-ignore-file
 
 (function () {
 const { core } = globalThis.__bootstrap;
 const { op_node_get_first_expression } = core.ops;
 
 return { getErrorSourceExpression: op_node_get_first_expression };
-})()
+})();

--- a/ext/node/polyfills/internal/hide_stack_frames.ts
+++ b/ext/node/polyfills/internal/hide_stack_frames.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { primordials } = globalThis.__bootstrap;
@@ -40,4 +39,4 @@ function hideStackFrames<T extends GenericFunction = GenericFunction>(
 }
 
 return { hideStackFrames };
-})()
+})();

--- a/ext/node/polyfills/internal/normalize_encoding.ts
+++ b/ext/node/polyfills/internal/normalize_encoding.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { primordials } = globalThis.__bootstrap;
@@ -78,4 +77,4 @@ function slowCases(enc) {
 }
 
 return { normalizeEncoding };
-})()
+})();

--- a/ext/node/polyfills/internal/primordials.mjs
+++ b/ext/node/polyfills/internal/primordials.mjs
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 // deno-lint-ignore-file prefer-primordials
 
@@ -21,17 +20,13 @@ const ObjectHasOwn = Object.hasOwn;
 const RegExpPrototypeTest = (that, ...args) => that.test(...args);
 const RegExpPrototypeExec = RegExp.prototype.exec;
 const StringFromCharCode = String.fromCharCode;
-const StringPrototypeCharCodeAt = (that, ...args) =>
-  that.charCodeAt(...args);
-const StringPrototypeEndsWith = (that, ...args) =>
-  that.endsWith(...args);
-const StringPrototypeIncludes = (that, ...args) =>
-  that.includes(...args);
+const StringPrototypeCharCodeAt = (that, ...args) => that.charCodeAt(...args);
+const StringPrototypeEndsWith = (that, ...args) => that.endsWith(...args);
+const StringPrototypeIncludes = (that, ...args) => that.includes(...args);
 const StringPrototypeReplace = (that, ...args) => that.replace(...args);
 const StringPrototypeSlice = (that, ...args) => that.slice(...args);
 const StringPrototypeSplit = (that, ...args) => that.split(...args);
-const StringPrototypeStartsWith = (that, ...args) =>
-  that.startsWith(...args);
+const StringPrototypeStartsWith = (that, ...args) => that.startsWith(...args);
 const StringPrototypeToUpperCase = (that) => that.toUpperCase();
 
 return {
@@ -61,4 +56,4 @@ return {
   StringPrototypeStartsWith,
   StringPrototypeToUpperCase,
 };
-})()
+})();

--- a/ext/node/polyfills/internal/streams/duplexify.js
+++ b/ext/node/polyfills/internal/streams/duplexify.js
@@ -240,18 +240,18 @@ function fromAsyncGen(fn) {
   const signal = ac.signal;
   const value = fn(
     async function* () {
-      while (true) {
-        const _promise = promise;
-        promise = null;
-        const { chunk, done, cb } = await _promise;
-        process.nextTick(cb);
-        if (done) return;
-        if (signal.aborted) {
-          throw new AbortError(undefined, { cause: signal.reason });
-        }
-        ({ promise, resolve } = PromiseWithResolvers());
-        yield chunk;
+    while (true) {
+      const _promise = promise;
+      promise = null;
+      const { chunk, done, cb } = await _promise;
+      process.nextTick(cb);
+      if (done) return;
+      if (signal.aborted) {
+        throw new AbortError(undefined, { cause: signal.reason });
       }
+      ({ promise, resolve } = PromiseWithResolvers());
+      yield chunk;
+    }
     }(),
     { signal },
   );

--- a/ext/node/polyfills/internal/util.mjs
+++ b/ext/node/polyfills/internal/util.mjs
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -10,8 +9,12 @@ const {
   ObjectCreate,
   StringPrototypeToUpperCase,
 } = core.loadExtScript("ext:deno_node/internal/primordials.mjs");
-const { ERR_UNKNOWN_SIGNAL } = core.loadExtScript("ext:deno_node/internal/errors.ts");
-const { os } = core.loadExtScript("ext:deno_node/internal_binding/constants.ts");
+const { ERR_UNKNOWN_SIGNAL } = core.loadExtScript(
+  "ext:deno_node/internal/errors.ts",
+);
+const { os } = core.loadExtScript(
+  "ext:deno_node/internal_binding/constants.ts",
+);
 const { validateFunction } = core.loadExtScript(
   "ext:deno_node/internal/validators.mjs",
 );
@@ -311,4 +314,4 @@ return {
     sleep,
   },
 };
-})()
+})();

--- a/ext/node/polyfills/internal/util/inspect.mjs
+++ b/ext/node/polyfills/internal/util/inspect.mjs
@@ -19,7 +19,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -728,4 +727,4 @@ return {
     styleText,
   },
 };
-})()
+})();

--- a/ext/node/polyfills/internal/util/types.ts
+++ b/ext/node/polyfills/internal/util/types.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 //
 // Adapted from Node.js. Copyright Joyent, Inc. and other Node contributors.
 //
@@ -24,7 +23,9 @@
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
-const bindingTypes = core.loadExtScript("ext:deno_node/internal_binding/types.ts");
+const bindingTypes = core.loadExtScript(
+  "ext:deno_node/internal_binding/types.ts",
+);
 const cryptoKeys = core.loadExtScript("ext:deno_node/internal/crypto/_keys.ts");
 const {
   ArrayBufferIsView,
@@ -174,4 +175,4 @@ return {
   isWeakMap,
   isWeakSet,
 };
-})()
+})();

--- a/ext/node/polyfills/internal/validators.mjs
+++ b/ext/node/polyfills/internal/validators.mjs
@@ -1,6 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -23,8 +22,12 @@ const {
 } = primordials;
 
 const { codes } = core.loadExtScript("ext:deno_node/internal/error_codes.ts");
-const { hideStackFrames } = core.loadExtScript("ext:deno_node/internal/hide_stack_frames.ts");
-const { isArrayBufferView } = core.loadExtScript("ext:deno_node/internal/util/types.ts");
+const { hideStackFrames } = core.loadExtScript(
+  "ext:deno_node/internal/hide_stack_frames.ts",
+);
+const { isArrayBufferView } = core.loadExtScript(
+  "ext:deno_node/internal/util/types.ts",
+);
 
 /**
  * @param {number} value
@@ -233,7 +236,9 @@ const validateOneOf = hideStackFrames((value, name, oneOf) => {
 });
 
 function validateEncoding(data, encoding) {
-  const { normalizeEncoding } = core.loadExtScript("ext:deno_node/internal/normalize_encoding.ts");
+  const { normalizeEncoding } = core.loadExtScript(
+    "ext:deno_node/internal/normalize_encoding.ts",
+  );
   const normalizedEncoding = normalizeEncoding(encoding);
   const length = data.length;
 
@@ -493,4 +498,4 @@ return {
   validateUint32,
   validateUnion,
 };
-})()
+})();

--- a/ext/node/polyfills/internal_binding/_libuv_winerror.ts
+++ b/ext/node/polyfills/internal_binding/_libuv_winerror.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core } = globalThis.__bootstrap;
@@ -10,4 +9,4 @@ function uvTranslateSysError(sysErrno: number): string {
 }
 
 return { uvTranslateSysError };
-})()
+})();

--- a/ext/node/polyfills/internal_binding/constants.ts
+++ b/ext/node/polyfills/internal_binding/constants.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { primordials } = globalThis.__bootstrap;
@@ -896,4 +895,4 @@ const trace = {
 } as const;
 
 return { os, fs, crypto, zlib, trace };
-})()
+})();

--- a/ext/node/polyfills/internal_binding/types.ts
+++ b/ext/node/polyfills/internal_binding/types.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 //
 // Adapted from Node.js. Copyright Joyent, Inc. and other Node contributors.
 //
@@ -85,4 +84,4 @@ return {
   isWeakMap,
   isWeakSet,
 };
-})()
+})();

--- a/ext/node/polyfills/internal_binding/uv.ts
+++ b/ext/node/polyfills/internal_binding/uv.ts
@@ -19,7 +19,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-// deno-fmt-ignore-file
 
 // This module ports:
 // - https://github.com/nodejs/node/blob/master/src/uv.cc
@@ -33,7 +32,9 @@
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const { osType } = core.loadExtScript("ext:deno_node/_util/os.ts");
-const { uvTranslateSysError } = core.loadExtScript("ext:deno_node/internal_binding/_libuv_winerror.ts");
+const { uvTranslateSysError } = core.loadExtScript(
+  "ext:deno_node/internal_binding/_libuv_winerror.ts",
+);
 const { Error } = primordials;
 
 // In Node these values are coming from libuv:
@@ -590,4 +591,4 @@ return {
   getErrorMap,
   getCodeMap,
 };
-})()
+})();

--- a/ext/os/30_os.js
+++ b/ext/os/30_os.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -162,4 +161,4 @@ return {
   systemMemoryInfo,
   uid,
 };
-})()
+})();

--- a/ext/os/40_signals.js
+++ b/ext/os/40_signals.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
@@ -82,4 +81,4 @@ async function loop(sigData) {
 }
 
 return { addSignalListener, removeSignalListener };
-})()
+})();

--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -848,4 +847,4 @@ return {
   spawnAndWait,
   spawnAndWaitSync,
 };
-})()
+})();

--- a/ext/telemetry/telemetry.ts
+++ b/ext/telemetry/telemetry.ts
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
@@ -1939,7 +1938,9 @@ const otelState = {
   TRACING_ENABLED: false,
   METRICS_ENABLED: false,
   PROPAGATORS: [] as TextMapPropagator[],
-  getOtelSpan: undefined as ((span: object) => OtelSpan | null | undefined) | undefined,
+  getOtelSpan: undefined as
+    | ((span: object) => OtelSpan | null | undefined)
+    | undefined,
 };
 
 // Keep module-level variables in sync with otelState for internal use
@@ -1968,4 +1969,4 @@ return {
   bootstrap: wrappedBootstrap,
   telemetry,
 };
-})()
+})();

--- a/ext/telemetry/util.ts
+++ b/ext/telemetry/util.ts
@@ -1,12 +1,15 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { internals, primordials } = globalThis.__bootstrap;
 
 const { String, StringPrototypeSlice } = primordials;
 
-type Span = { updateName(name: string): void; setAttribute(key: string, value: string): void; setStatus(status: { code: number; message: string }): void };
+type Span = {
+  updateName(name: string): void;
+  setAttribute(key: string, value: string): void;
+  setStatus(status: { code: number; message: string }): void;
+};
 
 function updateSpanFromRequest(span: Span, request: Request) {
   span.updateName(request.method);
@@ -82,4 +85,4 @@ return {
   updateSpanFromServerResponse,
   updateSpanFromError,
 };
-})()
+})();

--- a/ext/web/00_infra.js
+++ b/ext/web/00_infra.js
@@ -6,7 +6,6 @@
 /// <reference path="../web/internal.d.ts" />
 /// <reference path="../../cli/tsc/dts/lib.deno_web.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
 const {
@@ -503,4 +502,4 @@ return {
   serializeJSValueToJSONString,
   SymbolMetadata,
 };
-})()
+})();

--- a/ext/web/00_url.js
+++ b/ext/web/00_url.js
@@ -5,7 +5,6 @@
 /// <reference path="../../core/lib.deno_core.d.ts" />
 /// <reference path="../webidl/internal.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -36,7 +35,9 @@ const {
 } = primordials;
 
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
-const { createFilteredInspectProxy } = core.loadExtScript("ext:deno_web/01_console.js");
+const { createFilteredInspectProxy } = core.loadExtScript(
+  "ext:deno_web/01_console.js",
+);
 
 const _list = Symbol("list");
 const _urlObject = Symbol("url object");
@@ -907,4 +908,4 @@ return {
   URLSearchParams,
   URLSearchParamsPrototype,
 };
-})()
+})();

--- a/ext/web/01_broadcast_channel.js
+++ b/ext/web/01_broadcast_channel.js
@@ -2,7 +2,6 @@
 
 /// <reference path="../../core/internal.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -22,7 +21,9 @@ const {
 } = primordials;
 
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
-const { createFilteredInspectProxy } = core.loadExtScript("ext:deno_web/01_console.js");
+const { createFilteredInspectProxy } = core.loadExtScript(
+  "ext:deno_web/01_console.js",
+);
 const {
   defineEventHandler,
   EventTarget,
@@ -200,4 +201,4 @@ defineEventHandler(BroadcastChannel.prototype, "messageerror");
 const BroadcastChannelPrototype = BroadcastChannel.prototype;
 
 return { BroadcastChannel, refBroadcastChannel };
-})()
+})();

--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -2,7 +2,6 @@
 
 /// <reference path="../../core/internal.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
 const {
@@ -2096,15 +2095,15 @@ function formatError(err, constructor, tag, ctx, keys) {
 }
 
 const hexSliceLookupTable = function () {
-  const alphabet = "0123456789abcdef";
-  const table = [];
-  for (let i = 0; i < 16; ++i) {
-    const i16 = i * 16;
-    for (let j = 0; j < 16; ++j) {
-      table[i16 + j] = alphabet[i] + alphabet[j];
-    }
+const alphabet = "0123456789abcdef";
+const table = [];
+for (let i = 0; i < 16; ++i) {
+  const i16 = i * 16;
+  for (let j = 0; j < 16; ++j) {
+    table[i16 + j] = alphabet[i] + alphabet[j];
   }
-  return table;
+}
+return table;
 }();
 
 function hexSlice(buf, start, end) {
@@ -4149,4 +4148,4 @@ return {
   stripVTControlCharacters,
   styles,
 };
-})()
+})();

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -7,8 +7,6 @@
 /// <reference path="../web/internal.d.ts" />
 /// <reference path="../../cli/tsc/dts/lib.deno_web.d.ts" />
 
-// deno-fmt-ignore-file
-
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -327,4 +325,4 @@ return {
   QuotaExceededError,
   QuotaExceededErrorPrototype,
 };
-})()
+})();

--- a/ext/web/01_mimesniff.js
+++ b/ext/web/01_mimesniff.js
@@ -6,7 +6,6 @@
 /// <reference path="../web/internal.d.ts" />
 /// <reference path="../../cli/tsc/dts/lib.deno_web.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -450,4 +449,4 @@ return {
   serializeMimeType,
   sniffImage,
 };
-})()
+})();

--- a/ext/web/01_urlpattern.js
+++ b/ext/web/01_urlpattern.js
@@ -7,8 +7,6 @@
 /// <reference path="./internal.d.ts" />
 /// <reference path="../../cli/tsc/dts/lib.deno_url.d.ts" />
 
-// deno-fmt-ignore-file
-
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -488,4 +486,4 @@ webidl.converters.URLPatternOptions = webidl
   ]);
 
 return { URLPattern, urlPatternSettings };
-})()
+})();

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -5,8 +5,6 @@
 // parts still exists.  This means you will observe a lot of strange structures
 // and impossible logic branches based on what Deno currently supports.
 
-// deno-fmt-ignore-file
-
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -1603,4 +1601,4 @@ return {
   setIsTrusted,
   setTarget,
 };
-})()
+})();

--- a/ext/web/02_structured_clone.js
+++ b/ext/web/02_structured_clone.js
@@ -6,7 +6,6 @@
 /// <reference path="../web/internal.d.ts" />
 /// <reference path="../../cli/tsc/dts/lib.deno_web.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -146,4 +145,4 @@ function structuredClone(value) {
 }
 
 return { structuredClone };
-})()
+})();

--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -1,7 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-// deno-fmt-ignore-file
-
 // Web timers (setTimeout/setInterval) built on top of Node's Timeout class.
 // The Node Timeout class is the canonical timer implementation that wraps
 // core.createTimer. Web timers add WHATWG-specific behavior on top:
@@ -157,4 +155,4 @@ return {
   setTimeout,
   unrefTimer,
 };
-})()
+})();

--- a/ext/web/03_abort_signal.js
+++ b/ext/web/03_abort_signal.js
@@ -3,7 +3,6 @@
 // @ts-check
 /// <reference path="../../core/internal.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -24,7 +23,9 @@ const {
 
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
 const { assert } = core.loadExtScript("ext:deno_web/00_infra.js");
-const { createFilteredInspectProxy } = core.loadExtScript("ext:deno_web/01_console.js");
+const { createFilteredInspectProxy } = core.loadExtScript(
+  "ext:deno_web/01_console.js",
+);
 const {
   defineEventHandler,
   Event,
@@ -427,4 +428,4 @@ return {
   signalAbort,
   timerId,
 };
-})()
+})();

--- a/ext/web/04_global_interfaces.js
+++ b/ext/web/04_global_interfaces.js
@@ -3,7 +3,6 @@
 // @ts-check
 /// <reference path="../../core/internal.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -83,4 +82,4 @@ return {
   WorkerGlobalScope,
   workerGlobalScopeConstructorDescriptor,
 };
-})()
+})();

--- a/ext/web/05_base64.js
+++ b/ext/web/05_base64.js
@@ -6,8 +6,6 @@
 /// <reference path="../web/internal.d.ts" />
 /// <reference lib="esnext" />
 
-// deno-fmt-ignore-file
-
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const { op_base64_atob, op_base64_btoa } = core.ops;
@@ -62,4 +60,4 @@ function btoa(data) {
 }
 
 return { atob, btoa };
-})()
+})();

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -6,7 +6,6 @@
 /// <reference path="../../cli/tsc/dts/lib.deno_web.d.ts" />
 /// <reference lib="esnext" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
 const {
@@ -93,7 +92,9 @@ const {
 } = primordials;
 
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
-const { structuredClone } = core.loadExtScript("ext:deno_web/02_structured_clone.js");
+const { structuredClone } = core.loadExtScript(
+  "ext:deno_web/02_structured_clone.js",
+);
 const {
   AbortSignalPrototype,
   add,
@@ -102,8 +103,12 @@ const {
   signalAbort,
 } = core.loadExtScript("ext:deno_web/03_abort_signal.js");
 
-const { createFilteredInspectProxy } = core.loadExtScript("ext:deno_web/01_console.js");
-const { assert, AssertionError } = core.loadExtScript("ext:deno_web/00_infra.js");
+const { createFilteredInspectProxy } = core.loadExtScript(
+  "ext:deno_web/01_console.js",
+);
+const { assert, AssertionError } = core.loadExtScript(
+  "ext:deno_web/00_infra.js",
+);
 
 /** @template T */
 class Deferred {
@@ -7320,4 +7325,4 @@ return {
   WritableStreamDefaultWriter,
   writableStreamForRid,
 };
-})()
+})();

--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -9,7 +9,6 @@
 /// <reference path="../../cli/tsc/dts/lib.deno_web.d.ts" />
 /// <reference lib="esnext" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -47,7 +46,9 @@ const {
 } = primordials;
 
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
-const { createFilteredInspectProxy } = core.loadExtScript("ext:deno_web/01_console.js");
+const { createFilteredInspectProxy } = core.loadExtScript(
+  "ext:deno_web/01_console.js",
+);
 
 class TextDecoder {
   /** @type {string} */
@@ -584,4 +585,4 @@ return {
   TextEncoder,
   TextEncoderStream,
 };
-})()
+})();

--- a/ext/web/09_file.js
+++ b/ext/web/09_file.js
@@ -10,7 +10,6 @@
 /// <reference path="./internal.d.ts" />
 /// <reference lib="esnext" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -61,7 +60,9 @@ const {
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
 const { ReadableStream } = core.loadExtScript("ext:deno_web/06_streams.js");
 const { URL } = core.loadExtScript("ext:deno_web/00_url.js");
-const { createFilteredInspectProxy } = core.loadExtScript("ext:deno_web/01_console.js");
+const { createFilteredInspectProxy } = core.loadExtScript(
+  "ext:deno_web/01_console.js",
+);
 
 // TODO(lucacasonato): this needs to not be hardcoded and instead depend on
 // host os.
@@ -739,4 +740,4 @@ return {
   getParts,
   isBlob,
 };
-})()
+})();

--- a/ext/web/10_filereader.js
+++ b/ext/web/10_filereader.js
@@ -10,7 +10,6 @@
 /// <reference path="./internal.d.ts" />
 /// <reference lib="esnext" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const { op_encode_binary_string } = core.ops;
@@ -36,10 +35,18 @@ const {
 } = primordials;
 
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
-const { createFilteredInspectProxy } = core.loadExtScript("ext:deno_web/01_console.js");
-const { forgivingBase64Encode } = core.loadExtScript("ext:deno_web/00_infra.js");
-const { EventTarget, ProgressEvent } = core.loadExtScript("ext:deno_web/02_event.js");
-const { decode, TextDecoder } = core.loadExtScript("ext:deno_web/08_text_encoding.js");
+const { createFilteredInspectProxy } = core.loadExtScript(
+  "ext:deno_web/01_console.js",
+);
+const { forgivingBase64Encode } = core.loadExtScript(
+  "ext:deno_web/00_infra.js",
+);
+const { EventTarget, ProgressEvent } = core.loadExtScript(
+  "ext:deno_web/02_event.js",
+);
+const { decode, TextDecoder } = core.loadExtScript(
+  "ext:deno_web/08_text_encoding.js",
+);
 const { parseMimeType } = core.loadExtScript("ext:deno_web/01_mimesniff.js");
 const { DOMException } = core.loadExtScript("ext:deno_web/01_dom_exception.js");
 
@@ -514,4 +521,4 @@ function makeWrappedHandler(handler) {
 }
 
 return { FileReader };
-})()
+})();

--- a/ext/web/12_location.js
+++ b/ext/web/12_location.js
@@ -2,7 +2,6 @@
 
 /// <reference path="../../core/internal.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -441,4 +440,4 @@ return {
   workerLocationConstructorDescriptor,
   workerLocationDescriptor,
 };
-})()
+})();

--- a/ext/web/13_message_port.js
+++ b/ext/web/13_message_port.js
@@ -6,8 +6,6 @@
 /// <reference path="./internal.d.ts" />
 /// <reference path="../../cli/tsc/dts/lib.deno_web.d.ts" />
 
-// deno-fmt-ignore-file
-
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -688,4 +686,4 @@ return {
   structuredClone,
   unrefParentPort,
 };
-})()
+})();

--- a/ext/web/14_compression.js
+++ b/ext/web/14_compression.js
@@ -5,7 +5,6 @@
 /// <reference path="./internal.d.ts" />
 /// <reference path="../../cli/tsc/dts/lib.deno_web.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -20,7 +19,9 @@ const {
 } = primordials;
 
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
-const { createFilteredInspectProxy } = core.loadExtScript("ext:deno_web/01_console.js");
+const { createFilteredInspectProxy } = core.loadExtScript(
+  "ext:deno_web/01_console.js",
+);
 const { TransformStream } = core.loadExtScript("ext:deno_web/06_streams.js");
 
 webidl.converters.CompressionFormat = webidl.createEnumConverter(
@@ -164,4 +165,4 @@ webidl.configureInterface(DecompressionStream);
 const DecompressionStreamPrototype = DecompressionStream.prototype;
 
 return { CompressionStream, DecompressionStream };
-})()
+})();

--- a/ext/web/15_performance.js
+++ b/ext/web/15_performance.js
@@ -1,7 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-// deno-fmt-ignore-file
-
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const { op_now, op_time_origin } = core.ops;
@@ -838,4 +836,4 @@ return {
   PerformanceObserverEntryList,
   setTimeOrigin,
 };
-})()
+})();

--- a/ext/web/16_image_data.js
+++ b/ext/web/16_image_data.js
@@ -1,11 +1,12 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
 const { DOMException } = core.loadExtScript("ext:deno_web/01_dom_exception.js");
-const { createFilteredInspectProxy } = core.loadExtScript("ext:deno_web/01_console.js");
+const { createFilteredInspectProxy } = core.loadExtScript(
+  "ext:deno_web/01_console.js",
+);
 const {
   ObjectPrototypeIsPrototypeOf,
   Symbol,
@@ -264,4 +265,4 @@ class ImageData {
 const ImageDataPrototype = ImageData.prototype;
 
 return { _data, _height, _width, ImageData, ImageDataPrototype };
-})()
+})();

--- a/ext/webgpu/00_init.js
+++ b/ext/webgpu/00_init.js
@@ -1,5 +1,4 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-// deno-fmt-ignore-file
 
 (function () {
 const { core } = globalThis.__bootstrap;
@@ -7,4 +6,4 @@ const { core } = globalThis.__bootstrap;
 const loadWebGPU = core.createLazyLoader("ext:deno_webgpu/01_webgpu.js");
 
 return { loadWebGPU };
-})()
+})();

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -6,7 +6,6 @@
 
 /// <reference path="../../core/internal.d.ts" />
 
-// deno-fmt-ignore-file
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
@@ -1472,4 +1471,4 @@ return {
   setlikeObjectWrap,
   type,
 };
-})()
+})();

--- a/ext/webstorage/01_webstorage.js
+++ b/ext/webstorage/01_webstorage.js
@@ -2,8 +2,6 @@
 
 /// <reference path="../../core/internal.d.ts" />
 
-// deno-fmt-ignore-file
-
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const { op_webstorage_iterate_keys, Storage } = core.ops;
@@ -128,4 +126,4 @@ function sessionStorage() {
 }
 
 return { localStorage, sessionStorage, Storage };
-})()
+})();

--- a/libs/core/modules/testdata/lazy_script.js
+++ b/libs/core/modules/testdata/lazy_script.js
@@ -1,9 +1,9 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 (function () {
-  const foo = "foo";
-  const bar = 123;
-  function blah(a) {
-    Deno.core.print(a);
-  }
-  return { foo, bar, blah };
+const foo = "foo";
+const bar = 123;
+function blah(a) {
+  Deno.core.print(a);
+}
+return { foo, bar, blah };
 })();

--- a/libs/core/modules/testdata/lazy_script_dep.js
+++ b/libs/core/modules/testdata/lazy_script_dep.js
@@ -1,5 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 (function () {
-  const utils = Deno.core.loadExtScript("ext:test_ext/lazy_script.js");
-  return { fromDep: true, utils };
+const utils = Deno.core.loadExtScript("ext:test_ext/lazy_script.js");
+return { fromDep: true, utils };
 })();

--- a/libs/core_testing/unit/type_test.ts
+++ b/libs/core_testing/unit/type_test.ts
@@ -11,7 +11,7 @@ test(function testIsAnyArrayBuffer() {
 test(function testIsArgumentsObject() {
   let args: IArguments;
   (function () {
-    args = arguments;
+  args = arguments;
   })();
   assert(Deno.core.isArgumentsObject(args));
   assert(!Deno.core.isArgumentsObject({}));

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -437,7 +437,7 @@ fn permissions_trace() {
       test_util::assertions::assert_wildcard_match(&text, concat!(
       "┏ ⚠️  Deno requests sys access to \"hostname\".\r\n",
       "┠─ Requested by `Deno.hostname()` API.\r\n",
-      "┃  ├─ Object.hostname (ext:deno_os/30_os.js:45:10)\r\n",
+      "┃  ├─ Object.hostname (ext:deno_os/30_os.js:44:10)\r\n",
       "┃  ├─ foo (file://[WILDCARD]/run/permissions_trace.ts:2:8)\r\n",
       "┃  ├─ bar (file://[WILDCARD]/run/permissions_trace.ts:6:3)\r\n",
       "┃  └─ file://[WILDCARD]/run/permissions_trace.ts:9:1\r\n",

--- a/tests/specs/run/dom_readable_stream_from/main.ts
+++ b/tests/specs/run/dom_readable_stream_from/main.ts
@@ -1,4 +1,4 @@
 const asyncIterable = (async function* () {
-  yield* [1, 2, 3];
+yield* [1, 2, 3];
 })();
 console.log(ReadableStream.from(asyncIterable));

--- a/tests/specs/run/finalization_registry/finalization_registry.js
+++ b/tests/specs/run/finalization_registry/finalization_registry.js
@@ -12,9 +12,9 @@ const registry = new FinalizationRegistry((value) => {
 });
 
 (function () {
-  let x = {};
-  registry.register(x, "called!");
-  x = null;
+let x = {};
+registry.register(x, "called!");
+x = null;
 })();
 
 gc();

--- a/tests/testdata/run/no_validate_asm.js
+++ b/tests/testdata/run/no_validate_asm.js
@@ -2,19 +2,19 @@
 // are non-existent in the source.
 
 const _asmJsModule = function () {
-  "use asm";
+"use asm";
 
-  function func(
-    x,
-  ) {
-    x = +x; // cast to float
+function func(
+  x,
+) {
+  x = +x; // cast to float
 
-    ~x;
-    // asmjs error: `~` is only valid on integers
-    // should not log to stdout with --no-validate-asm
-  }
+  ~x;
+  // asmjs error: `~` is only valid on integers
+  // should not log to stdout with --no-validate-asm
+}
 
-  return {
-    f: func,
-  };
+return {
+  f: func,
+};
 }();

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -2227,8 +2227,8 @@ Deno.test(
 
 Deno.test("fetch async iterable", async () => {
   const iterable = (async function* () {
-    yield new Uint8Array([1, 2, 3, 4, 5]);
-    yield new Uint8Array([6, 7, 8, 9, 10]);
+  yield new Uint8Array([1, 2, 3, 4, 5]);
+  yield new Uint8Array([6, 7, 8, 9, 10]);
   })();
   const res = new Response(iterable);
   const actual = await res.bytes();
@@ -2238,8 +2238,8 @@ Deno.test("fetch async iterable", async () => {
 
 Deno.test("fetch iterable", async () => {
   const iterable = (function* () {
-    yield new Uint8Array([1, 2, 3, 4, 5]);
-    yield new Uint8Array([6, 7, 8, 9, 10]);
+  yield new Uint8Array([1, 2, 3, 4, 5]);
+  yield new Uint8Array([6, 7, 8, 9, 10]);
   })();
   const res = new Response(iterable);
   const actual = await res.bytes();

--- a/tests/unit/globals_test.ts
+++ b/tests/unit/globals_test.ts
@@ -136,10 +136,10 @@ Deno.test(async function arrayFromAsync() {
   // Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync#examples
   // Thank you.
   const asyncIterable = (async function* () {
-    for (let i = 0; i < 5; i++) {
-      await new Promise((resolve) => setTimeout(resolve, 10 * i));
-      yield i;
-    }
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10 * i));
+    yield i;
+  }
   })();
 
   const a = await Array.fromAsync(asyncIterable);


### PR DESCRIPTION
## Summary

- Bumps dprint-plugin-typescript from 0.95.15 to 0.96.0
- Enables the new `functionExpression.flatIife` option
- Removes all `// deno-fmt-ignore-file` directives from IIFE-wrapped lazy-loaded scripts

### Background

During the lazy-loaded script conversions (ext/ IIFE rewrites), we had to add `// deno-fmt-ignore-file` to every converted file because dprint would indent the entire IIFE body by 2 spaces, producing massive diffs.

dprint-plugin-typescript 0.96.0 (released today) adds the `functionExpression.flatIife` option (dprint/dprint-plugin-typescript#781) which tells the formatter to not indent the body of `(function () { ... })()` patterns. This lets us remove all the ignore directives while keeping the flat indentation style.

## Test plan

- [x] `cargo check` passes
- [x] Verified IIFE files are formatted correctly (no unwanted indentation)
- [ ] CI passes