### PR TITLE
ci: fix ARM Linux XL runner label

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -5820,7 +5820,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-arm-xl'' || ''ubuntu-24.04-arm'' }}'
+    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-arm64-xl'' || ''ubuntu-24.04-arm'' }}'
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -22,7 +22,7 @@ const cacheVersion = 113;
 
 const ubuntuX86Runner = "ubuntu-24.04";
 const ubuntuARMRunner = "ubuntu-24.04-arm";
-const ubuntuARMXlRunner = "ubuntu-24.04-arm-xl";
+const ubuntuARMXlRunner = "ubuntu-24.04-arm64-xl";
 const windowsX86Runner = "windows-2022";
 const windowsX86XlRunner = "windows-2022-xl";
 const windowsArmRunner = "windows-11-arm";


### PR DESCRIPTION
The runner label introduced in #34034 was incorrect — `ubuntu-24.04-arm-xl` does not match any provisioned runner, so the release LTO build on `main`/tags is unable to schedule. The correct label is `ubuntu-24.04-arm64-xl`.

This updates `ci.ts` and regenerates `ci.generated.yml`.

Closes bartlomieju/orchid-inbox#58