### PR TITLE
fix(core): clamp large timer delays to max

### DIFF
--- a/libs/core/02_timers.js
+++ b/libs/core/02_timers.js
@@ -5,6 +5,7 @@
   const {
     MathMax,
     MathTrunc,
+    NumberIsFinite,
     NumberMIN_SAFE_INTEGER,
   } = window.__bootstrap.primordials;
   const {
@@ -342,8 +343,10 @@
     } else {
       after *= 1;
     }
-    if (!(after >= 1 && after <= TIMEOUT_MAX)) {
+    if (!(after >= 1) || !NumberIsFinite(after)) {
       after = 1;
+    } else if (after > TIMEOUT_MAX) {
+      after = TIMEOUT_MAX;
     }
 
     const id = nextTimerId++;

--- a/tests/unit/timers_test.ts
+++ b/tests/unit/timers_test.ts
@@ -721,6 +721,15 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "AbortSignal.timeout() with large delay does not abort immediately",
+  fn: async () => {
+    const signal = AbortSignal.timeout(2 ** 53 - 1);
+    await delay(50);
+    assert(!signal.aborted);
+  },
+});
+
 // Regression test for https://github.com/denoland/deno/issues/19866
 Deno.test({
   name: "regression for #19866",


### PR DESCRIPTION
Fixes denoland/deno#32858
Closes bartlomieju/orchid-inbox#124

## Summary
- clamp finite core timer delays above `TIMEOUT_MAX` to `TIMEOUT_MAX` instead of 1 ms
- keep invalid, non-finite, and sub-1 delays clamped to 1 ms
- add regression coverage for `AbortSignal.timeout(2 ** 53 - 1)` staying un-aborted during a short observation window

## Verification
- `./x fmt`
- `./x lint-js`
- `./x test-unit timers`

AI assistance was used to prepare this PR.