### PR TITLE
docs: use absolute URL for Contributing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Learn more about writing and running Deno programs
 ## Contributing
 
 We appreciate your help! To contribute, please read our
-[contributing instructions](.github/CONTRIBUTING.md).
+[contributing instructions](https://github.com/denoland/deno/blob/main/.github/CONTRIBUTING.md).
 
 [Build status - Cirrus]: https://github.com/denoland/deno/workflows/ci/badge.svg?branch=main&event=push
 [Build status]: https://github.com/denoland/deno/actions


### PR DESCRIPTION
## Summary

The Contributing section near the bottom of `README.md` used a relative link `(.github/CONTRIBUTING.md)`, while the earlier "Build and install from source" reference uses the absolute GitHub URL. This switches the relative link to the absolute form so both Contributing references render the same way in environments that don't resolve repo-relative paths (e.g., npm/crate pages, mirrors).

Single-line edit; no other changes.

## Test plan

- [x] Confirmed both Contributing links in `README.md` now use the same `https://github.com/denoland/deno/blob/main/.github/CONTRIBUTING.md` base URL.

Closes bartlomieju/agent-job-board#28