### PR TITLE
fix(ext/node): readFile of large file via fd returns scrambled content

### DIFF
--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -259,7 +259,6 @@ const { URLPrototype } = core.loadExtScript("ext:deno_web/00_url.js");
 
 const {
   kIoMaxLength,
-  kReadFileBufferLength,
   kReadFileUnknownBufferLength,
 } = fsUtilConstants;
 
@@ -699,46 +698,52 @@ function readFileConcatBuffers(buffers: Uint8Array[]): Uint8Array {
 
 async function readFileFromFd(fd: number, options?: FileOptions) {
   const signal = options?.signal;
-  const encoding = options?.encoding;
   readFileCheckAborted(signal);
 
   const statFields = op_node_fs_fstat_sync(fd);
   readFileCheckAborted(signal);
 
-  let size = 0;
-  let length = 0;
-  if (statFields.isFile) {
-    size = statFields.size;
-    length = encoding ? MathMin(size, kReadFileBufferLength) : size;
-  }
-  if (length === 0) {
-    length = kReadFileUnknownBufferLength;
-  }
+  const isFile = statFields.isFile;
+  const size = isFile ? statFields.size : 0;
 
   if (size > kIoMaxLength) {
     throw new ERR_FS_FILE_TOO_LARGE(size);
   }
 
-  const buffer = new Uint8Array(length);
+  if (isFile && size > 0) {
+    // Known size: read into a single buffer with an advancing offset.
+    // Mirrors Node's readFileHandle which avoids the subarray-aliasing trap
+    // by writing successive reads into different regions of one buffer.
+    const buffer = new Uint8Array(size);
+    let totalRead = 0;
+    while (totalRead < size) {
+      readFileCheckAborted(signal);
+      const slice = TypedArrayPrototypeSubarray(buffer, totalRead);
+      // Use the deferred op so we yield to the event loop between reads,
+      // allowing abort signals scheduled via process.nextTick to fire.
+      const nread = await op_node_fs_read_deferred(fd, slice, -1n);
+      if (nread === 0) break;
+      totalRead += nread;
+    }
+    return totalRead === size
+      ? buffer
+      : TypedArrayPrototypeSubarray(buffer, 0, totalRead);
+  }
+
+  // Unknown size (pipes, sockets, /dev/stdin): allocate a fresh buffer per
+  // iteration so pushed subarrays don't alias a reused read buffer.
   const buffers: Uint8Array[] = [];
   let totalRead = 0;
-
   while (true) {
     readFileCheckAborted(signal);
-    // Use the deferred op so we yield to the event loop between reads,
-    // allowing abort signals scheduled via process.nextTick to fire.
-    const nread = await op_node_fs_read_deferred(fd, buffer, -1n);
-    if (nread === 0) {
-      break;
-    }
+    const chunk = new Uint8Array(kReadFileUnknownBufferLength);
+    const nread = await op_node_fs_read_deferred(fd, chunk, -1n);
+    if (nread === 0) break;
     totalRead += nread;
     if (totalRead > kIoMaxLength) {
       throw new ERR_FS_FILE_TOO_LARGE(totalRead);
     }
-    ArrayPrototypePush(
-      buffers,
-      TypedArrayPrototypeSubarray(buffer, 0, nread),
-    );
+    ArrayPrototypePush(buffers, TypedArrayPrototypeSubarray(chunk, 0, nread));
   }
 
   return readFileConcatBuffers(buffers);

--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -725,6 +725,7 @@ async function readFileFromFd(fd: number, options?: FileOptions) {
       if (nread === 0) break;
       totalRead += nread;
     }
+    readFileCheckAborted(signal);
     return totalRead === size
       ? buffer
       : TypedArrayPrototypeSubarray(buffer, 0, totalRead);

--- a/tests/unit_node/_fs/_fs_readFile_test.ts
+++ b/tests/unit_node/_fs/_fs_readFile_test.ts
@@ -243,3 +243,34 @@ Deno.test("fs.readFileSync creates new file when passed 'w+' flag", () => {
   assert(existsSync(filePath));
   Deno.removeSync(tmpDir, { recursive: true });
 });
+
+// Regression for https://github.com/denoland/deno/issues/34246: when fs.readFile
+// is given an fd + encoding, readFileFromFd used a shared buffer and pushed
+// aliased subarrays, so files larger than the per-read chunk size came back
+// with the right length but scrambled content.
+Deno.test("fs.promises.readFile(path, encoding) returns intact content for >512KB files", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const filePath = path.join(tmpDir, "large.txt");
+    // 600 KiB of ASCII so byte length == char length; enough to span multiple
+    // reads through the fd-based path.
+    let chunk = "";
+    for (let i = 0; i < 1024; i++) chunk += i.toString().padStart(8, "0");
+    const expected = chunk.repeat(75);
+    await Deno.writeTextFile(filePath, expected);
+
+    const viaPathUtf8 = await readFilePromise(filePath, "utf8");
+    assertEquals(viaPathUtf8.length, expected.length);
+    assertEquals(viaPathUtf8, expected);
+
+    const fh = await open(filePath, "r");
+    try {
+      const viaFhUtf8 = await fh.readFile("utf8");
+      assertEquals(viaFhUtf8, expected);
+    } finally {
+      await fh.close();
+    }
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #34246.

`readFileFromFd` allocated one shared read buffer and pushed `subarray` views of it for each chunk, then concatenated at the end. The subarrays alias the buffer, so when the read had to loop (i.e. when an `encoding` was provided and capped the buffer at `kReadFileBufferLength = 512 KB` while the file was larger), the next read overwrote the start of the buffer and corrupted all previously pushed chunks. The total length matched the file size, but the first chunk-worth of bytes was replaced with content from a later read.

The path-based `fs.promises.readFile(path, encoding)` bypassed this code until #34118, which rerouted it through `open()` → `fh.readFile()` → `fs.readFile(fd, {encoding}, cb)` — exposing the latent bug. It manifested as vite/rollup parse failures on large CJS modules like `react-dom-client.production.js` (536 KB).

Rewrote `readFileFromFd` to mirror Node's `readFileHandle` (`lib/internal/fs/promises.js`):
- Known size: single `Uint8Array(size)`, read with an advancing offset, return directly (one allocation, no concat).
- Unknown size (pipes, sockets, `/dev/stdin`): allocate a fresh buffer per iteration so pushed subarrays don't alias.

## Test plan

- [x] Added regression test in `tests/unit_node/_fs/_fs_readFile_test.ts`: writes a 600 KiB ASCII file (>512 KiB to trigger the multi-read fd path) and asserts both `fs.promises.readFile(path, "utf8")` and `fh.readFile("utf8")` return the exact original content. Fails on the buggy code (length matches but bytes are scrambled), passes on the fix.
- [x] Reproducer from #34246 (vite build of `dprint/website/playground`) now succeeds.