### PR TITLE
test: disable flaky wpt fetch abort general

### DIFF
--- a/tests/wpt/runner/expectations/fetch.json
+++ b/tests/wpt/runner/expectations/fetch.json
@@ -1473,7 +1473,9 @@
       "request.any.html": true,
       "request.any.worker.html": true,
       "general.any.html": true,
-      "general.any.worker.html": true,
+      "general.any.worker.html": {
+        "ignore": true
+      },
       "cache.https.any.html": false,
       "cache.https.any.worker.html": false,
       "destroyed-context.html": false,


### PR DESCRIPTION
Disables flaky WPT `/fetch/api/abort/general.any.worker.html` after main CI failed in subtest `Underlying connection is closed when aborting after receiving response - no-cors`.

Main CI failure: https://github.com/denoland/deno/actions/runs/25970496921
Tracking issue: #34126

This is a timing-dependent WPT fetch abort failure in the worker path; disabling it keeps main green while the underlying flake is tracked.