### PR TITLE
test: disable flaky test-dns-resolver-max-timeout

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1004,8 +1004,8 @@
     "parallel/test-dns-resolveany-bad-ancount.js": {},
     "parallel/test-dns-resolvens-typeerror.js": {},
     "parallel/test-dns-resolver-max-timeout.js": {
-      "flaky": true,
-      "windows": false // incredibly flaky in CI
+      "ignore": true,
+      "reason": "Flaky: timing-sensitive DNS timeout assertion; see #34176"
     },
     "parallel/test-dns-resolvesrv.js": {},
     "parallel/test-dns-resolvesrv-econnrefused.js": {},


### PR DESCRIPTION
Disables `parallel/test-dns-resolver-max-timeout.js`, which failed on main in ci.generated.yml run 25983020997.

The failure was a timing-sensitive DNS timeout assertion: `timeout1: 504, timeout2: 504`, then `assert.strictEqual(timeout1 > timeout2, true)`. The test was already marked flaky and disabled on Windows, but still exhausted retries on macOS.

Fixes #34176

@bartlomieju this is ready to merge