### PR TITLE
feat(ext/cron): scaffold Deno.cron.persistent API (no backends yet)

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -491,6 +491,125 @@ declare namespace Deno {
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
+   * Namespace augmentation of {@linkcode Deno.cron} that adds persistent
+   * (OS-scheduled) cron registration. Persistent crons survive process exit
+   * and reboot because they are registered with the host OS scheduler
+   * (`crontab` on Linux, `launchd` on macOS, `schtasks` on Windows).
+   *
+   * @category Cloud
+   * @experimental
+   */
+  export namespace cron {
+    /** **UNSTABLE**: New API, yet to be vetted.
+     *
+     * Options accepted by {@linkcode Deno.cron.persistent}.
+     *
+     * @category Cloud
+     * @experimental
+     */
+    export interface PersistentOptions {
+      /** Unique title. Re-registering with the same name overwrites the
+       * existing entry. Same naming rules as {@linkcode Deno.cron}
+       * (alphanumerics, hyphens, underscores, whitespace; ≤ 64 chars). */
+      name: string;
+      /** Unix-format cron expression or a {@linkcode Deno.CronSchedule}. */
+      schedule: string | CronSchedule;
+      /** Path to a module that exports `default.scheduled`. Resolved
+       * against the current working directory at registration time. */
+      script: string;
+      /** Permission flags forwarded to `deno run` when the OS scheduler
+       * fires (e.g. `["--allow-net", "--allow-read=."]`). */
+      permissions?: string[];
+      /** Working directory the script will run in. Defaults to the cwd of
+       * the registering process. */
+      cwd?: string;
+      /** Environment variables to set when the cron fires. */
+      env?: Record<string, string>;
+    }
+
+    /** **UNSTABLE**: New API, yet to be vetted.
+     *
+     * One row returned from {@linkcode Deno.cron.list}.
+     *
+     * @category Cloud
+     * @experimental
+     */
+    export interface PersistentEntry {
+      name: string;
+      schedule: string;
+      script: string;
+    }
+
+    /** **UNSTABLE**: New API, yet to be vetted.
+     *
+     * Register a persistent cron with the host OS scheduler. The current
+     * process exits without keeping a tokio loop alive — the OS launches
+     * `deno cron exec <script>` at each scheduled time, which calls the
+     * module's `default.scheduled(controller)` export.
+     *
+     * ```ts
+     * await Deno.cron.persistent({
+     *   name: "weekly-report",
+     *   schedule: "30 2 * * MON",
+     *   script: "./worker.ts",
+     *   permissions: ["--allow-net"],
+     * });
+     * ```
+     *
+     * The worker entry point:
+     *
+     * ```ts
+     * export default {
+     *   async scheduled(controller: Deno.CronController) {
+     *     console.log(controller.cron, controller.scheduledTime);
+     *   },
+     * };
+     * ```
+     *
+     * @category Cloud
+     * @experimental
+     */
+    export function persistent(options: PersistentOptions): Promise<void>;
+
+    /** **UNSTABLE**: New API, yet to be vetted.
+     *
+     * Unregister a persistent cron previously registered with
+     * {@linkcode Deno.cron.persistent}. Resolves silently if no entry
+     * matches.
+     *
+     * @category Cloud
+     * @experimental
+     */
+    export function remove(name: string): Promise<void>;
+
+    /** **UNSTABLE**: New API, yet to be vetted.
+     *
+     * List persistent crons registered by the current user on this host.
+     *
+     * @category Cloud
+     * @experimental
+     */
+    export function list(): Promise<PersistentEntry[]>;
+  }
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
+   * Argument passed to a persistent cron's `default.scheduled` handler.
+   *
+   * @category Cloud
+   * @experimental
+   */
+  export interface CronController {
+    /** The cron expression that triggered this run, normalized to a 5-field
+     * Unix cron string. */
+    readonly cron: string;
+    /** Unix timestamp in milliseconds at which the OS scheduler fired this
+     * run. May differ slightly from `Date.now()` if invocation was delayed. */
+    readonly scheduledTime: number;
+  }
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
    * A key to be persisted in a {@linkcode Deno.Kv}. A key is a sequence
    * of {@linkcode Deno.KvKeyPart}s.
    *

--- a/ext/cron/01_cron.ts
+++ b/ext/cron/01_cron.ts
@@ -2,10 +2,22 @@
 
 (function () {
 const { core, internals, primordials } = globalThis.__bootstrap;
-const { op_cron_create, op_cron_next } = core.ops;
 const {
+  op_cron_create,
+  op_cron_next,
+  op_cron_persistent_create,
+  op_cron_persistent_list,
+  op_cron_persistent_remove,
+} = core.ops;
+const {
+  ArrayIsArray,
   ArrayPrototypeJoin,
+  ArrayPrototypePush,
+  ArrayPrototypeSort,
   NumberPrototypeToString,
+  ObjectKeys,
+  ObjectPrototypeHasOwnProperty,
+  PromiseResolve,
   SafeArrayIterator,
   TypeError,
 } = primordials;
@@ -222,6 +234,116 @@ function cron(
     }
   })();
 }
+
+function persistent(
+  options: {
+    name: string;
+    schedule: string | Deno.CronSchedule;
+    script: string;
+    permissions?: string[];
+    cwd?: string;
+    env?: Record<string, string>;
+  },
+): Promise<void> {
+  if (options === null || typeof options !== "object") {
+    throw new TypeError(
+      "Cannot register persistent cron: options must be an object",
+    );
+  }
+  const { name, schedule, script } = options;
+  if (typeof name !== "string" || name.length === 0) {
+    throw new TypeError(
+      "Cannot register persistent cron: 'name' must be a non-empty string",
+    );
+  }
+  if (schedule === undefined) {
+    throw new TypeError(
+      "Cannot register persistent cron: 'schedule' is required",
+    );
+  }
+  if (typeof script !== "string" || script.length === 0) {
+    throw new TypeError(
+      "Cannot register persistent cron: 'script' must be a non-empty path",
+    );
+  }
+
+  const scheduleStr = parseScheduleToString(schedule);
+
+  const permissions = options.permissions ?? [];
+  if (!ArrayIsArray(permissions)) {
+    throw new TypeError(
+      "Cannot register persistent cron: 'permissions' must be an array of strings",
+    );
+  }
+  for (const p of new SafeArrayIterator(permissions)) {
+    if (typeof p !== "string") {
+      throw new TypeError(
+        "Cannot register persistent cron: 'permissions' entries must be strings",
+      );
+    }
+  }
+
+  const envObj = options.env;
+  const env: [string, string][] = [];
+  if (envObj !== undefined) {
+    if (envObj === null || typeof envObj !== "object") {
+      throw new TypeError(
+        "Cannot register persistent cron: 'env' must be an object",
+      );
+    }
+    for (const key of new SafeArrayIterator(ObjectKeys(envObj))) {
+      if (!ObjectPrototypeHasOwnProperty(envObj, key)) continue;
+      const value = envObj[key];
+      if (typeof value !== "string") {
+        throw new TypeError(
+          `Cannot register persistent cron: env value for '${key}' must be a string`,
+        );
+      }
+      ArrayPrototypePush(env, [key, value]);
+    }
+    // Sort for stable on-disk representation.
+    ArrayPrototypeSort(
+      env,
+      (a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0),
+    );
+  }
+
+  op_cron_persistent_create(
+    name,
+    scheduleStr,
+    script,
+    permissions,
+    options.cwd,
+    env,
+  );
+  return PromiseResolve();
+}
+
+function remove(name: string): Promise<void> {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new TypeError(
+      "Cannot remove persistent cron: 'name' must be a non-empty string",
+    );
+  }
+  op_cron_persistent_remove(name);
+  return PromiseResolve();
+}
+
+function list(): Promise<
+  { name: string; schedule: string; script: string }[]
+> {
+  return PromiseResolve(op_cron_persistent_list());
+}
+
+// Attach persistent-cron methods as properties of the `cron` function so
+// callers can do `Deno.cron.persistent(...)`.
+(cron as unknown as {
+  persistent: typeof persistent;
+  remove: typeof remove;
+  list: typeof list;
+}).persistent = persistent;
+(cron as unknown as { remove: typeof remove }).remove = remove;
+(cron as unknown as { list: typeof list }).list = list;
 
 // For testing
 internals.formatToCronSchedule = formatToCronSchedule;

--- a/ext/cron/interface.rs
+++ b/ext/cron/interface.rs
@@ -31,3 +31,37 @@ pub struct CronSpec {
   pub cron_schedule: String,
   pub backoff_schedule: Option<Vec<u32>>,
 }
+
+/// Registration spec for a persistent (OS-scheduled) cron.
+///
+/// Unlike `CronSpec`, the runtime that registers a persistent cron does not
+/// stay alive — the host OS scheduler is responsible for invoking
+/// `deno cron exec <script>` at each scheduled time.
+#[derive(Clone, Debug)]
+pub struct PersistentCronSpec {
+  pub name: String,
+  pub cron_schedule: String,
+  pub script: String,
+  pub cwd: Option<String>,
+  pub permissions: Vec<String>,
+  pub env: Vec<(String, String)>,
+}
+
+/// One row returned by `PersistentCronHandler::list()`.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersistentCronEntry {
+  pub name: String,
+  pub schedule: String,
+  pub script: String,
+}
+
+/// Backend for OS-scheduled (persistent) crons.
+///
+/// All methods are synchronous and are expected to complete quickly —
+/// registration writes to user-scoped scheduler state (crontab/launchd/
+/// schtasks) rather than waiting for cron deadlines.
+pub trait PersistentCronHandler {
+  fn register(&self, spec: PersistentCronSpec) -> Result<(), CronError>;
+  fn unregister(&self, name: &str) -> Result<(), CronError>;
+  fn list(&self) -> Result<Vec<PersistentCronEntry>, CronError>;
+}

--- a/ext/cron/lib.rs
+++ b/ext/cron/lib.rs
@@ -3,6 +3,7 @@
 mod handler_impl;
 mod interface;
 pub mod local;
+pub mod persistent;
 mod socket;
 
 use std::borrow::Cow;
@@ -19,6 +20,8 @@ use deno_error::JsErrorClass;
 use deno_features::FeatureChecker;
 pub use handler_impl::CronHandleImpl;
 pub use handler_impl::CronHandlerImpl;
+pub use persistent::PersistentCronHandlerImpl;
+pub use persistent::UnimplementedPersistentCronHandler;
 pub use socket::SocketCronHandle;
 pub use socket::SocketCronHandler;
 
@@ -27,19 +30,28 @@ pub use crate::interface::*;
 pub const UNSTABLE_FEATURE_NAME: &str = "cron";
 
 deno_core::extension!(deno_cron,
-  parameters = [ C: CronHandler ],
+  parameters = [ C: CronHandler, P: PersistentCronHandler ],
   ops = [
     op_cron_create<C>,
     op_cron_next<C>,
+    op_cron_persistent_create<P>,
+    op_cron_persistent_remove<P>,
+    op_cron_persistent_list<P>,
   ],
   lazy_loaded_js = [ "01_cron.ts" ],
   options = {
     cron_handler: C,
+    persistent_cron_handler: P,
   },
   state = |state, options| {
     state.put(Rc::new(options.cron_handler));
+    state.put(PersistentHandlerSlot(Rc::new(options.persistent_cron_handler)));
   }
 );
+
+/// Newtype wrapper so the persistent handler can be stored in `OpState`
+/// without colliding with the regular `Rc<C>` slot.
+struct PersistentHandlerSlot<P: PersistentCronHandler + 'static>(Rc<P>);
 
 struct CronResource<EH: CronHandle + 'static> {
   handle: Rc<EH>,
@@ -89,6 +101,12 @@ pub enum CronError {
   #[class(generic)]
   #[error("Error registering cron: {0}")]
   RejectedError(String),
+  #[class(generic)]
+  #[error("{0}")]
+  Unsupported(String),
+  #[class(generic)]
+  #[error("Persistent cron error: {0}")]
+  Persistent(String),
   #[class(inherit)]
   #[error(transparent)]
   Other(JsErrorBox),
@@ -159,6 +177,75 @@ where
   };
 
   cron_handler.next(prev_success).await
+}
+
+#[op2]
+fn op_cron_persistent_create<P>(
+  state: Rc<RefCell<OpState>>,
+  #[string] name: String,
+  #[string] cron_schedule: String,
+  #[string] script: String,
+  #[serde] permissions: Vec<String>,
+  #[string] cwd: Option<String>,
+  #[serde] env: Vec<(String, String)>,
+) -> Result<(), CronError>
+where
+  P: PersistentCronHandler + 'static,
+{
+  let handler = {
+    let state = state.borrow();
+    state
+      .borrow::<Arc<FeatureChecker>>()
+      .check_or_exit(UNSTABLE_FEATURE_NAME, "Deno.cron.persistent");
+    state.borrow::<PersistentHandlerSlot<P>>().0.clone()
+  };
+
+  validate_cron_name(&name)?;
+
+  handler.register(PersistentCronSpec {
+    name,
+    cron_schedule,
+    script,
+    cwd,
+    permissions,
+    env,
+  })
+}
+
+#[op2(fast)]
+fn op_cron_persistent_remove<P>(
+  state: Rc<RefCell<OpState>>,
+  #[string] name: String,
+) -> Result<(), CronError>
+where
+  P: PersistentCronHandler + 'static,
+{
+  let handler = {
+    let state = state.borrow();
+    state
+      .borrow::<Arc<FeatureChecker>>()
+      .check_or_exit(UNSTABLE_FEATURE_NAME, "Deno.cron.remove");
+    state.borrow::<PersistentHandlerSlot<P>>().0.clone()
+  };
+  handler.unregister(&name)
+}
+
+#[op2]
+#[serde]
+fn op_cron_persistent_list<P>(
+  state: Rc<RefCell<OpState>>,
+) -> Result<Vec<PersistentCronEntry>, CronError>
+where
+  P: PersistentCronHandler + 'static,
+{
+  let handler = {
+    let state = state.borrow();
+    state
+      .borrow::<Arc<FeatureChecker>>()
+      .check_or_exit(UNSTABLE_FEATURE_NAME, "Deno.cron.list");
+    state.borrow::<PersistentHandlerSlot<P>>().0.clone()
+  };
+  handler.list()
 }
 
 fn validate_cron_name(name: &str) -> Result<(), CronError> {

--- a/ext/cron/persistent.rs
+++ b/ext/cron/persistent.rs
@@ -1,0 +1,77 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Persistent (OS-scheduled) cron backend.
+//!
+//! Persistent crons are registered with the host OS scheduler — crontab on
+//! Linux, launchd on macOS, schtasks on Windows — so they survive process
+//! exit and reboot. Per-platform backends will be added in follow-up PRs;
+//! for now every platform reports unsupported.
+
+use crate::CronError;
+use crate::PersistentCronEntry;
+use crate::PersistentCronHandler;
+use crate::PersistentCronSpec;
+
+/// Default handler used until per-platform backends land. Every operation
+/// fails with [`CronError::Unsupported`].
+pub struct UnimplementedPersistentCronHandler;
+
+impl PersistentCronHandler for UnimplementedPersistentCronHandler {
+  fn register(&self, _spec: PersistentCronSpec) -> Result<(), CronError> {
+    Err(unsupported())
+  }
+
+  fn unregister(&self, _name: &str) -> Result<(), CronError> {
+    Err(unsupported())
+  }
+
+  fn list(&self) -> Result<Vec<PersistentCronEntry>, CronError> {
+    Err(unsupported())
+  }
+}
+
+/// Top-level persistent-cron handler enum mirroring [`CronHandlerImpl`].
+///
+/// Currently only `Unimplemented` exists; per-OS variants will be added
+/// alongside the launchd/crontab/schtasks backends.
+pub enum PersistentCronHandlerImpl {
+  Unimplemented(UnimplementedPersistentCronHandler),
+}
+
+impl PersistentCronHandlerImpl {
+  pub fn create_from_env() -> Self {
+    Self::Unimplemented(UnimplementedPersistentCronHandler)
+  }
+}
+
+impl Default for PersistentCronHandlerImpl {
+  fn default() -> Self {
+    Self::create_from_env()
+  }
+}
+
+impl PersistentCronHandler for PersistentCronHandlerImpl {
+  fn register(&self, spec: PersistentCronSpec) -> Result<(), CronError> {
+    match self {
+      Self::Unimplemented(h) => h.register(spec),
+    }
+  }
+
+  fn unregister(&self, name: &str) -> Result<(), CronError> {
+    match self {
+      Self::Unimplemented(h) => h.unregister(name),
+    }
+  }
+
+  fn list(&self) -> Result<Vec<PersistentCronEntry>, CronError> {
+    match self {
+      Self::Unimplemented(h) => h.list(),
+    }
+  }
+}
+
+fn unsupported() -> CronError {
+  CronError::Unsupported(
+    "persistent cron is not yet supported on this platform".to_string(),
+  )
+}

--- a/runtime/snapshot.rs
+++ b/runtime/snapshot.rs
@@ -39,7 +39,10 @@ pub fn create_runtime_snapshot(
     deno_net::deno_net::lazy_init(),
     deno_tls::deno_tls::lazy_init(),
     deno_kv::deno_kv::lazy_init::<deno_kv::sqlite::SqliteDbHandler>(),
-    deno_cron::deno_cron::init(deno_cron::local::LocalCronHandler::new()),
+    deno_cron::deno_cron::init(
+      deno_cron::local::LocalCronHandler::new(),
+      deno_cron::UnimplementedPersistentCronHandler,
+    ),
     deno_napi::deno_napi::lazy_init(),
     deno_http::deno_http::lazy_init(),
     deno_io::deno_io::lazy_init(),

--- a/runtime/snapshot_info.rs
+++ b/runtime/snapshot_info.rs
@@ -38,7 +38,10 @@ pub fn get_extensions_in_snapshot() -> Vec<Extension> {
       deno_kv::sqlite::SqliteDbHandler::new(None, None),
       deno_kv::KvConfig::builder().build(),
     ),
-    deno_cron::deno_cron::init(deno_cron::local::LocalCronHandler::new()),
+    deno_cron::deno_cron::init(
+      deno_cron::local::LocalCronHandler::new(),
+      deno_cron::UnimplementedPersistentCronHandler,
+    ),
     deno_napi::deno_napi::init(None),
     deno_http::deno_http::init(deno_http::Options::default()),
     deno_io::deno_io::init(Some(Default::default())),

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -566,7 +566,10 @@ impl WebWorker {
         ),
         deno_kv::KvConfig::builder().build(),
       ),
-      deno_cron::deno_cron::init(CronHandlerImpl::create_from_env()),
+      deno_cron::deno_cron::init(
+        CronHandlerImpl::create_from_env(),
+        deno_cron::PersistentCronHandlerImpl::create_from_env(),
+      ),
       deno_napi::deno_napi::init(services.deno_rt_native_addon_loader.clone()),
       deno_http::deno_http::init(deno_http::Options {
         no_legacy_abort: options.bootstrap.no_legacy_abort,

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -1084,7 +1084,10 @@ fn common_extensions<
     deno_net::deno_net::lazy_init(),
     deno_tls::deno_tls::init(),
     deno_kv::deno_kv::lazy_init::<MultiBackendDbHandler>(),
-    deno_cron::deno_cron::init(CronHandlerImpl::create_from_env()),
+    deno_cron::deno_cron::init(
+      CronHandlerImpl::create_from_env(),
+      deno_cron::PersistentCronHandlerImpl::create_from_env(),
+    ),
     deno_napi::deno_napi::lazy_init(),
     deno_http::deno_http::lazy_init(),
     deno_io::deno_io::lazy_init(),


### PR DESCRIPTION
First step toward persistent cron jobs in Deno — jobs that survive
process exit and reboot because they are registered with the host OS
scheduler (crontab on Linux, launchd on macOS, schtasks on Windows)
rather than kept alive by an in-process tokio loop. This PR lands the
public API surface and the Rust wiring only; every backend currently
returns "persistent cron is not yet supported on this platform". Per-OS
backends and the `deno cron exec` subcommand that the OS scheduler
invokes will follow in separate PRs.

`Deno.cron.persistent`, `Deno.cron.remove`, and `Deno.cron.list` are
namespace-attached methods on the existing `Deno.cron` function, so they
compose with the in-memory cron API. The worker entry point exports
`default.scheduled(controller)` matching the Cloudflare Workers Cron
Triggers shape. On the Rust side the `deno_cron` extension gains a
second generic `P: PersistentCronHandler`; for now only an
`Unimplemented` variant exists, returning `CronError::Unsupported` from
every method. Gated behind the existing `--unstable-cron` flag.