### PR TITLE
feat: add `deno ci` subcommand

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1763,6 +1763,8 @@ static DENO_HELP: &str = cstr!(
                   <p(245)>deno add jsr:@std/assert  |  deno add npm:express</>
     <g>bump-version</> Update version in the configuration file
     <g>install</>      Installs dependencies either in the local project or globally to a bin directory
+    <g>ci</>           Install dependencies in a clean, reproducible way for CI environments
+                  <p(245)>deno ci  |  deno ci --prod</>
     <g>uninstall</>    Uninstalls a dependency or an executable script in the installation root's bin directory
     <g>outdated</>     Find and update outdated dependencies
     <g>approve-scripts</> Approve npm lifecycle scripts

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -383,6 +383,12 @@ pub enum InstallFlagsLocal {
   Entrypoints(InstallEntrypointsFlags),
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CiFlags {
+  pub production: bool,
+  pub skip_types: bool,
+}
+
 /// Overrides for the target OS and architecture when installing npm packages.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct NpmInstallTargetFlags {
@@ -709,6 +715,7 @@ pub enum DenoSubcommand {
   Bundle(BundleFlags),
   Cache(CacheFlags),
   Check(CheckFlags),
+  Ci(CiFlags),
   Clean(CleanFlags),
   Compile(CompileFlags),
   Completions(CompletionsFlags),
@@ -2001,6 +2008,7 @@ pub fn flags_from_vec_with_initial_cwd(
         "init" => init_parse(&mut flags, &mut m)?,
         "info" => info_parse(&mut flags, &mut m)?,
         "install" => install_parse(&mut flags, &mut m, app)?,
+        "ci" => ci_parse(&mut flags, &mut m)?,
         "json_reference" => json_reference_parse(&mut flags, &mut m, app),
         "jupyter" => jupyter_parse(&mut flags, &mut m),
         "lint" => lint_parse(&mut flags, &mut m)?,
@@ -2274,6 +2282,7 @@ pub fn clap_root() -> Command {
         .subcommand(init_subcommand())
         .subcommand(info_subcommand())
         .subcommand(install_subcommand())
+        .subcommand(ci_subcommand())
         .subcommand(json_reference_subcommand())
         .subcommand(jupyter_subcommand())
         .subcommand(approve_scripts_subcommand())
@@ -3771,6 +3780,39 @@ These must be added to the path manually if required."), UnstableArgsConfig::Res
             .requires("prod"),
         )
     })
+}
+
+fn ci_subcommand() -> Command {
+  command(
+    "ci",
+    cstr!("Install dependencies in a clean, reproducible way for CI environments.
+
+Similar to <p(245)>npm ci</>: requires a <p(245)>deno.lock</> file, removes any existing <p(245)>node_modules</>
+directory, and then installs strictly from the lockfile. Errors if <p(245)>deno.lock</>
+is missing or out of date with the config file.
+
+  <p(245)>deno ci</>
+  <p(245)>deno ci --prod</>"),
+    UnstableArgsConfig::ResolutionAndRuntime,
+  )
+  .defer(|cmd| {
+    cmd
+      .arg(
+        Arg::new("prod")
+          .long("prod")
+          .alias("production")
+          .help("Only install production dependencies (excludes devDependencies)")
+          .action(ArgAction::SetTrue),
+      )
+      .arg(
+        Arg::new("skip-types")
+          .long("skip-types")
+          .help(cstr!("Exclude @types/* packages from installation.
+<y>Be careful, as it uses a name-based heuristic and may skip packages that ship runtime code.</>"))
+          .action(ArgAction::SetTrue)
+          .requires("prod"),
+      )
+  })
 }
 
 fn lockfile_only_arg() -> Arg {
@@ -7334,6 +7376,19 @@ fn install_parse(
       npm_target,
     ));
   }
+  Ok(())
+}
+
+fn ci_parse(
+  flags: &mut Flags,
+  matches: &mut ArgMatches,
+) -> clap::error::Result<()> {
+  unstable_args_parse(flags, matches, UnstableArgsConfig::ResolutionAndRuntime);
+  flags.frozen_lockfile = Some(true);
+  flags.subcommand = DenoSubcommand::Ci(CiFlags {
+    production: matches.get_flag("prod"),
+    skip_types: matches.get_flag("skip-types"),
+  });
   Ok(())
 }
 
@@ -15049,6 +15104,35 @@ mod tests {
       assert_eq!(long_flag, short_flag, "{} subcommand", command.get_name());
       assert_eq!(long_flag, subcommand, "{} subcommand", command.get_name());
     }
+  }
+
+  #[test]
+  fn ci_subcommand_defaults() {
+    let r = flags_from_vec(svec!["deno", "ci"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Ci(CiFlags::default()),
+        frozen_lockfile: Some(true),
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn ci_subcommand_prod_skip_types() {
+    let r = flags_from_vec(svec!["deno", "ci", "--prod", "--skip-types"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Ci(CiFlags {
+          production: true,
+          skip_types: true,
+        }),
+        frozen_lockfile: Some(true),
+        ..Flags::default()
+      }
+    );
   }
 
   #[test]

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -605,6 +605,7 @@ impl CliFactory {
             | DenoSubcommand::ApproveScripts { .. }
             | DenoSubcommand::Remove { .. }
             | DenoSubcommand::Cache { .. }
+            | DenoSubcommand::Ci { .. }
             | DenoSubcommand::Uninstall { .. } => true,
             DenoSubcommand::Install(flags) => match flags {
               InstallFlags::Local(flags, _) => match flags {
@@ -665,6 +666,7 @@ impl CliFactory {
                 InstallFlagsLocal::Add(_) => false,
               }
             }
+            DenoSubcommand::Ci(f) => f.production,
             _ => false,
           },
           skip_types: match cli_options.sub_command() {
@@ -675,6 +677,7 @@ impl CliFactory {
                 InstallFlagsLocal::Add(_) => false,
               }
             }
+            DenoSubcommand::Ci(f) => f.skip_types,
             _ => false,
           },
           resolve_npm_resolution_snapshot: Box::new(|| {
@@ -701,7 +704,8 @@ impl CliFactory {
       .get_or_try_init(|| match self.cli_options()?.sub_command() {
         DenoSubcommand::Install(InstallFlags::Local(_, _))
         | DenoSubcommand::Add(_)
-        | DenoSubcommand::Cache(_) => Ok(Some(Arc::new(
+        | DenoSubcommand::Cache(_)
+        | DenoSubcommand::Ci(_) => Ok(Some(Arc::new(
           crate::tools::installer::InstallReporter::new(),
         ))),
         _ => Ok(None),
@@ -716,6 +720,10 @@ impl CliFactory {
   pub async fn npm_resolver(&self) -> Result<&CliNpmResolver, AnyError> {
     self.initialize_npm_resolution_if_managed().await?;
     self.resolver_factory()?.npm_resolver()
+  }
+
+  pub fn node_modules_dir_path(&self) -> Result<Option<&Path>, AnyError> {
+    self.workspace_factory()?.node_modules_dir_path()
   }
 
   fn workspace_factory(&self) -> Result<&Arc<CliWorkspaceFactory>, AnyError> {
@@ -767,7 +775,7 @@ impl CliFactory {
     &self,
   ) -> Result<&Option<Arc<dyn deno_graph::source::Reporter>>, AnyError> {
     match self.cli_options()?.sub_command() {
-      DenoSubcommand::Install(_) => {
+      DenoSubcommand::Install(_) | DenoSubcommand::Ci(_) => {
         self.services.graph_reporter.get_or_try_init(|| {
           self.install_reporter().map(|opt| {
             opt.map(|r| r.clone() as Arc<dyn deno_graph::source::Reporter>)
@@ -1423,6 +1431,7 @@ fn new_workspace_factory_options(
       flags.subcommand,
       DenoSubcommand::Add(_)
         | DenoSubcommand::Audit(_)
+        | DenoSubcommand::Ci(_)
         | DenoSubcommand::Clean(_)
         | DenoSubcommand::Init(_)
         | DenoSubcommand::Install(_)

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -219,6 +219,9 @@ async fn run_subcommand(
     DenoSubcommand::Install(install_flags) => spawn_subcommand(async {
       tools::installer::install_command(Arc::new(flags), install_flags).await
     }),
+    DenoSubcommand::Ci(ci_flags) => spawn_subcommand(async {
+      tools::installer::ci_command(Arc::new(flags), ci_flags).await
+    }),
     DenoSubcommand::JSONReference(json_reference) => {
       spawn_subcommand(async move {
         display::write_to_stdout_ignore_sigpipe(

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -12,6 +12,7 @@ use deno_resolver::workspace::WorkspaceResolver;
 use super::InstallReporter;
 use super::print_install_report;
 use crate::args::AddFlags;
+use crate::args::CiFlags;
 use crate::args::Flags;
 use crate::args::InstallFlagsLocal;
 use crate::args::InstallTopLevelFlags;
@@ -189,6 +190,43 @@ async fn install_top_level(
   );
 
   Ok(())
+}
+
+pub async fn ci_command(
+  flags: Arc<Flags>,
+  ci_flags: CiFlags,
+) -> Result<(), AnyError> {
+  let factory = CliFactory::from_flags(flags.clone());
+  if factory.maybe_lockfile().await?.is_none() {
+    bail!(
+      "deno ci requires a lockfile, but none was found.\n  hint: run `deno install` to create one."
+    );
+  }
+  if let Some(node_modules_dir) = factory.node_modules_dir_path()?
+    && node_modules_dir.exists()
+  {
+    log::info!(
+      "{} {}",
+      deno_terminal::colors::gray("Removing"),
+      node_modules_dir.display()
+    );
+    std::fs::remove_dir_all(node_modules_dir).map_err(|err| {
+      deno_core::anyhow::anyhow!(
+        "failed to remove {}: {err}",
+        node_modules_dir.display()
+      )
+    })?;
+  }
+  drop(factory);
+  install_top_level(
+    flags,
+    InstallTopLevelFlags {
+      lockfile_only: false,
+      production: ci_flags.production,
+      skip_types: ci_flags.skip_types,
+    },
+  )
+  .await
 }
 
 pub fn check_if_installs_a_single_package_globally(

--- a/cli/tools/installer/mod.rs
+++ b/cli/tools/installer/mod.rs
@@ -28,6 +28,7 @@ mod local;
 pub use global::uninstall;
 use local::CategorizedInstalledDeps;
 use local::categorize_installed_npm_deps;
+pub use local::ci_command;
 
 #[derive(Default)]
 pub struct InstallStats {

--- a/tests/specs/install/ci/__test__.jsonc
+++ b/tests/specs/install/ci/__test__.jsonc
@@ -1,0 +1,47 @@
+{
+  "tempDir": true,
+  "tests": {
+    "no_lockfile": {
+      "args": "ci",
+      "output": "no_lockfile.out",
+      "exitCode": 1
+    },
+    "happy_path": {
+      "steps": [{
+        "args": [
+          "eval",
+          "import fs from 'node:fs'; fs.writeFileSync('deno.json', JSON.stringify({ imports: { 'esm-basic': 'npm:@denotest/esm-basic' }, nodeModulesDir: 'auto' }))"
+        ],
+        "output": ""
+      }, {
+        "args": "install",
+        "output": "[WILDCARD]"
+      }, {
+        "args": "ci",
+        "output": "happy_path.out"
+      }]
+    },
+    "stale_lockfile_errors": {
+      "steps": [{
+        "args": [
+          "eval",
+          "import fs from 'node:fs'; fs.writeFileSync('deno.json', JSON.stringify({ imports: { 'esm-basic': 'npm:@denotest/esm-basic' }, nodeModulesDir: 'auto' }))"
+        ],
+        "output": ""
+      }, {
+        "args": "install",
+        "output": "[WILDCARD]"
+      }, {
+        "args": [
+          "eval",
+          "import fs from 'node:fs'; fs.writeFileSync('deno.json', JSON.stringify({ imports: { 'esm-basic': 'npm:@denotest/esm-basic', 'bin': 'npm:@denotest/bin' }, nodeModulesDir: 'auto' }))"
+        ],
+        "output": ""
+      }, {
+        "args": "ci",
+        "output": "stale_lockfile.out",
+        "exitCode": 1
+      }]
+    }
+  }
+}

--- a/tests/specs/install/ci/happy_path.out
+++ b/tests/specs/install/ci/happy_path.out
@@ -1,0 +1,1 @@
+[WILDCARD]Removing [WILDCARD]node_modules[WILDCARD]

--- a/tests/specs/install/ci/no_lockfile.out
+++ b/tests/specs/install/ci/no_lockfile.out
@@ -1,0 +1,2 @@
+error: deno ci requires a lockfile, but none was found.
+  hint: run `deno install` to create one.

--- a/tests/specs/install/ci/stale_lockfile.out
+++ b/tests/specs/install/ci/stale_lockfile.out
@@ -1,0 +1,1 @@
+[WILDCARD]error: The lockfile is out of date.[WILDCARD]


### PR DESCRIPTION
Adds `deno ci`, a thin subcommand for reproducible installs in CI
environments. It mirrors `npm ci`: errors if `deno.lock` is missing,
removes any existing `node_modules` directory, then runs the install
with `--frozen` so the lockfile must match the config file exactly.
The intent is to give CI scripts and Dockerfiles an obvious,
greppable signal of "reproducible install" without having to remember
the right combination of flags on `deno install`.

`--prod` and `--skip-types` are accepted with the same semantics as
`deno install`.