### PR TITLE
docs(runtime): clarify worker Deno.exit behavior

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -1554,7 +1554,8 @@ declare namespace Deno {
    *
    * If no exit code is supplied then Deno will exit with return code of `0`.
    *
-   * In worker contexts this is an alias to `self.close();`.
+   * In worker contexts this closes the current worker using Deno's internal
+   * worker close operation. It does not call the current `self.close` property.
    *
    * ```ts
    * Deno.exit(5);

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -948,8 +948,8 @@ function bootstrapWorkerRuntime(
     event.defineEventHandler(globalThis, "message");
     event.defineEventHandler(globalThis, "error", undefined, true);
 
-    // `Deno.exit()` is an alias to `self.close()`. Setting and exit
-    // code using an op in worker context is a no-op.
+    // `Deno.exit()` closes the worker using the internal worker close
+    // operation. Setting an exit code using an op in worker context is a no-op.
     os.setExitHandler((_exitCode) => {
       workerClose();
     });

--- a/tests/specs/run/op_exit_op_set_exit_code_in_worker/op_exit_op_set_exit_code_in_worker.ts
+++ b/tests/specs/run/op_exit_op_set_exit_code_in_worker/op_exit_op_set_exit_code_in_worker.ts
@@ -1,6 +1,6 @@
 // Set exit code to some value, we'll ensure that `Deno.exit()` and
-// setting exit code in worker context is a no-op and is an alias for
-// `self.close()`.
+// setting exit code in worker context is a no-op. `Deno.exit()` should close
+// the worker without calling an overridden `self.close` property.
 
 // @ts-ignore Deno[Deno.internal].core doesn't have type-defs
 Deno[Deno.internal].core.ops.op_set_exit_code(21);
@@ -10,4 +10,16 @@ const worker = new Worker(
   { type: "module" },
 );
 
+worker.onmessage = (event) => {
+  console.log(event.data);
+  Deno.exit(1);
+};
+worker.onerror = (event) => {
+  console.log(event.message);
+  Deno.exit(1);
+};
+worker.onmessageerror = () => {
+  console.log("messageerror");
+  Deno.exit(1);
+};
 worker.postMessage("go");

--- a/tests/specs/run/op_exit_op_set_exit_code_in_worker/op_exit_op_set_exit_code_worker.js
+++ b/tests/specs/run/op_exit_op_set_exit_code_in_worker/op_exit_op_set_exit_code_worker.js
@@ -1,4 +1,7 @@
 self.onmessage = () => {
+  self.close = () => {
+    self.postMessage("overridden self.close was called");
+  };
   Deno[Deno.internal].core.ops.op_set_exit_code(42);
   Deno.exit();
 };


### PR DESCRIPTION
## Summary

- Clarifies that worker `Deno.exit()` closes the current worker through Deno's internal worker close operation.
- Documents that worker `Deno.exit()` does not call the current `self.close` property.
- Extends the existing worker exit run spec to cover an overridden `self.close` property.

## Tests

- `./x fmt --check runtime/js/99_main.js cli/tsc/dts/lib.deno.ns.d.ts tests/specs/run/op_exit_op_set_exit_code_in_worker/op_exit_op_set_exit_code_in_worker.ts tests/specs/run/op_exit_op_set_exit_code_in_worker/op_exit_op_set_exit_code_worker.js`
- `./x lint-js runtime/js/99_main.js tests/specs/run/op_exit_op_set_exit_code_in_worker/op_exit_op_set_exit_code_in_worker.ts tests/specs/run/op_exit_op_set_exit_code_in_worker/op_exit_op_set_exit_code_worker.js`
- `./x test-spec op_exit_op_set_exit_code_in_worker`
- `./target/debug/deno run --allow-read --allow-env --allow-sys tools/jsdoc_checker.js`

## Notes

AI tools were used to help prepare this PR.

Fixes denoland/deno#32778.
Closes bartlomieju/orchid-inbox#132.