### PR TITLE
perf(ext/node): de-genericize ops via DynNodeResolver trait (prototype)

### DIFF
--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -25,6 +25,8 @@ use node_resolver::InNpmPackageChecker;
 use node_resolver::IsBuiltInNodeModuleChecker;
 use node_resolver::NpmPackageFolderResolver;
 use node_resolver::PackageJsonResolverRc;
+use node_resolver::UrlOrPathRef;
+use node_resolver::errors::PackageFolderResolveError;
 use node_resolver::errors::PackageJsonLoadError;
 
 extern crate libz_sys as zlib;
@@ -161,6 +163,54 @@ pub struct NodeExtInitServices<
     NodeResolverRc<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
   pub pkg_json_resolver: PackageJsonResolverRc<TSys>,
   pub sys: TSys,
+}
+
+/// A type-erased subset of [`NodeResolver`]. Used by ops that only need a
+/// handful of resolver methods, so they don't have to be monomorphized over
+/// every concrete `(InNpmPackageChecker, NpmPackageFolderResolver, ExtNodeSys)`
+/// tuple. The wrapping costs one extra `Rc<dyn _>` indirection per call,
+/// which is negligible compared to the work the ops actually do.
+pub trait DynNodeResolver {
+  fn in_npm_package(&self, specifier: &Url) -> bool;
+  fn resolve_package_folder_from_package(
+    &self,
+    package_name: &str,
+    referrer: &UrlOrPathRef,
+  ) -> Result<std::path::PathBuf, PackageFolderResolveError>;
+}
+
+pub type DynNodeResolverRc = std::rc::Rc<dyn DynNodeResolver>;
+
+struct GenericNodeResolverAdapter<
+  TInNpmPackageChecker: InNpmPackageChecker,
+  TNpmPackageFolderResolver: NpmPackageFolderResolver,
+  TSys: ExtNodeSys,
+>(NodeResolverRc<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>);
+
+impl<
+  TInNpmPackageChecker: InNpmPackageChecker + 'static,
+  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
+  TSys: ExtNodeSys + 'static,
+> DynNodeResolver
+  for GenericNodeResolverAdapter<
+    TInNpmPackageChecker,
+    TNpmPackageFolderResolver,
+    TSys,
+  >
+{
+  fn in_npm_package(&self, specifier: &Url) -> bool {
+    self.0.in_npm_package(specifier)
+  }
+
+  fn resolve_package_folder_from_package(
+    &self,
+    package_name: &str,
+    referrer: &UrlOrPathRef,
+  ) -> Result<std::path::PathBuf, PackageFolderResolveError> {
+    self
+      .0
+      .resolve_package_folder_from_package(package_name, referrer)
+  }
 }
 
 deno_core::extension!(deno_node,
@@ -314,8 +364,8 @@ deno_core::extension!(deno_node,
     ops::require::op_require_init_paths,
     ops::require::op_require_node_module_paths<TSys>,
     ops::require::op_require_proxy_path,
-    ops::require::op_require_is_deno_dir_package<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
-    ops::require::op_require_resolve_deno_dir<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
+    ops::require::op_require_is_deno_dir_package,
+    ops::require::op_require_resolve_deno_dir,
     ops::require::op_require_is_maybe_cjs,
     ops::require::op_require_is_request_relative,
     ops::require::op_require_resolve_lookup_paths,
@@ -335,8 +385,8 @@ deno_core::extension!(deno_node,
     ops::util::op_node_guess_handle_type,
     ops::util::op_node_view_has_buffer,
     ops::util::op_node_get_own_non_index_properties,
-    ops::util::op_node_call_is_from_dependency<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
-    ops::util::op_node_in_npm_package<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
+    ops::util::op_node_call_is_from_dependency,
+    ops::util::op_node_in_npm_package,
     ops::util::op_node_parse_env,
     ops::worker_threads::op_worker_threads_filename<TSys>,
     ops::worker_threads::op_worker_get_resource_limits,
@@ -693,6 +743,10 @@ deno_core::extension!(deno_node,
       state.put(init.node_require_loader.clone());
       state.put(init.node_resolver.clone());
       state.put(init.pkg_json_resolver.clone());
+      let dyn_resolver: DynNodeResolverRc = std::rc::Rc::new(
+        GenericNodeResolverAdapter(init.node_resolver.clone()),
+      );
+      state.put(dyn_resolver);
     }
 
     // Always seed `NodeTlsState` so the shared client session cache is

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -249,20 +249,12 @@ pub fn op_require_is_request_relative(#[string] request: &str) -> bool {
 
 #[op2]
 #[string]
-pub fn op_require_resolve_deno_dir<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_require_resolve_deno_dir(
   state: &mut OpState,
   #[string] request: &str,
   #[string] parent_filename: &str,
 ) -> Result<Option<String>, deno_path_util::PathToUrlError> {
-  let resolver = state.borrow::<NodeResolverRc<
-    TInNpmPackageChecker,
-    TNpmPackageFolderResolver,
-    TSys,
-  >>();
+  let resolver = state.borrow::<crate::DynNodeResolverRc>();
 
   let path = Path::new(parent_filename);
   Ok(
@@ -277,19 +269,11 @@ pub fn op_require_resolve_deno_dir<
 }
 
 #[op2(fast)]
-pub fn op_require_is_deno_dir_package<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_require_is_deno_dir_package(
   state: &mut OpState,
   #[string] path: &str,
 ) -> bool {
-  let resolver = state.borrow::<NodeResolverRc<
-    TInNpmPackageChecker,
-    TNpmPackageFolderResolver,
-    TSys,
-  >>();
+  let resolver = state.borrow::<crate::DynNodeResolverRc>();
   match deno_path_util::url_from_file_path(Path::new(path)) {
     Ok(specifier) => resolver.in_npm_package(&specifier),
     Err(_) => false,

--- a/ext/node/ops/util.rs
+++ b/ext/node/ops/util.rs
@@ -7,11 +7,8 @@ use deno_core::op2;
 use deno_core::v8;
 use deno_dotenv::parse_env_content_hook;
 use deno_error::JsErrorBox;
-use node_resolver::InNpmPackageChecker;
-use node_resolver::NpmPackageFolderResolver;
 
-use crate::ExtNodeSys;
-use crate::NodeResolverRc;
+use crate::DynNodeResolverRc;
 
 #[repr(u32)]
 enum HandleType {
@@ -85,11 +82,7 @@ pub fn op_node_view_has_buffer(buffer: v8::Local<v8::ArrayBufferView>) -> bool {
 
 /// Checks if the current call site is from a dependency package.
 #[op2(fast)]
-pub fn op_node_call_is_from_dependency<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_node_call_is_from_dependency(
   state: &mut OpState,
   scope: &mut v8::PinScope<'_, '_>,
 ) -> bool {
@@ -131,21 +124,15 @@ pub fn op_node_call_is_from_dependency<
     if only_internal {
       return true;
     }
-    return state.borrow::<NodeResolverRc<
-        TInNpmPackageChecker,
-        TNpmPackageFolderResolver,
-        TSys,
-      >>().in_npm_package(&specifier);
+    return state
+      .borrow::<DynNodeResolverRc>()
+      .in_npm_package(&specifier);
   }
   only_internal
 }
 
 #[op2(fast)]
-pub fn op_node_in_npm_package<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_node_in_npm_package(
   state: &mut OpState,
   #[string] path: &str,
 ) -> bool {
@@ -161,11 +148,9 @@ pub fn op_node_in_npm_package<
     }
   };
 
-  state.borrow::<NodeResolverRc<
-    TInNpmPackageChecker,
-    TNpmPackageFolderResolver,
-    TSys,
-  >>().in_npm_package(&specifier)
+  state
+    .borrow::<DynNodeResolverRc>()
+    .in_npm_package(&specifier)
 }
 
 #[op2]


### PR DESCRIPTION
## Summary

Prototype/RFC for reducing `deno_node` compile-time cost by type-erasing the resolver in ops, so they don't have to be monomorphized over the `(InNpmPackageChecker, NpmPackageFolderResolver, ExtNodeSys)` tuple at the consumer crate (`runtime`/`cli`).

## Motivation

`ext/node` is declared with `parameters = [TInNpmPackageChecker, TNpmPackageFolderResolver, TSys]` (see `ext/node/lib.rs`). Of the ~240 ops in the crate, only ~13 actually use those generics — but every op carrying those generic args gets monomorphized in the crate that calls `deno_node::deno_node::lazy_init::<…>()` (today: `runtime/snapshot.rs`, `runtime/worker.rs`). Codegen for those ops therefore happens in `runtime`/`cli` rather than once in `ext/node`.

If all 13 generic ops are converted to a `dyn` adapter, the `parameters = [...]` on the extension can be dropped entirely, moving codegen back to `ext/node` and eliminating one source of monomorphization fan-out into `runtime`/`cli`.

## What this PR does

- Introduces `DynNodeResolver`: a small dyn-safe trait exposing the resolver methods needed by simple ops (`in_npm_package`, `resolve_package_folder_from_package`).
- Introduces `GenericNodeResolverAdapter<T1, T2, T3>` which holds the concrete `NodeResolverRc<...>` and implements `DynNodeResolver`.
- Stores `Rc<dyn DynNodeResolver>` in `OpState` at init time, alongside the existing generic resolver.
- Converts 4 ops to drop their generics and use `state.borrow::<DynNodeResolverRc>()`:
  - `ops::util::op_node_call_is_from_dependency`
  - `ops::util::op_node_in_npm_package`
  - `ops::require::op_require_is_deno_dir_package`
  - `ops::require::op_require_resolve_deno_dir`

The runtime overhead per call is one extra `Rc<dyn _>` indirection — negligible compared to the work these ops do.

## What this PR does NOT do

- Does not drop any parameter from `parameters = [...]`. Other ops in `require.rs`, `process.rs`, `worker_threads.rs`, `tls.rs`, `util.rs` still use the generics.
- Does not touch `PackageJsonResolverRc<TSys>` or direct `state.borrow::<TSys>()` lookups.

So compile-time impact of *this PR alone* is small. The point is to validate the pattern.

## Path forward (follow-up work)

To actually drop the extension parameters, the same pattern needs to be extended:

1. Grow `DynNodeResolver` with the remaining used methods: `package_exports_resolve`, `resolve_package_import`, `require_conditions`. Convert `op_require_try_self`, `op_require_resolve_exports`, `op_require_package_imports_resolve`. → drops `TInNpmPackageChecker` and `TNpmPackageFolderResolver`.
2. Add a `DynPackageJsonResolver` trait wrapping `get_closest_package_json` / `load_package_json`. Convert the `PackageJsonResolverRc<TSys>` borrow sites in `require.rs`.
3. Add a `DynExtNodeSys` trait wrapping `env_current_dir`, `env_var`, `fs_canonicalize`, `fs_read_to_string`, `fs_metadata`. Convert direct `state.borrow::<TSys>()` uses in `require.rs`, `process.rs`, `worker_threads.rs`, `tls.rs`. → drops `TSys`.
4. Remove `parameters = [...]` from `extension!(deno_node, …)`.

After step 4, `deno_node::deno_node::lazy_init()` is non-generic and op codegen lives in `ext/node` only.

## Test plan

- [x] `cargo check -p deno_node` — passes
- [x] `cargo check -p deno` — passes (full workspace including runtime + cli)
- [ ] `cargo build --bin deno`
- [ ] `cargo test -p deno_node`
- [ ] CI

## Compile-time delta

Not measured for this PR (would require `--timings` matrix on a clean target). The prototype's own delta is expected to be small (4 ops out of 13). The full conversion outlined in "Path forward" is where the win materializes — by removing the generic parameters from the extension entirely. I'd suggest gating the follow-up work on a measurement showing meaningful improvement after step 1 (the largest of the four steps above).

https://claude.ai/code/session_01Hqbk4M5ExLFnP4xYzTai1e