### PR TITLE
chore(skills): document PR title conventions for node-compat

### DIFF
--- a/.claude/skills/node-compat/SKILL.md
+++ b/.claude/skills/node-compat/SKILL.md
@@ -175,3 +175,13 @@ Re-run the test one final time to confirm the outcome matches expectations:
 
 The full schema for `config.jsonc` entries is in
 `tests/node_compat/schema.json`.
+
+## PR title conventions
+
+When opening a PR for node-compat work, use the appropriate prefix:
+
+- `test:` — when the PR only updates `tests/node_compat/config.jsonc` to skip,
+  ignore, or otherwise reclassify tests without changing implementation code.
+- `fix(ext/node):` — when the PR actually fixes the implementation so a
+  previously failing test now passes (typically changes under `ext/node/` plus
+  enabling the test in `config.jsonc`).


### PR DESCRIPTION
## Summary

- Adds a "PR title conventions" section to `.claude/skills/node-compat/SKILL.md`.
- `test:` for PRs that only update `tests/node_compat/config.jsonc` to skip/ignore tests.
- `fix(ext/node):` for PRs that actually fix the implementation so a previously failing test passes.

## Test plan

- [x] Skill file updated, no implementation changes.