### PR TITLE
fix(ext/fetch,ext/websocket): check resolved IPs against net deny list

### DIFF
--- a/ext/fetch/dns.rs
+++ b/ext/fetch/dns.rs
@@ -8,15 +8,22 @@ use std::task::Poll;
 use std::task::{self};
 use std::vec;
 
+use deno_permissions::PermissionsContainer;
 use hickory_resolver::name_server::TokioConnectionProvider;
 use hyper_util::client::legacy::connect::dns::GaiResolver;
 use hyper_util::client::legacy::connect::dns::Name;
 use tokio::task::JoinHandle;
 use tower::Service;
 
+#[derive(Clone, Debug)]
+pub struct Resolver {
+  kind: ResolverKind,
+  permissions: Option<PermissionsContainer>,
+}
+
 #[allow(clippy::large_enum_variant, reason = "TODO: investigate")]
 #[derive(Clone, Debug)]
-pub enum Resolver {
+enum ResolverKind {
   /// A resolver using blocking `getaddrinfo` calls in a threadpool.
   Gai(GaiResolver),
   /// hickory-resolver's userspace resolver.
@@ -49,20 +56,45 @@ impl Default for Resolver {
 
 impl Resolver {
   pub fn gai() -> Self {
-    Self::Gai(GaiResolver::new())
+    Self {
+      kind: ResolverKind::Gai(GaiResolver::new()),
+      permissions: None,
+    }
   }
 
   /// Create a [`AsyncResolver`] from system conf.
   pub fn hickory() -> Result<Self, hickory_resolver::ResolveError> {
-    Ok(Self::Hickory(
-      hickory_resolver::Resolver::builder_tokio()?.build(),
-    ))
+    Ok(Self {
+      kind: ResolverKind::Hickory(
+        hickory_resolver::Resolver::builder_tokio()?.build(),
+      ),
+      permissions: None,
+    })
   }
 
   pub fn hickory_from_resolver(
     resolver: hickory_resolver::Resolver<TokioConnectionProvider>,
   ) -> Self {
-    Self::Hickory(resolver)
+    Self {
+      kind: ResolverKind::Hickory(resolver),
+      permissions: None,
+    }
+  }
+
+  pub fn custom(resolver: Arc<dyn Resolve>) -> Self {
+    Self {
+      kind: ResolverKind::Custom(resolver),
+      permissions: None,
+    }
+  }
+
+  /// Attach a permissions container so that resolved addresses are checked
+  /// against the net deny list before being returned to the HTTP connector.
+  /// This mirrors the post-resolution check that `Deno.connect` performs and
+  /// prevents bypassing IP-literal deny rules via attacker-controlled DNS.
+  pub fn with_permissions(mut self, permissions: PermissionsContainer) -> Self {
+    self.permissions = Some(permissions);
+    self
   }
 }
 
@@ -106,34 +138,57 @@ impl Service<Name> for Resolver {
   }
 
   fn call(&mut self, name: Name) -> Self::Future {
-    let task = match self {
-      Resolver::Gai(gai_resolver) => {
+    let permissions = self.permissions.clone();
+    let task = match &mut self.kind {
+      ResolverKind::Gai(gai_resolver) => {
         let mut resolver = gai_resolver.clone();
         tokio::spawn(async move {
           let result = resolver.call(name).await?;
-          let x: Vec<_> = result.into_iter().collect();
-          let iter: SocketAddrs = x.into_iter();
-          Ok(iter)
+          let addrs: Vec<_> = result.into_iter().collect();
+          check_resolved_permissions(&addrs, permissions.as_ref())?;
+          Ok(addrs.into_iter())
         })
       }
-      Resolver::Hickory(async_resolver) => {
+      ResolverKind::Hickory(async_resolver) => {
         let resolver = async_resolver.clone();
         tokio::spawn(async move {
           let result = resolver.lookup_ip(name.as_str()).await?;
-
-          let x: Vec<_> =
+          let addrs: Vec<_> =
             result.into_iter().map(|x| SocketAddr::new(x, 0)).collect();
-          let iter: SocketAddrs = x.into_iter();
-          Ok(iter)
+          check_resolved_permissions(&addrs, permissions.as_ref())?;
+          Ok(addrs.into_iter())
         })
       }
-      Resolver::Custom(resolver) => {
+      ResolverKind::Custom(resolver) => {
         let resolver = resolver.clone();
-        tokio::spawn(async move { resolver.resolve(name).await })
+        tokio::spawn(async move {
+          let result = resolver.resolve(name).await?;
+          let addrs: Vec<_> = result.into_iter().collect();
+          check_resolved_permissions(&addrs, permissions.as_ref())?;
+          Ok(addrs.into_iter())
+        })
       }
     };
     ResolveFut { inner: task }
   }
+}
+
+fn check_resolved_permissions(
+  addrs: &[SocketAddr],
+  permissions: Option<&PermissionsContainer>,
+) -> io::Result<()> {
+  let Some(permissions) = permissions else {
+    return Ok(());
+  };
+  for addr in addrs {
+    permissions
+      .clone()
+      .check_net_resolved(&addr.ip(), addr.port(), "fetch()")
+      .map_err(|e| {
+        io::Error::new(io::ErrorKind::PermissionDenied, e.to_string())
+      })?;
+  }
+  Ok(())
 }
 
 #[cfg(test)]
@@ -155,7 +210,7 @@ mod tests {
 
   #[tokio::test]
   async fn custom_dns_resolver() {
-    let mut resolver = Resolver::Custom(Arc::new(DebugResolver(
+    let mut resolver = Resolver::custom(Arc::new(DebugResolver(
       "127.0.0.1:8080".parse().unwrap(),
     )));
     let mut addr = resolver

--- a/ext/fetch/dns.rs
+++ b/ext/fetch/dns.rs
@@ -10,10 +10,21 @@ use std::vec;
 
 use deno_permissions::PermissionsContainer;
 use hickory_resolver::name_server::TokioConnectionProvider;
+use http::Uri;
+use http::uri::Scheme;
 use hyper_util::client::legacy::connect::dns::GaiResolver;
 use hyper_util::client::legacy::connect::dns::Name;
 use tokio::task::JoinHandle;
 use tower::Service;
+
+tokio::task_local! {
+  /// The destination port for the in-flight HTTP/WS connection. Set by
+  /// [`PermissionedHttpConnector`] before invoking the inner connector so
+  /// that the DNS resolver below can run the post-resolution deny check
+  /// against the real request port instead of the placeholder `0` that
+  /// hyper-util's `HttpConnector` carries through `Service<Name>`.
+  static REQUEST_PORT: u16;
+}
 
 #[derive(Clone, Debug)]
 pub struct Resolver {
@@ -139,13 +150,16 @@ impl Service<Name> for Resolver {
 
   fn call(&mut self, name: Name) -> Self::Future {
     let permissions = self.permissions.clone();
+    // Capture the request port *before* spawning, since `tokio::spawn`
+    // detaches from the parent task and would lose the task-local.
+    let port = REQUEST_PORT.try_with(|p| *p).ok();
     let task = match &mut self.kind {
       ResolverKind::Gai(gai_resolver) => {
         let mut resolver = gai_resolver.clone();
         tokio::spawn(async move {
           let result = resolver.call(name).await?;
           let addrs: Vec<_> = result.into_iter().collect();
-          check_resolved_permissions(&addrs, permissions.as_ref())?;
+          check_resolved_permissions(&addrs, port, permissions.as_ref())?;
           Ok(addrs.into_iter())
         })
       }
@@ -155,7 +169,7 @@ impl Service<Name> for Resolver {
           let result = resolver.lookup_ip(name.as_str()).await?;
           let addrs: Vec<_> =
             result.into_iter().map(|x| SocketAddr::new(x, 0)).collect();
-          check_resolved_permissions(&addrs, permissions.as_ref())?;
+          check_resolved_permissions(&addrs, port, permissions.as_ref())?;
           Ok(addrs.into_iter())
         })
       }
@@ -164,7 +178,7 @@ impl Service<Name> for Resolver {
         tokio::spawn(async move {
           let result = resolver.resolve(name).await?;
           let addrs: Vec<_> = result.into_iter().collect();
-          check_resolved_permissions(&addrs, permissions.as_ref())?;
+          check_resolved_permissions(&addrs, port, permissions.as_ref())?;
           Ok(addrs.into_iter())
         })
       }
@@ -175,20 +189,73 @@ impl Service<Name> for Resolver {
 
 fn check_resolved_permissions(
   addrs: &[SocketAddr],
+  request_port: Option<u16>,
   permissions: Option<&PermissionsContainer>,
 ) -> io::Result<()> {
   let Some(permissions) = permissions else {
     return Ok(());
   };
   for addr in addrs {
+    // `addr.port()` is `0` for the GAI and Hickory paths because hyper-util's
+    // `HttpConnector` sets the destination port *after* DNS resolution. Prefer
+    // the real request port carried via [`REQUEST_PORT`].
+    let port = request_port.unwrap_or_else(|| addr.port());
     permissions
       .clone()
-      .check_net_resolved(&addr.ip(), addr.port(), "fetch()")
+      .check_net_resolved(&addr.ip(), port, "fetch()")
       .map_err(|e| {
         io::Error::new(io::ErrorKind::PermissionDenied, e.to_string())
       })?;
   }
   Ok(())
+}
+
+/// `Service<Uri>` adapter that runs ahead of hyper-util's `HttpConnector`.
+///
+/// `HttpConnector` only forwards the hostname to its `Service<Name>` resolver
+/// and applies the destination port afterwards, which means the resolver
+/// cannot check post-resolution permissions against the real request port.
+/// This wrapper extracts the port from the `Uri`, scopes it into the
+/// [`REQUEST_PORT`] task-local, and then delegates to the inner connector.
+#[derive(Clone, Debug)]
+pub struct PermissionedHttpConnector<C> {
+  inner: C,
+}
+
+impl<C> PermissionedHttpConnector<C> {
+  pub fn new(inner: C) -> Self {
+    Self { inner }
+  }
+}
+
+impl<C> Service<Uri> for PermissionedHttpConnector<C>
+where
+  C: Service<Uri>,
+  C::Future: Send + 'static,
+{
+  type Response = C::Response;
+  type Error = C::Error;
+  type Future =
+    Pin<Box<dyn Future<Output = Result<C::Response, C::Error>> + Send>>;
+
+  fn poll_ready(
+    &mut self,
+    cx: &mut task::Context<'_>,
+  ) -> Poll<Result<(), Self::Error>> {
+    self.inner.poll_ready(cx)
+  }
+
+  fn call(&mut self, uri: Uri) -> Self::Future {
+    let port = uri.port_u16().unwrap_or_else(|| {
+      if uri.scheme() == Some(&Scheme::HTTPS) {
+        443
+      } else {
+        80
+      }
+    });
+    let fut = self.inner.call(uri);
+    Box::pin(REQUEST_PORT.scope(port, fut))
+  }
 }
 
 #[cfg(test)]

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -306,8 +306,9 @@ pub fn get_or_create_client_from_state(
   if let Some(client) = state.try_borrow::<Client>() {
     Ok(client.clone())
   } else {
+    let permissions = state.borrow::<PermissionsContainer>().clone();
     let options = state.borrow::<Options>();
-    let client = create_client_from_options(options)?;
+    let client = create_client_from_options(options, Some(permissions))?;
     state.put::<Client>(client.clone());
     Ok(client)
   }
@@ -315,7 +316,12 @@ pub fn get_or_create_client_from_state(
 
 pub fn create_client_from_options(
   options: &Options,
+  permissions: Option<PermissionsContainer>,
 ) -> Result<Client, HttpClientCreateError> {
+  let dns_resolver = match permissions {
+    Some(p) => options.resolver.clone().with_permissions(p),
+    None => options.resolver.clone(),
+  };
   create_http_client(
     &options.user_agent,
     CreateHttpClientOptions {
@@ -324,7 +330,7 @@ pub fn create_client_from_options(
         .map_err(HttpClientCreateError::RootCertStore)?,
       ca_certs: vec![],
       proxy: options.proxy.clone(),
-      dns_resolver: options.resolver.clone(),
+      dns_resolver,
       unsafely_ignore_certificate_errors: options
         .unsafely_ignore_certificate_errors
         .clone(),
@@ -879,6 +885,7 @@ pub fn op_fetch_custom_client(
     }
   }
 
+  let permissions = state.borrow::<PermissionsContainer>().clone();
   let options = state.borrow::<Options>();
   let ca_certs = args
     .ca_certs
@@ -894,7 +901,7 @@ pub fn op_fetch_custom_client(
         .map_err(HttpClientCreateError::RootCertStore)?,
       ca_certs,
       proxy: args.proxy,
-      dns_resolver: dns::Resolver::default(),
+      dns_resolver: dns::Resolver::default().with_permissions(permissions),
       unsafely_ignore_certificate_errors: options
         .unsafely_ignore_certificate_errors
         .clone(),

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -1030,6 +1030,7 @@ pub fn create_http_client(
       .map_err(|_| HttpClientCreateError::InvalidAddress(local_address))?;
     http_connector.set_local_address(Some(local_addr));
   }
+  let http_connector = dns::PermissionedHttpConnector::new(http_connector);
 
   let user_agent = user_agent.parse::<HeaderValue>().map_err(|_| {
     HttpClientCreateError::InvalidUserAgent(user_agent.to_string())
@@ -1199,7 +1200,9 @@ impl Client {
   }
 }
 
-type Connector = proxy::ProxyConnector<HttpConnector<dns::Resolver>>;
+type Connector = proxy::ProxyConnector<
+  dns::PermissionedHttpConnector<HttpConnector<dns::Resolver>>,
+>;
 
 #[allow(
   clippy::declare_interior_mutable_const,

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -407,6 +407,7 @@ fn populate_common_request_headers(
 
 fn create_client_from_websocket_options(
   options: &FetchOptions,
+  permissions: PermissionsContainer,
   ca_certs: Vec<String>,
   unsafely_ignore_certificate_errors: bool,
 ) -> Result<deno_fetch::Client, HttpClientCreateError> {
@@ -418,7 +419,7 @@ fn create_client_from_websocket_options(
         .map_err(HttpClientCreateError::RootCertStore)?,
       ca_certs: ca_certs.into_iter().map(|cert| cert.into_bytes()).collect(),
       proxy: options.proxy.clone(),
-      dns_resolver: options.resolver.clone(),
+      dns_resolver: options.resolver.clone().with_permissions(permissions),
       unsafely_ignore_certificate_errors: unsafely_ignore_certificate_errors
         .then_some(vec![]),
       client_cert_chain_and_key: options
@@ -462,10 +463,12 @@ pub async fn op_ws_create(
       let r = s.resource_table.get::<HttpClientResource>(rid)?;
       (r.client.clone(), r.allow_host)
     } else if ca_certs.is_some() || unsafely_ignore_certificate_errors {
+      let permissions = s.borrow::<PermissionsContainer>().clone();
       let options = s.borrow::<FetchOptions>().clone();
       (
         create_client_from_websocket_options(
           &options,
+          permissions,
           ca_certs.unwrap_or_default(),
           unsafely_ignore_certificate_errors,
         )?,

--- a/tests/specs/permission/deny_net_fetch_resolved_ip/__test__.jsonc
+++ b/tests/specs/permission/deny_net_fetch_resolved_ip/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "deny_net_fetch_resolved_ip": {
+      "args": "run --allow-net --deny-net=127.0.0.1,[::1] main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/permission/deny_net_fetch_resolved_ip/main.out
+++ b/tests/specs/permission/deny_net_fetch_resolved_ip/main.out
@@ -1,0 +1,2 @@
+PASS: fetch to 127.0.0.1 denied
+PASS: fetch to localhost denied

--- a/tests/specs/permission/deny_net_fetch_resolved_ip/main.ts
+++ b/tests/specs/permission/deny_net_fetch_resolved_ip/main.ts
@@ -1,0 +1,27 @@
+// Regression test: --deny-net=127.0.0.1 must block fetch() requests whose
+// hostname resolves to a denied IP, mirroring the post-resolution check that
+// Deno.connect already performs.
+
+const server = Deno.serve(
+  { hostname: "0.0.0.0", port: 0, onListen: () => {} },
+  () => new Response("hello"),
+);
+const { port } = server.addr as Deno.NetAddr;
+
+try {
+  await fetch(`http://127.0.0.1:${port}/`);
+  console.log("FAIL: fetch to 127.0.0.1 was not denied");
+} catch {
+  console.log("PASS: fetch to 127.0.0.1 denied");
+}
+
+try {
+  await fetch(`http://localhost:${port}/`);
+  console.log(
+    "FAIL: fetch to localhost (resolves to denied IP) was not denied",
+  );
+} catch {
+  console.log("PASS: fetch to localhost denied");
+}
+
+await server.shutdown();

--- a/tests/specs/permission/deny_net_fetch_resolved_port/__test__.jsonc
+++ b/tests/specs/permission/deny_net_fetch_resolved_port/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "deny_net_fetch_resolved_port": {
+      "args": "run -A main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/permission/deny_net_fetch_resolved_port/main.out
+++ b/tests/specs/permission/deny_net_fetch_resolved_port/main.out
@@ -1,0 +1,3 @@
+PASS: fetch to 127.0.0.1 (deny port) denied
+PASS: fetch to localhost (deny port via DNS) denied
+PASS: fetch to localhost (different port) allowed

--- a/tests/specs/permission/deny_net_fetch_resolved_port/main.ts
+++ b/tests/specs/permission/deny_net_fetch_resolved_port/main.ts
@@ -1,0 +1,63 @@
+// Regression test: --deny-net=127.0.0.1:<port> must block fetch() requests
+// whose hostname resolves to the denied (ip, port) pair. The check needs to
+// run with the real request port, not the placeholder 0 that hyper-util's
+// DNS service receives.
+
+const server = Deno.serve(
+  { hostname: "0.0.0.0", port: 0, onListen: () => {} },
+  () => new Response("hello"),
+);
+const denyPort = (server.addr as Deno.NetAddr).port;
+
+// A second server on a different port so we can prove the deny rule is
+// port-scoped — fetching this one through `localhost` must still succeed.
+const allowedServer = Deno.serve(
+  { hostname: "0.0.0.0", port: 0, onListen: () => {} },
+  () => new Response("allowed"),
+);
+const allowedPort = (allowedServer.addr as Deno.NetAddr).port;
+
+const script = `
+try {
+  await fetch("http://127.0.0.1:${denyPort}/");
+  console.log("FAIL: fetch to 127.0.0.1 (deny port) was not denied");
+} catch {
+  console.log("PASS: fetch to 127.0.0.1 (deny port) denied");
+}
+
+try {
+  await fetch("http://localhost:${denyPort}/");
+  console.log("FAIL: fetch to localhost (deny port via DNS) was not denied");
+} catch {
+  console.log("PASS: fetch to localhost (deny port via DNS) denied");
+}
+
+try {
+  const res = await fetch("http://localhost:${allowedPort}/");
+  await res.text();
+  console.log("PASS: fetch to localhost (different port) allowed");
+} catch (e) {
+  console.log("FAIL: fetch to localhost (different port):", String(e));
+}
+`;
+
+const child = new Deno.Command(Deno.execPath(), {
+  args: [
+    "run",
+    "--allow-net",
+    `--deny-net=127.0.0.1:${denyPort},[::1]:${denyPort}`,
+    "-",
+  ],
+  stdin: "piped",
+  stdout: "piped",
+  stderr: "inherit",
+}).spawn();
+const writer = child.stdin.getWriter();
+await writer.write(new TextEncoder().encode(script));
+await writer.close();
+
+const { stdout } = await child.output();
+await Deno.stdout.write(stdout);
+
+await server.shutdown();
+await allowedServer.shutdown();

--- a/tests/specs/permission/deny_net_websocket_resolved_ip/__test__.jsonc
+++ b/tests/specs/permission/deny_net_websocket_resolved_ip/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "deny_net_websocket_resolved_ip": {
+      "args": "run --allow-net --deny-net=127.0.0.1,[::1] main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/permission/deny_net_websocket_resolved_ip/main.out
+++ b/tests/specs/permission/deny_net_websocket_resolved_ip/main.out
@@ -1,0 +1,2 @@
+PASS: ws to 127.0.0.1 denied
+PASS: ws to localhost denied

--- a/tests/specs/permission/deny_net_websocket_resolved_ip/main.ts
+++ b/tests/specs/permission/deny_net_websocket_resolved_ip/main.ts
@@ -1,0 +1,46 @@
+// Regression test: --deny-net=127.0.0.1 must block WebSocket connections
+// whose hostname resolves to a denied IP, mirroring the post-resolution
+// check that Deno.connect and fetch() already perform.
+
+const server = Deno.serve(
+  { hostname: "0.0.0.0", port: 0, onListen: () => {} },
+  (req) => {
+    const { socket, response } = Deno.upgradeWebSocket(req);
+    socket.onmessage = (e) => socket.send(e.data);
+    return response;
+  },
+);
+const { port } = server.addr as Deno.NetAddr;
+
+function tryConnect(url: string): Promise<"open" | "error"> {
+  return new Promise((resolve) => {
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      resolve("error");
+      return;
+    }
+    ws.onopen = () => {
+      ws.close();
+      resolve("open");
+    };
+    ws.onerror = () => resolve("error");
+  });
+}
+
+const direct = await tryConnect(`ws://127.0.0.1:${port}/`);
+console.log(
+  direct === "error"
+    ? "PASS: ws to 127.0.0.1 denied"
+    : "FAIL: ws to 127.0.0.1 was not denied",
+);
+
+const viaDns = await tryConnect(`ws://localhost:${port}/`);
+console.log(
+  viaDns === "error"
+    ? "PASS: ws to localhost denied"
+    : "FAIL: ws to localhost (resolves to denied IP) was not denied",
+);
+
+await server.shutdown();


### PR DESCRIPTION
`fetch()` and `WebSocket` both ran the static `check_net_url` and then
handed the URL to hyper, whose DNS resolver in `ext/fetch/dns.rs`
returned addresses straight to the connector. That meant a hostname
like `localhost` could pass the URL check and still connect to a denied
IP after DNS lookup. `Deno.connect`, `Deno.listen`, and friends already
run `check_net_resolved` on every resolved address in `ext/net/ops.rs`;
the HTTP/WS paths were the odd ones out.

Thread the `PermissionsContainer` through to the fetch DNS resolver and
run the same post-resolution check on each address before yielding it
to the HTTP connector. Applies to the default client, clients created
via `Deno.createHttpClient`, and any custom `Resolve` implementation.

WebSocket reuses the fetch HTTP client, so the default and
custom-client paths inherit the fix automatically. The one remaining
gap was `create_client_from_websocket_options` (used when a WebSocket
is opened with `ca_certs` or `unsafelyIgnoreCertificateErrors`), which
built a `deno_fetch::Client` directly without threading permissions.
Patched to mirror `create_client_from_options` in `ext/fetch`.