### PR TITLE
fix(ext/node): do not throw NotFound for fs.exists

### DIFF
--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -315,13 +315,19 @@ pub fn op_node_fs_exists_sync(
   state: &mut OpState,
   #[string] path: &str,
 ) -> Result<bool, deno_permissions::PermissionCheckError> {
-  let path = state.borrow_mut::<PermissionsContainer>().check_open(
+  let path_or_err = state.borrow_mut::<PermissionsContainer>().check_open(
     Cow::Borrowed(Path::new(path)),
     OpenAccessKind::ReadNoFollow,
     Some("node:fs.existsSync()"),
-  )?;
-  let fs = state.borrow::<FileSystemRc>();
-  Ok(fs.exists_sync(&path))
+  );
+  match path_or_err {
+    Ok(path) => {
+      let fs = state.borrow::<FileSystemRc>();
+      Ok(fs.exists_sync(&path))
+    }
+    Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+    Err(err) => Err(err),
+  }
 }
 
 #[op2(stack_trace)]
@@ -329,17 +335,21 @@ pub async fn op_node_fs_exists(
   state: Rc<RefCell<OpState>>,
   #[string] path: String,
 ) -> Result<bool, FsError> {
-  let (fs, path) = {
+  let (fs, path_or_err) = {
     let mut state = state.borrow_mut();
-    let path = state.borrow_mut::<PermissionsContainer>().check_open(
+    let path_or_err = state.borrow_mut::<PermissionsContainer>().check_open(
       Cow::Owned(PathBuf::from(path)),
       OpenAccessKind::ReadNoFollow,
       Some("node:fs.exists()"),
-    )?;
-    (state.borrow::<FileSystemRc>().clone(), path)
+    );
+    (state.borrow::<FileSystemRc>().clone(), path_or_err)
   };
 
-  Ok(fs.exists_async(path.into_owned()).await?)
+  match path_or_err {
+    Ok(path) => Ok(fs.exists_async(path.into_owned()).await?),
+    Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+    Err(err) => Err(FsError::Permission(err)),
+  }
 }
 
 fn get_open_options(flags: i32, mode: Option<u32>) -> OpenOptions {

--- a/tests/specs/permission/ignore_read/config/__test__.jsonc
+++ b/tests/specs/permission/ignore_read/config/__test__.jsonc
@@ -1,4 +1,4 @@
 {
   "args": "run --quiet -P main.ts",
-  "output": "true\n"
+  "output": "true\nfalse\nfalse\ntrue\n"
 }

--- a/tests/specs/permission/ignore_read/config/main.ts
+++ b/tests/specs/permission/ignore_read/config/main.ts
@@ -1,6 +1,33 @@
+import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
+
 try {
   Deno.readTextFileSync("./deno.json");
   console.log("loaded");
 } catch (err) {
   console.log(err instanceof Deno.errors.NotFound);
+}
+
+try {
+  console.log(fs.existsSync("./deno.json"));
+} catch {
+  console.log("failed");
+}
+try {
+  console.log(
+    await new Promise((resolve) => {
+      fs.exists("./deno.json", resolve);
+    }),
+  );
+} catch {
+  console.log("failed");
+}
+
+try {
+  await fsPromises.stat("./deno.json");
+} catch (err) {
+  console.log(
+    err instanceof Error && "code" in err &&
+      err.code === "ENOENT",
+  );
 }


### PR DESCRIPTION
This resolves the following issue:

```
# Before
$ echo '(await import("node:fs")).existsSync(".")' | deno repl --ignore-read
Deno 2.7.11+8295a2c
exit using ctrl+d, ctrl+c, or close()
Uncaught NotFound: No such file or directory (os error 2)
    at Module.existsSync (ext:deno_node/_fs/_fs_exists.ts:47:10)
    at <anonymous>:1:48

# After
$ echo '(await import("node:fs")).existsSync(".")' | deno repl --ignore-read
Deno 2.7.14
exit using ctrl+d, ctrl+c, or close()
false
```

`@std/fs/exists` is not affected by this issue because it uses `Deno.stat` and checks for `Deno.errors.NotFound` instead.

~~TODO: add tests (where to?)~~ edit: done