### PR TITLE
fix(ext/node): detect non-mtime stat changes in StatWatcher

### DIFF
--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -3110,13 +3110,18 @@ function symlinkSync(
 
 // -- watch --
 
+const statPromisified = promisify(stat) as {
+  (filename: string, options: { bigint: false }): Promise<Stats>;
+  (filename: string, options: { bigint: true }): Promise<BigIntStats>;
+};
 const statAsync = async (
   filename: string,
   bigint: boolean,
 ): Promise<Stats | BigIntStats> => {
   try {
-    const info = await Deno.stat(filename);
-    return CFISBIS(info, bigint);
+    return bigint
+      ? await statPromisified(filename, { bigint: true })
+      : await statPromisified(filename, { bigint: false });
   } catch {
     return bigint ? emptyBigIntStats : emptyStats;
   }

--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -170,7 +170,6 @@ const {
   ArrayBufferIsView,
   ArrayIsArray,
   BigInt,
-  DatePrototypeGetTime,
   DateUTC,
   Error,
   FunctionPrototypeBind,
@@ -3111,12 +3110,15 @@ function symlinkSync(
 
 // -- watch --
 
-const statPromisified = promisify(stat);
-const statAsync = async (filename: string): Promise<Stats | null> => {
+const statAsync = async (
+  filename: string,
+  bigint: boolean,
+): Promise<Stats | BigIntStats> => {
   try {
-    return await statPromisified(filename);
+    const info = await Deno.stat(filename);
+    return CFISBIS(info, bigint);
   } catch {
-    return emptyStats;
+    return bigint ? emptyBigIntStats : emptyStats;
   }
 };
 const emptyStats = new Stats(
@@ -3135,6 +3137,38 @@ const emptyStats = new Stats(
   DateUTC(1970, 0, 1, 0, 0, 0),
   DateUTC(1970, 0, 1, 0, 0, 0),
 ) as unknown as Stats;
+const emptyBigIntStats = new BigIntStats(
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+  0n,
+) as unknown as BigIntStats;
+
+// Mirrors libuv's `uv_fs_poll_t` field comparison so chmod/chown,
+// file replacement, and sub-mtime-resolution changes all fire "change".
+function statsChanged(
+  prev: Stats | BigIntStats,
+  curr: Stats | BigIntStats,
+): boolean {
+  return prev.mtimeMs !== curr.mtimeMs ||
+    prev.ctimeMs !== curr.ctimeMs ||
+    prev.size !== curr.size ||
+    prev.mode !== curr.mode ||
+    prev.uid !== curr.uid ||
+    prev.gid !== curr.gid ||
+    prev.ino !== curr.ino ||
+    prev.dev !== curr.dev;
+}
 
 function asyncIterableToCallback<T>(
   iter: AsyncIterable<T>,
@@ -3594,21 +3628,20 @@ class StatWatcher extends EventEmitter {
       this.#refCount++;
     }
 
+    const bigint = this.#bigint;
     (async () => {
-      let prev = await statAsync(filename);
+      let prev = await statAsync(filename, bigint);
 
-      if (prev === emptyStats) {
+      // libuv emits an initial "change" only when the first stat fails.
+      if (prev === emptyStats || prev === emptyBigIntStats) {
         this.emit("change", prev, prev);
       }
 
       try {
         while (true) {
           await this.#sleep(interval);
-          const curr = await statAsync(filename);
-          if (
-            DatePrototypeGetTime(curr?.mtime) !==
-              DatePrototypeGetTime(prev?.mtime)
-          ) {
+          const curr = await statAsync(filename, bigint);
+          if (statsChanged(prev, curr)) {
             this.emit("change", curr, prev);
             prev = curr;
           }

--- a/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/tests/unit_node/_fs/_fs_watch_test.ts
@@ -1,5 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { unwatchFile, watch, watchFile } from "node:fs";
+import {
+  type BigIntStats,
+  type Stats,
+  unwatchFile,
+  watch,
+  watchFile,
+} from "node:fs";
 import { watch as watchPromise } from "node:fs/promises";
 import { assert, assertEquals, assertRejects } from "@std/assert";
 import { spy } from "@std/testing/mock";
@@ -48,6 +54,60 @@ Deno.test({
     unwatchFile(file);
     await wait(100);
     assertEquals(spyFn.calls.length, 1);
+  },
+});
+
+Deno.test({
+  name: "watchFile detects metadata-only changes (chmod)",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const file = Deno.makeTempFileSync();
+    Deno.writeTextFileSync(file, "foo");
+    Deno.chmodSync(file, 0o644);
+
+    const calls: Array<[Stats, Stats]> = [];
+    watchFile(
+      file,
+      { interval: 10 },
+      (curr, prev) => calls.push([curr as Stats, prev as Stats]),
+    );
+
+    try {
+      await wait(50);
+      assertEquals(calls.length, 0);
+      Deno.chmodSync(file, 0o600);
+      await wait(150);
+      assertEquals(calls.length, 1);
+      assert(calls[0][0].mode !== calls[0][1].mode);
+    } finally {
+      unwatchFile(file);
+    }
+  },
+});
+
+Deno.test({
+  name: "watchFile honors bigint option",
+  async fn() {
+    const file = Deno.makeTempFileSync();
+    Deno.writeTextFileSync(file, "foo");
+
+    const calls: Array<[BigIntStats, BigIntStats]> = [];
+    watchFile(
+      file,
+      { interval: 10, bigint: true },
+      (curr, prev) => calls.push([curr as BigIntStats, prev as BigIntStats]),
+    );
+
+    try {
+      await wait(50);
+      Deno.writeTextFileSync(file, "bar");
+      await wait(150);
+      assert(calls.length >= 1);
+      assertEquals(typeof calls[0][0].mtimeMs, "bigint");
+      assertEquals(typeof calls[0][0].ino, "bigint");
+    } finally {
+      unwatchFile(file);
+    }
   },
 });
 


### PR DESCRIPTION
`fs.watchFile`'s `StatWatcher` only compared `mtime` between polls, so
metadata-only changes (chmod/chown), file replacements that preserved
mtime, and changes too small for mtime resolution went undetected. The
`bigint` option was also accepted but never reached the listener. Match
libuv's `uv_fs_poll_t` field comparison and pass `bigint` through to
the stat conversion.

Fixes #23049

https://claude.ai/code/session_01BN144R647WbGwBLa1aBNmi