### PR TITLE
fix(ext/node): support abstract Unix sockets in node:net pipe bind

### DIFF
--- a/ext/node/ops/pipe_wrap.rs
+++ b/ext/node/ops/pipe_wrap.rs
@@ -447,6 +447,11 @@ impl PipeWrap {
       }
       // SAFETY: pipe is valid (null-checked above).
       if let Some(path) = unsafe { &*pipe }.bind_path() {
+        // Abstract sockets (path starts with \0) have no filesystem
+        // entry, so chmod is a no-op.
+        if path.as_bytes().first().is_some_and(|&b| b == 0) {
+          return 0;
+        }
         let c_path = match std::ffi::CString::new(path) {
           Ok(p) => p,
           Err(_) => return uv_compat::UV_EINVAL,

--- a/ext/node/polyfills/net.ts
+++ b/ext/node/polyfills/net.ts
@@ -2720,6 +2720,19 @@ Server.prototype.listen = function (...args: unknown[]) {
     const pipeName = (this._pipeName = options.path);
     backlog = options.backlog || backlogFromArgs;
 
+    // Abstract Unix sockets (path starts with \0) have no filesystem
+    // entry, so readableAll/writableAll (which use chmod) are invalid.
+    if (
+      (options.readableAll === true || options.writableAll === true) &&
+      pipeName.charCodeAt(0) === 0
+    ) {
+      throw new ERR_INVALID_ARG_VALUE(
+        "options",
+        options,
+        "can not set readableAll or writableAllt to true when path is abstract unix socket",
+      );
+    }
+
     _listenInCluster(
       this,
       pipeName,

--- a/libs/core/uv_compat/pipe.rs
+++ b/libs/core/uv_compat/pipe.rs
@@ -351,7 +351,68 @@ pub unsafe fn uv_pipe_open(pipe: *mut uv_pipe_t, fd: c_int) -> c_int {
   0
 }
 
+/// Build a `sockaddr_un` from a path, handling both abstract sockets
+/// (path starts with `\0`, Linux-only) and filesystem sockets.
+///
+/// Returns `(addr, addr_len)` on success, or `UV_EINVAL` on failure.
+#[cfg(unix)]
+fn make_sockaddr_un(
+  path: &str,
+) -> Result<(libc::sockaddr_un, libc::socklen_t), c_int> {
+  let path_bytes = path.as_bytes();
+  if path_bytes.is_empty() {
+    return Err(super::UV_EINVAL);
+  }
+
+  // SAFETY: zeroing a sockaddr_un is safe — it's a plain C struct.
+  let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+  addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+
+  let is_abstract = path_bytes[0] == 0;
+  if is_abstract {
+    // Abstract socket (Linux): sun_path starts with \0 followed by the
+    // name bytes. No NUL terminator needed — the name length is
+    // determined by addr_len.
+    if path_bytes.len() > addr.sun_path.len() {
+      return Err(super::UV_EINVAL);
+    }
+    unsafe {
+      std::ptr::copy_nonoverlapping(
+        path_bytes.as_ptr(),
+        addr.sun_path.as_mut_ptr() as *mut u8,
+        path_bytes.len(),
+      );
+    }
+    let addr_len = std::mem::size_of::<libc::sa_family_t>() + path_bytes.len();
+    Ok((addr, addr_len as libc::socklen_t))
+  } else {
+    // Filesystem socket: must be NUL-terminated, reject interior NULs.
+    if path_bytes.contains(&0) {
+      return Err(super::UV_EINVAL);
+    }
+    // +1 for the NUL terminator
+    let total_len = path_bytes.len() + 1;
+    if total_len > addr.sun_path.len() {
+      return Err(super::UV_EINVAL);
+    }
+    unsafe {
+      std::ptr::copy_nonoverlapping(
+        path_bytes.as_ptr(),
+        addr.sun_path.as_mut_ptr() as *mut u8,
+        path_bytes.len(),
+      );
+      // NUL terminator (sun_path was zeroed, but be explicit)
+      *(addr.sun_path.as_mut_ptr().add(path_bytes.len()) as *mut u8) = 0;
+    }
+    let addr_len = std::mem::size_of::<libc::sa_family_t>() + total_len;
+    Ok((addr, addr_len as libc::socklen_t))
+  }
+}
+
 /// Bind to a Unix domain socket path.
+///
+/// Supports both filesystem sockets (`/tmp/foo.sock`) and abstract
+/// sockets (`\0foo` — Linux-only, used by Nitro/Nuxt on Linux).
 ///
 /// # Safety
 /// `pipe` must be a valid pointer to an initialized `uv_pipe_t`.
@@ -370,33 +431,16 @@ pub unsafe fn uv_pipe_bind(pipe: *mut uv_pipe_t, path: &str) -> c_int {
         return io_error_to_uv(&std::io::Error::last_os_error());
       }
 
-      // Bind it to the path.
-      let c_path = match std::ffi::CString::new(path) {
-        Ok(p) => p,
-        Err(_) => {
+      // Build the sockaddr_un (handles abstract and filesystem sockets).
+      let (addr, addr_len) = match make_sockaddr_un(path) {
+        Ok(v) => v,
+        Err(e) => {
           libc::close(fd);
-          return super::UV_EINVAL;
+          return e;
         }
       };
-      let mut addr: libc::sockaddr_un = std::mem::zeroed();
-      addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
-      let path_bytes = c_path.as_bytes_with_nul();
-      if path_bytes.len() > addr.sun_path.len() {
-        libc::close(fd);
-        return super::UV_EINVAL;
-      }
-      std::ptr::copy_nonoverlapping(
-        path_bytes.as_ptr(),
-        addr.sun_path.as_mut_ptr() as *mut u8,
-        path_bytes.len(),
-      );
-      let addr_len =
-        std::mem::size_of::<libc::sa_family_t>() + path_bytes.len();
-      if libc::bind(
-        fd,
-        &addr as *const _ as *const libc::sockaddr,
-        addr_len as libc::socklen_t,
-      ) != 0
+      if libc::bind(fd, &addr as *const _ as *const libc::sockaddr, addr_len)
+        != 0
       {
         let err = std::io::Error::last_os_error();
         libc::close(fd);
@@ -516,19 +560,13 @@ pub unsafe fn uv_pipe_connect(
       // Non-blocking connect on the pre-bound socket.
       // SAFETY: fd is a valid socket from uv_pipe_bind.
       unsafe {
-        let c_path = std::ffi::CString::new(path.as_str()).map_err(|_| {
-          std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid path")
-        })?;
-        let mut addr: libc::sockaddr_un = std::mem::zeroed();
-        addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
-        let path_bytes = c_path.as_bytes_with_nul();
-        std::ptr::copy_nonoverlapping(
-          path_bytes.as_ptr(),
-          addr.sun_path.as_mut_ptr() as *mut u8,
-          path_bytes.len(),
-        );
-        let addr_len =
-          std::mem::size_of::<libc::sa_family_t>() + path_bytes.len();
+        let (addr, addr_len) =
+          make_sockaddr_un(path.as_str()).map_err(|_| {
+            std::io::Error::new(
+              std::io::ErrorKind::InvalidInput,
+              "invalid path",
+            )
+          })?;
 
         // Set non-blocking before connect.
         let flags = libc::fcntl(fd, libc::F_GETFL);
@@ -888,8 +926,11 @@ pub(crate) unsafe fn close_pipe(pipe: *mut uv_pipe_t) {
 
     // Match libuv: unlink the socket file before closing the fd so
     // another server can bind to the same path immediately.
+    // Abstract sockets (path starts with \0) have no filesystem entry.
     #[cfg(unix)]
-    if let Some(ref path) = (*pipe).internal_bind_path {
+    if let Some(ref path) = (*pipe).internal_bind_path
+      && path.as_bytes().first().is_none_or(|&b| b != 0)
+    {
       #[allow(
         clippy::disallowed_methods,
         reason = "uv_compat is not compiled to WASM"

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -2692,6 +2692,8 @@
       "ignore": true,
       "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
+    "parallel/test-pipe-abstract-socket.js": {},
+    "parallel/test-pipe-abstract-socket-http.js": {},
     "parallel/test-pipe-address.js": {},
     "parallel/test-pipe-file-to-http.js": {},
     "parallel/test-pipe-head.js": {},


### PR DESCRIPTION
## Summary

Fixes #33759.

`CString::new()` in `uv_pipe_bind` rejected paths containing NUL bytes, but abstract Unix sockets (Linux) require a `\0` prefix in `sockaddr_un.sun_path`. This broke Nuxt 4 / Nitro, which uses `\0socketname` on Linux with Node >= 20.

### Root cause

Nitro's `getSocketAddress()` on Linux:
```js
if (process.platform === "linux") {
  const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
  if (nodeMajor >= 20) {
    return `\0${socketName}`;  // Abstract Unix socket
  }
}
```

In `uv_pipe_bind`, `CString::new(path)` returns `Err(NulError)` for this path → mapped to `UV_EINVAL` → bind silently fails → `uv_pipe_listen` finds `internal_fd = None` → returns `UV_EINVAL` → surfaces as `"listen EINVAL: invalid argument"`.

### Changes

- **`libs/core/uv_compat/pipe.rs`**: Extract `make_sockaddr_un()` helper that builds `sockaddr_un` correctly for both abstract sockets (raw bytes, no NUL terminator) and filesystem sockets (NUL-terminated, interior NULs rejected). Applied to both `uv_pipe_bind` and `uv_pipe_connect`.
- **`libs/core/uv_compat/pipe.rs`** (`close_pipe`): Skip `remove_file` for abstract sockets (no filesystem entry).
- **`ext/node/ops/pipe_wrap.rs`** (`fchmod`): No-op for abstract sockets (chmod doesn't apply).
- **`ext/node/polyfills/net.ts`**: Add `readableAll`/`writableAll` validation for abstract socket paths (matching Node.js behavior).
- **`tests/node_compat/config.jsonc`**: Enable `test-pipe-abstract-socket.js` and `test-pipe-abstract-socket-http.js`.

## Test plan

- Verified EINVAL no longer occurs with abstract socket paths (previously reproducible on all platforms)
- Verified filesystem socket paths still work correctly
- Verified `readableAll`/`writableAll` throws on abstract socket paths
- Verified Nuxt 4 dev server starts and serves HTTP 200 with the fix
- Enabled two Node.js compat tests (`test-pipe-abstract-socket.js`, `test-pipe-abstract-socket-http.js`) — both are Linux-only (self-skip on other platforms)