### PR TITLE
test: mark ts_no_recheck_on_redirect as flaky

### DIFF
--- a/tests/integration/check_tests.rs
+++ b/tests/integration/check_tests.rs
@@ -112,7 +112,8 @@ fn typecheck_declarations_unstable() {
   output.assert_exit_code(0);
 }
 
-#[test]
+// Flaky: depends on an external network fetch to docs.deno.com.
+#[test(flaky)]
 fn ts_no_recheck_on_redirect() {
   let test_context = TestContext::default();
   let check_command = test_context.new_command().args_vec([


### PR DESCRIPTION
## Summary

`integration::check::ts_no_recheck_on_redirect` is failing intermittently on PR CI runs (most recently observed on Windows in [run 25692273560](https://github.com/denoland/deno/actions/runs/25692273560/job/75432719733), seen by #33942 as one of two reported flakes).

The test executes:

```rust
deno run --allow-import --check run/017_import_redirect.ts
```

…where `017_import_redirect.ts` imports `http://docs.deno.com/examples/scripts/hello_world.ts` (set up by #29400 to dodge GitHub raw rate limits). When that external fetch is slow or fails, the first run never reaches the typecheck stage and the `[WILDCARD]Check [WILDCARD]` pattern match panics.

This change marks the test `#[test(flaky)]` so the runner retries on failure — the same pattern already used in `run_tests.rs` for other network-dependent integration tests. The `use util::test;` import is already in place.

A longer-term fix would route the import through the local redirect test server (`localhost:4546`) so the test no longer touches the public internet; that's a larger change and I'll leave it for a follow-up.

## Test plan

- [x] Pattern parity with existing `#[test(flaky)]` usages in `tests/integration/run_tests.rs`.
- [ ] CI verifies the test still runs (retried on first failure rather than failing the build).

Closes bartlomieju/orchid-inbox#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)