### PR TITLE
fix(lsp): keep Node fetch out of Deno globals

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -5273,7 +5273,7 @@ fn op_project_version(state: &mut OpState) -> usize {
 #[op2]
 #[serde]
 fn op_tsc_constants() -> crate::tsc::TscConstants {
-  crate::tsc::TscConstants::new()
+  crate::tsc::TscConstants::new_for_lsp()
 }
 
 struct TscRuntime {

--- a/cli/tsc/js.rs
+++ b/cli/tsc/js.rs
@@ -83,6 +83,12 @@ impl TscConstants {
         .collect(),
     }
   }
+
+  pub fn new_for_lsp() -> Self {
+    let mut constants = Self::new();
+    constants.node_only_globals.push("fetch");
+    constants
+  }
 }
 
 #[op2]

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -17528,6 +17528,25 @@ fn lsp_tsconfig_node_modules_dts_diagnostics() {
 }
 
 #[test(timeout = 300)]
+fn lsp_fetch_request_init_uses_deno_global() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write("deno.json", json!({}).to_string());
+  let file = temp_dir.source_file(
+    "main.ts",
+    r#"
+      const init: Parameters<typeof fetch>[1] = {};
+      new Request("https://deno.com", init);
+    "#,
+  );
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  let diagnostics = client.did_open_file(&file);
+  assert_eq!(json!(diagnostics.all()), json!([]));
+  client.shutdown();
+}
+
+#[test(timeout = 300)]
 fn lsp_tsconfig_root_dirs() {
   let context = TestContextBuilder::new()
     .use_http_server()


### PR DESCRIPTION
Fixes denoland/deno#33012.\n\nThis routes the built-in Node fetch declaration into the Node-only global table with RequestInit and ResponseInit, so Deno source files keep using Deno's fetch parameter type while Node package files still see the Node globals through the combined Node table.\n\nAdds an LSP regression for:\n\n```ts\nconst init: Parameters<typeof fetch>[1] = {};\nconst _ = new Request("https://deno.com", init);\n```\n\nValidation:\n- cargo fmt --check\n- git diff --check\n- cargo test -p deno --test integration lsp::lsp_fetch_request_init_uses_deno_global, attempted but the VM ran out of disk while compiling the deno crate\n\nAI disclosure: This PR was prepared with assistance from OpenAI Codex.\n\nCloses bartlomieju/orchid-inbox#118