### PR TITLE
fix(ext/node): satisfy agent-base node:https stack-trace check

### DIFF
--- a/ext/node/polyfills/https.ts
+++ b/ext/node/polyfills/https.ts
@@ -336,6 +336,14 @@ function request(...args: any[]) {
   return new ClientRequest(args[0], args[1], args[2]);
 }
 
+// `agent-base` (used by `@npmcli/agent`, `http-proxy-agent`, etc.) figures
+// out whether a polymorphic agent should behave as https by scanning the
+// current stack for `(https.js:` or `node:https:`. Without a marker the
+// stack only shows our polyfill path and the agent reports `protocol:
+// "http:"`, causing `http.ClientRequest` to throw `ERR_INVALID_PROTOCOL`
+// against an `https:` URL. Encode the marker in the function name.
+Object.defineProperty(request, "name", { value: "node:https:request" });
+
 return {
   Agent,
   Server,

--- a/tests/unit_node/https_test.ts
+++ b/tests/unit_node/https_test.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+import http from "node:http";
 import https from "node:https";
 import { assert, assertEquals } from "../unit/test_util.ts";
 import type { AddressInfo } from "node:net";
@@ -98,4 +99,56 @@ Deno.test({
 
     await server.finished;
   },
+});
+
+// Regression: `agent-base` (used by `@npmcli/agent`, `http-proxy-agent`, etc.)
+// decides whether a polymorphic agent should behave as https by scanning the
+// current stack for `node:https:`. Without that marker the agent reports
+// `protocol: "http:"`, and `http.ClientRequest` then throws
+// ERR_INVALID_PROTOCOL against an https URL — breaking `npm install` and
+// anything else that relies on agent-base.
+Deno.test("[node/https] request stack frame surfaces 'node:https:' for agent-base", () => {
+  // Mirrors agent-base@7's `protocol` getter: if the protocol wasn't set
+  // explicitly via the setter, scan the current stack for `node:https:` to
+  // decide whether we're inside an https request. The slot is keyed off a
+  // Symbol so it's only present after agent-base's own constructor runs —
+  // any `this.protocol = ...` assignment from `http.Agent`'s constructor
+  // (which runs first) is silently ignored, matching agent-base's behavior.
+  const INTERNAL = Symbol("AgentBaseInternalState");
+  // deno-lint-ignore no-explicit-any
+  class PolymorphicAgent extends (http.Agent as any) {
+    // deno-lint-ignore no-explicit-any
+    constructor(opts?: any) {
+      super(opts);
+      // deno-lint-ignore no-explicit-any
+      (this as any)[INTERNAL] = {};
+    }
+    get protocol() {
+      // deno-lint-ignore no-explicit-any
+      const state = (this as any)[INTERNAL];
+      if (state?.protocol !== undefined) return state.protocol;
+      const { stack } = new Error();
+      return stack && /node:https:/.test(stack) ? "https:" : "http:";
+    }
+    set protocol(v: string) {
+      // deno-lint-ignore no-explicit-any
+      const state = (this as any)[INTERNAL];
+      if (state) state.protocol = v;
+    }
+    // Prevent any actual socket/DNS work — we only care about the
+    // synchronous validation in `http.ClientRequest`'s constructor.
+    addRequest() {}
+  }
+
+  const agent = new PolymorphicAgent();
+  // Before the fix this threw synchronously with ERR_INVALID_PROTOCOL
+  // because `https.request`'s stack frame didn't contain `node:https:`,
+  // so the polymorphic agent reported protocol `"http:"` while the URL
+  // protocol was `"https:"`.
+  // deno-lint-ignore no-explicit-any
+  const req = https.request("https://example.com/", { agent: agent as any });
+  // We never let the request connect; swallow the abort error and the
+  // assertion is simply that construction did not throw.
+  req.on("error", () => {});
+  req.destroy();
 });


### PR DESCRIPTION
`npm install` (and any other consumer of `@npmcli/agent`,
`http-proxy-agent`, or `https-proxy-agent`) has been failing under deno
with `ERR_INVALID_PROTOCOL: Protocol "https:" not supported. Expected
"http:"`, thrown synchronously from `http.ClientRequest`. The
polymorphic agent in those packages, which extends `agent-base`,
reports `protocol: "http:"` even for `https.request(...)`.

The root cause is `agent-base@7`'s `protocol` getter. When its own
setter hasn't run yet — the common case for the singleton agents
`@npmcli/agent` caches — it falls back to scanning the current stack
for `(https.js:` or `node:https:` to decide whether the caller is the
https module. Real node satisfies that by virtue of its script URL
(`node:https:NNN:CC`), but the deno polyfill's stack frames read
`ext:deno_node/https.ts:NNN:CC`, so neither pattern matched, the agent
assumed http, and `http.ClientRequest` saw `options.protocol "https:"
!== agent.protocol "http:"` and threw.

Encode the marker in the `request` function's name so its call frame
reads `at node:https:request (...)` and agent-base's substring check
matches. The added unit test mirrors agent-base's `protocol` getter
exactly and asserts `https.request(httpsUrl, { agent })` no longer
throws `ERR_INVALID_PROTOCOL`; with the marker removed the test fails
with the original error, so it's a real regression guard.