### PR TITLE
fix(webidl): handle sequences after runtime restart

### DIFF
--- a/libs/core/webidl.rs
+++ b/libs/core/webidl.rs
@@ -298,12 +298,6 @@ crate::v8_static_strings! {
   VALUE = "value",
 }
 
-thread_local! {
-  static NEXT_ETERNAL: v8::Eternal<v8::String> = v8::Eternal::empty();
-  static DONE_ETERNAL: v8::Eternal<v8::String> = v8::Eternal::empty();
-  static VALUE_ETERNAL: v8::Eternal<v8::String> = v8::Eternal::empty();
-}
-
 // helper for iterating over a sequence
 fn for_each_in_sequence<'a, 'b, 'i>(
   scope: &mut v8::PinScope<'a, 'i>,
@@ -340,46 +334,19 @@ fn for_each_in_sequence<'a, 'b, 'i>(
     ));
   };
 
-  let next_key = NEXT_ETERNAL
-    .with(|eternal| {
-      if let Some(key) = eternal.get(scope) {
-        Ok(key)
-      } else {
-        let key = NEXT.v8_string(scope).map_err(|e| {
-          WebIdlError::other(prefix.clone(), context.borrowed(), e)
-        })?;
-        eternal.set(scope, key);
-        Ok(key)
-      }
-    })?
+  let next_key = NEXT
+    .v8_string(scope)
+    .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))?
     .into();
 
-  let done_key = DONE_ETERNAL
-    .with(|eternal| {
-      if let Some(key) = eternal.get(scope) {
-        Ok(key)
-      } else {
-        let key = DONE.v8_string(scope).map_err(|e| {
-          WebIdlError::other(prefix.clone(), context.borrowed(), e)
-        })?;
-        eternal.set(scope, key);
-        Ok(key)
-      }
-    })?
+  let done_key = DONE
+    .v8_string(scope)
+    .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))?
     .into();
 
-  let value_key = VALUE_ETERNAL
-    .with(|eternal| {
-      if let Some(key) = eternal.get(scope) {
-        Ok(key)
-      } else {
-        let key = VALUE.v8_string(scope).map_err(|e| {
-          WebIdlError::other(prefix.clone(), context.borrowed(), e)
-        })?;
-        eternal.set(scope, key);
-        Ok(key)
-      }
-    })?
+  let value_key = VALUE
+    .v8_string(scope)
+    .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))?
     .into();
 
   let mut len = 0;
@@ -1613,6 +1580,27 @@ mod tests {
       &Default::default(),
     );
     assert_eq!(converted.unwrap(), vec![1, 2]);
+  }
+
+  #[test]
+  fn sequence_after_runtime_reinit() {
+    fn convert_sequence() {
+      let mut runtime = JsRuntime::new(Default::default());
+      deno_core::scope!(scope, runtime);
+
+      let val = v8::Array::new(scope, 0);
+      let converted = Vec::<u8>::convert(
+        scope,
+        val.into(),
+        "prefix".into(),
+        (|| "context".into()).into(),
+        &Default::default(),
+      );
+      assert_eq!(converted.unwrap(), Vec::<u8>::new());
+    }
+
+    convert_sequence();
+    convert_sequence();
   }
 
   #[test]

--- a/tests/unit/webgpu_test.ts
+++ b/tests/unit/webgpu_test.ts
@@ -256,6 +256,21 @@ Deno.test({
 
 Deno.test({
   ignore: isWsl || isCIWithoutGPU,
+}, async function webgpuRequestDeviceWithEmptyDescriptor() {
+  const adapter = await navigator.gpu.requestAdapter();
+  assert(adapter);
+
+  const device = await adapter.requestDevice({
+    requiredFeatures: [],
+    requiredLimits: {},
+  });
+  assert(device);
+
+  device.destroy();
+});
+
+Deno.test({
+  ignore: isWsl || isCIWithoutGPU,
 }, async function webgpuNullWindowSurfaceThrows() {
   const adapter = await navigator.gpu.requestAdapter();
   assert(adapter);


### PR DESCRIPTION
Fixes denoland/deno#32828.
Closes bartlomieju/orchid-inbox#126

This removes thread-local V8 Eternal handles from the Rust WebIDL sequence converter. Those handles can outlive a worker isolate in watch mode, so a later runtime on the same thread could reuse keys from the previous isolate while converting descriptor sequences such as WebGPU requiredFeatures.

The patch keeps the existing static string definitions but creates isolate-local V8 strings for next, done, and value during conversion. It also adds regression coverage for sequence conversion after recreating JsRuntime and a WebGPU test for requestDevice with an explicit empty descriptor.

Tests:
- cargo test -p deno_core webidl::tests
- cargo check -p deno_webgpu
- ./x fmt
- ./x test-unit webgpuRequestDeviceWithEmptyDescriptor

AI assistance disclosure: This PR was prepared with help from OpenAI Codex.