### PR TITLE
fix(node): deduplicate MessagePort message listeners

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -1715,6 +1715,12 @@ function webMessagePortToNodeMessagePort(port: MessagePort) {
     }
     return this;
   };
+  port.listenerCount = function (name) {
+    const map = portListeners[name as "message" | "messageerror" | "close"] as
+      | typeof portListeners.message
+      | undefined;
+    return map?.size ?? 0;
+  };
   port[nodeWorkerThreadCloseCb] = () => {
     port.dispatchEvent(new Event("close"));
   };

--- a/tests/unit_node/worker_threads_test.ts
+++ b/tests/unit_node/worker_threads_test.ts
@@ -592,19 +592,24 @@ Deno.test({
     port1.on("message", onMessage);
     port1.on("message", onMessage);
     port1.on("message", onMessage);
+    assertEquals(port1.listenerCount("message"), 1);
 
     const first = Promise.withResolvers<void>();
-    port1.on("message", () => first.resolve());
+    port1.once("message", () => first.resolve());
+    assertEquals(port1.listenerCount("message"), 2);
     port2.postMessage("hi");
     await first.promise;
     assertEquals(output, ["hi"]);
+    assertEquals(port1.listenerCount("message"), 1);
 
     port1.off("message", onMessage);
+    assertEquals(port1.listenerCount("message"), 0);
     const second = Promise.withResolvers<void>();
-    port1.on("message", () => second.resolve());
+    port1.once("message", () => second.resolve());
     port2.postMessage("again");
     await second.promise;
     assertEquals(output, ["hi"]);
+    assertEquals(port1.listenerCount("message"), 0);
 
     port1.close();
     port2.close();


### PR DESCRIPTION
Fixes denoland/deno#33373
Closes bartlomieju/orchid-inbox#104

This updates the worker_threads MessagePort wrapper bookkeeping so repeated on("message", sameFn) calls keep a single effective registration and listenerCount("message") reflects the deduplicated listener map. off("message", sameFn) removes the installed wrapper, leaving no stale duplicate delivery path.

Tests:
- ./x fmt --check ext/node/polyfills/worker_threads.ts tests/unit_node/worker_threads_test.ts
- ./x test-node "MessagePort.on deduplicates listeners"
- ./x lint-js

AI tools were used to help prepare this contribution.