### PR TITLE
fix(doc): resolve npm entrypoints without types

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -40,6 +40,7 @@ use deno_resolver::deno_json::ToMaybeJsxImportSourceConfigError;
 use deno_resolver::file_fetcher::GraphLoaderReporterRc;
 use deno_resolver::graph::EnhanceGraphErrorMode;
 use deno_resolver::graph::EnhancedGraphError;
+use deno_resolver::graph::NpmTypesResolutionMode;
 use deno_resolver::graph::enhance_graph_error;
 use deno_resolver::graph::enhanced_integrity_error_message;
 use deno_resolver::graph::format_deno_graph_error;
@@ -819,6 +820,7 @@ impl ModuleGraphBuilder {
       self.cjs_tracker.as_ref(),
       &jsx_import_source_config_resolver,
       None,
+      NpmTypesResolutionMode::Strict,
     );
     let maybe_reporter = self.maybe_reporter.as_deref();
     let mut locker = self.lockfile.as_ref().map(|l| l.as_deno_graph_locker());
@@ -871,6 +873,7 @@ impl ModuleGraphBuilder {
           self.cjs_tracker.as_ref(),
           &jsx_import_source_config_resolver,
           Some(&cloned_graph),
+          NpmTypesResolutionMode::FallbackToExecution,
         );
 
         graph
@@ -1008,6 +1011,7 @@ impl ModuleGraphBuilder {
       self.cjs_tracker.as_ref(),
       &jsx_import_source_config_resolver,
       None,
+      NpmTypesResolutionMode::Strict,
     );
 
     graph.build_fast_check_type_graph(

--- a/libs/resolver/graph.rs
+++ b/libs/resolver/graph.rs
@@ -24,6 +24,7 @@ use node_resolver::InNpmPackageChecker;
 use node_resolver::IsBuiltInNodeModuleChecker;
 use node_resolver::NpmPackageFolderResolver;
 use node_resolver::UrlOrPath;
+use node_resolver::errors::NodeJsErrorCode;
 use node_resolver::errors::NodeJsErrorCoded;
 use url::Url;
 
@@ -170,6 +171,12 @@ pub struct ResolveWithGraphOptions {
   /// the loader can properly dynamic import and install npm packages
   /// when managed.
   pub maintain_npm_specifiers: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NpmTypesResolutionMode {
+  Strict,
+  FallbackToExecution,
 }
 
 pub type DefaultDenoResolverRc<TSys> = DenoResolverRc<
@@ -442,6 +449,7 @@ impl<
     cjs_tracker: &'a CjsTracker<TInNpmPackageChecker, TSys>,
     jsx_import_source_config_resolver: &'a JsxImportSourceConfigResolver,
     maybe_graph: Option<&'a deno_graph::ModuleGraph>,
+    npm_types_resolution_mode: NpmTypesResolutionMode,
   ) -> DenoGraphResolverAdapter<
     'a,
     TInNpmPackageChecker,
@@ -454,6 +462,7 @@ impl<
       resolver: self,
       jsx_import_source_config_resolver,
       maybe_graph,
+      npm_types_resolution_mode,
     }
   }
 }
@@ -474,6 +483,7 @@ pub struct DenoGraphResolverAdapter<
   >,
   jsx_import_source_config_resolver: &'a JsxImportSourceConfigResolver,
   maybe_graph: Option<&'a deno_graph::ModuleGraph>,
+  npm_types_resolution_mode: NpmTypesResolutionMode,
 }
 
 impl<
@@ -547,21 +557,18 @@ impl<
       });
     let node_resolution_kind =
       node_resolver::NodeResolutionKind::from_deno_graph(resolution_kind);
-    match self.maybe_graph {
-      Some(graph) => self
-        .resolver
-        .resolve_with_graph(
-          graph,
-          raw_specifier,
-          &referrer_range.specifier,
-          referrer_range.range.start,
-          ResolveWithGraphOptions {
-            mode: resolution_mode,
-            kind: node_resolution_kind,
-            maintain_npm_specifiers: false,
-          },
-        )
-        .map_err(|err| err.into_deno_graph_error()),
+    let resolve = |kind| match self.maybe_graph {
+      Some(graph) => self.resolver.resolve_with_graph(
+        graph,
+        raw_specifier,
+        &referrer_range.specifier,
+        referrer_range.range.start,
+        ResolveWithGraphOptions {
+          mode: resolution_mode,
+          kind,
+          maintain_npm_specifiers: false,
+        },
+      ),
       None => self
         .resolver
         .resolve(
@@ -569,9 +576,41 @@ impl<
           &referrer_range.specifier,
           referrer_range.range.start,
           resolution_mode,
-          node_resolution_kind,
+          kind,
         )
-        .map_err(|err| err.into_deno_graph_error()),
+        .map_err(|err| err.into()),
+    };
+
+    let result = resolve(node_resolution_kind);
+    if node_resolution_kind == node_resolver::NodeResolutionKind::Types
+      && self.npm_types_resolution_mode
+        == NpmTypesResolutionMode::FallbackToExecution
+      && result
+        .as_ref()
+        .is_err_and(|err| err.is_types_not_found_for_npm_resolution())
+    {
+      return resolve(node_resolver::NodeResolutionKind::Execution)
+        .map_err(|err| err.into_deno_graph_error());
+    }
+
+    result.map_err(|err| err.into_deno_graph_error())
+  }
+}
+
+impl ResolveWithGraphError {
+  fn is_types_not_found_for_npm_resolution(&self) -> bool {
+    match self.as_kind() {
+      ResolveWithGraphErrorKind::CouldNotResolveNpmReqRef(err) => {
+        err.source.code() == NodeJsErrorCode::ERR_TYPES_NOT_FOUND
+      }
+      ResolveWithGraphErrorKind::ResolveNpmReqRef(err) => {
+        err.err.as_kind().maybe_code()
+          == Some(NodeJsErrorCode::ERR_TYPES_NOT_FOUND)
+      }
+      ResolveWithGraphErrorKind::Resolve(err) => {
+        err.maybe_node_code() == Some(NodeJsErrorCode::ERR_TYPES_NOT_FOUND)
+      }
+      _ => false,
     }
   }
 }

--- a/tests/specs/doc/npm_entrypoint_without_types/__test__.jsonc
+++ b/tests/specs/doc/npm_entrypoint_without_types/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "doc --json main.ts",
+  "output": "doc.out"
+}

--- a/tests/specs/doc/npm_entrypoint_without_types/doc.out
+++ b/tests/specs/doc/npm_entrypoint_without_types/doc.out
@@ -1,0 +1,19 @@
+Download http://localhost:4260/debug
+Download http://localhost:4260/ms
+Download http://localhost:4260/debug/debug-4.3.5.tgz
+Download http://localhost:4260/ms/ms-2.1.2.tgz
+{
+  "version": 2,
+  "nodes": {
+    "[WILDLINE]/main.ts": {
+      "imports": [
+        {
+          "importedName": "Debug",
+          "originalName": "default",
+          "src": "[WILDLINE]/debug/4.3.5/src/index.js"
+        }
+      ],
+      "symbols": []
+    }
+  }
+}

--- a/tests/specs/doc/npm_entrypoint_without_types/main.ts
+++ b/tests/specs/doc/npm_entrypoint_without_types/main.ts
@@ -1,0 +1,4 @@
+import Debug from "npm:debug@4.3.5";
+
+const debug = Debug("bug-report");
+debug("hi");


### PR DESCRIPTION
Fixes denoland/deno#33033.

Updates the doc npm graph expansion so a types-only npm resolution that
reports missing declaration files can fall back to the package execution
entrypoint. The fallback is only enabled for the npm source analysis path
used by `deno doc`, so normal type checking keeps strict types resolution.

The regression covers a package root whose `package.json` `main` points at
`src/index.js` and has no bundled declarations. The resolved doc import now
points at the package main entrypoint instead of reporting
`debug/<version>/index.js`.

Verification:
- `cargo fmt --check`
- `cargo check -p deno_resolver --all-features`
- `cargo test -p specs_tests specs::doc::npm_entrypoint_without_types -- --no-capture`
- `./target/debug/deno doc --json main.ts` with `npm:debug@4.4.0`

AI assistance disclosure: implemented with help from OpenAI Codex.