### PR TITLE
perf(http): don't add Vary header if response is not compressed

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -719,10 +719,10 @@ fn modify_compressibility_from_response(
   compression: Compression,
   headers: &mut HeaderMap,
 ) -> Compression {
-  ensure_vary_accept_encoding(headers);
   if compression == Compression::None {
     return Compression::None;
   }
+  ensure_vary_accept_encoding(headers);
   if !is_response_compressible(headers) {
     return Compression::None;
   }

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -718,14 +718,14 @@ fn is_response_compressible(headers: &HeaderMap) -> bool {
 fn modify_compressibility_from_response(
   compression: Compression,
   headers: &mut HeaderMap,
-) -> Compression {
+) -> Compression {  
   if compression == Compression::None {
     return Compression::None;
   }
-  ensure_vary_accept_encoding(headers);
   if !is_response_compressible(headers) {
     return Compression::None;
   }
+  ensure_vary_accept_encoding(headers);
   let encoding = match compression {
     Compression::Brotli => "br",
     Compression::GZip => "gzip",
@@ -750,10 +750,6 @@ fn weaken_etag(hmap: &mut HeaderMap) {
   }
 }
 
-// Set Vary: Accept-Encoding header for direct body response.
-// Note: we set the header irrespective of whether or not we compress the data
-// to make sure cache services do not serve uncompressed data to clients that
-// support compression.
 fn ensure_vary_accept_encoding(hmap: &mut HeaderMap) {
   if let Some(v) = hmap.get_mut(hyper::header::VARY)
     && let Ok(s) = v.to_str()

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -718,7 +718,7 @@ fn is_response_compressible(headers: &HeaderMap) -> bool {
 fn modify_compressibility_from_response(
   compression: Compression,
   headers: &mut HeaderMap,
-) -> Compression {  
+) -> Compression {
   if compression == Compression::None {
     return Compression::None;
   }

--- a/tests/specs/run/all_proxy/test.out
+++ b/tests/specs/run/all_proxy/test.out
@@ -5,8 +5,7 @@ Response {
   headers: Headers {
     "content-length": "24",
     "content-type": "text/plain;charset=UTF-8",
-    date: "[WILDCARD]",
-    vary: "Accept-Encoding"
+    date: "[WILDCARD]"
   },
   ok: true,
   redirected: false,
@@ -21,8 +20,7 @@ Response {
   headers: Headers {
     "content-length": "23",
     "content-type": "text/plain;charset=UTF-8",
-    date: "[WILDCARD]",
-    vary: "Accept-Encoding"
+    date: "[WILDCARD]"
   },
   ok: true,
   redirected: false,

--- a/tests/specs/run/tunnel/test.out
+++ b/tests/specs/run/tunnel/test.out
@@ -2,7 +2,6 @@
 You are connected to https://localhost:[WILDLINE]
 HTTP/1.1 200 OK
 content-type: application/json
-vary: Accept-Encoding
 content-length: 203
 date: [WILDCARD]
 


### PR DESCRIPTION
Saves about 1MB in RSS under load, and in practice the thing it was guarding against isn't worth the hit