### PR TITLE
ci: bump cacheVersion to 113

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -88,7 +88,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-linux-x86_64-bench-
+          restore-keys: 113-cargo-home-linux-x86_64-bench-
       - name: Install Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         if: '(contains(github.event.pull_request.labels.*.name, ''ci-bench'') || github.ref == ''refs/heads/main'') && !startsWith(github.ref, ''refs/tags/'')'
@@ -243,7 +243,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-x86_64-bench-${{ github.sha }}'
+          key: '113-cargo-home-linux-x86_64-bench-${{ github.sha }}'
   build-debug-macos-x86_64:
     name: build debug macos-x86_64
     needs:
@@ -290,7 +290,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-macos-x86_64-build-main-
+          restore-keys: 113-cargo-home-macos-x86_64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -302,7 +302,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-macos-x86_64-debug-build-main-
+          restore-keys: 113-cargo-target-macos-x86_64-debug-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         with:
@@ -359,7 +359,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-macos-x86_64-build-main-${{ github.sha }}'
+          key: '113-cargo-home-macos-x86_64-build-main-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -370,7 +370,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-macos-x86_64-debug-build-main-${{ github.sha }}'
+          key: '113-cargo-target-macos-x86_64-debug-build-main-${{ github.sha }}'
   test-debug-macos-x86_64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}debug macos-x86_64'
     needs:
@@ -463,7 +463,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-macos-x86_64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-macos-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -475,7 +475,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-macos-x86_64-debug-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-macos-x86_64-debug-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -551,7 +551,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-macos-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-home-macos-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
@@ -562,7 +562,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-macos-x86_64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-target-macos-x86_64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
   build-release-macos-x86_64:
     name: build release macos-x86_64
     needs:
@@ -622,7 +622,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-macos-x86_64-build-main-
+          restore-keys: 113-cargo-home-macos-x86_64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -634,7 +634,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-macos-x86_64-release-build-main-
+          restore-keys: 113-cargo-target-macos-x86_64-release-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
@@ -908,7 +908,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-macos-x86_64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-macos-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -920,7 +920,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-macos-x86_64-release-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-macos-x86_64-release-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -1041,7 +1041,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-macos-aarch64-build-main-
+          restore-keys: 113-cargo-home-macos-aarch64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -1053,7 +1053,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-macos-aarch64-debug-build-main-
+          restore-keys: 113-cargo-target-macos-aarch64-debug-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         with:
@@ -1110,7 +1110,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-macos-aarch64-build-main-${{ github.sha }}'
+          key: '113-cargo-home-macos-aarch64-build-main-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -1121,7 +1121,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-macos-aarch64-debug-build-main-${{ github.sha }}'
+          key: '113-cargo-target-macos-aarch64-debug-build-main-${{ github.sha }}'
   test-debug-macos-aarch64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}debug macos-aarch64'
     needs:
@@ -1214,7 +1214,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-macos-aarch64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-macos-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -1226,7 +1226,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-macos-aarch64-debug-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-macos-aarch64-debug-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -1316,7 +1316,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-macos-aarch64-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-home-macos-aarch64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
@@ -1327,7 +1327,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-macos-aarch64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-target-macos-aarch64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
   test-libs-debug-macos-aarch64:
     name: test libs debug macos-aarch64
     needs:
@@ -1358,7 +1358,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-macos-aarch64-test-libs-
+          restore-keys: 113-cargo-home-macos-aarch64-test-libs-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
@@ -1370,7 +1370,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-macos-aarch64-debug-test-libs-
+          restore-keys: 113-cargo-target-macos-aarch64-debug-test-libs-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'')'
@@ -1434,7 +1434,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-macos-aarch64-test-libs-${{ github.sha }}'
+          key: '113-cargo-home-macos-aarch64-test-libs-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
@@ -1445,7 +1445,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-macos-aarch64-debug-test-libs-${{ github.sha }}'
+          key: '113-cargo-target-macos-aarch64-debug-test-libs-${{ github.sha }}'
   build-release-macos-aarch64:
     name: build release macos-aarch64
     needs:
@@ -1510,7 +1510,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-macos-aarch64-build-main-
+          restore-keys: 113-cargo-home-macos-aarch64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -1522,7 +1522,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-macos-aarch64-release-build-main-
+          restore-keys: 113-cargo-target-macos-aarch64-release-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
@@ -1796,7 +1796,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-macos-aarch64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-macos-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -1808,7 +1808,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-macos-aarch64-release-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-macos-aarch64-release-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -1926,7 +1926,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-windows-x86_64-build-main-
+          restore-keys: 113-cargo-home-windows-x86_64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -1938,7 +1938,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-windows-x86_64-debug-build-main-
+          restore-keys: 113-cargo-target-windows-x86_64-debug-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         with:
@@ -1995,7 +1995,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-windows-x86_64-build-main-${{ github.sha }}'
+          key: '113-cargo-home-windows-x86_64-build-main-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -2006,7 +2006,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-windows-x86_64-debug-build-main-${{ github.sha }}'
+          key: '113-cargo-target-windows-x86_64-debug-build-main-${{ github.sha }}'
   test-debug-windows-x86_64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}debug windows-x86_64'
     needs:
@@ -2099,7 +2099,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-windows-x86_64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-windows-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -2111,7 +2111,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-windows-x86_64-debug-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-windows-x86_64-debug-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -2178,7 +2178,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-windows-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-home-windows-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
@@ -2189,7 +2189,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-windows-x86_64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-target-windows-x86_64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
   test-libs-debug-windows-x86_64:
     name: test libs debug windows-x86_64
     needs:
@@ -2220,7 +2220,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-windows-x86_64-test-libs-
+          restore-keys: 113-cargo-home-windows-x86_64-test-libs-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
@@ -2232,7 +2232,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-windows-x86_64-debug-test-libs-
+          restore-keys: 113-cargo-target-windows-x86_64-debug-test-libs-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'')'
@@ -2273,7 +2273,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-windows-x86_64-test-libs-${{ github.sha }}'
+          key: '113-cargo-home-windows-x86_64-test-libs-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
@@ -2284,7 +2284,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-windows-x86_64-debug-test-libs-${{ github.sha }}'
+          key: '113-cargo-target-windows-x86_64-debug-test-libs-${{ github.sha }}'
   build-release-windows-x86_64:
     name: build release windows-x86_64
     needs:
@@ -2328,7 +2328,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-windows-x86_64-build-main-
+          restore-keys: 113-cargo-home-windows-x86_64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -2340,7 +2340,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-windows-x86_64-release-build-main-
+          restore-keys: 113-cargo-target-windows-x86_64-release-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
@@ -2639,7 +2639,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-windows-x86_64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-windows-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -2651,7 +2651,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-windows-x86_64-release-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-windows-x86_64-release-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -2746,7 +2746,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-windows-aarch64-build-main-
+          restore-keys: 113-cargo-home-windows-aarch64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -2758,7 +2758,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-windows-aarch64-debug-build-main-
+          restore-keys: 113-cargo-target-windows-aarch64-debug-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         with:
@@ -2815,7 +2815,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-windows-aarch64-build-main-${{ github.sha }}'
+          key: '113-cargo-home-windows-aarch64-build-main-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -2826,7 +2826,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-windows-aarch64-debug-build-main-${{ github.sha }}'
+          key: '113-cargo-target-windows-aarch64-debug-build-main-${{ github.sha }}'
   test-debug-windows-aarch64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}debug windows-aarch64'
     needs:
@@ -2919,7 +2919,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-windows-aarch64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-windows-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -2931,7 +2931,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-windows-aarch64-debug-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-windows-aarch64-debug-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -2998,7 +2998,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-windows-aarch64-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-home-windows-aarch64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
@@ -3009,7 +3009,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-windows-aarch64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-target-windows-aarch64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
   build-release-windows-aarch64:
     name: build release windows-aarch64
     needs:
@@ -3053,7 +3053,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-windows-aarch64-build-main-
+          restore-keys: 113-cargo-home-windows-aarch64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -3065,7 +3065,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-windows-aarch64-release-build-main-
+          restore-keys: 113-cargo-target-windows-aarch64-release-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
@@ -3364,7 +3364,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-windows-aarch64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-windows-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -3376,7 +3376,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-windows-aarch64-release-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-windows-aarch64-release-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -3477,7 +3477,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-linux-x86_64-build-main-
+          restore-keys: 113-cargo-home-linux-x86_64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -3489,7 +3489,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-linux-x86_64-release-build-main-
+          restore-keys: 113-cargo-target-linux-x86_64-release-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         with:
@@ -3759,7 +3759,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-x86_64-build-main-${{ github.sha }}'
+          key: '113-cargo-home-linux-x86_64-build-main-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -3770,7 +3770,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-linux-x86_64-release-build-main-${{ github.sha }}'
+          key: '113-cargo-target-linux-x86_64-release-build-main-${{ github.sha }}'
   test-release-linux-x86_64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}release linux-x86_64'
     needs:
@@ -3863,7 +3863,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -3875,7 +3875,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-linux-x86_64-release-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-linux-x86_64-release-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -4044,7 +4044,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
@@ -4055,7 +4055,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-linux-x86_64-release-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-target-linux-x86_64-release-test-${{ matrix.test_crate }}-${{ github.sha }}'
   wpt-release-linux-x86_64:
     name: wpt release linux-x86_64
     needs:
@@ -4095,7 +4095,7 @@ jobs:
             ./target/wpt_input_hash
             ./target/autobahn_input_hash
           key: never_saved
-          restore-keys: 112-wpt-target-linux-x86_64-release-
+          restore-keys: 113-wpt-target-linux-x86_64-release-
       - name: Install Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
         if: '!startsWith(github.ref, ''refs/tags/'')'
@@ -4162,7 +4162,7 @@ jobs:
           path: |-
             ./target/wpt_input_hash
             ./target/autobahn_input_hash
-          key: '112-wpt-target-linux-x86_64-release-${{ github.sha }}'
+          key: '113-wpt-target-linux-x86_64-release-${{ github.sha }}'
   build-debug-linux-x86_64:
     name: build debug linux-x86_64
     needs:
@@ -4203,7 +4203,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-linux-x86_64-build-main-
+          restore-keys: 113-cargo-home-linux-x86_64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -4215,7 +4215,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-linux-x86_64-debug-build-main-
+          restore-keys: 113-cargo-target-linux-x86_64-debug-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         with:
@@ -4367,7 +4367,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-x86_64-build-main-${{ github.sha }}'
+          key: '113-cargo-home-linux-x86_64-build-main-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -4378,7 +4378,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-linux-x86_64-debug-build-main-${{ github.sha }}'
+          key: '113-cargo-target-linux-x86_64-debug-build-main-${{ github.sha }}'
   test-debug-linux-x86_64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}debug linux-x86_64'
     needs:
@@ -4471,7 +4471,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -4483,7 +4483,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-linux-x86_64-debug-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-linux-x86_64-debug-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -4653,7 +4653,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
@@ -4664,7 +4664,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-linux-x86_64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-target-linux-x86_64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
   build-libs-debug-linux-x86_64:
     name: build libs debug linux-x86_64
     needs:
@@ -4698,7 +4698,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-linux-x86_64-build-libs-
+          restore-keys: 113-cargo-home-linux-x86_64-build-libs-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
@@ -4710,7 +4710,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-linux-x86_64-debug-build-libs-
+          restore-keys: 113-cargo-target-linux-x86_64-debug-build-libs-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'')'
@@ -4745,7 +4745,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-x86_64-build-libs-${{ github.sha }}'
+          key: '113-cargo-home-linux-x86_64-build-libs-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
@@ -4756,7 +4756,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-linux-x86_64-debug-build-libs-${{ github.sha }}'
+          key: '113-cargo-target-linux-x86_64-debug-build-libs-${{ github.sha }}'
   build-debug-linux-aarch64:
     name: build debug linux-aarch64
     needs:
@@ -4797,7 +4797,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-linux-aarch64-build-main-
+          restore-keys: 113-cargo-home-linux-aarch64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -4809,7 +4809,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-linux-aarch64-debug-build-main-
+          restore-keys: 113-cargo-target-linux-aarch64-debug-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         with:
@@ -4866,7 +4866,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-aarch64-build-main-${{ github.sha }}'
+          key: '113-cargo-home-linux-aarch64-build-main-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -4877,7 +4877,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-linux-aarch64-debug-build-main-${{ github.sha }}'
+          key: '113-cargo-target-linux-aarch64-debug-build-main-${{ github.sha }}'
   test-debug-linux-aarch64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}debug linux-aarch64'
     needs:
@@ -4970,7 +4970,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-linux-aarch64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-linux-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -4982,7 +4982,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-linux-aarch64-debug-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-linux-aarch64-debug-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -5061,7 +5061,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-aarch64-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-home-linux-aarch64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
@@ -5072,7 +5072,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-linux-aarch64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
+          key: '113-cargo-target-linux-aarch64-debug-test-${{ matrix.test_crate }}-${{ github.sha }}'
   test-libs-debug-linux-aarch64:
     name: test libs debug linux-aarch64
     needs:
@@ -5103,7 +5103,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-linux-aarch64-test-libs-
+          restore-keys: 113-cargo-home-linux-aarch64-test-libs-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
@@ -5115,7 +5115,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-linux-aarch64-debug-test-libs-
+          restore-keys: 113-cargo-target-linux-aarch64-debug-test-libs-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'')'
@@ -5162,7 +5162,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-aarch64-test-libs-${{ github.sha }}'
+          key: '113-cargo-home-linux-aarch64-test-libs-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
@@ -5173,7 +5173,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-linux-aarch64-debug-test-libs-${{ github.sha }}'
+          key: '113-cargo-target-linux-aarch64-debug-test-libs-${{ github.sha }}'
   build-release-linux-aarch64:
     name: build release linux-aarch64
     needs:
@@ -5217,7 +5217,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-linux-aarch64-build-main-
+          restore-keys: 113-cargo-home-linux-aarch64-build-main-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -5229,7 +5229,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-linux-aarch64-release-build-main-
+          restore-keys: 113-cargo-target-linux-aarch64-release-build-main-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
@@ -5591,7 +5591,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-linux-aarch64-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-home-linux-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
@@ -5603,7 +5603,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-linux-aarch64-release-test-${{ matrix.test_crate }}-'
+          restore-keys: '113-cargo-target-linux-aarch64-release-test-${{ matrix.test_crate }}-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
@@ -5816,7 +5816,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: '112-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-lint-'
+          restore-keys: '113-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-lint-'
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -5828,7 +5828,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '112-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-lint-'
+          restore-keys: '113-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-lint-'
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         with:
@@ -5859,7 +5859,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-lint-${{ github.sha }}'
+          key: '113-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-lint-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -5870,7 +5870,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-lint-${{ github.sha }}'
+          key: '113-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-lint-${{ github.sha }}'
   deno-core-test:
     name: deno_core test linux-x86_64
     needs:
@@ -5909,7 +5909,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: never_saved
-          restore-keys: 112-cargo-home-linux-x86_64-deno-core-test-
+          restore-keys: 113-cargo-home-linux-x86_64-deno-core-test-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
@@ -5921,7 +5921,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: 112-cargo-target-linux-x86_64-release-deno-core-test-
+          restore-keys: 113-cargo-target-linux-x86_64-release-deno-core-test-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
         if: '!startsWith(github.ref, ''refs/tags/'')'
@@ -6063,7 +6063,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '112-cargo-home-linux-x86_64-deno-core-test-${{ github.sha }}'
+          key: '113-cargo-home-linux-x86_64-deno-core-test-${{ github.sha }}'
       - name: Cache build output
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
@@ -6074,7 +6074,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '112-cargo-target-linux-x86_64-release-deno-core-test-${{ github.sha }}'
+          key: '113-cargo-target-linux-x86_64-release-deno-core-test-${{ github.sha }}'
   deno-core-miri:
     name: deno_core miri linux-x86_64
     needs:

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -18,7 +18,7 @@ import {
 // Bump this number when you want to purge the cache.
 // Note: the tools/release/01_bump_crate_versions.ts script will update this version
 // automatically via regex, so ensure that this line maintains this format.
-const cacheVersion = 112;
+const cacheVersion = 113;
 
 const ubuntuX86Runner = "ubuntu-24.04";
 const ubuntuARMRunner = "ubuntu-24.04-arm";


### PR DESCRIPTION
Bumps the CI cache version to invalidate all existing Actions caches. A
recent macOS x86_64 job had `cargo test` resolve to `rustup-init` instead
of the rustup proxy, suggesting a poisoned `~/.cargo/bin` state may be
cached under the old `112-` key prefix. Rotating the version forces a
clean cargo-home/cargo-target restore across every job.