### PR TITLE
test: enable test-inspector-break-e.js

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -2285,7 +2285,7 @@
     // "parallel/test-inspector-async-hook-setup-at-inspect-brk.js": {},
     // "parallel/test-inspector-async-stack-traces-set-interval.js": {},
     // "parallel/test-inspector-scriptparsed-context.js": {},
-    // "parallel/test-inspector-break-e.js": {},
+    "parallel/test-inspector-break-e.js": {},
     // "parallel/test-inspector-waiting-for-disconnect.js": {},
     // "parallel/test-inspector-worker-target.js"
     // "parallel/test-inspector-debug-brk-flag.js": {},


### PR DESCRIPTION
Already passing after #34192 (\"fix: report eval scripts as [eval] URL
for inspector\") plumbed the [eval] sourceURL through to
Debugger.scriptParsed and stack frames. That PR enabled the sibling
async-stack-traces-promise-then test at the time; this enables break-e
for the same reason — verified locally with three consecutive runs.

The three remaining inspector tests in the eval-URL family
(test-inspector-scriptparsed-context, test-inspector-async-hook-setup-
at-inspect-brk, test-inspector-async-stack-traces-set-interval) need
work outside the scope of this change: breakOnFirstLine plumbing on
vm.Script::Compile and V8Inspector::asyncTask{Scheduled,Started,
Finished} bindings, both of which require additions in rusty_v8 first.