### PR TITLE
fix(ext/node): skip ESM load hook bridge for CJS modules

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1107,26 +1107,40 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
     let specifier = specifier.clone();
     let maybe_referrer = maybe_referrer.cloned();
 
-    // When load hooks are active, delegate to JS hooks first
-    if self.0.hook_registry.load_active.get() && !options.is_synchronous {
+    // When load hooks are active, delegate to JS hooks first.
+    // Skip the hook bridge for CJS modules — they go through the
+    // default loader which invokes the sync load hook chain
+    // (executeLoadHookChain) in Module._load. Going through both
+    // the ESM bridge AND the CJS path would call hooks twice.
+    if self.0.hook_registry.load_active.get()
+      && !options.is_synchronous
+      && !{
+        let media_type = deno_media_type::MediaType::from_specifier(&specifier);
+        self
+          .0
+          .shared
+          .cjs_tracker
+          .is_maybe_cjs(&specifier, media_type)
+          .unwrap_or(false)
+      }
+    {
       let receiver = self.0.hook_registry.push_load(specifier.to_string());
       return deno_core::ModuleLoadResponse::Async(
         async move {
-          let hook_result: Result<Option<String>, String> = match receiver.await
-          {
+          let hook_result = match receiver.await {
             Ok(r) => r,
             Err(_) => {
               return Err(JsErrorBox::generic("module load hook cancelled"));
             }
           };
           match hook_result {
-            Ok(Some(source)) => Ok(deno_core::ModuleSource::new(
+            Ok((Some(source), _format)) => Ok(deno_core::ModuleSource::new(
               deno_core::ModuleType::JavaScript,
               deno_core::ModuleSourceCode::String(source.into()),
               &specifier,
               None,
             )),
-            Ok(None) => {
+            Ok((None, _)) => {
               // Fallthrough: hooks didn't intercept, use default
               inner
                 .load_inner(

--- a/ext/node/ops/module_hooks.rs
+++ b/ext/node/ops/module_hooks.rs
@@ -27,8 +27,10 @@ struct PendingLoad {
 
 type ResolveSender =
   deno_core::futures::channel::oneshot::Sender<Result<Option<String>, String>>;
+/// Load hook result: (source, format). Format is e.g. "commonjs", "module".
+type LoadResult = (Option<String>, Option<String>);
 type LoadSender =
-  deno_core::futures::channel::oneshot::Sender<Result<Option<String>, String>>;
+  deno_core::futures::channel::oneshot::Sender<Result<LoadResult, String>>;
 
 /// Shared hook registry between ops and the module loader.
 ///
@@ -54,6 +56,10 @@ pub struct LoaderHookRegistry {
   pending_loads: Rc<RefCell<VecDeque<PendingLoad>>>,
   load_waker: Rc<RefCell<Option<Waker>>>,
   load_senders: Rc<RefCell<HashMap<u32, LoadSender>>>,
+  /// Maps load request ID to URL for dedup tracking.
+  load_id_keys: Rc<RefCell<HashMap<u32, String>>>,
+  /// Piggybacking senders for duplicate load requests.
+  load_waiters: Rc<RefCell<HashMap<String, Vec<LoadSender>>>>,
 }
 
 impl LoaderHookRegistry {
@@ -90,16 +96,33 @@ impl LoaderHookRegistry {
   }
 
   /// Push a load request and return a receiver for the response.
-  /// `Ok(Some(source))` = hook provided source, `Ok(None)` = fallthrough.
+  /// `Ok((Some(source), format))` = hook provided source,
+  /// `Ok((None, _))` = fallthrough.
   pub fn push_load(
     &self,
     url: String,
-  ) -> deno_core::futures::channel::oneshot::Receiver<
-    Result<Option<String>, String>,
-  > {
+  ) -> deno_core::futures::channel::oneshot::Receiver<Result<LoadResult, String>>
+  {
+    // Dedup: if there's already a pending load for this URL, piggyback.
+    if self.load_waiters.borrow().contains_key(&url) {
+      let (sender, receiver) = deno_core::futures::channel::oneshot::channel();
+      self
+        .load_waiters
+        .borrow_mut()
+        .get_mut(&url)
+        .unwrap()
+        .push(sender);
+      return receiver;
+    }
+    self
+      .load_waiters
+      .borrow_mut()
+      .insert(url.clone(), Vec::new());
+
     let id = self.next_id();
     let (sender, receiver) = deno_core::futures::channel::oneshot::channel();
     self.load_senders.borrow_mut().insert(id, sender);
+    self.load_id_keys.borrow_mut().insert(id, url.clone());
     self
       .pending_loads
       .borrow_mut()
@@ -189,15 +212,24 @@ pub fn op_module_hooks_respond_load(
   state: &mut OpState,
   id: u32,
   #[string] source: Option<String>,
+  #[string] format: Option<String>,
   #[string] error: Option<String>,
 ) {
   let registry = state.borrow::<LoaderHookRegistry>().clone();
+  let result: Result<LoadResult, String> = if let Some(err) = error {
+    Err(err)
+  } else {
+    Ok((source, format))
+  };
+  // Fulfill piggybacking waiters.
+  if let Some(key) = registry.load_id_keys.borrow_mut().remove(&id)
+    && let Some(waiters) = registry.load_waiters.borrow_mut().remove(&key)
+  {
+    for waiter in waiters {
+      let _ = waiter.send(result.clone());
+    }
+  }
   if let Some(sender) = registry.load_senders.borrow_mut().remove(&id) {
-    let result: Result<Option<String>, String> = if let Some(err) = error {
-      Err(err)
-    } else {
-      Ok(source) // None = fallthrough
-    };
     let _ = sender.send(result);
   }
 }

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -656,13 +656,14 @@ function _startEsmLoadLoop() {
           const source = typeof result.source === "string"
             ? result.source
             : new TextDecoder().decode(result.source);
-          op_module_hooks_respond_load(id, source, null);
+          const format = result.format || null;
+          op_module_hooks_respond_load(id, source, format, null);
         } else {
           // Fallthrough: tell Rust to use default loading
-          op_module_hooks_respond_load(id, null, null);
+          op_module_hooks_respond_load(id, null, null, null);
         }
       } catch (e) {
-        op_module_hooks_respond_load(id, null, String(e));
+        op_module_hooks_respond_load(id, null, null, String(e));
       }
     }
   })();

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -104,6 +104,7 @@
     "module-hooks/test-module-hooks-load-context-merged.js": {},
     "module-hooks/test-module-hooks-load-context-optional-esm.mjs": {},
     "module-hooks/test-module-hooks-load-context-optional.js": {},
+    "module-hooks/test-module-hooks-load-import-cjs.js": {},
     "module-hooks/test-module-hooks-load-mock.js": {},
     "module-hooks/test-module-hooks-load-short-circuit-required-middle.js": {},
     "module-hooks/test-module-hooks-load-short-circuit-required-start.js": {},


### PR DESCRIPTION
## Summary

When `module.registerHooks()` registers load hooks, CJS modules imported via
`import()` would get their hooks called twice — once through the ESM load hook
bridge (Rust side) and once through the sync CJS load hook chain in
`Module._load`. This caused `mustCall(fn, 1)` assertions to fail.

Fix: skip the ESM load hook bridge for CJS modules (detected via file extension
and `cjs_tracker`). CJS modules go through the default loader which already
invokes the sync load hook chain with proper CJS globals (`exports`, `require`,
`module`, `__filename`, `__dirname`).

Also:
- Pass `format` from JS load loop to Rust via `op_module_hooks_respond_load`
- Add load request deduplication in `LoaderHookRegistry` (same pattern as
  resolve dedup)

## Test plan
- `./x test-compat test-module-hooks-load-import-cjs` — now passes
- Added to `tests/node_compat/config.jsonc`