### PR TITLE
fix(ext/node): support shouldUpgradeCallback in http server

### DIFF
--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -72,6 +72,7 @@ const {
 const { kEmptyObject } = core.loadExtScript("ext:deno_node/internal/util.mjs");
 const {
   validateBoolean,
+  validateFunction,
   validateInteger,
   validateLinkHeaderValue,
   validateObject,
@@ -760,6 +761,15 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
   resetSocketTimeout(server, socket, state);
 
   if (req.upgrade) {
+    if (
+      server.shouldUpgradeCallback !== undefined &&
+      !server.shouldUpgradeCallback(req)
+    ) {
+      req.upgrade = false;
+    }
+  }
+
+  if (req.upgrade) {
     req.upgrade = req.method === "CONNECT" || true;
     if (req.upgrade) return 0;
   }
@@ -1213,6 +1223,19 @@ function storeHTTPOptions(options) {
     this.rejectNonStandardBodyWrites = rejectNonStandardBodyWrites;
   } else {
     this.rejectNonStandardBodyWrites = false;
+  }
+
+  const shouldUpgradeCallback = options.shouldUpgradeCallback;
+  if (shouldUpgradeCallback !== undefined) {
+    validateFunction(
+      shouldUpgradeCallback,
+      "options.shouldUpgradeCallback",
+    );
+    this.shouldUpgradeCallback = shouldUpgradeCallback;
+  } else {
+    this.shouldUpgradeCallback = function () {
+      return this.listenerCount("upgrade") > 0;
+    };
   }
 }
 ObjectSetPrototypeOf(Server.prototype, net.Server.prototype);

--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -760,7 +760,7 @@ function updateOutgoingData(socket, state, delta) {
 function parserOnIncoming(server, socket, state, req, keepAlive) {
   resetSocketTimeout(server, socket, state);
 
-  if (req.upgrade) {
+  if (req.upgrade && req.method !== "CONNECT") {
     if (
       server.shouldUpgradeCallback !== undefined &&
       !server.shouldUpgradeCallback(req)

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1826,6 +1826,8 @@
     "parallel/test-http-upgrade-client.js": {},
     "parallel/test-http-upgrade-client2.js": {},
     "parallel/test-http-upgrade-reconsume-stream.js": {},
+    "parallel/test-http-upgrade-server-callback.js": {},
+    "parallel/test-http-upgrade-server.js": {},
     "parallel/test-http-url.parse-auth-with-header-in-request.js": {},
     "parallel/test-http-url.parse-auth.js": {},
     "parallel/test-http-url.parse-basic.js": {},


### PR DESCRIPTION
Adds Node-compatible `shouldUpgradeCallback` handling to `node:http` servers.

The server now validates a user-provided callback, installs Node's default callback that upgrades only when an `upgrade` listener exists, and consults the callback before committing requests to the upgrade path.

Also enables the passing HTTP upgrade compat tests in `tests/node_compat/config.jsonc`.

Tests:
- `./x test-compat test-http-upgrade-server-callback.js`
- `./x test-compat test-http-upgrade-server.js`