### PR TITLE
fix(ext/node): attach addAbortListener to EventEmitter, fix errorMonitor

### DIFF
--- a/ext/node/polyfills/_events.mjs
+++ b/ext/node/polyfills/_events.mjs
@@ -105,13 +105,15 @@ EventEmitter.getEventListeners = getEventListeners;
 EventEmitter.setMaxListeners = setMaxListeners;
 EventEmitter.getMaxListeners = getMaxListeners;
 EventEmitter.listenerCount = listenerCount;
+EventEmitter.addAbortListener = addAbortListener;
 // Backwards-compat with node 0.10.x
 EventEmitter.EventEmitter = EventEmitter;
 EventEmitter.usingDomains = false;
 
 EventEmitter.captureRejectionSymbol = kRejection;
-const captureRejectionSymbol = EventEmitter.captureRejectionSymbol;
-const errorMonitor = EventEmitter.errorMonitor;
+EventEmitter.errorMonitor = kErrorMonitor;
+const captureRejectionSymbol = kRejection;
+const errorMonitor = kErrorMonitor;
 
 ObjectDefineProperty(EventEmitter, "captureRejections", {
   get() {
@@ -124,8 +126,6 @@ ObjectDefineProperty(EventEmitter, "captureRejections", {
   },
   enumerable: true,
 });
-
-EventEmitter.errorMonitor = kErrorMonitor;
 
 // The default for captureRejections is false
 ObjectDefineProperty(EventEmitter.prototype, kCapture, {

--- a/tests/unit_node/events_test.ts
+++ b/tests/unit_node/events_test.ts
@@ -1,6 +1,13 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-import events, { addAbortListener, EventEmitter } from "node:events";
+import events, {
+  addAbortListener,
+  errorMonitor,
+  EventEmitter,
+} from "node:events";
+import * as eventsNs from "node:events";
+import { createRequire } from "node:module";
+import { assert, assertEquals, assertStrictEquals } from "@std/assert";
 
 EventEmitter.captureRejections = true;
 
@@ -93,6 +100,49 @@ Deno.test("EventEmitter works if Array.prototype.push is deleted", () => {
   } finally {
     Array.prototype.push = ArrayPrototypePush;
   }
+});
+
+Deno.test("node:events default and namespace shape matches Node", () => {
+  // The default export is the EventEmitter constructor with named exports
+  // attached as static properties (issue #34261).
+  assertStrictEquals(events, EventEmitter);
+  assertStrictEquals(eventsNs.default, EventEmitter);
+
+  // Both ESM default and namespace expose addAbortListener as a function.
+  assertEquals(typeof events.addAbortListener, "function");
+  // @ts-ignore: @types/node namespace shape is incomplete here
+  assertEquals(typeof eventsNs.addAbortListener, "function");
+  assertStrictEquals(events.addAbortListener, addAbortListener);
+  // @ts-ignore: @types/node namespace shape is incomplete here
+  assertStrictEquals(eventsNs.addAbortListener, addAbortListener);
+
+  // errorMonitor must be a symbol on the EventEmitter function, on the
+  // namespace import, and on the named import (all three were broken before).
+  assertEquals(typeof events.errorMonitor, "symbol");
+  assertEquals(typeof eventsNs.errorMonitor, "symbol");
+  assertEquals(typeof errorMonitor, "symbol");
+  assertStrictEquals(events.errorMonitor, errorMonitor);
+  assertStrictEquals(eventsNs.errorMonitor, errorMonitor);
+
+  // CommonJS require() must agree with the ESM default export.
+  const require = createRequire(import.meta.url);
+  const cjsEvents = require("node:events");
+  assertStrictEquals(cjsEvents, EventEmitter);
+  assertEquals(typeof cjsEvents.addAbortListener, "function");
+  assertStrictEquals(cjsEvents.addAbortListener, addAbortListener);
+  assertStrictEquals(cjsEvents.errorMonitor, errorMonitor);
+});
+
+Deno.test("require('node:events').addAbortListener works (issue #34261)", async () => {
+  const require = createRequire(import.meta.url);
+  const { addAbortListener: addAbortListenerCjs } = require("node:events");
+  assert(typeof addAbortListenerCjs === "function");
+
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const ac = new AbortController();
+  addAbortListenerCjs(ac.signal, () => resolve());
+  ac.abort();
+  await promise;
 });
 
 Deno.test("EventEmitter works if Object.setPrototypeOf is deleted", () => {


### PR DESCRIPTION
`require("node:events").addAbortListener` was `undefined`, so libraries
that hit the CJS path (notably undici 8.x used by `npm:undici`) crashed
with `addAbortListenerNative is not a function`. Node attaches every
named export as a static property on the `EventEmitter` constructor, and
that's also what the ESM default export points at; Deno did this for
most properties but had never assigned `EventEmitter.addAbortListener`,
so both the CJS export and `import events from "node:events"` were
missing it.

The same file also captured the local `errorMonitor` binding before
`EventEmitter.errorMonitor = kErrorMonitor` ran, so the named export and
the namespace import resolved to `undefined` even though the property
on the constructor itself was correct. Both bindings now read from
`kErrorMonitor` directly.

Fixes #34261