### PR TITLE
fix(ext/node): use primordials in internal_binding/symbols.ts

### DIFF
--- a/ext/node/polyfills/internal_binding/symbols.ts
+++ b/ext/node/polyfills/internal_binding/symbols.ts
@@ -23,9 +23,10 @@
 // This module ports:
 // - https://github.com/nodejs/node/blob/master/src/node_symbols.cc
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
 (function () {
+const { primordials } = globalThis.__bootstrap;
+const { Symbol } = primordials;
+
 const asyncIdSymbol: unique symbol = Symbol("asyncIdSymbol");
 const ownerSymbol: unique symbol = Symbol("ownerSymbol");
 


### PR DESCRIPTION
Uses primordials in `ext/node/polyfills/internal_binding/symbols.ts`.

Towards #24236
