### PR TITLE
feat(cli): add --watch flag to deno check

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -202,6 +202,7 @@ pub struct CheckFlags {
   pub doc: bool,
   pub doc_only: bool,
   pub check_js: bool,
+  pub watch: Option<WatchFlags>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -753,6 +754,9 @@ impl DenoSubcommand {
         watch: Some(flags), ..
       }) => Some(WatchFlagsRef::WithPaths(flags)),
       Self::Bench(BenchFlags {
+        watch: Some(flags), ..
+      })
+      | Self::Check(CheckFlags {
         watch: Some(flags), ..
       })
       | Self::Lint(LintFlags {
@@ -2878,6 +2882,9 @@ Unless --reload is specified, this command will not re-download already cached d
         .arg(allow_import_arg())
         .arg(deny_import_arg())
         .arg(v8_flags_arg())
+        .arg(watch_arg(false))
+        .arg(watch_exclude_arg())
+        .arg(no_clear_screen_arg())
       }
     )
 }
@@ -6723,6 +6730,7 @@ fn check_parse(
     doc: matches.get_flag("doc"),
     doc_only: matches.get_flag("doc-only"),
     check_js: matches.get_flag("check-js"),
+    watch: watch_arg_parse(matches)?,
   });
   flags.code_cache_enabled = !matches.get_flag("no-code-cache");
   allow_and_deny_import_parse(flags, matches)?;
@@ -10142,6 +10150,7 @@ mod tests {
           doc: false,
           doc_only: false,
           check_js: false,
+          watch: None,
         }),
         type_check_mode: TypeCheckMode::Local,
         code_cache_enabled: true,
@@ -10158,6 +10167,7 @@ mod tests {
           doc: false,
           doc_only: false,
           check_js: false,
+          watch: None,
         }),
         type_check_mode: TypeCheckMode::Local,
         code_cache_enabled: true,
@@ -10174,6 +10184,7 @@ mod tests {
           doc: true,
           doc_only: false,
           check_js: false,
+          watch: None,
         }),
         type_check_mode: TypeCheckMode::Local,
         code_cache_enabled: true,
@@ -10190,6 +10201,7 @@ mod tests {
           doc: false,
           doc_only: true,
           check_js: false,
+          watch: None,
         }),
         type_check_mode: TypeCheckMode::Local,
         code_cache_enabled: true,
@@ -10220,6 +10232,7 @@ mod tests {
             doc: false,
             doc_only: false,
             check_js: false,
+            watch: None,
           }),
           type_check_mode: TypeCheckMode::All,
           code_cache_enabled: true,
@@ -10249,6 +10262,7 @@ mod tests {
           doc: false,
           doc_only: false,
           check_js: true,
+          watch: None,
         }),
         type_check_mode: TypeCheckMode::Local,
         code_cache_enabled: true,
@@ -15998,6 +16012,7 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
           doc: false,
           doc_only: false,
           check_js: false,
+          watch: None,
         }),
         type_check_mode: TypeCheckMode::Local,
         code_cache_enabled: true,

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -11,13 +11,40 @@ use crate::factory::CliFactory;
 use crate::graph_container::CheckSpecifiersOptions;
 use crate::graph_container::CollectSpecifiersOptions;
 use crate::util::extract;
+use crate::util::file_watcher;
 
 pub async fn check(
   flags: Arc<Flags>,
   check_flags: CheckFlags,
 ) -> Result<(), AnyError> {
-  let factory = CliFactory::from_flags(flags);
+  if let Some(watch_flags) = &check_flags.watch {
+    let no_clear_screen = watch_flags.no_clear_screen;
+    file_watcher::watch_func(
+      flags,
+      file_watcher::PrintConfig::new("Check", !no_clear_screen),
+      move |flags, watcher_communicator, changed_paths| {
+        let check_flags = check_flags.clone();
+        watcher_communicator.show_path_changed(changed_paths);
+        Ok(async move {
+          let factory = CliFactory::from_flags_for_watcher(
+            flags,
+            watcher_communicator.clone(),
+          );
+          check_with_factory(&factory, check_flags).await
+        })
+      },
+    )
+    .await
+  } else {
+    let factory = CliFactory::from_flags(flags);
+    check_with_factory(&factory, check_flags).await
+  }
+}
 
+async fn check_with_factory(
+  factory: &CliFactory,
+  check_flags: CheckFlags,
+) -> Result<(), AnyError> {
   let main_graph_container = factory.main_module_graph_container().await?;
 
   let specifiers = main_graph_container.collect_specifiers(

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -492,6 +492,35 @@ async fn fmt_check_all_files_on_each_change_test() {
 }
 
 #[test(flaky)]
+async fn check_watch_test() {
+  let t = TempDir::new();
+  let file_to_check = t.path().join("main.ts");
+  file_to_check.write("const x: number = \"hello\";\n");
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("check")
+    .arg(&file_to_check)
+    .arg("--watch")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (_stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  let next_line = next_line(&mut stderr_lines).await.unwrap();
+  assert_contains!(&next_line, "Check started");
+  assert_contains!(wait_contains("TS2322", &mut stderr_lines).await, "TS2322");
+  wait_contains("Check failed.", &mut stderr_lines).await;
+
+  // Fix the type error.
+  file_to_check.write("const x: number = 42;\nconsole.log(x);\n");
+
+  wait_contains("Check finished.", &mut stderr_lines).await;
+
+  check_alive_then_kill(child);
+}
+
+#[test(flaky)]
 async fn run_watch_no_dynamic() {
   let t = TempDir::new();
   let file_to_watch = t.path().join("file_to_watch.js");


### PR DESCRIPTION
Adds `--watch` support to `deno check`, so that the type checker re-runs
automatically whenever a file in the dependency graph changes. This has
been a long-standing user request — the existing workaround is to wrap
`deno check` in an external file-watching tool, which is less precise and
doesn't reuse anything across runs.

The implementation follows the same shape as `run --watch`: when the flag
is present, the check pass is run inside `file_watcher::watch_func`, and
the factory is built via `from_flags_for_watcher` so the graph loader's
`FileWatcherReporter` automatically registers every loaded module with
the watcher. No bespoke path collection is needed beyond what the module
graph already exposes.

Closes #14858