### PR TITLE
fix(ext/node): module hook fixes for ESM nextLoad, createRequire URL, and builtin redirects

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -767,7 +767,21 @@ function executeEsmLoadHookChain(fileUrl, context) {
       currentContext = { ...currentContext, ...ctx };
     }
     if (index >= loadHooks.length) {
-      // End of chain - signal fallthrough to Rust default loading
+      // End of chain - perform default load so user hooks calling
+      // nextLoad() receive the actual source they can transform.
+      if (StringPrototypeStartsWith(loadUrl, "node:")) {
+        return { source: null, format: "builtin", shortCircuit: true };
+      }
+      if (StringPrototypeStartsWith(loadUrl, "file://")) {
+        const source = op_require_read_file(url.fileURLToPath(loadUrl));
+        return {
+          source,
+          format: currentContext?.format ?? undefined,
+          shortCircuit: true,
+        };
+      }
+      // For other schemes (data:, http(s):, etc.) we cannot synchronously
+      // produce source here; fall through to Rust default loading.
       return { source: null, shortCircuit: true };
     }
     const hook = loadHooks[index++];

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -510,6 +510,7 @@ let insideLoadHook = false;
 let utf8Decoder;
 let esmLoadLoopRunning = false;
 const requireResolveOptionsMarker = Symbol("require.resolve");
+const kSourceURL = Symbol("kSourceURL");
 
 function executeResolveHookChain(specifier, context, parent, isMain, options) {
   // Collect resolve hooks from hookEntries in LIFO order
@@ -1475,11 +1476,13 @@ Module._load = function (request, parent, isMain) {
   }
 
   maybeEmitNativeModuleDeprecation(filename);
-  const mod = loadNativeModule(filename, request);
-  if (
-    mod
-  ) {
-    return mod.exports;
+  // A resolve hook that redirected `require('zlib')` to a file path must
+  // not silently fall back to the native module via the original request.
+  if (!SetPrototypeHas(cjsHookResolvedFilenames, filename)) {
+    const mod = loadNativeModule(filename, request);
+    if (mod) {
+      return mod.exports;
+    }
   }
   // Don't call updateChildren(), Module constructor already does.
   const module = cachedModule || new Module(filename, parent);
@@ -1580,9 +1583,10 @@ Module._resolveFilename = function (
     // observable.
     request !== parent?.filename
   ) {
-    const parentURL = parent?.filename
-      ? url.pathToFileURL(parent.filename).href
-      : undefined;
+    const parentURL = parent?.[kSourceURL] ??
+      (parent?.filename
+        ? url.pathToFileURL(parent.filename).href
+        : undefined);
     const context = {
       conditions: ["node", "require"],
       importAttributes: { __proto__: null },
@@ -2217,11 +2221,17 @@ Module._extensions[".node"] = function (module, filename) {
   );
 };
 
-function createRequireFromPath(filename) {
+function createRequireFromPath(filename, sourceURL) {
   const proxyPath = op_require_proxy_path(filename) ?? filename;
   const mod = new Module(proxyPath);
   mod.filename = proxyPath;
   mod.paths = Module._nodeModulePaths(mod.path);
+  if (sourceURL !== undefined) {
+    // Preserve the original URL (with query/hash) for resolve hooks'
+    // `context.parentURL`, which would otherwise lose those parts via
+    // pathToFileURL(filename).
+    mod[kSourceURL] = sourceURL;
+  }
   return makeRequireFunction(mod);
 }
 
@@ -2303,7 +2313,7 @@ function createRequire(filenameOrUrl) {
     );
   }
   const filename = op_require_as_file_path(fileUrlStr) ?? fileUrlStr;
-  return createRequireFromPath(filename);
+  return createRequireFromPath(filename, fileUrlStr);
 }
 
 function isBuiltin(moduleName) {

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -774,12 +774,18 @@ function executeEsmLoadHookChain(fileUrl, context) {
         return { source: null, format: "builtin", shortCircuit: true };
       }
       if (StringPrototypeStartsWith(loadUrl, "file://")) {
-        const source = op_require_read_file(url.fileURLToPath(loadUrl));
-        return {
-          source,
-          format: currentContext?.format ?? undefined,
-          shortCircuit: true,
-        };
+        try {
+          const source = op_require_read_file(url.fileURLToPath(loadUrl));
+          return {
+            source,
+            format: currentContext?.format ?? undefined,
+            shortCircuit: true,
+          };
+        } catch {
+          // File isn't available synchronously (e.g. embedded in a compiled
+          // binary's eszip); fall through to Rust default loading.
+          return { source: null, shortCircuit: true };
+        }
       }
       // For other schemes (data:, http(s):, etc.) we cannot synchronously
       // produce source here; fall through to Rust default loading.

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -1584,9 +1584,7 @@ Module._resolveFilename = function (
     request !== parent?.filename
   ) {
     const parentURL = parent?.[kSourceURL] ??
-      (parent?.filename
-        ? url.pathToFileURL(parent.filename).href
-        : undefined);
+      (parent?.filename ? url.pathToFileURL(parent.filename).href : undefined);
     const context = {
       conditions: ["node", "require"],
       importAttributes: { __proto__: null },

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -157,21 +157,27 @@
       "ignore": true,
       "reason": "Node.js snapshot/heap profiling features (--build-snapshot, --heap-prof, --heapsnapshot-near-heap-limit) are not implemented in Deno"
     },
+    "module-hooks/test-module-hooks-create-require-with-url.mjs": {},
     "module-hooks/test-module-hooks-load-context-merged.js": {},
     "module-hooks/test-module-hooks-load-context-optional.js": {},
     "module-hooks/test-module-hooks-load-async-and-sync.js": {
       "ignore": true,
       "reason": "Depends on deprecated module.register() loader hooks, which Deno intentionally does not implement"
     },
+    "module-hooks/test-module-hooks-load-esm.js": {},
+    "module-hooks/test-module-hooks-load-esm-mock.js": {},
     "module-hooks/test-module-hooks-load-short-circuit.js": {},
     "module-hooks/test-module-hooks-load-short-circuit-required-middle.js": {},
     "module-hooks/test-module-hooks-load-short-circuit-required-start.js": {},
+    "module-hooks/test-module-hooks-load-url-change-import.mjs": {},
     "module-hooks/test-module-hooks-preload.js": {
       "ignore": true,
       "reason": "Depends on deprecated module.register() loader hooks, which Deno intentionally does not implement"
     },
+    "module-hooks/test-module-hooks-resolve-builtin-on-disk-require.js": {},
     "module-hooks/test-module-hooks-resolve-context-merged.js": {},
     "module-hooks/test-module-hooks-resolve-context-optional.js": {},
+    "module-hooks/test-module-hooks-resolve-load-builtin-override-both.js": {},
     "module-hooks/test-module-hooks-resolve-require-resolve-loaded-with-source.js": {
       "ignore": true,
       "reason": "Depends on deprecated module.register() loader hooks, which Deno intentionally does not implement"


### PR DESCRIPTION
A trio of fixes to `node:module` registerHooks() compat behavior, motivated
by failing tests in the bundled `test-module-hooks` suite.

In the ESM load hook chain, `nextLoad()` used to return `{ source: null }`
when the chain fell through, breaking user hooks that wrap `nextLoad` to
transform real source. The terminal step now reads the file from disk for
`file://` URLs (and returns the builtin marker for `node:*`), matching the
contract followed by the CJS path.

`createRequire(url)` dropped a URL's query/hash because the resolve hook
chain rebuilt `context.parentURL` from the Module's filename via
`pathToFileURL`. The original URL is now stashed on the Module under a
private symbol and preferred when populating `parentURL`.

When a resolve hook redirected `require('zlib')` to a file path,
`Module._load` would still hit `loadNativeModule(filename, request)` and
return the native builtin via the original request name. The fallback is
now skipped when the filename came from a hook (tracked in
`cjsHookResolvedFilenames`).

Six previously-failing module-hooks compat tests are enabled in
`tests/node_compat/config.jsonc` as a result.