### PR TITLE
test: mark flaky test-process-exit-code-validation

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -2844,7 +2844,9 @@
     "parallel/test-process-exception-capture.js": {},
     "parallel/test-process-execve-no-args.js": {},
     "parallel/test-process-execve-worker-threads.js": {},
-    "parallel/test-process-exit-code-validation.js": {},
+    "parallel/test-process-exit-code-validation.js": {
+      "flaky": true
+    },
     "parallel/test-process-exit-from-before-exit.js": {},
     "parallel/test-process-exit-handler.js": {},
     "parallel/test-process-exit-recursive.js": {},


### PR DESCRIPTION
Marks `parallel/test-process-exit-code-validation.js` as flaky after it timed out after 20000ms on main CI: https://github.com/denoland/deno/actions/runs/25936726631/job/76250878372

A later main CI run passed, so this appears intermittent. Tracking issue: #34123

@bartlomieju this is ready to merge