### PR TITLE
fix(compile): serve default export fetch in standalone

### DIFF
--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -703,14 +703,15 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
 
     denoNs.build.standalone = standalone;
 
+    const autoServeOnMatch = autoServe || standalone;
     let serveIsMain_ = serveIsMain;
     let serveWorkerCountOrIndex_ = serveWorkerCountOrIndex;
-    if (autoServe) {
+    if (autoServeOnMatch) {
       serveIsMain_ = true;
       serveWorkerCountOrIndex_ = 0;
     }
 
-    if (mode === executionModes.serve || autoServe) {
+    if (mode === executionModes.serve || autoServeOnMatch) {
       const hasMultipleThreads = serveIsMain_
         ? serveWorkerCountOrIndex_ > 0 // count > 0
         : true;
@@ -756,7 +757,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
         }
 
         if (serve) {
-          if (mode === executionModes.run && !autoServe) {
+          if (mode === executionModes.run && !autoServeOnMatch) {
             import.meta.log(
               "error",
               `%cwarning: %cDetected %cexport default { fetch }%c, did you mean to run \"deno serve\"?`,
@@ -766,7 +767,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
               "font-weight: normal;",
             );
           }
-          if (mode === executionModes.serve || autoServe) {
+          if (mode === executionModes.serve || autoServeOnMatch) {
             serve({
               servePort,
               serveHost,

--- a/tests/specs/compile/default_export_fetch/__test__.jsonc
+++ b/tests/specs/compile/default_export_fetch/__test__.jsonc
@@ -1,0 +1,33 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "if": "unix",
+      "args": "compile -A --output server main.ts",
+      "output": "compile.out"
+    },
+    {
+      "if": "unix",
+      "commandName": "./server",
+      "args": [],
+      "envs": {
+        "DENO_SERVE_ADDRESS": "tcp:127.0.0.1:0"
+      },
+      "output": "main.out"
+    },
+    {
+      "if": "windows",
+      "args": "compile -A --output server.exe main.ts",
+      "output": "compile.out"
+    },
+    {
+      "if": "windows",
+      "commandName": "./server.exe",
+      "args": [],
+      "envs": {
+        "DENO_SERVE_ADDRESS": "tcp:127.0.0.1:0"
+      },
+      "output": "main.out"
+    }
+  ]
+}

--- a/tests/specs/compile/default_export_fetch/compile.out
+++ b/tests/specs/compile/default_export_fetch/compile.out
@@ -1,0 +1,9 @@
+Check [WILDCARD]main.ts
+Compile [WILDCARD]main.ts to server[WILDCARD]
+
+Embedded Files
+
+server
+└── main.ts ([WILDLINE])
+
+[WILDCARD]

--- a/tests/specs/compile/default_export_fetch/compile.out
+++ b/tests/specs/compile/default_export_fetch/compile.out
@@ -3,7 +3,7 @@ Compile [WILDCARD]main.ts to server[WILDCARD]
 
 Embedded Files
 
-server
+server[WILDLINE]
 └── main.ts ([WILDLINE])
 
 [WILDCARD]

--- a/tests/specs/compile/default_export_fetch/main.out
+++ b/tests/specs/compile/default_export_fetch/main.out
@@ -1,0 +1,1 @@
+served: Hello World

--- a/tests/specs/compile/default_export_fetch/main.ts
+++ b/tests/specs/compile/default_export_fetch/main.ts
@@ -1,0 +1,14 @@
+export default {
+  async onListen(addr) {
+    if (addr.transport !== "tcp") {
+      throw new Error(`unexpected transport: ${addr.transport}`);
+    }
+    const { hostname, port } = addr;
+    const response = await fetch(`http://${hostname}:${port}/`);
+    console.log(`served: ${await response.text()}`);
+    Deno.exit(0);
+  },
+  fetch() {
+    return new Response("Hello World");
+  },
+} satisfies Deno.ServeDefaultExport;


### PR DESCRIPTION
Closes #33754

This fixes standalone binaries produced by `deno compile` when the entrypoint uses the declarative server export pattern:

```ts
export default {
  fetch() {
    return new Response("Hello World");
  },
};
```

Previously, compiled binaries ran in `run` mode, so they detected the default `fetch` export but only printed the `did you mean to run "deno serve"?` warning instead of starting the server.

This change makes standalone binaries use the existing auto-serve path when a valid declarative server export is present, while preserving the warning-only behavior for normal `deno run`.

### Tests

- `./x test-spec specs::compile::default_export_fetch`
- `./x fmt --check`
- `./x lint-js`
