### PR TITLE
test: ignore test-domain-no-error-handler-abort-on-uncaught tests

### DIFF
--- a/.claude/skills/node-compat/SKILL.md
+++ b/.claude/skills/node-compat/SKILL.md
@@ -175,3 +175,13 @@ Re-run the test one final time to confirm the outcome matches expectations:
 
 The full schema for `config.jsonc` entries is in
 `tests/node_compat/schema.json`.
+
+## PR title conventions
+
+When opening a PR for node-compat work, use the appropriate prefix:
+
+- `test:` — when the PR only updates `tests/node_compat/config.jsonc` to skip,
+  ignore, or otherwise reclassify tests without changing implementation code.
+- `fix(ext/node):` — when the PR actually fixes the implementation so a
+  previously failing test now passes (typically changes under `ext/node/` plus
+  enabling the test in `config.jsonc`).

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1016,6 +1016,46 @@
     "parallel/test-domain-nested-throw.js": {},
     "parallel/test-domain-nested.js": {},
     "parallel/test-domain-nexttick.js": {},
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-0.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-1.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-2.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-3.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-4.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-5.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-6.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-7.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-8.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
+    "parallel/test-domain-no-error-handler-abort-on-uncaught-9.js": {
+      "ignore": true,
+      "reason": "Requires Node.js's --abort-on-uncaught-exception V8 flag (via common.childShouldThrowAndAbort), which Deno does not support"
+    },
     "parallel/test-domain-run.js": {},
     "parallel/test-domain-safe-exit.js": {},
     "parallel/test-domain-stack-empty-in-process-uncaughtexception.js": {},


### PR DESCRIPTION
## Summary

- Ignores all 10 `test-domain-no-error-handler-abort-on-uncaught-{0..9}.js` tests in `tests/node_compat/config.jsonc`.
- These tests use `common.childShouldThrowAndAbort()`, which spawns a child with Node.js's `--abort-on-uncaught-exception` V8 flag and asserts the child aborts (SIGABRT). Deno does not support this V8 flag, so the child exits normally and the assertion fails — this is an inherent incompatibility, not a fixable bug.

## Test plan

- [x] `./x test-compat test-domain-no-error-handler-abort-on-uncaught` — all 10 now report `ignored`