### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows

### DIFF
--- a/.github/workflows/ecosystem_compat_test.generated.yml
+++ b/.github/workflows/ecosystem_compat_test.generated.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: 0 10 * * 1-5
   workflow_dispatch: {}
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: '${{ matrix.runner }}'

--- a/.github/workflows/node_compat_test.generated.yml
+++ b/.github/workflows/node_compat_test.generated.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: 0 10 * * *
   workflow_dispatch: {}
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: '${{ matrix.runner }}'

--- a/.github/workflows/pr.generated.yml
+++ b/.github/workflows/pr.generated.yml
@@ -10,6 +10,10 @@ on:
       - opened
       - edited
       - synchronize
+
+permissions:
+  contents: read
+
 jobs:
   main:
     name: lint title

--- a/.github/workflows/version_bump.generated.yml
+++ b/.github/workflows/version_bump.generated.yml
@@ -14,6 +14,10 @@ on:
           - major
           - rc
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: version bump


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.