### PR TITLE
chore: upgrade deno_task_shell to 0.32.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75003f3c39a260a891af8a2b4f13c58f74b14636bcb2a0b89c76adb412f3dcdc"
+checksum = "a5724630e5d004297ca84920ef90cbf8a5459b06f8cd553e1a75d9f3ad5cd6fd"
 dependencies = [
  "anyhow",
  "bitflags 2.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_path_util = "=0.6.4"
 deno_semver = "=0.10.0"
-deno_task_shell = "=0.31.0"
+deno_task_shell = "=0.32.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"


### PR DESCRIPTION
Picks up two upstream changes in deno_task_shell: support for `set -e`
/ `set +e` (and the `set -o errexit` long form), which aborts the
surrounding sequential list on the first non-zero exit, and the POSIX
null command `:` as a builtin.

See denoland/deno_task_shell#171 and denoland/deno_task_shell#175.