### PR TITLE
fix(core): evaluate pre-instantiated module in lazy_load_esm_module

### DIFF
--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -2514,6 +2514,25 @@ impl ModuleMap {
       {
         let handle = module_map_data.get_handle(id).unwrap();
         let handle_local = v8::Local::new(scope, handle);
+        // The module may be present in the map but not yet evaluated — e.g.
+        // when this lazy load fires from a sibling ES module that V8 is
+        // evaluating earlier in DFS post-order. Returning the namespace
+        // before evaluation leaves `export const` bindings in the temporal
+        // dead zone, so trigger evaluation here.
+        if handle_local.get_status() == v8::ModuleStatus::Instantiated {
+          let value = handle_local.evaluate(scope).unwrap();
+          if !self.evaluating_top_level.get() {
+            scope.perform_microtask_checkpoint();
+          }
+          let promise = v8::Local::<v8::Promise>::try_from(value).unwrap();
+          let result = promise.result(scope);
+          if !result.is_undefined() {
+            return Err(
+              CoreErrorKind::Js(exception_to_err(scope, result, false, true))
+                .into_box(),
+            );
+          }
+        }
         let module =
           v8::Global::new(scope, handle_local.get_module_namespace());
         return Ok(module);

--- a/libs/core/modules/testdata/lazy_load_sibling_a.js
+++ b/libs/core/modules/testdata/lazy_load_sibling_a.js
@@ -1,0 +1,8 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// During this module's evaluation, lazy-load the sibling module B. When
+// `main.js` statically imports both A and B, V8 instantiates both during
+// the link phase and evaluates them in DFS post-order, so B is registered
+// in the module map (instantiated) but not yet evaluated when A evaluates.
+const lazyB = Deno.core.createLazyLoader("custom:lazy_b");
+export const { value } = lazyB();

--- a/libs/core/modules/testdata/lazy_load_sibling_b.js
+++ b/libs/core/modules/testdata/lazy_load_sibling_b.js
@@ -1,0 +1,6 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// `value` is in the temporal dead zone until this module is evaluated.
+// If A retrieves B's namespace before B has evaluated, accessing `.value`
+// throws `Cannot access 'value' before initialization`.
+export const value = "b-value";

--- a/libs/core/modules/testdata/lazy_load_sibling_main.js
+++ b/libs/core/modules/testdata/lazy_load_sibling_main.js
@@ -1,0 +1,12 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Statically import both lazy-loaded ESM siblings.
+import { value as aValue } from "custom:lazy_a";
+import { value as bValue } from "custom:lazy_b";
+
+if (aValue !== "b-value") {
+  throw new Error("expected aValue to be 'b-value', got: " + aValue);
+}
+if (bValue !== "b-value") {
+  throw new Error("expected bValue to be 'b-value', got: " + bValue);
+}

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -628,6 +628,48 @@ async fn test_lazy_loaded_esm_aliased_via_import() {
   result.await.unwrap();
 }
 
+/// Regression test for https://github.com/denoland/deno/issues/33940
+///
+/// When two lazy-loaded ESM modules (A and B) are statically imported as
+/// siblings, V8 instantiates both during the link phase and evaluates them
+/// in DFS post-order. If A's evaluation calls `createLazyLoader(B)()`, the
+/// `op_lazy_load_esm` early-return path used to hand back B's module
+/// namespace without first evaluating it, so any `export const` bindings in
+/// B were in the temporal dead zone — producing `Cannot access 'X' before
+/// initialization`. This reproduces the gemini-cli failure where
+/// `events_esm.ts` eagerly destructures `EventEmitterAsyncResource`, whose
+/// getter lazy-loads `async_hooks_esm.ts` (a sibling in the user's bundle).
+#[tokio::test]
+async fn test_lazy_load_esm_evaluates_pre_instantiated_sibling() {
+  deno_core::extension!(
+    test_ext,
+    lazy_loaded_esm = [
+      dir "modules/testdata",
+      "custom:lazy_a" = "lazy_load_sibling_a.js",
+      "custom:lazy_b" = "lazy_load_sibling_b.js",
+    ]
+  );
+
+  let loader = Rc::new(StaticModuleLoader::with(
+    ModuleSpecifier::parse("file:///main.js").unwrap(),
+    crate::ascii_str_include!("testdata/lazy_load_sibling_main.js"),
+  ));
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![test_ext::init()],
+    module_loader: Some(loader),
+    ..Default::default()
+  });
+
+  let mod_id = runtime
+    .load_main_es_module(&ModuleSpecifier::parse("file:///main.js").unwrap())
+    .await
+    .unwrap();
+  let result = runtime.mod_evaluate(mod_id);
+  runtime.run_event_loop(Default::default()).await.unwrap();
+  result.await.unwrap();
+}
+
 #[test]
 fn test_lazy_loaded_script() {
   deno_core::extension!(


### PR DESCRIPTION
The early-return path of `lazy_load_esm_module` handed back a module's
namespace without checking the module's evaluation status. When the
module was already registered in the module map (e.g. as a static
import in the caller's bundle that V8 instantiated during the link
phase) but V8 hadn't reached it yet in DFS post-order, the namespace's
`export const` bindings were in the temporal dead zone — so any caller
that destructured the lazy namespace at module evaluation time saw
`Cannot access 'X' before initialization`. The fix evaluates the
module before returning the namespace when its status is
`Instantiated`, mirroring the existing logic in
`lazy_load_es_module_with_code`.

The user-visible symptom was gemini-cli failing at startup with
`Cannot access 'AsyncResource' before initialization`. The recent
events_esm.ts wrapper destructures `EventEmitterAsyncResource`, whose
lazy getter loads `node:async_hooks` — itself a sibling static import
elsewhere in the bundle, so it had been instantiated but not yet
evaluated.

Fixes #33940