### PR TITLE
refactor(ext/node): drop TInNpmPackageChecker generic from deno_node

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -956,7 +956,6 @@ fn wait_for_start(
     init_v8(&Flags::default());
 
     let unconfigured = deno_runtime::UnconfiguredRuntime::new::<
-      deno_resolver::npm::DenoInNpmPackageChecker,
       crate::npm::CliNpmResolver,
       crate::sys::CliSys,
     >(deno_runtime::UnconfiguredRuntimeOptions {

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -321,12 +321,13 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
   fn create_node_init_services(
     &self,
     node_require_loader: NodeRequireLoaderRc,
-  ) -> NodeExtInitServices<DenoInNpmPackageChecker, NpmResolver<TSys>, TSys> {
+  ) -> NodeExtInitServices<NpmResolver<TSys>, TSys> {
     NodeExtInitServices {
       node_require_loader,
       node_resolver: self.node_resolver.clone(),
       pkg_json_resolver: self.pkg_json_resolver.clone(),
       sys: self.sys.clone(),
+      _phantom: std::marker::PhantomData,
     }
   }
 

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -560,7 +560,6 @@ mod tests {
 
   use deno_core::FsModuleLoader;
   use deno_core::resolve_path;
-  use deno_resolver::npm::DenoInNpmPackageChecker;
   use deno_runtime::deno_fs::RealFs;
   use deno_runtime::deno_permissions::Permissions;
   use deno_runtime::permissions::RuntimePermissionDescriptorParser;
@@ -582,11 +581,7 @@ mod tests {
       ..Default::default()
     };
 
-    MainWorker::bootstrap_from_options::<
-      DenoInNpmPackageChecker,
-      CliNpmResolver,
-      CliSys,
-    >(
+    MainWorker::bootstrap_from_options::<CliNpmResolver, CliSys>(
       &main_module,
       WorkerServiceOptions {
         deno_rt_native_addon_loader: None,

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -150,22 +150,156 @@ fn op_node_load_env_file(
   Ok(())
 }
 
+/// Dyn-safe surface of [`node_resolver::NodeResolver`] for the methods
+/// invoked from the `deno_node` extension's ops. Storing the resolver as
+/// `Rc<dyn DynNodeResolver>` lets us drop the `TInNpmPackageChecker`
+/// generic from the extension and its ops; callers' existing
+/// `NodeResolverRc<...>` coerces to this trait object automatically via
+/// the blanket impl on `node_resolver::NodeResolver`.
+pub trait DynNodeResolver {
+  fn in_npm_package(&self, specifier: &Url) -> bool;
+
+  fn resolve_package_folder_from_package(
+    &self,
+    specifier: &str,
+    referrer: &node_resolver::UrlOrPathRef,
+  ) -> Result<
+    std::path::PathBuf,
+    node_resolver::errors::PackageFolderResolveError,
+  >;
+
+  fn package_exports_resolve(
+    &self,
+    package_json_path: &Path,
+    package_subpath: &str,
+    package_exports: &deno_core::serde_json::Map<
+      String,
+      deno_core::serde_json::Value,
+    >,
+    maybe_referrer: Option<&node_resolver::UrlOrPathRef>,
+    resolution_mode: node_resolver::ResolutionMode,
+    conditions: &[Cow<'static, str>],
+    resolution_kind: node_resolver::NodeResolutionKind,
+  ) -> Result<
+    node_resolver::UrlOrPath,
+    node_resolver::errors::PackageExportsResolveError,
+  >;
+
+  fn resolve_package_import(
+    &self,
+    name: &str,
+    maybe_referrer: Option<&node_resolver::UrlOrPathRef>,
+    referrer_pkg_json: Option<&deno_package_json::PackageJson>,
+    resolution_mode: node_resolver::ResolutionMode,
+    resolution_kind: node_resolver::NodeResolutionKind,
+  ) -> Result<
+    node_resolver::UrlOrPath,
+    node_resolver::errors::PackageImportsResolveError,
+  >;
+
+  fn require_conditions(&self) -> &[Cow<'static, str>];
+}
+
+impl<TInNpm, TIsBuiltIn, TNpm, TSys> DynNodeResolver
+  for node_resolver::NodeResolver<TInNpm, TIsBuiltIn, TNpm, TSys>
+where
+  TInNpm: InNpmPackageChecker + 'static,
+  TIsBuiltIn: IsBuiltInNodeModuleChecker + 'static,
+  TNpm: NpmPackageFolderResolver + 'static,
+  TSys: node_resolver::NodeResolverSys + 'static,
+{
+  fn in_npm_package(&self, specifier: &Url) -> bool {
+    node_resolver::NodeResolver::in_npm_package(self, specifier)
+  }
+
+  fn resolve_package_folder_from_package(
+    &self,
+    specifier: &str,
+    referrer: &node_resolver::UrlOrPathRef,
+  ) -> Result<
+    std::path::PathBuf,
+    node_resolver::errors::PackageFolderResolveError,
+  > {
+    node_resolver::NodeResolver::resolve_package_folder_from_package(
+      self, specifier, referrer,
+    )
+  }
+
+  fn package_exports_resolve(
+    &self,
+    package_json_path: &Path,
+    package_subpath: &str,
+    package_exports: &deno_core::serde_json::Map<
+      String,
+      deno_core::serde_json::Value,
+    >,
+    maybe_referrer: Option<&node_resolver::UrlOrPathRef>,
+    resolution_mode: node_resolver::ResolutionMode,
+    conditions: &[Cow<'static, str>],
+    resolution_kind: node_resolver::NodeResolutionKind,
+  ) -> Result<
+    node_resolver::UrlOrPath,
+    node_resolver::errors::PackageExportsResolveError,
+  > {
+    node_resolver::NodeResolver::package_exports_resolve(
+      self,
+      package_json_path,
+      package_subpath,
+      package_exports,
+      maybe_referrer,
+      resolution_mode,
+      conditions,
+      resolution_kind,
+    )
+  }
+
+  fn resolve_package_import(
+    &self,
+    name: &str,
+    maybe_referrer: Option<&node_resolver::UrlOrPathRef>,
+    referrer_pkg_json: Option<&deno_package_json::PackageJson>,
+    resolution_mode: node_resolver::ResolutionMode,
+    resolution_kind: node_resolver::NodeResolutionKind,
+  ) -> Result<
+    node_resolver::UrlOrPath,
+    node_resolver::errors::PackageImportsResolveError,
+  > {
+    node_resolver::NodeResolver::resolve_package_import(
+      self,
+      name,
+      maybe_referrer,
+      referrer_pkg_json,
+      resolution_mode,
+      resolution_kind,
+    )
+  }
+
+  fn require_conditions(&self) -> &[Cow<'static, str>] {
+    node_resolver::NodeResolver::require_conditions(self)
+  }
+}
+
+#[allow(clippy::disallowed_types, reason = "definition")]
+pub type DynNodeResolverRc = deno_fs::sync::MaybeArc<dyn DynNodeResolver>;
+
 #[derive(Clone)]
 pub struct NodeExtInitServices<
-  TInNpmPackageChecker: InNpmPackageChecker,
   TNpmPackageFolderResolver: NpmPackageFolderResolver,
   TSys: ExtNodeSys,
 > {
   pub node_require_loader: NodeRequireLoaderRc,
-  pub node_resolver:
-    NodeResolverRc<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
+  pub node_resolver: DynNodeResolverRc,
   pub pkg_json_resolver: PackageJsonResolverRc<TSys>,
   pub sys: TSys,
+  /// Phantom marker so callers can keep typing the package-folder resolver
+  /// alongside `sys`. Retained until the matching generic is removed from
+  /// the `deno_node` extension in a follow-up.
+  pub _phantom: std::marker::PhantomData<TNpmPackageFolderResolver>,
 }
 
 deno_core::extension!(deno_node,
   deps = [ deno_io, deno_fs ],
-  parameters = [TInNpmPackageChecker: InNpmPackageChecker, TNpmPackageFolderResolver: NpmPackageFolderResolver, TSys: ExtNodeSys],
+  parameters = [TNpmPackageFolderResolver: NpmPackageFolderResolver, TSys: ExtNodeSys],
   ops = [
     ops::assert::op_node_get_first_expression,
 
@@ -314,12 +448,12 @@ deno_core::extension!(deno_node,
     ops::require::op_require_init_paths,
     ops::require::op_require_node_module_paths<TSys>,
     ops::require::op_require_proxy_path,
-    ops::require::op_require_is_deno_dir_package<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
-    ops::require::op_require_resolve_deno_dir<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
+    ops::require::op_require_is_deno_dir_package,
+    ops::require::op_require_resolve_deno_dir,
     ops::require::op_require_is_maybe_cjs,
     ops::require::op_require_is_request_relative,
     ops::require::op_require_resolve_lookup_paths,
-    ops::require::op_require_try_self<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
+    ops::require::op_require_try_self<TSys>,
     ops::require::op_require_real_path<TSys>,
     ops::require::op_require_path_is_absolute,
     ops::require::op_require_path_dirname,
@@ -328,15 +462,15 @@ deno_core::extension!(deno_node,
     ops::require::op_require_path_basename,
     ops::require::op_require_read_file,
     ops::require::op_require_as_file_path,
-    ops::require::op_require_resolve_exports<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
+    ops::require::op_require_resolve_exports<TSys>,
     ops::require::op_require_read_package_scope<TSys>,
-    ops::require::op_require_package_imports_resolve<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
+    ops::require::op_require_package_imports_resolve<TSys>,
     ops::require::op_require_break_on_next_statement,
     ops::util::op_node_guess_handle_type,
     ops::util::op_node_view_has_buffer,
     ops::util::op_node_get_own_non_index_properties,
-    ops::util::op_node_call_is_from_dependency<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
-    ops::util::op_node_in_npm_package<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>,
+    ops::util::op_node_call_is_from_dependency,
+    ops::util::op_node_in_npm_package,
     ops::util::op_node_parse_env,
     ops::worker_threads::op_worker_threads_filename<TSys>,
     ops::worker_threads::op_worker_get_resource_limits,
@@ -696,7 +830,7 @@ deno_core::extension!(deno_node,
     "path/mod.ts",
   ],
   options = {
-    maybe_init: Option<NodeExtInitServices<TInNpmPackageChecker, TNpmPackageFolderResolver, TSys>>,
+    maybe_init: Option<NodeExtInitServices<TNpmPackageFolderResolver, TSys>>,
     fs: deno_fs::FileSystemRc,
   },
   state = |state, options| {

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -19,9 +19,7 @@ use deno_path_util::normalize_path;
 use deno_path_util::url_from_file_path;
 use deno_path_util::url_to_file_path;
 use deno_permissions::PermissionsContainer;
-use node_resolver::InNpmPackageChecker;
 use node_resolver::NodeResolutionKind;
-use node_resolver::NpmPackageFolderResolver;
 use node_resolver::ResolutionMode;
 use node_resolver::UrlOrPath;
 use node_resolver::UrlOrPathRef;
@@ -29,9 +27,9 @@ use node_resolver::cache::NodeResolutionThreadLocalCache;
 use node_resolver::errors::PackageJsonLoadError;
 use sys_traits::FsMetadataValue;
 
+use crate::DynNodeResolverRc;
 use crate::ExtNodeSys;
 use crate::NodeRequireLoaderRc;
-use crate::NodeResolverRc;
 use crate::PackageJsonResolverRc;
 
 #[must_use = "the resolved return value to mitigate time-of-check to time-of-use issues"]
@@ -249,20 +247,12 @@ pub fn op_require_is_request_relative(#[string] request: &str) -> bool {
 
 #[op2]
 #[string]
-pub fn op_require_resolve_deno_dir<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_require_resolve_deno_dir(
   state: &mut OpState,
   #[string] request: &str,
   #[string] parent_filename: &str,
 ) -> Result<Option<String>, deno_path_util::PathToUrlError> {
-  let resolver = state.borrow::<NodeResolverRc<
-    TInNpmPackageChecker,
-    TNpmPackageFolderResolver,
-    TSys,
-  >>();
+  let resolver = state.borrow::<DynNodeResolverRc>();
 
   let path = Path::new(parent_filename);
   Ok(
@@ -277,19 +267,11 @@ pub fn op_require_resolve_deno_dir<
 }
 
 #[op2(fast)]
-pub fn op_require_is_deno_dir_package<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_require_is_deno_dir_package(
   state: &mut OpState,
   #[string] path: &str,
 ) -> bool {
-  let resolver = state.borrow::<NodeResolverRc<
-    TInNpmPackageChecker,
-    TNpmPackageFolderResolver,
-    TSys,
-  >>();
+  let resolver = state.borrow::<DynNodeResolverRc>();
   match deno_path_util::url_from_file_path(Path::new(path)) {
     Ok(specifier) => resolver.in_npm_package(&specifier),
     Err(_) => false,
@@ -441,11 +423,7 @@ pub fn op_require_path_basename(
 
 #[op2(stack_trace)]
 #[string]
-pub fn op_require_try_self<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_require_try_self<TSys: ExtNodeSys + 'static>(
   state: &mut OpState,
   #[string] parent_path: &str,
   #[string] request: &str,
@@ -478,11 +456,7 @@ pub fn op_require_try_self<
   };
 
   if let Some(exports) = &pkg.exports {
-    let node_resolver = state.borrow::<NodeResolverRc<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TSys,
-    >>();
+    let node_resolver = state.borrow::<DynNodeResolverRc>();
     let referrer = UrlOrPathRef::from_path(&pkg.path);
     // invalidate the resolution cache in case things have changed
     NodeResolutionThreadLocalCache::clear();
@@ -534,11 +508,7 @@ pub fn op_require_as_file_path(#[string] file_or_url: &str) -> Option<String> {
 
 #[op2(stack_trace)]
 #[string]
-pub fn op_require_resolve_exports<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_require_resolve_exports<TSys: ExtNodeSys + 'static>(
   state: &mut OpState,
   uses_local_node_modules_dir: bool,
   #[string] modules_path_str: &str,
@@ -549,11 +519,7 @@ pub fn op_require_resolve_exports<
   #[serde] conditions: Option<Vec<String>>,
 ) -> Result<Option<String>, RequireError> {
   let sys = state.borrow::<TSys>();
-  let node_resolver = state.borrow::<NodeResolverRc<
-    TInNpmPackageChecker,
-    TNpmPackageFolderResolver,
-    TSys,
-  >>();
+  let node_resolver = state.borrow::<DynNodeResolverRc>();
   let pkg_json_resolver = state.borrow::<PackageJsonResolverRc<TSys>>();
 
   let modules_path = Path::new(&modules_path_str);
@@ -648,11 +614,7 @@ pub fn op_require_read_package_scope<TSys: ExtNodeSys + 'static>(
 
 #[op2(stack_trace)]
 #[string]
-pub fn op_require_package_imports_resolve<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_require_package_imports_resolve<TSys: ExtNodeSys + 'static>(
   state: &mut OpState,
   #[string] referrer_filename: &str,
   #[string] request: &str,
@@ -667,11 +629,7 @@ pub fn op_require_package_imports_resolve<
   };
 
   if pkg.imports.is_some() {
-    let node_resolver = state.borrow::<NodeResolverRc<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TSys,
-    >>();
+    let node_resolver = state.borrow::<DynNodeResolverRc>();
     NodeResolutionThreadLocalCache::clear();
     let url = node_resolver.resolve_package_import(
       request,

--- a/ext/node/ops/util.rs
+++ b/ext/node/ops/util.rs
@@ -7,11 +7,8 @@ use deno_core::op2;
 use deno_core::v8;
 use deno_dotenv::parse_env_content_hook;
 use deno_error::JsErrorBox;
-use node_resolver::InNpmPackageChecker;
-use node_resolver::NpmPackageFolderResolver;
 
-use crate::ExtNodeSys;
-use crate::NodeResolverRc;
+use crate::DynNodeResolverRc;
 
 #[repr(u32)]
 enum HandleType {
@@ -85,11 +82,7 @@ pub fn op_node_view_has_buffer(buffer: v8::Local<v8::ArrayBufferView>) -> bool {
 
 /// Checks if the current call site is from a dependency package.
 #[op2(fast)]
-pub fn op_node_call_is_from_dependency<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_node_call_is_from_dependency(
   state: &mut OpState,
   scope: &mut v8::PinScope<'_, '_>,
 ) -> bool {
@@ -131,21 +124,15 @@ pub fn op_node_call_is_from_dependency<
     if only_internal {
       return true;
     }
-    return state.borrow::<NodeResolverRc<
-        TInNpmPackageChecker,
-        TNpmPackageFolderResolver,
-        TSys,
-      >>().in_npm_package(&specifier);
+    return state
+      .borrow::<DynNodeResolverRc>()
+      .in_npm_package(&specifier);
   }
   only_internal
 }
 
 #[op2(fast)]
-pub fn op_node_in_npm_package<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
-  TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
-  TSys: ExtNodeSys + 'static,
->(
+pub fn op_node_in_npm_package(
   state: &mut OpState,
   #[string] path: &str,
 ) -> bool {
@@ -161,11 +148,9 @@ pub fn op_node_in_npm_package<
     }
   };
 
-  state.borrow::<NodeResolverRc<
-    TInNpmPackageChecker,
-    TNpmPackageFolderResolver,
-    TSys,
-  >>().in_npm_package(&specifier)
+  state
+    .borrow::<DynNodeResolverRc>()
+    .in_npm_package(&specifier)
 }
 
 #[op2]

--- a/runtime/snapshot.rs
+++ b/runtime/snapshot.rs
@@ -7,7 +7,6 @@ use std::rc::Rc;
 use deno_core::Extension;
 use deno_core::snapshot::*;
 use deno_core::v8;
-use deno_resolver::npm::DenoInNpmPackageChecker;
 use deno_resolver::npm::NpmResolver;
 
 use crate::ops;
@@ -49,7 +48,6 @@ pub fn create_runtime_snapshot(
     deno_node_crypto::deno_node_crypto::lazy_init(),
     deno_node_sqlite::deno_node_sqlite::lazy_init(),
     deno_node::deno_node::lazy_init::<
-      DenoInNpmPackageChecker,
       NpmResolver<sys_traits::impls::RealSys>,
       sys_traits::impls::RealSys,
     >(),

--- a/runtime/snapshot_info.rs
+++ b/runtime/snapshot_info.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use deno_core::Extension;
-use deno_resolver::npm::DenoInNpmPackageChecker;
 use deno_resolver::npm::NpmResolver;
 
 use crate::ops;
@@ -48,7 +47,6 @@ pub fn get_extensions_in_snapshot() -> Vec<Extension> {
     deno_node_crypto::deno_node_crypto::init(),
     deno_node_sqlite::deno_node_sqlite::init(),
     deno_node::deno_node::init::<
-      DenoInNpmPackageChecker,
       NpmResolver<sys_traits::impls::RealSys>,
       sys_traits::impls::RealSys,
     >(None, fs.clone()),

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -58,7 +58,6 @@ use deno_web::Transferable;
 use deno_web::create_entangled_message_port;
 use deno_web::serialize_transferables;
 use log::debug;
-use node_resolver::InNpmPackageChecker;
 use node_resolver::NpmPackageFolderResolver;
 
 use crate::BootstrapOptions;
@@ -356,7 +355,6 @@ fn create_handles(
 }
 
 pub struct WebWorkerServiceOptions<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
   TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
   TExtNodeSys: ExtNodeSys + 'static,
 > {
@@ -368,13 +366,8 @@ pub struct WebWorkerServiceOptions<
   pub fs: Arc<dyn FileSystem>,
   pub main_inspector_session_tx: MainInspectorSessionChannel,
   pub module_loader: Rc<dyn ModuleLoader>,
-  pub node_services: Option<
-    NodeExtInitServices<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TExtNodeSys,
-    >,
-  >,
+  pub node_services:
+    Option<NodeExtInitServices<TNpmPackageFolderResolver, TExtNodeSys>>,
   pub npm_process_state_provider: Option<NpmProcessStateProviderRc>,
   pub permissions: PermissionsContainer,
   pub root_cert_store_provider: Option<Arc<dyn RootCertStoreProvider>>,
@@ -446,15 +439,10 @@ impl Drop for WebWorker {
 
 impl WebWorker {
   pub fn bootstrap_from_options<
-    TInNpmPackageChecker: InNpmPackageChecker + 'static,
     TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
     TExtNodeSys: ExtNodeSys + 'static,
   >(
-    services: WebWorkerServiceOptions<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TExtNodeSys,
-    >,
+    services: WebWorkerServiceOptions<TNpmPackageFolderResolver, TExtNodeSys>,
     options: WebWorkerOptions,
   ) -> (Self, SendableWebWorkerHandle) {
     let (mut worker, handle, bootstrap_options) =
@@ -464,15 +452,10 @@ impl WebWorker {
   }
 
   pub fn from_options<
-    TInNpmPackageChecker: InNpmPackageChecker + 'static,
     TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
     TExtNodeSys: ExtNodeSys + 'static,
   >(
-    services: WebWorkerServiceOptions<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TExtNodeSys,
-    >,
+    services: WebWorkerServiceOptions<TNpmPackageFolderResolver, TExtNodeSys>,
     mut options: WebWorkerOptions,
   ) -> (Self, SendableWebWorkerHandle, BootstrapOptions) {
     // Permissions: many ops depend on this
@@ -578,11 +561,10 @@ impl WebWorker {
       deno_process::deno_process::init(services.npm_process_state_provider),
       deno_node_crypto::deno_node_crypto::init(),
       deno_node_sqlite::deno_node_sqlite::init(),
-      deno_node::deno_node::init::<
-        TInNpmPackageChecker,
-        TNpmPackageFolderResolver,
-        TExtNodeSys,
-      >(services.node_services, services.fs),
+      deno_node::deno_node::init::<TNpmPackageFolderResolver, TExtNodeSys>(
+        services.node_services,
+        services.fs,
+      ),
       // Runtime ops that are always initialized for WebWorkers
       ops::runtime::deno_runtime::init(options.main_module.clone()),
       ops::worker_host::deno_worker_host::init(

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -48,7 +48,6 @@ use deno_tls::TlsKeys;
 use deno_web::BlobStore;
 use deno_web::InMemoryBroadcastChannel;
 use log::debug;
-use node_resolver::InNpmPackageChecker;
 use node_resolver::NpmPackageFolderResolver;
 
 use crate::BootstrapOptions;
@@ -167,7 +166,6 @@ impl Drop for MainWorker {
 }
 
 pub struct WorkerServiceOptions<
-  TInNpmPackageChecker: InNpmPackageChecker,
   TNpmPackageFolderResolver: NpmPackageFolderResolver,
   TExtNodeSys: ExtNodeSys,
 > {
@@ -182,13 +180,8 @@ pub struct WorkerServiceOptions<
   /// If not provided runtime will error if code being
   /// executed tries to load modules.
   pub module_loader: Rc<dyn ModuleLoader>,
-  pub node_services: Option<
-    NodeExtInitServices<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TExtNodeSys,
-    >,
-  >,
+  pub node_services:
+    Option<NodeExtInitServices<TNpmPackageFolderResolver, TExtNodeSys>>,
   pub npm_process_state_provider: Option<NpmProcessStateProviderRc>,
   pub permissions: PermissionsContainer,
   pub root_cert_store_provider: Option<Arc<dyn RootCertStoreProvider>>,
@@ -340,16 +333,11 @@ pub fn create_op_metrics(
 
 impl MainWorker {
   pub fn bootstrap_from_options<
-    TInNpmPackageChecker: InNpmPackageChecker + 'static,
     TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
     TExtNodeSys: ExtNodeSys + 'static,
   >(
     main_module: &ModuleSpecifier,
-    services: WorkerServiceOptions<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TExtNodeSys,
-    >,
+    services: WorkerServiceOptions<TNpmPackageFolderResolver, TExtNodeSys>,
     options: WorkerOptions,
   ) -> Self {
     let (mut worker, bootstrap_options) =
@@ -359,16 +347,11 @@ impl MainWorker {
   }
 
   fn from_options<
-    TInNpmPackageChecker: InNpmPackageChecker + 'static,
     TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
     TExtNodeSys: ExtNodeSys + 'static,
   >(
     main_module: &ModuleSpecifier,
-    services: WorkerServiceOptions<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TExtNodeSys,
-    >,
+    services: WorkerServiceOptions<TNpmPackageFolderResolver, TExtNodeSys>,
     mut options: WorkerOptions,
   ) -> (Self, BootstrapOptions) {
     fn create_cache_inner(options: &WorkerOptions) -> Option<CreateCache> {
@@ -447,7 +430,6 @@ impl MainWorker {
       js_runtime
     } else {
       let mut extensions = common_extensions::<
-        TInNpmPackageChecker,
         TNpmPackageFolderResolver,
         TExtNodeSys,
       >(options.startup_snapshot.is_some(), false);
@@ -575,11 +557,10 @@ impl MainWorker {
         deno_fs::deno_fs::args(services.fs.clone()),
         deno_os::deno_os::args(Some(exit_code.clone())),
         deno_process::deno_process::args(services.npm_process_state_provider),
-        deno_node::deno_node::args::<
-          TInNpmPackageChecker,
-          TNpmPackageFolderResolver,
-          TExtNodeSys,
-        >(services.node_services, services.fs.clone()),
+        deno_node::deno_node::args::<TNpmPackageFolderResolver, TExtNodeSys>(
+          services.node_services,
+          services.fs.clone(),
+        ),
         ops::runtime::deno_runtime::args(main_module.clone()),
         ops::worker_host::deno_worker_host::args(
           options.create_web_worker_cb.clone(),
@@ -1057,7 +1038,6 @@ impl MainWorker {
 }
 
 fn common_extensions<
-  TInNpmPackageChecker: InNpmPackageChecker + 'static,
   TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
   TExtNodeSys: ExtNodeSys + 'static,
 >(
@@ -1093,11 +1073,7 @@ fn common_extensions<
     deno_process::deno_process::lazy_init(),
     deno_node_crypto::deno_node_crypto::init(),
     deno_node_sqlite::deno_node_sqlite::init(),
-    deno_node::deno_node::lazy_init::<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TExtNodeSys,
-    >(),
+    deno_node::deno_node::lazy_init::<TNpmPackageFolderResolver, TExtNodeSys>(),
     // Ops from this crate
     ops::runtime::deno_runtime::lazy_init(),
     ops::worker_host::deno_worker_host::lazy_init(),
@@ -1208,17 +1184,13 @@ pub struct UnconfiguredRuntime {
 
 impl UnconfiguredRuntime {
   pub fn new<
-    TInNpmPackageChecker: InNpmPackageChecker + 'static,
     TNpmPackageFolderResolver: NpmPackageFolderResolver + 'static,
     TExtNodeSys: ExtNodeSys + 'static,
   >(
     options: UnconfiguredRuntimeOptions,
   ) -> Self {
-    let mut extensions = common_extensions::<
-      TInNpmPackageChecker,
-      TNpmPackageFolderResolver,
-      TExtNodeSys,
-    >(true, true);
+    let mut extensions =
+      common_extensions::<TNpmPackageFolderResolver, TExtNodeSys>(true, true);
 
     extensions.extend(options.additional_extensions);
 


### PR DESCRIPTION
The `deno_node` extension carried three generic parameters
(`TInNpmPackageChecker`, `TNpmPackageFolderResolver`, `TSys`), which
forced every op that touched the resolver to be monomorphized per
backend and propagated the checker generic through the entire runtime
and CLI worker plumbing for a slot that in practice always holds
`DenoInNpmPackageChecker`.

This adds a dyn-safe `DynNodeResolver` trait inside `ext/node` that
mirrors the five `NodeResolver` methods the ops actually call, with a
blanket impl on `node_resolver::NodeResolver` so callers' existing
`NodeResolverRc` coerces to `Rc<dyn DynNodeResolver>` at the boundary
without any change to `libs/node_resolver` or `libs/resolver`.
`NodeExtInitServices` stores the resolver as the trait object, so its
`TInNpmPackageChecker` generic and the matching entry in the
extension's `parameters = [...]` both drop out, along with the
corresponding generic on `WorkerServiceOptions`,
`WebWorkerServiceOptions`, `MainWorker::bootstrap_from_options`, and
the related `cli/lib` worker plumbing. `TNpmPackageFolderResolver` is
retained as `PhantomData` so its removal can be a separate, similarly
contained follow-up.