### PR TITLE
fix(ext/node): enforce maxBuffer in child_process.spawnSync

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1646,13 +1646,18 @@ function spawnSync(
       input: input_,
       timeout,
       killSignal,
+      maxBuffer,
     });
 
     const status = output.signal ? null : output.code;
     let stdout = output.stdout ? Buffer.from(output.stdout) : null;
     let stderr = output.stderr ? Buffer.from(output.stderr) : null;
 
+    // Defensive: if Rust didn't kill on overflow (e.g. maxBuffer was
+    // unlimited but the JS layer somehow still has a longer buffer), fall
+    // back to the post-hoc length check.
     if (
+      output.killedByMaxBuffer ||
       (stdout && stdout.length > maxBuffer) ||
       (stderr && stderr.length > maxBuffer)
     ) {
@@ -1669,11 +1674,13 @@ function spawnSync(
     }
 
     result.pid = output.pid;
-    // When killed by timeout, report the killSignal (matching Node.js behavior).
-    // On Windows there are no real Unix signals, but Node still reports the
-    // configured killSignal so callers can detect the timeout.
-    result.status = output.killedByTimeout ? null : status;
-    result.signal = output.killedByTimeout
+    // When killed by timeout or maxBuffer, report the killSignal (matching
+    // Node.js behavior). On Windows there are no real Unix signals, but
+    // Node still reports the configured killSignal so callers can detect
+    // why the child was terminated.
+    const killedByDeno = output.killedByTimeout || output.killedByMaxBuffer;
+    result.status = killedByDeno ? null : status;
+    result.signal = killedByDeno
       ? _resolveKillSignalName(killSignal)
       : output.signal;
     result.stdout = stdout;

--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -23,6 +23,7 @@ const {
   TypedArrayPrototypeSet,
   Uint8Array,
   TypeError,
+  NumberIsFinite,
   ObjectEntries,
   SafeArrayIterator,
   String,
@@ -372,6 +373,7 @@ function nodeSpawnSyncChild({
   input,
   timeout,
   killSignal,
+  maxBuffer,
 }) {
   const spawnArgs = {
     cmd: pathFromURL(args[0]),
@@ -391,11 +393,21 @@ function nodeSpawnSyncChild({
     input,
     argv0,
   };
-  if (timeout != null && timeout > 0) {
+  const hasTimeout = timeout != null && timeout > 0;
+  // Only forward a finite, non-negative `maxBuffer` to the op so that
+  // Infinity / missing values map to "no limit" on the Rust side.
+  const hasMaxBuffer = typeof maxBuffer === "number" &&
+    NumberIsFinite(maxBuffer) && maxBuffer >= 0;
+  if (hasTimeout) {
     spawnArgs.timeout = timeout;
-    if (killSignal != null) {
-      spawnArgs.killSignal = killSignal;
-    }
+  }
+  if (hasMaxBuffer) {
+    spawnArgs.maxBuffer = maxBuffer;
+  }
+  // killSignal applies to both `timeout` and `maxBuffer` kills, matching
+  // Node's behavior.
+  if (killSignal != null && (hasTimeout || hasMaxBuffer)) {
+    spawnArgs.killSignal = killSignal;
   }
   const result = op_spawn_sync(spawnArgs);
   return {
@@ -407,6 +419,7 @@ function nodeSpawnSyncChild({
     stderr: result.stderr,
     pid: result.pid,
     killedByTimeout: result.killedByTimeout,
+    killedByMaxBuffer: result.killedByMaxBuffer,
   };
 }
 

--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -1424,20 +1424,19 @@ fn op_spawn_sync(
     /* allow_cwd_inherit */ false,
   )?;
 
-  // When timeout or maxBuffer is specified on Unix, create a new process
-  // group so we can kill the entire tree (shell + children), not just the
-  // shell. Otherwise a shell-wrapped child that exceeds the limit would
-  // outlive the kill signal. maxBuffer only matters when at least one of
-  // stdout/stderr is piped — without a pipe there's nothing to overflow,
-  // and Node.js's spawnSync default `maxBuffer` (1 MiB) means we'd otherwise
-  // move every spawnSync child into its own process group. That breaks TTY
-  // operations like `setRawMode` from inherited stdio (the kernel raises
-  // SIGTTOU on a background-group `tcsetattr`, stopping the child and
-  // hanging the parent).
+  // When a timeout is specified on Unix, create a new process group so the
+  // watchdog can kill the entire tree (shell + children), not just the shell.
+  //
+  // The `maxBuffer` kill path deliberately does NOT force a new group. Node's
+  // spawnSync defaults `maxBuffer` to 1 MiB, so doing so would move every
+  // spawnSync child with a piped stdout/stderr into its own process group,
+  // detaching it from the controlling terminal's foreground group. That breaks
+  // TTY operations like `setRawMode` on inherited stdin: a background-group
+  // `tcsetattr` raises SIGTTOU, which stops the child and hangs the parent.
+  // Node enforces `maxBuffer` by killing only the direct child, so the
+  // maxBuffer reader threads below do the same (see `kill_child`).
   #[cfg(unix)]
-  if timeout.is_some_and(|t| t > 0)
-    || (max_buffer.is_some() && (stdout || stderr))
-  {
+  if timeout.is_some_and(|t| t > 0) {
     command.process_group(0);
   }
 
@@ -1475,33 +1474,55 @@ fn op_spawn_sync(
   #[cfg(windows)]
   let child_pid_for_kill = child.id().expect("Process ID should be set.");
 
-  // Kill the spawned child (its whole process group on Unix). Called either
-  // by the timeout watchdog or the maxBuffer reader threads.
-  let kill_child: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
-    #[cfg(unix)]
-    // SAFETY: child_pid_for_kill is the PID of the just-spawned child;
-    // signaling its process group (negative PID) terminates shell-wrapped
-    // subprocesses too. There is a minor race window if the child has
-    // already exited and the PID was recycled; in practice the watchdog
-    // and readers race against EOF / wait() returning so this window is
-    // negligible.
-    unsafe {
-      libc::kill(-(child_pid_for_kill as i32), kill_signal_int);
-    }
-    #[cfg(windows)]
-    // SAFETY: standard Win32 calls; child_pid_for_kill is a valid PID.
-    unsafe {
-      let handle = windows_sys::Win32::System::Threading::OpenProcess(
-        windows_sys::Win32::System::Threading::PROCESS_TERMINATE,
-        false.into(),
-        child_pid_for_kill,
-      );
-      if !handle.is_null() {
-        windows_sys::Win32::System::Threading::TerminateProcess(handle, 1);
-        windows_sys::Win32::Foundation::CloseHandle(handle);
+  // How far the kill should reach.
+  enum KillScope {
+    // Signal the child's whole process group. Only valid on the timeout path,
+    // where `process_group(0)` above made the child a group leader; this also
+    // reaps shell-wrapped subprocesses.
+    ProcessGroup,
+    // Signal only the direct child. Used by the maxBuffer path, matching Node,
+    // which never moves the child into a new group for `maxBuffer`.
+    Child,
+  }
+
+  // Kill the spawned child with the requested scope.
+  let kill_child: Arc<dyn Fn(KillScope) + Send + Sync> =
+    Arc::new(move |scope: KillScope| {
+      #[cfg(unix)]
+      {
+        // A negative PID targets the process group. There is a minor race
+        // window if the child has already exited and the PID was recycled; in
+        // practice the watchdog and readers race against EOF / wait()
+        // returning so this window is negligible.
+        let pid = child_pid_for_kill as i32;
+        let target = match scope {
+          KillScope::ProcessGroup => -pid,
+          KillScope::Child => pid,
+        };
+        // SAFETY: `target` references the just-spawned child (or its group).
+        unsafe {
+          libc::kill(target, kill_signal_int);
+        }
       }
-    }
-  });
+      #[cfg(windows)]
+      {
+        // Windows has no process groups here; both scopes terminate the direct
+        // child.
+        let _ = scope;
+        // SAFETY: standard Win32 calls; child_pid_for_kill is a valid PID.
+        unsafe {
+          let handle = windows_sys::Win32::System::Threading::OpenProcess(
+            windows_sys::Win32::System::Threading::PROCESS_TERMINATE,
+            false.into(),
+            child_pid_for_kill,
+          );
+          if !handle.is_null() {
+            windows_sys::Win32::System::Threading::TerminateProcess(handle, 1);
+            windows_sys::Win32::Foundation::CloseHandle(handle);
+          }
+        }
+      }
+    });
 
   // Take stdout/stderr pipes from child so we can read them in background
   // threads. This lets us drop the pipes on timeout to unblock the readers
@@ -1518,7 +1539,7 @@ fn op_spawn_sync(
     mut pipe: R,
     max_buffer: Option<u64>,
     killed_by_max_buffer: Arc<AtomicBool>,
-    kill_child: Arc<dyn Fn() + Send + Sync>,
+    kill_child: Arc<dyn Fn(KillScope) + Send + Sync>,
   ) -> Vec<u8> {
     let mut buf = Vec::new();
     // No limit: fall back to read_to_end so we don't waste cycles checking.
@@ -1537,7 +1558,9 @@ fn op_spawn_sync(
             if buf.len() as u64 > limit {
               overflowed = true;
               if !killed_by_max_buffer.swap(true, Ordering::SeqCst) {
-                kill_child();
+                // Kill only the direct child (matching Node); no process
+                // group is created for the maxBuffer path.
+                kill_child(KillScope::Child);
               }
             }
           }
@@ -1588,7 +1611,9 @@ fn op_spawn_sync(
         return;
       }
       killed.store(true, Ordering::SeqCst);
-      kill_child();
+      // Kill the whole process group: a new group was created above when a
+      // timeout is set, so this also reaps shell-wrapped subprocesses.
+      kill_child(KillScope::ProcessGroup);
     });
   }
   drop(kill_child);

--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -1427,9 +1427,17 @@ fn op_spawn_sync(
   // When timeout or maxBuffer is specified on Unix, create a new process
   // group so we can kill the entire tree (shell + children), not just the
   // shell. Otherwise a shell-wrapped child that exceeds the limit would
-  // outlive the kill signal.
+  // outlive the kill signal. maxBuffer only matters when at least one of
+  // stdout/stderr is piped — without a pipe there's nothing to overflow,
+  // and Node.js's spawnSync default `maxBuffer` (1 MiB) means we'd otherwise
+  // move every spawnSync child into its own process group. That breaks TTY
+  // operations like `setRawMode` from inherited stdio (the kernel raises
+  // SIGTTOU on a background-group `tcsetattr`, stopping the child and
+  // hanging the parent).
   #[cfg(unix)]
-  if timeout.is_some_and(|t| t > 0) || max_buffer.is_some() {
+  if timeout.is_some_and(|t| t > 0)
+    || (max_buffer.is_some() && (stdout || stderr))
+  {
     command.process_group(0);
   }
 

--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -320,6 +320,11 @@ pub struct SpawnArgs {
     allow(dead_code, reason = "deserialized from JS but only used on Unix")
   )]
   kill_signal: Option<KillSignal>,
+  /// Maximum number of bytes that may accumulate in stdout/stderr before the
+  /// child is killed. Mirrors Node.js `child_process.spawnSync({ maxBuffer })`.
+  /// `None` means unlimited.
+  #[serde(default)]
+  max_buffer: Option<u64>,
 }
 
 #[derive(Clone, Deserialize)]
@@ -479,6 +484,7 @@ pub struct SpawnOutput {
   stdout: Option<Uint8Array>,
   stderr: Option<Uint8Array>,
   killed_by_timeout: bool,
+  killed_by_max_buffer: bool,
 }
 
 type CreateCommand = (
@@ -1408,6 +1414,7 @@ fn op_spawn_sync(
   let stderr = matches!(args.stdio.stderr, StdioOrFd::Stdio(Stdio::Piped));
   let input = args.input.clone();
   let timeout = args.timeout;
+  let max_buffer = args.max_buffer;
   #[cfg(unix)]
   let kill_signal = args.kill_signal.clone();
   let (mut command, _, _, _) = create_command(
@@ -1417,10 +1424,12 @@ fn op_spawn_sync(
     /* allow_cwd_inherit */ false,
   )?;
 
-  // When timeout is specified on Unix, create a new process group so we can
-  // kill the entire tree (shell + children) on timeout, not just the shell.
+  // When timeout or maxBuffer is specified on Unix, create a new process
+  // group so we can kill the entire tree (shell + children), not just the
+  // shell. Otherwise a shell-wrapped child that exceeds the limit would
+  // outlive the kill signal.
   #[cfg(unix)]
-  if timeout.is_some_and(|t| t > 0) {
+  if timeout.is_some_and(|t| t > 0) || max_buffer.is_some() {
     command.process_group(0);
   }
 
@@ -1440,26 +1449,111 @@ fn op_spawn_sync(
     stdin.flush()?;
   }
 
+  // Resolve the configured kill signal once so it can be shared with the
+  // background threads that enforce timeout and maxBuffer. On Windows there
+  // are no real Unix signals, but the signal is still tracked so JS can
+  // surface the configured `killSignal` to callers.
+  #[cfg(unix)]
+  let kill_signal_int: i32 = match &kill_signal {
+    Some(KillSignal::Number(n)) => *n,
+    Some(KillSignal::String(s)) => {
+      deno_signals::signal_str_to_int(s).unwrap_or(libc::SIGTERM)
+    }
+    None => libc::SIGTERM,
+  };
+
+  #[cfg(unix)]
+  let child_pid_for_kill = child.id();
+  #[cfg(windows)]
+  let child_pid_for_kill = child.id().expect("Process ID should be set.");
+
+  // Kill the spawned child (its whole process group on Unix). Called either
+  // by the timeout watchdog or the maxBuffer reader threads.
+  let kill_child: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+    #[cfg(unix)]
+    // SAFETY: child_pid_for_kill is the PID of the just-spawned child;
+    // signaling its process group (negative PID) terminates shell-wrapped
+    // subprocesses too. There is a minor race window if the child has
+    // already exited and the PID was recycled; in practice the watchdog
+    // and readers race against EOF / wait() returning so this window is
+    // negligible.
+    unsafe {
+      libc::kill(-(child_pid_for_kill as i32), kill_signal_int);
+    }
+    #[cfg(windows)]
+    // SAFETY: standard Win32 calls; child_pid_for_kill is a valid PID.
+    unsafe {
+      let handle = windows_sys::Win32::System::Threading::OpenProcess(
+        windows_sys::Win32::System::Threading::PROCESS_TERMINATE,
+        false.into(),
+        child_pid_for_kill,
+      );
+      if !handle.is_null() {
+        windows_sys::Win32::System::Threading::TerminateProcess(handle, 1);
+        windows_sys::Win32::Foundation::CloseHandle(handle);
+      }
+    }
+  });
+
   // Take stdout/stderr pipes from child so we can read them in background
   // threads. This lets us drop the pipes on timeout to unblock the readers
   // (matching libuv's behavior of stopping pipe reads after process kill).
   let child_stdout = child.stdout.take();
   let child_stderr = child.stderr.take();
 
-  let stdout_handle = child_stdout.map(|pipe| {
-    std::thread::spawn(move || {
-      let mut buf = Vec::new();
-      let mut pipe = pipe;
+  let killed_by_max_buffer = Arc::new(AtomicBool::new(false));
+
+  // Read a pipe to EOF, enforcing `max_buffer` if set. On overflow the first
+  // reader to notice flips `killed_by_max_buffer` (CAS-style) and kills the
+  // child; the subsequent EOF lets both reader threads return.
+  fn read_with_limit<R: std::io::Read>(
+    mut pipe: R,
+    max_buffer: Option<u64>,
+    killed_by_max_buffer: Arc<AtomicBool>,
+    kill_child: Arc<dyn Fn() + Send + Sync>,
+  ) -> Vec<u8> {
+    let mut buf = Vec::new();
+    // No limit: fall back to read_to_end so we don't waste cycles checking.
+    let Some(limit) = max_buffer else {
       let _ = std::io::Read::read_to_end(&mut pipe, &mut buf);
-      buf
+      return buf;
+    };
+    let mut tmp = [0u8; 64 * 1024];
+    let mut overflowed = false;
+    loop {
+      match pipe.read(&mut tmp) {
+        Ok(0) => break,
+        Ok(n) => {
+          if !overflowed {
+            buf.extend_from_slice(&tmp[..n]);
+            if buf.len() as u64 > limit {
+              overflowed = true;
+              if !killed_by_max_buffer.swap(true, Ordering::SeqCst) {
+                kill_child();
+              }
+            }
+          }
+          // After overflow, drain the pipe without buffering further so
+          // the child's pending writes don't keep the pipe open.
+        }
+        Err(_) => break,
+      }
+    }
+    buf
+  }
+
+  let stdout_handle = child_stdout.map(|pipe| {
+    let killed = killed_by_max_buffer.clone();
+    let kill_child = kill_child.clone();
+    std::thread::spawn(move || {
+      read_with_limit(pipe, max_buffer, killed, kill_child)
     })
   });
   let stderr_handle = child_stderr.map(|pipe| {
+    let killed = killed_by_max_buffer.clone();
+    let kill_child = kill_child.clone();
     std::thread::spawn(move || {
-      let mut buf = Vec::new();
-      let mut pipe = pipe;
-      let _ = std::io::Read::read_to_end(&mut pipe, &mut buf);
-      buf
+      read_with_limit(pipe, max_buffer, killed, kill_child)
     })
   });
 
@@ -1471,20 +1565,9 @@ fn op_spawn_sync(
   if let Some(timeout_ms) = timeout
     && timeout_ms > 0
   {
-    #[cfg(unix)]
-    let child_id = child.id();
-    #[cfg(windows)]
-    let child_id = child.id().expect("Process ID should be set.");
     let killed = killed_by_timeout.clone();
     let cancel2 = cancel.clone();
-    #[cfg(unix)]
-    let signal: i32 = match &kill_signal {
-      Some(KillSignal::Number(n)) => *n,
-      Some(KillSignal::String(s)) => {
-        deno_signals::signal_str_to_int(s).unwrap_or(libc::SIGTERM)
-      }
-      None => libc::SIGTERM,
-    };
+    let kill_child = kill_child.clone();
     std::thread::spawn(move || {
       let (lock, cvar) = &*cancel2;
       let guard = lock.lock().unwrap();
@@ -1497,40 +1580,10 @@ fn op_spawn_sync(
         return;
       }
       killed.store(true, Ordering::SeqCst);
-      // NOTE: There is a minor race window where the child exits and its
-      // PID gets recycled before we send the kill signal. The condvar
-      // cancel above prevents this in practice (the main thread cancels
-      // the timer immediately after wait() returns), but if the OS
-      // recycles the PID in that narrow window we could signal the wrong
-      // process. This matches libuv's behavior.
-      #[cfg(unix)]
-      // SAFETY: child_id is a valid PID from the spawned child process.
-      // We use negative PID to kill the entire process group (created via
-      // process_group(0) above), ensuring shell children are also killed.
-      // NOTE: There is a minor theoretical race window where the child
-      // could exit and its PID get recycled between wait() returning and
-      // the condvar cancel reaching this thread. In practice the condvar
-      // cancellation is near-instant so this window is negligible.
-      unsafe {
-        libc::kill(-(child_id as i32), signal);
-      }
-      #[cfg(windows)]
-      // SAFETY: child_id is a valid PID from the spawned child process.
-      // OpenProcess/TerminateProcess/CloseHandle are safe to call with
-      // valid arguments.
-      unsafe {
-        let handle = windows_sys::Win32::System::Threading::OpenProcess(
-          windows_sys::Win32::System::Threading::PROCESS_TERMINATE,
-          false.into(),
-          child_id,
-        );
-        if !handle.is_null() {
-          windows_sys::Win32::System::Threading::TerminateProcess(handle, 1);
-          windows_sys::Win32::Foundation::CloseHandle(handle);
-        }
-      }
+      kill_child();
     });
   }
+  drop(kill_child);
 
   #[cfg(unix)]
   let status = child.wait().map_err(|e| ProcessError::SpawnFailed {
@@ -1555,6 +1608,7 @@ fn op_spawn_sync(
   }
 
   let timed_out = killed_by_timeout.load(Ordering::SeqCst);
+  let buffered_overflow = killed_by_max_buffer.load(Ordering::SeqCst);
 
   // Collect stdout/stderr from background reader threads.
   // On Unix, the process group kill ensures all children are dead and
@@ -1571,7 +1625,7 @@ fn op_spawn_sync(
     }
     #[cfg(windows)]
     {
-      if timed_out {
+      if timed_out || buffered_overflow {
         // Brief timeout to avoid blocking on orphaned grandchildren.
         let start = std::time::Instant::now();
         loop {
@@ -1605,6 +1659,7 @@ fn op_spawn_sync(
       None
     },
     killed_by_timeout: timed_out,
+    killed_by_max_buffer: buffered_overflow,
   })
 }
 

--- a/tests/specs/node/child_process_spawnsync_max_buffer/__test__.jsonc
+++ b/tests/specs/node/child_process_spawnsync_max_buffer/__test__.jsonc
@@ -6,7 +6,7 @@
     },
     "inherit_stdio_does_not_hang": {
       "args": "run -A inherit.ts",
-      "output": "ok\n"
+      "output": "child done\nok\n"
     }
   }
 }

--- a/tests/specs/node/child_process_spawnsync_max_buffer/__test__.jsonc
+++ b/tests/specs/node/child_process_spawnsync_max_buffer/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run -A main.ts",
+  "output": "ok\n"
+}

--- a/tests/specs/node/child_process_spawnsync_max_buffer/__test__.jsonc
+++ b/tests/specs/node/child_process_spawnsync_max_buffer/__test__.jsonc
@@ -1,4 +1,12 @@
 {
-  "args": "run -A main.ts",
-  "output": "ok\n"
+  "tests": {
+    "kill_on_overflow": {
+      "args": "run -A main.ts",
+      "output": "ok\n"
+    },
+    "inherit_stdio_does_not_hang": {
+      "args": "run -A inherit.ts",
+      "output": "ok\n"
+    }
+  }
 }

--- a/tests/specs/node/child_process_spawnsync_max_buffer/inherit.ts
+++ b/tests/specs/node/child_process_spawnsync_max_buffer/inherit.ts
@@ -1,0 +1,33 @@
+// Regression test: when spawnSync inherits stdio, the implicit Node default
+// `maxBuffer` must NOT cause the child to be moved into a new process group.
+// Doing so makes `tcsetattr` (e.g. `setRawMode`) raise SIGTTOU and hang the
+// parent indefinitely when stdin is a controlling TTY — see CI failures on
+// `pseudo-tty/test-set-raw-mode-reset.js` after the maxBuffer change.
+//
+// We can't easily attach a real TTY here, but we can verify the cheaper
+// invariant: spawnSync with `stdio: 'inherit'` (no piped output) returns
+// promptly with status 0 instead of hanging on the runner's outer timeout.
+import { spawnSync } from "node:child_process";
+
+const start = Date.now();
+const result = spawnSync(
+  Deno.execPath(),
+  ["eval", "console.log('child done')"],
+  { stdio: "inherit", timeout: 10_000 },
+);
+const elapsedMs = Date.now() - start;
+
+if (result.status !== 0) {
+  throw new Error(
+    `expected status === 0, got: status=${result.status} signal=${result.signal} elapsed=${elapsedMs}ms`,
+  );
+}
+if (result.signal !== null) {
+  throw new Error(`expected signal === null, got: ${result.signal}`);
+}
+if (elapsedMs >= 9_000) {
+  throw new Error(
+    `spawnSync inherit-stdio took ${elapsedMs}ms — looks like it hung`,
+  );
+}
+console.log("ok");

--- a/tests/specs/node/child_process_spawnsync_max_buffer/main.ts
+++ b/tests/specs/node/child_process_spawnsync_max_buffer/main.ts
@@ -1,0 +1,51 @@
+// Regression test for https://github.com/denoland/deno/issues/34045 —
+// `child_process.spawnSync` must terminate the child once stdout/stderr
+// exceeds `maxBuffer`, instead of hanging while the child writes forever.
+import { spawnSync } from "node:child_process";
+
+const child = `
+// Write much more than the maxBuffer below so the limit is hit quickly.
+const chunk = "x".repeat(64 * 1024);
+while (true) {
+  Deno.stdout.writeSync(new TextEncoder().encode(chunk));
+}
+`;
+
+const start = Date.now();
+const result = spawnSync(Deno.execPath(), ["eval", child], {
+  maxBuffer: 32 * 1024,
+  // Enforce an upper bound so the test fails loudly rather than hanging if
+  // the maxBuffer enforcement regresses.
+  timeout: 15_000,
+});
+const elapsedMs = Date.now() - start;
+
+if (result.error === undefined || result.error === null) {
+  throw new Error(
+    `expected an error to be set, got: ${JSON.stringify(result)}`,
+  );
+}
+// deno-lint-ignore no-explicit-any
+const code = (result.error as any).code;
+if (code !== "ENOBUFS") {
+  throw new Error(
+    `expected error.code === "ENOBUFS", got: ${code} (elapsed=${elapsedMs}ms)`,
+  );
+}
+if (result.status !== null) {
+  throw new Error(`expected status === null, got: ${result.status}`);
+}
+if (typeof result.signal !== "string" || result.signal.length === 0) {
+  throw new Error(`expected a kill signal, got: ${result.signal}`);
+}
+if (typeof result.pid !== "number" || result.pid <= 0) {
+  throw new Error(`expected a valid pid, got: ${result.pid}`);
+}
+// The child should be killed quickly after the limit is hit. Anything close
+// to the timeout means we hung waiting for the child.
+if (elapsedMs >= 14_000) {
+  throw new Error(
+    `spawnSync took ${elapsedMs}ms — looks like the child was not killed promptly`,
+  );
+}
+console.log("ok");


### PR DESCRIPTION
## Summary

`spawnSync` previously read stdout/stderr to EOF on background threads, so a child that wrote unbounded data hung the parent forever — the JS-side `maxBuffer` length check only fired *after* the process exited.

This change tracks the cumulative byte count for each pipe inside the reader threads. On overflow, the first reader to notice terminates the child (its process group on Unix, via `TerminateProcess` on Windows) with the configured `killSignal`. The spawn result then reports:

- `signal: 'SIGTERM'` (or the configured `killSignal`)
- `status: null`
- `error.code === 'ENOBUFS'`

…matching Node.js behavior.

The same kill path is reused by the existing `timeout` watchdog; both now share a single `kill_child` closure to keep the signal-resolution logic in one place.

Repro from the issue:

```js
const { spawnSync } = require('child_process');
// test.c: setuid(0); while (1) printf("hello");
const r = spawnSync('./test');
console.log(r);
```

Before: Deno hung indefinitely.
After: returns with `signal: 'SIGTERM'`, `error.code: 'ENOBUFS'`, and a buffer just above `maxBuffer`.

## Test plan

- [x] New spec test `tests/specs/node/child_process_spawnsync_max_buffer` reproduces the hang scenario and asserts `ENOBUFS` + signal + bounded elapsed time.
- [x] Existing `child_process_spawnsync_extra_stdio` spec still passes.
- [x] `cargo check -p deno_process` clean.
- [x] `./tools/lint.js` clean.

Closes #34045
Closes bartlomieju/orchid-inbox#71