### PR TITLE
fix(ext/node): cap Buffer kMaxLength to V8's safe byte length

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -150,7 +150,12 @@ float32Array[0] = -1; // 0xBF800000
 // check this with `os.endianness()` because that is determined at compile time.
 const bigEndian = uInt8Float32Array[3] === 0;
 
-const kMaxLength = NumberMAX_SAFE_INTEGER;
+// Max length for a Buffer. Matches Node.js, which uses
+// `v8::TypedArray::kMaxByteLength` (32 GiB - 1 on sandboxed V8 builds).
+// Setting this any higher risks tripping V8's
+// `external_memory_max_reasonable_size` check (32 GiB by default) and
+// triggering a fatal V8 error instead of a JS RangeError. See #34043.
+const kMaxLength = 0x7FFFFFFFF;
 const kStringMaxLength = 536870888;
 const MAX_UINT32 = 2 ** 32;
 

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -41,6 +41,39 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "[node/buffer] Buffer constructor throws RangeError instead of panicking for excessive size",
+  fn() {
+    // Regression for https://github.com/denoland/deno/issues/34043 - calling
+    // Buffer with a value like Date.now() used to crash V8 with a fatal error
+    // because the size exceeded V8's external-memory budget. It should now
+    // throw a JS RangeError just like Node.
+    const tooLarge = Number.MAX_SAFE_INTEGER;
+    assertThrows(
+      // @ts-expect-error Buffer() (without new) is valid at runtime but TS says otherwise.
+      () => Buffer(tooLarge),
+      RangeError,
+      '"size" is out of range',
+    );
+    assertThrows(
+      () => Buffer.alloc(tooLarge),
+      RangeError,
+      '"size" is out of range',
+    );
+    assertThrows(
+      () => Buffer.allocUnsafe(tooLarge),
+      RangeError,
+      '"size" is out of range',
+    );
+    assertThrows(
+      () => Buffer.allocUnsafeSlow(tooLarge),
+      RangeError,
+      '"size" is out of range',
+    );
+  },
+});
+
+Deno.test({
   name: "[node/buffer] alloc(0) creates an empty buffer",
   fn() {
     const buffer: Buffer = Buffer.alloc(0);


### PR DESCRIPTION
## Summary

Fix a fatal V8 panic when calling `Buffer(n)` with a very large numeric argument (e.g. `Buffer(Date.now())`).

The `kMaxLength` constant in `internal/buffer.mjs` was set to `Number.MAX_SAFE_INTEGER` (~9e15), so calls like `Buffer(Date.now())` (~1.78 TiB) passed the polyfill's `validateNumber` check and reached `new Uint8Array(size)`. V8 then tried to register the allocation via `AdjustAmountOfExternalAllocatedMemory`, which trips a `CHECK_LT(change_in_bytes, kMaxReasonableBytes)` (32 GiB by default from `--external-memory-max-reasonable-size`) and aborts the process.

```
deno run -A repro.cjs
# thread 'main' panicked at cli/lib.rs:566:5:
# Fatal error in :0: Check failed: change_in_bytes < kMaxReasonableBytes.
```

This patch lowers `kMaxLength` to `0x7FFFFFFFF` (32 GiB - 1), matching Node.js (which uses `v8::TypedArray::kMaxByteLength`, i.e. `kMaxSafeBufferSizeForSandbox` on sandboxed V8 builds). All four allocation entrypoints (`Buffer(n)`, `Buffer.alloc`, `Buffer.allocUnsafe`, `Buffer.allocUnsafeSlow`) flow through `assertSize` / `validateNumber`, so the polyfill now throws `RangeError: ERR_OUT_OF_RANGE` for oversized requests before V8 is involved:

```
error: Uncaught (in promise) RangeError: The value of "size" is out of range.
It must be >= 0 && <= 34359738367. Received 1_778_773_783_036
```

## Test plan

- [x] `cargo build --bin deno` succeeds
- [x] The reproduction from #34043 now throws a `RangeError` instead of panicking
- [x] New regression test in `tests/unit_node/buffer_test.ts`
- [x] Existing buffer tests (55 cases) still pass
- [x] `tools/format.js` and `tools/lint.js --js` produce no errors

Closes #34043
Closes bartlomieju/orchid-inbox#74