### PR TITLE
fix(watch): keep watcher alive when exit runs on restart

### DIFF
--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -24,6 +24,7 @@ use deno_runtime::coverage::CoverageCollector;
 use deno_runtime::cpu_prof_filename;
 use deno_runtime::cpu_profiler::CpuProfiler;
 use deno_runtime::deno_os::OpExitCallbacks;
+use deno_runtime::deno_os::OpExitInterceptor;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_runtime::worker::MainWorker;
 use deno_semver::npm::NpmPackageReqReference;
@@ -197,14 +198,29 @@ impl CliMainWorker {
     struct FileWatcherModuleExecutor {
       inner: CliMainWorker,
       pending_unload: bool,
+      exit_interceptor: OpExitInterceptor,
     }
 
     impl FileWatcherModuleExecutor {
-      pub fn new(worker: CliMainWorker) -> FileWatcherModuleExecutor {
+      pub fn new(mut worker: CliMainWorker) -> FileWatcherModuleExecutor {
+        let handle =
+          worker.worker.js_runtime().v8_isolate().thread_safe_handle();
+        let exit_interceptor = OpExitInterceptor::new(handle);
+        worker
+          .worker
+          .js_runtime()
+          .op_state()
+          .borrow_mut()
+          .put(exit_interceptor.clone());
         FileWatcherModuleExecutor {
           inner: worker,
           pending_unload: false,
+          exit_interceptor,
         }
+      }
+
+      fn did_intercept_exit(&self) -> bool {
+        self.exit_interceptor.did_intercept()
       }
 
       /// Execute the given main module emitting load and unload events before and after execution
@@ -217,6 +233,9 @@ impl CliMainWorker {
         self.pending_unload = true;
         if let Err(e) = self.inner.execute_main_module().await {
           self.pending_unload = false;
+          if self.did_intercept_exit() {
+            return Ok(());
+          }
           return Err(e);
         }
         self.inner.worker.dispatch_load_event()?;
@@ -224,7 +243,12 @@ impl CliMainWorker {
         let result = loop {
           match self.inner.worker.run_event_loop(false).await {
             Ok(()) => {}
-            Err(error) => break Err(error),
+            Err(error) => {
+              if self.did_intercept_exit() {
+                break Ok(());
+              }
+              break Err(error);
+            }
           }
           let web_continue = self.inner.worker.dispatch_beforeunload_event()?;
           if !web_continue {
@@ -238,6 +262,10 @@ impl CliMainWorker {
         self.pending_unload = false;
 
         result?;
+
+        if self.did_intercept_exit() {
+          return Ok(());
+        }
 
         self.inner.worker.dispatch_unload_event()?;
         self.inner.worker.dispatch_process_exit_event()?;

--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -6,6 +6,7 @@ use std::env;
 use std::ffi::OsString;
 use std::ops::ControlFlow;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
 
@@ -48,6 +49,30 @@ pub fn exit(code: i32) -> ! {
     reason = "exit is the intended behavior"
   )]
   std::process::exit(code);
+}
+
+#[derive(Clone)]
+pub struct OpExitInterceptor {
+  handle: v8::IsolateHandle,
+  did_intercept: Arc<AtomicBool>,
+}
+
+impl OpExitInterceptor {
+  pub fn new(handle: v8::IsolateHandle) -> Self {
+    Self {
+      handle,
+      did_intercept: Arc::new(AtomicBool::new(false)),
+    }
+  }
+
+  pub fn did_intercept(&self) -> bool {
+    self.did_intercept.load(Ordering::Relaxed)
+  }
+
+  fn intercept(&self) {
+    self.did_intercept.store(true, Ordering::Relaxed);
+    self.handle.terminate_execution();
+  }
 }
 
 /// Callbacks to run before the process exits via `Deno.exit()`.
@@ -350,6 +375,10 @@ fn op_exit(state: &mut OpState) {
     cbs.run();
   }
   if let Some(exit_code) = state.try_borrow::<ExitCode>() {
+    if let Some(interceptor) = state.try_borrow::<OpExitInterceptor>() {
+      interceptor.intercept();
+      return;
+    }
     exit(exit_code.get())
   }
 }

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -1530,6 +1530,66 @@ async fn run_watch_sigterm_on_restart() {
   check_alive_then_kill(child);
 }
 
+async fn run_watch_sigterm_exit_on_restart(exit_call: &str) {
+  let t = TempDir::new();
+  let file_to_watch = t.path().join("file_to_watch.js");
+  file_to_watch.write(format!(
+    r#"
+      import process from "node:process";
+      Deno.addSignalListener("SIGTERM", () => {{
+        console.log("received SIGTERM");
+        {exit_call};
+      }});
+      setInterval(() => {{}}, 1000);
+    "#
+  ));
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch")
+    .arg("-L")
+    .arg("debug")
+    .arg("--allow-all")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+
+  file_to_watch.write(format!(
+    r#"
+      import process from "node:process";
+      Deno.addSignalListener("SIGTERM", () => {{
+        console.log("received SIGTERM");
+        {exit_call};
+      }});
+      setInterval(() => {{}}, 1000);
+      // changed
+    "#
+  ));
+
+  wait_contains("received SIGTERM", &mut stdout_lines).await;
+  wait_contains("Restarting", &mut stderr_lines).await;
+  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+  check_alive_then_kill(child);
+}
+
+/// Test that Deno.exit() in a SIGTERM handler does not exit watch mode.
+#[test(flaky)]
+async fn run_watch_sigterm_deno_exit_on_restart() {
+  run_watch_sigterm_exit_on_restart("Deno.exit(0)").await;
+}
+
+/// Test that process.exit() in a SIGTERM handler does not exit watch mode.
+#[test(flaky)]
+async fn run_watch_sigterm_process_exit_on_restart() {
+  run_watch_sigterm_exit_on_restart("process.exit(0)").await;
+}
+
 /// Test that both SIGINT and SIGTERM are dispatched on Ctrl+C in watch mode.
 #[cfg(unix)]
 #[test(flaky)]


### PR DESCRIPTION
Fixes denoland/deno#33043.

This adds a watch-only native exit interceptor for `Deno.exit()` and `process.exit()`. In watch mode, the interceptor terminates the current isolate execution instead of calling `std::process::exit()`, so a synthetic restart `SIGTERM` can finish the current run without killing the outer watcher process.

The watcher worker treats an intercepted exit as a clean end of the current operation and continues with restart handling. Normal non-watch exit behavior still goes through `std::process::exit()`.

Tests:
- `cargo test -p deno --test integration run_watch_sigterm --no-run`
- `cargo test -p integration_tests --test integration run_watch_sigterm_deno_exit_on_restart`
- `cargo test -p integration_tests --test integration run_watch_sigterm_process_exit_on_restart`
- `cargo test -p integration_tests --test integration run_watch_sigterm_on_restart`

Closes bartlomieju/orchid-inbox#116