### PR TITLE
test(ext/node): cover nested nextTick ESM ordering

### DIFF
--- a/tests/specs/node/next_tick_microtask_order/__test__.jsonc
+++ b/tests/specs/node/next_tick_microtask_order/__test__.jsonc
@@ -4,6 +4,10 @@
       "args": "run -A main.mjs",
       "output": "esm.out"
     },
+    "esm_nested": {
+      "args": "run -A nested.mjs",
+      "output": "nested.out"
+    },
     "cjs": {
       "args": "run -A main.cjs",
       "output": "cjs.out"

--- a/tests/specs/node/next_tick_microtask_order/nested.mjs
+++ b/tests/specs/node/next_tick_microtask_order/nested.mjs
@@ -1,0 +1,23 @@
+import { nextTick } from "node:process";
+
+const order = [];
+
+Promise.resolve().then(() => {
+  order.push("promise");
+  nextTick(() => order.push("tick from promise"));
+});
+
+queueMicrotask(() => {
+  order.push("microtask");
+  nextTick(() => order.push("tick from microtask"));
+});
+
+nextTick(() => {
+  order.push("tick");
+  Promise.resolve().then(() => order.push("promise from tick"));
+  queueMicrotask(() => order.push("microtask from tick"));
+});
+
+setTimeout(() => {
+  console.log(order.join("\n"));
+}, 0);

--- a/tests/specs/node/next_tick_microtask_order/nested.out
+++ b/tests/specs/node/next_tick_microtask_order/nested.out
@@ -1,0 +1,7 @@
+promise
+microtask
+tick
+tick from promise
+tick from microtask
+promise from tick
+microtask from tick


### PR DESCRIPTION
Adds a nested ESM ordering regression test for process.nextTick callbacks scheduled from top-level microtasks. This keeps coverage around denoland/deno#34052 after the core ordering fix.

Closes bartlomieju/orchid-inbox#83

AI assistance: This PR was prepared with Codex.