### PR TITLE
test: disable flaky specs::install::global::allow_scripts on windows-aarch64

### DIFF
--- a/tests/specs/install/global/allow_scripts/__test__.jsonc
+++ b/tests/specs/install/global/allow_scripts/__test__.jsonc
@@ -1,4 +1,7 @@
 {
+  // Skipped on windows-aarch64: flakes intermittently (`flakyCount: 4`),
+  // independently reproduced across orthogonal PRs. Tracked in #33976.
+  "if": "notWindowsArm",
   "tempDir": true,
   "steps": [{
     "if": "unix",


### PR DESCRIPTION
Adds top-level `"if": "notWindowsArm"` to `tests/specs/install/global/allow_scripts/__test__.jsonc`, skipping the test on `windows-aarch64` only.

The test exercises `deno install -g --allow-scripts npm:@denotest/lifecycle-scripts-simple` followed by executing the installed bin. It flakes intermittently on `test specs (2/2) debug windows-aarch64`, with the runner reporting `flakyCount: 4` (it already retried internally and still couldn't pass).

### Evidence

| PR     | Touches                | Run                                                                                  | Attempt 1   | Attempt 2 (rerun) |
| ------ | ---------------------- | ------------------------------------------------------------------------------------ | ----------- | ----------------- |
| #33972 | `ext/node` fs.readdir  | [25698214471](https://github.com/denoland/deno/actions/runs/25698214471)              | failure (`flakyCount: 4`) | success |
| #33964 | `ext/node` loader-hook | [25692848953](https://github.com/denoland/deno/actions/runs/25692848953)              | failure (`flakyCount: 4`) | (PR force-pushed; rerun superseded) |
| #33942 | `ext/node` vm          | [25692273560](https://github.com/denoland/deno/actions/runs/25692273560)              | failure     | — |

None of those PRs touch the install path, npm lifecycle scripts, or anything adjacent. Pass on `windows-x86_64`, all linux, all macos, and on `release windows-aarch64` (same SHA) — isolated to `debug windows-aarch64`. Rerunning attempt 2 on #33972 passed against the same SHA, which is the cleanest possible flake signal.

The sister test `compile_allow_scripts` (same dir) has the same shape but no flake evidence yet — leaving it alone.

Tracked in #33976.

@bartlomieju this is ready to merge.