### PR TITLE
fix(ext/tls): upgrade rustls to fix SSL cert validation regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9014,9 +9014,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ regex = "^1.7.0"
 reqwest = { version = "=0.12.5", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "socks", "json", "http2"] } # pinned because of https://github.com/seanmonstar/reqwest/pull/1955
 rstest = "0"
 rusqlite = { version = "0.37.0", features = ["unlock_notify", "bundled", "session", "modern_sqlite", "limits", "backup"] } # "modern_sqlite": need sqlite >= 3.49.0 for some db configs
-rustls = { version = "=0.23.28", default-features = false, features = ["logging", "std", "tls12", "aws_lc_rs"] }
+rustls = { version = "=0.23.40", default-features = false, features = ["logging", "std", "tls12", "aws_lc_rs"] }
 rustls-pemfile = "2"
 rustls-tokio-stream = "=0.8.0"
 rustls-webpki = "0.102"


### PR DESCRIPTION
## Summary

- Upgrades `rustls` from 0.23.28 to 0.23.40 to fix a regression where `fetch()` fails on servers with certain SSL certificate configurations (ecdsa-with-SHA256 signature + secp384r1/P-384 key).
- The root cause was that `rustls-webpki` 0.103.4+ (bumped in #33510) returns a new error variant (`UnsupportedSignatureAlgorithmForPublicKeyContext`) that `rustls` 0.23.28 didn't handle, breaking the algorithm fallback loop during TLS handshake. `rustls` 0.23.29+ handles this correctly.

Fixes #33866

## Test plan

- Verified `deno eval 'await fetch("https://static1.e621.net/")'` succeeds with the fix (returns 404) instead of throwing `UnsupportedSignatureAlgorithmForPublicKeyContext` error