### PR TITLE
fix(ext/node): prevent top-level `await test(...)` deadlock in node:test

### DIFF
--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -21,6 +21,7 @@ const {
   ObjectPrototypeIsPrototypeOf,
   Promise,
   PromisePrototypeThen,
+  PromiseResolve,
   ReflectApply,
   ReflectConstruct,
   SafeArrayIterator,
@@ -562,11 +563,9 @@ function prepareDenoTest(name, options, fn, overrides) {
 
   activeNodeTests++;
 
-  const { promise, resolve } = Promise.withResolvers();
-
   const denoTestOptions = {
     name: prepared.name,
-    fn: wrapTestFn(prepared.fn, resolve, prepared.name),
+    fn: wrapTestFn(prepared.fn, noop, prepared.name),
     only: prepared.options.only,
     ignore: !!prepared.options.todo || !!prepared.options.skip,
     sanitizeOnly: false,
@@ -575,7 +574,12 @@ function prepareDenoTest(name, options, fn, overrides) {
     sanitizeResources: false,
   };
   Deno.test(denoTestOptions);
-  return promise;
+  // The Deno test runner only executes registered tests after the module
+  // has finished evaluating, so we cannot return a promise that resolves on
+  // completion: top-level `await test(...)` would deadlock the module. The
+  // test still runs and is reported by the runner; we return an already
+  // resolved promise so the await unblocks.
+  return PromiseResolve();
 }
 
 function wrapSuiteFn(fn, resolve, name, parentNodeContext) {
@@ -616,11 +620,9 @@ function prepareDenoTestForSuite(name, options, fn, overrides) {
 
   activeNodeTests++;
 
-  const { promise, resolve } = Promise.withResolvers();
-
   const denoTestOptions = {
     name: prepared.name,
-    fn: wrapSuiteFn(prepared.fn, resolve, prepared.name, undefined),
+    fn: wrapSuiteFn(prepared.fn, noop, prepared.name, undefined),
     only: prepared.options.only,
     ignore: !!prepared.options.todo || !!prepared.options.skip,
     sanitizeOnly: false,
@@ -629,7 +631,9 @@ function prepareDenoTestForSuite(name, options, fn, overrides) {
     sanitizeResources: false,
   };
   Deno.test(denoTestOptions);
-  return promise;
+  // See `prepareDenoTest`: returning a completion promise here would
+  // deadlock top-level `await suite(...)`.
+  return PromiseResolve();
 }
 
 function test(name, options, fn, overrides) {

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -574,11 +574,13 @@ function prepareDenoTest(name, options, fn, overrides) {
     sanitizeResources: false,
   };
   Deno.test(denoTestOptions);
-  // The Deno test runner only executes registered tests after the module
-  // has finished evaluating, so we cannot return a promise that resolves on
-  // completion: top-level `await test(...)` would deadlock the module. The
-  // test still runs and is reported by the runner; we return an already
-  // resolved promise so the await unblocks.
+  // Node resolves the returned promise on test completion, but the
+  // Deno runner only executes registered tests after the module
+  // finishes evaluating, so top-level `await test(...)` deadlocks.
+  // Resolve immediately to unblock; the test still runs and is
+  // reported normally. Trade-off: code that awaits `test()` for
+  // sequencing (`await test('a'); await test('b')`) sees them run
+  // out of order.
   return PromiseResolve();
 }
 
@@ -631,8 +633,8 @@ function prepareDenoTestForSuite(name, options, fn, overrides) {
     sanitizeResources: false,
   };
   Deno.test(denoTestOptions);
-  // See `prepareDenoTest`: returning a completion promise here would
-  // deadlock top-level `await suite(...)`.
+  // See `prepareDenoTest` for the Node-divergence trade-off; top-level
+  // `await suite(...)` would deadlock if we waited for completion.
   return PromiseResolve();
 }
 

--- a/tests/specs/node/node_test_top_level_await/__test__.jsonc
+++ b/tests/specs/node/node_test_top_level_await/__test__.jsonc
@@ -1,0 +1,12 @@
+{
+  "tests": {
+    "test_await": {
+      "args": "test test.mjs",
+      "output": "test.out"
+    },
+    "suite_await": {
+      "args": "test suite.mjs",
+      "output": "suite.out"
+    }
+  }
+}

--- a/tests/specs/node/node_test_top_level_await/suite.mjs
+++ b/tests/specs/node/node_test_top_level_await/suite.mjs
@@ -1,0 +1,14 @@
+// Regression test for https://github.com/denoland/deno/issues/32326
+// Top-level `await suite(...)` must not deadlock the module either.
+
+import { suite, test } from "node:test";
+import assert from "node:assert";
+
+await suite("a suite", () => {
+  test("first", () => {
+    assert.strictEqual(1 + 1, 2);
+  });
+  test("second", () => {
+    assert.ok(true);
+  });
+});

--- a/tests/specs/node/node_test_top_level_await/suite.out
+++ b/tests/specs/node/node_test_top_level_await/suite.out
@@ -1,0 +1,7 @@
+running 1 test from ./suite.mjs
+a suite ...
+  first ... ok ([WILDLINE])
+  second ... ok ([WILDLINE])
+a suite ... ok ([WILDLINE])
+
+ok | 1 passed (2 steps) | 0 failed ([WILDLINE])

--- a/tests/specs/node/node_test_top_level_await/suite.out
+++ b/tests/specs/node/node_test_top_level_await/suite.out
@@ -5,3 +5,4 @@ a suite ...
 a suite ... ok ([WILDLINE])
 
 ok | 1 passed (2 steps) | 0 failed ([WILDLINE])
+

--- a/tests/specs/node/node_test_top_level_await/test.mjs
+++ b/tests/specs/node/node_test_top_level_await/test.mjs
@@ -1,0 +1,14 @@
+// Regression test for https://github.com/denoland/deno/issues/32326
+// Top-level `await test(...)` must not deadlock the module.
+
+import test from "node:test";
+import assert from "node:assert";
+
+await test("a test", () => {
+  assert.strictEqual(1 + 1, 2);
+});
+
+await test("another test", async () => {
+  await new Promise((resolve) => setTimeout(resolve, 1));
+  assert.ok(true);
+});

--- a/tests/specs/node/node_test_top_level_await/test.out
+++ b/tests/specs/node/node_test_top_level_await/test.out
@@ -3,3 +3,4 @@ a test ... ok ([WILDLINE])
 another test ... ok ([WILDLINE])
 
 ok | 2 passed | 0 failed ([WILDLINE])
+

--- a/tests/specs/node/node_test_top_level_await/test.out
+++ b/tests/specs/node/node_test_top_level_await/test.out
@@ -1,0 +1,5 @@
+running 2 tests from ./test.mjs
+a test ... ok ([WILDLINE])
+another test ... ok ([WILDLINE])
+
+ok | 2 passed | 0 failed ([WILDLINE])


### PR DESCRIPTION
## Summary

Fixes #32326.

The `test()` and `suite()` entry points in `node:test` returned a promise
that only resolved when the underlying `Deno.test()` callback executed.
Because `Deno.test()` defers execution until after the module finishes
evaluating, the following common Node.js pattern would deadlock:

```js
import test from "node:test";
import assert from "node:assert";

await test("a test", () => {
  assert.strictEqual(1 + 1, 2);
});
```

The module could not finish evaluating because of the `await`, and the
test could not start because the module had not finished evaluating,
producing `error: Top-level await promise never resolved`.

The fix returns an already-resolved promise from `prepareDenoTest` and
`prepareDenoTestForSuite`. The test/suite is still registered with the
Deno test runner and runs (and is reported) normally; only the awaited
promise no longer waits for completion. Subtests and `await t.test(...)`
inside a parent test are unaffected because they go through
`denoContext.step()`, which executes synchronously inside the parent.

## Test plan

- [x] Original reproduction from the issue now passes:
  ```
  $ deno test -A a.test.mjs
  running 1 test from ./a.test.mjs
  a test ... ok (0ms)
  ok | 1 passed | 0 failed
  ```
- [x] Multiple sequential `await test(...)` calls register and run, including failures.
- [x] `await suite(...)` works the same way.
- [x] Subtests via `await t.test(...)` still work.
- [x] Existing `tests/specs/node/node_test_*` spec tests still produce the same output.
- [x] New regression spec test added at `tests/specs/node/node_test_top_level_await/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158CC3raG22nTkVksQrreug)_