### PR TITLE
fix(ext/websocket): don't panic on H2 stream reset in poll_write

### DIFF
--- a/ext/websocket/stream.rs
+++ b/ext/websocket/stream.rs
@@ -103,14 +103,33 @@ impl AsyncWrite for WebSocketStream {
         }
 
         send.reserve_capacity(buf.len());
-        let res = ready!(send.poll_capacity(cx));
+        match ready!(send.poll_capacity(cx)) {
+          Some(Ok(())) => {} // capacity reserved
+          Some(Err(e)) => {
+            return Poll::Ready(Err(std::io::Error::new(
+              ErrorKind::ConnectionReset,
+              e,
+            )));
+          }
+          None => {
+            // The h2 stream is closed (typically a peer-sent
+            // RST_STREAM). Surface as a write error instead of
+            // panicking on `capacity() == 0` below. See #33953.
+            return Poll::Ready(Err(std::io::Error::new(
+              ErrorKind::ConnectionReset,
+              "h2 stream closed",
+            )));
+          }
+        }
 
-        // TODO(mmastrac): the documentation is not entirely clear what to do here, so we'll continue
-        _ = res;
-
-        // We'll try to send whatever we have capacity for
+        // We'll try to send whatever we have capacity for.
         let size = std::cmp::min(buf.len(), send.capacity());
-        assert!(size > 0);
+        if size == 0 {
+          return Poll::Ready(Err(std::io::Error::new(
+            ErrorKind::WriteZero,
+            "no h2 capacity",
+          )));
+        }
 
         let buf: Bytes = Bytes::copy_from_slice(&buf[0..size]);
         let len = buf.len();

--- a/ext/websocket/stream.rs
+++ b/ext/websocket/stream.rs
@@ -104,7 +104,7 @@ impl AsyncWrite for WebSocketStream {
 
         send.reserve_capacity(buf.len());
         match ready!(send.poll_capacity(cx)) {
-          Some(Ok(())) => {} // capacity reserved
+          Some(Ok(_)) => {} // capacity reserved
           Some(Err(e)) => {
             return Poll::Ready(Err(std::io::Error::new(
               ErrorKind::ConnectionReset,


### PR DESCRIPTION
The H2 arm of `poll_write` in `ext/websocket/stream.rs` (RFC 8441 WebSockets over HTTP/2) ignored the result of `poll_capacity` — when the peer sends `RST_STREAM`, `poll_capacity` returns `Ready(None)`, `send.capacity()` returns 0, and the next `assert!(size > 0)` panicked the process. The previous comment (`// TODO(mmastrac): the documentation is not entirely clear what to do here, so we'll continue`) flagged the gap; this PR resolves it.

After this change, the same RST_STREAM scenario surfaces as a regular write error (`io::ErrorKind::ConnectionReset` for the `Some(Err)`/`None` paths, `WriteZero` if `capacity()` would otherwise be 0). `ws.send()` then bubbles up as a JS `NetworkError` instead of aborting the runtime.

The reporter (KTibow / Kimi K2.6 under human oversight) shipped an excellent diagnosis with a downloadable [repro zip](https://github.com/user-attachments/files/27574883/h2-ws-panic-repro.zip) — a Rust h2 server + Deno client that reproduces the panic in seconds. The same script exits cleanly after this change.

No regression test in this PR: a unit/spec test would require an H2 server that injects a `RST_STREAM` mid-write, which the existing `tests/specs/` / `tests/unit/websocket_test.ts` harnesses don't currently support without a sidecar Rust binary. Happy to add that in a follow-up PR if you'd like.

`deno fmt --check` / `deno lint` aren't useful on a `.rs` file; the worker host doesn't have `rustfmt` available so the Rust formatting will get its first authoritative check from CI.

Credit to @KTibow for the diagnosis, the verbatim-correct suggested fix, and the reproducer.

Fixes #33953.

@bartlomieju

---

🤖 Filed by `agor` (worker `work2-2`, bot `lunadogbot`). Tracking claim: bartlomieju/agent-job-board#26. (Note: `@lunadogbot` still needs CLA acceptance from the operator side, same as #33978 and #33980.)
