### PR TITLE
fix(ext/process): respect AbortSignal in Deno.Command.output()

### DIFF
--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -617,6 +617,7 @@ function spawnInner(command, {
   env = { __proto__: null },
   uid = undefined,
   gid = undefined,
+  signal = undefined,
   stdin = "null",
   stdout = "piped",
   stderr = "piped",
@@ -655,29 +656,50 @@ function spawnInner(command, {
   const stdoutRid = child.stdoutRid;
   const stderrRid = child.stderrRid;
 
+  let onAbort = null;
+  if (signal !== undefined) {
+    onAbort = () => {
+      try {
+        op_spawn_kill(child.rid, "SIGTERM");
+      } catch {
+        // Ignore the error for https://github.com/denoland/deno/issues/27112
+      }
+    };
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal[abortSignal.add](onAbort);
+    }
+  }
+
   return PromisePrototypeThen(
     SafePromiseAll([
       op_spawn_wait(child.rid),
       stdoutRid != null ? readAllRid(stdoutRid) : null,
       stderrRid != null ? readAllRid(stderrRid) : null,
     ]),
-    ({ 0: status, 1: stdout, 2: stderr }) => ({
-      success: status.success,
-      code: status.code,
-      signal: status.signal,
-      get stdout() {
-        if (stdout == null) {
-          throw new TypeError("Cannot get 'stdout': 'stdout' is not piped");
-        }
-        return stdout;
-      },
-      get stderr() {
-        if (stderr == null) {
-          throw new TypeError("Cannot get 'stderr': 'stderr' is not piped");
-        }
-        return stderr;
-      },
-    }),
+    ({ 0: status, 1: stdout, 2: stderr }) => {
+      if (onAbort !== null) {
+        signal[abortSignal.remove](onAbort);
+      }
+      return {
+        success: status.success,
+        code: status.code,
+        signal: status.signal,
+        get stdout() {
+          if (stdout == null) {
+            throw new TypeError("Cannot get 'stdout': 'stdout' is not piped");
+          }
+          return stdout;
+        },
+        get stderr() {
+          if (stderr == null) {
+            throw new TypeError("Cannot get 'stderr': 'stderr' is not piped");
+          }
+          return stderr;
+        },
+      };
+    },
   );
 }
 

--- a/tests/unit/command_test.ts
+++ b/tests/unit/command_test.ts
@@ -471,6 +471,39 @@ Deno.test(
 );
 
 Deno.test(
+  { permissions: { run: true, read: true } },
+  async function commandOutputAbort() {
+    const ac = new AbortController();
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "eval",
+        "setTimeout(console.log, 1e8)",
+      ],
+      signal: ac.signal,
+      stdout: "null",
+      stderr: "null",
+    });
+    const start = performance.now();
+    queueMicrotask(() => ac.abort());
+    const output = await command.output();
+    const duration = performance.now() - start;
+    assert(
+      duration < 5000,
+      `Expected output() to be aborted promptly, but ran for ${
+        duration.toFixed(2)
+      }ms`,
+    );
+    assertEquals(output.success, false);
+    if (Deno.build.os === "windows") {
+      assertEquals(output.code, 1);
+      assertEquals(output.signal, null);
+    } else {
+      assertEquals(output.code, 143);
+    }
+  },
+);
+
+Deno.test(
   { permissions: { read: true, run: false } },
   async function commandPermissions() {
     await assertRejects(async () => {


### PR DESCRIPTION
## Summary

`Command.output()`'s fast path (`spawnInner` in `ext/process/40_process.js`) bypasses `ChildProcess`. When that path was introduced in #33335 it silently dropped the `signal` option during destructuring, so passing an `AbortSignal` to `new Deno.Command()` and then calling `.output()` no longer killed the child when the signal fired.

This restores the behavior by mirroring what `ChildProcess.constructor` does:
- Accept `signal` from options.
- Register an `op_spawn_kill(rid, "SIGTERM")` handler on abort. Errors are swallowed for #27112 (the process may already be gone by the time the handler runs).
- Handle the already-aborted case explicitly — `AbortSignal[add]` early-returns without registering when `signal.aborted` is already true, so we kill the child immediately instead of leaking it.
- Remove the abort handler once the wait promise resolves.

## Test plan

Regression test added in `tests/unit/command_test.ts` (`commandOutputAbort`), modeled on the existing `commandAbort` test for `.spawn()`.

Repro from the issue, against the patched build:

```
$ deno test --allow-run reproduce.test.ts
Deno.Command.output() with signal ... ok (504ms)
ok | 1 passed | 0 failed (513ms)
```

Fixes #34066

Closes bartlomieju/orchid-inbox#78