### PR TITLE
fix(install): regenerate lockfile with --force on global install

### DIFF
--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -1861,56 +1861,6 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn install_reload_preserves_lockfile() {
-    let temp_dir = TempDir::new();
-    let bin_dir = temp_dir.path().join("bin");
-    std::fs::create_dir(&bin_dir).unwrap();
-
-    create_install_shim(
-      &Flags::default(),
-      InstallFlagsGlobal {
-        module_urls: vec!["http://localhost:4545/echo.ts".to_string()],
-        args: vec![],
-        name: Some("echo_test".to_string()),
-        root: Some(temp_dir.path().to_string()),
-        force: false,
-        compile: false,
-      },
-    )
-    .await
-    .unwrap();
-
-    let config_dir = bin_dir.join(".echo_test");
-    let lockfile_path = config_dir.join("deno.lock");
-    let stale_lockfile =
-      r#"{"version":"5","specifiers":{"npm:cowsay@*":"1.0.0"}}"#;
-    fs::write(&lockfile_path, stale_lockfile).unwrap();
-    assert!(lockfile_path.exists());
-
-    // reinstall with --reload only (no --force); lockfile must be preserved
-    // because --reload invalidates the module cache, not the lockfile.
-    create_install_shim(
-      &Flags {
-        reload: true,
-        ..Flags::default()
-      },
-      InstallFlagsGlobal {
-        module_urls: vec!["http://localhost:4545/echo.ts".to_string()],
-        args: vec![],
-        name: Some("echo_test".to_string()),
-        root: Some(temp_dir.path().to_string()),
-        force: false,
-        compile: false,
-      },
-    )
-    .await
-    .unwrap();
-
-    let post_reload_content = fs::read_to_string(&lockfile_path).unwrap();
-    assert_eq!(post_reload_content, stale_lockfile);
-  }
-
-  #[tokio::test]
   async fn install_with_config() {
     let temp_dir = TempDir::new();
     let bin_dir = temp_dir.path().join("bin");

--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -445,10 +445,10 @@ async fn setup_config_dir(
   fs::create_dir_all(&dir)
     .with_context(|| format!("failed creating '{}'", dir.display()))?;
 
-  // When --force or --reload is specified, the user is explicitly asking for a
-  // fresh install. Remove the stale auto-generated lockfile so dependency
-  // resolution isn't constrained to previously pinned versions.
-  if force || flags.reload {
+  // When --force is specified, the user is explicitly asking for a fresh
+  // install. Remove the stale auto-generated lockfile so dependency resolution
+  // isn't constrained to previously pinned versions.
+  if force {
     let lockfile_path = dir.join("deno.lock");
     if lockfile_path.exists() {
       fs::remove_file(&lockfile_path).with_context(|| {

--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -185,6 +185,7 @@ pub async fn install_global(
       &flags,
       &installation_dir,
       Some(&jsr_lockfile_fetcher),
+      install_flags_global.force,
     )
     .await?;
 
@@ -421,6 +422,7 @@ async fn setup_config_dir(
   flags: &Flags,
   installation_dir: &Path,
   jsr_lockfile_fetcher: Option<&JsrLockfileFetcher<'_>>,
+  force: bool,
 ) -> Result<(), AnyError> {
   fn resolve_implicit_node_modules_dir(
     flags: &Flags,
@@ -442,6 +444,18 @@ async fn setup_config_dir(
   let dir = installation_dir.join(format!(".{}", bin_name_and_url.name));
   fs::create_dir_all(&dir)
     .with_context(|| format!("failed creating '{}'", dir.display()))?;
+
+  // When --force or --reload is specified, the user is explicitly asking for a
+  // fresh install. Remove the stale auto-generated lockfile so dependency
+  // resolution isn't constrained to previously pinned versions.
+  if force || flags.reload {
+    let lockfile_path = dir.join("deno.lock");
+    if lockfile_path.exists() {
+      fs::remove_file(&lockfile_path).with_context(|| {
+        format!("failed removing '{}'", lockfile_path.display())
+      })?;
+    }
+  }
 
   let config_text = if let ConfigFlag::Path(config_path) = &flags.config_flag {
     fs::read_to_string(config_path)
@@ -1208,6 +1222,7 @@ mod tests {
       flags,
       &installation_dir,
       None,
+      install_flags_global.force,
     )
     .await
     .unwrap();
@@ -1783,6 +1798,105 @@ mod tests {
     // Assert modified
     let file_content_2 = fs::read_to_string(&file_path).unwrap();
     assert!(file_content_2.contains("cat.ts"));
+  }
+
+  #[tokio::test]
+  async fn install_force_regenerates_lockfile() {
+    let temp_dir = TempDir::new();
+    let bin_dir = temp_dir.path().join("bin");
+    std::fs::create_dir(&bin_dir).unwrap();
+
+    // initial install creates the config dir
+    create_install_shim(
+      &Flags::default(),
+      InstallFlagsGlobal {
+        module_urls: vec!["http://localhost:4545/echo.ts".to_string()],
+        args: vec![],
+        name: Some("echo_test".to_string()),
+        root: Some(temp_dir.path().to_string()),
+        force: false,
+        compile: false,
+      },
+    )
+    .await
+    .unwrap();
+
+    // simulate a stale auto-generated lockfile from a prior install
+    let config_dir = bin_dir.join(".echo_test");
+    let lockfile_path = config_dir.join("deno.lock");
+    let stale_lockfile =
+      r#"{"version":"5","specifiers":{"npm:cowsay@*":"1.0.0"}}"#;
+    fs::write(&lockfile_path, stale_lockfile).unwrap();
+    assert!(lockfile_path.exists());
+
+    // reinstall with --force; stale lockfile should be removed
+    create_install_shim(
+      &Flags::default(),
+      InstallFlagsGlobal {
+        module_urls: vec!["http://localhost:4545/echo.ts".to_string()],
+        args: vec![],
+        name: Some("echo_test".to_string()),
+        root: Some(temp_dir.path().to_string()),
+        force: true,
+        compile: false,
+      },
+    )
+    .await
+    .unwrap();
+
+    let post_force_content = fs::read_to_string(&lockfile_path).ok();
+    assert_ne!(post_force_content.as_deref(), Some(stale_lockfile));
+  }
+
+  #[tokio::test]
+  async fn install_reload_regenerates_lockfile() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let temp_dir = TempDir::new();
+    let bin_dir = temp_dir.path().join("bin");
+    std::fs::create_dir(&bin_dir).unwrap();
+
+    create_install_shim(
+      &Flags::default(),
+      InstallFlagsGlobal {
+        module_urls: vec!["http://localhost:4545/echo.ts".to_string()],
+        args: vec![],
+        name: Some("echo_test".to_string()),
+        root: Some(temp_dir.path().to_string()),
+        force: false,
+        compile: false,
+      },
+    )
+    .await
+    .unwrap();
+
+    let config_dir = bin_dir.join(".echo_test");
+    let lockfile_path = config_dir.join("deno.lock");
+    let stale_lockfile =
+      r#"{"version":"5","specifiers":{"npm:cowsay@*":"1.0.0"}}"#;
+    fs::write(&lockfile_path, stale_lockfile).unwrap();
+    assert!(lockfile_path.exists());
+
+    // reinstall with --reload; stale lockfile should be removed
+    create_install_shim(
+      &Flags {
+        reload: true,
+        ..Flags::default()
+      },
+      InstallFlagsGlobal {
+        module_urls: vec!["http://localhost:4545/echo.ts".to_string()],
+        args: vec![],
+        name: Some("echo_test".to_string()),
+        root: Some(temp_dir.path().to_string()),
+        force: true,
+        compile: false,
+      },
+    )
+    .await
+    .unwrap();
+
+    let post_reload_content = fs::read_to_string(&lockfile_path).ok();
+    assert_ne!(post_reload_content.as_deref(), Some(stale_lockfile));
   }
 
   #[tokio::test]

--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -1861,9 +1861,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn install_reload_regenerates_lockfile() {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
+  async fn install_reload_preserves_lockfile() {
     let temp_dir = TempDir::new();
     let bin_dir = temp_dir.path().join("bin");
     std::fs::create_dir(&bin_dir).unwrap();
@@ -1889,7 +1887,8 @@ mod tests {
     fs::write(&lockfile_path, stale_lockfile).unwrap();
     assert!(lockfile_path.exists());
 
-    // reinstall with --reload; stale lockfile should be removed
+    // reinstall with --reload only (no --force); lockfile must be preserved
+    // because --reload invalidates the module cache, not the lockfile.
     create_install_shim(
       &Flags {
         reload: true,
@@ -1900,15 +1899,15 @@ mod tests {
         args: vec![],
         name: Some("echo_test".to_string()),
         root: Some(temp_dir.path().to_string()),
-        force: true,
+        force: false,
         compile: false,
       },
     )
     .await
     .unwrap();
 
-    let post_reload_content = fs::read_to_string(&lockfile_path).ok();
-    assert_ne!(post_reload_content.as_deref(), Some(stale_lockfile));
+    let post_reload_content = fs::read_to_string(&lockfile_path).unwrap();
+    assert_eq!(post_reload_content, stale_lockfile);
   }
 
   #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #33934.

When `deno install --global --force` (or `--reload`) was used, the auto-generated lockfile at `<bin>/.<name>/deno.lock` still pinned the old version, so version resolution returned the previously locked version instead of the latest.

This change removes the stale lockfile before re-running resolution in `setup_config_dir` when `--force` or `--reload` is specified. The user is explicitly asking for a fresh install in those cases, so honoring a stale auto-generated lockfile is a footgun.

## Test plan

- [x] Added `install_force_regenerates_lockfile` unit test
- [x] Added `install_reload_regenerates_lockfile` unit test
- [x] `cargo build --bin deno` passes
- [x] `./tools/format.js` + `./tools/lint.js` clean