### PR TITLE
fix(watch): apply `--watch-exclude` filter to file change events

### DIFF
--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -507,14 +507,21 @@ fn new_watcher(
         return;
       }
 
-      let paths: Vec<PathBuf> = event
+      let canonicalized: Vec<PathBuf> = event
         .paths
         .iter()
         .filter_map(|path| canonicalize_path(path).ok())
+        .collect();
+      let paths: Vec<PathBuf> = canonicalized
+        .iter()
         .filter(|path| !exclude_set.matches_path(path))
+        .cloned()
         .collect();
 
-      if paths.is_empty() {
+      // Only bail when the empty result was caused by exclusion, not
+      // by canonicalize failures — preserves pre-PR behavior for
+      // file-removal events.
+      if paths.is_empty() && !canonicalized.is_empty() {
         return;
       }
 

--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -312,7 +312,7 @@ where
   let initial_cwd_url = initial_cwd
     .as_ref()
     .and_then(|path| deno_path_util::url_from_directory_path(path).ok());
-  let exclude_set = flags.resolve_watch_exclude_set()?;
+  let exclude_set = Arc::new(flags.resolve_watch_exclude_set()?);
   let (paths_to_watch_tx, mut paths_to_watch_rx) =
     tokio::sync::mpsc::unbounded_channel();
   let (restart_tx, mut restart_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -363,7 +363,7 @@ where
       tokio::task::yield_now().await;
     }
 
-    let mut watcher = new_watcher(watcher_sender.clone())?;
+    let mut watcher = new_watcher(watcher_sender.clone(), exclude_set.clone())?;
     consume_paths_to_watch(&mut watcher, &mut paths_to_watch_rx, &exclude_set);
 
     let receiver_future = async {
@@ -492,6 +492,7 @@ where
 
 fn new_watcher(
   sender: Arc<mpsc::UnboundedSender<Vec<PathBuf>>>,
+  exclude_set: Arc<PathOrPatternSet>,
 ) -> Result<RecommendedWatcher, AnyError> {
   Ok(Watcher::new(
     move |res: Result<NotifyEvent, NotifyError>| {
@@ -506,11 +507,16 @@ fn new_watcher(
         return;
       }
 
-      let paths = event
+      let paths: Vec<PathBuf> = event
         .paths
         .iter()
         .filter_map(|path| canonicalize_path(path).ok())
+        .filter(|path| !exclude_set.matches_path(path))
         .collect();
+
+      if paths.is_empty() {
+        return;
+      }
 
       sender.send(paths).unwrap();
     },

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -1941,6 +1941,89 @@ async fn run_watch_with_excluded_paths() {
   check_alive_then_kill(child);
 }
 
+// Regression test for https://github.com/denoland/deno/issues/26217
+// When using `--watch=.` (directory), excluded files within that directory
+// should not trigger restarts.
+#[test(flaky)]
+async fn run_watch_directory_with_excluded_file() {
+  let t = TempDir::new();
+
+  let file_to_watch = t.path().join("file_to_watch.js");
+  file_to_watch.write("console.log('hello');");
+
+  let file_to_exclude = t.path().join("file_to_exclude.txt");
+  file_to_exclude.write("original content");
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch=.")
+    .arg("--watch-exclude=file_to_exclude.txt")
+    .arg("-L")
+    .arg("debug")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_contains("hello", &mut stdout_lines).await;
+  wait_contains("finished", &mut stderr_lines).await;
+
+  // Modify excluded file - should NOT trigger restart
+  file_to_exclude.write("modified content");
+
+  // Modify watched file - should trigger restart
+  file_to_watch.write("console.log('restarted');");
+  wait_contains("Restarting", &mut stderr_lines).await;
+  wait_contains("restarted", &mut stdout_lines).await;
+
+  check_alive_then_kill(child);
+}
+
+// When using `--watch=.`, excluded subdirectories should not trigger restarts
+// for any file changes within them.
+#[test(flaky)]
+async fn run_watch_directory_with_excluded_subdirectory() {
+  let t = TempDir::new();
+
+  let file_to_watch = t.path().join("main.js");
+  file_to_watch.write("console.log('start');");
+
+  let sub_dir = t.path().join("ignored_dir");
+  sub_dir.create_dir_all();
+  let sub_file = sub_dir.join("data.txt");
+  sub_file.write("data");
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch=.")
+    .arg("--watch-exclude=ignored_dir")
+    .arg("-L")
+    .arg("debug")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_contains("start", &mut stdout_lines).await;
+  wait_contains("finished", &mut stderr_lines).await;
+
+  // Modify file inside excluded subdirectory - should NOT trigger restart
+  sub_file.write("data updated");
+
+  // Modify watched file - should trigger restart
+  file_to_watch.write("console.log('restarted');");
+  wait_contains("Restarting", &mut stderr_lines).await;
+  wait_contains("restarted", &mut stdout_lines).await;
+
+  check_alive_then_kill(child);
+}
+
 #[test(flaky)]
 async fn run_hmr_server() {
   let t = TempDir::new();


### PR DESCRIPTION
## Summary

Fixes #26217

When watching a directory with `--watch=.`, the `--watch-exclude` flag was
ineffective for files within that directory. The OS-level file watcher reports
changes to all files recursively, bypassing the exclude filter which only
prevented *adding* excluded paths to the watcher — not filtering notifications
from recursively-watched parent directories.

Fix: filter changed paths against the exclude set inside the `new_watcher()`
callback before sending them through the channel. If all paths in a debounced
batch are excluded, the event is dropped entirely.

Supersedes #26309 and #31976.

## Test plan
- Added `run_watch_directory_with_excluded_file` — verifies a file excluded by
  name doesn't trigger restart when its parent dir is watched
- Added `run_watch_directory_with_excluded_subdirectory` — verifies files inside
  an excluded subdirectory don't trigger restart