### PR TITLE
chore: add Claude Code skills for PR review, issue triage, node compat, and code quality

### DIFF
--- a/.claude/skills/fmt/SKILL.md
+++ b/.claude/skills/fmt/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: fmt
+description: Format all code in the repository. Run before opening a PR or committing changes.
+user-invocable: true
+allowed-tools: Bash(./x fmt)
+---
+
+# Format Code
+
+Run the Deno code formatter:
+
+```sh
+./x fmt
+```
+
+If any files were changed, stage and report them.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -43,10 +43,25 @@ Only attempt reproduction for bug reports that have a clear repro case.
 
 ### Setup
 
-Create a temporary directory for the reproduction:
+Prefer running reproductions inside a Docker container for isolation. Fall back to a local temp directory only if Docker is unavailable.
+
+**Docker (preferred):**
+
+```sh
+# Run repro with latest canary
+docker run --rm -v "$REPRO_DIR":/repro -w /repro denoland/deno:canary deno run repro.ts
+
+# Run repro with a specific version (e.g., 2.1.4)
+docker run --rm -v "$REPRO_DIR":/repro -w /repro denoland/deno:2.1.4 deno run repro.ts
+```
+
+Use `docker run --rm` so containers are cleaned up automatically. Mount the repro files via `-v`.
+
+**Local fallback (if Docker is not available):**
 
 ```sh
 REPRO_DIR=$(mktemp -d)
+deno run "$REPRO_DIR/repro.ts"
 ```
 
 ### Get Deno versions
@@ -55,21 +70,15 @@ Try to reproduce with both:
 1. **The version from the issue** (if specified) — to confirm the bug exists
 2. **Latest canary** — to check if it's already fixed
 
-```sh
-# Check current deno version
-deno --version
-
-# Install canary if needed
-deno upgrade --canary
-```
+Use the appropriate Docker image tag for each version (e.g., `denoland/deno:2.1.4`, `denoland/deno:canary`).
 
 If the issue specifies a particular Deno version and the bug does NOT reproduce on canary, note that it may already be fixed. Check git log for relevant fixes.
 
 ### Run the reproduction
 
 - Extract the reproduction code from the issue body
-- Write it to a file in the temp directory
-- Run it with the appropriate `deno` subcommand and flags
+- Write it to a local temp directory
+- Run it inside a Docker container (or locally as fallback) with the appropriate `deno` subcommand and flags
 - Capture both stdout and stderr
 - Compare actual output against the expected behavior described in the issue
 

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: issue-triage
+description: Triage a Deno GitHub issue — reproduce bugs, classify, label, and comment with findings. Use when asked to triage an issue or when an issue number/URL is provided for triage.
+argument-hint: <issue-number-or-url>
+allowed-tools: Bash(gh *) Bash(deno *) Bash(git *) Bash(mktemp *) Bash(rm *) Bash(cat *) Read Write Glob Grep Agent
+---
+
+# Deno Issue Triage
+
+Triage issue `$ARGUMENTS` on the `denoland/deno` repository.
+
+## Step 1: Read the issue
+
+```!
+gh issue view $ARGUMENTS --repo denoland/deno --json number,title,body,author,labels,state,comments,createdAt,url
+```
+
+## Step 2: Classify the issue
+
+Determine what kind of issue this is:
+
+- **Bug report** — something isn't working as expected
+- **Feature request / suggestion** — a new capability or enhancement
+- **Question** — a usage question, not a bug
+- **Duplicate** — already reported (search closed and open issues with `gh issue list --search "keywords" --state all`)
+- **Invalid** — not actionable, not a Deno issue, or insufficient info
+
+If the issue is clearly a question, duplicate, or invalid, skip reproduction and go straight to Step 5.
+
+## Step 3: Check for missing information
+
+A valid bug report needs:
+- Deno version (`deno --version` output)
+- Operating system
+- Reproduction steps or minimal reproduction code
+- Expected behavior vs actual behavior
+
+If any of these are missing, label as `needs info` and comment asking the author to provide the missing details. Do not attempt reproduction without a clear repro case.
+
+## Step 4: Reproduce the bug
+
+Only attempt reproduction for bug reports that have a clear repro case.
+
+### Setup
+
+Create a temporary directory for the reproduction:
+
+```sh
+REPRO_DIR=$(mktemp -d)
+```
+
+### Get Deno versions
+
+Try to reproduce with both:
+1. **The version from the issue** (if specified) — to confirm the bug exists
+2. **Latest canary** — to check if it's already fixed
+
+```sh
+# Check current deno version
+deno --version
+
+# Install canary if needed
+deno upgrade --canary
+```
+
+If the issue specifies a particular Deno version and the bug does NOT reproduce on canary, note that it may already be fixed. Check git log for relevant fixes.
+
+### Run the reproduction
+
+- Extract the reproduction code from the issue body
+- Write it to a file in the temp directory
+- Run it with the appropriate `deno` subcommand and flags
+- Capture both stdout and stderr
+- Compare actual output against the expected behavior described in the issue
+
+If the reproduction involves specific npm packages, `deno.json` config, or multi-file setups, recreate the full environment as described.
+
+### Clean up
+
+```sh
+rm -rf "$REPRO_DIR"
+```
+
+### Record findings
+
+Note:
+- Does the bug reproduce on the reported version?
+- Does the bug reproduce on canary?
+- Any additional observations (e.g., different error message, partial fix, related issues)
+
+## Step 5: Label the issue
+
+Add labels based on your classification. Keep it minimal — usually a single area label is sufficient. Do not over-label.
+
+### Type labels (add one if applicable)
+
+| Label | When to use |
+|-------|-------------|
+| `bug` | Confirmed bug — always add for verified bug reports |
+| `feat` | Accepted new feature |
+| `suggestion` | Feature request not yet accepted |
+| `question` | Usage question |
+| `duplicate` | Duplicate of another issue |
+| `invalid` | Not actionable |
+| `panic` | Deno panics/crashes |
+| `regression` | Something that used to work but is now broken |
+
+### Area labels (add one that best matches)
+
+| Label | Area |
+|-------|------|
+| `node compat` | General Node.js compatibility |
+| `node API` | Specific `node:*` module APIs |
+| `ext/node`, `ext/fs`, `ext/net`, `ext/http`, `ext/fetch`, `ext/web`, `ext/crypto`, `ext/console`, `ext/url`, `ext/websocket`, `ext/kv` | Specific extension |
+| `cli` | CLI behavior, flags, subcommands |
+| `lsp` | Language server |
+| `runtime` | Runtime crate |
+| `permissions` | Permission system |
+| `compile` | `deno compile` |
+| `testing` | `deno test` and coverage |
+| `task runner` | `deno task` |
+| `install` | `deno install` / `deno add` |
+| `tsc` | TypeScript compiler |
+| `types` | TypeScript type issues |
+| `config` | `deno.json` configuration |
+| `node resolution` | Node/npm module resolution |
+| `publish` | `deno publish` |
+| `lint` | `deno lint` |
+| `wasm` | WebAssembly |
+
+### Priority labels (add only when clearly warranted)
+
+| Label | When to use |
+|-------|-------------|
+| `high priority` | Severe impact, blocks users, security issue |
+| `quick fix` | Obviously simple fix |
+
+### Adding labels
+
+```sh
+gh issue edit $ARGUMENTS --repo denoland/deno --add-label "bug"
+```
+
+Remove the `needs triage` or `triage required 👀` label if present:
+
+```sh
+gh issue edit $ARGUMENTS --repo denoland/deno --remove-label "needs triage" --remove-label "triage required 👀"
+```
+
+## Step 6: Comment on the issue
+
+Post a triage comment with your findings. Structure:
+
+For **confirmed bugs**:
+```
+Confirmed on [version]. [Brief description of what you observed.]
+
+[If tested on canary: "Also reproduces on canary." or "Does not reproduce on canary — may already be fixed."]
+```
+
+For **needs info**:
+```
+Thanks for reporting. Could you provide [missing info]? This will help us investigate.
+```
+
+For **duplicates**:
+```
+This looks like a duplicate of #XXXX. Closing in favor of that issue.
+```
+
+For **questions**:
+```
+This is a usage question rather than a bug. [Brief answer or pointer to docs.] Closing this — feel free to ask on https://discord.gg/deno if you have more questions.
+```
+
+### Posting the comment
+
+```sh
+gh issue comment $ARGUMENTS --repo denoland/deno --body "comment text"
+```
+
+Close the issue if it's a duplicate, question, or invalid:
+
+```sh
+gh issue close $ARGUMENTS --repo denoland/deno --reason "not planned"
+```
+
+## Rules
+
+- Always confirm with the user before posting comments or modifying labels on GitHub.
+- Do not close bug reports — only close duplicates, questions, and invalid issues.
+- Keep labels minimal. One type label + one area label is usually enough.
+- Be kind to reporters. Thank them, especially first-time reporters.
+- If you cannot reproduce a bug, say so honestly — do not guess at causes.
+- If the reproduction requires permissions or resources you don't have access to, note that and skip reproduction.
+- Never dismiss an issue without investigation.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -22,20 +22,25 @@ Determine what kind of issue this is:
 - **Bug report** — something isn't working as expected
 - **Feature request / suggestion** — a new capability or enhancement
 - **Question** — a usage question, not a bug
-- **Duplicate** — already reported (search closed and open issues with `gh issue list --search "keywords" --state all`)
+- **Duplicate** — already reported (search closed and open issues with
+  `gh issue list --search "keywords" --state all`)
 - **Invalid** — not actionable, not a Deno issue, or insufficient info
 
-If the issue is clearly a question, duplicate, or invalid, skip reproduction and go straight to Step 5.
+If the issue is clearly a question, duplicate, or invalid, skip reproduction and
+go straight to Step 5.
 
 ## Step 3: Check for missing information
 
 A valid bug report needs:
+
 - Deno version (`deno --version` output)
 - Operating system
 - Reproduction steps or minimal reproduction code
 - Expected behavior vs actual behavior
 
-If any of these are missing, label as `needs info` and comment asking the author to provide the missing details. Do not attempt reproduction without a clear repro case.
+If any of these are missing, label as `needs info` and comment asking the author
+to provide the missing details. Do not attempt reproduction without a clear
+repro case.
 
 ## Step 4: Reproduce the bug
 
@@ -43,7 +48,8 @@ Only attempt reproduction for bug reports that have a clear repro case.
 
 ### Setup
 
-Prefer running reproductions inside a Docker container for isolation. Fall back to a local temp directory only if Docker is unavailable.
+Prefer running reproductions inside a Docker container for isolation. Fall back
+to a local temp directory only if Docker is unavailable.
 
 **Docker (preferred):**
 
@@ -55,7 +61,8 @@ docker run --rm -v "$REPRO_DIR":/repro -w /repro denoland/deno:canary deno run r
 docker run --rm -v "$REPRO_DIR":/repro -w /repro denoland/deno:2.1.4 deno run repro.ts
 ```
 
-Use `docker run --rm` so containers are cleaned up automatically. Mount the repro files via `-v`.
+Use `docker run --rm` so containers are cleaned up automatically. Mount the
+repro files via `-v`.
 
 **Local fallback (if Docker is not available):**
 
@@ -67,22 +74,27 @@ deno run "$REPRO_DIR/repro.ts"
 ### Get Deno versions
 
 Try to reproduce with both:
+
 1. **The version from the issue** (if specified) — to confirm the bug exists
 2. **Latest canary** — to check if it's already fixed
 
-Use the appropriate Docker image tag for each version (e.g., `denoland/deno:2.1.4`, `denoland/deno:canary`).
+Use the appropriate Docker image tag for each version (e.g.,
+`denoland/deno:2.1.4`, `denoland/deno:canary`).
 
-If the issue specifies a particular Deno version and the bug does NOT reproduce on canary, note that it may already be fixed. Check git log for relevant fixes.
+If the issue specifies a particular Deno version and the bug does NOT reproduce
+on canary, note that it may already be fixed. Check git log for relevant fixes.
 
 ### Run the reproduction
 
 - Extract the reproduction code from the issue body
 - Write it to a local temp directory
-- Run it inside a Docker container (or locally as fallback) with the appropriate `deno` subcommand and flags
+- Run it inside a Docker container (or locally as fallback) with the appropriate
+  `deno` subcommand and flags
 - Capture both stdout and stderr
 - Compare actual output against the expected behavior described in the issue
 
-If the reproduction involves specific npm packages, `deno.json` config, or multi-file setups, recreate the full environment as described.
+If the reproduction involves specific npm packages, `deno.json` config, or
+multi-file setups, recreate the full environment as described.
 
 ### Clean up
 
@@ -93,56 +105,59 @@ rm -rf "$REPRO_DIR"
 ### Record findings
 
 Note:
+
 - Does the bug reproduce on the reported version?
 - Does the bug reproduce on canary?
-- Any additional observations (e.g., different error message, partial fix, related issues)
+- Any additional observations (e.g., different error message, partial fix,
+  related issues)
 
 ## Step 5: Label the issue
 
-Add labels based on your classification. Keep it minimal — usually a single area label is sufficient. Do not over-label.
+Add labels based on your classification. Keep it minimal — usually a single area
+label is sufficient. Do not over-label.
 
 ### Type labels (add one if applicable)
 
-| Label | When to use |
-|-------|-------------|
-| `bug` | Confirmed bug — always add for verified bug reports |
-| `feat` | Accepted new feature |
-| `suggestion` | Feature request not yet accepted |
-| `question` | Usage question |
-| `duplicate` | Duplicate of another issue |
-| `invalid` | Not actionable |
-| `panic` | Deno panics/crashes |
-| `regression` | Something that used to work but is now broken |
+| Label        | When to use                                         |
+| ------------ | --------------------------------------------------- |
+| `bug`        | Confirmed bug — always add for verified bug reports |
+| `feat`       | Accepted new feature                                |
+| `suggestion` | Feature request not yet accepted                    |
+| `question`   | Usage question                                      |
+| `duplicate`  | Duplicate of another issue                          |
+| `invalid`    | Not actionable                                      |
+| `panic`      | Deno panics/crashes                                 |
+| `regression` | Something that used to work but is now broken       |
 
 ### Area labels (add one that best matches)
 
-| Label | Area |
-|-------|------|
-| `node compat` | General Node.js compatibility |
-| `node API` | Specific `node:*` module APIs |
-| `ext/node`, `ext/fs`, `ext/net`, `ext/http`, `ext/fetch`, `ext/web`, `ext/crypto`, `ext/console`, `ext/url`, `ext/websocket`, `ext/kv` | Specific extension |
-| `cli` | CLI behavior, flags, subcommands |
-| `lsp` | Language server |
-| `runtime` | Runtime crate |
-| `permissions` | Permission system |
-| `compile` | `deno compile` |
-| `testing` | `deno test` and coverage |
-| `task runner` | `deno task` |
-| `install` | `deno install` / `deno add` |
-| `tsc` | TypeScript compiler |
-| `types` | TypeScript type issues |
-| `config` | `deno.json` configuration |
-| `node resolution` | Node/npm module resolution |
-| `publish` | `deno publish` |
-| `lint` | `deno lint` |
-| `wasm` | WebAssembly |
+| Label                                                                                                                                  | Area                             |
+| -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `node compat`                                                                                                                          | General Node.js compatibility    |
+| `node API`                                                                                                                             | Specific `node:*` module APIs    |
+| `ext/node`, `ext/fs`, `ext/net`, `ext/http`, `ext/fetch`, `ext/web`, `ext/crypto`, `ext/console`, `ext/url`, `ext/websocket`, `ext/kv` | Specific extension               |
+| `cli`                                                                                                                                  | CLI behavior, flags, subcommands |
+| `lsp`                                                                                                                                  | Language server                  |
+| `runtime`                                                                                                                              | Runtime crate                    |
+| `permissions`                                                                                                                          | Permission system                |
+| `compile`                                                                                                                              | `deno compile`                   |
+| `testing`                                                                                                                              | `deno test` and coverage         |
+| `task runner`                                                                                                                          | `deno task`                      |
+| `install`                                                                                                                              | `deno install` / `deno add`      |
+| `tsc`                                                                                                                                  | TypeScript compiler              |
+| `types`                                                                                                                                | TypeScript type issues           |
+| `config`                                                                                                                               | `deno.json` configuration        |
+| `node resolution`                                                                                                                      | Node/npm module resolution       |
+| `publish`                                                                                                                              | `deno publish`                   |
+| `lint`                                                                                                                                 | `deno lint`                      |
+| `wasm`                                                                                                                                 | WebAssembly                      |
 
 ### Priority labels (add only when clearly warranted)
 
-| Label | When to use |
-|-------|-------------|
+| Label           | When to use                                 |
+| --------------- | ------------------------------------------- |
 | `high priority` | Severe impact, blocks users, security issue |
-| `quick fix` | Obviously simple fix |
+| `quick fix`     | Obviously simple fix                        |
 
 ### Adding labels
 
@@ -161,6 +176,7 @@ gh issue edit $ARGUMENTS --repo denoland/deno --remove-label "needs triage" --re
 Post a triage comment with your findings. Structure:
 
 For **confirmed bugs**:
+
 ```
 Confirmed on [version]. [Brief description of what you observed.]
 
@@ -168,16 +184,19 @@ Confirmed on [version]. [Brief description of what you observed.]
 ```
 
 For **needs info**:
+
 ```
 Thanks for reporting. Could you provide [missing info]? This will help us investigate.
 ```
 
 For **duplicates**:
+
 ```
 This looks like a duplicate of #XXXX. Closing in favor of that issue.
 ```
 
 For **questions**:
+
 ```
 This is a usage question rather than a bug. [Brief answer or pointer to docs.] Closing this — feel free to ask on https://discord.gg/deno if you have more questions.
 ```
@@ -196,10 +215,13 @@ gh issue close $ARGUMENTS --repo denoland/deno --reason "not planned"
 
 ## Rules
 
-- Always confirm with the user before posting comments or modifying labels on GitHub.
-- Do not close bug reports — only close duplicates, questions, and invalid issues.
+- Always confirm with the user before posting comments or modifying labels on
+  GitHub.
+- Do not close bug reports — only close duplicates, questions, and invalid
+  issues.
 - Keep labels minimal. One type label + one area label is usually enough.
 - Be kind to reporters. Thank them, especially first-time reporters.
 - If you cannot reproduce a bug, say so honestly — do not guess at causes.
-- If the reproduction requires permissions or resources you don't have access to, note that and skip reproduction.
+- If the reproduction requires permissions or resources you don't have access
+  to, note that and skip reproduction.
 - Never dismiss an issue without investigation.

--- a/.claude/skills/lint-all/SKILL.md
+++ b/.claude/skills/lint-all/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: lint-all
+description: Lint all code (Rust + JS/TS). Use before opening a PR when Rust code was changed.
+user-invocable: true
+allowed-tools: Bash(./x lint)
+---
+
+# Lint All Code
+
+Run the full linter (Rust + JS/TS):
+
+```sh
+./x lint
+```
+
+If there are lint errors, fix them and re-run until clean.

--- a/.claude/skills/lint-js/SKILL.md
+++ b/.claude/skills/lint-js/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: lint-js
+description: Lint JS/TS code only. Use before opening a PR when only JavaScript or TypeScript files were changed (no Rust).
+user-invocable: true
+allowed-tools: Bash(./x lint-js)
+---
+
+# Lint JS/TS Code
+
+Run the JS/TS linter:
+
+```sh
+./x lint-js
+```
+
+If there are lint errors, fix them and re-run until clean.

--- a/.claude/skills/node-compat/SKILL.md
+++ b/.claude/skills/node-compat/SKILL.md
@@ -16,7 +16,8 @@ Work on Node.js compatibility test `$ARGUMENTS`.
 ./x test-compat $ARGUMENTS
 ```
 
-If the test passes, report success and stop — there is nothing to fix.
+If the test passes, report success and ensure test is specified in
+`tests/node_compat/config.jsonc`.
 
 ## Step 2: Diagnose the failure
 
@@ -82,24 +83,19 @@ provides negligible value:
 If the failure is fixable:
 
 1. Locate the relevant code in `ext/node/` (or elsewhere).
-2. Implement the fix. Match Node.js behavior — check Node.js docs and/or source
+2. Implement the fix. Match Node.js behavior - check Node.js docs and/or source
    code, not just what "seems right."
 3. Use lazy-loaded imports where possible.
 4. Use primordials for internal JS code to avoid prototype pollution.
-5. Re-run the test to verify the fix:
+5. Rebuild the source code with `./x build` - this is paramount, changes won't
+   take effect until you do.
+6. Re-run the test to verify the fix:
 
 ```sh
 ./x test-compat $ARGUMENTS
 ```
 
-6. Run related tests to check for regressions:
-
-```sh
-# Run unit_node tests for the affected module
-cargo test unit_node::<module>
-```
-
-7. Once the test passes, make sure the test is listed in
+6. Once the test passes, make sure the test is listed in
    `tests/node_compat/config.jsonc` with an empty config:
 
 ```jsonc
@@ -123,6 +119,8 @@ If the test cannot or should not be fixed, update
 }
 ```
 
+`"reason"` must be specified otherwise the lint step will fail!
+
 ### Platform-specific skip
 
 If the test only fails on certain platforms:
@@ -145,6 +143,10 @@ If you want the test to run but expect a specific failure:
 }
 ```
 
+This is a good middle ground for tests that are generally compatible but have a
+specific known issue. If a fix is ever done this assertion will notify the
+implementer to update the config.
+
 ### Writing good reasons
 
 Reasons should be specific and actionable. Good examples:
@@ -161,14 +163,7 @@ Bad examples:
 - "Doesn't work" (says nothing)
 - "Node-specific" (which part?)
 
-## Step 6: Format and verify
-
-After making changes:
-
-```sh
-tools/format.js
-tools/lint.js --js
-```
+## Step 6: Verify
 
 Re-run the test one final time to confirm the outcome matches expectations:
 

--- a/.claude/skills/node-compat/SKILL.md
+++ b/.claude/skills/node-compat/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: node-compat
+description: Run a Node.js compatibility test, diagnose failures, and either fix the implementation, skip, or ignore the test. Use when asked to work on node compat tests.
+argument-hint: <test-name>
+allowed-tools: Bash Read Write Edit Glob Grep Agent
+---
+
+# Node Compat Test
+
+Work on Node.js compatibility test `$ARGUMENTS`.
+
+## Step 1: Build and run the test
+
+```sh
+./x build
+./x test-compat $ARGUMENTS
+```
+
+If the test passes, report success and stop — there is nothing to fix.
+
+## Step 2: Diagnose the failure
+
+Read the test file to understand what it tests:
+
+```sh
+# Tests live under tests/node_compat/test/
+```
+
+Use `Grep` and `Read` to find the test source, then analyze:
+
+1. **What Node.js API or behavior is being tested?**
+2. **What is the actual error or assertion failure?**
+3. **Where is the relevant Deno implementation?** Check `ext/node/` (polyfills,
+   ops, internal bindings), `runtime/`, or `cli/`.
+
+Read the corresponding Node.js docs and/or source code to understand the
+expected behavior.
+
+## Step 3: Classify the failure
+
+Determine which category this failure falls into:
+
+### A. Fixable bug
+
+The Deno implementation is wrong or incomplete, but can be corrected. This
+includes:
+
+- Missing method/property on a polyfill
+- Wrong return value or error type
+- Missing event emission
+- Incorrect argument handling
+- Hard-to-fix but still fundamentally implementable behaviors
+
+**Action:** Fix the implementation (Step 4).
+
+### B. Inherent incompatibility
+
+The test relies on Node.js internals or architecture that Deno fundamentally
+cannot or will not support:
+
+- `internalBinding()` calls to Node's C++ layer
+- Node.js-specific CLI flags (`--inspect`, `--prof`, etc.)
+- V8 internals exposed through Node-specific APIs
+- Node.js-specific build/addon tooling (node-gyp internals)
+- Tests for Node.js's own test infrastructure
+
+**Action:** Ignore the test with a reason (Step 5).
+
+### C. Not worth fixing
+
+The test exercises an edge case or behavior that is technically possible but
+provides negligible value:
+
+- Extremely obscure error message wording differences
+- Node.js-specific deprecation warnings
+- Behavior that no real-world code depends on
+
+**Action:** Ignore or skip the test with a reason (Step 5).
+
+## Step 4: Fix the implementation
+
+If the failure is fixable:
+
+1. Locate the relevant code in `ext/node/` (or elsewhere).
+2. Implement the fix. Match Node.js behavior — check Node.js docs and/or source
+   code, not just what "seems right."
+3. Use lazy-loaded imports where possible.
+4. Use primordials for internal JS code to avoid prototype pollution.
+5. Re-run the test to verify the fix:
+
+```sh
+./x test-compat $ARGUMENTS
+```
+
+6. Run related tests to check for regressions:
+
+```sh
+# Run unit_node tests for the affected module
+cargo test unit_node::<module>
+```
+
+7. Once the test passes, make sure the test is listed in
+   `tests/node_compat/config.jsonc` with an empty config:
+
+```jsonc
+"category/test-name.js": {}
+```
+
+The entries in `config.jsonc` are sorted alphabetically within their category.
+Place the new entry in the correct position.
+
+## Step 5: Skip or ignore the test
+
+If the test cannot or should not be fixed, update
+`tests/node_compat/config.jsonc`.
+
+### Ignore (test should never run — inherent incompatibility)
+
+```jsonc
+"category/test-name.js": {
+  "ignore": true,
+  "reason": "Brief, specific explanation of why this can't work in Deno"
+}
+```
+
+### Platform-specific skip
+
+If the test only fails on certain platforms:
+
+```jsonc
+"category/test-name.js": {
+  "windows": false
+}
+```
+
+### Expected failure (test runs but fails with known output)
+
+If you want the test to run but expect a specific failure:
+
+```jsonc
+"category/test-name.js": {
+  "exitCode": 1,
+  "output": "[WILDCARD]specific error message[WILDCARD]",
+  "reason": "Brief explanation of why this fails"
+}
+```
+
+### Writing good reasons
+
+Reasons should be specific and actionable. Good examples:
+
+- "Tests Node.js internal C++ binding (internalBinding('zlib').Zlib) which is
+  not implemented in Deno"
+- "requires `deno --interactive` flag (not yet implemented)"
+- "URL.createObjectURL does not throw ERR_INVALID_ARG_TYPE for non-Blob
+  arguments"
+
+Bad examples:
+
+- "Not supported" (too vague)
+- "Doesn't work" (says nothing)
+- "Node-specific" (which part?)
+
+## Step 6: Format and verify
+
+After making changes:
+
+```sh
+tools/format.js
+tools/lint.js --js
+```
+
+Re-run the test one final time to confirm the outcome matches expectations:
+
+```sh
+./x test-compat $ARGUMENTS
+```
+
+## Config reference
+
+The full schema for `config.jsonc` entries is in
+`tests/node_compat/schema.json`.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: review-pr
+description: Review a Deno runtime pull request for correctness, tests, security, and conventions. Use when asked to review a PR or when a PR number/URL is provided for review.
+argument-hint: <pr-number-or-url>
+allowed-tools: Bash(gh *) Bash(git *) Read Glob Grep Agent
+---
+
+# Deno PR Reviewer
+
+Review PR `$ARGUMENTS` on the `denoland/deno` repository.
+
+## Step 1: Gather PR context
+
+Fetch the PR metadata, diff, and comments:
+
+```!
+gh pr view $ARGUMENTS --json number,title,body,author,labels,state,reviewDecision,commits,files,isDraft,createdAt,url
+```
+
+```!
+gh pr diff $ARGUMENTS
+```
+
+```!
+gh pr view $ARGUMENTS --comments --json comments
+```
+
+```!
+gh pr checks $ARGUMENTS --json name,state,conclusion 2>/dev/null || echo "No checks found"
+```
+
+## Step 2: Gate checks
+
+Before reviewing code, check these gates. If any fail, flag them prominently at
+the top of your review and do not approve.
+
+1. **CI status** — All checks must pass. Point the author to specific failing
+   checks. Known flaky tests (labeled `ci-test-flaky`) can be re-run.
+2. **PR title format** — Must follow `type(scope): description`. Types: `feat`,
+   `fix`, `perf`, `refactor`, `chore`, `docs`, `test`, `revert`, `BREAKING`.
+   Scope examples: `ext/node`, `ext/fetch`, `cli`, `lsp`, `runtime`.
+3. **No force pushes** — PRs are squash-merged. Authors should push new commits,
+   not rewrite history.
+4. **Focused scope** — No drive-by cleanups or unrelated changes. Those belong
+   in separate PRs.
+5. **AI disclosure** — If the PR looks AI-generated (boilerplate-heavy, generic
+   comments, suspiciously broad) but has no disclosure, ask about it.
+6. **Linked issue (external contributors)** — If the PR author is not a
+   `denoland` org member, the PR must link to an issue. If there is no linked
+   issue, request changes and ask the author to open an issue and discuss the
+   change first.
+
+## Step 3: Code review
+
+Read every changed file in the diff. Use the repo tools (`Read`, `Grep`, `Glob`)
+to understand surrounding context when needed.
+
+### Rust code
+
+- **Correctness**: Edge cases handled? No `.unwrap()` on user-controlled data?
+- **Error handling**: Proper error types, meaningful messages, no swallowed
+  errors.
+- **Performance**: No unnecessary allocations/copies, no blocking in async code.
+- **Safety**: No `unsafe` without strong justification. No command injection,
+  path traversal, or permission bypasses.
+- **Permissions**: New capabilities must go through Deno's permission system.
+  Watch `ext/node/` especially — Node.js APIs sometimes assume full access.
+- **Dependencies**: New Cargo deps need strong justification. Prefer existing
+  deps or stdlib.
+
+### JavaScript/TypeScript code
+
+- **Node.js compatibility** (`ext/node/`): Does the implementation match Node.js
+  behavior? Check against Node.js docs and/or source code.
+- **Primordials**: Internal JS should use primordials
+  (`globalThis.__bootstrap.primordials`) to avoid prototype pollution. Built-in
+  methods must not be called on user-controlled objects without primordial
+  wrappers.
+- **Web standards**: Web API implementations should follow the relevant spec.
+  WPT coverage is preferred.
+- **Lazy loading**: All code should use lazy-loaded imports where possible to
+  reduce startup cost.
+
+### Tests
+
+- Every bug fix needs a test that would have caught the bug. Every feature needs
+  happy-path + edge-case tests.
+- Prefer unit tests over spec tests over integration tests. Only use spec tests
+  when the behavior requires CLI-level validation.
+- Spec tests live in `tests/specs/` using `__test__.jsonc`. Use `[WILDCARD]` for
+  non-deterministic output, `[UNORDERED_START]`/`[UNORDERED_END]` for
+  non-deterministic ordering.
+- Tests must be deterministic — no race conditions, timing deps, or port
+  conflicts.
+
+### Security-sensitive areas
+
+Pay extra attention to changes in:
+
+- `runtime/permissions.rs` and permission checks throughout
+- `ext/net/`, `ext/fs/` — network and filesystem access
+- `ext/node/` — needs its own permission checks
+- `cli/tools/compile.rs` — standalone binary compilation
+- Any code that shells out or processes user-controlled paths/URLs
+
+## Step 4: PR-type-specific checks
+
+Apply additional checks based on the PR type:
+
+- **Node.js compat** (`ext/node/`): Verify behavior against Node.js docs and/or
+  source code, not just what "seems right". New polyfills must be registered in
+  `ext/node/polyfills/01_require.js`.
+- **Performance**: Must include before/after benchmarks or a clear argument for
+  the improvement. Watch for correctness regressions.
+- **Dependency updates**: Check changelog for breaking changes. Prioritize
+  security updates.
+- **WPT changes**: Verify passes are real, not just skipped assertions.
+  Expectation file updates must match actual results. Suggest `ci-wpt-test`
+  label if not present.
+- **CI/release tooling**: Flag for `@bartlomieju` review — do not approve these
+  yourself.
+
+## Step 5: Write your review
+
+Post a review using `gh pr review`. Structure:
+
+1. **Summary** (1-2 sentences): What the PR does and your overall assessment.
+2. **Gate issues** (if any): Blocking problems that must be fixed.
+3. **Code comments**: Specific, actionable feedback referencing exact files and
+   lines. Use `nit:` prefix for non-blocking suggestions. Suggest fixes when
+   possible, not just "this is wrong."
+4. **Verdict**: Approve, request changes, or comment.
+
+### Tone
+
+- Direct: "This needs a test" not "It would be wonderful if we could add a test
+  here."
+- Kind: Thank contributors, especially first-timers. Assume good intent.
+- Helpful: If rejecting, show what a good version looks like.
+- Brief: If the contributor clearly knows what they're doing, keep it tight.
+
+### Posting the review
+
+Prefer inline comments on specific lines where possible. Use a single review
+with both a summary body and inline comments:
+
+```
+gh api repos/denoland/deno/pulls/{number}/reviews -f event=COMMENT -f body="summary" -f comments='[{"path":"file.rs","line":42,"body":"comment"}]'
+```
+
+Use `event=APPROVE` or `event=REQUEST_CHANGES` as appropriate instead of
+`COMMENT`.
+
+For simple reviews without inline comments, fall back to:
+
+```
+gh pr review $ARGUMENTS --comment --body "review text"
+```
+
+### Merge readiness
+
+You do NOT have merge permissions. When a PR is ready:
+
+- For first-time contributors: comment
+  `@bartlomieju LGTM, needs maintainer signoff (first-time contributor)`
+- For regular contributors: comment `@bartlomieju this is ready to merge`
+
+## Rules
+
+- Never approve a PR with failing CI.
+- Never approve PRs that bypass the permission system.
+- Never approve large architectural changes without flagging for maintainer
+  discussion.
+- Do not bikeshed style if it passes the linter.
+- Do not request changes for things automated checks already enforce.
+- Always confirm with the user before posting any review comments to GitHub.

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -702,6 +702,7 @@ async function ensureNoNewTopLevelEntries() {
   // Keep the root of the repository clean.
   const allowed = new Set([
     ".cargo",
+    ".claude",
     ".devcontainer",
     ".github",
     "x",


### PR DESCRIPTION
## Summary

Adds Claude Code skills (`.claude/skills/`) so agents working on this repo can invoke common workflows:

- `/review-pr <number>` — review a PR for correctness, tests, security, and conventions; posts inline GitHub comments
- `/issue-triage <number>` — triage an issue by reproducing bugs in Docker containers (canary + reported version), classifying, labeling, and commenting
- `/node-compat <test>` — run a node compat test, diagnose failures, and either fix the implementation or skip/ignore with a reason
- `/fmt` — run `./x fmt`
- `/lint-js` — run `./x lint-js` (JS/TS only changes)
- `/lint-all` — run `./x lint` (when Rust code was touched)

## Test plan

- [ ] Invoke `/review-pr` against an open PR and verify review output
- [ ] Invoke `/issue-triage` against an open issue and verify reproduction + labeling
- [ ] Invoke `/node-compat` against a failing node compat test
- [ ] Invoke `/fmt`, `/lint-js`, `/lint-all` and verify they run the correct commands