### PR TITLE
test: use local server for ip_address_unsafe_ssl test

### DIFF
--- a/tests/specs/cert/ip_address_unsafe_ssl/__test__.jsonc
+++ b/tests/specs/cert/ip_address_unsafe_ssl/__test__.jsonc
@@ -1,4 +1,4 @@
 {
-  "args": "run --quiet --reload --allow-net --unsafely-ignore-certificate-errors=1.1.1.1 ip_address_unsafe_ssl.ts",
+  "args": "run --quiet --reload --allow-net --unsafely-ignore-certificate-errors=127.0.0.1 ip_address_unsafe_ssl.ts",
   "output": "ip_address_unsafe_ssl.ts.out"
 }

--- a/tests/specs/cert/ip_address_unsafe_ssl/ip_address_unsafe_ssl.ts
+++ b/tests/specs/cert/ip_address_unsafe_ssl/ip_address_unsafe_ssl.ts
@@ -1,2 +1,5 @@
-const r = await fetch("https://1.1.1.1");
+// Use the local test HTTPS server (port 5545) via its IP address.
+// The cert is issued for "localhost", not 127.0.0.1, so this exercises
+// --unsafely-ignore-certificate-errors with an IP address.
+const r = await fetch("https://127.0.0.1:5545/echo.ts");
 console.log(r.status);

--- a/tests/specs/cert/ip_address_unsafe_ssl/ip_address_unsafe_ssl.ts.out
+++ b/tests/specs/cert/ip_address_unsafe_ssl/ip_address_unsafe_ssl.ts.out
@@ -1,2 +1,2 @@
-DANGER: TLS certificate validation is disabled for: 1.1.1.1
+DANGER: TLS certificate validation is disabled for: 127.0.0.1
 200


### PR DESCRIPTION
## Summary

- Replace external dependency on `1.1.1.1` (Cloudflare) with the local test HTTPS server at `127.0.0.1:5545`
- The test cert is issued for `localhost`, so connecting via IP address still exercises `--unsafely-ignore-certificate-errors` with an IP, without depending on an external service
- Cloudflare recently started returning 301 redirects from `https://1.1.1.1`, breaking this test

## Test plan

- [x] `ip_address_unsafe_ssl` spec test validates the same behavior (IP-based cert bypass) using only local infrastructure