### PR TITLE
fix(ext/cache): add Cache.keys

### DIFF
--- a/cli/tsc/dts/lib.deno_cache.d.ts
+++ b/cli/tsc/dts/lib.deno_cache.d.ts
@@ -53,6 +53,14 @@ interface Cache {
     options?: CacheQueryOptions,
   ): Promise<Response | undefined>;
   /**
+   * Return the requests that match the provided request, or all requests in
+   * the cache if no request is provided.
+   */
+  keys(
+    request?: RequestInfo | URL,
+    options?: CacheQueryOptions,
+  ): Promise<Request[]>;
+  /**
    * Delete cache object matching the provided request.
    *
    * How is the API different from browsers?

--- a/ext/cache/01_cache.js
+++ b/ext/cache/01_cache.js
@@ -5,6 +5,7 @@
 const { core, primordials } = globalThis.__bootstrap;
 const {
   op_cache_delete,
+  op_cache_keys,
   op_cache_match,
   op_cache_put,
   op_cache_storage_delete,
@@ -224,6 +225,65 @@ class Cache {
     }
   }
 
+  /** See https://w3c.github.io/ServiceWorker/#cache-keys */
+  async keys(request = undefined, options = undefined) {
+    webidl.assertBranded(this, CachePrototype);
+    const prefix = "Failed to execute 'keys' on 'Cache'";
+    let convertedRequest = request;
+    if (request !== undefined) {
+      convertedRequest = webidl.converters["RequestInfo_DOMString"](
+        request,
+        prefix,
+        "Argument 1",
+      );
+    }
+    options = webidl.converters["CacheQueryOptions"](
+      options,
+      prefix,
+      "Argument 2",
+    );
+
+    let requestUrl = null;
+    let requestHeaders = [];
+    if (request !== undefined) {
+      let r = null;
+      if (ObjectPrototypeIsPrototypeOf(RequestPrototype, convertedRequest)) {
+        r = convertedRequest;
+        if (convertedRequest.method !== "GET" && !options.ignoreMethod) {
+          return [];
+        }
+      } else if (
+        typeof convertedRequest === "string" ||
+        ObjectPrototypeIsPrototypeOf(URLPrototype, convertedRequest)
+      ) {
+        r = new Request(convertedRequest);
+      }
+
+      const url = new URL(r.url);
+      url.hash = "";
+      const innerRequest = toInnerRequest(r);
+      // deno-lint-ignore prefer-primordials
+      requestUrl = url.toString();
+      requestHeaders = innerRequest.headerList;
+    }
+
+    const keys = await op_cache_keys({
+      cacheId: this[_id],
+      requestUrl,
+      requestHeaders,
+      options,
+    });
+    const requests = [];
+    for (let i = 0; i < keys.length; ++i) {
+      const key = keys[i];
+      ArrayPrototypePush(
+        requests,
+        new Request(key.requestUrl, { headers: key.requestHeaders }),
+      );
+    }
+    return requests;
+  }
+
   /** See https://w3c.github.io/ServiceWorker/#cache-delete */
   async delete(request, _options) {
     webidl.assertBranded(this, CachePrototype);
@@ -331,6 +391,27 @@ webidl.configureInterface(CacheStorage);
 webidl.configureInterface(Cache);
 const CacheStoragePrototype = CacheStorage.prototype;
 const CachePrototype = Cache.prototype;
+
+webidl.converters["CacheQueryOptions"] = webidl.createDictionaryConverter(
+  "CacheQueryOptions",
+  [
+    {
+      key: "ignoreMethod",
+      converter: webidl.converters.boolean,
+      defaultValue: false,
+    },
+    {
+      key: "ignoreSearch",
+      converter: webidl.converters.boolean,
+      defaultValue: false,
+    },
+    {
+      key: "ignoreVary",
+      converter: webidl.converters.boolean,
+      defaultValue: false,
+    },
+  ],
+);
 
 let cacheStorageStorage;
 function cacheStorage() {

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -105,6 +105,7 @@ deno_core::extension!(deno_cache,
     op_cache_storage_keys,
     op_cache_put,
     op_cache_match,
+    op_cache_keys,
     op_cache_delete,
   ],
   lazy_loaded_js = [ "01_cache.js" ],
@@ -134,6 +135,29 @@ pub struct CachePutRequest {
 #[serde(rename_all = "camelCase")]
 pub struct CacheMatchRequest {
   pub cache_id: i64,
+  pub request_url: String,
+  pub request_headers: Vec<(ByteString, ByteString)>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheQueryOptions {
+  pub ignore_search: bool,
+  pub ignore_vary: bool,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheKeysRequest {
+  pub cache_id: i64,
+  pub request_url: Option<String>,
+  pub request_headers: Vec<(ByteString, ByteString)>,
+  pub options: CacheQueryOptions,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheKey {
   pub request_url: String,
   pub request_headers: Vec<(ByteString, ByteString)>,
 }
@@ -223,6 +247,16 @@ impl CacheImpl {
     match self {
       Self::Sqlite(cache) => cache.r#match(request).await,
       Self::Lsc(cache) => cache.r#match(request).await,
+    }
+  }
+
+  pub async fn keys(
+    &self,
+    request: CacheKeysRequest,
+  ) -> Result<Vec<CacheKey>, CacheError> {
+    match self {
+      Self::Sqlite(cache) => cache.keys(request).await,
+      Self::Lsc(cache) => cache.keys(request).await,
     }
   }
 
@@ -362,6 +396,16 @@ pub async fn op_cache_match(
 }
 
 #[op2]
+#[serde]
+pub async fn op_cache_keys(
+  state: Rc<RefCell<OpState>>,
+  #[serde] request: CacheKeysRequest,
+) -> Result<Vec<CacheKey>, CacheError> {
+  let cache = get_cache(&state)?;
+  cache.keys(request).await
+}
+
+#[op2]
 pub async fn op_cache_delete(
   state: Rc<RefCell<OpState>>,
   #[serde] request: CacheDeleteRequest,
@@ -405,6 +449,114 @@ pub fn vary_header_matches(
     }
   }
   true
+}
+
+pub fn cache_key_matches_request(
+  query_request_url: Option<&str>,
+  query_request_headers: &[(ByteString, ByteString)],
+  cached_request_url: &str,
+  cached_request_headers: &[(ByteString, ByteString)],
+  cached_response_headers: &[(ByteString, ByteString)],
+  options: &CacheQueryOptions,
+) -> bool {
+  let Some(query_request_url) = query_request_url else {
+    return true;
+  };
+
+  if !request_url_matches(
+    query_request_url,
+    cached_request_url,
+    options.ignore_search,
+  ) {
+    return false;
+  }
+
+  if !options.ignore_vary
+    && let Some(vary_header) = get_header("vary", cached_response_headers)
+    && !vary_header_matches(
+      &vary_header,
+      query_request_headers,
+      cached_request_headers,
+    )
+  {
+    return false;
+  }
+
+  true
+}
+
+fn request_url_matches(
+  query_request_url: &str,
+  cached_request_url: &str,
+  ignore_search: bool,
+) -> bool {
+  if !ignore_search {
+    return query_request_url == cached_request_url;
+  }
+
+  match (
+    strip_url_query(query_request_url),
+    strip_url_query(cached_request_url),
+  ) {
+    (Some(query_request_url), Some(cached_request_url)) => {
+      query_request_url == cached_request_url
+    }
+    _ => query_request_url == cached_request_url,
+  }
+}
+
+fn strip_url_query(url: &str) -> Option<String> {
+  let mut url = deno_core::url::Url::parse(url).ok()?;
+  url.set_query(None);
+  url.set_fragment(None);
+  Some(url.to_string())
+}
+
+#[test]
+fn test_request_url_matches_ignore_search() {
+  assert!(request_url_matches(
+    "https://deno.com/cache?query=1",
+    "https://deno.com/cache?query=2",
+    true,
+  ));
+  assert!(!request_url_matches(
+    "https://deno.com/cache?query=1",
+    "https://deno.com/cache?query=2",
+    false,
+  ));
+}
+
+#[test]
+fn test_cache_key_matches_request_vary() {
+  let query_request_headers =
+    vec![(ByteString::from("accept"), ByteString::from("text/html"))];
+  let cached_request_headers = vec![(
+    ByteString::from("accept"),
+    ByteString::from("application/json"),
+  )];
+  let cached_response_headers =
+    vec![(ByteString::from("vary"), ByteString::from("accept"))];
+  let options = CacheQueryOptions::default();
+  assert!(!cache_key_matches_request(
+    Some("https://deno.com/cache"),
+    &query_request_headers,
+    "https://deno.com/cache",
+    &cached_request_headers,
+    &cached_response_headers,
+    &options,
+  ));
+  let options = CacheQueryOptions {
+    ignore_vary: true,
+    ..Default::default()
+  };
+  assert!(cache_key_matches_request(
+    Some("https://deno.com/cache"),
+    &query_request_headers,
+    "https://deno.com/cache",
+    &cached_request_headers,
+    &cached_response_headers,
+    &options,
+  ));
 }
 
 #[test]

--- a/ext/cache/lscache.rs
+++ b/ext/cache/lscache.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use async_stream::try_stream;
@@ -21,10 +22,13 @@ use slab::Slab;
 
 use crate::CacheDeleteRequest;
 use crate::CacheError;
+use crate::CacheKey;
+use crate::CacheKeysRequest;
 use crate::CacheMatchRequest;
 use crate::CacheMatchResponseMeta;
 use crate::CachePutRequest;
 use crate::CacheResponseResource;
+use crate::cache_key_matches_request;
 use crate::get_header;
 use crate::get_headers_from_vary_header;
 use crate::lsc_shard::CacheShard;
@@ -35,6 +39,14 @@ const REQHDR_PREFIX: &str = "x-lsc-meta-reqhdr-";
 pub struct LscBackend {
   shard: Rc<RefCell<Option<Rc<CacheShard>>>>,
   id2name: Rc<RefCell<Slab<String>>>,
+  keys: Rc<RefCell<HashMap<String, Vec<LscCacheKey>>>>,
+}
+
+#[derive(Clone)]
+struct LscCacheKey {
+  request_url: String,
+  request_headers: Vec<(ByteString, ByteString)>,
+  response_headers: Vec<(ByteString, ByteString)>,
 }
 
 impl LscBackend {
@@ -157,6 +169,23 @@ impl LscBackend {
     );
     let body = UnsyncBoxBody::new(body);
     shard.put_object(&object_key, headers, body).await?;
+
+    let key = LscCacheKey {
+      request_url: request_response.request_url,
+      request_headers: request_response.request_headers,
+      response_headers: request_response.response_headers,
+    };
+    let mut keys = self.keys.borrow_mut();
+    let cache_keys = keys.entry(cache_name).or_default();
+    if let Some(existing) = cache_keys
+      .iter_mut()
+      .find(|existing| existing.request_url == key.request_url)
+    {
+      *existing = key;
+    } else {
+      cache_keys.push(key);
+    }
+
     Ok(())
   }
 
@@ -264,6 +293,48 @@ impl LscBackend {
     Ok(Some((meta, Some(body))))
   }
 
+  pub async fn keys(
+    &self,
+    request: CacheKeysRequest,
+  ) -> Result<Vec<CacheKey>, CacheError> {
+    let Some(_shard) = self.shard.borrow().as_ref().cloned() else {
+      return Err(CacheError::NotAvailable);
+    };
+
+    let Some(cache_name) = self
+      .id2name
+      .borrow()
+      .get(request.cache_id as usize)
+      .cloned()
+    else {
+      return Err(CacheError::NotFound);
+    };
+
+    let keys = self.keys.borrow();
+    let Some(cache_keys) = keys.get(&cache_name) else {
+      return Ok(Vec::new());
+    };
+
+    let mut result = Vec::new();
+    for key in cache_keys {
+      if cache_key_matches_request(
+        request.request_url.as_deref(),
+        &request.request_headers,
+        &key.request_url,
+        &key.request_headers,
+        &key.response_headers,
+        &request.options,
+      ) {
+        result.push(CacheKey {
+          request_url: key.request_url.clone(),
+          request_headers: key.request_headers.clone(),
+        });
+      }
+    }
+
+    Ok(result)
+  }
+
   pub async fn delete(
     &self,
     request: CacheDeleteRequest,
@@ -280,6 +351,7 @@ impl LscBackend {
     else {
       return Err(CacheError::NotFound);
     };
+    let request_url = request.request_url.clone();
     let object_key = build_cache_object_key(
       cache_name.as_bytes(),
       request.request_url.as_bytes(),
@@ -298,6 +370,9 @@ impl LscBackend {
       )?,
     );
     shard.put_object_empty(&object_key, headers).await?;
+    if let Some(cache_keys) = self.keys.borrow_mut().get_mut(&cache_name) {
+      cache_keys.retain(|key| key.request_url != request_url);
+    }
     Ok(true)
   }
 }

--- a/ext/cache/lscache.rs
+++ b/ext/cache/lscache.rs
@@ -10,13 +10,19 @@ use bytes::Bytes;
 use deno_core::BufMutView;
 use deno_core::ByteString;
 use deno_core::Resource;
+use deno_core::serde::Deserialize;
+use deno_core::serde::Serialize;
+use deno_core::serde_json;
 use deno_core::unsync::spawn;
+use deno_error::JsErrorBox;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use http::HeaderMap;
 use http::HeaderName;
 use http::HeaderValue;
 use http::header::VARY;
+use http_body_util::BodyExt;
+use http_body_util::Full;
 use http_body_util::combinators::UnsyncBoxBody;
 use slab::Slab;
 
@@ -39,14 +45,99 @@ const REQHDR_PREFIX: &str = "x-lsc-meta-reqhdr-";
 pub struct LscBackend {
   shard: Rc<RefCell<Option<Rc<CacheShard>>>>,
   id2name: Rc<RefCell<Slab<String>>>,
-  keys: Rc<RefCell<HashMap<String, Vec<LscCacheKey>>>>,
+  keys: Rc<RefCell<HashMap<String, LscCacheKeys>>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct LscCacheKey {
   request_url: String,
   request_headers: Vec<(ByteString, ByteString)>,
   response_headers: Vec<(ByteString, ByteString)>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PersistedLscCacheKey {
+  request_url: String,
+  request_headers: Vec<(Vec<u8>, Vec<u8>)>,
+  response_headers: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+impl From<&LscCacheKey> for PersistedLscCacheKey {
+  fn from(key: &LscCacheKey) -> Self {
+    Self {
+      request_url: key.request_url.clone(),
+      request_headers: key
+        .request_headers
+        .iter()
+        .map(|(name, value)| (name.to_vec(), value.to_vec()))
+        .collect(),
+      response_headers: key
+        .response_headers
+        .iter()
+        .map(|(name, value)| (name.to_vec(), value.to_vec()))
+        .collect(),
+    }
+  }
+}
+
+impl From<PersistedLscCacheKey> for LscCacheKey {
+  fn from(key: PersistedLscCacheKey) -> Self {
+    Self {
+      request_url: key.request_url,
+      request_headers: key
+        .request_headers
+        .into_iter()
+        .map(|(name, value)| (ByteString::from(name), ByteString::from(value)))
+        .collect(),
+      response_headers: key
+        .response_headers
+        .into_iter()
+        .map(|(name, value)| (ByteString::from(name), ByteString::from(value)))
+        .collect(),
+    }
+  }
+}
+
+#[derive(Clone, Default)]
+struct LscCacheKeys {
+  order: Vec<String>,
+  entries: HashMap<String, LscCacheKey>,
+}
+
+impl LscCacheKeys {
+  fn insert(&mut self, key: LscCacheKey) {
+    let request_url = key.request_url.clone();
+    if !self.entries.contains_key(&request_url) {
+      self.order.push(request_url.clone());
+    }
+    self.entries.insert(request_url, key);
+  }
+
+  fn remove(&mut self, request_url: &str) -> bool {
+    if self.entries.remove(request_url).is_some() {
+      self.order.retain(|url| url != request_url);
+      true
+    } else {
+      false
+    }
+  }
+
+  fn iter(&self) -> impl Iterator<Item = &LscCacheKey> {
+    self.order.iter().filter_map(|url| self.entries.get(url))
+  }
+
+  fn from_keys(keys: Vec<LscCacheKey>) -> Self {
+    let mut result = Self::default();
+    for key in keys {
+      result.insert(key);
+    }
+    result
+  }
+
+  #[cfg(test)]
+  fn to_vec(&self) -> Vec<LscCacheKey> {
+    self.iter().cloned().collect()
+  }
 }
 
 impl LscBackend {
@@ -66,7 +157,14 @@ impl LscBackend {
     if cache_name.is_empty() {
       return Err(CacheError::EmptyName);
     }
-    let id = self.id2name.borrow_mut().insert(cache_name);
+    let maybe_shard = self.shard.borrow().as_ref().cloned();
+    let cache_keys = if let Some(shard) = maybe_shard {
+      load_cache_keys(&shard, &cache_name).await?
+    } else {
+      LscCacheKeys::default()
+    };
+    let id = self.id2name.borrow_mut().insert(cache_name.clone());
+    self.keys.borrow_mut().insert(cache_name, cache_keys);
     Ok(id as i64)
   }
 
@@ -175,16 +273,14 @@ impl LscBackend {
       request_headers: request_response.request_headers,
       response_headers: request_response.response_headers,
     };
-    let mut keys = self.keys.borrow_mut();
-    let cache_keys = keys.entry(cache_name).or_default();
-    if let Some(existing) = cache_keys
-      .iter_mut()
-      .find(|existing| existing.request_url == key.request_url)
-    {
-      *existing = key;
-    } else {
-      cache_keys.push(key);
-    }
+    let cache_keys = {
+      let keys = self.keys.borrow();
+      let mut cache_keys = keys.get(&cache_name).cloned().unwrap_or_default();
+      cache_keys.insert(key);
+      cache_keys
+    };
+    persist_cache_keys(&shard, &cache_name, &cache_keys).await?;
+    self.keys.borrow_mut().insert(cache_name, cache_keys);
 
     Ok(())
   }
@@ -316,7 +412,7 @@ impl LscBackend {
     };
 
     let mut result = Vec::new();
-    for key in cache_keys {
+    for key in cache_keys.iter() {
       if cache_key_matches_request(
         request.request_url.as_deref(),
         &request.request_headers,
@@ -370,8 +466,22 @@ impl LscBackend {
       )?,
     );
     shard.put_object_empty(&object_key, headers).await?;
-    if let Some(cache_keys) = self.keys.borrow_mut().get_mut(&cache_name) {
-      cache_keys.retain(|key| key.request_url != request_url);
+    let cache_keys = {
+      let keys = self.keys.borrow();
+      if let Some(cache_keys) = keys.get(&cache_name).cloned() {
+        let mut cache_keys = cache_keys;
+        if cache_keys.remove(&request_url) {
+          Some(cache_keys)
+        } else {
+          None
+        }
+      } else {
+        None
+      }
+    };
+    if let Some(cache_keys) = cache_keys {
+      persist_cache_keys(&shard, &cache_name, &cache_keys).await?;
+      self.keys.borrow_mut().insert(cache_name, cache_keys);
     }
     Ok(true)
   }
@@ -413,7 +523,320 @@ fn vary_header_matches(
 fn build_cache_object_key(cache_name: &[u8], request_url: &[u8]) -> String {
   format!(
     "v1/{}/{}",
-    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(cache_name),
-    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(request_url),
+    encode_key_part(cache_name),
+    encode_key_part(request_url),
   )
+}
+
+fn build_cache_keys_object_key(cache_name: &[u8]) -> String {
+  format!("v1/{}/metadata/keys", encode_key_part(cache_name))
+}
+
+fn encode_key_part(value: &[u8]) -> String {
+  base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(value)
+}
+
+async fn load_cache_keys(
+  shard: &CacheShard,
+  cache_name: &str,
+) -> Result<LscCacheKeys, CacheError> {
+  let object_key = build_cache_keys_object_key(cache_name.as_bytes());
+  let Some(res) = shard.get_object(&object_key).await? else {
+    return Ok(LscCacheKeys::default());
+  };
+  if res.headers().contains_key("x-lsc-meta-deleted-at") {
+    return Ok(LscCacheKeys::default());
+  }
+  let body = res.into_body().collect().await?.to_bytes();
+  let keys: Vec<PersistedLscCacheKey> =
+    serde_json::from_slice(&body).map_err(json_error)?;
+  Ok(LscCacheKeys::from_keys(
+    keys.into_iter().map(Into::into).collect(),
+  ))
+}
+
+async fn persist_cache_keys(
+  shard: &CacheShard,
+  cache_name: &str,
+  cache_keys: &LscCacheKeys,
+) -> Result<(), CacheError> {
+  let keys = cache_keys
+    .iter()
+    .map(PersistedLscCacheKey::from)
+    .collect::<Vec<_>>();
+  let body = serde_json::to_vec(&keys).map_err(json_error)?;
+  let body = Full::new(Bytes::from(body)).map_err(|err| match err {});
+  let body = UnsyncBoxBody::new(body);
+  let mut headers = HeaderMap::new();
+  headers.insert(
+    HeaderName::from_bytes(b"content-type")?,
+    HeaderValue::from_bytes(b"application/json")?,
+  );
+  shard
+    .put_object(
+      &build_cache_keys_object_key(cache_name.as_bytes()),
+      headers,
+      body,
+    )
+    .await
+}
+
+fn json_error(err: serde_json::Error) -> CacheError {
+  CacheError::Other(JsErrorBox::generic(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+  use std::convert::Infallible;
+  use std::sync::Arc;
+  use std::sync::Mutex;
+
+  use hyper::Method;
+  use hyper::Request;
+  use hyper::Response;
+  use hyper::StatusCode;
+  use hyper::body::Incoming;
+  use hyper::service::service_fn;
+  use hyper_util::rt::TokioIo;
+
+  use super::*;
+
+  #[derive(Clone)]
+  struct StoredObject {
+    headers: HeaderMap,
+    body: Bytes,
+  }
+
+  type StoredObjects = Arc<Mutex<HashMap<String, StoredObject>>>;
+
+  fn lsc_cache_key(request_url: &str) -> LscCacheKey {
+    LscCacheKey {
+      request_url: request_url.to_string(),
+      request_headers: vec![(
+        ByteString::from("accept"),
+        ByteString::from("*/*"),
+      )],
+      response_headers: vec![(
+        ByteString::from("content-type"),
+        ByteString::from("text/plain"),
+      )],
+    }
+  }
+
+  fn cache_keys_request(cache_id: i64) -> CacheKeysRequest {
+    CacheKeysRequest {
+      cache_id,
+      request_url: None,
+      request_headers: Vec::new(),
+      options: Default::default(),
+    }
+  }
+
+  fn cache_put_request(cache_id: i64, request_url: &str) -> CachePutRequest {
+    CachePutRequest {
+      cache_id,
+      request_url: request_url.to_string(),
+      request_headers: vec![(
+        ByteString::from("accept"),
+        ByteString::from("*/*"),
+      )],
+      response_headers: vec![(
+        ByteString::from("content-type"),
+        ByteString::from("text/plain"),
+      )],
+      response_status: 200,
+      response_status_text: "OK".to_string(),
+      response_rid: None,
+    }
+  }
+
+  async fn start_lsc_object_server() -> String {
+    let objects = Arc::new(Mutex::new(HashMap::new()));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+      while let Ok((stream, _)) = listener.accept().await {
+        let objects = objects.clone();
+        tokio::spawn(async move {
+          let service = service_fn(move |req| {
+            handle_lsc_object_request(req, objects.clone())
+          });
+          let io = TokioIo::new(stream);
+          let _ = hyper::server::conn::http1::Builder::new()
+            .serve_connection(io, service)
+            .await;
+        });
+      }
+    });
+    endpoint
+  }
+
+  async fn handle_lsc_object_request(
+    req: Request<Incoming>,
+    objects: StoredObjects,
+  ) -> Result<Response<Full<Bytes>>, Infallible> {
+    let Some(object_key) = req.uri().path().strip_prefix("/objects/") else {
+      return Ok(response(StatusCode::NOT_FOUND, HeaderMap::new(), None));
+    };
+    let object_key = object_key.to_string();
+
+    match *req.method() {
+      Method::GET => {
+        let Some(object) = objects.lock().unwrap().get(&object_key).cloned()
+        else {
+          return Ok(response(StatusCode::NOT_FOUND, HeaderMap::new(), None));
+        };
+        Ok(response(StatusCode::OK, object.headers, Some(object.body)))
+      }
+      Method::PUT => {
+        let headers = req
+          .headers()
+          .iter()
+          .filter(|(name, _)| {
+            !matches!(
+              name.as_str(),
+              "authorization" | "host" | "content-length"
+            )
+          })
+          .map(|(name, value)| (name.clone(), value.clone()))
+          .collect();
+        let body = req.into_body().collect().await.unwrap().to_bytes();
+        objects
+          .lock()
+          .unwrap()
+          .insert(object_key, StoredObject { headers, body });
+        Ok(response(StatusCode::OK, HeaderMap::new(), None))
+      }
+      _ => Ok(response(
+        StatusCode::METHOD_NOT_ALLOWED,
+        HeaderMap::new(),
+        None,
+      )),
+    }
+  }
+
+  fn response(
+    status: StatusCode,
+    headers: HeaderMap,
+    body: Option<Bytes>,
+  ) -> Response<Full<Bytes>> {
+    let mut response = Response::builder().status(status);
+    for (name, value) in headers {
+      if let Some(name) = name {
+        response = response.header(name, value);
+      }
+    }
+    response.body(Full::new(body.unwrap_or_default())).unwrap()
+  }
+
+  #[test]
+  fn lsc_cache_keys_replace_without_reordering() {
+    let mut keys = LscCacheKeys::default();
+    keys.insert(lsc_cache_key("https://example.com/a"));
+    keys.insert(lsc_cache_key("https://example.com/b"));
+    let mut replacement = lsc_cache_key("https://example.com/a");
+    replacement.request_headers = vec![(
+      ByteString::from("accept"),
+      ByteString::from("application/json"),
+    )];
+    keys.insert(replacement);
+
+    assert_eq!(
+      keys
+        .iter()
+        .map(|key| key.request_url.as_str())
+        .collect::<Vec<_>>(),
+      vec!["https://example.com/a", "https://example.com/b"]
+    );
+    assert_eq!(keys.entries.len(), 2);
+    assert_eq!(
+      keys.entries["https://example.com/a"].request_headers,
+      vec![(
+        ByteString::from("accept"),
+        ByteString::from("application/json")
+      )]
+    );
+  }
+
+  #[test]
+  fn lsc_cache_keys_serde_roundtrip() {
+    let mut keys = LscCacheKeys::default();
+    keys.insert(lsc_cache_key("https://example.com/a"));
+    keys.insert(lsc_cache_key("https://example.com/b"));
+
+    let serialized = serde_json::to_vec(
+      &keys
+        .iter()
+        .map(PersistedLscCacheKey::from)
+        .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    let deserialized: Vec<PersistedLscCacheKey> =
+      serde_json::from_slice(&serialized).unwrap();
+    let keys = LscCacheKeys::from_keys(
+      deserialized.into_iter().map(Into::into).collect(),
+    );
+
+    assert_eq!(
+      keys.to_vec(),
+      vec![
+        lsc_cache_key("https://example.com/a"),
+        lsc_cache_key("https://example.com/b")
+      ]
+    );
+  }
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn lsc_cache_keys_survive_backend_reopen() {
+    let shard = Rc::new(CacheShard::new(
+      start_lsc_object_server().await,
+      "test-token".to_string(),
+    ));
+    let backend = LscBackend::default();
+    backend.set_shard(shard.clone());
+    let cache_id = backend.storage_open("cache-v1".to_string()).await.unwrap();
+    backend
+      .put(cache_put_request(cache_id, "https://example.com/a"), None)
+      .await
+      .unwrap();
+    backend
+      .put(cache_put_request(cache_id, "https://example.com/b"), None)
+      .await
+      .unwrap();
+
+    let restarted_backend = LscBackend::default();
+    restarted_backend.set_shard(shard.clone());
+    let restarted_cache_id = restarted_backend
+      .storage_open("cache-v1".to_string())
+      .await
+      .unwrap();
+    let keys = restarted_backend
+      .keys(cache_keys_request(restarted_cache_id))
+      .await
+      .unwrap();
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0].request_url, "https://example.com/a");
+    assert_eq!(keys[1].request_url, "https://example.com/b");
+
+    restarted_backend
+      .delete(CacheDeleteRequest {
+        cache_id: restarted_cache_id,
+        request_url: "https://example.com/a".to_string(),
+      })
+      .await
+      .unwrap();
+
+    let reopened_after_delete = LscBackend::default();
+    reopened_after_delete.set_shard(shard);
+    let reopened_cache_id = reopened_after_delete
+      .storage_open("cache-v1".to_string())
+      .await
+      .unwrap();
+    let keys = reopened_after_delete
+      .keys(cache_keys_request(reopened_cache_id))
+      .await
+      .unwrap();
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0].request_url, "https://example.com/b");
+  }
 }

--- a/ext/cache/sqlite.rs
+++ b/ext/cache/sqlite.rs
@@ -133,10 +133,10 @@ impl SqliteBackedCache {
     let cache_storage_dir = self.cache_storage_dir.clone();
     spawn_blocking(move || {
       let db = db.lock();
-      let inserted = db.execute(
+      db.execute(
         "INSERT OR IGNORE INTO cache_storage (cache_name) VALUES (?1)",
         params![cache_name],
-      )? > 0;
+      )?;
       let cache_id = db.query_row(
         "SELECT id FROM cache_storage WHERE cache_name = ?1",
         params![cache_name],
@@ -145,12 +145,6 @@ impl SqliteBackedCache {
           Ok(id)
         },
       )?;
-      if inserted {
-        db.execute(
-          "DELETE FROM request_response_list WHERE cache_id = ?1",
-          params![cache_id],
-        )?;
-      }
       let responses_dir = get_responses_dir(cache_storage_dir, cache_id);
       #[allow(
         clippy::disallowed_methods,

--- a/ext/cache/sqlite.rs
+++ b/ext/cache/sqlite.rs
@@ -21,10 +21,13 @@ use tokio::io::AsyncWriteExt;
 
 use crate::CacheDeleteRequest;
 use crate::CacheError;
+use crate::CacheKey;
+use crate::CacheKeysRequest;
 use crate::CacheMatchRequest;
 use crate::CacheMatchResponseMeta;
 use crate::CachePutRequest;
 use crate::CacheResponseResource;
+use crate::cache_key_matches_request;
 use crate::deserialize_headers;
 use crate::get_header;
 use crate::serialize_headers;
@@ -130,10 +133,10 @@ impl SqliteBackedCache {
     let cache_storage_dir = self.cache_storage_dir.clone();
     spawn_blocking(move || {
       let db = db.lock();
-      db.execute(
+      let inserted = db.execute(
         "INSERT OR IGNORE INTO cache_storage (cache_name) VALUES (?1)",
         params![cache_name],
-      )?;
+      )? > 0;
       let cache_id = db.query_row(
         "SELECT id FROM cache_storage WHERE cache_name = ?1",
         params![cache_name],
@@ -142,6 +145,12 @@ impl SqliteBackedCache {
           Ok(id)
         },
       )?;
+      if inserted {
+        db.execute(
+          "DELETE FROM request_response_list WHERE cache_id = ?1",
+          params![cache_id],
+        )?;
+      }
       let responses_dir = get_responses_dir(cache_storage_dir, cache_id);
       #[allow(
         clippy::disallowed_methods,
@@ -195,6 +204,10 @@ impl SqliteBackedCache {
         )
         .optional()?;
       if let Some(cache_id) = maybe_cache_id {
+        db.execute(
+          "DELETE FROM request_response_list WHERE cache_id = ?1",
+          params![cache_id],
+        )?;
         let cache_dir = cache_storage_dir.join(cache_id.to_string());
         #[allow(
           clippy::disallowed_methods,
@@ -363,6 +376,51 @@ impl SqliteBackedCache {
       Some((cache_meta, None)) => Ok(Some((cache_meta, None))),
       None => Ok(None),
     }
+  }
+
+  pub async fn keys(
+    &self,
+    request: CacheKeysRequest,
+  ) -> Result<Vec<CacheKey>, CacheError> {
+    let db = self.connection.clone();
+    spawn_blocking(move || {
+      let db = db.lock();
+      let mut stmt = db.prepare(
+        "SELECT request_url, request_headers, response_headers
+             FROM request_response_list
+             WHERE cache_id = ?1
+             ORDER BY id",
+      )?;
+      let rows = stmt.query_map(params![request.cache_id], |row| {
+        let request_url: String = row.get(0)?;
+        let request_headers: Vec<u8> = row.get(1)?;
+        let response_headers: Vec<u8> = row.get(2)?;
+        let request_headers: Vec<(ByteString, ByteString)> =
+          deserialize_headers(&request_headers);
+        let response_headers: Vec<(ByteString, ByteString)> =
+          deserialize_headers(&response_headers);
+        Ok((request_url, request_headers, response_headers))
+      })?;
+      let mut keys = Vec::new();
+      for row in rows {
+        let (request_url, request_headers, response_headers) = row?;
+        if cache_key_matches_request(
+          request.request_url.as_deref(),
+          &request.request_headers,
+          &request_url,
+          &request_headers,
+          &response_headers,
+          &request.options,
+        ) {
+          keys.push(CacheKey {
+            request_url,
+            request_headers,
+          });
+        }
+      }
+      Ok::<Vec<CacheKey>, CacheError>(keys)
+    })
+    .await?
   }
 
   pub async fn delete(

--- a/tests/unit/cache_api_test.ts
+++ b/tests/unit/cache_api_test.ts
@@ -127,6 +127,111 @@ Deno.test(async function cacheApi() {
   assertFalse(await caches.has(cacheName));
 });
 
+Deno.test(async function cacheKeys() {
+  const cacheName = "cache-keys";
+  await caches.delete(cacheName);
+  const cache = await caches.open(cacheName);
+
+  assertEquals(typeof cache.keys, "function");
+  assertEquals(await cache.keys(), []);
+
+  await cache.put(
+    new Request("https://example.com/a", {
+      headers: { "X-Test": "one" },
+    }),
+    new Response("a"),
+  );
+  await cache.put("https://example.com/b?x=1", new Response("b"));
+  await cache.put(
+    new Request("https://example.com/vary", {
+      headers: { "Accept": "application/json" },
+    }),
+    new Response("vary", {
+      headers: { "Vary": "Accept" },
+    }),
+  );
+
+  const all = await cache.keys();
+  assertEquals(all.length, 3);
+  assert(all[0] instanceof Request);
+  assertEquals(all.map((request) => request.url), [
+    "https://example.com/a",
+    "https://example.com/b?x=1",
+    "https://example.com/vary",
+  ]);
+  assertEquals(all[0].headers.get("x-test"), "one");
+
+  const explicitUndefined = await cache.keys(undefined);
+  assertEquals(explicitUndefined.map((request) => request.url), [
+    "https://example.com/a",
+    "https://example.com/b?x=1",
+    "https://example.com/vary",
+  ]);
+
+  const fragmentMatch = await cache.keys("https://example.com/a#frag");
+  assertEquals(fragmentMatch.map((request) => request.url), [
+    "https://example.com/a",
+  ]);
+  const urlMatch = await cache.keys(new URL("https://example.com/a"));
+  assertEquals(urlMatch.map((request) => request.url), [
+    "https://example.com/a",
+  ]);
+
+  assertEquals(await cache.keys("https://example.com/missing"), []);
+
+  const ignoreSearch = await cache.keys("https://example.com/b?x=2", {
+    ignoreSearch: true,
+  });
+  assertEquals(ignoreSearch.map((request) => request.url), [
+    "https://example.com/b?x=1",
+  ]);
+
+  const headRequest = new Request("https://example.com/a", {
+    method: "HEAD",
+  });
+  assertEquals(await cache.keys(headRequest), []);
+  const ignoreMethod = await cache.keys(headRequest, { ignoreMethod: true });
+  assertEquals(ignoreMethod.map((request) => request.url), [
+    "https://example.com/a",
+  ]);
+
+  assertEquals(await cache.keys("https://example.com/vary"), []);
+  assertEquals(
+    await cache.keys(
+      new Request("https://example.com/vary", {
+        headers: { "Accept": "text/html" },
+      }),
+    ),
+    [],
+  );
+  const varyMatch = await cache.keys(
+    new Request("https://example.com/vary", {
+      headers: { "Accept": "application/json" },
+    }),
+  );
+  assertEquals(varyMatch.map((request) => request.url), [
+    "https://example.com/vary",
+  ]);
+  const ignoreVary = await cache.keys("https://example.com/vary", {
+    ignoreVary: true,
+  });
+  assertEquals(ignoreVary.map((request) => request.url), [
+    "https://example.com/vary",
+  ]);
+
+  assert(await cache.delete("https://example.com/a"));
+  const afterDelete = await cache.keys();
+  assertEquals(afterDelete.map((request) => request.url), [
+    "https://example.com/b?x=1",
+    "https://example.com/vary",
+  ]);
+
+  assert(await caches.delete(cacheName));
+  const recreated = await caches.open(cacheName);
+  assertEquals(await recreated.keys(), []);
+  assert(await caches.delete(cacheName));
+});
+
 Deno.test(async function cacheStorageMatch() {
   const names = ["match-a", "match-b", "match-c"];
   for (const name of names) {

--- a/tests/wpt/runner/expectations/fetch.json
+++ b/tests/wpt/runner/expectations/fetch.json
@@ -1474,8 +1474,8 @@
       "request.any.worker.html": true,
       "general.any.html": true,
       "general.any.worker.html": true,
-      "cache.https.any.html": false,
-      "cache.https.any.worker.html": false,
+      "cache.https.any.html": true,
+      "cache.https.any.worker.html": true,
       "destroyed-context.html": false,
       "keepalive.html": {
         "expectedFailures": [

--- a/tests/wpt/runner/expectations/service-workers.json
+++ b/tests/wpt/runner/expectations/service-workers.json
@@ -90,15 +90,12 @@
       "Cache interface: operation add(RequestInfo)",
       "Cache interface: operation addAll(sequence<RequestInfo>)",
       "Cache interface: operation delete(RequestInfo, optional CacheQueryOptions)",
-      "Cache interface: operation keys(optional RequestInfo, optional CacheQueryOptions)",
       "Cache interface: self.cacheInstance must inherit property \"matchAll(optional RequestInfo, optional CacheQueryOptions)\" with the proper type",
       "Cache interface: calling matchAll(optional RequestInfo, optional CacheQueryOptions) on self.cacheInstance with too few arguments must throw TypeError",
       "Cache interface: self.cacheInstance must inherit property \"add(RequestInfo)\" with the proper type",
       "Cache interface: calling add(RequestInfo) on self.cacheInstance with too few arguments must throw TypeError",
       "Cache interface: self.cacheInstance must inherit property \"addAll(sequence<RequestInfo>)\" with the proper type",
       "Cache interface: calling addAll(sequence<RequestInfo>) on self.cacheInstance with too few arguments must throw TypeError",
-      "Cache interface: self.cacheInstance must inherit property \"keys(optional RequestInfo, optional CacheQueryOptions)\" with the proper type",
-      "Cache interface: calling keys(optional RequestInfo, optional CacheQueryOptions) on self.cacheInstance with too few arguments must throw TypeError",
       "CacheStorage interface: operation match(RequestInfo, optional MultiCacheQueryOptions)",
       "Window interface: attribute caches",
       "Navigator interface: attribute serviceWorker",
@@ -176,15 +173,12 @@
       "Cache interface: operation add(RequestInfo)",
       "Cache interface: operation addAll(sequence<RequestInfo>)",
       "Cache interface: operation delete(RequestInfo, optional CacheQueryOptions)",
-      "Cache interface: operation keys(optional RequestInfo, optional CacheQueryOptions)",
       "Cache interface: self.cacheInstance must inherit property \"matchAll(optional RequestInfo, optional CacheQueryOptions)\" with the proper type",
       "Cache interface: calling matchAll(optional RequestInfo, optional CacheQueryOptions) on self.cacheInstance with too few arguments must throw TypeError",
       "Cache interface: self.cacheInstance must inherit property \"add(RequestInfo)\" with the proper type",
       "Cache interface: calling add(RequestInfo) on self.cacheInstance with too few arguments must throw TypeError",
       "Cache interface: self.cacheInstance must inherit property \"addAll(sequence<RequestInfo>)\" with the proper type",
       "Cache interface: calling addAll(sequence<RequestInfo>) on self.cacheInstance with too few arguments must throw TypeError",
-      "Cache interface: self.cacheInstance must inherit property \"keys(optional RequestInfo, optional CacheQueryOptions)\" with the proper type",
-      "Cache interface: calling keys(optional RequestInfo, optional CacheQueryOptions) on self.cacheInstance with too few arguments must throw TypeError",
       "CacheStorage interface: operation match(RequestInfo, optional MultiCacheQueryOptions)",
       "WorkerGlobalScope interface: attribute caches",
       "WorkerNavigator interface: attribute serviceWorker"
@@ -222,8 +216,16 @@
         "Cache.delete with ignoreSearch option (when it is specified as false)"
       ]
     },
-    "cache-keys.https.any.html": false,
-    "cache-keys.https.any.worker.html": false,
+    "cache-keys.https.any.html": {
+      "expectedFailures": [
+        "Cache.keys without parameters and VARY entries"
+      ]
+    },
+    "cache-keys.https.any.worker.html": {
+      "expectedFailures": [
+        "Cache.keys without parameters and VARY entries"
+      ]
+    },
     "cache-match.https.any.worker.html": {
       "expectedFailures": [
         "Cache.match supports ignoreMethod",


### PR DESCRIPTION
Closes #33783.

## Summary

This implements `Cache.prototype.keys()` for Deno's Cache API. PR #33275 added `CacheStorage.keys()`, but `Cache.keys()` was still undefined, so callers could not list cached requests from an opened cache.

This PR:
- adds the JS/WebIDL surface and Deno cache typings for `Cache.keys()`
- wires `op_cache_keys` through the SQLite and LSC cache backends
- supports request matching behavior for fragments, `ignoreSearch`, `ignoreMethod`, and `ignoreVary`
- clears stale SQLite cache request rows when cache storage entries are deleted or newly recreated
- updates the WPT expectations for the newly supported `Cache.keys()` IDL/tests while preserving the existing same-URL Vary limitation as an expected failure

## Tests

- `cargo check -p deno_cache`
- `cargo test -p deno_cache`
- `cargo build --bin deno`
- `./x test-unit cacheKeys`
- `./x test-unit cache`
- `./x lint-js`
- `./x fmt`
- `cargo fmt --check -p deno_cache`
- `node --check ext/cache/01_cache.js`
- `./tests/wpt/wpt.ts run --binary=./target/debug/deno --quiet -- /service-workers/cache-storage/cache-keys.https.any.html /service-workers/cache-storage/cache-keys.https.any.worker.html`
