### PR TITLE
fix(package_json, resolver): skip empty dependency names to prevent lockfile corruption

### DIFF
--- a/libs/package_json/lib.rs
+++ b/libs/package_json/lib.rs
@@ -624,6 +624,9 @@ impl PackageJson {
       };
       let mut result = IndexMap::with_capacity(deps.len());
       for (key, value) in deps {
+        if key.is_empty() {
+          continue;
+        }
         result
           .entry(StackString::from(key.as_str()))
           .or_insert_with(|| PackageJsonDepValue::parse(key, value));
@@ -812,6 +815,20 @@ mod test {
         ),
       ])
     );
+  }
+
+  #[test]
+  fn test_resolve_local_package_json_deps_skips_empty_keys() {
+    let mut package_json =
+      PackageJson::load_from_string(PathBuf::from("/package.json"), "{}")
+        .unwrap();
+    package_json.dependencies = Some(IndexMap::from([
+      ("test".to_string(), "^1.2".to_string()),
+      ("".to_string(), ".".to_string()),
+    ]));
+    let deps = package_json.resolve_local_package_json_deps();
+    assert_eq!(deps.dependencies.len(), 1);
+    assert!(deps.dependencies.contains_key("test"));
   }
 
   #[test]

--- a/libs/resolver/lockfile.rs
+++ b/libs/resolver/lockfile.rs
@@ -411,6 +411,7 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
             deps
               .map(|i| {
                 i.iter()
+                  .filter(|(k, _)| !k.is_empty())
                   .filter_map(|(k, v)| PackageJsonDepValue::parse(k, v).ok())
                   .filter_map(|dep| match dep {
                     PackageJsonDepValue::Req(req) => {


### PR DESCRIPTION
When package.json has an empty string dependency key (e.g. `"": "."`), the empty name propagates through to the lockfile as an invalid package requirement. On the first run, Deno serializes it to the lockfile, but on the second run, deserialization fails with `Invalid package requirement '@.'`.

This PR skips empty dependency names at two levels:

1. **`libs/package_json/lib.rs`** (`resolve_local_package_json_deps`): Filter out empty keys when building the dependency map. This prevents the invalid entry from entering the system at the parsing level.
2. **`libs/resolver/lockfile.rs`** (`collect_deps`): Filter out empty keys when collecting link package deps for the lockfile. Belt-and-suspenders defense for the lockfile path specifically.

Empty-string dependency names are not valid npm package identifiers and serve no purpose, so silently ignoring them is the correct behavior.

Fixes #32113