### PR TITLE
fix(ext/cache): implement Cache.keys()

### DIFF
--- a/cli/tsc/dts/lib.deno_cache.d.ts
+++ b/cli/tsc/dts/lib.deno_cache.d.ts
@@ -63,6 +63,16 @@ interface Cache {
     request: RequestInfo | URL,
     options?: CacheQueryOptions,
   ): Promise<boolean>;
+  /**
+   * Return requests matching cached objects.
+   *
+   * How is the API different from browsers?
+   * 1. You cannot match cache objects using by relative paths.
+   */
+  keys(
+    request?: RequestInfo | URL,
+    options?: CacheQueryOptions,
+  ): Promise<readonly Request[]>;
 }
 
 /** @category Cache */

--- a/ext/cache/01_cache.js
+++ b/ext/cache/01_cache.js
@@ -4,6 +4,7 @@
 const { core, primordials } = globalThis.__bootstrap;
 const {
   op_cache_delete,
+  op_cache_keys,
   op_cache_match,
   op_cache_put,
   op_cache_storage_delete,
@@ -13,6 +14,7 @@ const {
 } = core.ops;
 const {
   ArrayPrototypePush,
+  ObjectFreeze,
   ObjectPrototypeIsPrototypeOf,
   StringPrototypeSplit,
   StringPrototypeTrim,
@@ -253,6 +255,65 @@ class Cache {
     });
   }
 
+  /** See https://w3c.github.io/ServiceWorker/#cache-keys */
+  async keys(request = undefined, options = undefined) {
+    webidl.assertBranded(this, CachePrototype);
+    const prefix = "Failed to execute 'keys' on 'Cache'";
+    if (request !== undefined) {
+      request = webidl.converters["RequestInfo_DOMString"](
+        request,
+        prefix,
+        "Argument 1",
+      );
+    }
+    options = webidl.converters["CacheQueryOptions"](
+      options,
+      prefix,
+      "Argument 2",
+    );
+
+    let r = null;
+    if (ObjectPrototypeIsPrototypeOf(RequestPrototype, request)) {
+      r = request;
+    } else if (
+      typeof request === "string" ||
+      ObjectPrototypeIsPrototypeOf(URLPrototype, request)
+    ) {
+      r = new Request(request);
+    }
+
+    let requestUrl = null;
+    let requestHeaders = [];
+    if (r !== null) {
+      if (r.method !== "GET" && !options.ignoreMethod) {
+        return ObjectFreeze([]);
+      }
+
+      const url = new URL(r.url);
+      url.hash = "";
+      // deno-lint-ignore prefer-primordials
+      requestUrl = url.toString();
+      requestHeaders = toInnerRequest(r).headerList;
+    }
+
+    const metas = await op_cache_keys({
+      cacheId: this[_id],
+      requestUrl,
+      requestHeaders,
+      ignoreSearch: options.ignoreSearch,
+      ignoreVary: options.ignoreVary,
+    });
+    const requests = [];
+    for (let i = 0; i < metas.length; ++i) {
+      const meta = metas[i];
+      ArrayPrototypePush(
+        requests,
+        new Request(meta.requestUrl, { headers: meta.requestHeaders }),
+      );
+    }
+    return ObjectFreeze(requests);
+  }
+
   /** See https://w3c.github.io/ServiceWorker/#cache-matchall
    *
    * Note: the function is private as we don't want to expose
@@ -328,6 +389,26 @@ class Cache {
 
 webidl.configureInterface(CacheStorage);
 webidl.configureInterface(Cache);
+webidl.converters["CacheQueryOptions"] = webidl.createDictionaryConverter(
+  "CacheQueryOptions",
+  [
+    {
+      key: "ignoreMethod",
+      defaultValue: false,
+      converter: webidl.converters["boolean"],
+    },
+    {
+      key: "ignoreSearch",
+      defaultValue: false,
+      converter: webidl.converters["boolean"],
+    },
+    {
+      key: "ignoreVary",
+      defaultValue: false,
+      converter: webidl.converters["boolean"],
+    },
+  ],
+);
 const CacheStoragePrototype = CacheStorage.prototype;
 const CachePrototype = Cache.prototype;
 

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -49,6 +49,9 @@ pub enum CacheError {
   #[error("Cache deletion is not supported")]
   DeletionNotSupported,
   #[class(type)]
+  #[error("Cache keys are not supported")]
+  KeysNotSupported,
+  #[class(type)]
   #[error("Content-Encoding is not allowed in response headers")]
   ContentEncodingNotAllowed,
   #[class(generic)]
@@ -105,6 +108,7 @@ deno_core::extension!(deno_cache,
     op_cache_storage_keys,
     op_cache_put,
     op_cache_match,
+    op_cache_keys,
     op_cache_delete,
   ],
   lazy_loaded_js = [ "01_cache.js" ],
@@ -134,6 +138,23 @@ pub struct CachePutRequest {
 #[serde(rename_all = "camelCase")]
 pub struct CacheMatchRequest {
   pub cache_id: i64,
+  pub request_url: String,
+  pub request_headers: Vec<(ByteString, ByteString)>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheKeysRequest {
+  pub cache_id: i64,
+  pub request_url: Option<String>,
+  pub request_headers: Vec<(ByteString, ByteString)>,
+  pub ignore_search: bool,
+  pub ignore_vary: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheKeysResponse {
   pub request_url: String,
   pub request_headers: Vec<(ByteString, ByteString)>,
 }
@@ -223,6 +244,16 @@ impl CacheImpl {
     match self {
       Self::Sqlite(cache) => cache.r#match(request).await,
       Self::Lsc(cache) => cache.r#match(request).await,
+    }
+  }
+
+  pub async fn keys(
+    &self,
+    request: CacheKeysRequest,
+  ) -> Result<Vec<CacheKeysResponse>, CacheError> {
+    match self {
+      Self::Sqlite(cache) => cache.keys(request).await,
+      Self::Lsc(cache) => cache.keys(request).await,
     }
   }
 
@@ -359,6 +390,16 @@ pub async fn op_cache_match(
     }
     None => Ok(None),
   }
+}
+
+#[op2]
+#[serde]
+pub async fn op_cache_keys(
+  state: Rc<RefCell<OpState>>,
+  #[serde] request: CacheKeysRequest,
+) -> Result<Vec<CacheKeysResponse>, CacheError> {
+  let cache = get_cache(&state)?;
+  cache.keys(request).await
 }
 
 #[op2]

--- a/ext/cache/lscache.rs
+++ b/ext/cache/lscache.rs
@@ -21,6 +21,8 @@ use slab::Slab;
 
 use crate::CacheDeleteRequest;
 use crate::CacheError;
+use crate::CacheKeysRequest;
+use crate::CacheKeysResponse;
 use crate::CacheMatchRequest;
 use crate::CacheMatchResponseMeta;
 use crate::CachePutRequest;
@@ -262,6 +264,13 @@ impl LscBackend {
     let body = CacheResponseResource::lsc(body);
 
     Ok(Some((meta, Some(body))))
+  }
+
+  pub async fn keys(
+    &self,
+    _request: CacheKeysRequest,
+  ) -> Result<Vec<CacheKeysResponse>, CacheError> {
+    Err(CacheError::KeysNotSupported)
   }
 
   pub async fn delete(

--- a/ext/cache/sqlite.rs
+++ b/ext/cache/sqlite.rs
@@ -21,6 +21,8 @@ use tokio::io::AsyncWriteExt;
 
 use crate::CacheDeleteRequest;
 use crate::CacheError;
+use crate::CacheKeysRequest;
+use crate::CacheKeysResponse;
 use crate::CacheMatchRequest;
 use crate::CacheMatchResponseMeta;
 use crate::CachePutRequest;
@@ -365,6 +367,102 @@ impl SqliteBackedCache {
     }
   }
 
+  pub async fn keys(
+    &self,
+    request: CacheKeysRequest,
+  ) -> Result<Vec<CacheKeysResponse>, CacheError> {
+    let db = self.connection.clone();
+    spawn_blocking(move || {
+      let db = db.lock();
+      let mut stmt = if request.request_url.is_some() && !request.ignore_search
+      {
+        db.prepare(
+          "SELECT request_url, request_headers, response_headers
+             FROM request_response_list
+             WHERE cache_id = ?1 AND request_url = ?2
+             ORDER BY id",
+        )?
+      } else {
+        db.prepare(
+          "SELECT request_url, request_headers, response_headers
+             FROM request_response_list
+             WHERE cache_id = ?1
+             ORDER BY id",
+        )?
+      };
+
+      let mut keys = Vec::new();
+      if let Some(request_url) = &request.request_url
+        && !request.ignore_search
+      {
+        let rows = stmt.query_map((request.cache_id, request_url), |row| {
+          let request_url: String = row.get(0)?;
+          let request_headers: Vec<u8> = row.get(1)?;
+          let response_headers: Vec<u8> = row.get(2)?;
+          Ok((
+            request_url,
+            deserialize_headers(&request_headers),
+            deserialize_headers(&response_headers),
+          ))
+        })?;
+        for row in rows {
+          let (request_url, request_headers, response_headers) = row?;
+          if request.ignore_vary
+            || request_matches_vary(
+              &response_headers,
+              &request.request_headers,
+              &request_headers,
+            )
+          {
+            keys.push(CacheKeysResponse {
+              request_url,
+              request_headers,
+            });
+          }
+        }
+      } else {
+        let rows = stmt.query_map([request.cache_id], |row| {
+          let request_url: String = row.get(0)?;
+          let request_headers: Vec<u8> = row.get(1)?;
+          let response_headers: Vec<u8> = row.get(2)?;
+          Ok((
+            request_url,
+            deserialize_headers(&request_headers),
+            deserialize_headers(&response_headers),
+          ))
+        })?;
+        for row in rows {
+          let (cached_url, request_headers, response_headers) = row?;
+          let url_matches =
+            request.request_url.as_ref().is_none_or(|request_url| {
+              urls_match(
+                cached_url.as_str(),
+                request_url,
+                request.ignore_search,
+              )
+            });
+          if url_matches
+            && (request.request_url.is_none()
+              || request.ignore_vary
+              || request_matches_vary(
+                &response_headers,
+                &request.request_headers,
+                &request_headers,
+              ))
+          {
+            keys.push(CacheKeysResponse {
+              request_url: cached_url,
+              request_headers,
+            });
+          }
+        }
+      }
+
+      Ok::<Vec<CacheKeysResponse>, CacheError>(keys)
+    })
+    .await?
+  }
+
   pub async fn delete(
     &self,
     request: CacheDeleteRequest,
@@ -381,6 +479,40 @@ impl SqliteBackedCache {
     })
     .await?
   }
+}
+
+fn request_matches_vary(
+  response_headers: &[(ByteString, ByteString)],
+  query_request_headers: &[(ByteString, ByteString)],
+  cached_request_headers: &[(ByteString, ByteString)],
+) -> bool {
+  if let Some(vary_header) = get_header("vary", response_headers) {
+    vary_header_matches(
+      &vary_header,
+      query_request_headers,
+      cached_request_headers,
+    )
+  } else {
+    true
+  }
+}
+
+fn urls_match(
+  cached_url: &str,
+  request_url: &str,
+  ignore_search: bool,
+) -> bool {
+  if ignore_search {
+    strip_url_search(cached_url) == strip_url_search(request_url)
+  } else {
+    cached_url == request_url
+  }
+}
+
+fn strip_url_search(url: &str) -> &str {
+  url
+    .split_once('?')
+    .map_or(url, |(without_search, _)| without_search)
 }
 
 async fn insert_cache_asset(

--- a/tests/unit/cache_api_test.ts
+++ b/tests/unit/cache_api_test.ts
@@ -46,6 +46,74 @@ Deno.test(async function cacheStorageKeys() {
   assert(await caches.delete("keys-c"));
 });
 
+Deno.test(async function cacheKeys() {
+  const cacheName = "cache-keys";
+  await caches.delete(cacheName);
+  const cache = await caches.open(cacheName);
+
+  const empty = await cache.keys();
+  assert(Array.isArray(empty));
+  assert(Object.isFrozen(empty));
+  assertEquals(empty, []);
+
+  const reqA = new Request("https://example.com/cache-keys/a?x=1", {
+    headers: { "x-test": "a" },
+  });
+  const reqB = new Request("https://example.com/cache-keys/b?x=2");
+  await cache.put(reqA, new Response("a"));
+  await cache.put(reqB, new Response("b"));
+
+  const keys = await cache.keys();
+  assert(Object.isFrozen(keys));
+  assertEquals(keys.length, 2);
+  assert(keys[0] instanceof Request);
+  assert(keys[1] instanceof Request);
+  assertEquals(keys[0].url, reqA.url);
+  assertEquals(keys[0].method, "GET");
+  assertEquals(keys[0].headers.get("x-test"), "a");
+  assertEquals(keys[1].url, reqB.url);
+
+  const exact = await cache.keys("https://example.com/cache-keys/a?x=1");
+  assertEquals(exact.length, 1);
+  assertEquals(exact[0].url, reqA.url);
+
+  const ignoredSearch = await cache.keys(
+    "https://example.com/cache-keys/a?x=not-the-same",
+    { ignoreSearch: true },
+  );
+  assertEquals(ignoredSearch.length, 1);
+  assertEquals(ignoredSearch[0].url, reqA.url);
+
+  const headRequest = new Request("https://example.com/cache-keys/a?x=1", {
+    method: "HEAD",
+  });
+  assertEquals(await cache.keys(headRequest), []);
+  const ignoredMethod = await cache.keys(headRequest, { ignoreMethod: true });
+  assertEquals(ignoredMethod.length, 1);
+  assertEquals(ignoredMethod[0].url, reqA.url);
+
+  const varyReq = new Request("https://example.com/cache-keys/vary", {
+    headers: { "accept": "application/json" },
+  });
+  await cache.put(
+    varyReq,
+    new Response("vary", { headers: { "vary": "accept" } }),
+  );
+  assertEquals(
+    await cache.keys("https://example.com/cache-keys/vary"),
+    [],
+  );
+  assertEquals(
+    (await cache.keys("https://example.com/cache-keys/vary", {
+      ignoreVary: true,
+    })).length,
+    1,
+  );
+  assertEquals((await cache.keys(varyReq)).length, 1);
+
+  assert(await caches.delete(cacheName));
+});
+
 Deno.test(async function cacheApi() {
   const cacheName = "cache-v1";
   const cache = await caches.open(cacheName);

--- a/tests/wpt/runner/expectations/service-workers.json
+++ b/tests/wpt/runner/expectations/service-workers.json
@@ -90,15 +90,12 @@
       "Cache interface: operation add(RequestInfo)",
       "Cache interface: operation addAll(sequence<RequestInfo>)",
       "Cache interface: operation delete(RequestInfo, optional CacheQueryOptions)",
-      "Cache interface: operation keys(optional RequestInfo, optional CacheQueryOptions)",
       "Cache interface: self.cacheInstance must inherit property \"matchAll(optional RequestInfo, optional CacheQueryOptions)\" with the proper type",
       "Cache interface: calling matchAll(optional RequestInfo, optional CacheQueryOptions) on self.cacheInstance with too few arguments must throw TypeError",
       "Cache interface: self.cacheInstance must inherit property \"add(RequestInfo)\" with the proper type",
       "Cache interface: calling add(RequestInfo) on self.cacheInstance with too few arguments must throw TypeError",
       "Cache interface: self.cacheInstance must inherit property \"addAll(sequence<RequestInfo>)\" with the proper type",
       "Cache interface: calling addAll(sequence<RequestInfo>) on self.cacheInstance with too few arguments must throw TypeError",
-      "Cache interface: self.cacheInstance must inherit property \"keys(optional RequestInfo, optional CacheQueryOptions)\" with the proper type",
-      "Cache interface: calling keys(optional RequestInfo, optional CacheQueryOptions) on self.cacheInstance with too few arguments must throw TypeError",
       "CacheStorage interface: operation match(RequestInfo, optional MultiCacheQueryOptions)",
       "Window interface: attribute caches",
       "Navigator interface: attribute serviceWorker",
@@ -176,15 +173,12 @@
       "Cache interface: operation add(RequestInfo)",
       "Cache interface: operation addAll(sequence<RequestInfo>)",
       "Cache interface: operation delete(RequestInfo, optional CacheQueryOptions)",
-      "Cache interface: operation keys(optional RequestInfo, optional CacheQueryOptions)",
       "Cache interface: self.cacheInstance must inherit property \"matchAll(optional RequestInfo, optional CacheQueryOptions)\" with the proper type",
       "Cache interface: calling matchAll(optional RequestInfo, optional CacheQueryOptions) on self.cacheInstance with too few arguments must throw TypeError",
       "Cache interface: self.cacheInstance must inherit property \"add(RequestInfo)\" with the proper type",
       "Cache interface: calling add(RequestInfo) on self.cacheInstance with too few arguments must throw TypeError",
       "Cache interface: self.cacheInstance must inherit property \"addAll(sequence<RequestInfo>)\" with the proper type",
       "Cache interface: calling addAll(sequence<RequestInfo>) on self.cacheInstance with too few arguments must throw TypeError",
-      "Cache interface: self.cacheInstance must inherit property \"keys(optional RequestInfo, optional CacheQueryOptions)\" with the proper type",
-      "Cache interface: calling keys(optional RequestInfo, optional CacheQueryOptions) on self.cacheInstance with too few arguments must throw TypeError",
       "CacheStorage interface: operation match(RequestInfo, optional MultiCacheQueryOptions)",
       "WorkerGlobalScope interface: attribute caches",
       "WorkerNavigator interface: attribute serviceWorker"
@@ -222,8 +216,6 @@
         "Cache.delete with ignoreSearch option (when it is specified as false)"
       ]
     },
-    "cache-keys.https.any.html": false,
-    "cache-keys.https.any.worker.html": false,
     "cache-match.https.any.worker.html": {
       "expectedFailures": [
         "Cache.match supports ignoreMethod",


### PR DESCRIPTION
Closes bartlomieju/orchid-inbox#89
Fixes denoland/deno#33783

Summary:
- Adds Cache.prototype.keys() and a matching op_cache_keys backend path.
- Reads cached request metadata from sqlite, including filtering for ignoreSearch, ignoreMethod, and ignoreVary behavior.
- Returns frozen arrays of Request instances from JS and adds unit coverage for empty caches, populated caches, filtering, methods, Vary handling, and frozen results.

Tests:
- cargo test -p deno_cache
- ./x test-unit cache_api_test
- ./target/debug/deno eval 'const cache = await caches.open("test"); console.log(typeof cache.keys); console.log((await cache.keys()).length); await caches.delete("test");'\n\nAI disclosure: This PR was implemented with AI assistance from OpenAI Codex.