### PR TITLE
fix(ops): use supported fast isolate access

### DIFF
--- a/libs/ops/op2/dispatch_fast.rs
+++ b/libs/ops/op2/dispatch_fast.rs
@@ -753,15 +753,14 @@ fn map_v8_fastcall_arg_to_arg(
     Arg::Ref(RefType::Ref, Special::Isolate) => {
       *needs_fast_api_callback_options = true;
       gs_quote!(generator_state(fast_api_callback_options) => {
-        let #arg_ident = unsafe { deno_core::v8::Isolate::from_raw_isolate_ptr(#fast_api_callback_options.isolate) };
-        let #arg_ident = &#arg_ident;
+        let #arg_ident = unsafe { #fast_api_callback_options.isolate_unchecked_mut() };
+        let #arg_ident = &*#arg_ident;
       })
     }
     Arg::Ref(RefType::Mut, Special::Isolate) => {
       *needs_fast_api_callback_options = true;
       gs_quote!(generator_state(fast_api_callback_options) => {
-        let mut #arg_ident = unsafe { deno_core::v8::Isolate::from_raw_isolate_ptr(#fast_api_callback_options.isolate) };
-        let #arg_ident = &mut #arg_ident;
+        let #arg_ident = unsafe { #fast_api_callback_options.isolate_unchecked_mut() };
       })
     }
     Arg::Ref(RefType::Ref, Special::OpState) => {

--- a/libs/ops/op2/test_cases/sync/fast_isolate.out
+++ b/libs/ops/op2/test_cases/sync/fast_isolate.out
@@ -1,0 +1,559 @@
+#[allow(non_camel_case_types)]
+const fn op_isolate_ref() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_isolate_ref {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_isolate_ref {
+        const NAME: &'static str = stringify!(op_isolate_ref);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_isolate_ref),
+            false,
+            false,
+            false,
+            1usize as u8,
+            false,
+            Self::v8_fn_ptr as _,
+            Self::slow_function_impl,
+            ::deno_core::AccessorType::None,
+            Some({
+                use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
+                deno_core::v8::fast_api::CFunction::new(
+                    Self::v8_fn_ptr_fast as _,
+                    &deno_core::v8::fast_api::CFunctionInfo::new(
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
+                        deno_core::v8::fast_api::Int64Representation::BigInt,
+                    ),
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
+                deno_core::v8::fast_api::CFunction::new(
+                    Self::v8_fn_ptr_fast_metrics as _,
+                    &deno_core::v8::fast_api::CFunctionInfo::new(
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
+                        deno_core::v8::fast_api::Int64Representation::BigInt,
+                    ),
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_isolate_ref {
+        pub const fn name() -> &'static str {
+            <Self as deno_core::_ops::Op>::NAME
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
+        ) -> () {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast_unchecked(unsafe { fast_api_callback_options.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast<'s>(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let result = {
+                let arg0 = unsafe { fast_api_callback_options.isolate_unchecked_mut() };
+                let arg0 = &*arg0;
+                Self::call(arg0)
+            };
+            result as _
+        }
+        fn slow_function_impl<'s>(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            let info: &'s _ = unsafe { &*info };
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast_unchecked(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let arg0 = unsafe {
+                    deno_core::v8::Isolate::from_raw_isolate_ptr(opctx.isolate)
+                };
+                let arg0 = &arg0;
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+    }
+    impl op_isolate_ref {
+        #[allow(clippy::too_many_arguments)]
+        fn call(_isolate: &v8::Isolate) {}
+    }
+    <op_isolate_ref as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
+const fn op_isolate_mut() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_isolate_mut {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_isolate_mut {
+        const NAME: &'static str = stringify!(op_isolate_mut);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_isolate_mut),
+            false,
+            false,
+            false,
+            1usize as u8,
+            false,
+            Self::v8_fn_ptr as _,
+            Self::slow_function_impl,
+            ::deno_core::AccessorType::None,
+            Some({
+                use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
+                deno_core::v8::fast_api::CFunction::new(
+                    Self::v8_fn_ptr_fast as _,
+                    &deno_core::v8::fast_api::CFunctionInfo::new(
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
+                        deno_core::v8::fast_api::Int64Representation::BigInt,
+                    ),
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
+                deno_core::v8::fast_api::CFunction::new(
+                    Self::v8_fn_ptr_fast_metrics as _,
+                    &deno_core::v8::fast_api::CFunctionInfo::new(
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
+                        deno_core::v8::fast_api::Int64Representation::BigInt,
+                    ),
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_isolate_mut {
+        pub const fn name() -> &'static str {
+            <Self as deno_core::_ops::Op>::NAME
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
+        ) -> () {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast_unchecked(unsafe { fast_api_callback_options.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast<'s>(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let result = {
+                let arg0 = unsafe { fast_api_callback_options.isolate_unchecked_mut() };
+                Self::call(arg0)
+            };
+            result as _
+        }
+        fn slow_function_impl<'s>(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            let info: &'s _ = unsafe { &*info };
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast_unchecked(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let mut arg0 = unsafe {
+                    deno_core::v8::Isolate::from_raw_isolate_ptr(opctx.isolate)
+                };
+                let arg0 = &mut arg0;
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+    }
+    impl op_isolate_mut {
+        #[allow(clippy::too_many_arguments)]
+        fn call(_isolate: &mut v8::Isolate) {}
+    }
+    <op_isolate_mut as ::deno_core::_ops::Op>::DECL
+}
+
+impl Foo {
+    pub const DECL: deno_core::_ops::OpMethodDecl = deno_core::_ops::OpMethodDecl {
+        methods: &[Foo::doubleValue()],
+        static_methods: &[],
+        constructor: Some(Foo::new()),
+        name: ::deno_core::__op_name_fast!(Foo),
+        type_name: || std::any::type_name::<Foo>(),
+        inherits_type_name: || None,
+    };
+    #[allow(non_camel_case_types)]
+    const fn new() -> ::deno_core::_ops::OpDecl {
+        #[allow(non_camel_case_types)]
+        struct new {
+            _unconstructable: ::std::marker::PhantomData<()>,
+        }
+        impl ::deno_core::_ops::Op for new {
+            const NAME: &'static str = stringify!(new);
+            const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+                ::deno_core::__op_name_fast!(new),
+                false,
+                false,
+                false,
+                1usize as u8,
+                false,
+                Self::v8_fn_ptr as _,
+                Self::slow_function_impl,
+                ::deno_core::AccessorType::None,
+                None,
+                None,
+                ::deno_core::OpMetadata {
+                    ..::deno_core::OpMetadata::default()
+                },
+            );
+        }
+        impl new {
+            pub const fn name() -> &'static str {
+                <Self as deno_core::_ops::Op>::NAME
+            }
+            fn slow_function_impl<'s>(
+                info: *const deno_core::v8::FunctionCallbackInfo,
+            ) -> usize {
+                let info: &'s _ = unsafe { &*info };
+                #[cfg(debug_assertions)]
+                let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                    &<Self as deno_core::_ops::Op>::DECL,
+                );
+                let scope = ::std::pin::pin!(
+                    unsafe { deno_core::v8::CallbackScope::new(info) }
+                );
+                let mut scope = scope.init();
+                let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(
+                    info,
+                );
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                    info,
+                );
+                let result = {
+                    let arg0 = args.get(0usize as i32);
+                    let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                        deno_core::_ops::throw_error_one_byte_info(
+                            &info,
+                            "expected u32",
+                        );
+                        return 1;
+                    };
+                    let arg0 = arg0 as _;
+                    Self::call(arg0)
+                };
+                rv.set(
+                    deno_core::_ops::RustToV8::to_v8(
+                        Some(
+                            deno_core::cppgc::wrap_object(
+                                &mut scope,
+                                args.this(),
+                                result,
+                            ),
+                        ),
+                        &mut scope,
+                    ),
+                );
+                return 0;
+            }
+            extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+                Self::slow_function_impl(info);
+            }
+        }
+        impl new {
+            #[allow(clippy::too_many_arguments)]
+            fn call(value: u32) -> Foo {
+                Foo { value: Cell::new(value) }
+            }
+        }
+        <new as ::deno_core::_ops::Op>::DECL
+    }
+    #[allow(non_camel_case_types)]
+    const fn doubleValue() -> ::deno_core::_ops::OpDecl {
+        #[allow(non_camel_case_types)]
+        struct doubleValue {
+            _unconstructable: ::std::marker::PhantomData<()>,
+        }
+        impl ::deno_core::_ops::Op for doubleValue {
+            const NAME: &'static str = stringify!(doubleValue);
+            const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+                ::deno_core::__op_name_fast!(doubleValue),
+                false,
+                false,
+                false,
+                1usize as u8,
+                false,
+                Self::v8_fn_ptr as _,
+                Self::slow_function_impl,
+                ::deno_core::AccessorType::None,
+                Some({
+                    use deno_core::v8::fast_api::Type as CType;
+                    use deno_core::v8;
+                    deno_core::v8::fast_api::CFunction::new(
+                        Self::v8_fn_ptr_fast as _,
+                        &deno_core::v8::fast_api::CFunctionInfo::new(
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::Flags::empty(),
+                            ),
+                            &[
+                                CType::V8Value.as_info(),
+                                CType::CallbackOptions.as_info(),
+                            ],
+                            deno_core::v8::fast_api::Int64Representation::BigInt,
+                        ),
+                    )
+                }),
+                Some({
+                    use deno_core::v8::fast_api::Type as CType;
+                    use deno_core::v8;
+                    deno_core::v8::fast_api::CFunction::new(
+                        Self::v8_fn_ptr_fast_metrics as _,
+                        &deno_core::v8::fast_api::CFunctionInfo::new(
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::Flags::empty(),
+                            ),
+                            &[
+                                CType::V8Value.as_info(),
+                                CType::CallbackOptions.as_info(),
+                            ],
+                            deno_core::v8::fast_api::Int64Representation::BigInt,
+                        ),
+                    )
+                }),
+                ::deno_core::OpMetadata {
+                    ..::deno_core::OpMetadata::default()
+                },
+            );
+        }
+        impl doubleValue {
+            pub const fn name() -> &'static str {
+                <Self as deno_core::_ops::Op>::NAME
+            }
+            #[allow(clippy::too_many_arguments)]
+            extern "C" fn v8_fn_ptr_fast_metrics<'s>(
+                this: deno_core::v8::Local<deno_core::v8::Object>,
+                fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                    's,
+                >,
+            ) -> u32 {
+                let fast_api_callback_options: &'s mut _ = unsafe {
+                    &mut *fast_api_callback_options
+                };
+                let opctx: &'s _ = unsafe {
+                    &*(deno_core::v8::Local::<
+                        deno_core::v8::External,
+                    >::cast_unchecked(unsafe { fast_api_callback_options.data })
+                        .value() as *const deno_core::_ops::OpCtx)
+                };
+                deno_core::_ops::dispatch_metrics_fast(
+                    opctx,
+                    deno_core::_ops::OpMetricsEvent::Dispatched,
+                );
+                let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+                deno_core::_ops::dispatch_metrics_fast(
+                    opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+                res
+            }
+            #[allow(clippy::too_many_arguments)]
+            extern "C" fn v8_fn_ptr_fast<'s>(
+                this: deno_core::v8::Local<deno_core::v8::Object>,
+                fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                    's,
+                >,
+            ) -> u32 {
+                #[cfg(debug_assertions)]
+                let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                    &<Self as deno_core::_ops::Op>::DECL,
+                );
+                let fast_api_callback_options: &'s mut _ = unsafe {
+                    &mut *fast_api_callback_options
+                };
+                let mut scope = unsafe {
+                    fast_api_callback_options.isolate_unchecked_mut()
+                };
+                let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
+                    Foo,
+                >(&mut scope, this.into()) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected Foo",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let self_ = unsafe { self_.as_ref() };
+                let result = {
+                    let arg0 = unsafe {
+                        fast_api_callback_options.isolate_unchecked_mut()
+                    };
+                    let arg0 = &*arg0;
+                    self_.call(arg0)
+                };
+                result as _
+            }
+            fn slow_function_impl<'s>(
+                info: *const deno_core::v8::FunctionCallbackInfo,
+            ) -> usize {
+                let info: &'s _ = unsafe { &*info };
+                #[cfg(debug_assertions)]
+                let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                    &<Self as deno_core::_ops::Op>::DECL,
+                );
+                let scope = ::std::pin::pin!(
+                    unsafe { deno_core::v8::CallbackScope::new(info) }
+                );
+                let mut scope = scope.init();
+                let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(
+                    info,
+                );
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                    info,
+                );
+                let opctx: &'s _ = unsafe {
+                    &*(deno_core::v8::Local::<
+                        deno_core::v8::External,
+                    >::cast_unchecked(args.data())
+                        .value() as *const deno_core::_ops::OpCtx)
+                };
+                let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
+                    Foo,
+                >(&mut scope, args.this().into()) else {
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Foo");
+                    return 1;
+                };
+                let self_ = unsafe { self_.as_ref() };
+                let result = {
+                    let arg0 = unsafe {
+                        deno_core::v8::Isolate::from_raw_isolate_ptr(opctx.isolate)
+                    };
+                    let arg0 = &arg0;
+                    Foo::call(self_, arg0)
+                };
+                deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+                return 0;
+            }
+            extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+                Self::slow_function_impl(info);
+            }
+        }
+        trait Callable {
+            fn call(&self, _isolate: &v8::Isolate) -> u32;
+        }
+        impl Callable for Foo {
+            #[allow(clippy::too_many_arguments)]
+            fn call(&self, _isolate: &v8::Isolate) -> u32 {
+                self.value.get() * 2
+            }
+        }
+        <doubleValue as ::deno_core::_ops::Op>::DECL
+    }
+}

--- a/libs/ops/op2/test_cases/sync/fast_isolate.rs
+++ b/libs/ops/op2/test_cases/sync/fast_isolate.rs
@@ -1,0 +1,43 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#![deny(warnings)]
+deno_ops_compile_test_runner::prelude!();
+
+use std::cell::Cell;
+
+use deno_core::cppgc::GarbageCollected;
+use deno_core::v8;
+
+#[op2(fast)]
+fn op_isolate_ref(_isolate: &v8::Isolate) {}
+
+#[op2(fast)]
+fn op_isolate_mut(_isolate: &mut v8::Isolate) {}
+
+pub struct Foo {
+  value: Cell<u32>,
+}
+
+unsafe impl GarbageCollected for Foo {
+  fn trace(&self, _visitor: &mut v8::cppgc::Visitor) {}
+
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"Foo"
+  }
+}
+
+#[op2]
+impl Foo {
+  #[constructor]
+  #[cppgc]
+  fn new(value: u32) -> Foo {
+    Foo {
+      value: Cell::new(value),
+    }
+  }
+
+  #[fast]
+  fn double_value(&self, _isolate: &v8::Isolate) -> u32 {
+    self.value.get() * 2
+  }
+}


### PR DESCRIPTION
Fixes denoland/deno#32953.
Closes bartlomieju/orchid-inbox#121

## Summary

- Generate fast op isolate arguments via `FastApiCallbackOptions::isolate_unchecked_mut()` instead of reading the private `isolate` field.
- Add focused op2 sync coverage for fast `&v8::Isolate` and `&mut v8::Isolate` arguments.
- Add a README-shaped object-wrap fast method using `&v8::Isolate` so that case is covered by compile tests.

## Verification

- `UPDATE_EXPECTED=1 cargo test -p deno_ops op2::tests::test_proc_macro_sync`
- `cargo test -p deno_ops op2::tests::test_proc_macro_sync`
- `cargo test -p deno_ops_compile_test_runner op2`
- `cargo fmt --check -p deno_ops`
- `./x fmt --check` was attempted, but this checkout is missing the `tests/util/std` submodule content and failed with `Module not found "file:///home/exedev/orch/work/issue-121/tests/util/std/path/mod.ts"` before formatting project files.

## AI disclosure

This PR was implemented with assistance from OpenAI Codex.
