### PR TITLE
fix node net async id fallback

### DIFF
--- a/ext/node/polyfills/net.ts
+++ b/ext/node/polyfills/net.ts
@@ -267,9 +267,19 @@ interface IpcSocketConnectOptions extends ConnectOptions {
 type SocketConnectOptions = TcpSocketConnectOptions | IpcSocketConnectOptions;
 
 function _getNewAsyncId(handle?: Handle): number {
-  return !handle || typeof handle.getAsyncId !== "function"
-    ? newAsyncId()
-    : handle.getAsyncId();
+  if (!handle || typeof handle.getAsyncId !== "function") {
+    return newAsyncId();
+  }
+
+  try {
+    return handle.getAsyncId();
+  } catch (err) {
+    if (err instanceof TypeError && err.message === "expected AsyncWrap") {
+      return newAsyncId();
+    }
+
+    throw err;
+  }
 }
 
 interface NormalizedArgs {

--- a/tests/unit_node/net_test.ts
+++ b/tests/unit_node/net_test.ts
@@ -8,6 +8,9 @@ import * as dns from "node:dns";
 import * as dnsPromises from "node:dns/promises";
 import util from "node:util";
 import console from "node:console";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 
 Deno.test("[node/net] close event emits after error event - when host is not found", async () => {
   const socket = net.createConnection(27009, "doesnotexist");
@@ -45,6 +48,18 @@ Deno.test("[node/net] close event emits after error event - when connection is r
 
   // `error` happens before `close`
   assertEquals(events, ["error", "close"]);
+});
+
+Deno.test("[node/net] Socket falls back when handle getAsyncId has wrong receiver", () => {
+  const { TCP } = require("internal/test/binding").internalBinding("tcp_wrap");
+  const socket = new net.Socket({
+    handle: {
+      getAsyncId: TCP.prototype.getAsyncId,
+    },
+    readable: false,
+  } as net.SocketConstructorOpts);
+
+  socket.destroy();
 });
 
 Deno.test("[node/net] the port is available immediately after close callback", async () => {


### PR DESCRIPTION
Fixes node:net socket initialization when a handle exposes a native getAsyncId method but is not an AsyncWrap receiver. In that case the native op throws "expected AsyncWrap" before connection setup, which matches the pg/sequelize report from denoland/deno#33879.

This falls back to a fresh async id for that specific brand-check TypeError and keeps rethrowing all other getAsyncId failures.

Tested:

- cargo build --bin deno
- ./x test-node net_test

Closes bartlomieju/orchid-inbox#92