### PR TITLE
fix(lsp): don't panic on unresolved dts import hover

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1922,7 +1922,7 @@ impl Inner {
           self
             .resolution_to_hover_text(&dep.maybe_type, module.scope.as_deref()),
         ),
-        (true, true, _) => unreachable!("{}", json!(params)),
+        (true, true, _) => return Ok(None),
       };
       let value = if let Some(docs) = self.module_registry.get_hover(dep).await
       {

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -2790,6 +2790,33 @@ fn lsp_hover_dependency() {
   client.shutdown();
 }
 
+#[test(timeout = 300)]
+fn lsp_hover_unresolved_dependency_in_dts() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.did_open(json!({
+    "textDocument": {
+      "uri": "file:///a/types.d.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "import UI5Element from 'unresolved-bare-specifier';\n",
+    }
+  }));
+
+  let res = client.write_request(
+    "textDocument/hover",
+    json!({
+      "textDocument": {
+        "uri": "file:///a/types.d.ts",
+      },
+      "position": { "line": 0, "character": 29 }
+    }),
+  );
+  assert_eq!(res, json!(null));
+  client.shutdown();
+}
+
 // This tests for a regression covered by denoland/deno#12753 where the lsp was
 // unable to resolve dependencies when there was an invalid syntax in the module
 #[test(timeout = 300)]


### PR DESCRIPTION
Fixes #33723
Closes bartlomieju/orchid-inbox#87

## Summary
- Return no hover when a dependency hover in a `.d.ts` file has neither code nor type resolution.
- Add an LSP regression test for hovering an unresolved bare import in `types.d.ts`.

## Verification
- `cargo fmt --check`
- `cargo test -p integration_tests --test integration lsp::lsp_hover_unresolved_dependency_in_dts`
- `PATH="$PWD/target/debug:$PATH" ./tools/format.js --check cli/lsp/language_server.rs tests/integration/lsp_tests.rs`
- `PATH="$PWD/target/debug:$PATH" ./tools/lint.js --rs`

## AI Assistance
This PR was prepared with AI assistance.