### PR TITLE
feat(fmt): support file-specific overrides

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -19,6 +19,7 @@ pub use deno_config::deno_json::BenchConfig;
 pub use deno_config::deno_json::CompilerOptions;
 pub use deno_config::deno_json::ConfigFile;
 use deno_config::deno_json::FmtConfig;
+use deno_config::deno_json::FmtOverrideConfig;
 pub use deno_config::deno_json::FmtOptionsConfig;
 pub use deno_config::deno_json::LintRulesConfig;
 use deno_config::deno_json::NodeModulesDirMode;
@@ -122,6 +123,7 @@ pub struct UnstableFmtOptions {
 #[derive(Clone, Debug)]
 pub struct FmtOptions {
   pub options: FmtOptionsConfig,
+  pub overrides: Vec<FmtOverrideConfig>,
   pub unstable: UnstableFmtOptions,
   pub files: FilePatterns,
 }
@@ -136,6 +138,7 @@ impl FmtOptions {
   pub fn new_with_base(base: PathBuf) -> Self {
     Self {
       options: FmtOptionsConfig::default(),
+      overrides: Vec::new(),
       unstable: Default::default(),
       files: FilePatterns::new_with_base(base),
     }
@@ -146,14 +149,40 @@ impl FmtOptions {
     unstable: UnstableFmtOptions,
     fmt_flags: &FmtFlags,
   ) -> Self {
+    let options = fmt_config.options;
     Self {
-      options: resolve_fmt_options(fmt_flags, fmt_config.options),
+      options: resolve_fmt_options(fmt_flags, options.clone()),
+      overrides: fmt_config
+        .overrides
+        .into_iter()
+        .map(|override_config| FmtOverrideConfig {
+          files: override_config.files,
+          options: resolve_fmt_options(
+            fmt_flags,
+            options.clone().merge_overrides(override_config.options),
+          ),
+        })
+        .collect(),
       unstable: UnstableFmtOptions {
         component: unstable.component || fmt_flags.unstable_component,
         sql: unstable.sql || fmt_flags.unstable_sql,
       },
       files: fmt_config.files,
     }
+  }
+
+  pub fn options_for_path(&self, path: &Path) -> &FmtOptionsConfig {
+    self
+      .overrides
+      .iter()
+      .rev()
+      .find_map(|override_config| {
+        override_config
+          .files
+          .matches_path(path)
+          .then_some(&override_config.options)
+      })
+      .unwrap_or(&self.options)
   }
 }
 

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -686,6 +686,151 @@
             "type": "string"
           }
         },
+        "overrides": {
+          "type": "array",
+          "description": "File-specific formatter options applied in order. Later matching overrides take precedence.",
+          "items": {
+            "type": "object",
+            "required": ["files"],
+            "properties": {
+              "files": {
+                "type": "array",
+                "description": "List of files, directories or globs this override applies to.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "useTabs": {
+                "description": "Whether to use tabs (true) or spaces (false) for indentation.",
+                "type": "boolean",
+                "default": false
+              },
+              "lineWidth": {
+                "description": "The width of a line the printer will try to stay under. Note that the printer may exceed this width in certain cases.",
+                "type": "number",
+                "default": 80
+              },
+              "indentWidth": {
+                "description": "The number of characters for an indent.",
+                "type": "number",
+                "default": 2
+              },
+              "singleQuote": {
+                "type": "boolean",
+                "description": "Whether to use single quote (true) or double quote (false) for quotation.",
+                "default": false
+              },
+              "proseWrap": {
+                "description": "Define how prose should be wrapped in Markdown files.",
+                "default": "always",
+                "enum": ["always", "never", "preserve"]
+              },
+              "semiColons": {
+                "description": "Whether to prefer using semicolons.",
+                "type": "boolean",
+                "default": true
+              },
+              "quoteProps": {
+                "description": "Change when properties in objects are quoted in JavaScript and TypeScript.",
+                "default": "preserve",
+                "enum": ["asNeeded", "consistent", "preserve"]
+              },
+              "newLineKind": {
+                "description": "The newline character to use.",
+                "default": "lf",
+                "enum": ["auto", "crlf", "lf", "system"]
+              },
+              "useBraces": {
+                "description": "Whether to use braces for if statements, for statements, and while statements in JavaScript and TypeScript.",
+                "default": "whenNotSingleLine",
+                "enum": ["maintain", "whenNotSingleLine", "always", "preferNone"]
+              },
+              "bracePosition": {
+                "description": "The position of opening braces for blocks in JavaScript and TypeScript.",
+                "default": "sameLine",
+                "enum": [
+                  "maintain",
+                  "sameLine",
+                  "nextLine",
+                  "sameLineUnlessHanging"
+                ]
+              },
+              "singleBodyPosition": {
+                "description": "The position of the body in single body blocks in JavaScript and TypeScript.",
+                "default": "sameLineUnlessHanging",
+                "enum": [
+                  "maintain",
+                  "sameLine",
+                  "nextLine",
+                  "sameLineUnlessHanging"
+                ]
+              },
+              "nextControlFlowPosition": {
+                "description": "Where to place the next control flow within a control flow statement in JavaScript and TypeScript.",
+                "default": "sameLine",
+                "enum": [
+                  "maintain",
+                  "sameLine",
+                  "nextLine"
+                ]
+              },
+              "trailingCommas": {
+                "description": "Whether to add trailing commas in JavaScript and TypeScript.",
+                "default": "onlyMultiLine",
+                "enum": ["never", "always", "onlyMultiLine"]
+              },
+              "operatorPosition": {
+                "description": "Where to place the operator for expressions that span multiple lines in JavaScript and TypeScript.",
+                "default": "sameLine",
+                "enum": [
+                  "maintain",
+                  "sameLine",
+                  "nextLine"
+                ]
+              },
+              "jsx.bracketPosition": {
+                "description": "If the end angle bracket of a jsx open element or self closing element should be on the same or next line when the attributes span multiple lines.",
+                "default": "nextLine",
+                "enum": ["maintain", "sameLine", "nextLine"]
+              },
+              "jsx.forceNewLineSurroundingContent": {
+                "description": "Forces newlines surrounding the content of JSX elements.",
+                "default": false,
+                "type": "boolean"
+              },
+              "jsx.multiLineParens": {
+                "description": "Surrounds the top-most JSX element or fragment in parentheses when it spans multiple lines.",
+                "default": "prefer",
+                "enum": ["never", "prefer", "always"]
+              },
+              "typeLiteral.separatorKind": {
+                "description": "The kind of separator to use in type literals.",
+                "default": "semiColon",
+                "enum": ["comma", "semiColon"]
+              },
+              "spaceAround": {
+                "description": "Whether to place spaces around enclosed expressions in JavaScript and TypeScript.",
+                "default": false,
+                "type": "boolean"
+              },
+              "spaceSurroundingProperties": {
+                "description": "Whether to add a space surrounding the properties of single line object-like nodes in JavaScript and TypeScript.",
+                "default": true,
+                "type": "boolean"
+              },
+              "vueComponentCase": {
+                "description": "Case style for Vue component tags.",
+                "default": "ignore",
+                "enum": ["ignore", "pascal-case", "kebab-case"]
+              },
+              "angularNextControlFlowSameLine": {
+                "description": "Whether Angular next control-flow clauses stay on the same line.",
+                "default": true,
+                "type": "boolean"
+              }
+            }
+          }
+        },
         "useTabs": {
           "description": "Whether to use tabs (true) or spaces (false) for indentation.",
           "type": "boolean",

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -243,14 +243,17 @@ async fn format_files(
     let paths = paths_with_options.paths;
     let incremental_cache = Arc::new(IncrementalCache::new(
       caches.fmt_incremental_cache_db(),
-      CacheDBHash::from_hashable((&fmt_options.options, &fmt_options.unstable)),
+      CacheDBHash::from_hashable((
+        &fmt_options.options,
+        &fmt_options.overrides,
+        &fmt_options.unstable,
+      )),
       &paths,
     ));
     formatter
       .handle_files(
         paths,
-        fmt_options.options,
-        fmt_options.unstable,
+        fmt_options,
         incremental_cache.clone(),
         cli_options.ext_flag().clone(),
       )
@@ -913,8 +916,7 @@ trait Formatter {
   async fn handle_files(
     &self,
     paths: Vec<PathBuf>,
-    fmt_options: FmtOptionsConfig,
-    unstable_options: UnstableFmtOptions,
+    fmt_options: FmtOptions,
     incremental_cache: Arc<IncrementalCache>,
     ext: Option<String>,
   ) -> Result<(), AnyError>;
@@ -947,8 +949,7 @@ impl Formatter for CheckFormatter {
   async fn handle_files(
     &self,
     paths: Vec<PathBuf>,
-    fmt_options: FmtOptionsConfig,
-    unstable_options: UnstableFmtOptions,
+    fmt_options: FmtOptions,
     incremental_cache: Arc<IncrementalCache>,
     ext: Option<String>,
   ) -> Result<(), AnyError> {
@@ -980,8 +981,8 @@ impl Formatter for CheckFormatter {
         match format_file(
           &file_path,
           &file,
-          &fmt_options,
-          &unstable_options,
+          fmt_options.options_for_path(&file_path),
+          &fmt_options.unstable,
           ext.clone(),
         ) {
           Ok(Some(formatted_text)) => {
@@ -1068,8 +1069,7 @@ impl Formatter for RealFormatter {
   async fn handle_files(
     &self,
     paths: Vec<PathBuf>,
-    fmt_options: FmtOptionsConfig,
-    unstable_options: UnstableFmtOptions,
+    fmt_options: FmtOptions,
     incremental_cache: Arc<IncrementalCache>,
     ext: Option<String>,
   ) -> Result<(), AnyError> {
@@ -1094,8 +1094,8 @@ impl Formatter for RealFormatter {
           format_file(
             file_path,
             file,
-            &fmt_options,
-            &unstable_options,
+            fmt_options.options_for_path(file_path),
+            &fmt_options.unstable,
             ext.clone(),
           )
         }) {

--- a/libs/config/deno_json/mod.rs
+++ b/libs/config/deno_json/mod.rs
@@ -430,6 +430,54 @@ impl FmtOptionsConfig {
       && self.vue_component_case.is_none()
       && self.angular_next_control_flow_same_line.is_none()
   }
+
+  pub fn merge_overrides(
+    self,
+    overrides: FmtOptionsConfig,
+  ) -> FmtOptionsConfig {
+    FmtOptionsConfig {
+      use_tabs: overrides.use_tabs.or(self.use_tabs),
+      line_width: overrides.line_width.or(self.line_width),
+      indent_width: overrides.indent_width.or(self.indent_width),
+      single_quote: overrides.single_quote.or(self.single_quote),
+      prose_wrap: overrides.prose_wrap.or(self.prose_wrap),
+      semi_colons: overrides.semi_colons.or(self.semi_colons),
+      quote_props: overrides.quote_props.or(self.quote_props),
+      new_line_kind: overrides.new_line_kind.or(self.new_line_kind),
+      use_braces: overrides.use_braces.or(self.use_braces),
+      brace_position: overrides.brace_position.or(self.brace_position),
+      single_body_position: overrides
+        .single_body_position
+        .or(self.single_body_position),
+      next_control_flow_position: overrides
+        .next_control_flow_position
+        .or(self.next_control_flow_position),
+      trailing_commas: overrides.trailing_commas.or(self.trailing_commas),
+      operator_position: overrides.operator_position.or(self.operator_position),
+      jsx_bracket_position: overrides
+        .jsx_bracket_position
+        .or(self.jsx_bracket_position),
+      jsx_force_new_lines_surrounding_content: overrides
+        .jsx_force_new_lines_surrounding_content
+        .or(self.jsx_force_new_lines_surrounding_content),
+      jsx_multi_line_parens: overrides
+        .jsx_multi_line_parens
+        .or(self.jsx_multi_line_parens),
+      type_literal_separator_kind: overrides
+        .type_literal_separator_kind
+        .or(self.type_literal_separator_kind),
+      space_around: overrides.space_around.or(self.space_around),
+      space_surrounding_properties: overrides
+        .space_surrounding_properties
+        .or(self.space_surrounding_properties),
+      vue_component_case: overrides
+        .vue_component_case
+        .or(self.vue_component_case),
+      angular_next_control_flow_same_line: overrides
+        .angular_next_control_flow_same_line
+        .or(self.angular_next_control_flow_same_line),
+    }
+  }
 }
 
 /// Choose between flat and nested fmt options.
@@ -508,6 +556,7 @@ struct SerializedFmtConfig {
   pub deprecated_options: FmtOptionsConfig,
   pub include: Option<Vec<String>>,
   pub exclude: Vec<String>,
+  pub overrides: Vec<SerializedFmtOverrideConfig>,
   #[serde(rename = "files")]
   pub deprecated_files: serde_json::Value,
 }
@@ -553,13 +602,52 @@ impl SerializedFmtConfig {
     Ok(FmtConfig {
       options: choose_fmt_options(options, self.deprecated_options),
       files: files.into_resolved(config_file_specifier)?,
+      overrides: self
+        .overrides
+        .into_iter()
+        .map(|override_config| {
+          override_config.into_resolved(config_file_specifier)
+        })
+        .collect::<Result<Vec<_>, _>>()?,
+    })
+  }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+struct SerializedFmtOverrideConfig {
+  pub files: Vec<String>,
+  #[serde(flatten)]
+  pub options: FmtOptionsConfig,
+}
+
+impl SerializedFmtOverrideConfig {
+  pub fn into_resolved(
+    self,
+    config_file_specifier: &Url,
+  ) -> Result<FmtOverrideConfig, IntoResolvedError> {
+    let config_dir = url_to_file_path(&url_parent(config_file_specifier))?;
+    Ok(FmtOverrideConfig {
+      files: PathOrPatternSet::from_include_relative_path_or_patterns(
+        &config_dir,
+        &self.files,
+      )
+      .map_err(IntoResolvedErrorKind::InvalidInclude)?,
+      options: self.options,
     })
   }
 }
 
 #[derive(Clone, Debug, Hash, PartialEq)]
+pub struct FmtOverrideConfig {
+  pub files: PathOrPatternSet,
+  pub options: FmtOptionsConfig,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq)]
 pub struct FmtConfig {
   pub options: FmtOptionsConfig,
+  pub overrides: Vec<FmtOverrideConfig>,
   pub files: FilePatterns,
 }
 
@@ -567,6 +655,7 @@ impl FmtConfig {
   pub fn new_with_base(base: PathBuf) -> Self {
     Self {
       options: Default::default(),
+      overrides: Default::default(),
       files: FilePatterns::new_with_base(base),
     }
   }
@@ -1953,6 +2042,7 @@ impl ConfigFile {
       }
       None => Ok(FmtConfig {
         options: Default::default(),
+        overrides: Default::default(),
         files: self.to_exclude_files_config()?,
       }),
     }
@@ -2574,6 +2664,7 @@ mod tests {
             PathBuf::from("/deno/src/testdata/")
           )]),
         },
+        overrides: Default::default(),
         options: FmtOptionsConfig {
           use_tabs: Some(true),
           line_width: Some(80),

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -2142,12 +2142,16 @@ impl WorkspaceDirectory {
           url_to_file_path(&self.dir_url).unwrap(),
         ),
         options: Default::default(),
+        overrides: Default::default(),
       },
     };
     let root_config = match &self.deno_json.root {
       Some(root) => root.to_fmt_config()?,
       None => return Ok(member_config),
     };
+
+    let mut overrides = root_config.overrides;
+    overrides.extend(member_config.overrides);
 
     Ok(FmtConfig {
       options: FmtOptionsConfig {
@@ -2240,6 +2244,7 @@ impl WorkspaceDirectory {
           .angular_next_control_flow_same_line
           .or(root_config.options.angular_next_control_flow_same_line),
       },
+      overrides,
       files: combine_patterns(root_config.files, member_config.files),
     })
   }
@@ -3799,6 +3804,7 @@ pub mod test {
     assert_eq!(
       fmt_config,
       FmtConfig {
+        overrides: Default::default(),
         options: FmtOptionsConfig {
           use_tabs: Some(false),
           line_width: Some(120),
@@ -3843,6 +3849,7 @@ pub mod test {
     assert_eq!(
       root_fmt_config,
       FmtConfig {
+        overrides: Default::default(),
         options: FmtOptionsConfig {
           use_tabs: Some(true),
           line_width: Some(80),
@@ -4082,6 +4089,7 @@ pub mod test {
           .unwrap(),
         FmtConfig {
           options: Default::default(),
+          overrides: Default::default(),
           files: expected_files.clone(),
         }
       );

--- a/tests/integration/fmt_tests.rs
+++ b/tests/integration/fmt_tests.rs
@@ -323,6 +323,42 @@ fn fmt_with_glob_config_and_flags() {
 }
 
 #[test]
+fn fmt_with_overrides_config() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir().path();
+  temp_dir.join("deno.json").write_json(&json!({
+    "fmt": {
+      "singleQuote": false,
+      "semiColons": true,
+      "overrides": [
+        {
+          "files": ["single.ts"],
+          "singleQuote": true,
+          "semiColons": false
+        }
+      ]
+    }
+  }));
+
+  temp_dir.join("main.ts").write("const message = 'hello'\n");
+  temp_dir
+    .join("single.ts")
+    .write("const message = \"hello\";\n");
+
+  let output = context.new_command().arg("fmt").run();
+  output.assert_exit_code(0);
+
+  assert_eq!(
+    temp_dir.join("main.ts").read_to_string(),
+    "const message = \"hello\";\n"
+  );
+  assert_eq!(
+    temp_dir.join("single.ts").read_to_string(),
+    "const message = 'hello'\n"
+  );
+}
+
+#[test]
 fn opt_out_top_level_exclude_via_fmt_unexclude() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let temp_dir = context.temp_dir().path();


### PR DESCRIPTION
Prototype for file-specific formatter options in `deno.json`.

## Summary

Adds `fmt.overrides`, a Prettier-like array of file-specific formatter options. Each override has a `files` list and formatter option fields. Overrides are resolved against the config file directory and applied in order, with later matching overrides taking precedence.

Example:

```json
{
  "fmt": {
    "singleQuote": false,
    "semiColons": true,
    "overrides": [
      {
        "files": ["single.ts", "generated/**/*.ts"],
        "singleQuote": true,
        "semiColons": false
      }
    ]
  }
}
```

This PR currently includes:

- config parsing and schema support for `fmt.overrides`
- workspace/member config propagation
- per-file formatter option resolution in `deno fmt`
- a focused integration test for override behavior

## Validation

Ran locally:

- `cargo check -q -p deno`
- `cargo test -q -p deno_config --lib deno_json::tests --no-run`
- `jq empty cli/schemas/config-file.v1.json && git diff --check`

Still TODO before marking ready:

- run the focused integration test to completion
- run broader formatter/integration coverage
- settle final API naming/shape

## AI Disclosure

This prototype and PR description were prepared with help from ChatGPT/Codex.