### PR TITLE
chore: update sys_traits to 0.1.28 and unpin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10507,9 +10507,9 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a79feaa49de4a6c8191bdbd5fb3eada50671e9367d874d1c12e3d36db131414"
+checksum = "88826d6169418c98e8bc52a43f79d50907dfa3e87ba5161930d42c6f980b35ee"
 dependencies = [
  "filetime",
  "getrandom 0.2.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ sourcemap = "9.1.2"
 static_assertions = "1"
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
-sys_traits = "=0.1.27"
+sys_traits = "0.1.28"
 tar = "=0.4.45"
 tempfile = "3.4.0"
 termcolor = "1.1.3"


### PR DESCRIPTION
* https://github.com/dsherret/sys_traits/pull/81

I'm updating dprint to use deno_npmrc.