### PR TITLE
fix: merge named permission set allowlists with CLI

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1636,7 +1636,24 @@ fn flags_to_permissions_options(
     if allow_all_flag {
       Some(vec![])
     } else if let Some(value) = value {
-      Some(value.clone())
+      if value.is_empty() {
+        Some(vec![])
+      } else if let Some(config) = config {
+        match config {
+          PermissionConfigValue::All => Some(vec![]),
+          PermissionConfigValue::Some(items) => {
+            let mut merged = items
+              .iter()
+              .map(|value| parse_config_value(value))
+              .collect::<Vec<_>>();
+            merged.extend(value.iter().cloned());
+            Some(merged)
+          }
+          PermissionConfigValue::None => Some(value.clone()),
+        }
+      } else {
+        Some(value.clone())
+      }
     } else if let Some(config) = config {
       match config {
         PermissionConfigValue::All => Some(vec![]),
@@ -2166,6 +2183,52 @@ mod test {
           deny_import: None,
           prompt: true
         }
+      );
+    }
+    {
+      let flags = PermissionFlags {
+        allow_net: Some(vec!["cli-net-allow".to_string()]),
+        allow_read: Some(vec!["./cli-read-allow".to_string()]),
+        ..Default::default()
+      };
+      let config = PermissionsObjectWithBase {
+        base: deno_path_util::url_from_file_path(&base_dir.join("deno.json"))
+          .unwrap(),
+        permissions: PermissionsObject {
+          read: AllowDenyIgnorePermissionConfig {
+            allow: Some(PermissionConfigValue::Some(vec![
+              "./config-read-allow".to_string(),
+            ])),
+            ..Default::default()
+          },
+          net: AllowDenyPermissionConfig {
+            allow: Some(PermissionConfigValue::Some(vec![
+              "config-net-allow".to_string(),
+            ])),
+            ..Default::default()
+          },
+          ..Default::default()
+        },
+      };
+      let permissions_options =
+        flags_to_permissions_options(&flags, Some(&config)).unwrap();
+      assert_eq!(
+        permissions_options.allow_read,
+        Some(vec![
+          base_dir
+            .join("config-read-allow")
+            .into_os_string()
+            .into_string()
+            .unwrap(),
+          "./cli-read-allow".to_string(),
+        ])
+      );
+      assert_eq!(
+        permissions_options.allow_net,
+        Some(vec![
+          "config-net-allow".to_string(),
+          "cli-net-allow".to_string(),
+        ])
       );
     }
   }

--- a/tests/specs/run/config_permissions/basic/__test__.jsonc
+++ b/tests/specs/run/config_permissions/basic/__test__.jsonc
@@ -4,6 +4,10 @@
       "args": "run -P=data-read main.ts",
       "output": "read.out"
     },
+    "merge_data_read_with_cli_allowlists": {
+      "args": "run -P=data-read --allow-read=./cli_data --allow-net=localhost:4545 merge.ts",
+      "output": "merge.out"
+    },
     "write": {
       "args": "run -P=data-write main.ts",
       "output": "write.out"

--- a/tests/specs/run/config_permissions/basic/deno.json
+++ b/tests/specs/run/config_permissions/basic/deno.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "data-read": {
-      "read": ["./data"]
+      "read": ["./data"],
+      "net": ["example.com"]
     },
     "data-write": {
       "write": {

--- a/tests/specs/run/config_permissions/basic/merge.out
+++ b/tests/specs/run/config_permissions/basic/merge.out
@@ -1,0 +1,5 @@
+Warning Permissions in the config file is an experimental feature and may change in the future.
+granted
+granted
+granted
+granted

--- a/tests/specs/run/config_permissions/basic/merge.ts
+++ b/tests/specs/run/config_permissions/basic/merge.ts
@@ -1,0 +1,10 @@
+console.log(Deno.permissions.querySync({ name: "read", path: "./data" }).state);
+console.log(
+  Deno.permissions.querySync({ name: "read", path: "./cli_data" }).state,
+);
+console.log(
+  Deno.permissions.querySync({ name: "net", host: "example.com" }).state,
+);
+console.log(
+  Deno.permissions.querySync({ name: "net", host: "localhost:4545" }).state,
+);


### PR DESCRIPTION
Closes bartlomieju/orchid-inbox#130

Fixes denoland/deno#32795.

Summary:
- Merge finite CLI allowlists with finite per-kind allowlists from named permission sets.
- Keep allow-all behavior for `--allow-all`, bare allow flags, and config allow-all values.
- Add config permission spec coverage for merged read and net allowlists.

Tests:
- `cargo test -p deno test_flags_to_permission_options`
- `/home/exedev/orch/work/issue-130/target/debug/deno run -P=data-read --allow-read=./cli_data --allow-net=localhost:4545 merge.ts` from `tests/specs/run/config_permissions/basic`
- `/home/exedev/orch/work/issue-130/target/debug/deno run -P=data-read main.ts` from `tests/specs/run/config_permissions/basic`
- `deno fmt cli/args/mod.rs tests/specs/run/config_permissions/basic/__test__.jsonc tests/specs/run/config_permissions/basic/deno.json tests/specs/run/config_permissions/basic/merge.ts`

Note: `./x fmt ...` was attempted first, but this checkout is missing the `tests/util/std` submodule content required by `tools/util.js`.

AI-assisted: This PR was implemented with help from OpenAI Codex.