### PR TITLE
test: disable flaky test-cluster-send-deadlock

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -529,7 +529,10 @@
     "parallel/test-cluster-rr-handle-keep-loop-alive.js": { "windows": false },
     "parallel/test-cluster-rr-handle-ref-unref.js": { "windows": false },
     "parallel/test-cluster-rr-ref.js": { "windows": false },
-    "parallel/test-cluster-send-deadlock.js": { "windows": false },
+    "parallel/test-cluster-send-deadlock.js": {
+      "ignore": true,
+      "reason": "Flaky timeout on linux-aarch64, see #34180",
+    },
     "parallel/test-cluster-send-socket-to-worker-http-server.js": {
       "windows": false
     },

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -531,7 +531,7 @@
     "parallel/test-cluster-rr-ref.js": { "windows": false },
     "parallel/test-cluster-send-deadlock.js": {
       "ignore": true,
-      "reason": "Flaky timeout on linux-aarch64, see #34180",
+      "reason": "Flaky timeout on linux-aarch64, see #34180"
     },
     "parallel/test-cluster-send-socket-to-worker-http-server.js": {
       "windows": false


### PR DESCRIPTION
Disables node_compat::parallel::test-cluster-send-deadlock.js after it timed out after 10000ms on linux-aarch64 in main CI: https://github.com/denoland/deno/actions/runs/25984988506/job/76381947670\n\nTracking issue: #34180\n\n@bartlomieju this is ready to merge