### PR TITLE
fix(ext/node): improve https agent compat

### DIFF
--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -1076,6 +1076,7 @@ function tlsConnectionListener(rawSocket) {
     ALPNCallback: this.ALPNCallback,
     SNICallback: sniCallback,
     pauseOnConnect: this.pauseOnConnect,
+    handshakeTimeout: this._handshakeTimeout,
   });
 
   // TLS init can fail synchronously (e.g. missing cert/key, unsupported

--- a/ext/node/polyfills/https.ts
+++ b/ext/node/polyfills/https.ts
@@ -253,7 +253,7 @@ Agent.prototype.createConnection = function createConnection(
   ...args: any[]
 ) {
   let options = args[0];
-  let cb = typeof args[args.length - 1] === "function"
+  const cb = typeof args[args.length - 1] === "function"
     ? args[args.length - 1]
     : undefined;
 

--- a/ext/node/polyfills/https.ts
+++ b/ext/node/polyfills/https.ts
@@ -250,26 +250,28 @@ Agent.prototype._evictSession = function _evictSession(
 
 Agent.prototype.createConnection = function createConnection(
   this: any,
-  options: any,
-  cb?: any,
+  ...args: any[]
 ) {
-  if (typeof options === "number") {
+  let options = args[0];
+  let cb = typeof args[args.length - 1] === "function"
+    ? args[args.length - 1]
+    : undefined;
+
+  if (typeof args[0] === "number") {
     // createConnection(port, host, options) signature
-    const args = arguments;
     const opts: any = {};
-    if (args[0] !== null && typeof args[0] === "object") {
-      Object.assign(opts, args[0]);
-    } else if (args[1] !== null && typeof args[1] === "object") {
-      Object.assign(opts, args[1]);
-    } else if (args[2] !== null && typeof args[2] === "object") {
-      Object.assign(opts, args[2]);
+    for (let i = 1; i < args.length; i++) {
+      if (args[i] !== null && typeof args[i] === "object") {
+        Object.assign(opts, args[i]);
+      }
     }
     if (typeof args[0] === "number") opts.port = args[0];
     if (typeof args[1] === "string") opts.host = args[1];
-    if (typeof args[args.length - 1] === "function") {
-      cb = args[args.length - 1];
-    }
     options = opts;
+  } else if (options !== null && typeof options === "object") {
+    options = { ...options };
+  } else {
+    options = {};
   }
 
   // Look up cached TLS session for reuse

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -2099,6 +2099,7 @@
     "parallel/test-https-abortcontroller.js": {},
     "parallel/test-https-agent-abort-controller.js": {},
     "parallel/test-https-agent-constructor.js": {},
+    "parallel/test-https-agent-create-connection.js": {},
     "parallel/test-https-agent-getname.js": {},
     "parallel/test-https-agent-servername.js": {},
     "parallel/test-https-agent-sockets-leak.js": {},
@@ -2141,6 +2142,7 @@
       "ignore": true,
       "reason": "NODE_TLS_REJECT_UNAUTHORIZED=0 does not fully suppress cert verification errors"
     },
+    "parallel/test-https-timeout-server.js": {},
     "parallel/test-https-timeout-server-2.js": {},
     "parallel/test-https-timeout.js": {},
     "parallel/test-https-truncate.js": {},


### PR DESCRIPTION
## Summary

- pass tls.Server handshakeTimeout through to accepted server-side TLSSocket instances
- normalize https.Agent#createConnection(port[, host][, options][, cb]) call forms without mutating options
- enable the now-passing Node compat tests for HTTPS agent createConnection and HTTPS handshake timeout

## Tests

- ./x fmt
- ./x build
- ./x test-compat test-https-agent-create-connection.js
- ./x test-compat test-https-timeout-server.js