### PR TITLE
fix(ext/node): translate args through shell wrappers around the deno binary

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -9,6 +9,7 @@
 (function () {
 const { core } = __bootstrap;
 const {
+  op_fs_read_file_sync,
   op_node_in_npm_package,
   op_node_ipc_buffer_constructor,
   op_node_ipc_read_advanced,
@@ -20,6 +21,7 @@ const {
   op_node_parse_shell_args,
   op_node_translate_cli_args,
 } = core.ops;
+const utf8Decoder = new TextDecoder("utf-8", { fatal: false });
 const {
   ArrayIsArray,
   ArrayPrototypeFilter,
@@ -1307,6 +1309,81 @@ function escapeShellArg(arg) {
 }
 
 /**
+ * Detect whether `file` is a thin shell-script (or .cmd) wrapper whose only
+ * job is to `exec` the Deno binary with passthrough args - the pattern that
+ * tools like `yarn` write to make a Deno-as-Node bridge available on PATH
+ * for npm lifecycle scripts. If `file` doesn't exist or doesn't match the
+ * pattern, returns `null`.
+ *
+ * Detecting these wrappers lets us treat the spawn as if it directly
+ * targeted Deno, so the normal Node.js to Deno arg translation runs and
+ * propagates `-A` and other compat flags down to the child. Otherwise the
+ * wrapper execs `deno postinstall.js` with default (no) permissions and
+ * any sys/read/write access in the script throws `NotCapable`.
+ */
+function detectDenoExecWrapper(file: string): string | null {
+  let content: string;
+  try {
+    const bytes = op_fs_read_file_sync(file);
+    if (bytes.length === 0 || bytes.length > 4096) {
+      return null;
+    }
+    content = utf8Decoder.decode(bytes);
+  } catch {
+    return null;
+  }
+  // POSIX wrapper: `#!/bin/sh\n\nexec "<deno>" "$@"` (yarn 1's exact form).
+  // Tolerate optional env-var prefix and either form of "$@" quoting.
+  const unix = content.match(
+    /^#![^\n]*\n[\s\S]*?\bexec\s+(?:[A-Za-z_][A-Za-z0-9_]*="[^"]*"\s+)*"([^"\n]+)"(?:\s+"?\$@"?)?\s*$/m,
+  );
+  if (unix) {
+    return unix[1];
+  }
+  // Windows .cmd wrapper: `@"<deno>" %*` (yarn 1's form on Windows).
+  const cmd = content.match(
+    /^@(?:[A-Za-z_][A-Za-z0-9_]*="[^"]*"\s+)*"([^"\r\n]+)"[^\r\n]*%\*\s*$/m,
+  );
+  if (cmd) {
+    return cmd[1];
+  }
+  return null;
+}
+
+/**
+ * Look up a bare command name on env.PATH and return the first existing
+ * candidate path, or null if not found. Mirrors basic `execvp` lookup
+ * semantics. Existence is probed via a sync read attempt (lighter than
+ * adding a stat op for one consumer; the caller re-reads the file anyway).
+ */
+// deno-lint-ignore no-explicit-any
+function resolveCommandOnPath(cmd: string, env: any): string | null {
+  if (cmd.includes("/") || (isWindows && cmd.includes("\\"))) {
+    return null;
+  }
+  const pathVar = env?.PATH ?? env?.Path ?? env?.path;
+  if (typeof pathVar !== "string" || pathVar.length === 0) {
+    return null;
+  }
+  const sep = isWindows ? ";" : ":";
+  const extensions = isWindows ? [".cmd", ".bat", ".exe", ""] : [""];
+  const dirs = pathVar.split(sep);
+  for (const dir of dirs) {
+    if (!dir) continue;
+    for (const ext of extensions) {
+      const candidate = `${dir}/${cmd}${ext}`;
+      try {
+        op_fs_read_file_sync(candidate);
+        return candidate;
+      } catch {
+        // try next
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Transforms a shell command that invokes Deno with Node.js flags into Deno-compatible flags.
  * Uses the Rust CLI parser (op_node_translate_cli_args) to handle argument translation,
  * including subcommand detection, -c/--check flag handling, and adding "run -A".
@@ -1349,6 +1426,25 @@ function transformDenoShellCommand(
         startsWithDeno = true;
         shellVarPrefix = shellVarMatch[0];
         denoPathLength = shellVarMatch[0].length;
+      }
+    }
+  }
+
+  // If the command's first word is a bare bin name that resolves on
+  // env.PATH to a thin shell wrapper around the Deno binary (yarn 1's
+  // generated `node` wrapper, etc.), rewrite the command to invoke Deno
+  // directly so the translation below can add `-A` and friends.
+  if (!startsWithDeno && env) {
+    const firstWord = command.match(/^[^\s]+/);
+    if (firstWord) {
+      const resolved = resolveCommandOnPath(firstWord[0], env);
+      if (resolved && detectDenoExecWrapper(resolved) === denoPath) {
+        startsWithDeno = true;
+        denoPathLength = firstWord[0].length;
+        // Rebuild the command with the literal deno path in place of the
+        // wrapper name so downstream quoting/splicing works the same way.
+        command = denoPath + command.slice(firstWord[0].length);
+        denoPathLength = denoPath.length;
       }
     }
   }
@@ -1473,7 +1569,15 @@ function buildCommand(
   env,
 ) {
   let includeNpmProcessState = false;
-  if (file === Deno.execPath() && !Deno.build.standalone) {
+  const denoPath = Deno.execPath();
+  // If `file` is a thin shell wrapper around the Deno binary (e.g. yarn 1's
+  // generated `node` wrapper that does `exec "<deno>" "$@"`), treat the
+  // spawn as if it directly targeted Deno so the Node.js arg translation
+  // below adds `-A`, `--unstable-bare-node-builtins`, etc.
+  if (file !== denoPath && detectDenoExecWrapper(file) === denoPath) {
+    file = denoPath;
+  }
+  if (file === denoPath && !Deno.build.standalone) {
     // Ensure all args are strings (Node allows numbers in args array)
     args = args.map((arg) => String(arg));
 

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import CP from "node:child_process";
+import process from "node:process";
 import { Buffer } from "node:buffer";
 import {
   assert,
@@ -1391,6 +1392,62 @@ Deno.test({
       assertEquals(content, "hello from child\n");
     } finally {
       Deno.removeSync(tmpFile);
+    }
+  },
+});
+
+// Regression: yarn 1's npm-lifecycle bridge writes a `node` shell wrapper
+// (`#!/bin/sh\nexec "<deno>" "$@"`) and prepends its directory to PATH so
+// child scripts find it as `node`. Before the wrapper-detection logic in
+// `buildCommand`/`transformDenoShellCommand`, both spawn shapes invoked
+// `deno postinstall.js` with default (no) permissions, breaking any
+// lifecycle script that touched sys/read APIs (e.g. `process.report` in
+// `napi-postinstall`).
+Deno.test({
+  name: "spawnDenoExecWrapperInheritsNodeCompat",
+  ignore: Deno.build.os === "windows",
+  fn() {
+    const dir = Deno.makeTempDirSync();
+    const wrapper = `${dir}/node`;
+    Deno.writeTextFileSync(
+      wrapper,
+      `#!/bin/sh\nexec "${Deno.execPath()}" "$@"\n`,
+    );
+    Deno.chmodSync(wrapper, 0o755);
+
+    const script = `${dir}/probe.js`;
+    Deno.writeTextFileSync(
+      script,
+      "const os=require('os');console.log('cpus:'+os.cpus().length);",
+    );
+
+    try {
+      // Case (a): spawn the wrapper directly by absolute path.
+      const direct = spawnSync(wrapper, [script], { encoding: "utf8" });
+      assertEquals(
+        direct.status,
+        0,
+        `direct wrapper spawn exited ${direct.status}: ${direct.stderr}`,
+      );
+      assertStringIncludes(direct.stdout as string, "cpus:");
+
+      // Case (b): shell -c with PATH lookup (mirrors yarn's lifecycle exec).
+      const viaPath = spawnSync(
+        "/bin/sh",
+        ["-c", `node ${script}`],
+        {
+          encoding: "utf8",
+          env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+        },
+      );
+      assertEquals(
+        viaPath.status,
+        0,
+        `sh -c wrapper spawn exited ${viaPath.status}: ${viaPath.stderr}`,
+      );
+      assertStringIncludes(viaPath.stdout as string, "cpus:");
+    } finally {
+      Deno.removeSync(dir, { recursive: true });
     }
   },
 });

--- a/tools/ecosystem_compat_tests.ts
+++ b/tools/ecosystem_compat_tests.ts
@@ -12,10 +12,13 @@ async function teardownTestRepo() {
   await $`rm -rf nextjs-demo`;
 }
 
-async function runPackageManager(pm: string, cmd: string) {
+async function runPackageManager(pm: string, args: string[]) {
   const state = Date.now();
+  // pnpm's bundled upath2 reads `who.__proto__.constructor`, which Deno
+  // exposes only behind `--unstable-unsafe-proto`.
+  const denoFlags = pm === "pnpm" ? ["--unstable-unsafe-proto"] : [];
   const result =
-    await $`cd nextjs-demo ; rm -rf node_modules ; ${Deno.execPath()} run -A --no-config npm:${pm} ${cmd}`
+    await $`cd nextjs-demo ; rm -rf node_modules ; ${Deno.execPath()} run -A ${denoFlags} --no-config npm:${pm} ${args}`
       .stdout("inheritPiped").stderr("inheritPiped").noThrow().timeout(
         "120s",
       );
@@ -30,7 +33,7 @@ async function runPackageManager(pm: string, cmd: string) {
 
 async function testNpm() {
   $.logStep("Testing npm...");
-  const report = await runPackageManager("npm", "install");
+  const report = await runPackageManager("npm", ["install"]);
   if (report.exitCode === 0) {
     $.logStep("npm install succeeded");
   } else {
@@ -41,7 +44,7 @@ async function testNpm() {
 
 async function testYarn() {
   $.logStep("Testing yarn...");
-  const report = await runPackageManager("yarn", "install");
+  const report = await runPackageManager("yarn", ["install"]);
   if (report.exitCode === 0) {
     $.logStep("yarn install succeeded");
   } else {
@@ -52,7 +55,14 @@ async function testYarn() {
 
 async function testPnpm() {
   $.logStep("Testing pnpm...");
-  const report = await runPackageManager("pnpm", "install");
+  // pnpm 11's strict-builds policy exits 1 with `ERR_PNPM_IGNORED_BUILDS`
+  // in non-interactive mode whenever a dependency has an unapproved
+  // postinstall script (e.g. `unrs-resolver`); allow them all so the
+  // smoke test reflects whether the install actually works.
+  const report = await runPackageManager("pnpm", [
+    "install",
+    "--config.dangerouslyAllowAllBuilds=true",
+  ]);
   if (report.exitCode === 0) {
     $.logStep("pnpm install succeeded");
   } else {


### PR DESCRIPTION
npm lifecycle tools like yarn 1 generate a `node` shell wrapper that
does

    #!/bin/sh
    exec "<deno>" "$@"

and prepend its directory to PATH so child scripts find it as `node`.
When a lifecycle script then runs (directly or via `sh -c "node ..."`)
the wrapper execs `deno postinstall.js` bare - no `run -A`, no Node.js
compat flags - and any sys/read/write API throws `NotCapable`.
Concretely this has been surfacing as `unrs-resolver`'s postinstall
calling `process.report.getReport()` on Linux runners and failing
every `yarn install` in the ecosystem compat test for the past week.

The existing `buildCommand` and `transformDenoShellCommand` paths
already translate Node-style args to Deno-style ones, but they key
off `file === Deno.execPath()`, so a shell wrapper that proxies to
deno is invisible to them. This change detects the wrapper by
reading the script and matching against the POSIX exec-deno pattern
(yarn 1's exact form) or the Windows `.cmd` equivalent, then rewrites
the spawn to target the deno binary directly so the existing
translation runs and propagates `-A` and friends to the child.

The bundled test exercises both spawn shapes (direct wrapper path and
`sh -c "<bare-name>"` via PATH lookup) and asserts the child can use a
require()'d node:os module - a stand-in for the lifecycle-script
behaviors that fail today.

Also brings the ecosystem compat test runner in line with pnpm 11's
strict-builds policy: `--unstable-unsafe-proto` (upath2 reads
`__proto__.constructor`) and `--config.dangerouslyAllowAllBuilds=true`
so postinstall scripts actually run instead of pnpm exiting 1 with
`ERR_PNPM_IGNORED_BUILDS` in non-interactive mode.