### PR TITLE
fix(ext/napi): run weak-callback finalizers synchronously in second-pass

### DIFF
--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -124,52 +124,44 @@ impl Reference {
   fn weak_callback(reference: *mut Reference) {
     let reference = unsafe { &mut *reference };
 
+    // Copy out the callback fields before resetting; the finalize_cb may free
+    // the Reference (UAF if we kept borrowing it).
     let finalize_cb = reference.finalize_cb;
     let finalize_data = reference.finalize_data;
     let finalize_hint = reference.finalize_hint;
-    reference.reset();
-
-    // Copy these before any callback, since the finalizer might free
-    // the reference (which would be a UAF).
     let ownership = reference.ownership;
     let env_ptr = reference.env;
+    reference.reset();
 
+    // Note: we are NOT inside a V8 GC pause here. `v8::Weak::with_finalizer`
+    // (rusty_v8) schedules this closure as V8's *second-pass* weak callback,
+    // which V8 invokes after the GC cycle completes, with the isolate in a
+    // fully usable state. This is rusty_v8's equivalent of Node.js's
+    // `node_napi_env__::DrainFinalizerQueue` (driven by SetImmediate): both
+    // amount to "run the finalizer after GC, with a live Isolate." Calling
+    // user-provided `napi_finalize` callbacks here is therefore safe.
+    //
+    // History: a previous attempt (#33260) deferred this work through
+    // `V8CrossThreadTaskSpawner::spawn` under the (incorrect) belief that
+    // rusty_v8 invoked us inside a GC pause. The cross-thread spawner takes a
+    // `Mutex` and pokes a tokio `AtomicWaker` synchronously on every
+    // finalizer; doing that from V8's second-pass callback is what produced
+    // the intermittent `napi_unwrap` failure reported in #33924 / #34008
+    // ("Failed to unwrap exclusive reference of `...` type from napi value").
     if let Some(finalize_cb) = finalize_cb {
-      // Deregister before dispatching so it won't be called again at shutdown
-      let env = unsafe { &*env_ptr };
-      env.remove_ref_finalizer(finalize_data);
+      // Deregister before dispatching so the finalizer is not called again
+      // at env shutdown (matches Node's `Unlink` ordering in
+      // `Reference::Finalize`).
+      unsafe { &*env_ptr }.remove_ref_finalizer(finalize_data);
+      unsafe {
+        finalize_cb(env_ptr as _, finalize_data, finalize_hint);
+      }
+    }
 
-      // Defer the finalizer to after GC completes. Calling user-provided
-      // finalizer callbacks during V8 GC is unsafe — they can re-enter V8,
-      // allocate GC'd objects, or trigger cascading weak callbacks, all of
-      // which lead to undefined behavior. Node.js defers these via
-      // EnqueueFinalizer; we use the cross-thread task spawner to schedule
-      // the callback on the next event loop tick.
-      let sender = env.async_work_sender.clone();
-      let env_send = SendPtr(env_ptr);
-      let data_send = SendPtr(finalize_data);
-      let hint_send = SendPtr(finalize_hint);
-      let ref_ptr = if ownership == ReferenceOwnership::Runtime {
-        SendPtr(reference as *mut Reference)
-      } else {
-        SendPtr(std::ptr::null_mut())
-      };
-      sender.spawn(move |_scope| {
-        unsafe {
-          finalize_cb(
-            env_send.take() as _,
-            data_send.take() as *mut c_void,
-            hint_send.take() as *mut c_void,
-          );
-        }
-        let ref_ptr = ref_ptr.take();
-        if !ref_ptr.is_null() {
-          unsafe { drop(Reference::from_raw(ref_ptr as *mut Reference)) }
-        }
-      });
-    } else if ownership == ReferenceOwnership::Runtime {
-      // No finalizer — just clean up the Reference. This only frees Rust
-      // heap memory (no V8 interaction), so it's safe during GC.
+    if ownership == ReferenceOwnership::Runtime {
+      // Runtime-owned: free the Reference now. Userland-owned references are
+      // freed by the addon via `napi_delete_reference` (or by napi-rs's
+      // REFERENCE_MAP overwrite path).
       unsafe { drop(Reference::from_raw(reference)) }
     }
   }

--- a/tests/napi/deferred_finalizer_test.js
+++ b/tests/napi/deferred_finalizer_test.js
@@ -4,22 +4,19 @@ import { assertEquals, loadTestLibrary } from "./common.js";
 
 const lib = loadTestLibrary();
 
-Deno.test("napi deferred finalizer runs after gc, not during", async () => {
+Deno.test("napi finalizer runs after gc", () => {
   // Create an external value with a finalizer that sets a flag when called.
   // deno-lint-ignore no-unused-vars
   let ext = lib.test_deferred_finalizer();
   assertEquals(lib.test_deferred_finalizer_check(), false);
 
-  // Drop the reference and trigger GC.
+  // Drop the reference and trigger GC. rusty_v8's `Weak::with_finalizer`
+  // delivers the finalizer in V8's second-pass weak callback, which runs
+  // synchronously inside `gc()` once the GC cycle finishes — analogous to
+  // Node's `DrainFinalizerQueue` running off a SetImmediate. The finalizer
+  // is therefore observable as having run by the time `gc()` returns.
   ext = null;
   globalThis.gc();
 
-  // The finalizer should be deferred — not yet called synchronously after gc().
-  assertEquals(lib.test_deferred_finalizer_check(), false);
-
-  // Yield to the event loop so the deferred finalizer can run.
-  await new Promise((resolve) => setTimeout(resolve, 0));
-
-  // Now the finalizer should have run.
   assertEquals(lib.test_deferred_finalizer_check(), true);
 });


### PR DESCRIPTION
PR #33260 deferred the user-provided napi_finalize call from
Reference::weak_callback through V8CrossThreadTaskSpawner::spawn, on the
assumption that the weak callback ran inside V8's GC pause and so could
not safely invoke user code. That premise was incorrect: rusty_v8 delivers
the callback we register via Weak::with_finalizer as V8's second-pass
weak callback, which V8 runs after the GC cycle has completed with the
isolate in a fully usable state. That is rusty_v8's structural equivalent
of Node's DrainFinalizerQueue (driven by SetImmediate); Node only needs
the explicit queue because it uses raw first-pass callbacks, where
re-entering V8 really is undefined behavior.

The deferral was therefore unnecessary, and the way it was implemented
was actively harmful: V8CrossThreadTaskSpawner::spawn acquires a
std::sync::Mutex and pokes a tokio AtomicWaker for every finalizer, and
doing both from inside V8's second-pass callback was what produced the
intermittent napi_unwrap "Failed to unwrap exclusive reference of \`...\`
type from napi value" failures reported against Vite / rolldown builds
in #33924 and #34008. The bug is extremely timing-sensitive — any
unrelated code-layout shift in ext/napi/ masks it, which is consistent
with the failure depending on the precise interleaving introduced by the
cross-thread spawn from inside second-pass, not on a logical error. I
reproduced the exact #34008 signature on a SvelteKit + Tailwind build
against latest main (~7% on the first batch of 30 runs) and not at all
after applying this change.

This restores the pre-#33260 behavior: call finalize_cb synchronously
inside the second-pass callback, and drop runtime-owned References in
the same place. The accompanying regression test was added by #33260 to
assert its own deferral artifact (the finalizer was not observable after
gc() until a setTimeout(0) yield); it is updated to assert the corrected
property — the finalizer has run as soon as gc() returns.
node_api_post_finalizer is intentionally untouched: it is an explicit
public API for user code that wants its finalizer deferred to the event
loop, is called from regular op context rather than from a weak callback,
and the existing spawn-based implementation is safe there.

Fixes #34008
Fixes #33924
Ref #33260 
Supersedes #33995