### PR TITLE
fix(fmt): recover from formatter panics

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -545,6 +545,29 @@ fn should_fallback_on_run_error(script_err: &str) -> bool {
   re.is_match(script_err)
 }
 
+thread_local! {
+  /// When true, the panic hook lets `catch_unwind` handle the panic instead
+  /// of exiting the process.
+  static CATCHING_UNWIND: std::cell::Cell<bool> =
+    const { std::cell::Cell::new(false) };
+}
+
+pub fn catch_unwind_with_hook<R>(
+  f: impl FnOnce() -> R + std::panic::UnwindSafe,
+) -> std::thread::Result<R> {
+  struct CatchingUnwindGuard;
+
+  impl Drop for CatchingUnwindGuard {
+    fn drop(&mut self) {
+      CATCHING_UNWIND.with(|c| c.set(false));
+    }
+  }
+
+  CATCHING_UNWIND.with(|c| c.set(true));
+  let _guard = CatchingUnwindGuard;
+  std::panic::catch_unwind(f)
+}
+
 #[allow(clippy::print_stderr, reason = "panic hook")]
 fn setup_panic_hook() {
   // This function does two things inside of the panic hook:
@@ -554,6 +577,10 @@ fn setup_panic_hook() {
   //   should be reported to us.
   let orig_hook = std::panic::take_hook();
   std::panic::set_hook(Box::new(move |panic_info| {
+    if CATCHING_UNWIND.with(|c| c.get()) {
+      return;
+    }
+
     eprintln!("\n============================================================");
     eprintln!("Deno has panicked. This is a bug in Deno. Please report this");
     eprintln!("at https://github.com/denoland/deno/issues/new.");

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -866,21 +866,13 @@ pub fn format_file(
         None
       }
     }
-    _ => {
-      let config = get_resolved_typescript_config(fmt_options);
-      dprint_plugin_typescript::format_text(
-        dprint_plugin_typescript::FormatTextOptions {
-          path: file_path,
-          extension: Some(&ext),
-          text: file.text.to_string(),
-          config: &config,
-          external_formatter: Some(&create_external_formatter_for_typescript(
-            unstable_options,
-            fmt_options,
-          )),
-        },
-      )?
-    }
+    _ => format_typescript_with_panic_recovery(
+      file_path,
+      &ext,
+      &file.text,
+      fmt_options,
+      unstable_options,
+    )?,
   };
 
   Ok(match maybe_result {
@@ -898,14 +890,69 @@ pub fn format_parsed_source(
   fmt_options: &FmtOptionsConfig,
   unstable_options: &UnstableFmtOptions,
 ) -> Result<Option<String>, AnyError> {
-  dprint_plugin_typescript::format_parsed_source(
-    parsed_source,
-    &get_resolved_typescript_config(fmt_options),
-    Some(&create_external_formatter_for_typescript(
-      unstable_options,
-      fmt_options,
-    )),
-  )
+  let config = get_resolved_typescript_config(fmt_options);
+  let external_formatter =
+    create_external_formatter_for_typescript(unstable_options, fmt_options);
+  match crate::catch_unwind_with_hook(std::panic::AssertUnwindSafe(|| {
+    dprint_plugin_typescript::format_parsed_source(
+      parsed_source,
+      &config,
+      Some(&external_formatter),
+    )
+  })) {
+    Ok(result) => result,
+    Err(payload) => {
+      log::warn!(
+        "Formatter panicked for '{}': {}, leaving unformatted",
+        parsed_source.specifier(),
+        panic_payload_message(&payload),
+      );
+      Ok(None)
+    }
+  }
+}
+
+fn format_typescript_with_panic_recovery(
+  file_path: &Path,
+  ext: &str,
+  text: &str,
+  fmt_options: &FmtOptionsConfig,
+  unstable_options: &UnstableFmtOptions,
+) -> Result<Option<String>, AnyError> {
+  let config = get_resolved_typescript_config(fmt_options);
+  let external_formatter =
+    create_external_formatter_for_typescript(unstable_options, fmt_options);
+  let file_path_owned = file_path.to_path_buf();
+  let text = text.to_string();
+  match crate::catch_unwind_with_hook(std::panic::AssertUnwindSafe(|| {
+    dprint_plugin_typescript::format_text(
+      dprint_plugin_typescript::FormatTextOptions {
+        path: &file_path_owned,
+        extension: Some(ext),
+        text,
+        config: &config,
+        external_formatter: Some(&external_formatter),
+      },
+    )
+  })) {
+    Ok(result) => result,
+    Err(payload) => {
+      log::warn!(
+        "Formatter panicked for '{}': {}, leaving unformatted",
+        file_path.display(),
+        panic_payload_message(&payload),
+      );
+      Ok(None)
+    }
+  }
+}
+
+fn panic_payload_message(payload: &Box<dyn std::any::Any + Send>) -> &str {
+  payload
+    .downcast_ref::<&str>()
+    .copied()
+    .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+    .unwrap_or("<non-string panic>")
 }
 
 #[async_trait]
@@ -2018,5 +2065,32 @@ mod test {
     .unwrap()
     .unwrap();
     assert_eq!(file_text, "let a = 1;\n",);
+  }
+
+  #[test]
+  fn test_html_tagged_template_multiline_comment_does_not_panic() {
+    // Regression test for https://github.com/denoland/deno/issues/32954
+    let result = format_file(
+      Path::new("test.ts"),
+      &FileContents {
+        had_bom: false,
+        text: r#"export default function panicRenderHTML() {
+  return html`
+    <form>
+        <!--<label
+          for="email"
+        >Email</label>-->
+      <input />
+    </form>
+  `;
+}
+"#
+        .into(),
+      },
+      &FmtOptionsConfig::default(),
+      &UnstableFmtOptions::default(),
+      None,
+    );
+    assert!(result.is_ok());
   }
 }

--- a/tests/specs/fmt/formatter_panic/__test__.jsonc
+++ b/tests/specs/fmt/formatter_panic/__test__.jsonc
@@ -1,0 +1,15 @@
+{
+  "tempDir": true,
+  "tests": {
+    "html_comment_panic": {
+      "args": "fmt main.ts",
+      "output": "main.out",
+      "exitCode": 0
+    },
+    "html_comment_check": {
+      "args": "fmt --check main.ts",
+      "output": "check.out",
+      "exitCode": 0
+    }
+  }
+}

--- a/tests/specs/fmt/formatter_panic/check.out
+++ b/tests/specs/fmt/formatter_panic/check.out
@@ -1,0 +1,2 @@
+Formatter panicked for '[WILDCARD]main.ts': For some reason finish_indent was called without a corresponding start_indent., leaving unformatted
+Checked 1 file

--- a/tests/specs/fmt/formatter_panic/main.out
+++ b/tests/specs/fmt/formatter_panic/main.out
@@ -1,0 +1,2 @@
+Formatter panicked for '[WILDCARD]main.ts': For some reason finish_indent was called without a corresponding start_indent., leaving unformatted
+Checked 1 file

--- a/tests/specs/fmt/formatter_panic/main.ts
+++ b/tests/specs/fmt/formatter_panic/main.ts
@@ -1,0 +1,10 @@
+export default function panicRenderHTML() {
+  return html`
+    <form>
+        <!--<label
+          for="email"
+        >Email</label>-->
+      <input />
+    </form>
+  `;
+}


### PR DESCRIPTION
## Summary
- catch TypeScript formatter panics while allowing Deno's panic hook to stay active for normal panics
- leave files unchanged and log the panic payload when embedded markup formatting panics
- add a regression test for multiline HTML comments in html tagged templates

Closes denoland/deno#32954
Closes bartlomieju/orchid-inbox#120

## Test plan
- [x] cargo test -p deno --lib test_html_tagged_template_multiline_comment_does_not_panic
- [x] cargo fmt --check -p deno
- [x] git diff --check
- [ ] cargo test specs::fmt::formatter_panic -- --no-capture, blocked locally by VM disk exhaustion while linking after target/ reached 45G

## AI disclosure
This PR was implemented with AI assistance from Codex.