### PR TITLE
feat(ext/node): buffer Network.* bodies for inspector body-fetch commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,6 +2161,7 @@ version = "0.400.0"
 dependencies = [
  "anyhow",
  "az",
+ "base64 0.22.1",
  "bencher",
  "bincode",
  "bit-set",

--- a/ext/node/ops/inspector.rs
+++ b/ext/node/ops/inspector.rs
@@ -122,6 +122,8 @@ pub fn op_inspector_emit_protocol_event(
     event_name.as_str(),
     "Network.requestWillBeSent"
       | "Network.responseReceived"
+      | "Network.loadingFinished"
+      | "Network.loadingFailed"
       | "Network.dataReceived"
       | "Network.dataSent"
   );
@@ -154,12 +156,16 @@ pub fn op_inspector_emit_protocol_event(
       .or_insert(serde_json::Value::Bool(false));
   }
 
-  if needs_capture {
-    inspector.capture_network_event(&event_name, &parsed);
-  }
+  let should_broadcast = if needs_capture {
+    inspector.capture_network_event(&event_name, &parsed)
+  } else {
+    true
+  };
 
-  let augmented = serde_json::to_string(&parsed).unwrap();
-  inspector.broadcast_to_sessions(&event_name, &augmented);
+  if should_broadcast {
+    let augmented = serde_json::to_string(&parsed).unwrap();
+    inspector.broadcast_to_sessions(&event_name, &augmented);
+  }
 }
 
 fn capture_initiator(scope: &mut v8::PinScope<'_, '_>) -> serde_json::Value {

--- a/ext/node/ops/inspector.rs
+++ b/ext/node/ops/inspector.rs
@@ -118,8 +118,15 @@ pub fn op_inspector_emit_protocol_event(
   let needs_initiator = event_name == "Network.requestWillBeSent"
     || event_name == "Network.webSocketCreated";
   let needs_has_post_data = event_name == "Network.requestWillBeSent";
+  let needs_capture = matches!(
+    event_name.as_str(),
+    "Network.requestWillBeSent"
+      | "Network.responseReceived"
+      | "Network.dataReceived"
+      | "Network.dataSent"
+  );
 
-  if !needs_initiator && !needs_has_post_data {
+  if !needs_initiator && !needs_has_post_data && !needs_capture {
     inspector.broadcast_to_sessions(&event_name, &params);
     return;
   }
@@ -145,6 +152,10 @@ pub fn op_inspector_emit_protocol_event(
     request
       .entry("hasPostData")
       .or_insert(serde_json::Value::Bool(false));
+  }
+
+  if needs_capture {
+    inspector.capture_network_event(&event_name, &parsed);
   }
 
   let augmented = serde_json::to_string(&parsed).unwrap();

--- a/ext/node/polyfills/inspector.js
+++ b/ext/node/polyfills/inspector.js
@@ -82,8 +82,9 @@ function encodeNetworkData(data) {
     const view = new Uint8Array(data);
     return op_base64_encode_from_buffer(view, 0, view.byteLength);
   }
-  // Unknown shape: leave as-is and let JSON.stringify handle it.
-  return data;
+  throw new TypeError(
+    "Expected data to be a string, Buffer, Uint8Array, or ArrayBuffer",
+  );
 }
 
 class Session extends EventEmitter {

--- a/ext/node/polyfills/inspector.js
+++ b/ext/node/polyfills/inspector.js
@@ -6,6 +6,7 @@
 (function () {
 const { core, primordials } = globalThis.__bootstrap;
 const {
+  op_base64_encode_from_buffer,
   op_get_extras_binding_object,
   op_inspector_close,
   op_inspector_connect,
@@ -53,11 +54,37 @@ function isLoopback(host) {
 const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
+  ObjectAssign,
   SymbolDispose,
   JSONParse,
   JSONStringify,
   SafeMap,
+  TypedArrayPrototypeGetByteLength,
+  TypedArrayPrototypeGetSymbolToStringTag,
+  Uint8Array,
 } = primordials;
+
+function encodeNetworkData(data) {
+  if (data == null) return undefined;
+  if (typeof data === "string") {
+    // Encode UTF-8 string as base64.
+    const buf = core.encode(data);
+    return op_base64_encode_from_buffer(buf, 0, buf.byteLength);
+  }
+  if (TypedArrayPrototypeGetSymbolToStringTag(data) === "Uint8Array") {
+    return op_base64_encode_from_buffer(
+      data,
+      0,
+      TypedArrayPrototypeGetByteLength(data),
+    );
+  }
+  if (data instanceof ArrayBuffer) {
+    const view = new Uint8Array(data);
+    return op_base64_encode_from_buffer(view, 0, view.byteLength);
+  }
+  // Unknown shape: leave as-is and let JSON.stringify handle it.
+  return data;
+}
 
 class Session extends EventEmitter {
   #connection = null;
@@ -247,6 +274,16 @@ function broadcastToFrontend(eventName, params) {
   op_inspector_emit_protocol_event(eventName, JSONStringify(params ?? {}));
 }
 
+function broadcastNetworkData(eventName, params) {
+  if (params && params.data !== undefined) {
+    const encoded = encodeNetworkData(params.data);
+    if (encoded !== params.data) {
+      params = ObjectAssign({ __proto__: null }, params, { data: encoded });
+    }
+  }
+  broadcastToFrontend(eventName, params);
+}
+
 const Network = {
   requestWillBeSent: (params) =>
     broadcastToFrontend("Network.requestWillBeSent", params),
@@ -256,8 +293,9 @@ const Network = {
     broadcastToFrontend("Network.loadingFinished", params),
   loadingFailed: (params) =>
     broadcastToFrontend("Network.loadingFailed", params),
-  dataReceived: (params) => broadcastToFrontend("Network.dataReceived", params),
-  dataSent: (params) => broadcastToFrontend("Network.dataSent", params),
+  dataReceived: (params) =>
+    broadcastNetworkData("Network.dataReceived", params),
+  dataSent: (params) => broadcastNetworkData("Network.dataSent", params),
   webSocketCreated: (params) =>
     broadcastToFrontend("Network.webSocketCreated", params),
   webSocketHandshakeResponseReceived: (params) =>

--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -28,6 +28,7 @@ uv_compat_export = []
 [dependencies]
 anyhow.workspace = true
 az = "1.2.1"
+base64 = { workspace = true }
 bincode.workspace = true
 bit-set.workspace = true
 bit-vec.workspace = true

--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -51,6 +51,249 @@ impl InspectorMsg {
   }
 }
 
+/// Maximum number of in-flight + completed requests kept for
+/// Network.getResponseBody/streamResourceContent. Older entries are evicted.
+const NETWORK_BUFFER_MAX_REQUESTS: usize = 32;
+/// Per-request body cap. Beyond this, additional chunks are dropped and
+/// the entry is marked truncated.
+const NETWORK_BUFFER_MAX_BYTES_PER_REQUEST: usize = 10 * 1024 * 1024;
+
+#[derive(Debug, Default)]
+struct NetworkDataEntry {
+  /// Top-level `charset` from `Network.requestWillBeSent`, if any.
+  /// Used by `Network.getRequestPostData` to decide whether the captured
+  /// request body can be returned as a utf-8 string.
+  request_charset: Option<String>,
+  /// `response.charset` from `Network.responseReceived`, if any.
+  /// Used by `Network.getResponseBody` to decide between utf-8 string
+  /// and base64 binary output.
+  response_charset: Option<String>,
+  /// Accumulated request body bytes. Populated from `request.postData` on
+  /// `requestWillBeSent`, then any subsequent `Network.dataSent` chunks.
+  post_data: Vec<u8>,
+  /// Decoded response body bytes, concatenated across `Network.dataReceived`
+  /// events.
+  data: Vec<u8>,
+  truncated: bool,
+}
+
+/// Bounded per-process buffer of request/response bodies, keyed by
+/// CDP `requestId`. Sized to keep peak memory usage predictable so that
+/// long-running processes attached to a debugger don't grow unbounded.
+#[derive(Debug, Default)]
+struct NetworkDataBuffer {
+  entries: HashMap<String, NetworkDataEntry>,
+  /// FIFO of request IDs in insertion order; oldest evicted first.
+  order: std::collections::VecDeque<String>,
+}
+
+impl NetworkDataBuffer {
+  fn ensure_capacity(&mut self) {
+    while self.order.len() >= NETWORK_BUFFER_MAX_REQUESTS {
+      if let Some(oldest) = self.order.pop_front() {
+        self.entries.remove(&oldest);
+      } else {
+        break;
+      }
+    }
+  }
+
+  fn touch(&mut self, request_id: &str) -> &mut NetworkDataEntry {
+    if !self.entries.contains_key(request_id) {
+      self.ensure_capacity();
+      self.order.push_back(request_id.to_string());
+      self
+        .entries
+        .insert(request_id.to_string(), NetworkDataEntry::default());
+    }
+    self.entries.get_mut(request_id).unwrap()
+  }
+
+  fn set_request_charset(&mut self, request_id: &str, charset: Option<String>) {
+    let entry = self.touch(request_id);
+    if charset.is_some() {
+      entry.request_charset = charset;
+    }
+  }
+
+  fn set_response_charset(
+    &mut self,
+    request_id: &str,
+    charset: Option<String>,
+  ) {
+    let entry = self.touch(request_id);
+    if charset.is_some() {
+      entry.response_charset = charset;
+    }
+  }
+
+  fn append_post_data(&mut self, request_id: &str, bytes: &[u8]) {
+    let entry = self.touch(request_id);
+    Self::extend_capped(&mut entry.post_data, &mut entry.truncated, bytes);
+  }
+
+  fn append_data(&mut self, request_id: &str, bytes: &[u8]) {
+    let entry = self.touch(request_id);
+    Self::extend_capped(&mut entry.data, &mut entry.truncated, bytes);
+  }
+
+  fn extend_capped(target: &mut Vec<u8>, truncated: &mut bool, bytes: &[u8]) {
+    if *truncated {
+      return;
+    }
+    let remaining =
+      NETWORK_BUFFER_MAX_BYTES_PER_REQUEST.saturating_sub(target.len());
+    if bytes.len() > remaining {
+      target.extend_from_slice(&bytes[..remaining]);
+      *truncated = true;
+    } else {
+      target.extend_from_slice(bytes);
+    }
+  }
+
+  fn get(&self, request_id: &str) -> Option<&NetworkDataEntry> {
+    self.entries.get(request_id)
+  }
+}
+
+fn is_utf8_charset(charset: Option<&str>) -> bool {
+  charset
+    .map(|c| c.eq_ignore_ascii_case("utf-8") || c.eq_ignore_ascii_case("utf8"))
+    .unwrap_or(false)
+}
+
+fn encode_b64(bytes: &[u8]) -> String {
+  base64::Engine::encode(&base64::engine::general_purpose::STANDARD, bytes)
+}
+
+/// Build the CDP response for `Network.getResponseBody`. If the captured
+/// response had `charset: utf-8`, return the body as a decoded string and
+/// `base64Encoded: false`; otherwise return the raw bytes as base64.
+fn build_get_response_body(
+  buf: &NetworkDataBuffer,
+  request_id: &str,
+) -> Result<serde_json::Value, &'static str> {
+  let entry = buf.get(request_id).ok_or("Request not found")?;
+  if is_utf8_charset(entry.response_charset.as_deref())
+    && let Ok(s) = std::str::from_utf8(&entry.data)
+  {
+    return Ok(json!({ "body": s, "base64Encoded": false }));
+  }
+  Ok(json!({
+    "body": encode_b64(&entry.data),
+    "base64Encoded": true,
+  }))
+}
+
+/// Build the CDP response for `Network.streamResourceContent`. Returns the
+/// currently-buffered body as base64. (Node also keeps the stream open for
+/// future chunks, but our simpler implementation just returns what's buffered;
+/// the test's `Network.dataReceived` listener receives the rest.)
+fn build_stream_resource_content(
+  buf: &NetworkDataBuffer,
+  request_id: &str,
+) -> Result<serde_json::Value, &'static str> {
+  let entry = buf.get(request_id).ok_or("Request not found")?;
+  Ok(json!({ "bufferedData": encode_b64(&entry.data) }))
+}
+
+/// Build the CDP response for `Network.getRequestPostData`. Node only
+/// supports text bodies here — if the captured request had no `charset`
+/// (or one we don't treat as utf-8), reject so callers fall back to
+/// inspecting the raw `dataSent` events.
+fn build_get_request_post_data(
+  buf: &NetworkDataBuffer,
+  request_id: &str,
+) -> Result<serde_json::Value, &'static str> {
+  let entry = buf.get(request_id).ok_or("Request not found")?;
+  if entry.post_data.is_empty() {
+    return Err("No post data available for the request");
+  }
+  if !is_utf8_charset(entry.request_charset.as_deref()) {
+    return Err("Binary request body is not supported");
+  }
+  let s = std::str::from_utf8(&entry.post_data)
+    .map_err(|_| "Request body is not valid UTF-8")?;
+  Ok(json!({ "postData": s }))
+}
+
+fn make_cdp_error_response(id: &serde_json::Value, message: &str) -> String {
+  json!({
+    "id": id,
+    "error": {
+      "code": -32602,
+      "message": message,
+    }
+  })
+  .to_string()
+}
+
+fn make_cdp_ok_response(
+  id: &serde_json::Value,
+  result: serde_json::Value,
+) -> String {
+  json!({
+    "id": id,
+    "result": result,
+  })
+  .to_string()
+}
+
+enum CustomDomainOutcome {
+  Empty,
+  Result(serde_json::Value),
+  Error(&'static str),
+}
+
+/// Dispatch a CDP command to one of the custom domains we own
+/// (`Network.*`, `DOMStorage.enable/disable`). Returns `None` if the method
+/// isn't ours and should be forwarded to V8.
+fn dispatch_custom_domain(
+  method: &str,
+  parsed: &serde_json::Value,
+  session: &InspectorSession,
+) -> Option<CustomDomainOutcome> {
+  match method {
+    "Network.enable" => {
+      session.state.network_enabled.set(true);
+      Some(CustomDomainOutcome::Empty)
+    }
+    "Network.disable" => {
+      session.state.network_enabled.set(false);
+      Some(CustomDomainOutcome::Empty)
+    }
+    "DOMStorage.enable" => {
+      session.state.dom_storage_enabled.set(true);
+      Some(CustomDomainOutcome::Empty)
+    }
+    "DOMStorage.disable" => {
+      session.state.dom_storage_enabled.set(false);
+      Some(CustomDomainOutcome::Empty)
+    }
+    "Network.getResponseBody"
+    | "Network.streamResourceContent"
+    | "Network.getRequestPostData" => {
+      let request_id = parsed
+        .pointer("/params/requestId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+      let buf = session.state.network_data.borrow();
+      let result = match method {
+        "Network.getResponseBody" => build_get_response_body(&buf, request_id),
+        "Network.streamResourceContent" => {
+          build_stream_resource_content(&buf, request_id)
+        }
+        _ => build_get_request_post_data(&buf, request_id),
+      };
+      Some(match result {
+        Ok(v) => CustomDomainOutcome::Result(v),
+        Err(msg) => CustomDomainOutcome::Error(msg),
+      })
+    }
+    _ => None,
+  }
+}
+
 // TODO(bartlomieju): remove this
 pub type SessionProxySender = UnboundedSender<InspectorMsg>;
 // TODO(bartlomieju): remove this
@@ -177,6 +420,11 @@ struct JsRuntimeInspectorState {
   nodeworker_enabled: Rc<Cell<bool>>,
   auto_attach_enabled: Rc<Cell<bool>>,
   discover_targets_enabled: Rc<Cell<bool>>,
+  /// Shared buffer of captured Network.* request/response bodies, populated
+  /// from `op_inspector_emit_protocol_event` and read by the dispatcher
+  /// when handling `Network.getResponseBody`/`getRequestPostData`/
+  /// `streamResourceContent`.
+  network_data: Rc<RefCell<NetworkDataBuffer>>,
 }
 
 struct JsRuntimeInspectorClient(Rc<JsRuntimeInspectorState>);
@@ -361,6 +609,7 @@ impl JsRuntimeInspectorState {
                 self.auto_attach_enabled.clone(),
                 self.discover_targets_enabled.clone(),
                 self.flags.clone(),
+                self.network_data.clone(),
               );
 
               let prev = sessions.handshake.replace(session);
@@ -589,6 +838,7 @@ impl JsRuntimeInspector {
       nodeworker_enabled: Rc::new(Cell::new(false)),
       auto_attach_enabled: Rc::new(Cell::new(false)),
       discover_targets_enabled: Rc::new(Cell::new(false)),
+      network_data: Rc::new(RefCell::new(NetworkDataBuffer::default())),
     });
     let client = Box::new(JsRuntimeInspectorClient(state.clone()));
     let v8_inspector_client = v8::inspector::V8InspectorClient::new(client);
@@ -810,6 +1060,69 @@ impl JsRuntimeInspector {
     rx
   }
 
+  /// Capture an incoming `Network.*` event payload into the shared body buffer
+  /// before it is broadcast to sessions. Called from
+  /// `op_inspector_emit_protocol_event` so subsequent
+  /// `Network.getResponseBody`/`streamResourceContent`/`getRequestPostData`
+  /// CDP commands have something to return.
+  pub fn capture_network_event(
+    &self,
+    event_name: &str,
+    params: &serde_json::Value,
+  ) {
+    let request_id = match params.get("requestId").and_then(|v| v.as_str()) {
+      Some(id) => id,
+      None => return,
+    };
+
+    let mut buf = self.state.network_data.borrow_mut();
+    match event_name {
+      "Network.requestWillBeSent" => {
+        let charset = params
+          .get("charset")
+          .and_then(|v| v.as_str())
+          .map(|s| s.to_string());
+        buf.set_request_charset(request_id, charset);
+        if let Some(post_data) =
+          params.pointer("/request/postData").and_then(|v| v.as_str())
+        {
+          buf.append_post_data(request_id, post_data.as_bytes());
+        } else {
+          // Still touch the entry so eviction order tracks it.
+          let _ = buf.touch(request_id);
+        }
+      }
+      "Network.responseReceived" => {
+        let charset = params
+          .pointer("/response/charset")
+          .and_then(|v| v.as_str())
+          .map(|s| s.to_string());
+        buf.set_response_charset(request_id, charset);
+      }
+      "Network.dataReceived" => {
+        if let Some(data_b64) = params.get("data").and_then(|v| v.as_str())
+          && let Ok(bytes) = base64::Engine::decode(
+            &base64::engine::general_purpose::STANDARD,
+            data_b64,
+          )
+        {
+          buf.append_data(request_id, &bytes);
+        }
+      }
+      "Network.dataSent" => {
+        if let Some(data_b64) = params.get("data").and_then(|v| v.as_str())
+          && let Ok(bytes) = base64::Engine::decode(
+            &base64::engine::general_purpose::STANDARD,
+            data_b64,
+          )
+        {
+          buf.append_post_data(request_id, &bytes);
+        }
+      }
+      _ => {}
+    }
+  }
+
   /// Broadcast a protocol event notification to all sessions that have the
   /// given domain enabled. Used for custom domains like Network.
   pub fn broadcast_to_sessions(&self, event_name: &str, params_json: &str) {
@@ -861,6 +1174,7 @@ impl JsRuntimeInspector {
         inspector.state.auto_attach_enabled.clone(),
         inspector.state.discover_targets_enabled.clone(),
         inspector.state.flags.clone(),
+        inspector.state.network_data.clone(),
       );
 
       let session_id = {
@@ -1046,44 +1360,26 @@ impl SessionContainer {
   ) {
     let session = self.local.get(&session_id).unwrap();
 
-    // Try custom domain dispatch before sending to V8
+    // Try custom-domain dispatch before sending to V8. For methods we own
+    // (Network.*, DOMStorage.enable/disable), generate the response here
+    // and skip V8 entirely.
     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&message)
       && let Some(method) = parsed.get("method").and_then(|m| m.as_str())
+      && let Some(outcome) = dispatch_custom_domain(method, &parsed, session)
     {
-      let handled = match method {
-        "Network.enable" => {
-          session.state.network_enabled.set(true);
-          true
-        }
-        "Network.disable" => {
-          session.state.network_enabled.set(false);
-          true
-        }
-        "DOMStorage.enable" => {
-          session.state.dom_storage_enabled.set(true);
-          true
-        }
-        "DOMStorage.disable" => {
-          session.state.dom_storage_enabled.set(false);
-          true
-        }
-        _ => false,
-      };
-      if handled {
-        // Send success response if there's an id
-        if let Some(id) = parsed.get("id").cloned() {
-          let call_id = id.as_i64().unwrap_or(0) as i32;
-          (session.state.send)(InspectorMsg {
-            kind: InspectorMsgKind::Message(call_id),
-            content: json!({
-              "id": id,
-              "result": {}
-            })
-            .to_string(),
-          });
-        }
-        return;
+      if let Some(id) = parsed.get("id") {
+        let call_id = id.as_i64().unwrap_or(0) as i32;
+        let content = match outcome {
+          CustomDomainOutcome::Empty => make_cdp_ok_response(id, json!({})),
+          CustomDomainOutcome::Result(v) => make_cdp_ok_response(id, v),
+          CustomDomainOutcome::Error(msg) => make_cdp_error_response(id, msg),
+        };
+        (session.state.send)(InspectorMsg {
+          kind: InspectorMsgKind::Message(call_id),
+          content,
+        });
       }
+      return;
     }
 
     session.dispatch_message(message);
@@ -1250,6 +1546,8 @@ struct InspectorSessionState {
   noderuntime_enabled: Cell<bool>,
   // Inspector flags (shared with JsRuntimeInspectorState) for checking waiting_for_session
   flags: Rc<RefCell<InspectorFlags>>,
+  // Shared body buffer used by the Network.* command handlers.
+  network_data: Rc<RefCell<NetworkDataBuffer>>,
 }
 
 /// An inspector session that proxies messages to concrete "transport layer",
@@ -1275,6 +1573,7 @@ impl InspectorSession {
     auto_attach_enabled: Rc<Cell<bool>>,
     discover_targets_enabled: Rc<Cell<bool>>,
     flags: Rc<RefCell<InspectorFlags>>,
+    network_data: Rc<RefCell<NetworkDataBuffer>>,
   ) -> Rc<Self> {
     let state = InspectorSessionState {
       is_dispatching_message,
@@ -1290,6 +1589,7 @@ impl InspectorSession {
       dom_storage_enabled: Cell::new(false),
       noderuntime_enabled: Cell::new(false),
       flags,
+      network_data,
     };
 
     let v8_session = v8_inspector.connect(
@@ -1440,6 +1740,9 @@ async fn pump_inspector_session_messages(
 
     let params = parsed.get("params").cloned();
     let msg_id = parsed.get("id").cloned();
+    // Body-fetch commands send their own response and skip the default
+    // `{result: {}}` send at the bottom of the loop.
+    let mut custom_response: Option<String> = None;
 
     match method {
       "Network.enable" => {
@@ -1453,6 +1756,31 @@ async fn pump_inspector_session_messages(
       }
       "DOMStorage.disable" => {
         session.state.dom_storage_enabled.set(false);
+      }
+      "Network.getResponseBody"
+      | "Network.streamResourceContent"
+      | "Network.getRequestPostData" => {
+        let request_id = params
+          .as_ref()
+          .and_then(|p| p.get("requestId"))
+          .and_then(|v| v.as_str())
+          .unwrap_or("");
+        let buf = session.state.network_data.borrow();
+        let result = match method {
+          "Network.getResponseBody" => {
+            build_get_response_body(&buf, request_id)
+          }
+          "Network.streamResourceContent" => {
+            build_stream_resource_content(&buf, request_id)
+          }
+          _ => build_get_request_post_data(&buf, request_id),
+        };
+        if let Some(id) = msg_id.as_ref() {
+          custom_response = Some(match result {
+            Ok(v) => make_cdp_ok_response(id, v),
+            Err(msg) => make_cdp_error_response(id, msg),
+          });
+        }
       }
       "NodeRuntime.enable" => {
         session.state.noderuntime_enabled.set(true);
@@ -1548,16 +1876,19 @@ async fn pump_inspector_session_messages(
       }
     }
 
-    // Send response after handling the command
+    // Send response after handling the command.
     if let Some(id) = msg_id {
       let call_id = id.as_i64().unwrap_or(0) as i32;
-      (session.state.send)(InspectorMsg {
-        kind: InspectorMsgKind::Message(call_id),
-        content: json!({
+      let content = custom_response.unwrap_or_else(|| {
+        json!({
           "id": id,
           "result": {}
         })
-        .to_string(),
+        .to_string()
+      });
+      (session.state.send)(InspectorMsg {
+        kind: InspectorMsgKind::Message(call_id),
+        content,
       });
     }
   }

--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -54,8 +54,8 @@ impl InspectorMsg {
 /// Maximum number of in-flight + completed requests kept for
 /// Network.getResponseBody/streamResourceContent. Older entries are evicted.
 const NETWORK_BUFFER_MAX_REQUESTS: usize = 32;
-/// Per-request body cap. Beyond this, additional chunks are dropped and
-/// the entry is marked truncated.
+/// Per-request body cap. Beyond this, additional chunks are silently dropped
+/// (matching Node's behavior in `RequestEntry::push_*_data_blob`).
 const NETWORK_BUFFER_MAX_BYTES_PER_REQUEST: usize = 10 * 1024 * 1024;
 
 #[derive(Debug, Default)]
@@ -74,7 +74,15 @@ struct NetworkDataEntry {
   /// Decoded response body bytes, concatenated across `Network.dataReceived`
   /// events.
   data: Vec<u8>,
-  truncated: bool,
+  /// `true` once the request body is fully sent: either no `hasPostData` was
+  /// declared, or `Network.dataSent` with `finished: true` arrived.
+  is_request_finished: bool,
+  /// `true` once `Network.loadingFinished` arrived for this request.
+  is_response_finished: bool,
+  /// `true` once `Network.streamResourceContent` was called for this request:
+  /// further `Network.dataReceived` events bypass the buffer and flow over the
+  /// wire instead, matching Node's `is_streaming` switch.
+  is_streaming: bool,
 }
 
 /// Bounded per-process buffer of request/response bodies, keyed by
@@ -98,119 +106,107 @@ impl NetworkDataBuffer {
     }
   }
 
-  fn touch(&mut self, request_id: &str) -> &mut NetworkDataEntry {
-    if !self.entries.contains_key(request_id) {
-      self.ensure_capacity();
-      self.order.push_back(request_id.to_string());
-      self
-        .entries
-        .insert(request_id.to_string(), NetworkDataEntry::default());
-    }
-    self.entries.get_mut(request_id).unwrap()
-  }
-
-  fn set_request_charset(&mut self, request_id: &str, charset: Option<String>) {
-    let entry = self.touch(request_id);
-    if charset.is_some() {
-      entry.request_charset = charset;
-    }
-  }
-
-  fn set_response_charset(
-    &mut self,
-    request_id: &str,
-    charset: Option<String>,
-  ) {
-    let entry = self.touch(request_id);
-    if charset.is_some() {
-      entry.response_charset = charset;
-    }
-  }
-
-  fn append_post_data(&mut self, request_id: &str, bytes: &[u8]) {
-    let entry = self.touch(request_id);
-    Self::extend_capped(&mut entry.post_data, &mut entry.truncated, bytes);
-  }
-
-  fn append_data(&mut self, request_id: &str, bytes: &[u8]) {
-    let entry = self.touch(request_id);
-    Self::extend_capped(&mut entry.data, &mut entry.truncated, bytes);
-  }
-
-  fn extend_capped(target: &mut Vec<u8>, truncated: &mut bool, bytes: &[u8]) {
-    if *truncated {
+  fn insert(&mut self, request_id: &str, entry: NetworkDataEntry) {
+    if self.entries.contains_key(request_id) {
       return;
     }
-    let remaining =
-      NETWORK_BUFFER_MAX_BYTES_PER_REQUEST.saturating_sub(target.len());
-    if bytes.len() > remaining {
-      target.extend_from_slice(&bytes[..remaining]);
-      *truncated = true;
-    } else {
-      target.extend_from_slice(bytes);
-    }
+    self.ensure_capacity();
+    self.order.push_back(request_id.to_string());
+    self.entries.insert(request_id.to_string(), entry);
   }
 
   fn get(&self, request_id: &str) -> Option<&NetworkDataEntry> {
     self.entries.get(request_id)
   }
+
+  fn get_mut(&mut self, request_id: &str) -> Option<&mut NetworkDataEntry> {
+    self.entries.get_mut(request_id)
+  }
+
+  fn erase(&mut self, request_id: &str) {
+    if self.entries.remove(request_id).is_some() {
+      self.order.retain(|id| id != request_id);
+    }
+  }
 }
 
+fn extend_capped(target: &mut Vec<u8>, bytes: &[u8]) {
+  let remaining =
+    NETWORK_BUFFER_MAX_BYTES_PER_REQUEST.saturating_sub(target.len());
+  let take = bytes.len().min(remaining);
+  target.extend_from_slice(&bytes[..take]);
+}
+
+/// Charset string matching Node's `request_charset == "utf-8"` check
+/// in `network_agent.cc`. Anything else is treated as binary.
 fn is_utf8_charset(charset: Option<&str>) -> bool {
-  charset
-    .map(|c| c.eq_ignore_ascii_case("utf-8") || c.eq_ignore_ascii_case("utf8"))
-    .unwrap_or(false)
+  charset == Some("utf-8")
 }
 
 fn encode_b64(bytes: &[u8]) -> String {
   base64::Engine::encode(&base64::engine::general_purpose::STANDARD, bytes)
 }
 
-/// Build the CDP response for `Network.getResponseBody`. If the captured
-/// response had `charset: utf-8`, return the body as a decoded string and
-/// `base64Encoded: false`; otherwise return the raw bytes as base64.
+/// Build the CDP response for `Network.getResponseBody`. Matches Node's
+/// `NetworkAgent::getResponseBody`: rejects if the response hasn't finished,
+/// returns utf-8 as string or otherwise as base64, then erases the entry.
 fn build_get_response_body(
-  buf: &NetworkDataBuffer,
+  buf: &mut NetworkDataBuffer,
   request_id: &str,
 ) -> Result<serde_json::Value, &'static str> {
   let entry = buf.get(request_id).ok_or("Request not found")?;
-  if is_utf8_charset(entry.response_charset.as_deref())
+  if entry.is_streaming {
+    return Err("Response body of the request is been streamed");
+  }
+  if !entry.is_response_finished {
+    return Err("Response data is not finished yet");
+  }
+  let result = if is_utf8_charset(entry.response_charset.as_deref())
     && let Ok(s) = std::str::from_utf8(&entry.data)
   {
-    return Ok(json!({ "body": s, "base64Encoded": false }));
-  }
-  Ok(json!({
-    "body": encode_b64(&entry.data),
-    "base64Encoded": true,
-  }))
+    json!({ "body": s, "base64Encoded": false })
+  } else {
+    json!({
+      "body": encode_b64(&entry.data),
+      "base64Encoded": true,
+    })
+  };
+  buf.erase(request_id);
+  Ok(result)
 }
 
-/// Build the CDP response for `Network.streamResourceContent`. Returns the
-/// currently-buffered body as base64. (Node also keeps the stream open for
-/// future chunks, but our simpler implementation just returns what's buffered;
-/// the test's `Network.dataReceived` listener receives the rest.)
+/// Build the CDP response for `Network.streamResourceContent`. Matches Node's
+/// `NetworkAgent::streamResourceContent`: returns currently-buffered data,
+/// flips the entry to streaming mode (so subsequent `Network.dataReceived`
+/// events flow over the wire), drains the buffer, and erases the entry if the
+/// response already finished.
 fn build_stream_resource_content(
-  buf: &NetworkDataBuffer,
+  buf: &mut NetworkDataBuffer,
   request_id: &str,
 ) -> Result<serde_json::Value, &'static str> {
-  let entry = buf.get(request_id).ok_or("Request not found")?;
-  Ok(json!({ "bufferedData": encode_b64(&entry.data) }))
+  let entry = buf.get_mut(request_id).ok_or("Request not found")?;
+  entry.is_streaming = true;
+  let buffered = std::mem::take(&mut entry.data);
+  let is_response_finished = entry.is_response_finished;
+  if is_response_finished {
+    buf.erase(request_id);
+  }
+  Ok(json!({ "bufferedData": encode_b64(&buffered) }))
 }
 
-/// Build the CDP response for `Network.getRequestPostData`. Node only
-/// supports text bodies here — if the captured request had no `charset`
-/// (or one we don't treat as utf-8), reject so callers fall back to
-/// inspecting the raw `dataSent` events.
+/// Build the CDP response for `Network.getRequestPostData`. Matches Node's
+/// `NetworkAgent::getRequestPostData`: rejects if not yet finished, rejects
+/// binary bodies, otherwise returns the body as a utf-8 string.
 fn build_get_request_post_data(
   buf: &NetworkDataBuffer,
   request_id: &str,
 ) -> Result<serde_json::Value, &'static str> {
   let entry = buf.get(request_id).ok_or("Request not found")?;
-  if entry.post_data.is_empty() {
-    return Err("No post data available for the request");
+  if !entry.is_request_finished {
+    return Err("Request data is not finished yet");
   }
   if !is_utf8_charset(entry.request_charset.as_deref()) {
-    return Err("Binary request body is not supported");
+    return Err("Unable to serialize binary request body");
   }
   let s = std::str::from_utf8(&entry.post_data)
     .map_err(|_| "Request body is not valid UTF-8")?;
@@ -277,11 +273,13 @@ fn dispatch_custom_domain(
         .pointer("/params/requestId")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-      let buf = session.state.network_data.borrow();
+      let mut buf = session.state.network_data.borrow_mut();
       let result = match method {
-        "Network.getResponseBody" => build_get_response_body(&buf, request_id),
+        "Network.getResponseBody" => {
+          build_get_response_body(&mut buf, request_id)
+        }
         "Network.streamResourceContent" => {
-          build_stream_resource_content(&buf, request_id)
+          build_stream_resource_content(&mut buf, request_id)
         }
         _ => build_get_request_post_data(&buf, request_id),
       };
@@ -1065,14 +1063,20 @@ impl JsRuntimeInspector {
   /// `op_inspector_emit_protocol_event` so subsequent
   /// `Network.getResponseBody`/`streamResourceContent`/`getRequestPostData`
   /// CDP commands have something to return.
+  ///
+  /// Returns `true` if the event should still be broadcast to sessions, or
+  /// `false` if the event was fully consumed by the buffer. Matches Node's
+  /// `NetworkAgent`: `dataSent` is purely a capture event, and `dataReceived`
+  /// is only forwarded once `streamResourceContent` has flipped the entry
+  /// into streaming mode.
   pub fn capture_network_event(
     &self,
     event_name: &str,
     params: &serde_json::Value,
-  ) {
-    let request_id = match params.get("requestId").and_then(|v| v.as_str()) {
-      Some(id) => id,
-      None => return,
+  ) -> bool {
+    let Some(request_id) = params.get("requestId").and_then(|v| v.as_str())
+    else {
+      return true;
     };
 
     let mut buf = self.state.network_data.borrow_mut();
@@ -1082,44 +1086,87 @@ impl JsRuntimeInspector {
           .get("charset")
           .and_then(|v| v.as_str())
           .map(|s| s.to_string());
-        buf.set_request_charset(request_id, charset);
+        let has_post_data = params
+          .pointer("/request/hasPostData")
+          .and_then(|v| v.as_bool())
+          .unwrap_or(false);
+        let mut entry = NetworkDataEntry {
+          request_charset: charset,
+          is_request_finished: !has_post_data,
+          ..NetworkDataEntry::default()
+        };
         if let Some(post_data) =
           params.pointer("/request/postData").and_then(|v| v.as_str())
         {
-          buf.append_post_data(request_id, post_data.as_bytes());
-        } else {
-          // Still touch the entry so eviction order tracks it.
-          let _ = buf.touch(request_id);
+          extend_capped(&mut entry.post_data, post_data.as_bytes());
         }
+        buf.insert(request_id, entry);
+        true
       }
       "Network.responseReceived" => {
-        let charset = params
-          .pointer("/response/charset")
-          .and_then(|v| v.as_str())
-          .map(|s| s.to_string());
-        buf.set_response_charset(request_id, charset);
+        if let Some(entry) = buf.get_mut(request_id) {
+          entry.response_charset = params
+            .pointer("/response/charset")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        }
+        true
+      }
+      "Network.loadingFinished" => {
+        if let Some(entry) = buf.get_mut(request_id) {
+          entry.is_response_finished = true;
+          if entry.is_streaming {
+            buf.erase(request_id);
+          }
+        }
+        true
+      }
+      "Network.loadingFailed" => {
+        buf.erase(request_id);
+        true
       }
       "Network.dataReceived" => {
+        let Some(entry) = buf.get_mut(request_id) else {
+          // No tracked request — pass through to the wire.
+          return true;
+        };
+        if entry.is_streaming {
+          // Streaming mode: bypass the buffer and forward to sessions.
+          return true;
+        }
         if let Some(data_b64) = params.get("data").and_then(|v| v.as_str())
           && let Ok(bytes) = base64::Engine::decode(
             &base64::engine::general_purpose::STANDARD,
             data_b64,
           )
         {
-          buf.append_data(request_id, &bytes);
+          extend_capped(&mut entry.data, &bytes);
         }
+        false
       }
       "Network.dataSent" => {
+        let Some(entry) = buf.get_mut(request_id) else {
+          return false;
+        };
+        if params
+          .get("finished")
+          .and_then(|v| v.as_bool())
+          .unwrap_or(false)
+        {
+          entry.is_request_finished = true;
+          return false;
+        }
         if let Some(data_b64) = params.get("data").and_then(|v| v.as_str())
           && let Ok(bytes) = base64::Engine::decode(
             &base64::engine::general_purpose::STANDARD,
             data_b64,
           )
         {
-          buf.append_post_data(request_id, &bytes);
+          extend_capped(&mut entry.post_data, &bytes);
         }
+        false
       }
-      _ => {}
+      _ => true,
     }
   }
 
@@ -1740,48 +1787,24 @@ async fn pump_inspector_session_messages(
 
     let params = parsed.get("params").cloned();
     let msg_id = parsed.get("id").cloned();
-    // Body-fetch commands send their own response and skip the default
-    // `{result: {}}` send at the bottom of the loop.
-    let mut custom_response: Option<String> = None;
+
+    if let Some(outcome) = dispatch_custom_domain(method, &parsed, &session) {
+      if let Some(id) = msg_id {
+        let call_id = id.as_i64().unwrap_or(0) as i32;
+        let content = match outcome {
+          CustomDomainOutcome::Empty => make_cdp_ok_response(&id, json!({})),
+          CustomDomainOutcome::Result(v) => make_cdp_ok_response(&id, v),
+          CustomDomainOutcome::Error(msg) => make_cdp_error_response(&id, msg),
+        };
+        (session.state.send)(InspectorMsg {
+          kind: InspectorMsgKind::Message(call_id),
+          content,
+        });
+      }
+      continue;
+    }
 
     match method {
-      "Network.enable" => {
-        session.state.network_enabled.set(true);
-      }
-      "Network.disable" => {
-        session.state.network_enabled.set(false);
-      }
-      "DOMStorage.enable" => {
-        session.state.dom_storage_enabled.set(true);
-      }
-      "DOMStorage.disable" => {
-        session.state.dom_storage_enabled.set(false);
-      }
-      "Network.getResponseBody"
-      | "Network.streamResourceContent"
-      | "Network.getRequestPostData" => {
-        let request_id = params
-          .as_ref()
-          .and_then(|p| p.get("requestId"))
-          .and_then(|v| v.as_str())
-          .unwrap_or("");
-        let buf = session.state.network_data.borrow();
-        let result = match method {
-          "Network.getResponseBody" => {
-            build_get_response_body(&buf, request_id)
-          }
-          "Network.streamResourceContent" => {
-            build_stream_resource_content(&buf, request_id)
-          }
-          _ => build_get_request_post_data(&buf, request_id),
-        };
-        if let Some(id) = msg_id.as_ref() {
-          custom_response = Some(match result {
-            Ok(v) => make_cdp_ok_response(id, v),
-            Err(msg) => make_cdp_error_response(id, msg),
-          });
-        }
-      }
       "NodeRuntime.enable" => {
         session.state.noderuntime_enabled.set(true);
         // If the runtime is paused on start (--inspect-brk), emit
@@ -1876,19 +1899,17 @@ async fn pump_inspector_session_messages(
       }
     }
 
-    // Send response after handling the command.
+    // Send default `{result: {}}` ack for commands handled above
+    // that don't produce their own response payload.
     if let Some(id) = msg_id {
       let call_id = id.as_i64().unwrap_or(0) as i32;
-      let content = custom_response.unwrap_or_else(|| {
-        json!({
+      (session.state.send)(InspectorMsg {
+        kind: InspectorMsgKind::Message(call_id),
+        content: json!({
           "id": id,
           "result": {}
         })
-        .to_string()
-      });
-      (session.state.send)(InspectorMsg {
-        kind: InspectorMsgKind::Message(call_id),
-        content,
+        .to_string(),
       });
     }
   }

--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -147,19 +147,50 @@ fn encode_b64(bytes: &[u8]) -> String {
   base64::Engine::encode(&base64::engine::general_purpose::STANDARD, bytes)
 }
 
+/// CDP error returned by the custom-domain handlers. The error code mirrors
+/// Node's `protocol::DispatchResponse` constants used in `network_agent.cc`:
+/// `InvalidParams` for caller-state issues (request not found, not finished,
+/// streaming), `ServerError` for the binary-request-body case that the
+/// protocol doesn't model.
+enum CdpError {
+  InvalidParams(&'static str),
+  ServerError(&'static str),
+}
+
+impl CdpError {
+  fn code(&self) -> i32 {
+    match self {
+      // Per JSON-RPC spec and Node's DispatchResponse::InvalidParams.
+      Self::InvalidParams(_) => -32602,
+      // Per Node's DispatchResponse::ServerError.
+      Self::ServerError(_) => -32000,
+    }
+  }
+
+  fn message(&self) -> &'static str {
+    match self {
+      Self::InvalidParams(m) | Self::ServerError(m) => m,
+    }
+  }
+}
+
 /// Build the CDP response for `Network.getResponseBody`. Matches Node's
 /// `NetworkAgent::getResponseBody`: rejects if the response hasn't finished,
 /// returns utf-8 as string or otherwise as base64, then erases the entry.
 fn build_get_response_body(
   buf: &mut NetworkDataBuffer,
   request_id: &str,
-) -> Result<serde_json::Value, &'static str> {
-  let entry = buf.get(request_id).ok_or("Request not found")?;
+) -> Result<serde_json::Value, CdpError> {
+  let entry = buf
+    .get(request_id)
+    .ok_or(CdpError::InvalidParams("Request not found"))?;
   if entry.is_streaming {
-    return Err("Response body of the request is been streamed");
+    return Err(CdpError::InvalidParams(
+      "Response body of the request is been streamed",
+    ));
   }
   if !entry.is_response_finished {
-    return Err("Response data is not finished yet");
+    return Err(CdpError::InvalidParams("Response data is not finished yet"));
   }
   let result = if is_utf8_charset(entry.response_charset.as_deref())
     && let Ok(s) = std::str::from_utf8(&entry.data)
@@ -183,8 +214,10 @@ fn build_get_response_body(
 fn build_stream_resource_content(
   buf: &mut NetworkDataBuffer,
   request_id: &str,
-) -> Result<serde_json::Value, &'static str> {
-  let entry = buf.get_mut(request_id).ok_or("Request not found")?;
+) -> Result<serde_json::Value, CdpError> {
+  let entry = buf
+    .get_mut(request_id)
+    .ok_or(CdpError::InvalidParams("Request not found"))?;
   entry.is_streaming = true;
   let buffered = std::mem::take(&mut entry.data);
   let is_response_finished = entry.is_response_finished;
@@ -200,25 +233,32 @@ fn build_stream_resource_content(
 fn build_get_request_post_data(
   buf: &NetworkDataBuffer,
   request_id: &str,
-) -> Result<serde_json::Value, &'static str> {
-  let entry = buf.get(request_id).ok_or("Request not found")?;
+) -> Result<serde_json::Value, CdpError> {
+  let entry = buf
+    .get(request_id)
+    .ok_or(CdpError::InvalidParams("Request not found"))?;
   if !entry.is_request_finished {
-    return Err("Request data is not finished yet");
+    return Err(CdpError::InvalidParams("Request data is not finished yet"));
   }
   if !is_utf8_charset(entry.request_charset.as_deref()) {
-    return Err("Unable to serialize binary request body");
+    // Node returns ServerError here, not InvalidParams: the protocol simply
+    // doesn't model binary post bodies, so this is a server-side limitation
+    // rather than a caller mistake.
+    return Err(CdpError::ServerError(
+      "Unable to serialize binary request body",
+    ));
   }
   let s = std::str::from_utf8(&entry.post_data)
-    .map_err(|_| "Request body is not valid UTF-8")?;
+    .map_err(|_| CdpError::ServerError("Request body is not valid UTF-8"))?;
   Ok(json!({ "postData": s }))
 }
 
-fn make_cdp_error_response(id: &serde_json::Value, message: &str) -> String {
+fn make_cdp_error_response(id: &serde_json::Value, error: &CdpError) -> String {
   json!({
     "id": id,
     "error": {
-      "code": -32602,
-      "message": message,
+      "code": error.code(),
+      "message": error.message(),
     }
   })
   .to_string()
@@ -238,7 +278,7 @@ fn make_cdp_ok_response(
 enum CustomDomainOutcome {
   Empty,
   Result(serde_json::Value),
-  Error(&'static str),
+  Error(CdpError),
 }
 
 /// Dispatch a CDP command to one of the custom domains we own
@@ -285,7 +325,7 @@ fn dispatch_custom_domain(
       };
       Some(match result {
         Ok(v) => CustomDomainOutcome::Result(v),
-        Err(msg) => CustomDomainOutcome::Error(msg),
+        Err(err) => CustomDomainOutcome::Error(err),
       })
     }
     _ => None,
@@ -1419,7 +1459,7 @@ impl SessionContainer {
         let content = match outcome {
           CustomDomainOutcome::Empty => make_cdp_ok_response(id, json!({})),
           CustomDomainOutcome::Result(v) => make_cdp_ok_response(id, v),
-          CustomDomainOutcome::Error(msg) => make_cdp_error_response(id, msg),
+          CustomDomainOutcome::Error(err) => make_cdp_error_response(id, &err),
         };
         (session.state.send)(InspectorMsg {
           kind: InspectorMsgKind::Message(call_id),
@@ -1794,7 +1834,7 @@ async fn pump_inspector_session_messages(
         let content = match outcome {
           CustomDomainOutcome::Empty => make_cdp_ok_response(&id, json!({})),
           CustomDomainOutcome::Result(v) => make_cdp_ok_response(&id, v),
-          CustomDomainOutcome::Error(msg) => make_cdp_error_response(&id, msg),
+          CustomDomainOutcome::Error(err) => make_cdp_error_response(&id, &err),
         };
         (session.state.send)(InspectorMsg {
           kind: InspectorMsgKind::Message(call_id),

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4774,6 +4774,8 @@
     "parallel/test-inspector-has-inspector-false.js": {},
     "parallel/test-inspector-ip-detection.js": {},
     "parallel/test-inspector-network-arbitrary-data.js": {},
+    "parallel/test-inspector-network-data-received.js": {},
+    "parallel/test-inspector-network-data-sent.js": {},
     "parallel/test-listen-fd-cluster.js": {
       "linux": false,
       "darwin": false,


### PR DESCRIPTION
The Node-style inspector Network domain shipped in #32707 plumbed event
broadcast for Network.dataReceived / dataSent / requestWillBeSent /
responseReceived, but the three CDP commands consumers actually use to
pull bodies back out — Network.getResponseBody,
Network.streamResourceContent, and Network.getRequestPostData — weren't
implemented, so any tool that called them got a -32601 method-not-found
error.

This adds a bounded per-process buffer (32 requests max, 10 MB per
request, FIFO eviction) on the inspector that captures bodies as the
events flow through op_inspector_emit_protocol_event, plus dispatcher
handlers for the three commands on both the local-session and WebSocket
paths. Charset handling mirrors Node: utf-8 returns a decoded string,
anything else returns base64. Raw Buffer/Uint8Array data passed to
inspector.Network.dataReceived/.dataSent is base64-encoded at the
polyfill layer to match the wire format consumers expect.

Clears four node_compat tests:
test-inspector-network-data-received.js,
test-inspector-network-data-sent.js,
test-inspector-network-arbitrary-data.js, and
test-inspector-emit-protocol-event.js. Wiring fetch / node:http / http2 /
ws as event producers is a follow-up that will build on this buffer.