### PR TITLE
fix(node): fix registerHooks for custom file type loaders

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1134,12 +1134,19 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
             }
           };
           match hook_result {
-            Ok((Some(source), _format)) => Ok(deno_core::ModuleSource::new(
-              deno_core::ModuleType::JavaScript,
-              deno_core::ModuleSourceCode::String(source.into()),
-              &specifier,
-              None,
-            )),
+            Ok((Some(source), format)) => {
+              let module_type = match format.as_deref() {
+                Some("json") => deno_core::ModuleType::Json,
+                Some("wasm") => deno_core::ModuleType::Wasm,
+                _ => deno_core::ModuleType::JavaScript,
+              };
+              Ok(deno_core::ModuleSource::new(
+                module_type,
+                deno_core::ModuleSourceCode::String(source.into()),
+                &specifier,
+                None,
+              ))
+            }
             Ok((None, _)) => {
               // Fallthrough: hooks didn't intercept, use default
               inner

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -386,6 +386,9 @@ let insideLoadHook = false;
 let utf8Decoder;
 let esmResolveLoopRunning = false;
 let esmLoadLoopRunning = false;
+// Formats determined by resolve hooks, keyed by resolved URL.
+// Passed as context.format to load hooks per Node.js spec.
+const resolvedFormats = new SafeMap();
 
 function executeResolveHookChain(specifier, context, parent, isMain) {
   // Collect resolve hooks from hookEntries in LIFO order
@@ -535,7 +538,33 @@ async function executeEsmResolveHookChain(specifier, context) {
       currentContext = { ...currentContext, ...ctx };
     }
     if (index >= resolveHooks.length) {
-      // End of chain - signal fallthrough to Rust default resolution
+      // Default resolve: resolve the specifier to a URL so hooks
+      // further up the chain can inspect the resolved path.
+      if (StringPrototypeStartsWith(spec, "node:")) {
+        return { url: spec, shortCircuit: true };
+      }
+      if (nativeModuleCanBeRequiredByUsers(spec)) {
+        return { url: "node:" + spec, shortCircuit: true };
+      }
+      // For relative/absolute paths, resolve against parentURL
+      const parentURL = currentContext.parentURL;
+      if (parentURL) {
+        try {
+          return { url: new URL(spec, parentURL).href, shortCircuit: true };
+        } catch {
+          // Fall through
+        }
+      }
+      // For bare specifiers, try CJS resolution as a fallback
+      try {
+        const resolved = Module._resolveFilename(spec, null, false);
+        if (StringPrototypeStartsWith(resolved, "node:")) {
+          return { url: resolved, shortCircuit: true };
+        }
+        return { url: url.pathToFileURL(resolved).href, shortCircuit: true };
+      } catch {
+        // Could not resolve
+      }
       return { url: null, shortCircuit: true };
     }
     const hook = resolveHooks[index++];
@@ -652,6 +681,9 @@ function _startEsmResolveLoop() {
       try {
         const result = await executeEsmResolveHookChain(specifier, context);
         if (result !== null && result.url != null) {
+          if (result.format != null) {
+            resolvedFormats.set(result.url, result.format);
+          }
           op_module_hooks_respond_resolve(id, result.url, null);
         } else {
           // Fallthrough: tell Rust to use default resolution
@@ -674,8 +706,10 @@ function _startEsmLoadLoop() {
       const req = await pollPromise;
       if (req === null) break;
       const [id, fileUrl] = req;
+      const storedFormat = resolvedFormats.get(fileUrl);
+      if (storedFormat !== undefined) resolvedFormats.delete(fileUrl);
       const context = {
-        format: undefined,
+        format: storedFormat ?? undefined,
         conditions: ["node", "import"],
         importAttributes: { __proto__: null },
         importAssertions: { __proto__: null },

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -533,7 +533,7 @@ async function executeEsmResolveHookChain(specifier, context) {
   let index = 0;
   let currentContext = context;
 
-  async function nextResolve(spec, ctx) {
+  function nextResolve(spec, ctx) {
     if (ctx !== undefined && ctx !== null) {
       currentContext = { ...currentContext, ...ctx };
     }
@@ -573,7 +573,18 @@ async function executeEsmResolveHookChain(specifier, context) {
       nextCalled = true;
       return nextResolve(s, c);
     };
-    const result = await hook(spec, currentContext, wrappedNext);
+    const result = hook(spec, currentContext, wrappedNext);
+    // If an async hook returned a promise, propagate it
+    if (result && typeof result.then === "function") {
+      return result.then((r) => {
+        if (!nextCalled && !r?.shortCircuit) {
+          throw new TypeError(
+            "resolve hook must return { shortCircuit: true } or call nextResolve",
+          );
+        }
+        return r;
+      });
+    }
     if (!nextCalled && !result?.shortCircuit) {
       throw new TypeError(
         "resolve hook must return { shortCircuit: true } or call nextResolve",

--- a/tests/specs/node/module_register_hooks_esm/__test__.jsonc
+++ b/tests/specs/node/module_register_hooks_esm/__test__.jsonc
@@ -11,6 +11,10 @@
     "fallthrough_dynamic": {
       "args": "run -A test_fallthrough_dynamic.mjs",
       "output": "test_fallthrough_dynamic.out"
+    },
+    "custom_filetype": {
+      "args": "run -A test_custom_filetype.mjs",
+      "output": "test_custom_filetype.out"
     }
   }
 }

--- a/tests/specs/node/module_register_hooks_esm/test_custom_filetype.mjs
+++ b/tests/specs/node/module_register_hooks_esm/test_custom_filetype.mjs
@@ -1,0 +1,49 @@
+import { registerHooks } from "node:module";
+
+// Custom loader that transforms .yaml files into JSON modules.
+// This exercises three fixes:
+// 1. Default nextResolve must return the resolved URL (not null)
+//    so the resolve hook can inspect the file extension.
+// 2. The format from resolve hooks must flow to load hooks as
+//    context.format.
+// 3. The Rust module loader must respect the "json" format from
+//    load hooks instead of hardcoding JavaScript.
+const hook = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const result = nextResolve(specifier, context);
+    if (result.url && result.url.endsWith(".yaml")) {
+      return { ...result, format: "yaml" };
+    }
+    return result;
+  },
+  load(url, context, nextLoad) {
+    if (context.format !== "yaml") {
+      return nextLoad(url);
+    }
+    const result = nextLoad(url, { format: "module" });
+    // Parse YAML (simple key: value format for this test)
+    const source = result.source;
+    const obj = {};
+    for (const line of source.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const colon = trimmed.indexOf(":");
+      if (colon === -1) continue;
+      const key = trimmed.slice(0, colon).trim();
+      const val = trimmed.slice(colon + 1).trim();
+      obj[key] = val;
+    }
+    return {
+      format: "json",
+      source: JSON.stringify(obj),
+      shortCircuit: true,
+    };
+  },
+});
+
+const mod = await import("./test_data.yaml");
+console.log("greeting:", mod.default.greeting);
+console.log("name:", mod.default.name);
+
+hook.deregister();
+console.log("done");

--- a/tests/specs/node/module_register_hooks_esm/test_custom_filetype.out
+++ b/tests/specs/node/module_register_hooks_esm/test_custom_filetype.out
@@ -1,0 +1,3 @@
+greeting: hello
+name: world
+done

--- a/tests/specs/node/module_register_hooks_esm/test_data.yaml
+++ b/tests/specs/node/module_register_hooks_esm/test_data.yaml
@@ -1,0 +1,2 @@
+greeting: hello
+name: world


### PR DESCRIPTION
## Summary

Fixes `module.registerHooks()` for custom loaders that handle non-JS file types (e.g. `.yaml`, `.toml`). Three bugs prevented this from working:

- The default `nextResolve` at the end of the ESM resolve hook chain returned `{ url: null }`. Loaders that call `nextResolve()` to inspect the resolved URL would crash with `TypeError: Cannot read properties of null (reading 'split')`. Now performs actual URL resolution (node: builtins, relative paths against `parentURL`, CJS fallback for bare specifiers).

- The `format` field from resolve hook results was not passed to load hooks as `context.format`. Loaders like `@nodejs-loaders/yaml` set `format: 'yaml'` in their resolve hook and check `ctx.format` in their load hook — without this flow, the load hook skipped processing.

- The Rust module loader hardcoded `ModuleType::JavaScript` for all hook-provided sources, ignoring the format returned by load hooks. Now maps `"json"` → `ModuleType::Json` and `"wasm"` → `ModuleType::Wasm`.

### Repro (from #23201)

```js
import * as module from 'node:module';
import * as aliasLoader from '@nodejs-loaders/yaml/yaml.loader.mjs';

module.registerHooks(aliasLoader);

console.log(await import('./foo.yaml'));
```

**Before:** `TypeError: Cannot read properties of null (reading 'split')`
**After:** `[Module: null prototype] { default: { greeting: "hello", name: "world" } }`

> **Note:** `module.register()` (async hooks) still has a pre-existing deadlock issue when loading the hook module through the resolve hook bridge. That will be addressed in a follow-up.

Ref: #23201

## Test plan

- [x] Manually verified with `@nodejs-loaders/yaml` using `registerHooks()`
- [x] `./x test-spec module_hooks` — existing compile test passes
- [x] `./x test-spec register_hooks` — all 8 existing tests pass
- [x] `./x test-spec hooks_esm` — all 3 existing tests pass