### PR TITLE
fix(ext/node): don't emit ServerResponse 'finish' after client abort

### DIFF
--- a/ext/node/polyfills/_http_outgoing.ts
+++ b/ext/node/polyfills/_http_outgoing.ts
@@ -1202,6 +1202,10 @@ function connectionCorkNT(conn: any) {
 
 function onFinish(outmsg: any) {
   if (outmsg?.socket?._hadError) return;
+  // If the response (or its socket) was destroyed before `res.end()` ran
+  // (e.g. the client aborted the connection), do not emit 'finish' - Node
+  // only emits 'close' in that scenario.
+  if (outmsg?.destroyed || outmsg?.socket?.destroyed) return;
   outmsg.emit("finish");
 }
 

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -22,6 +22,7 @@ import { retry } from "@std/async/retry";
 
 import { gzip } from "node:zlib";
 import { Buffer } from "node:buffer";
+import { setImmediate } from "node:timers";
 import { execCode } from "../unit/test_util.ts";
 
 // Destroy idle keep-alive sockets before each test so that sequential
@@ -720,6 +721,49 @@ Deno.test("[node/http] ServerResponse _implicitHeader", async () => {
 
   await promise;
 });
+
+// https://github.com/denoland/deno/issues/34002
+Deno.test(
+  "[node/http] ServerResponse does not emit 'finish' after client abort",
+  async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    let client: http.ClientRequest;
+    let finishEmitted = false;
+    let closeEmitted = false;
+
+    const server = http.createServer((_req, res) => {
+      res.on("finish", () => {
+        finishEmitted = true;
+      });
+      res.on("close", () => {
+        closeEmitted = true;
+      });
+
+      client.abort();
+
+      setImmediate(() => {
+        setImmediate(() => {
+          res.end("ok");
+          setImmediate(() => {
+            server.close(() => {
+              assertEquals(finishEmitted, false);
+              assertEquals(closeEmitted, true);
+              resolve();
+            });
+          });
+        });
+      });
+    });
+
+    server.listen(0, () => {
+      const { port } = server.address() as { port: number };
+      client = http.get(`http://127.0.0.1:${port}`);
+      client.on("error", () => {});
+    });
+
+    await promise;
+  },
+);
 
 // https://github.com/denoland/deno/issues/21509
 Deno.test("[node/http] ServerResponse flushHeaders", async () => {


### PR DESCRIPTION
## Summary

Fixes #34002.

When the client aborts an HTTP request before `res.end()` runs, the
server-side socket fires its `'close'` event, which calls
`emitCloseNT(res)` on the in-flight `ServerResponse`. `emitCloseNT` sets
`destroyed = true` / `_closed = true` and emits `'close'`. The deferred
`res.end()` then schedules `onFinish` via the `_send` callback,
and `onFinish` only checked `socket._hadError` — that flag is not set on
the abort path in Deno, so `'finish'` was emitted *after* `'close'`.

Node emits only `'close'` in that scenario.

This PR adds a `destroyed` guard to `onFinish` so the response stops
emitting `'finish'` once it has already been destroyed (either via the
response or its socket).

## Reproducer (from #34002)

```js
const http = require('http');

let client;
let count = 0;

const server = http.createServer((req, res) => {
  res.on('finish', () => { console.log('finish'); count++; });
  res.on('close', () => { console.log('close'); count++; });

  client.abort();

  setImmediate(() => {
    setImmediate(() => {
      res.end('ok');
      setImmediate(() => {
        server.close(() => { console.log('event count:', count); });
      });
    });
  });
});

server.listen(0, () => {
  client = http.get(`http://127.0.0.1:${server.address().port}`);
  client.on('error', () => {});
});
```

Before (Deno 2.7.14 release):
```
finish
close
event count: 2
```

After (Node, and Deno with this fix):
```
close
event count: 1
```

## Test plan

- [x] Added `tests/unit_node/http_test.ts` regression test
      `"[node/http] ServerResponse does not emit 'finish' after client abort"`
- [x] All existing `ServerResponse` tests still pass (`deno test -A
      tests/unit_node/http_test.ts --filter "ServerResponse"`)
- [x] `tools/format.js` clean
- [x] `tools/lint.js --js` clean

Closes bartlomieju/orchid-inbox#47