### PR TITLE
fix(ext/node): match Node's empty libc version on non-glibc builds

### DIFF
--- a/ext/node/polyfills/internal/process/report.ts
+++ b/ext/node/polyfills/internal/process/report.ts
@@ -24,6 +24,12 @@ const todoUndefined = undefined;
 function getReport(_err) {
   const os = lazyOs();
   const dumpEventTime = new Date();
+  // Match Node.js: glibcVersion* are populated from gnu_get_libc_version()
+  // when built against glibc, and are empty strings otherwise (e.g. musl,
+  // Windows, macOS). Deno.build.env carries the target-triple env component
+  // ("gnu" for glibc, "musl" for musl, "msvc" on Windows, undefined on macOS).
+  const isGlibc = Deno.build.env === "gnu";
+  const glibcVersion = isGlibc ? "2.38" : "";
   return {
     header: {
       reportVersion: 3,
@@ -37,8 +43,8 @@ function getReport(_err) {
       cwd: Deno.cwd(),
       commandLine: ["node"],
       nodejsVersion: `v${versions.node}`,
-      glibcVersionRuntime: "2.38",
-      glibcVersionCompiler: "2.38",
+      glibcVersionRuntime: glibcVersion,
+      glibcVersionCompiler: glibcVersion,
       wordSize: 64,
       arch: arch(),
       platform: Deno.build.os,

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1205,6 +1205,9 @@ Deno.test({
     assert(typeof result.header.host === "string");
     delete result.header.host;
 
+    // glibc version is "" on non-glibc builds (musl, Windows, macOS), matching
+    // Node's behavior where gnu_get_libc_version() is unavailable.
+    const expectedGlibcVersion = Deno.build.env === "gnu" ? "2.38" : "";
     // test hardcoded part
     assertEquals(result, {
       header: {
@@ -1213,8 +1216,8 @@ Deno.test({
         trigger: "GetReport",
         threadId: 0,
         commandLine: ["node"],
-        glibcVersionRuntime: "2.38",
-        glibcVersionCompiler: "2.38",
+        glibcVersionRuntime: expectedGlibcVersion,
+        glibcVersionCompiler: expectedGlibcVersion,
         wordSize: 64,
         release: {
           name: "node",


### PR DESCRIPTION
Closes #33948.

The process.report polyfill at \`ext/node/polyfills/internal/process/report.ts\` hard-coded \`glibcVersionRuntime\` and \`glibcVersionCompiler\` to \`\"2.38\"\` regardless of the actual build target. On Alpine (musl), that misleads downstream tooling — rollup keys off the same field to decide whether the runtime is glibc, and gets the wrong answer. The reporter (#33948) hit this on \`deno 2.7.4\` on Alpine edge.

Node populates these from \`gnu_get_libc_version(3)\`, which is only available when linked against glibc. On musl, Windows, and macOS Node returns the empty string for both fields. This PR matches that.

The check is gated on \`Deno.build.env\` — the LLVM target-triple env component: \`\"gnu\"\` for glibc, \`\"musl\"\` for musl, \`\"msvc\"\` on Windows, undefined on macOS. Only \`\"gnu\"\` returns the populated version; everything else returns \`\"\"\`.

Updated the process_test.ts assertion the same way so the existing test still passes on glibc but no longer pins a value that's wrong on musl/windows/macOS.

Open to a different signal source if you'd rather use a Deno op or a build-time constant — \`build.env\` was the smallest available change.