### PR TITLE
chore: bump deno_task_shell to 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3279,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8e2c943f7b09f1473c7b43e7bbcc85f1edbcf3c27524f0016fe3e3b668d983"
+checksum = "75003f3c39a260a891af8a2b4f13c58f74b14636bcb2a0b89c76adb412f3dcdc"
 dependencies = [
  "anyhow",
  "bitflags 2.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_path_util = "=0.6.4"
 deno_semver = "=0.10.0"
-deno_task_shell = "=0.30.0"
+deno_task_shell = "=0.31.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"


### PR DESCRIPTION
Picks up denoland/deno_task_shell#175, which adds the POSIX `:` (null
command) as a shell builtin alongside `true` and `false`. Without it
`deno task` fails with `:: command not found` (exit 127) on any
package.json whose script is the bare colon no-op, e.g. the
`"test": ":"` script in the aube benchmark fixture
(https://aube.en.dev/benchmarks.html) that previously prevented Deno
from completing the install-test scenario at all. Verified locally:
`deno task test` against a minimal `{ "scripts": { "test": ":" } }`
package now exits 0.