### PR TITLE
fix:Implement Cache.prototype.keys() for Deno's Cache API

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,70 @@
+# PR: Implement Cache.prototype.keys() for Deno's Cache API
+
+## Summary
+This PR implements the missing `Cache.prototype.keys()` method for Deno's Cache API. PR #33275 added `CacheStorage.keys()`, but `Cache.keys()` was still undefined, preventing callers from listing cached requests from an opened cache.
+
+## Problem
+Currently, when users try to use `cache.keys()` (where `cache` is an instance obtained via `caches.open()`), they get:
+```javascript
+const cache = await caches.open('test');
+console.log(typeof cache.keys); // 'undefined'
+await cache.keys(); // TypeError: cache.keys is not a function
+```
+
+The `Cache.keys()` method is essential for iterating over cached requests in a specific cache, which is a fundamentally different use case from `CacheStorage.keys()` (which lists cache names).
+
+## Changes
+
+### 1. Rust Backend Changes
+- Added `op_cache_keys` operation to the cache extension
+- Added `CacheKeysRequest` struct for the operation
+- Implemented `keys()` method in `CacheImpl` trait
+- Implemented SQLite backend support: queries `request_url` from `request_response_list` table
+- Implemented LSC backend stub (returns empty list as LSC doesn't support listing keys directly)
+
+### 2. JavaScript/WebIDL Changes
+- Added `op_cache_keys` import in `01_cache.js`
+- Implemented `keys()` method in `Cache` class that:
+  - Calls the Rust operation to get URLs
+  - Converts URLs to `Request` objects (per Web Cache API spec)
+  - Returns array of `Request` objects
+
+### 3. TypeScript Definitions
+- Added `keys(): Promise<Request[]>` method to `Cache` interface in `lib.deno_cache.d.ts`
+
+### 4. Tests
+- Added comprehensive test in `cache_api_test.ts` that:
+  - Tests empty cache returns empty array
+  - Tests cache with entries returns correct `Request` objects
+  - Verifies all expected URLs are present
+
+## API Compatibility
+The implementation follows the [Web Cache API specification](https://w3c.github.io/ServiceWorker/#cache-keys):
+- Returns a `Promise<Request[]>` 
+- Each `Request` in the array represents a cached request
+- The order is implementation-defined (currently insertion order from SQLite)
+
+## Testing
+The implementation includes:
+- Unit test for `Cache.keys()` functionality
+- JavaScript syntax validation
+- TypeScript definition updates
+
+## Branch Name
+`fix-cache-keys-method`
+
+## Commit Message
+```
+fix(cache): implement missing Cache.keys() method
+
+PR #33275 added CacheStorage.keys() but missed Cache.keys() implementation.
+This adds the missing method to allow listing cached requests from an opened cache.
+
+- Add op_cache_keys operation and CacheKeysRequest struct
+- Implement keys() method in CacheImpl trait for SQLite and LSC backends
+- Add keys() method to Cache class in JavaScript
+- Update TypeScript definitions
+- Add unit tests for Cache.keys() functionality
+
+Fixes: # (issue number if applicable)
+```

--- a/cli/tsc/dts/lib.deno_cache.d.ts
+++ b/cli/tsc/dts/lib.deno_cache.d.ts
@@ -63,6 +63,10 @@ interface Cache {
     request: RequestInfo | URL,
     options?: CacheQueryOptions,
   ): Promise<boolean>;
+  /**
+   * Return an array of all request objects stored in the cache.
+   */
+  keys(): Promise<Request[]>;
 }
 
 /** @category Cache */

--- a/ext/cache/01_cache.js
+++ b/ext/cache/01_cache.js
@@ -5,6 +5,7 @@
 const { core, primordials } = globalThis.__bootstrap;
 const {
   op_cache_delete,
+  op_cache_keys,
   op_cache_match,
   op_cache_put,
   op_cache_storage_delete,
@@ -320,6 +321,19 @@ class Cache {
     // Step 5.4-5.5: don't apply in this context.
 
     return responses;
+  }
+
+  async keys() {
+    webidl.assertBranded(this, CachePrototype);
+    const urls = await op_cache_keys({
+      cacheId: this[_id],
+    });
+    // Convert URLs to Request objects
+    const requests = [];
+    for (let i = 0; i < urls.length; ++i) {
+      requests.push(new Request(urls[i]));
+    }
+    return requests;
   }
 
   [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -106,6 +106,7 @@ deno_core::extension!(deno_cache,
     op_cache_put,
     op_cache_match,
     op_cache_delete,
+    op_cache_keys,
   ],
   lazy_loaded_js = [ "01_cache.js" ],
   options = {
@@ -156,6 +157,12 @@ pub struct CacheMatchResponseMeta {
 pub struct CacheDeleteRequest {
   pub cache_id: i64,
   pub request_url: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheKeysRequest {
+  pub cache_id: i64,
 }
 
 #[derive(Clone)]
@@ -233,6 +240,16 @@ impl CacheImpl {
     match self {
       Self::Sqlite(cache) => cache.delete(request).await,
       Self::Lsc(cache) => cache.delete(request).await,
+    }
+  }
+
+  pub async fn keys(
+    &self,
+    request: CacheKeysRequest,
+  ) -> Result<Vec<String>, CacheError> {
+    match self {
+      Self::Sqlite(cache) => cache.keys(request).await,
+      Self::Lsc(cache) => cache.keys(request).await,
     }
   }
 }
@@ -368,6 +385,16 @@ pub async fn op_cache_delete(
 ) -> Result<bool, CacheError> {
   let cache = get_cache(&state)?;
   cache.delete(request).await
+}
+
+#[op2]
+#[serde]
+pub async fn op_cache_keys(
+  state: Rc<RefCell<OpState>>,
+  #[serde] request: CacheKeysRequest,
+) -> Result<Vec<String>, CacheError> {
+  let cache = get_cache(&state)?;
+  cache.keys(request).await
 }
 
 pub fn get_cache(

--- a/ext/cache/lscache.rs
+++ b/ext/cache/lscache.rs
@@ -300,6 +300,28 @@ impl LscBackend {
     shard.put_object_empty(&object_key, headers).await?;
     Ok(true)
   }
+
+  pub async fn keys(
+    &self,
+    request: crate::CacheKeysRequest,
+  ) -> Result<Vec<String>, CacheError> {
+    let Some(shard) = self.shard.borrow().as_ref().cloned() else {
+      return Err(CacheError::NotAvailable);
+    };
+
+    let Some(cache_name) = self
+      .id2name
+      .borrow()
+      .get(request.cache_id as usize)
+      .cloned()
+    else {
+      return Err(CacheError::NotFound);
+    };
+
+    // LSC backend doesn't support listing keys directly
+    // Return empty list for now
+    Ok(Vec::new())
+  }
 }
 impl deno_core::Resource for LscBackend {
   fn name(&self) -> std::borrow::Cow<'_, str> {

--- a/ext/cache/sqlite.rs
+++ b/ext/cache/sqlite.rs
@@ -381,6 +381,26 @@ impl SqliteBackedCache {
     })
     .await?
   }
+
+  pub async fn keys(
+    &self,
+    request: crate::CacheKeysRequest,
+  ) -> Result<Vec<String>, CacheError> {
+    let db = self.connection.clone();
+    spawn_blocking(move || {
+      let db = db.lock();
+      let mut stmt = db.prepare(
+        "SELECT request_url FROM request_response_list WHERE cache_id = ?1 ORDER BY id",
+      )?;
+      let rows = stmt.query_map([request.cache_id], |row| row.get::<_, String>(0))?;
+      let mut urls = Vec::new();
+      for row in rows {
+        urls.push(row?);
+      }
+      Ok::<Vec<String>, CacheError>(urls)
+    })
+    .await?
+  }
 }
 
 async fn insert_cache_asset(

--- a/tests/unit/cache_api_test.ts
+++ b/tests/unit/cache_api_test.ts
@@ -305,3 +305,42 @@ Deno.test(async function cachePutResource() {
   const res = await cache.match(request);
   assertEquals(await res?.text(), "Contents".repeat(1024));
 });
+
+
+Deno.test(async function cacheKeys() {
+  const cacheName = "cache-keys-test";
+  const cache = await caches.open(cacheName);
+  
+  // Test empty cache
+  const emptyKeys = await cache.keys();
+  assertEquals(emptyKeys.length, 0);
+  
+  // Add some entries
+  const urls = [
+    "https://example.com/a",
+    "https://example.com/b",
+    "https://example.com/c",
+  ];
+  
+  for (const url of urls) {
+    await cache.put(url, new Response(`response for ${url}`));
+  }
+  
+  // Get keys
+  const keys = await cache.keys();
+  assertEquals(keys.length, 3);
+  
+  // Verify all keys are Request objects
+  for (const key of keys) {
+    assert(key instanceof Request);
+  }
+  
+  // Verify all expected URLs are present
+  const keyUrls = keys.map((req) => req.url);
+  for (const url of urls) {
+    assert(keyUrls.includes(url), `Expected URL ${url} to be in keys`);
+  }
+  
+  // Clean up
+  assert(await caches.delete(cacheName));
+});


### PR DESCRIPTION
## Summary
This PR implements the missing Cache.prototype.keys() method for Deno's Cache API. PR #33275 added CacheStorage.keys(), but Cache.keys() was still undefined, preventing callers from listing cached requests from an opened cache.
 fixes #33783
## Changes Made
### 1. Rust Backend
-Added op_cache_keys operation to the cache extension
-Added CacheKeysRequest struct
-Implemented keys() method in CacheImpl trait
-SQLite backend: Queries request_url from request_response_list table
-LSC backend: Returns empty list (stub implementation)
### 2.JavaScript/WebIDL
-Added op_cache_keys import in 01_cache.js
-Implemented keys() method in Cache class
-Converts URLs to Request objects per Web Cache API spec
### 3.TypeScript Definitions
-Added keys(): Promise<Request[]> to Cache interface in lib.deno_cache.d.ts

### 4.Tests

Added comprehensive unit test in cache_api_test.ts
Tests empty cache, cache with entries, and proper Request object conversion

## API Compatibility

Follows Web Cache API specification
Returns Promise<Request[]>
Each Request represents a cached request
Order is implementation-defined (currently insertion order)

## Testing

Unit test validates functionality
JavaScript syntax validated
TypeScript definitions updated

The implementation fixes the issue where cache.keys() was undefined despite the PR #33275 claiming to have added both CacheStorage.keys() and Cache.keys() methods.