### PR TITLE
fix(ext/node): avoid retaining sync writev chunks

### DIFF
--- a/ext/node/ops/stream_wrap_state.rs
+++ b/ext/node/ops/stream_wrap_state.rs
@@ -136,14 +136,13 @@ pub(crate) struct WriteRequestCallbackState {
   pub stream_handle: v8::Global<v8::Object>,
   pub stream_base_state: v8::Global<v8::Int32Array>,
   pub bytes: usize,
-  /// Owned byte buffers that back the write's iovecs (specifically,
-  /// the encoded-strings concat buffer for mixed `writev` calls).
+  /// Owned byte buffers that back encoded string iovecs for async `writev`
+  /// calls.
   /// Kept alive by this field until the request is taken from the
   /// registry in `after_uv_write`; dropped there, which releases the
-  /// memory via the system allocator. Buffer-chunk iovecs don't go
-  /// here — they're retained JS-side via `req.buffer = data` in
-  /// `writevGeneric` (matches Node's StreamBase behavior, which
-  /// doesn't retain chunks on the WriteWrap either).
+  /// memory via the system allocator. Fully synchronous writes don't
+  /// allocate owned storage, and buffer-chunk iovecs don't go here — they're
+  /// retained JS-side while the native write is pending in `writevGeneric`.
   ///
   /// Typed as `Box<[MaybeUninit<u8>]>` rather than `Vec<u8>` because
   /// the encoders only fill the windows referenced by iovecs — bytes

--- a/ext/node/polyfills/internal/stream_base_commons.ts
+++ b/ext/node/polyfills/internal/stream_base_commons.ts
@@ -206,8 +206,8 @@ export function writevGeneric(
 
   const err = req.handle.writev(req, chunks, allBuffers);
 
-  // Retain chunks
-  if (err === 0) {
+  // Retain chunks while the native write is pending.
+  if (err === 0 && streamBaseState[kLastWriteWasAsync]) {
     req._chunks = chunks;
   }
 

--- a/tests/unit_node/net_test.ts
+++ b/tests/unit_node/net_test.ts
@@ -8,6 +8,107 @@ import * as dns from "node:dns";
 import * as dnsPromises from "node:dns/promises";
 import util from "node:util";
 import console from "node:console";
+import process from "node:process";
+
+type StreamWrapBinding = {
+  streamBaseState: Int32Array;
+  kBytesWritten: number;
+  kLastWriteWasAsync: number;
+};
+
+type TestWriteReq = {
+  _chunks?: unknown[];
+  async: boolean;
+  bytes: number;
+  oncomplete(status: number): void;
+};
+
+function dispatchFakeWritev(writeWasAsync: boolean) {
+  // @ts-ignore: untyped internal binding, used here to simulate native write
+  // completion state without relying on OS socket buffering behavior.
+  const streamWrap = process.binding("stream_wrap") as StreamWrapBinding;
+  const {
+    streamBaseState,
+    kBytesWritten,
+    kLastWriteWasAsync,
+  } = streamWrap;
+
+  let writeReq: TestWriteReq | undefined;
+  let callbackCalled = false;
+  const chunks = [
+    { chunk: "hello", encoding: "utf8" },
+    { chunk: "world", encoding: "utf8" },
+  ];
+  const handle = {
+    getAsyncId() {
+      return 1;
+    },
+    readStart() {
+      return 0;
+    },
+    readStop() {
+      return 0;
+    },
+    close() {},
+    writev(req: TestWriteReq, writeChunks: unknown[]) {
+      writeReq = req;
+      streamBaseState[kBytesWritten] = writeChunks.length;
+      streamBaseState[kLastWriteWasAsync] = writeWasAsync ? 1 : 0;
+      return 0;
+    },
+  };
+  const socket = new net.Socket({
+    handle,
+    readable: false,
+  } as unknown as net.SocketConstructorOpts);
+
+  (socket as unknown as {
+    _writev(chunks: unknown[], cb: () => void): void;
+  })._writev(chunks, () => {
+    callbackCalled = true;
+  });
+
+  return {
+    callbackCalled: () => callbackCalled,
+    resetWriteState() {
+      streamBaseState[kBytesWritten] = 0;
+      streamBaseState[kLastWriteWasAsync] = 0;
+    },
+    socket,
+    writeReq: () => writeReq,
+  };
+}
+
+Deno.test("[node/net] writev only retains chunks for async native writes", () => {
+  const syncWrite = dispatchFakeWritev(false);
+  try {
+    assert(syncWrite.callbackCalled());
+    assertEquals(syncWrite.writeReq()?.async, false);
+    assertEquals(syncWrite.writeReq()?._chunks, undefined);
+  } finally {
+    syncWrite.resetWriteState();
+    syncWrite.socket.destroy();
+  }
+
+  const asyncWrite = dispatchFakeWritev(true);
+  try {
+    assert(!asyncWrite.callbackCalled());
+    assertEquals(asyncWrite.writeReq()?.async, true);
+    assertEquals(asyncWrite.writeReq()?._chunks, [
+      "hello",
+      "utf8",
+      "world",
+      "utf8",
+    ]);
+
+    asyncWrite.writeReq()?.oncomplete(0);
+    assert(asyncWrite.callbackCalled());
+  } finally {
+    asyncWrite.resetWriteState();
+    asyncWrite.socket.destroy();
+  }
+});
+
 
 Deno.test("[node/net] close event emits after error event - when host is not found", async () => {
   const socket = net.createConnection(27009, "doesnotexist");


### PR DESCRIPTION
Fixes #33848

This resolves a memory retention issue in node:http when writes are dispatched via writev. Previously, writevGeneric() would keep a reference to req._chunks after every successful writev call—even when the native write completed synchronously. In scenarios with many small chunked HTTP responses in-process, this caused unnecessary retention of per-request JS chunk arrays.

The fix ensures that chunks are only retained when the native write is async (pending). Synchronous write completions no longer retain JS chunks, while asynchronous operations still retain chunks when required.

Changes:
- Sync native writev completions no longer retain JS chunks
- Async writev operations still retain chunks for buffer-backed iovecs
- Updated documentation to reflect retention behavior
- Added regression test to ensure chunks are not retained for sync writev

The leak did not occur with Deno.serve() or external clients because those paths either don't use writev or properly manage per-request state at the OS level.

<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
