### PR TITLE
fix(publish): strip fast check private field decorators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.108.2"
-source = "git+https://github.com/denoland/deno_graph?rev=3fd46774cc878798e666f2f6564f66de9db81175#3fd46774cc878798e666f2f6564f66de9db81175"
+source = "git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2#69d174a7a1d3428c88de91f400841b9714ae67d2"
 dependencies = [
  "async-trait",
  "boxed_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,8 +2459,7 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.108.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf8dde12e88c720eceb649d7aa38abb202840b5e780ee8b1bb12250f0668266"
+source = "git+https://github.com/denoland/deno_graph?rev=3fd46774cc878798e666f2f6564f66de9db81175#3fd46774cc878798e666f2f6564f66de9db81175"
 dependencies = [
  "async-trait",
  "boxed_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
- "unicode-width 0.2.2",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -1867,7 +1867,7 @@ dependencies = [
  "deno_doc",
  "deno_dotenv",
  "deno_error",
- "deno_graph",
+ "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
  "deno_lib",
  "deno_lint",
  "deno_lockfile",
@@ -2301,7 +2301,7 @@ dependencies = [
  "cfg-if",
  "comrak",
  "deno_ast",
- "deno_graph",
+ "deno_graph 0.108.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "deno_path_util",
  "deno_terminal",
  "handlebars",
@@ -2454,6 +2454,39 @@ dependencies = [
  "thiserror 2.0.12",
  "winapi",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "deno_graph"
+version = "0.108.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf8dde12e88c720eceb649d7aa38abb202840b5e780ee8b1bb12250f0668266"
+dependencies = [
+ "async-trait",
+ "boxed_error",
+ "capacity_builder",
+ "chrono",
+ "data-url",
+ "deno_ast",
+ "deno_error",
+ "deno_media_type",
+ "deno_path_util",
+ "deno_semver",
+ "deno_unsync",
+ "futures",
+ "indexmap 2.12.0",
+ "log",
+ "monch",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sys_traits",
+ "thiserror 2.0.12",
+ "url",
+ "wasm_dep_analyzer",
 ]
 
 [[package]]
@@ -2980,7 +3013,7 @@ dependencies = [
  "chrono",
  "deno_config",
  "deno_error",
- "deno_graph",
+ "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
  "deno_lockfile",
  "deno_npm",
  "deno_npm_cache",
@@ -3187,7 +3220,7 @@ dependencies = [
  "deno_cache_dir",
  "deno_config",
  "deno_error",
- "deno_graph",
+ "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
  "deno_lockfile",
  "deno_maybe_sync",
  "deno_media_type",
@@ -4481,7 +4514,7 @@ dependencies = [
  "base64 0.21.7",
  "deno_ast",
  "deno_error",
- "deno_graph",
+ "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
  "deno_npm",
  "deno_semver",
  "futures",
@@ -7232,7 +7265,7 @@ dependencies = [
  "capacity_builder",
  "dashmap",
  "deno_error",
- "deno_graph",
+ "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
  "deno_maybe_sync",
  "deno_media_type",
  "deno_package_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
  "deno_doc",
  "deno_dotenv",
  "deno_error",
- "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
+ "deno_graph",
  "deno_lib",
  "deno_lint",
  "deno_lockfile",
@@ -2301,7 +2301,7 @@ dependencies = [
  "cfg-if",
  "comrak",
  "deno_ast",
- "deno_graph 0.108.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deno_graph",
  "deno_path_util",
  "deno_terminal",
  "handlebars",
@@ -2461,38 +2461,6 @@ name = "deno_graph"
 version = "0.108.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf8dde12e88c720eceb649d7aa38abb202840b5e780ee8b1bb12250f0668266"
-dependencies = [
- "async-trait",
- "boxed_error",
- "capacity_builder",
- "chrono",
- "data-url",
- "deno_ast",
- "deno_error",
- "deno_media_type",
- "deno_path_util",
- "deno_semver",
- "deno_unsync",
- "futures",
- "indexmap 2.12.0",
- "log",
- "monch",
- "once_cell",
- "parking_lot",
- "regex",
- "serde",
- "serde_json",
- "sha2",
- "sys_traits",
- "thiserror 2.0.12",
- "url",
- "wasm_dep_analyzer",
-]
-
-[[package]]
-name = "deno_graph"
-version = "0.108.2"
-source = "git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2#69d174a7a1d3428c88de91f400841b9714ae67d2"
 dependencies = [
  "async-trait",
  "boxed_error",
@@ -3013,7 +2981,7 @@ dependencies = [
  "chrono",
  "deno_config",
  "deno_error",
- "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
+ "deno_graph",
  "deno_lockfile",
  "deno_npm",
  "deno_npm_cache",
@@ -3220,7 +3188,7 @@ dependencies = [
  "deno_cache_dir",
  "deno_config",
  "deno_error",
- "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
+ "deno_graph",
  "deno_lockfile",
  "deno_maybe_sync",
  "deno_media_type",
@@ -4514,7 +4482,7 @@ dependencies = [
  "base64 0.21.7",
  "deno_ast",
  "deno_error",
- "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
+ "deno_graph",
  "deno_npm",
  "deno_semver",
  "futures",
@@ -7265,7 +7233,7 @@ dependencies = [
  "capacity_builder",
  "dashmap",
  "deno_error",
- "deno_graph 0.108.2 (git+https://github.com/denoland/deno_graph?rev=69d174a7a1d3428c88de91f400841b9714ae67d2)",
+ "deno_graph",
  "deno_maybe_sync",
  "deno_media_type",
  "deno_package_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ deno_ast = { version = "=0.53.2", features = ["transpiling"] }
 deno_core_icudata = "0.77.0"
 deno_doc = "=0.199.0"
 deno_error = "=0.7.1"
-deno_graph = { git = "https://github.com/denoland/deno_graph", rev = "3fd46774cc878798e666f2f6564f66de9db81175", default-features = false }
+deno_graph = { git = "https://github.com/denoland/deno_graph", rev = "69d174a7a1d3428c88de91f400841b9714ae67d2", default-features = false }
 deno_lint = "=0.84.1"
 deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ deno_ast = { version = "=0.53.2", features = ["transpiling"] }
 deno_core_icudata = "0.77.0"
 deno_doc = "=0.199.0"
 deno_error = "=0.7.1"
-deno_graph = { version = "=0.108.2", default-features = false }
+deno_graph = { git = "https://github.com/denoland/deno_graph", rev = "3fd46774cc878798e666f2f6564f66de9db81175", default-features = false }
 deno_lint = "=0.84.1"
 deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ deno_ast = { version = "=0.53.2", features = ["transpiling"] }
 deno_core_icudata = "0.77.0"
 deno_doc = "=0.199.0"
 deno_error = "=0.7.1"
-deno_graph = { git = "https://github.com/denoland/deno_graph", rev = "69d174a7a1d3428c88de91f400841b9714ae67d2", default-features = false }
+deno_graph = { version = "0.108.2", default-features = false }
 deno_lint = "=0.84.1"
 deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"

--- a/cli/fast_check.rs
+++ b/cli/fast_check.rs
@@ -1,0 +1,54 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+use std::sync::Arc;
+
+/// Removes decorator-only lines from fast-check emitted output.
+///
+/// Fast-check output is declaration-like TypeScript, so decorators are never
+/// valid there. A simple line filter is sufficient for the emitted shape.
+pub fn strip_decorators(text: &str) -> String {
+  let mut sanitized = String::with_capacity(text.len());
+  let mut changed = false;
+
+  for line in text.split_inclusive('\n') {
+    let line_without_newline = line.strip_suffix('\n').unwrap_or(line);
+    if line_without_newline.trim_start().starts_with('@') {
+      changed = true;
+      continue;
+    }
+    sanitized.push_str(line);
+  }
+
+  if changed { sanitized } else { text.to_owned() }
+}
+
+pub fn strip_decorators_arc(text: &Arc<str>) -> Arc<str> {
+  let sanitized = strip_decorators(text);
+  if sanitized.as_str() == text.as_ref() {
+    text.clone()
+  } else {
+    sanitized.into()
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn strips_decorator_lines() {
+    let text = r#"export class Auth {
+  @Inject("jwt")
+  declare private readonly options?: any;
+}
+"#;
+
+    assert_eq!(
+      strip_decorators(text),
+      r#"export class Auth {
+  declare private readonly options?: any;
+}
+"#
+    );
+  }
+}

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -4,6 +4,7 @@ mod args;
 mod cache;
 mod cdp;
 mod factory;
+mod fast_check;
 mod file_fetcher;
 mod graph_container;
 mod graph_util;

--- a/cli/tools/pack/mod.rs
+++ b/cli/tools/pack/mod.rs
@@ -20,6 +20,7 @@ use deno_terminal::colors;
 use crate::args::Flags;
 use crate::args::PackFlags;
 use crate::factory::CliFactory;
+use crate::fast_check::strip_decorators;
 use crate::graph_util::CreatePublishGraphOptions;
 use crate::util::display::human_size;
 
@@ -939,7 +940,7 @@ fn extract_dts(
         &Default::default(),
         &emit_options,
       ) {
-        Ok(emitted) => return Some(emitted.text),
+        Ok(emitted) => return Some(strip_decorators(&emitted.text)),
         Err(e) => {
           // No fall-through to fast_check.source: it's simplified
           // TypeScript, not valid .d.ts. We return None so the .d.ts

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -1132,7 +1132,8 @@ mod tests {
 
   #[test]
   fn keeps_decorators_on_non_fast_check_output() {
-    let source: Arc<str> = "@Inject(\"jwt\")\n  readonly options?: any;\n".into();
+    let source: Arc<str> =
+      "@Inject(\"jwt\")\n  readonly options?: any;\n".into();
     let actual = strip_invalid_fast_check_decorators(source.clone());
     assert!(Arc::ptr_eq(&actual, &source));
   }

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -41,6 +41,7 @@ use thiserror::Error;
 use crate::args::CompilerOptions;
 use crate::args::TypeCheckMode;
 use crate::cache::ModuleInfoCache;
+use crate::fast_check::strip_decorators_arc;
 use crate::node::CliNodeResolver;
 use crate::npm::CliNpmResolver;
 use crate::resolver::CliCjsTracker;
@@ -1182,7 +1183,7 @@ pub fn load_for_tsc<T: LoadContent, M: Mapper>(
           Some(
             module
               .fast_check_module()
-              .map(|m| T::from_arc_str(m.source.clone()))
+              .map(|m| T::from_arc_str(strip_decorators_arc(&m.source)))
               .unwrap_or(T::from_arc_str(module.source.text.clone())),
           )
         }

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -14,6 +14,11 @@ use std::sync::LazyLock;
 use std::sync::OnceLock;
 
 use deno_ast::MediaType;
+use deno_ast::SourceRangedForSpanned as _;
+use deno_ast::swc::ast::Accessibility;
+use deno_ast::swc::ast::ClassProp;
+use deno_ast::swc::ecma_visit::Visit;
+use deno_ast::swc::ecma_visit::VisitWith as _;
 use deno_core::ModuleSpecifier;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Deserializer;
@@ -1080,39 +1085,60 @@ pub trait LoadContent: AsRef<str> {
   fn from_arc_str(source: Arc<str>) -> Self;
 }
 
-fn strip_invalid_fast_check_decorators(source: Arc<str>) -> Arc<str> {
+fn sanitize_fast_check_source_for_tsc(source: Arc<str>) -> Arc<str> {
   if !source.contains('@') || !source.contains("declare private ") {
     return source;
   }
 
-  let mut decorator_start = None;
-  let mut changed = false;
-  let mut output = source.as_bytes().to_vec();
-  let mut offset = 0;
-  for line in source.split_inclusive('\n') {
-    let trimmed = line.trim_start();
-    if trimmed.starts_with('@') {
-      decorator_start.get_or_insert(offset);
-    } else if trimmed.starts_with("declare private ")
-      && let Some(start) = decorator_start.take()
-    {
-      for byte in output.iter_mut().take(offset).skip(start) {
-        if *byte != b'\n' && *byte != b'\r' {
-          *byte = b' ';
-        }
-      }
-      changed = true;
-    } else if !trimmed.is_empty() {
-      decorator_start = None;
-    }
-    offset += line.len();
+  struct InvalidDecoratorCollector {
+    ranges: Vec<deno_ast::SourceRange>,
   }
 
-  if changed {
-    String::from_utf8(output).unwrap().into()
-  } else {
-    source
+  impl Visit for InvalidDecoratorCollector {
+    fn visit_class_prop(&mut self, n: &ClassProp) {
+      if n.declare && n.accessibility == Some(Accessibility::Private) {
+        self.ranges
+          .extend(n.decorators.iter().map(|decorator| decorator.range()));
+      }
+      n.visit_children_with(self);
+    }
   }
+
+  let specifier =
+    ModuleSpecifier::parse("internal:///fast_check.ts").unwrap();
+  let parsed_source = match deno_ast::parse_module(deno_ast::ParseParams {
+    specifier,
+    text: source.clone(),
+    media_type: MediaType::TypeScript,
+    capture_tokens: false,
+    scope_analysis: false,
+    maybe_syntax: None,
+  }) {
+    Ok(parsed_source) => parsed_source,
+    Err(_) => return source,
+  };
+  let mut collector = InvalidDecoratorCollector { ranges: Vec::new() };
+  parsed_source.program_ref().visit_with(&mut collector);
+  if collector.ranges.is_empty() {
+    return source;
+  }
+
+  let start_pos = parsed_source.start_pos();
+  let text_changes = collector
+    .ranges
+    .into_iter()
+    .map(|range| {
+      let range = range.as_byte_range(start_pos);
+      deno_ast::TextChange {
+        new_text: source[range.clone()]
+          .chars()
+          .map(|c| if matches!(c, '\n' | '\r') { c } else { ' ' })
+          .collect(),
+        range,
+      }
+    })
+    .collect();
+  deno_ast::apply_text_changes(&source, text_changes).into()
 }
 
 #[cfg(test)]
@@ -1120,21 +1146,23 @@ mod tests {
   use super::*;
 
   #[test]
-  fn strips_fast_check_decorator_from_private_declare_field() {
+  fn sanitizes_fast_check_decorator_from_private_declare_field() {
     let source: Arc<str> =
-      "@Inject(\"jwt\")\n  declare private readonly options?: any;\n".into();
-    let actual = strip_invalid_fast_check_decorators(source);
+      "class Auth {\n  @Inject(\"jwt\")\n  declare private readonly options?: any;\n}\n"
+        .into();
+    let actual = sanitize_fast_check_source_for_tsc(source);
     assert_eq!(
       actual.as_ref(),
-      "              \n  declare private readonly options?: any;\n"
+      "class Auth {\n                \n  declare private readonly options?: any;\n}\n"
     );
   }
 
   #[test]
-  fn keeps_decorators_on_non_fast_check_output() {
+  fn keeps_valid_fast_check_decorators() {
     let source: Arc<str> =
-      "@Inject(\"jwt\")\n  readonly options?: any;\n".into();
-    let actual = strip_invalid_fast_check_decorators(source.clone());
+      "class Auth {\n  @Inject(\"jwt\")\n  readonly options?: any;\n}\n"
+        .into();
+    let actual = sanitize_fast_check_source_for_tsc(source.clone());
     assert!(Arc::ptr_eq(&actual, &source));
   }
 }
@@ -1242,7 +1270,7 @@ pub fn load_for_tsc<T: LoadContent, M: Mapper>(
             module
               .fast_check_module()
               .map(|m| {
-                T::from_arc_str(strip_invalid_fast_check_decorators(
+                T::from_arc_str(sanitize_fast_check_source_for_tsc(
                   m.source.clone(),
                 ))
               })

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -1080,65 +1080,6 @@ pub trait LoadContent: AsRef<str> {
   fn from_arc_str(source: Arc<str>) -> Self;
 }
 
-fn strip_invalid_fast_check_decorators(source: Arc<str>) -> Arc<str> {
-  if !source.contains('@') || !source.contains("declare private ") {
-    return source;
-  }
-
-  let mut decorator_start = None;
-  let mut changed = false;
-  let mut output = source.as_bytes().to_vec();
-  let mut offset = 0;
-  for line in source.split_inclusive('\n') {
-    let trimmed = line.trim_start();
-    if trimmed.starts_with('@') {
-      decorator_start.get_or_insert(offset);
-    } else if trimmed.starts_with("declare private ")
-      && let Some(start) = decorator_start.take()
-    {
-      for byte in output.iter_mut().take(offset).skip(start) {
-        if *byte != b'\n' && *byte != b'\r' {
-          *byte = b' ';
-        }
-      }
-      changed = true;
-    } else if !trimmed.is_empty() {
-      decorator_start = None;
-    }
-    offset += line.len();
-  }
-
-  if changed {
-    String::from_utf8(output).unwrap().into()
-  } else {
-    source
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn strips_fast_check_decorator_from_private_declare_field() {
-    let source: Arc<str> =
-      "@Inject(\"jwt\")\n  declare private readonly options?: any;\n".into();
-    let actual = strip_invalid_fast_check_decorators(source);
-    assert_eq!(
-      actual.as_ref(),
-      "              \n  declare private readonly options?: any;\n"
-    );
-  }
-
-  #[test]
-  fn keeps_decorators_on_non_fast_check_output() {
-    let source: Arc<str> =
-      "@Inject(\"jwt\")\n  readonly options?: any;\n".into();
-    let actual = strip_invalid_fast_check_decorators(source.clone());
-    assert!(Arc::ptr_eq(&actual, &source));
-  }
-}
-
 #[derive(Debug)]
 pub struct LoadResponse<T: LoadContent> {
   data: T,
@@ -1241,11 +1182,7 @@ pub fn load_for_tsc<T: LoadContent, M: Mapper>(
           Some(
             module
               .fast_check_module()
-              .map(|m| {
-                T::from_arc_str(strip_invalid_fast_check_decorators(
-                  m.source.clone(),
-                ))
-              })
+              .map(|m| T::from_arc_str(m.source.clone()))
               .unwrap_or(T::from_arc_str(module.source.text.clone())),
           )
         }

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -1080,6 +1080,64 @@ pub trait LoadContent: AsRef<str> {
   fn from_arc_str(source: Arc<str>) -> Self;
 }
 
+fn strip_invalid_fast_check_decorators(source: Arc<str>) -> Arc<str> {
+  if !source.contains('@') || !source.contains("declare private ") {
+    return source;
+  }
+
+  let mut decorator_start = None;
+  let mut changed = false;
+  let mut output = source.as_bytes().to_vec();
+  let mut offset = 0;
+  for line in source.split_inclusive('\n') {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with('@') {
+      decorator_start.get_or_insert(offset);
+    } else if trimmed.starts_with("declare private ")
+      && let Some(start) = decorator_start.take()
+    {
+      for byte in output.iter_mut().take(offset).skip(start) {
+        if *byte != b'\n' && *byte != b'\r' {
+          *byte = b' ';
+        }
+      }
+      changed = true;
+    } else if !trimmed.is_empty() {
+      decorator_start = None;
+    }
+    offset += line.len();
+  }
+
+  if changed {
+    String::from_utf8(output).unwrap().into()
+  } else {
+    source
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn strips_fast_check_decorator_from_private_declare_field() {
+    let source: Arc<str> =
+      "@Inject(\"jwt\")\n  declare private readonly options?: any;\n".into();
+    let actual = strip_invalid_fast_check_decorators(source);
+    assert_eq!(
+      actual.as_ref(),
+      "              \n  declare private readonly options?: any;\n"
+    );
+  }
+
+  #[test]
+  fn keeps_decorators_on_non_fast_check_output() {
+    let source: Arc<str> = "@Inject(\"jwt\")\n  readonly options?: any;\n".into();
+    let actual = strip_invalid_fast_check_decorators(source.clone());
+    assert!(Arc::ptr_eq(&actual, &source));
+  }
+}
+
 #[derive(Debug)]
 pub struct LoadResponse<T: LoadContent> {
   data: T,
@@ -1182,7 +1240,11 @@ pub fn load_for_tsc<T: LoadContent, M: Mapper>(
           Some(
             module
               .fast_check_module()
-              .map(|m| T::from_arc_str(m.source.clone()))
+              .map(|m| {
+                T::from_arc_str(strip_invalid_fast_check_decorators(
+                  m.source.clone(),
+                ))
+              })
               .unwrap_or(T::from_arc_str(module.source.text.clone())),
           )
         }

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -14,11 +14,6 @@ use std::sync::LazyLock;
 use std::sync::OnceLock;
 
 use deno_ast::MediaType;
-use deno_ast::SourceRangedForSpanned as _;
-use deno_ast::swc::ast::Accessibility;
-use deno_ast::swc::ast::ClassProp;
-use deno_ast::swc::ecma_visit::Visit;
-use deno_ast::swc::ecma_visit::VisitWith as _;
 use deno_core::ModuleSpecifier;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Deserializer;
@@ -1085,60 +1080,39 @@ pub trait LoadContent: AsRef<str> {
   fn from_arc_str(source: Arc<str>) -> Self;
 }
 
-fn sanitize_fast_check_source_for_tsc(source: Arc<str>) -> Arc<str> {
+fn strip_invalid_fast_check_decorators(source: Arc<str>) -> Arc<str> {
   if !source.contains('@') || !source.contains("declare private ") {
     return source;
   }
 
-  struct InvalidDecoratorCollector {
-    ranges: Vec<deno_ast::SourceRange>,
-  }
-
-  impl Visit for InvalidDecoratorCollector {
-    fn visit_class_prop(&mut self, n: &ClassProp) {
-      if n.declare && n.accessibility == Some(Accessibility::Private) {
-        self.ranges
-          .extend(n.decorators.iter().map(|decorator| decorator.range()));
+  let mut decorator_start = None;
+  let mut changed = false;
+  let mut output = source.as_bytes().to_vec();
+  let mut offset = 0;
+  for line in source.split_inclusive('\n') {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with('@') {
+      decorator_start.get_or_insert(offset);
+    } else if trimmed.starts_with("declare private ")
+      && let Some(start) = decorator_start.take()
+    {
+      for byte in output.iter_mut().take(offset).skip(start) {
+        if *byte != b'\n' && *byte != b'\r' {
+          *byte = b' ';
+        }
       }
-      n.visit_children_with(self);
+      changed = true;
+    } else if !trimmed.is_empty() {
+      decorator_start = None;
     }
+    offset += line.len();
   }
 
-  let specifier =
-    ModuleSpecifier::parse("internal:///fast_check.ts").unwrap();
-  let parsed_source = match deno_ast::parse_module(deno_ast::ParseParams {
-    specifier,
-    text: source.clone(),
-    media_type: MediaType::TypeScript,
-    capture_tokens: false,
-    scope_analysis: false,
-    maybe_syntax: None,
-  }) {
-    Ok(parsed_source) => parsed_source,
-    Err(_) => return source,
-  };
-  let mut collector = InvalidDecoratorCollector { ranges: Vec::new() };
-  parsed_source.program_ref().visit_with(&mut collector);
-  if collector.ranges.is_empty() {
-    return source;
+  if changed {
+    String::from_utf8(output).unwrap().into()
+  } else {
+    source
   }
-
-  let start_pos = parsed_source.start_pos();
-  let text_changes = collector
-    .ranges
-    .into_iter()
-    .map(|range| {
-      let range = range.as_byte_range(start_pos);
-      deno_ast::TextChange {
-        new_text: source[range.clone()]
-          .chars()
-          .map(|c| if matches!(c, '\n' | '\r') { c } else { ' ' })
-          .collect(),
-        range,
-      }
-    })
-    .collect();
-  deno_ast::apply_text_changes(&source, text_changes).into()
 }
 
 #[cfg(test)]
@@ -1146,23 +1120,21 @@ mod tests {
   use super::*;
 
   #[test]
-  fn sanitizes_fast_check_decorator_from_private_declare_field() {
+  fn strips_fast_check_decorator_from_private_declare_field() {
     let source: Arc<str> =
-      "class Auth {\n  @Inject(\"jwt\")\n  declare private readonly options?: any;\n}\n"
-        .into();
-    let actual = sanitize_fast_check_source_for_tsc(source);
+      "@Inject(\"jwt\")\n  declare private readonly options?: any;\n".into();
+    let actual = strip_invalid_fast_check_decorators(source);
     assert_eq!(
       actual.as_ref(),
-      "class Auth {\n                \n  declare private readonly options?: any;\n}\n"
+      "              \n  declare private readonly options?: any;\n"
     );
   }
 
   #[test]
-  fn keeps_valid_fast_check_decorators() {
+  fn keeps_decorators_on_non_fast_check_output() {
     let source: Arc<str> =
-      "class Auth {\n  @Inject(\"jwt\")\n  readonly options?: any;\n}\n"
-        .into();
-    let actual = sanitize_fast_check_source_for_tsc(source.clone());
+      "@Inject(\"jwt\")\n  readonly options?: any;\n".into();
+    let actual = strip_invalid_fast_check_decorators(source.clone());
     assert!(Arc::ptr_eq(&actual, &source));
   }
 }
@@ -1270,7 +1242,7 @@ pub fn load_for_tsc<T: LoadContent, M: Mapper>(
             module
               .fast_check_module()
               .map(|m| {
-                T::from_arc_str(sanitize_fast_check_source_for_tsc(
+                T::from_arc_str(strip_invalid_fast_check_decorators(
                   m.source.clone(),
                 ))
               })

--- a/cli/type_checker.rs
+++ b/cli/type_checker.rs
@@ -36,6 +36,7 @@ use crate::args::TypeCheckMode;
 use crate::cache::CacheDBHash;
 use crate::cache::Caches;
 use crate::cache::TypeCheckCache;
+use crate::fast_check::strip_decorators_arc;
 use crate::graph_util::BuildFastCheckGraphOptions;
 use crate::graph_util::ModuleGraphBuilder;
 use crate::graph_util::module_error_for_tsc_diagnostic;
@@ -1047,11 +1048,14 @@ impl<'a> GraphWalker<'a> {
           && let Some(hasher) = &mut self.maybe_hasher
         {
           hasher.write_str(module.specifier.as_str());
+          let source_text = module
+            .fast_check_module()
+            .map(|s| strip_decorators_arc(&s.source));
           hasher.write_str(
             // the fast check module will only be set when publishing
-            module
-              .fast_check_module()
-              .map(|s| s.source.as_ref())
+            source_text
+              .as_ref()
+              .map(|s| s.as_ref())
               .unwrap_or(&module.source.text),
           );
         }

--- a/tests/specs/publish/decorated_private_field/__test__.jsonc
+++ b/tests/specs/publish/decorated_private_field/__test__.jsonc
@@ -1,4 +1,5 @@
 {
+  "tempDir": true,
   "args": "publish --token 'sadfasdf' --dry-run",
   "output": "publish.out"
 }

--- a/tests/specs/publish/decorated_private_field/__test__.jsonc
+++ b/tests/specs/publish/decorated_private_field/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "publish --token 'sadfasdf' --dry-run",
+  "output": "publish.out"
+}

--- a/tests/specs/publish/decorated_private_field/deno.json
+++ b/tests/specs/publish/decorated_private_field/deno.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/decorators",
+  "version": "1.0.0",
+  "exports": "./mod.ts"
+}

--- a/tests/specs/publish/decorated_private_field/deno.json
+++ b/tests/specs/publish/decorated_private_field/deno.json
@@ -1,5 +1,6 @@
 {
   "name": "@example/decorators",
   "version": "1.0.0",
+  "license": "MIT",
   "exports": "./mod.ts"
 }

--- a/tests/specs/publish/decorated_private_field/mod.ts
+++ b/tests/specs/publish/decorated_private_field/mod.ts
@@ -1,0 +1,8 @@
+function Inject(_token: string) {
+  return (_value: undefined, _context: ClassFieldDecoratorContext) => {};
+}
+
+export class Auth {
+  @Inject("jwt")
+  private readonly options?: { issuer: string };
+}

--- a/tests/specs/publish/decorated_private_field/publish.out
+++ b/tests/specs/publish/decorated_private_field/publish.out
@@ -2,6 +2,6 @@ Check [WILDCARD]mod.ts
 Checking for slow types in the public API...
 Check [WILDCARD]mod.ts
 Simulating publish of @example/decorators@1.0.0 with files:
-   [WILDCARD]deno.json (83B)
+   [WILDCARD]deno.json (103B)
    [WILDCARD]mod.ts (199B)
 Success Dry run complete

--- a/tests/specs/publish/decorated_private_field/publish.out
+++ b/tests/specs/publish/decorated_private_field/publish.out
@@ -1,0 +1,7 @@
+Check [WILDCARD]mod.ts
+Checking for slow types in the public API...
+Check [WILDCARD]mod.ts
+Simulating publish of @example/decorators@1.0.0 with files:
+   [WILDCARD]deno.json (83B)
+   [WILDCARD]mod.ts (199B)
+Success Dry run complete


### PR DESCRIPTION
Closes bartlomieju/orchid-inbox#102
Fixes denoland/deno#33753

Summary:
- Strip decorator lines from fast-check declaration output before publish and type-check consumers use it.
- Keep the change scoped to generated fast-check text so valid source files are untouched.
- Add `tempDir: true` to the publish regression fixture so the dry-run only sees package files, not the spec harness files.
- Keep `deno_graph` on the registry release because the git rev breaks `cli/tools/doc.rs` against the current `deno_doc` dependency.

Verification:
- `cargo test --manifest-path tests/specs/Cargo.toml --test specs -- decorated_private_field`
- `git diff --check`