### PR TITLE
perf(ext/web): optimize TextEncoder encodeInto result

### DIFF
--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -21,6 +21,7 @@ const {
   op_encoding_decode_single,
   op_encoding_decode_utf8,
   op_encoding_encode_into,
+  op_encoding_encode_into_fallback,
   op_encoding_new_decoder,
   op_encoding_normalize_label,
 } = core.ops;
@@ -28,6 +29,7 @@ const {
   DataViewPrototypeGetBuffer,
   DataViewPrototypeGetByteLength,
   DataViewPrototypeGetByteOffset,
+  MathTrunc,
   ObjectPrototypeIsPrototypeOf,
   PromiseReject,
   PromiseResolve,
@@ -298,10 +300,18 @@ class TextEncoder {
         encodeIntoOpts,
       );
     }
-    op_encoding_encode_into(source, destination, encodeIntoBuf);
+    const packed = op_encoding_encode_into(source, destination);
+    if (packed === ENCODE_INTO_PACKED_SENTINEL) {
+      op_encoding_encode_into_fallback(source, destination, encodeIntoBuf);
+      return {
+        read: encodeIntoBuf[0],
+        written: encodeIntoBuf[1],
+      };
+    }
+    const read = MathTrunc(packed / ENCODE_INTO_PACKED_MULTIPLIER);
     return {
-      read: encodeIntoBuf[0],
-      written: encodeIntoBuf[1],
+      read,
+      written: packed - read * ENCODE_INTO_PACKED_MULTIPLIER,
     };
   }
 
@@ -319,6 +329,8 @@ class TextEncoder {
 
 const encodeIntoBuf = new Uint32Array(2);
 const encodeIntoOpts = { __proto__: null, allowShared: true };
+const ENCODE_INTO_PACKED_SENTINEL = -1;
+const ENCODE_INTO_PACKED_MULTIPLIER = 0x100000000;
 
 webidl.configureInterface(TextEncoder);
 const TextEncoderPrototype = TextEncoder.prototype;

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -77,6 +77,7 @@ deno_core::extension!(deno_web,
     op_encoding_new_decoder,
     op_encoding_decode,
     op_encoding_encode_into,
+    op_encoding_encode_into_fallback,
     op_blob_create_part,
     op_blob_slice_part,
     op_blob_read_part,
@@ -682,8 +683,46 @@ unsafe impl deno_core::GarbageCollected for TextDecoderResource {
   }
 }
 
+const ENCODE_INTO_PACKED_SENTINEL: f64 = -1.0;
+const ENCODE_INTO_MAX_PACKED_READ: usize = (1 << 21) - 1;
+const ENCODE_INTO_PACKED_MULTIPLIER: f64 = (1u64 << 32) as f64;
+
+#[inline]
+fn pack_encode_into_result(read: usize, written: usize) -> f64 {
+  debug_assert!(read <= ENCODE_INTO_MAX_PACKED_READ);
+  debug_assert!(written <= u32::MAX as usize);
+  (read as f64) * ENCODE_INTO_PACKED_MULTIPLIER + written as f64
+}
+
 #[op2(fast(op_encoding_encode_into_fast))]
 fn op_encoding_encode_into(
+  scope: &mut v8::PinScope<'_, '_>,
+  input: v8::Local<v8::Value>,
+  #[buffer] buffer: &mut [u8],
+) -> Result<f64, WebError> {
+  let s = v8::Local::<v8::String>::try_from(input)?;
+
+  if s.length() > ENCODE_INTO_MAX_PACKED_READ
+    && buffer.len() > ENCODE_INTO_MAX_PACKED_READ
+  {
+    return Ok(ENCODE_INTO_PACKED_SENTINEL);
+  }
+
+  let mut nchars = 0;
+  let len = s.write_utf8_v2(
+    scope,
+    buffer,
+    v8::WriteFlags::kReplaceInvalidUtf8,
+    Some(&mut nchars),
+  );
+
+  debug_assert!(nchars <= ENCODE_INTO_MAX_PACKED_READ);
+  debug_assert!(len <= u32::MAX as usize);
+  Ok(pack_encode_into_result(nchars, len))
+}
+
+#[op2(fast)]
+fn op_encoding_encode_into_fallback(
   scope: &mut v8::PinScope<'_, '_>,
   input: v8::Local<v8::Value>,
   #[buffer] buffer: &mut [u8],
@@ -707,8 +746,7 @@ fn op_encoding_encode_into(
 fn op_encoding_encode_into_fast(
   #[string] input: Cow<'_, str>,
   #[buffer] buffer: &mut [u8],
-  #[buffer] out_buf: &mut [u32],
-) {
+) -> f64 {
   // Since `input` is already UTF-8, we can simply find the last UTF-8 code
   // point boundary from input that fits in `buffer`, and copy the bytes up to
   // that point.
@@ -730,16 +768,21 @@ fn op_encoding_encode_into_fast(
     boundary
   };
 
-  buffer[..boundary].copy_from_slice(input[..boundary].as_bytes());
-
   // The `read` output parameter is measured in UTF-16 code units.
-  out_buf[0] = match input {
+  let read = match input {
     // Borrowed Cow strings are zero-copy views into the V8 heap.
     // Thus, they are guarantee to be SeqOneByteString.
-    Cow::Borrowed(v) => v[..boundary].len() as u32,
-    Cow::Owned(v) => v[..boundary].encode_utf16().count() as u32,
+    Cow::Borrowed(v) => v[..boundary].len(),
+    Cow::Owned(ref v) => v[..boundary].encode_utf16().count(),
   };
-  out_buf[1] = boundary as u32;
+
+  if read > ENCODE_INTO_MAX_PACKED_READ || boundary > u32::MAX as usize {
+    return ENCODE_INTO_PACKED_SENTINEL;
+  }
+
+  buffer[..boundary].copy_from_slice(input[..boundary].as_bytes());
+
+  pack_encode_into_result(read, boundary)
 }
 
 pub struct Location(pub Url);


### PR DESCRIPTION
## Summary

Optimizes `TextEncoder.encodeInto()` by returning the common `read` / `written` result as a packed number from the op, instead of writing those two counters through the shared `Uint32Array` out-buffer on every call.

For very large results that cannot be represented exactly in the packed number format, the implementation falls back to the previous out-buffer path.

## Benchmark

Local benchmark with `Deno.bench()` on Apple M1 Max, comparing this branch's release binary against current canary (`2.7.14+f256361`).

```js
const enc = new TextEncoder();
const ascii120 = "hello world\n".repeat(10);
const dest = new Uint8Array(64);

let sink = 0;

Deno.bench("TextEncoder.encodeInto short", () => {
  sink += enc.encodeInto(ascii120, dest).written;
});
```

Results:

| Runtime | `TextEncoder.encodeInto short` |
| --- | ---: |
| canary `2.7.14+f256361` | ~88 ns/iter |
| this branch | ~77 ns/iter |

This is roughly a 12% improvement in the short-string encodeInto path.

## Validation

- `./x fmt`
- `cargo check -p deno_web --benches`
- `cargo test -p deno_web`
