### PR TITLE
test: disable flaky wpt websocket close

### DIFF
--- a/tests/wpt/runner/expectations/websockets.json
+++ b/tests/wpt/runner/expectations/websockets.json
@@ -490,7 +490,8 @@
       "close.any.html?default": {
         "expectedFailures": [
           "incomplete closing handshake should be considered unclean close"
-        ]
+        ],
+        "flaky": true
       },
       "close.any.worker.html?default": {
         "expectedFailures": [


### PR DESCRIPTION
Run https://github.com/denoland/deno/actions/runs/25972858887 failed on main because /websockets/stream/tentative/close.any.html?default unexpectedly passed the expected failure "incomplete closing handshake should be considered unclean close". A newer main run, https://github.com/denoland/deno/actions/runs/25972873163, passed, so mark the expectation flaky.\n\nFixes #34145\n\n@bartlomieju this is ready to merge