### PR TITLE
ci: use larger ARM Linux runner for release LTO build on main/tags

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -59,7 +59,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-xl'' || ''ubuntu-24.04'' }}'
+    runs-on: ubuntu-24.04
     timeout-minutes: 240
     defaults:
       run:
@@ -3888,7 +3888,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-xl'' || ''ubuntu-24.04'' }}'
+    runs-on: ubuntu-24.04
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240
@@ -5820,7 +5820,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || ''ubuntu-24.04-arm'' }}'
+    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-arm-xl'' || ''ubuntu-24.04-arm'' }}'
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240
@@ -6588,7 +6588,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true' && needs.pre_build.outputs.skip_deno_core_test != 'true'
-    runs-on: '${{ github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-xl'' || ''ubuntu-24.04'' }}'
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     defaults:
       run:
@@ -6814,7 +6814,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-xl'' || ''ubuntu-24.04'' }}'
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     defaults:
       run:

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -21,8 +21,8 @@ import {
 const cacheVersion = 113;
 
 const ubuntuX86Runner = "ubuntu-24.04";
-const ubuntuX86XlRunner = "ubuntu-24.04-xl";
 const ubuntuARMRunner = "ubuntu-24.04-arm";
+const ubuntuARMXlRunner = "ubuntu-24.04-arm-xl";
 const windowsX86Runner = "windows-2022";
 const windowsX86XlRunner = "windows-2022-xl";
 const windowsArmRunner = "windows-11-arm";
@@ -48,15 +48,20 @@ const Runners = {
   linuxX86Xl: {
     os: "linux",
     arch: "x86_64",
-    runner: isDenoland.and(isMainOrTag).then(ubuntuX86XlRunner).else(
-      ubuntuX86Runner,
-    ),
-    testRunner: ubuntuX86Runner,
+    runner: ubuntuX86Runner,
   },
   linuxArm: {
     os: "linux",
     arch: "aarch64",
     runner: ubuntuARMRunner,
+  },
+  linuxArmXl: {
+    os: "linux",
+    arch: "aarch64",
+    runner: isDenoland.and(isMainOrTag).then(ubuntuARMXlRunner).else(
+      ubuntuARMRunner,
+    ),
+    testRunner: ubuntuARMRunner,
   },
   macosX86: {
     os: "macos",
@@ -570,7 +575,7 @@ const buildItems = handleBuildItems([{
   ...Runners.linuxArm,
   profile: "debug",
 }, {
-  ...Runners.linuxArm,
+  ...Runners.linuxArmXl,
   profile: "release",
   use_sysroot: true,
   skip_pr: true,


### PR DESCRIPTION
Follow-up to #34029, which routed the release Linux LTO build to a
larger x86_64 runner (ubuntu-24.04-xl). The intent was the opposite: to
move the release build onto a larger ARM runner. This reverts linuxX86Xl
back to the standard ubuntu-24.04 runner and adds a linuxArmXl runner
config that targets ubuntu-24.04-arm-xl for the aarch64 release plus
sysroot build when running on denoland/deno's main branch or on a tag.
PRs and forks continue to use the standard ubuntu-24.04-arm runner.