### PR TITLE
fix(ext/node): emit destroy for cleared immediates

### DIFF
--- a/libs/core/01_core.js
+++ b/libs/core/01_core.js
@@ -196,6 +196,7 @@
       }
     }
     immediate[kRefed] = null;
+    emitDestroy(immediate.asyncId);
     immediate._onImmediate = null;
     immediateQueue.remove(immediate);
   }

--- a/tests/unit_node/async_hooks_test.ts
+++ b/tests/unit_node/async_hooks_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 import { AsyncLocalStorage, AsyncResource, createHook } from "node:async_hooks";
 import process from "node:process";
-import { setImmediate } from "node:timers";
+import { clearImmediate, setImmediate } from "node:timers";
 import { assert, assertEquals } from "@std/assert";
 
 Deno.test(async function foo() {
@@ -159,6 +159,31 @@ Deno.test(function runInAsyncScopeFiresBeforeAndAfter() {
     hook.disable();
   }
   assertEquals(events, ["before", "fn", "after"]);
+});
+
+Deno.test(function clearImmediateEmitsDestroy() {
+  let immediateAsyncId: number | undefined;
+  const destroyed: number[] = [];
+  const hook = createHook({
+    init(asyncId, type) {
+      if (type === "Immediate") {
+        immediateAsyncId = asyncId;
+      }
+    },
+    destroy(asyncId) {
+      destroyed.push(asyncId);
+    },
+  });
+
+  hook.enable();
+  try {
+    const immediate = setImmediate(() => {});
+    assert(typeof immediateAsyncId === "number");
+    clearImmediate(immediate);
+    assert(destroyed.includes(immediateAsyncId!));
+  } finally {
+    hook.disable();
+  }
 });
 
 Deno.test(async function worksWithAsyncAPIs() {


### PR DESCRIPTION
Closes #34079

This updates the immediate cancellation path to emit the async_hooks destroy callback for cleared Immediate resources, matching Node.js behavior.

Tests:
- cargo test -p unit_node_tests --test unit_node -- async_hooks_test
- ./target/debug/deno fmt --config tools/deno.json libs/core/01_core.js tests/unit_node/async_hooks_test.ts --check