### PR TITLE
fix(ext/node): surface ERR_REQUIRE_ASYNC_MODULE/CYCLE_MODULE codes and fix TLA retry

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -2310,21 +2310,13 @@ function _throwIfEsmCycle(cachedModule, parent) {
         op_require_is_maybe_cjs(fn) === false))
   ) {
     const parentPath = parent?.filename ?? "<unknown>";
-    const err = new Error(
-      `Cannot require() ES Module ${fn} in a cycle. (from ${parentPath})`,
-    );
-    err.code = "ERR_REQUIRE_CYCLE_MODULE";
-    throw err;
+    throw new internalErrors.ERR_REQUIRE_CYCLE_MODULE(fn, parentPath);
   }
 }
 
 function _throwRequireAsyncModule(specifier, module) {
   const parent = module?.parent?.filename ?? "<unknown>";
-  const err = new Error(
-    `require() cannot be used on an ESM graph with top-level await. Use import() instead. To see where the top-level await comes from, use --stack-trace-limit=100 and inspect the dependency graph. Requiring ${specifier}. From ${parent}`,
-  );
-  err.code = "ERR_REQUIRE_ASYNC_MODULE";
-  throw err;
+  throw new internalErrors.ERR_REQUIRE_ASYNC_MODULE(specifier, parent);
 }
 
 // Like loadESMFromCJS but uses op_import_sync_with_source to compile

--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -2034,6 +2034,29 @@ class ERR_QUIC_TLS13_REQUIRED extends NodeError {
     super("ERR_QUIC_TLS13_REQUIRED", `QUIC requires TLS version 1.3`);
   }
 }
+class ERR_REQUIRE_ASYNC_MODULE extends NodeError {
+  constructor(filename: string, parentFilename: string) {
+    super(
+      "ERR_REQUIRE_ASYNC_MODULE",
+      `require() cannot be used on an ESM graph with top-level await. Use import() instead. To see where the top-level await comes from, use --stack-trace-limit=100 and inspect the dependency graph. Requiring ${filename}. From ${parentFilename}`,
+    );
+    this.name = `Error [${this.code}]`;
+    this.toString = nodeErrorToStringWithEmbeddedCode;
+  }
+}
+class ERR_REQUIRE_CYCLE_MODULE extends NodeError {
+  constructor(filename: string, parentFilename: string) {
+    super(
+      "ERR_REQUIRE_CYCLE_MODULE",
+      `Cannot require() ES Module ${filename} in a cycle. (from ${parentFilename})`,
+    );
+    this.name = `Error [${this.code}]`;
+    this.toString = nodeErrorToStringWithEmbeddedCode;
+  }
+}
+function nodeErrorToStringWithEmbeddedCode(this: NodeErrorAbstraction) {
+  return `${this.name}: ${this.message}`;
+}
 class ERR_SCRIPT_EXECUTION_INTERRUPTED extends NodeError {
   constructor() {
     super(
@@ -3392,6 +3415,8 @@ return {
   ERR_QUICSTREAM_OPEN_FAILED,
   ERR_QUICSTREAM_UNSUPPORTED_PUSH,
   ERR_QUIC_TLS13_REQUIRED,
+  ERR_REQUIRE_ASYNC_MODULE,
+  ERR_REQUIRE_CYCLE_MODULE,
   ERR_SCRIPT_EXECUTION_INTERRUPTED,
   ERR_SERVER_ALREADY_LISTEN,
   ERR_SERVER_NOT_RUNNING,
@@ -3697,6 +3722,8 @@ return {
     ERR_QUICSTREAM_OPEN_FAILED,
     ERR_QUICSTREAM_UNSUPPORTED_PUSH,
     ERR_QUIC_TLS13_REQUIRED,
+    ERR_REQUIRE_ASYNC_MODULE,
+    ERR_REQUIRE_CYCLE_MODULE,
     ERR_SCRIPT_EXECUTION_INTERRUPTED,
     ERR_SERVER_ALREADY_LISTEN,
     ERR_SERVER_NOT_RUNNING,

--- a/libs/core/ops_builtin.rs
+++ b/libs/core/ops_builtin.rs
@@ -558,9 +558,10 @@ async fn do_load_job<'s, 'i>(
           exception_to_err(scope, exception, false, false)
         })?;
     }
-    v8::ModuleStatus::Instantiated
-    | v8::ModuleStatus::Instantiating
-    | v8::ModuleStatus::Evaluating => {
+    v8::ModuleStatus::Instantiated => {
+      // Already instantiated — caller (op_import_sync) will evaluate.
+    }
+    v8::ModuleStatus::Instantiating | v8::ModuleStatus::Evaluating => {
       return Err(
         JsErrorBox::generic(format!(
           "Cannot require() ES Module {specifier} in a cycle."
@@ -691,6 +692,14 @@ fn op_import_sync<'s, 'i>(
   let module = module_map_rc
     .get_module(scope, module_id)
     .expect("Module must exist");
+
+  // A module that was evaluated asynchronously (e.g. via `await import()`)
+  // and contains top-level await cannot be loaded via `require()`. Detect
+  // this regardless of current status so retries after async load still
+  // throw ERR_REQUIRE_ASYNC_MODULE.
+  if module.is_graph_async() {
+    return Err(CoreErrorKind::TLA.into_box());
+  }
 
   match module.get_status() {
     v8::ModuleStatus::Uninstantiated

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -67,21 +67,63 @@
     "es-module/test-import-preload-require-cycle.js": {},
     "es-module/test-loaders-hidden-from-users.js": {},
     "es-module/test-require-as-esm-interop.mjs": {},
+    "es-module/test-require-module.js": {
+      "ignore": true,
+      "reason": "Test fixtures rely on Node's implicit CommonJS detection for .js files without a package.json; Deno defaults to ESM."
+    },
+    "es-module/test-require-module-cached-tla.js": {},
     "es-module/test-require-module-cycle-cjs-esm-esm.js": {},
     "es-module/test-require-module-defined-esmodule.js": {},
     "es-module/test-require-module-detect-entry-point-aou.js": {},
     "es-module/test-require-module-detect-entry-point.js": {},
     "es-module/test-require-module-dont-detect-cjs.js": {},
+    "es-module/test-require-module-dynamic-import-1.js": {
+      "ignore": true,
+      "reason": "Test fixtures rely on Node's implicit CommonJS detection for .js files without a package.json; Deno defaults to ESM."
+    },
+    "es-module/test-require-module-dynamic-import-2.js": {
+      "ignore": true,
+      "reason": "Test fixtures rely on Node's implicit CommonJS detection for .js files without a package.json; Deno defaults to ESM."
+    },
     "es-module/test-require-module-dynamic-import-3.js": {},
     "es-module/test-require-module-retry-import-evaluating.js": {},
     "es-module/test-require-module-dynamic-import-4.js": {},
+    "es-module/test-require-module-feature-detect.js": {
+      "ignore": true,
+      "reason": "Tests Node's process.features.require_module flag, which Deno does not expose."
+    },
+    "es-module/test-require-module-instantiated.mjs": {},
+    "es-module/test-require-module-preload.js": {
+      "ignore": true,
+      "reason": "Tests Node's --require / --import preload CLI flags, which Deno does not implement."
+    },
     "es-module/test-require-module-synchronous-rejection-handling.js": {},
+    "es-module/test-require-module-tla-execution.js": {},
     "es-module/test-require-module-tla-nested.js": {},
+    "es-module/test-require-module-tla-print-execution.js": {
+      "ignore": true,
+      "reason": "Requires Node's --experimental-print-required-tla CLI flag, which Deno does not implement."
+    },
     "es-module/test-require-module-tla-rejected.js": {},
     "es-module/test-require-module-tla-resolved.js": {},
+    "es-module/test-require-module-tla-retry-import.js": {},
+    "es-module/test-require-module-tla-retry-import-2.js": {},
+    "es-module/test-require-module-tla-retry-require.js": {},
     "es-module/test-require-module-tla-unresolved.js": {},
     "es-module/test-require-module-transpiled.js": {},
+    "es-module/test-require-module-twice.js": {
+      "ignore": true,
+      "reason": "Test fixtures rely on Node's implicit CommonJS detection for .js files without a package.json; Deno defaults to ESM."
+    },
+    "es-module/test-require-module-warning.js": {
+      "ignore": true,
+      "reason": "Tests Node's --trace-require-module / ExperimentalWarning stderr emissions, which Deno does not emit."
+    },
     "es-module/test-require-module-with-detection.js": {},
+    "es-module/test-require-node-modules-warning.js": {
+      "ignore": true,
+      "reason": "Tests Node's --trace-require-module / ExperimentalWarning stderr emissions, which Deno does not emit."
+    },
     "es-module/test-typescript-commonjs.mjs": {},
     "es-module/test-typescript-eval.mjs": {},
     "es-module/test-typescript-module.mjs": {},
@@ -2979,8 +3021,24 @@
     // "parallel/test-repl-top-level-await.js": {},
     "parallel/test-require-cache.js": {},
     "parallel/test-require-dot.js": {},
+    "parallel/test-require-empty-main.js": {
+      "ignore": true,
+      "reason": "Test fixtures rely on Node's implicit CommonJS detection for .js files without a package.json; Deno defaults to ESM."
+    },
     "parallel/test-require-exceptions.js": {},
     "parallel/test-require-extension-over-directory.js": {},
+    "parallel/test-require-extensions-main.js": {
+      "ignore": true,
+      "reason": "Test fixtures rely on Node's implicit CommonJS detection for .js files without a package.json; Deno defaults to ESM."
+    },
+    "parallel/test-require-extensions-same-filename-as-dir.js": {
+      "ignore": true,
+      "reason": "Test fixtures rely on Node's implicit CommonJS detection for .js files without a package.json; Deno defaults to ESM."
+    },
+    "parallel/test-require-extensions-same-filename-as-dir-trailing-slash.js": {
+      "ignore": true,
+      "reason": "Test fixtures rely on Node's implicit CommonJS detection for .js files without a package.json; Deno defaults to ESM."
+    },
     "parallel/test-require-invalid-main-no-exports.js": {},
     "parallel/test-require-invalid-package.js": {},
     "parallel/test-require-json.js": {},
@@ -2990,6 +3048,10 @@
     "parallel/test-require-resolve.js": {},
     "parallel/test-require-resolve-invalid-paths.js": {},
     "parallel/test-require-resolve-opts-paths-relative.js": {},
+    "parallel/test-require-unicode.js": {
+      "ignore": true,
+      "reason": "Test fixtures rely on Node's implicit CommonJS detection for .js files without a package.json; Deno defaults to ESM."
+    },
     "parallel/test-runner-aftereach-runtime-skip.js": {},
     "parallel/test-runner-aliases.js": {},
     "parallel/test-runner-cli-concurrency.js": {

--- a/tests/specs/run/require_esm/main.out
+++ b/tests/specs/run/require_esm/main.out
@@ -1,6 +1,6 @@
 [Module: null prototype] { sync_js: 1 }
 [Module: null prototype] { sync_mjs: 1 }
-error: Uncaught (in promise) Error: require() cannot be used on an ESM graph with top-level await.[WILDCARD]
+error: Uncaught (in promise) Error[WILDCARD]: require() cannot be used on an ESM graph with top-level await.[WILDCARD]
 require("./async.js");
 ^
     at [WILDCARD]


### PR DESCRIPTION
Tests in node_compat that exercise `require()` of TLA ESM modules were
failing because Deno's uncaught-error printer reads `err.name` and
`err.message`, while the helpers in `node:module` only set `err.code`.
Stderr regexes like `/ERR_REQUIRE_ASYNC_MODULE/` therefore never matched.
This adds `ERR_REQUIRE_ASYNC_MODULE` and `ERR_REQUIRE_CYCLE_MODULE` as
proper `NodeError` subclasses with `name = "Error [CODE]"` so the printer
surfaces the code, and routes the existing helpers through them.

Two retry paths in `op_import_sync` also incorrectly let TLA modules
through after a previous failure. `do_load_job` was throwing a cycle
error for `ModuleStatus::Instantiated`, which masked the TLA case (real
cycles are still caught by `import_sync_eval_stack` and the
`Instantiating`/`Evaluating` arms). And once a TLA module had been
loaded via `await import()`, its status became `Evaluated` and a
subsequent `require()` returned the namespace silently; an upfront
`is_graph_async()` check now throws `ERR_REQUIRE_ASYNC_MODULE` instead.

Six TLA / instantiated-cycle tests are enabled in
`tests/node_compat/config.jsonc`. Thirteen further tests are listed as
ignored with explicit reasons — nine that depend on Node's implicit
CommonJS detection for `.js` files (Deno defaults to ESM), and four
gated on Node-specific surfaces Deno doesn't implement
(`--experimental-print-required-tla`, `process.features.require_module`,
`--require`/`--import` preload, `--trace-require-module` /
ExperimentalWarning emissions).