### PR TITLE
chore: fix build

### DIFF
--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -638,7 +638,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
             }
           };
           match hook_result {
-            Ok(Some(source)) => {
+            Ok((Some(source), _format)) => {
               // Hook provided transformed source
               Ok(deno_core::ModuleSource::new(
                 deno_core::ModuleType::JavaScript,
@@ -647,7 +647,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
                 None,
               ))
             }
-            Ok(None) => {
+            Ok((None, _)) => {
               // Fallthrough: hooks didn't intercept, use default loading
               this.load_inner(&specifier, &requested_module_type)
             }


### PR DESCRIPTION
## Summary

- Fix type mismatch in `cli/rt/run.rs` where `hook_result` of type `Result<(Option<String>, Option<String>), String>` was incorrectly matched as `Ok(Some(...))` / `Ok(None)` instead of `Ok((Some(...), _))` / `Ok((None, _))`
- This broke the `build debug linux-aarch64` CI job which compiles `denort` separately

## Test plan

- `cargo check` passes
- Fixes https://github.com/denoland/deno/actions/runs/25424695566/job/74575078352