### PR TITLE
fix(ext/node): avoid retaining sync writev chunks

### DIFF
--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -91,10 +91,18 @@ fn move_string_iovecs_to_owned_storage(
     return None;
   }
 
-  let mut async_storage = Box::new_uninit_slice(string_storage.len());
-  let async_storage_ptr = async_storage.as_mut_ptr();
   let string_storage_start = string_storage.as_ptr() as usize;
   let string_storage_end = string_storage_start + string_storage.len();
+
+  if !iovecs.iter().any(|buf| {
+    let base = buf.base as usize;
+    base >= string_storage_start && base < string_storage_end
+  }) {
+    return None;
+  }
+
+  let mut async_storage = Box::new_uninit_slice(string_storage.len());
+  let async_storage_ptr = async_storage.as_mut_ptr();
   // SAFETY: copying MaybeUninit bytes does not read them; iovecs only point at
   // ranges filled by the string encoders.
   unsafe {
@@ -219,6 +227,27 @@ mod tests {
       move_string_iovecs_to_owned_storage(
         std::slice::from_mut(&mut iovec),
         &[],
+      )
+      .is_none()
+    );
+    assert_eq!(iovec.base, original_base);
+    assert_eq!(iovec.len, buffer_storage.len());
+  }
+
+  #[test]
+  fn move_string_iovecs_to_owned_storage_ignores_buffer_only_tail() {
+    let string_storage = [MaybeUninit::<u8>::new(1); 4];
+    let mut buffer_storage = [1_u8, 2, 3, 4];
+    let mut iovec = uv_buf_t {
+      base: buffer_storage.as_mut_ptr() as *mut c_char,
+      len: buffer_storage.len(),
+    };
+    let original_base = iovec.base;
+
+    assert!(
+      move_string_iovecs_to_owned_storage(
+        std::slice::from_mut(&mut iovec),
+        &string_storage,
       )
       .is_none()
     );

--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -83,6 +83,43 @@ enum StreamBaseStateFields {
   // NumStreamBaseStateFields = 4,
 }
 
+fn move_string_iovecs_to_owned_storage(
+  iovecs: &mut [uv_buf_t],
+  string_storage: &[std::mem::MaybeUninit<u8>],
+) -> Option<Box<[std::mem::MaybeUninit<u8>]>> {
+  if string_storage.is_empty() {
+    return None;
+  }
+
+  let mut async_storage = Box::new_uninit_slice(string_storage.len());
+  let async_storage_ptr = async_storage.as_mut_ptr();
+  let string_storage_start = string_storage.as_ptr() as usize;
+  let string_storage_end = string_storage_start + string_storage.len();
+  // SAFETY: copying MaybeUninit bytes does not read them; iovecs only point at
+  // ranges filled by the string encoders.
+  unsafe {
+    std::ptr::copy_nonoverlapping(
+      string_storage.as_ptr(),
+      async_storage_ptr,
+      string_storage.len(),
+    );
+  }
+
+  for buf in iovecs {
+    let base = buf.base as usize;
+    if base < string_storage_start || base >= string_storage_end {
+      continue;
+    }
+    let offset = base - string_storage_start;
+    debug_assert!(offset + buf.len <= string_storage.len());
+    // SAFETY: the range check above guarantees this offset points inside
+    // `async_storage`, which mirrors `string_storage` byte-for-byte.
+    buf.base = unsafe { async_storage_ptr.add(offset) as *mut c_char };
+  }
+
+  Some(async_storage)
+}
+
 // ---------------------------------------------------------------------------
 // WriteWrap — cppgc object that wraps a uv_write_t request.
 // ---------------------------------------------------------------------------
@@ -114,6 +151,79 @@ impl WriteWrap {
 
   pub fn req_ptr(&mut self) -> *mut uv_write_t {
     self.req.as_mut_ptr()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::mem::MaybeUninit;
+
+  use super::*;
+
+  #[test]
+  fn move_string_iovecs_to_owned_storage_remaps_string_ranges() {
+    let mut string_storage = [MaybeUninit::<u8>::uninit(); 8];
+    for (slot, byte) in string_storage.iter_mut().zip(*b"abcdefgh") {
+      slot.write(byte);
+    }
+    let mut buffer_storage = [1_u8, 2, 3, 4];
+
+    let string_storage_ptr = string_storage.as_mut_ptr();
+    let mut iovecs = vec![
+      uv_buf_t {
+        // Simulate a partially consumed string iovec.
+        base: unsafe { string_storage_ptr.add(2) as *mut c_char },
+        len: 3,
+      },
+      uv_buf_t {
+        base: buffer_storage.as_mut_ptr() as *mut c_char,
+        len: buffer_storage.len(),
+      },
+      uv_buf_t {
+        base: unsafe { string_storage_ptr.add(6) as *mut c_char },
+        len: 2,
+      },
+    ];
+    let original_buffer_base = iovecs[1].base;
+
+    let owned =
+      move_string_iovecs_to_owned_storage(&mut iovecs, &string_storage)
+        .unwrap();
+    let owned_start = owned.as_ptr() as usize;
+
+    assert_eq!(iovecs[0].base as usize, owned_start + 2);
+    assert_eq!(iovecs[0].len, 3);
+    assert_eq!(iovecs[1].base, original_buffer_base);
+    assert_eq!(iovecs[1].len, buffer_storage.len());
+    assert_eq!(iovecs[2].base as usize, owned_start + 6);
+    assert_eq!(iovecs[2].len, 2);
+
+    // SAFETY: the test initialized every byte in `string_storage` above, and
+    // the helper copies the same byte range into `owned`.
+    let owned_bytes = unsafe {
+      std::slice::from_raw_parts(owned.as_ptr() as *const u8, owned.len())
+    };
+    assert_eq!(owned_bytes, b"abcdefgh");
+  }
+
+  #[test]
+  fn move_string_iovecs_to_owned_storage_ignores_empty_storage() {
+    let mut buffer_storage = [1_u8, 2, 3, 4];
+    let mut iovec = uv_buf_t {
+      base: buffer_storage.as_mut_ptr() as *mut c_char,
+      len: buffer_storage.len(),
+    };
+    let original_base = iovec.base;
+
+    assert!(
+      move_string_iovecs_to_owned_storage(
+        std::slice::from_mut(&mut iovec),
+        &[],
+      )
+      .is_none()
+    );
+    assert_eq!(iovec.base, original_base);
+    assert_eq!(iovec.len, buffer_storage.len());
   }
 }
 
@@ -1324,14 +1434,13 @@ impl LibUvStreamWrap {
     //
     // Retention strategy (matches Node):
     //   - Buffer chunks: iovec points directly at the ArrayBuffer
-    //     backing store; NO per-chunk retention. JS side keeps chunks
-    //     alive via `req.buffer = data` on the WriteWrap (see
-    //     stream_base_commons.js `writevGeneric`).
+    //     backing store; NO per-chunk retention here. JS side keeps
+    //     chunks alive while the native write is pending on the WriteWrap
+    //     (see stream_base_commons.ts `writevGeneric`).
     //   - String chunks: encode into stack storage first. Only
-    //     allocate a V8 BackingStore if we have to go async, and
-    //     only size it to the unwritten tail. Matches Node's stack
-    //     storage optimization in WriteString and its single-alloc
-    //     `ArrayBuffer::NewBackingStore` for the string storage.
+    //     allocate owned storage if we have to go async. Matches Node's
+    //     stack storage optimization in WriteString and its single-alloc
+    //     `ArrayBuffer::NewBackingStore` for string storage.
     let array_len = chunks.length();
     let (count, stride): (u32, u32) = if all_buffers {
       (array_len, 1)
@@ -1361,23 +1470,13 @@ impl LibUvStreamWrap {
       }
     }
 
-    // Single owned `Box<[MaybeUninit<u8>]>` for the concat of all
-    // encoded strings. Functional shape mirrors Node's
-    // `NewBackingStore(storage_size)` at stream_base.cc:247 but stays
-    // outside V8 entirely — no persistent handles, no GC-visible
-    // ArrayBuffer objects, just a heap allocation.
-    //
-    // Typed as `MaybeUninit<u8>` so the "bytes may be uninit until an
-    // encoder fills them" contract is enforced by the type system.
-    // Encoders take `&mut [MaybeUninit<u8>]` windows; iovec base
-    // pointers cast through `*mut u8` and only reference written
-    // sub-ranges.
-    let mut string_storage: Box<[std::mem::MaybeUninit<u8>]> =
-      if string_size > 0 {
-        Box::new_uninit_slice(string_size)
-      } else {
-        Box::new_uninit_slice(0)
-      };
+    // Inline storage for encoded strings. Most node:http chunked responses are
+    // tiny and fully drain in uv_try_writev(), so keeping this on the stack
+    // avoids one native heap allocation per synchronous writev.
+    let mut string_storage: smallvec::SmallVec<
+      [std::mem::MaybeUninit<u8>; 16 * 1024],
+    > = smallvec::SmallVec::new();
+    string_storage.resize_with(string_size, std::mem::MaybeUninit::uninit);
     let string_storage_ptr: *mut std::mem::MaybeUninit<u8> =
       string_storage.as_mut_ptr();
 
@@ -1401,9 +1500,8 @@ impl LibUvStreamWrap {
         };
         // SAFETY: data_ptr is the ArrayBuffer backing store start;
         // the Uint8Array view guarantees byte_off + byte_len is
-        // within the allocation. JS retains the chunk via
-        // `req.buffer = data` on the write request — we don't need
-        // our own retention.
+        // within the allocation. JS retains the chunk while the native write
+        // is pending, so we don't need our own retention.
         let base = unsafe {
           (data_ptr.as_ptr() as *mut u8).add(byte_off) as *mut c_char
         };
@@ -1463,7 +1561,8 @@ impl LibUvStreamWrap {
     // Sync scatter-gather try-write. Mirrors Node's
     // StreamBase::Write → DoTryWrite pre-async path. When this fully
     // drains (common for small HTTP responses) we skip the async
-    // request entirely — zero heap allocations.
+    // request entirely and avoid native heap allocations on the common small
+    // string path.
     let (sync_written, fully_drained) = {
       let slices: smallvec::SmallVec<[std::io::IoSlice; 16]> = iovecs
         .iter()
@@ -1529,14 +1628,15 @@ impl LibUvStreamWrap {
       }
     }
 
-    // Own the string concat buffer on the async request's callback
-    // state. Buffer chunks are retained JS-side via `req.buffer =
-    // data`, so `owned_buffers` only holds the string storage (or
-    // nothing at all if this writev was Buffers-only).
+    // Own encoded string bytes on the async request's callback state. Buffer
+    // chunks are retained JS-side, and fully synchronous writes return above
+    // without allocating owned storage.
     let mut owned: smallvec::SmallVec<[Box<[std::mem::MaybeUninit<u8>]>; 1]> =
       smallvec::SmallVec::new();
-    if !string_storage.is_empty() {
-      owned.push(string_storage);
+    if let Some(async_storage) =
+      move_string_iovecs_to_owned_storage(&mut iovecs, &string_storage)
+    {
+      owned.push(async_storage);
     }
 
     self.do_writev_async(

--- a/ext/node/ops/stream_wrap_state.rs
+++ b/ext/node/ops/stream_wrap_state.rs
@@ -136,14 +136,13 @@ pub(crate) struct WriteRequestCallbackState {
   pub stream_handle: v8::Global<v8::Object>,
   pub stream_base_state: v8::Global<v8::Int32Array>,
   pub bytes: usize,
-  /// Owned byte buffers that back the write's iovecs (specifically,
-  /// the encoded-strings concat buffer for mixed `writev` calls).
+  /// Owned byte buffers that back encoded string iovecs for async `writev`
+  /// calls.
   /// Kept alive by this field until the request is taken from the
   /// registry in `after_uv_write`; dropped there, which releases the
-  /// memory via the system allocator. Buffer-chunk iovecs don't go
-  /// here — they're retained JS-side via `req.buffer = data` in
-  /// `writevGeneric` (matches Node's StreamBase behavior, which
-  /// doesn't retain chunks on the WriteWrap either).
+  /// memory via the system allocator. Fully synchronous writes don't
+  /// allocate owned storage, and buffer-chunk iovecs don't go here — they're
+  /// retained JS-side while the native write is pending in `writevGeneric`.
   ///
   /// Typed as `Box<[MaybeUninit<u8>]>` rather than `Vec<u8>` because
   /// the encoders only fill the windows referenced by iovecs — bytes

--- a/ext/node/polyfills/internal/stream_base_commons.ts
+++ b/ext/node/polyfills/internal/stream_base_commons.ts
@@ -206,8 +206,8 @@ export function writevGeneric(
 
   const err = req.handle.writev(req, chunks, allBuffers);
 
-  // Retain chunks
-  if (err === 0) {
+  // Retain chunks while the native write is pending.
+  if (err === 0 && streamBaseState[kLastWriteWasAsync]) {
     req._chunks = chunks;
   }
 

--- a/tests/unit_node/net_test.ts
+++ b/tests/unit_node/net_test.ts
@@ -8,6 +8,106 @@ import * as dns from "node:dns";
 import * as dnsPromises from "node:dns/promises";
 import util from "node:util";
 import console from "node:console";
+import process from "node:process";
+
+type StreamWrapBinding = {
+  streamBaseState: Int32Array;
+  kBytesWritten: number;
+  kLastWriteWasAsync: number;
+};
+
+type TestWriteReq = {
+  _chunks?: unknown[];
+  async: boolean;
+  bytes: number;
+  oncomplete(status: number): void;
+};
+
+function dispatchFakeWritev(writeWasAsync: boolean) {
+  // @ts-ignore: untyped internal binding, used here to simulate native write
+  // completion state without relying on OS socket buffering behavior.
+  const streamWrap = process.binding("stream_wrap") as StreamWrapBinding;
+  const {
+    streamBaseState,
+    kBytesWritten,
+    kLastWriteWasAsync,
+  } = streamWrap;
+
+  let writeReq: TestWriteReq | undefined;
+  let callbackCalled = false;
+  const chunks = [
+    { chunk: "hello", encoding: "utf8" },
+    { chunk: "world", encoding: "utf8" },
+  ];
+  const handle = {
+    getAsyncId() {
+      return 1;
+    },
+    readStart() {
+      return 0;
+    },
+    readStop() {
+      return 0;
+    },
+    close() {},
+    writev(req: TestWriteReq, writeChunks: unknown[]) {
+      writeReq = req;
+      streamBaseState[kBytesWritten] = writeChunks.length;
+      streamBaseState[kLastWriteWasAsync] = writeWasAsync ? 1 : 0;
+      return 0;
+    },
+  };
+  const socket = new net.Socket({
+    handle,
+    readable: false,
+  } as unknown as net.SocketConstructorOpts);
+
+  (socket as unknown as {
+    _writev(chunks: unknown[], cb: () => void): void;
+  })._writev(chunks, () => {
+    callbackCalled = true;
+  });
+
+  return {
+    callbackCalled: () => callbackCalled,
+    resetWriteState() {
+      streamBaseState[kBytesWritten] = 0;
+      streamBaseState[kLastWriteWasAsync] = 0;
+    },
+    socket,
+    writeReq: () => writeReq,
+  };
+}
+
+Deno.test("[node/net] writev only retains chunks for async native writes", () => {
+  const syncWrite = dispatchFakeWritev(false);
+  try {
+    assert(syncWrite.callbackCalled());
+    assertEquals(syncWrite.writeReq()?.async, false);
+    assertEquals(syncWrite.writeReq()?._chunks, undefined);
+  } finally {
+    syncWrite.resetWriteState();
+    syncWrite.socket.destroy();
+  }
+
+  const asyncWrite = dispatchFakeWritev(true);
+  try {
+    assert(!asyncWrite.callbackCalled());
+    assertEquals(asyncWrite.writeReq()?.async, true);
+    assertEquals(asyncWrite.writeReq()?._chunks, [
+      "hello",
+      "utf8",
+      "world",
+      "utf8",
+    ]);
+
+    asyncWrite.writeReq()?.oncomplete(0);
+    assert(asyncWrite.callbackCalled());
+  } finally {
+    asyncWrite.resetWriteState();
+    asyncWrite.socket.destroy();
+  }
+});
 
 Deno.test("[node/net] close event emits after error event - when host is not found", async () => {
   const socket = net.createConnection(27009, "doesnotexist");


### PR DESCRIPTION
Fixes #33848

This PR addresses a memory retention issue in `node:http` when writes are dispatched via `writev`.

Previously, `writevGeneric()` would keep a reference to `req._chunks` after every successful `writev` call, even when the native write completed synchronously. In scenarios with many small chunked HTTP responses, this caused unnecessary retention of per-request JS chunk arrays. Additionally, the native `writev` path eagerly allocated owned string storage before determining whether the write would actually need to be handled asynchronously.

### What's changed

* Synchronous native `writev` completions no longer retain JS chunks
* Asynchronous `writev` operations still retain chunks when required (e.g. buffer-backed iovecs)
* String iovecs use inline storage on the synchronous fast path
* String data is only copied into owned storage if the write falls back to the async path
* If a partial synchronous drain leaves only buffer-backed iovecs for the async tail, the string storage migration now returns without allocating

### Tests

* Added regression test to ensure `_chunks` are not retained for synchronous `writev`
* Verified that `_chunks` are still retained for asynchronous `writev`
* Added Rust unit tests for correct remapping of string iovecs into owned storage in async scenarios
* Added Rust unit test for the buffer-only async tail case, where string storage should not be retained

### Current status

* Rebased onto current `denoland/main` (`e69a05dbe`) after review `4255556700`
* PR head is now `fba50c50976ba64322be8a45c026b57be294b551`
* GitHub checks after the rebase: `license/cla` passing, `lint title` passing
* `fibibot` review `4255556700` had no actionable inline threads and described the change as approve-quality pending full CI authorization

### Local validation note

I could not re-run the focused local Rust/Node tests in this checkout because this environment does not have `cargo` or `deno` on `PATH`. The relevant commands to run once the toolchain is available are:

```sh
cargo test -p deno_node move_string_iovecs_to_owned_storage
cargo test -p unit_node_tests --test unit_node -- "writev only retains chunks"
```