### PR TITLE
test: disable flaky test-cluster-send-deadlock

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -529,7 +529,10 @@
     "parallel/test-cluster-rr-handle-keep-loop-alive.js": { "windows": false },
     "parallel/test-cluster-rr-handle-ref-unref.js": { "windows": false },
     "parallel/test-cluster-rr-ref.js": { "windows": false },
-    "parallel/test-cluster-send-deadlock.js": { "windows": false },
+    "parallel/test-cluster-send-deadlock.js": {
+      "ignore": true,
+      "reason": "Flaky: cluster IPC test timed out after 10000ms on main linux-aarch64 CI in runs 25868700017 and 25984988506."
+    },
     "parallel/test-cluster-send-socket-to-worker-http-server.js": {
       "windows": false
     },


### PR DESCRIPTION
Disables `node_compat::parallel::test-cluster-send-deadlock.js` after repeated 10000ms timeouts on main CI.

Failing run: https://github.com/denoland/deno/actions/runs/25984988506/job/76381947670
Previous flaky rerun: https://github.com/denoland/deno/actions/runs/25868700017
Tracking issue: #34180