### PR TITLE
ci: update to use pull_request

### DIFF
--- a/.github/workflows/pr.generated.yml
+++ b/.github/workflows/pr.generated.yml
@@ -5,7 +5,7 @@
 
 name: pr
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/pr.ts
+++ b/.github/workflows/pr.ts
@@ -5,7 +5,7 @@ import { createWorkflow, step } from "jsr:@david/gagen@0.3.1";
 const workflow = createWorkflow({
   name: "pr",
   on: {
-    pull_request_target: {
+    pull_request: {
       types: ["opened", "edited", "synchronize"],
     },
   },


### PR DESCRIPTION
There's no security issue here, but it's just more secure and there's no need for pull_request_target.