### PR TITLE
fix(node): map fs NotCapable errors to EPERM

### DIFF
--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -83,6 +83,7 @@ const { os: osConstants } = core.loadExtScript(
 const { hideStackFrames } = core.loadExtScript(
   "ext:deno_node/internal/hide_stack_frames.ts",
 );
+const DenoNotCapablePrototype = Deno.errors.NotCapable.prototype;
 
 // Lazy loader for getSystemErrorName to break circular dep with _utils.ts
 let _getSystemErrorName;
@@ -374,7 +375,7 @@ const handleDnsError = hideStackFrames(
       return dnsException(err?.uv_errcode, syscall, address);
     }
 
-    if (ObjectPrototypeIsPrototypeOf(Deno.errors.NotCapable.prototype, err)) {
+    if (ObjectPrototypeIsPrototypeOf(DenoNotCapablePrototype, err)) {
       return dnsException(codeMap.get("EPERM")!, syscall, address);
     }
 
@@ -3055,12 +3056,24 @@ interface UvExceptionContext {
   path?: string;
   dest?: string;
 }
+
+function denoNotCapableErrorToNodeError(ctx: UvExceptionContext) {
+  return uvException({
+    errno: codeMap.get("EPERM")!,
+    ...ctx,
+  });
+}
+
 function denoErrorToNodeError(e: Error, ctx: UvExceptionContext) {
   if (ObjectPrototypeIsPrototypeOf(Deno.errors.BadResource.prototype, e)) {
     return uvException({
       errno: UV_EBADF,
       ...ctx,
     });
+  }
+
+  if (ObjectPrototypeIsPrototypeOf(DenoNotCapablePrototype, e)) {
+    return denoNotCapableErrorToNodeError(ctx);
   }
 
   const errno = extractOsErrorNumberFromErrorMessage(e);
@@ -3084,6 +3097,10 @@ function denoWriteFileErrorToNodeError(
       errno: UV_EBADF,
       ...ctx,
     });
+  }
+
+  if (ObjectPrototypeIsPrototypeOf(DenoNotCapablePrototype, e)) {
+    return denoNotCapableErrorToNodeError(ctx);
   }
 
   let errno = extractOsErrorNumberFromErrorMessage(e);

--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -83,7 +83,6 @@ const { os: osConstants } = core.loadExtScript(
 const { hideStackFrames } = core.loadExtScript(
   "ext:deno_node/internal/hide_stack_frames.ts",
 );
-const DenoNotCapablePrototype = Deno.errors.NotCapable.prototype;
 
 // Lazy loader for getSystemErrorName to break circular dep with _utils.ts
 let _getSystemErrorName;
@@ -375,13 +374,17 @@ const handleDnsError = hideStackFrames(
       return dnsException(err?.uv_errcode, syscall, address);
     }
 
-    if (ObjectPrototypeIsPrototypeOf(DenoNotCapablePrototype, err)) {
+    if (isDenoNotCapableError(err)) {
       return dnsException(codeMap.get("EPERM")!, syscall, address);
     }
 
     return denoErrorToNodeError(err, { syscall });
   },
 );
+
+function isDenoNotCapableError(err: Error) {
+  return ObjectPrototypeIsPrototypeOf(Deno.errors.NotCapable.prototype, err);
+}
 
 /**
  * @param code A libuv error number or a c-ares error code
@@ -3072,7 +3075,7 @@ function denoErrorToNodeError(e: Error, ctx: UvExceptionContext) {
     });
   }
 
-  if (ObjectPrototypeIsPrototypeOf(DenoNotCapablePrototype, e)) {
+  if (isDenoNotCapableError(e)) {
     return denoNotCapableErrorToNodeError(ctx);
   }
 
@@ -3099,7 +3102,7 @@ function denoWriteFileErrorToNodeError(
     });
   }
 
-  if (ObjectPrototypeIsPrototypeOf(DenoNotCapablePrototype, e)) {
+  if (isDenoNotCapableError(e)) {
     return denoNotCapableErrorToNodeError(ctx);
   }
 

--- a/tests/specs/x/permission_flags/deny_write_npm.out
+++ b/tests/specs/x/permission_flags/deny_write_npm.out
@@ -1,3 +1,3 @@
 Download [WILDCARD]
-error: Uncaught (in promise) NotCapable: Requires write access to "test.txt", run again with the --allow-write flag
+error: Uncaught (in promise) Error: EPERM: operation not permitted, open 'test.txt'
 [WILDCARD]

--- a/tests/unit_node/_fs/_fs_mkdir_test.ts
+++ b/tests/unit_node/_fs/_fs_mkdir_test.ts
@@ -5,6 +5,7 @@ import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { existsSync, mkdir, mkdirSync } from "node:fs";
 
 const tmpDir = "./tmpdir";
+const epermErrno = Deno.build.os === "windows" ? -4048 : -1;
 
 function assertNodePermissionError(
   err: unknown,
@@ -16,7 +17,7 @@ function assertNodePermissionError(
 
   const nodeErr = err as NodeJS.ErrnoException;
   assert(nodeErr.code === "EPERM");
-  assert(nodeErr.errno === -1);
+  assert(nodeErr.errno === epermErrno);
   assert(nodeErr.syscall === syscall);
   if (path !== undefined) {
     assert(nodeErr.path === path);

--- a/tests/unit_node/_fs/_fs_mkdir_test.ts
+++ b/tests/unit_node/_fs/_fs_mkdir_test.ts
@@ -1,10 +1,27 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 import * as path from "@std/path";
-import { assert } from "@std/assert";
+import { assert, assertThrows } from "@std/assert";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { existsSync, mkdir, mkdirSync } from "node:fs";
 
 const tmpDir = "./tmpdir";
+
+function assertNodePermissionError(
+  err: unknown,
+  syscall: string,
+  path?: string,
+) {
+  assert(err instanceof Error);
+  assert(!(err instanceof Deno.errors.NotCapable));
+
+  const nodeErr = err as NodeJS.ErrnoException;
+  assert(nodeErr.code === "EPERM");
+  assert(nodeErr.errno === -1);
+  assert(nodeErr.syscall === syscall);
+  if (path !== undefined) {
+    assert(nodeErr.path === path);
+  }
+}
 
 Deno.test({
   name: "[node/fs] mkdir",
@@ -26,6 +43,16 @@ Deno.test({
     mkdirSync(tmpDir);
     assert(existsSync(tmpDir));
     Deno.removeSync(tmpDir);
+  },
+});
+
+Deno.test({
+  name: "[node/fs] mkdirSync maps denied write permission to Node EPERM",
+  permissions: { write: false },
+  fn: () => {
+    const dir = path.join(Deno.cwd(), "_fs_mkdirSync_denied_write");
+    const err = assertThrows(() => mkdirSync(dir));
+    assertNodePermissionError(err, "mkdir", dir);
   },
 });
 

--- a/tests/unit_node/_fs/_fs_open_test.ts
+++ b/tests/unit_node/_fs/_fs_open_test.ts
@@ -31,6 +31,7 @@ import { open as openPromise } from "node:fs/promises";
 import { join, parse } from "node:path";
 
 const tempDir = parse(Deno.makeTempFileSync()).dir;
+const epermErrno = Deno.build.os === "windows" ? -4048 : -1;
 
 function assertNodePermissionError(
   err: unknown,
@@ -42,7 +43,7 @@ function assertNodePermissionError(
 
   const nodeErr = err as NodeJS.ErrnoException;
   assertEquals(nodeErr.code, "EPERM");
-  assertEquals(nodeErr.errno, -1);
+  assertEquals(nodeErr.errno, epermErrno);
   assertEquals(nodeErr.syscall, syscall);
   if (path !== undefined) {
     assertEquals(nodeErr.path, path);

--- a/tests/unit_node/_fs/_fs_open_test.ts
+++ b/tests/unit_node/_fs/_fs_open_test.ts
@@ -10,7 +10,13 @@ import {
   O_TRUNC,
   O_WRONLY,
 } from "node:constants";
-import { assertEquals, assertRejects, assertThrows, fail } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertThrows,
+  fail,
+} from "@std/assert";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import {
   closeSync,
@@ -25,6 +31,23 @@ import { open as openPromise } from "node:fs/promises";
 import { join, parse } from "node:path";
 
 const tempDir = parse(Deno.makeTempFileSync()).dir;
+
+function assertNodePermissionError(
+  err: unknown,
+  syscall: string,
+  path?: string,
+) {
+  assert(err instanceof Error);
+  assert(!(err instanceof Deno.errors.NotCapable));
+
+  const nodeErr = err as NodeJS.ErrnoException;
+  assertEquals(nodeErr.code, "EPERM");
+  assertEquals(nodeErr.errno, -1);
+  assertEquals(nodeErr.syscall, syscall);
+  if (path !== undefined) {
+    assertEquals(nodeErr.path, path);
+  }
+}
 
 Deno.test({
   name: "ASYNC: open file",
@@ -50,6 +73,16 @@ Deno.test({
     const file = Deno.makeTempFileSync();
     const fd = openSync(file, "r");
     closeSync(fd);
+  },
+});
+
+Deno.test({
+  name: "openSync maps denied write permission to Node EPERM",
+  permissions: { write: false },
+  fn() {
+    const file = join(Deno.cwd(), "_fs_openSync_denied_write.txt");
+    const err = assertThrows(() => openSync(file, "w"));
+    assertNodePermissionError(err, "open", file);
   },
 });
 

--- a/tests/unit_node/_fs/_fs_writeFile_test.ts
+++ b/tests/unit_node/_fs/_fs_writeFile_test.ts
@@ -28,6 +28,7 @@ if (Deno.build.os === "windows") {
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testDataDir = path.resolve(moduleDir, "testdata");
 const decoder = new TextDecoder("utf-8");
+const epermErrno = Deno.build.os === "windows" ? -4048 : -1;
 
 function assertNodePermissionError(
   err: unknown,
@@ -39,7 +40,7 @@ function assertNodePermissionError(
 
   const nodeErr = err as NodeJS.ErrnoException;
   assertEquals(nodeErr.code, "EPERM");
-  assertEquals(nodeErr.errno, -1);
+  assertEquals(nodeErr.errno, epermErrno);
   assertEquals(nodeErr.syscall, syscall);
   if (path !== undefined) {
     assertEquals(nodeErr.path, path);

--- a/tests/unit_node/_fs/_fs_writeFile_test.ts
+++ b/tests/unit_node/_fs/_fs_writeFile_test.ts
@@ -29,6 +29,23 @@ const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testDataDir = path.resolve(moduleDir, "testdata");
 const decoder = new TextDecoder("utf-8");
 
+function assertNodePermissionError(
+  err: unknown,
+  syscall: string,
+  path?: string,
+) {
+  assert(err instanceof Error);
+  assert(!(err instanceof Deno.errors.NotCapable));
+
+  const nodeErr = err as NodeJS.ErrnoException;
+  assertEquals(nodeErr.code, "EPERM");
+  assertEquals(nodeErr.errno, -1);
+  assertEquals(nodeErr.syscall, syscall);
+  if (path !== undefined) {
+    assertEquals(nodeErr.path, path);
+  }
+}
+
 Deno.test("Callback must be a function error", function fn() {
   assertThrows(
     () => {
@@ -85,6 +102,16 @@ Deno.test("Invalid encoding results in error()", function testEncodingErrors() {
     Error,
     `The argument 'encoding' is invalid encoding. Received 'made-up-encoding'`,
   );
+});
+
+Deno.test({
+  name: "writeFileSync maps denied write permission to Node EPERM",
+  permissions: { write: false },
+  fn() {
+    const file = path.join(Deno.cwd(), "_fs_writeFileSync_denied_write.txt");
+    const err = assertThrows(() => writeFileSync(file, "hello world"));
+    assertNodePermissionError(err, "open", file);
+  },
 });
 
 Deno.test(

--- a/tests/unit_node/v8_test.ts
+++ b/tests/unit_node/v8_test.ts
@@ -2,6 +2,8 @@
 import * as v8 from "node:v8";
 import { assert, assertEquals, assertThrows } from "@std/assert";
 
+const epermErrno = Deno.build.os === "windows" ? -4048 : -1;
+
 // https://github.com/nodejs/node/blob/a2bbe5ff216bc28f8dac1c36a8750025a93c3827/test/parallel/test-v8-version-tag.js#L6
 Deno.test({
   name: "cachedDataVersionTag success",
@@ -71,7 +73,7 @@ Deno.test({
 
     const nodeErr = err as NodeJS.ErrnoException;
     assertEquals(nodeErr.code, "EPERM");
-    assertEquals(nodeErr.errno, -1);
+    assertEquals(nodeErr.errno, epermErrno);
     assertEquals(nodeErr.syscall, "open");
     assertEquals(nodeErr.path, "test.heapsnapshot");
   },

--- a/tests/unit_node/v8_test.ts
+++ b/tests/unit_node/v8_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 import * as v8 from "node:v8";
-import { assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 
 // https://github.com/nodejs/node/blob/a2bbe5ff216bc28f8dac1c36a8750025a93c3827/test/parallel/test-v8-version-tag.js#L6
 Deno.test({
@@ -64,8 +64,15 @@ Deno.test({
   name: "writeHeapSnapshot requires write permission",
   permissions: { write: false },
   fn() {
-    assertThrows(() => {
+    const err = assertThrows(() => {
       v8.writeHeapSnapshot("test.heapsnapshot");
-    }, Deno.errors.NotCapable);
+    });
+    assert(!(err instanceof Deno.errors.NotCapable));
+
+    const nodeErr = err as NodeJS.ErrnoException;
+    assertEquals(nodeErr.code, "EPERM");
+    assertEquals(nodeErr.errno, -1);
+    assertEquals(nodeErr.syscall, "open");
+    assertEquals(nodeErr.path, "test.heapsnapshot");
   },
 });


### PR DESCRIPTION
Closes bartlomieju/orchid-inbox#133
Fixes denoland/deno#32583

## Summary
- Map Deno.errors.NotCapable through node:fs error conversion helpers to Node-compatible EPERM errors.
- Preserve existing OS errno extraction for filesystem errors that include an os error number.
- Add regression coverage for writeFileSync, openSync, and mkdirSync under denied write permissions.

## Verification
- ./x fmt --check
- ./x lint-js
- ./x test-node _fs_open_test
- ./x test-node _fs_mkdir_test
- ./x test-node _fs_writeFile_test
- ./target/debug/deno run --allow-read --allow-write=/tmp/allowed <permission repro script>

## Notes
- Read .github/CONTRIBUTING.md before opening this PR.
- This contribution was authored with AI assistance.