### PR TITLE
ci: use larger Linux runner for LTO release build on main/tags

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -59,7 +59,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: ubuntu-24.04
+    runs-on: '${{ github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-xl'' || ''ubuntu-24.04'' }}'
     timeout-minutes: 240
     defaults:
       run:
@@ -3888,7 +3888,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: ubuntu-24.04
+    runs-on: '${{ github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-xl'' || ''ubuntu-24.04'' }}'
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240
@@ -6588,7 +6588,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true' && needs.pre_build.outputs.skip_deno_core_test != 'true'
-    runs-on: ubuntu-24.04
+    runs-on: '${{ github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-xl'' || ''ubuntu-24.04'' }}'
     timeout-minutes: 60
     defaults:
       run:
@@ -6814,7 +6814,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: ubuntu-24.04
+    runs-on: '${{ github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-xl'' || ''ubuntu-24.04'' }}'
     timeout-minutes: 60
     defaults:
       run:

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -21,6 +21,7 @@ import {
 const cacheVersion = 113;
 
 const ubuntuX86Runner = "ubuntu-24.04";
+const ubuntuX86XlRunner = "ubuntu-24.04-xl";
 const ubuntuARMRunner = "ubuntu-24.04-arm";
 const windowsX86Runner = "windows-2022";
 const windowsX86XlRunner = "windows-2022-xl";
@@ -47,7 +48,10 @@ const Runners = {
   linuxX86Xl: {
     os: "linux",
     arch: "x86_64",
-    runner: ubuntuX86Runner,
+    runner: isDenoland.and(isMainOrTag).then(ubuntuX86XlRunner).else(
+      ubuntuX86Runner,
+    ),
+    testRunner: ubuntuX86Runner,
   },
   linuxArm: {
     os: "linux",


### PR DESCRIPTION
The release Linux build does full LTO and has been hitting out-of-memory
on the standard GitHub-hosted runner on main. This routes the
release-linux-x86_64 build to ubuntu-24.04-xl when running on
denoland/deno's main branch or on a tag, so the link step has enough
memory to complete. PRs and forks keep using the default ubuntu-24.04
runner, and the corresponding test and WPT jobs stay on the standard
runner since they don't need the extra capacity.