### PR TITLE
feat(init): add `--cli` template

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -351,6 +351,7 @@ pub struct InitFlags {
   pub lib: bool,
   pub serve: bool,
   pub empty: bool,
+  pub cli: bool,
   pub yes: bool,
 }
 
@@ -3509,14 +3510,14 @@ fn init_subcommand() -> Command {
           Arg::new("npm")
             .long("npm")
             .help("Generate a npm create-* project")
-            .conflicts_with_all(["lib", "serve", "empty", "jsr"])
+            .conflicts_with_all(["lib", "serve", "empty", "cli", "jsr"])
             .action(ArgAction::SetTrue),
         )
         .arg(
           Arg::new("jsr")
             .long("jsr")
             .help("Generate a project from a JSR package")
-            .conflicts_with_all(["lib", "serve", "empty", "npm"])
+            .conflicts_with_all(["lib", "serve", "empty", "cli", "npm"])
             .action(ArgAction::SetTrue),
         )
         .arg(
@@ -3536,7 +3537,14 @@ fn init_subcommand() -> Command {
           Arg::new("empty")
             .long("empty")
             .help("Generate a minimal project with just main.ts and deno.json")
-            .conflicts_with_all(["lib", "serve", "npm", "jsr"])
+            .conflicts_with_all(["lib", "serve", "cli", "npm", "jsr"])
+            .action(ArgAction::SetTrue),
+        )
+        .arg(
+          Arg::new("cli")
+            .long("cli")
+            .help("Generate an example CLI project with subcommands")
+            .conflicts_with_all(["lib", "serve", "empty", "npm", "jsr"])
             .action(ArgAction::SetTrue),
         )
         .arg(
@@ -7134,6 +7142,7 @@ fn init_parse(
   let mut lib = matches.get_flag("lib");
   let mut serve = matches.get_flag("serve");
   let mut empty = matches.get_flag("empty");
+  let mut cli = matches.get_flag("cli");
   let mut yes = matches.get_flag("yes");
   let mut dir = None;
   let mut package = None;
@@ -7167,6 +7176,7 @@ fn init_parse(
         lib = inner_matches.get_flag("lib");
         serve = inner_matches.get_flag("serve");
         empty = inner_matches.get_flag("empty");
+        cli = inner_matches.get_flag("cli");
         yes = inner_matches.get_flag("yes");
       }
     }
@@ -7189,6 +7199,7 @@ fn init_parse(
     lib,
     serve,
     empty,
+    cli,
     yes,
   });
 
@@ -7216,6 +7227,7 @@ fn create_parse(
     lib: false,
     serve: false,
     empty: false,
+    cli: false,
     yes: matches.get_flag("yes"),
   });
 
@@ -14174,6 +14186,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14191,6 +14204,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14208,6 +14222,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         log_level: Some(Level::Error),
@@ -14226,6 +14241,7 @@ mod tests {
           lib: true,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14243,11 +14259,54 @@ mod tests {
           lib: false,
           serve: true,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
       }
     );
+
+    let r = flags_from_vec(svec!["deno", "init", "--cli"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Init(InitFlags {
+          package: None,
+          package_args: vec![],
+          dir: None,
+          lib: false,
+          serve: false,
+          empty: false,
+          cli: true,
+          yes: false,
+        }),
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec!["deno", "init", "foo", "--cli"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Init(InitFlags {
+          package: None,
+          package_args: vec![],
+          dir: Some(String::from("foo")),
+          lib: false,
+          serve: false,
+          empty: false,
+          cli: true,
+          yes: false,
+        }),
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec!["deno", "init", "--cli", "--lib"]);
+    assert!(r.is_err());
+
+    let r = flags_from_vec(svec!["deno", "init", "--cli", "--empty"]);
+    assert!(r.is_err());
 
     let r = flags_from_vec(svec!["deno", "init", "foo", "--lib"]);
     assert_eq!(
@@ -14260,6 +14319,7 @@ mod tests {
           lib: true,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14283,6 +14343,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14300,6 +14361,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14317,6 +14379,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14334,6 +14397,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: true,
         }),
         ..Flags::default()
@@ -14352,6 +14416,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14370,6 +14435,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14394,6 +14460,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: true,
         }),
         ..Flags::default()
@@ -14418,6 +14485,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14459,6 +14527,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14476,6 +14545,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14497,6 +14567,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: true,
         }),
         ..Flags::default()
@@ -14515,6 +14586,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14532,6 +14604,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14549,6 +14622,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: true,
         }),
         ..Flags::default()
@@ -14572,6 +14646,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14594,6 +14669,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: false,
         }),
         ..Flags::default()
@@ -14613,6 +14689,7 @@ mod tests {
           lib: false,
           serve: false,
           empty: false,
+          cli: false,
           yes: true,
         }),
         ..Flags::default()

--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -159,6 +159,174 @@ Deno.test(async function serverFetchStatic() {
         }
       }),
     )?;
+  } else if init_flags.cli {
+    create_file(
+      &dir,
+      "main.ts",
+      r##"// A small CLI scaffold with subcommands.
+// Run `deno run main.ts --help` to see available commands.
+
+import { parseArgs, type ParseArgsConfig } from "node:util";
+import {
+  bold,
+  cyan,
+  dim,
+  green,
+  red,
+  yellow,
+} from "jsr:@std/fmt@^1/colors";
+
+type OptionConfig = NonNullable<ParseArgsConfig["options"]>[string] & {
+  description: string;
+};
+
+interface Command {
+  description: string;
+  usage: string;
+  options?: Record<string, OptionConfig>;
+  run: (
+    positionals: string[],
+    values: Record<string, unknown>,
+  ) => void | Promise<void>;
+}
+
+const COMMANDS: Record<string, Command> = {
+  hello: {
+    description: "Print a friendly greeting",
+    usage: "hello <name> [--shout]",
+    options: {
+      shout: {
+        type: "boolean",
+        short: "s",
+        description: "Print the greeting in uppercase",
+      },
+    },
+    run(positionals, values) {
+      const name = positionals[0] ?? "world";
+      let message = `Hello, ${name}!`;
+      if (values.shout) message = message.toUpperCase();
+      console.log(green(message));
+    },
+  },
+  add: {
+    description: "Add a sequence of numbers",
+    usage: "add <a> <b> [...]",
+    run(positionals) {
+      if (positionals.length < 2) {
+        console.error(red("Error: provide at least two numbers"));
+        Deno.exit(1);
+      }
+      const numbers = positionals.map(Number);
+      if (numbers.some(Number.isNaN)) {
+        console.error(red("Error: all arguments must be numbers"));
+        Deno.exit(1);
+      }
+      const total = numbers.reduce((a, b) => a + b, 0);
+      console.log(cyan(`${numbers.join(" + ")} = ${total}`));
+    },
+  },
+  time: {
+    description: "Print the current time",
+    usage: "time [--iso]",
+    options: {
+      iso: {
+        type: "boolean",
+        description: "Format as an ISO 8601 timestamp",
+      },
+    },
+    run(_positionals, values) {
+      const now = new Date();
+      console.log(yellow(values.iso ? now.toISOString() : now.toString()));
+    },
+  },
+};
+
+const BIN = "mycli";
+
+function printHelp(): void {
+  console.log();
+  console.log(`  ${bold(cyan(BIN))} ${dim("-")} A small CLI scaffold`);
+  console.log();
+  console.log(`  ${bold("USAGE")}`);
+  console.log(`    ${dim("$")} ${BIN} ${green("<command>")} [options]`);
+  console.log();
+  console.log(`  ${bold("COMMANDS")}`);
+  for (const [name, cmd] of Object.entries(COMMANDS)) {
+    console.log(`    ${green(name.padEnd(10))} ${cmd.description}`);
+  }
+  console.log();
+  console.log(
+    `  Run ${cyan(`${BIN} <command> --help`)} for command-specific help.`,
+  );
+  console.log();
+}
+
+function printCommandHelp(name: string, cmd: Command): void {
+  console.log();
+  console.log(`  ${bold(cyan(name))} ${dim("-")} ${cmd.description}`);
+  console.log();
+  console.log(`  ${bold("USAGE")}`);
+  console.log(`    ${dim("$")} ${BIN} ${green(cmd.usage)}`);
+  if (cmd.options && Object.keys(cmd.options).length > 0) {
+    console.log();
+    console.log(`  ${bold("OPTIONS")}`);
+    for (const [optName, opt] of Object.entries(cmd.options)) {
+      const flag = opt.short
+        ? `-${opt.short}, --${optName}`
+        : `    --${optName}`;
+      console.log(`    ${yellow(flag.padEnd(20))} ${opt.description}`);
+    }
+  }
+  console.log();
+}
+
+function main(args: string[]): void {
+  const [name, ...rest] = args;
+
+  if (!name || name === "--help" || name === "-h" || name === "help") {
+    printHelp();
+    return;
+  }
+
+  const cmd = COMMANDS[name];
+  if (!cmd) {
+    console.error(red(`Unknown command: ${name}`));
+    printHelp();
+    Deno.exit(1);
+  }
+
+  if (rest.includes("--help") || rest.includes("-h")) {
+    printCommandHelp(name, cmd);
+    return;
+  }
+
+  const { values, positionals } = parseArgs({
+    args: rest,
+    options: cmd.options ?? {},
+    allowPositionals: true,
+  });
+
+  cmd.run(positionals, values);
+}
+
+if (import.meta.main) {
+  main(Deno.args);
+}
+"##,
+    )?;
+
+    create_json_file(
+      &dir,
+      "deno.json",
+      &json!({
+        "tasks": {
+          "dev": "deno run --watch main.ts hello"
+        },
+        "imports": {
+          "@std/fmt": "jsr:@std/fmt@1"
+        }
+      }),
+    )?;
   } else if init_flags.lib {
     // Extract the directory name to use as the project name
     let project_name = dir
@@ -292,6 +460,18 @@ Deno.test("returns json on /api", async () => {
     info!("");
     info!("  {}", colors::gray("# Run the tests"));
     info!("  deno test -R");
+  } else if init_flags.cli {
+    info!("  {}", colors::gray("# Show available subcommands"));
+    info!("  deno run main.ts --help");
+    info!("");
+    info!("  {}", colors::gray("# Try a subcommand"));
+    info!("  deno run main.ts hello world");
+    info!("");
+    info!(
+      "  {}",
+      colors::gray("# Run with file watching during development")
+    );
+    info!("  deno task dev");
   } else if init_flags.lib {
     info!("  {}", colors::gray("# Run the tests"));
     info!("  deno test");

--- a/tests/specs/init/cli/__test__.jsonc
+++ b/tests/specs/init/cli/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "init --cli project",
+  "output": "init.out"
+}

--- a/tests/specs/init/cli/init.out
+++ b/tests/specs/init/cli/init.out
@@ -1,0 +1,6 @@
+[WILDCARD]Project initialized[WILDCARD]
+[WILDCARD]Run these commands to get started[WILDCARD]
+[WILDCARD]cd project[WILDCARD]
+[WILDCARD]deno run main.ts --help[WILDCARD]
+[WILDCARD]deno run main.ts hello world[WILDCARD]
+[WILDCARD]deno task dev[WILDCARD]


### PR DESCRIPTION
Adds a new `deno init --cli` template that scaffolds a single-file CLI
with subcommands. Each subcommand is declared as a structured object
(description, usage, options, run) so help output can be generated
from the same source of truth, mirroring the pattern used by the
in-repo `./x` developer CLI. The generated program uses `parseArgs`
from `node:util` for flag parsing and `jsr:@std/fmt/colors` for styled
output, giving users a working starting point that exercises both the
Node compatibility layer and the JSR ecosystem.