### PR TITLE
test: fix flaky fetch abort WPT

### DIFF
--- a/tests/wpt/runner/expectations/fetch.json
+++ b/tests/wpt/runner/expectations/fetch.json
@@ -1473,7 +1473,9 @@
       "request.any.html": true,
       "request.any.worker.html": true,
       "general.any.html": true,
-      "general.any.worker.html": true,
+      "general.any.worker.html": {
+        "flaky": true
+      },
       "cache.https.any.html": false,
       "cache.https.any.worker.html": false,
       "destroyed-context.html": false,


### PR DESCRIPTION
Mark `/fetch/api/abort/general.any.worker.html` as flaky so the WPT runner retries it instead of failing main on an intermittent abort race.

Failing main CI run: https://github.com/denoland/deno/actions/runs/25975381600/job/76358617879

Evidence: run 25975381600 failed only `Underlying connection is closed when aborting after receiving response - no-cors`; the next main run 25975786283 passed.

@bartlomieju this is ready to merge.