### PR TITLE
fix(http): advertise Deno.serve keep-alive timeout

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5506,6 +5506,16 @@ declare namespace Deno {
      *
      * @default {511} */
     tcpBacklog?: number;
+
+    /** The HTTP/1.1 keep-alive timeout in milliseconds.
+     *
+     * When set to a non-zero value, idle keep-alive connections are closed
+     * after this timeout and HTTP/1.1 responses include a
+     * `Keep-Alive: timeout=N` header advertising the configured lifetime in
+     * seconds.
+     *
+     * @default {undefined} */
+    keepAliveTimeout?: number;
   }
 
   /**

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -57,6 +57,8 @@ const {
   Uint8Array,
   Promise,
   Number,
+  NumberIsFinite,
+  MathFloor,
 } = primordials;
 
 const { InnerBody } = core.loadExtScript("ext:deno_fetch/22_body.js");
@@ -724,6 +726,7 @@ type RawServeOptions = {
   reusePort?: boolean;
   key?: string;
   cert?: string;
+  keepAliveTimeout?: number;
   onError?: (error: unknown) => Response | Promise<Response>;
   onListen?: (params: { hostname: string; port: number }) => void;
   handler?: RawHandler;
@@ -744,6 +747,21 @@ function formatHostName(hostname: string): string {
 
   // Add brackets around ipv6 hostname
   return StringPrototypeIncludes(hostname, ":") ? `[${hostname}]` : hostname;
+}
+
+function validateKeepAliveTimeout(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  value = Number(value);
+  if (
+    !NumberIsFinite(value) || value < 0 || value > 2147483647
+  ) {
+    throw new TypeError(
+      "keepAliveTimeout must be a finite number between 0 and 2147483647",
+    );
+  }
+  return MathFloor(value);
 }
 
 // Flag to track if DENO_SERVE_ADDRESS override has been consumed
@@ -884,6 +902,9 @@ function serveInner(options, handler) {
   const wantsVsock = ObjectHasOwn(options, "cid");
   const wantsTunnel = options.tunnel === true;
   const signal = options.signal;
+  const keepAliveTimeout = validateKeepAliveTimeout(
+    options.keepAliveTimeout,
+  );
   const onError = options.onError ??
     function (error) {
       internals.log("error", error);
@@ -999,13 +1020,27 @@ function serveInner(options, handler) {
     }
   };
 
-  return serveHttpOnListener(listener, signal, handler, onError, onListen);
+  return serveHttpOnListener(
+    listener,
+    signal,
+    handler,
+    onError,
+    onListen,
+    keepAliveTimeout,
+  );
 }
 
 /**
  * Serve HTTP/1.1 and/or HTTP/2 on an arbitrary listener.
  */
-function serveHttpOnListener(listener, signal, handler, onError, onListen) {
+function serveHttpOnListener(
+  listener,
+  signal,
+  handler,
+  onError,
+  onListen,
+  keepAliveTimeout = undefined,
+) {
   let serverContext = undefined;
   let callback = undefined;
   const promiseErrorHandler = (error) => {
@@ -1022,7 +1057,7 @@ function serveHttpOnListener(listener, signal, handler, onError, onListen) {
 
   serverContext = new CallbackContext(
     signal,
-    op_http_serve(listener[internalRidSymbol], dispatch),
+    op_http_serve(listener[internalRidSymbol], keepAliveTimeout, dispatch),
     listener,
   );
   callback = mapToCallback(serverContext, handler, onError);
@@ -1052,7 +1087,7 @@ function serveHttpOnConnection(connection, signal, handler, onError, onListen) {
 
   serverContext = new CallbackContext(
     signal,
-    op_http_serve_on(connection[internalRidSymbol], dispatch),
+    op_http_serve_on(connection[internalRidSymbol], undefined, dispatch),
     null,
   );
   callback = mapToCallback(serverContext, handler, onError);

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -7,6 +7,7 @@ use std::future::poll_fn;
 use std::io;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -55,6 +56,7 @@ use hyper::service::HttpService;
 use hyper::service::service_fn;
 use hyper::upgrade::OnUpgrade;
 use hyper_util::rt::TokioIo;
+use hyper_util::rt::TokioTimer;
 use once_cell::sync::Lazy;
 use smallvec::SmallVec;
 use tokio::io::AsyncReadExt;
@@ -64,6 +66,7 @@ use tokio::net::TcpStream;
 use super::fly_accept_encoding;
 use crate::LocalExecutor;
 use crate::Options;
+use crate::ServeOptions;
 use crate::compressible::is_content_compressible;
 use crate::extract_network_stream;
 use crate::network_buffered_stream::NetworkStreamPrefixCheck;
@@ -913,10 +916,19 @@ fn serve_http11_unconditional(
   io: impl HttpServeStream,
   svc: impl HttpService<Incoming, ResBody = HttpRecordResponse> + 'static,
   cancel: Rc<CancelHandle>,
+  serve_options: ServeOptions,
   http1_builder_hook: Option<fn(http1::Builder) -> http1::Builder>,
 ) -> impl Future<Output = Result<(), hyper::Error>> + 'static {
   let mut builder = http1::Builder::new();
   builder.keep_alive(true).writev(*USE_WRITEV);
+  if let Some(keep_alive_timeout) = serve_options
+    .keep_alive_timeout
+    .filter(|timeout| *timeout > 0)
+  {
+    builder
+      .timer(TokioTimer::new())
+      .header_read_timeout(Duration::from_millis(keep_alive_timeout));
+  }
 
   if let Some(http1_builder_hook) = http1_builder_hook {
     builder = http1_builder_hook(builder);
@@ -968,6 +980,7 @@ async fn serve_http2_autodetect(
   svc: impl HttpService<Incoming, ResBody = HttpRecordResponse> + 'static,
   cancel: Rc<CancelHandle>,
   options: Options,
+  serve_options: ServeOptions,
 ) -> Result<(), HttpNextError> {
   let prefix = NetworkStreamPrefixCheck::new(io, HTTP2_PREFIX);
   let (matches, io) =
@@ -977,9 +990,15 @@ async fn serve_http2_autodetect(
       .await
       .map_err(HttpNextError::Hyper)
   } else {
-    serve_http11_unconditional(io, svc, cancel, options.http1_builder_hook)
-      .await
-      .map_err(HttpNextError::Hyper)
+    serve_http11_unconditional(
+      io,
+      svc,
+      cancel,
+      serve_options,
+      options.http1_builder_hook,
+    )
+    .await
+    .map_err(HttpNextError::Hyper)
   }
 }
 
@@ -1004,6 +1023,7 @@ fn serve_https(
   lifetime: HttpLifetime,
   callback: Rc<ServerCallback>,
   options: Options,
+  serve_options: ServeOptions,
 ) -> JoinHandle<Result<(), HttpNextError>> {
   let HttpLifetime {
     server_state,
@@ -1020,6 +1040,7 @@ fn serve_https(
       server_state.clone(),
       move |record| dispatch_to_js(&callback, record),
       legacy_abort,
+      serve_options.keep_alive_timeout,
     )
   });
   spawn(
@@ -1042,12 +1063,20 @@ fn serve_https(
           io,
           svc,
           listen_cancel_handle,
+          serve_options,
           options.http1_builder_hook,
         )
         .await
         .map_err(HttpNextError::Hyper)
       } else {
-        serve_http2_autodetect(io, svc, listen_cancel_handle, options).await
+        serve_http2_autodetect(
+          io,
+          svc,
+          listen_cancel_handle,
+          options,
+          serve_options,
+        )
+        .await
       }
     }
     .try_or_cancel(connection_cancel_handle),
@@ -1060,6 +1089,7 @@ fn serve_http(
   lifetime: HttpLifetime,
   callback: Rc<ServerCallback>,
   options: Options,
+  serve_options: ServeOptions,
   wait_for_connection: bool,
 ) -> JoinHandle<Result<(), HttpNextError>> {
   let HttpLifetime {
@@ -1077,6 +1107,7 @@ fn serve_http(
       server_state.clone(),
       move |record| dispatch_to_js(&callback, record),
       legacy_abort,
+      serve_options.keep_alive_timeout,
     )
   });
   let connection_cancel_handle_for_outer = connection_cancel_handle.clone();
@@ -1108,6 +1139,7 @@ fn serve_http(
               io,
               svc,
               listen_cancel_handle,
+              serve_options,
               options.http1_builder_hook,
             )
             .await
@@ -1133,6 +1165,7 @@ fn serve_http_on<HTTP>(
   lifetime: HttpLifetime,
   callback: Rc<ServerCallback>,
   options: Options,
+  serve_options: ServeOptions,
   wait_for_connection: bool,
 ) -> JoinHandle<Result<(), HttpNextError>>
 where
@@ -1150,11 +1183,17 @@ where
       lifetime,
       callback,
       options,
+      serve_options,
       wait_for_connection,
     ),
-    NetworkStream::Tls(conn) => {
-      serve_https(conn, connection_properties, lifetime, callback, options)
-    }
+    NetworkStream::Tls(conn) => serve_https(
+      conn,
+      connection_properties,
+      lifetime,
+      callback,
+      options,
+      serve_options,
+    ),
     #[cfg(unix)]
     NetworkStream::Unix(conn) => serve_http(
       conn,
@@ -1162,6 +1201,7 @@ where
       lifetime,
       callback,
       options,
+      serve_options,
       wait_for_connection,
     ),
     #[cfg(any(
@@ -1175,6 +1215,7 @@ where
       lifetime,
       callback,
       options,
+      serve_options,
       wait_for_connection,
     ),
     NetworkStream::Tunnel(conn) => serve_http(
@@ -1183,6 +1224,7 @@ where
       lifetime,
       callback,
       options,
+      serve_options,
       wait_for_connection,
     ),
     #[cfg(windows)]
@@ -1192,6 +1234,7 @@ where
       lifetime,
       callback,
       options,
+      serve_options,
       wait_for_connection,
     ),
   }
@@ -1264,6 +1307,7 @@ pub fn op_http_serve<'scope, HTTP>(
   isolate: &mut v8::Isolate,
   state: Rc<RefCell<OpState>>,
   #[smi] listener_rid: ResourceId,
+  #[smi] keep_alive_timeout: Option<u32>,
   callback: v8::Local<'scope, v8::Function>,
 ) -> Result<(ResourceId, &'static str, String, bool), HttpNextError>
 where
@@ -1285,6 +1329,9 @@ where
     let state = state.borrow();
     *state.borrow::<Options>()
   };
+  let serve_options = ServeOptions {
+    keep_alive_timeout: keep_alive_timeout.map(u64::from),
+  };
 
   let listen_properties_clone: HttpListenProperties = listen_properties.clone();
   let handle = spawn(async move {
@@ -1298,6 +1345,7 @@ where
         lifetime.clone(),
         callback.clone(),
         options,
+        serve_options,
         false,
       );
     }
@@ -1324,6 +1372,7 @@ pub fn op_http_serve_on<'scope, HTTP>(
   isolate: &mut v8::Isolate,
   state: Rc<RefCell<OpState>>,
   #[smi] connection_rid: ResourceId,
+  #[smi] keep_alive_timeout: Option<u32>,
   callback: v8::Local<'scope, v8::Function>,
 ) -> Result<(ResourceId, &'static str, String, bool), HttpNextError>
 where
@@ -1349,6 +1398,9 @@ where
     resource.lifetime(),
     callback,
     options,
+    ServeOptions {
+      keep_alive_timeout: keep_alive_timeout.map(u64::from),
+    },
     true,
   );
 

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -138,6 +138,12 @@ pub struct Options {
   pub no_legacy_abort: bool,
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ServeOptions {
+  /// HTTP/1 keep-alive idle timeout in milliseconds.
+  pub keep_alive_timeout: Option<u64>,
+}
+
 #[cfg(not(feature = "default_property_extractor"))]
 deno_core::extension!(
   deno_http,

--- a/ext/http/service.rs
+++ b/ext/http/service.rs
@@ -25,7 +25,10 @@ use hyper::body::Body;
 use hyper::body::Frame;
 use hyper::body::Incoming;
 use hyper::body::SizeHint;
+use hyper::header::CONNECTION;
 use hyper::header::HeaderMap;
+use hyper::header::HeaderName;
+use hyper::header::HeaderValue;
 use hyper::upgrade::OnUpgrade;
 use scopeguard::ScopeGuard;
 use scopeguard::guard;
@@ -40,6 +43,8 @@ use crate::response_body::ResponseStreamResult;
 
 pub type Request = hyper::Request<Incoming>;
 pub type Response = hyper::Response<HttpRecordResponse>;
+
+const KEEP_ALIVE: HeaderName = HeaderName::from_static("keep-alive");
 
 #[cfg(feature = "__http_tracing")]
 pub static RECORD_COUNT: std::sync::atomic::AtomicUsize =
@@ -291,6 +296,7 @@ pub(crate) async fn handle_request<F>(
   server_state: SignallingRc<HttpServerState>, // Keep server alive for duration of this future.
   dispatch: F,
   legacy_abort: bool,
+  keep_alive_timeout: Option<u64>,
 ) -> Result<Response, hyper_v014::Error>
 where
   F: FnOnce(Rc<HttpRecord>),
@@ -363,8 +369,49 @@ where
   // Defuse the guard. Must not await after this point.
   let record = ScopeGuard::into_inner(guarded_record);
   http_trace!(record, "handle_request complete");
+  advertise_keep_alive_timeout(&record, keep_alive_timeout);
   let response = record.into_response();
   Ok(response)
+}
+
+fn header_contains_token(header: &HeaderValue, token: &[u8]) -> bool {
+  header.as_bytes().split(|&b| b == b',').any(|part| {
+    let part = part.trim_ascii();
+    part.eq_ignore_ascii_case(token)
+  })
+}
+
+fn request_supports_http1_keep_alive(
+  request_parts: &http::request::Parts,
+) -> bool {
+  if request_parts.version != http::Version::HTTP_11 {
+    return false;
+  }
+  !request_parts
+    .headers
+    .get_all(CONNECTION)
+    .iter()
+    .any(|value| header_contains_token(value, b"close"))
+}
+
+fn advertise_keep_alive_timeout(
+  record: &HttpRecord,
+  keep_alive_timeout: Option<u64>,
+) {
+  let Some(keep_alive_timeout) = keep_alive_timeout else {
+    return;
+  };
+  if !request_supports_http1_keep_alive(&record.request_parts()) {
+    return;
+  }
+  if keep_alive_timeout == 0 {
+    return;
+  }
+  let timeout_secs = keep_alive_timeout / 1000;
+  let value = HeaderValue::from_str(&format!("timeout={timeout_secs}"))
+    .expect("keep-alive timeout header should be valid");
+  let mut response_parts = record.response_parts();
+  response_parts.headers.insert(KEEP_ALIVE, value);
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -945,6 +992,7 @@ mod tests {
           tx.try_send(record).unwrap();
         },
         true,
+        None,
       )
     });
 

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -101,7 +101,7 @@ Deno.test(
   { permissions: { net: true } },
   async function httpServerKeepAliveTimeoutAdvertisedAndEnforced() {
     const listening = Promise.withResolvers<void>();
-    await using server = Deno.serve({
+    await using _server = Deno.serve({
       port: servePort,
       keepAliveTimeout: 1000,
       onListen: onListen(listening.resolve),

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -97,6 +97,50 @@ Deno.test(async function httpServerShutsDownPortBeforeResolving() {
   listener!.close();
 });
 
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerKeepAliveTimeoutAdvertisedAndEnforced() {
+    const listening = Promise.withResolvers<void>();
+    await using server = Deno.serve({
+      port: servePort,
+      keepAliveTimeout: 1000,
+      onListen: onListen(listening.resolve),
+    }, () => new Response("ok"));
+    await listening.promise;
+
+    const conn = await Deno.connect({ port: servePort });
+    try {
+      const encoder = new TextEncoder();
+      const writer = new BufWriter(conn);
+      const reader = new BufReader(conn);
+      const request =
+        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: keep-alive\r\n\r\n";
+      await writer.write(encoder.encode(request));
+      await writer.flush();
+
+      const tpr = new TextProtoReader(reader);
+      const statusLine = await tpr.readLine();
+      assertEquals(statusLine, "HTTP/1.1 200 OK");
+      const headers = await tpr.readMimeHeader();
+      if (headers === null) {
+        fail("expected response headers");
+      }
+      assertEquals(headers.get("keep-alive"), "timeout=1");
+
+      const contentLength = Number(headers.get("content-length"));
+      assertEquals(contentLength, 2);
+      const body = new Uint8Array(contentLength);
+      assertEquals(await reader.readFull(body), body);
+      assertEquals(new TextDecoder().decode(body), "ok");
+
+      await delay(1500);
+      assertEquals(await reader.read(new Uint8Array(1)), null);
+    } finally {
+      conn.close();
+    }
+  },
+);
+
 // When shutting down abruptly, we require that all in-progress connections are aborted,
 // no new connections are allowed, and no new transactions are allowed on existing connections.
 Deno.test(


### PR DESCRIPTION
Fixes denoland/deno#32497.
Closes bartlomieju/orchid-inbox#135

This adds a `keepAliveTimeout` option for TCP `Deno.serve` HTTP/1.1 servers. When set to a non-zero value, Deno configures Hyper with a timer-backed HTTP/1 header read timeout so idle keep-alive connections close on the configured schedule, and responses advertise the lifetime with `Keep-Alive: timeout=N`.

Verification:
- `cargo fmt --check`
- `deno fmt --check tests/unit/serve_test.ts cli/tsc/dts/lib.deno.ns.d.ts`
- `cargo check -p deno_http`
- `cargo test -p deno_http test_handle_request`
- `cargo build -p deno`
- `./target/debug/deno test --no-check -A --config tests/config/deno.json tests/unit/serve_test.ts --filter httpServerKeepAliveTimeoutAdvertisedAndEnforced`
- `cargo test -p deno --test integration serve:: -- --nocapture`

Note: direct unit test execution required initializing `tests/util/std` so the repo import map could resolve local std test utilities.