### PR TITLE
feat(lsp): report test coverage notifications

### DIFF
--- a/cli/lsp/client.rs
+++ b/cli/lsp/client.rs
@@ -23,6 +23,7 @@ pub enum TestingNotification {
   Module(testing_lsp_custom::TestModuleNotificationParams),
   DeleteModule(testing_lsp_custom::TestModuleDeleteNotificationParams),
   Progress(testing_lsp_custom::TestRunProgressParams),
+  Coverage(testing_lsp_custom::TestCoverageNotificationParams),
 }
 
 #[derive(Clone)]
@@ -269,6 +270,14 @@ impl ClientTrait for TowerClient {
         self
           .0
           .send_notification::<testing_lsp_custom::TestRunProgressNotification>(
+            params,
+          )
+          .await
+      }
+      TestingNotification::Coverage(params) => {
+        self
+          .0
+          .send_notification::<testing_lsp_custom::TestCoverageNotification>(
             params,
           )
           .await

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -29,6 +30,7 @@ use super::definitions::TestModule;
 use super::lsp_custom;
 use super::server::TestServerTests;
 use crate::args::DenoSubcommand;
+use crate::args::Flags;
 use crate::args::flags_from_vec;
 use crate::args::parallelism_count;
 use crate::factory::CliFactory;
@@ -39,6 +41,7 @@ use crate::lsp::logging::lsp_log;
 use crate::lsp::urls::uri_parse_unencoded;
 use crate::lsp::urls::uri_to_url;
 use crate::lsp::urls::url_to_uri;
+use crate::tools::coverage::collect_coverage_reports;
 use crate::tools::test;
 use crate::tools::test::FailFastTracker;
 use crate::tools::test::TestFailure;
@@ -227,12 +230,21 @@ impl TestRun {
     client: &Client,
     maybe_root_uri: Option<&ModuleSpecifier>,
   ) -> Result<(), AnyError> {
-    let args = self.get_args();
+    let coverage_dir = if self.kind == lsp_custom::TestRunKind::Coverage {
+      Some(
+        tempfile::Builder::new()
+          .prefix("deno_lsp_coverage_")
+          .tempdir()?,
+      )
+    } else {
+      None
+    };
+    let args = self.get_args(coverage_dir.as_ref().map(|dir| dir.path()));
     lsp_log!("Executing test run with arguments: {}", args.join(" "));
     let flags = Arc::new(flags_from_vec(
       args.into_iter().map(|s| From::from(s.as_ref())).collect(),
     )?);
-    let factory = CliFactory::from_flags(flags);
+    let factory = CliFactory::from_flags(flags.clone());
     let cli_options = factory.cli_options()?;
     let permission_desc_parser = factory.permission_desc_parser()?;
     let main_graph_container = factory.main_module_graph_container().await?;
@@ -471,12 +483,75 @@ impl TestRun {
       join_result??;
     }
 
-    result??;
+    let test_result = result?;
+
+    if let Some(coverage_dir) = coverage_dir.as_ref()
+      && let Err(err) = self
+        .send_coverage_notification(client, flags, coverage_dir.path())
+        .await
+    {
+      lsp_log!("Failed to collect test coverage: {err:#}");
+    }
+
+    test_result?;
 
     Ok(())
   }
 
-  fn get_args(&self) -> Vec<Cow<'_, str>> {
+  async fn send_coverage_notification(
+    &self,
+    client: &Client,
+    flags: Arc<Flags>,
+    coverage_dir: &Path,
+  ) -> Result<(), AnyError> {
+    let coverage_dir = coverage_dir.to_string_lossy().into_owned();
+    let (_, reports) = spawn_blocking(move || {
+      collect_coverage_reports(
+        flags,
+        vec![coverage_dir],
+        vec![],
+        vec![],
+        vec![],
+        None,
+      )
+    })
+    .await??;
+    let files = reports
+      .into_iter()
+      .filter_map(|(report, _)| {
+        let uri = url_to_uri(report.url()).ok()?;
+        let lines = report
+          .found_lines()
+          .iter()
+          .filter_map(|(line, count)| {
+            Some(lsp_custom::TestCoverageLine {
+              line: u32::try_from(*line).ok()?,
+              count: u32::try_from((*count).max(0)).ok()?,
+            })
+          })
+          .collect::<Vec<_>>();
+
+        if lines.is_empty() {
+          None
+        } else {
+          Some(lsp_custom::TestCoverageFile {
+            text_document: lsp::TextDocumentIdentifier { uri },
+            lines,
+          })
+        }
+      })
+      .collect::<Vec<_>>();
+
+    if !files.is_empty() {
+      client.send_test_notification(TestingNotification::Coverage(
+        lsp_custom::TestCoverageNotificationParams { id: self.id, files },
+      ));
+    }
+
+    Ok(())
+  }
+
+  fn get_args(&self, coverage_dir: Option<&Path>) -> Vec<Cow<'_, str>> {
     let mut args = vec![Cow::Borrowed("deno"), Cow::Borrowed("test")];
     args.extend(
       self
@@ -487,6 +562,13 @@ impl TestRun {
         .map(|s| Cow::Borrowed(s.as_str())),
     );
     args.push(Cow::Borrowed("--trace-leaks"));
+    if let Some(coverage_dir) = coverage_dir {
+      args.push(Cow::Owned(format!(
+        "--coverage={}",
+        coverage_dir.to_string_lossy()
+      )));
+      args.push(Cow::Borrowed("--coverage-raw-data-only"));
+    }
     for unstable_feature in self.workspace_settings.unstable.as_deref() {
       let flag = format!("--unstable-{unstable_feature}");
       if !args.contains(&Cow::Borrowed(&flag)) {
@@ -929,6 +1011,30 @@ mod tests {
         "0b7c6bf3cd617018d33a1bf982a08fe088c5bb54fcd5eb9e802e7c137ec1af94"
           .to_string()
       ]
+    );
+  }
+
+  #[test]
+  fn test_get_args_for_coverage_run() {
+    let run = TestRun {
+      id: 1,
+      kind: lsp_custom::TestRunKind::Coverage,
+      filters: Default::default(),
+      queue: Default::default(),
+      tests: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+      token: CancellationToken::new(),
+      workspace_settings: config::WorkspaceSettings::default(),
+    };
+    let args = run.get_args(Some(Path::new("/tmp/deno_lsp_coverage_test")));
+    assert!(
+      args.iter().any(|arg| {
+        arg.as_ref() == "--coverage=/tmp/deno_lsp_coverage_test"
+      })
+    );
+    assert!(
+      args
+        .iter()
+        .any(|arg| { arg.as_ref() == "--coverage-raw-data-only" })
     );
   }
 }

--- a/cli/lsp/testing/lsp_custom.rs
+++ b/cli/lsp/testing/lsp_custom.rs
@@ -115,6 +115,28 @@ pub struct TestRunProgressParams {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct TestCoverageLine {
+  /// Zero-based line number matching LSP positions.
+  pub line: u32,
+  pub count: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TestCoverageFile {
+  pub text_document: lsp::TextDocumentIdentifier,
+  pub lines: Vec<TestCoverageLine>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TestCoverageNotificationParams {
+  pub id: u32,
+  pub files: Vec<TestCoverageFile>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct TestIdentifier {
   /// The module identifier which contains the test.
   pub text_document: lsp::TextDocumentIdentifier,
@@ -185,4 +207,12 @@ impl lsp::notification::Notification for TestRunProgressNotification {
   type Params = TestRunProgressParams;
 
   const METHOD: &'static str = "deno/testRunProgress";
+}
+
+pub enum TestCoverageNotification {}
+
+impl lsp::notification::Notification for TestCoverageNotification {
+  type Params = TestCoverageNotificationParams;
+
+  const METHOD: &'static str = "deno/testCoverage";
 }

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -72,6 +72,16 @@ pub struct CoverageReport {
   output: Option<PathBuf>,
 }
 
+impl CoverageReport {
+  pub fn url(&self) -> &ModuleSpecifier {
+    &self.url
+  }
+
+  pub fn found_lines(&self) -> &[(usize, i64)] {
+    &self.found_lines
+  }
+}
+
 struct GenerateCoverageReportOptions<'a> {
   script_module_specifier: Url,
   script_media_type: MediaType,
@@ -582,15 +592,14 @@ fn filter_coverages(
     .collect::<Vec<cdp::ScriptCoverage>>()
 }
 
-pub fn cover_files(
+pub fn collect_coverage_reports(
   flags: Arc<Flags>,
   files_include: Vec<String>,
   files_ignore: Vec<String>,
   include: Vec<String>,
   exclude: Vec<String>,
   output: Option<String>,
-  reporters: &[&dyn CoverageReporter],
-) -> Result<(), AnyError> {
+) -> Result<(PathBuf, Vec<(CoverageReport, String)>), AnyError> {
   if files_include.is_empty() {
     return Err(anyhow!("No matching coverage profiles found"));
   }
@@ -748,6 +757,27 @@ pub fn cover_files(
   if file_reports.is_empty() {
     return Err(anyhow!("No covered files included in the report"));
   }
+
+  Ok((coverage_root, file_reports))
+}
+
+pub fn cover_files(
+  flags: Arc<Flags>,
+  files_include: Vec<String>,
+  files_ignore: Vec<String>,
+  include: Vec<String>,
+  exclude: Vec<String>,
+  output: Option<String>,
+  reporters: &[&dyn CoverageReporter],
+) -> Result<(), AnyError> {
+  let (coverage_root, file_reports) = collect_coverage_reports(
+    flags,
+    files_include,
+    files_ignore,
+    include,
+    exclude,
+    output,
+  )?;
 
   for reporter in reporters {
     reporter.done(&coverage_root, &file_reports);

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -14591,6 +14591,117 @@ Deno.test({
 }
 
 #[test(timeout = 300)]
+fn lsp_testing_api_coverage() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+
+  let mod_contents = r#"export const value = "covered";
+export function check(input: string) {
+  if (input === "covered") {
+    return true;
+  }
+  return false;
+}
+"#;
+  let contents = r#"import { check, value } from "./mod.ts";
+
+Deno.test("coverage", () => {
+  if (!check(value)) {
+    throw new Error("unexpected");
+  }
+});
+"#;
+  temp_dir.write("./mod.ts", mod_contents);
+  temp_dir.write("./test.ts", contents);
+  temp_dir.write("./deno.jsonc", "{}");
+  let uri = url_to_uri(&temp_dir.url().join("test.ts").unwrap()).unwrap();
+  let mod_uri = url_to_uri(&temp_dir.url().join("mod.ts").unwrap()).unwrap();
+
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.change_configuration(json!({
+    "deno": {
+      "enable": true,
+    },
+  }));
+
+  client.did_open(json!({
+    "textDocument": {
+      "uri": uri,
+      "languageId": "typescript",
+      "version": 1,
+      "text": contents,
+    }
+  }));
+
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testModule");
+  let params: TestModuleNotificationParams =
+    serde_json::from_value(notification.unwrap()).unwrap();
+  assert_eq!(params.text_document.uri.as_str(), uri.as_str());
+  assert_eq!(params.tests.len(), 1);
+
+  let res = client.write_request_with_res_as::<TestRunResponseParams>(
+    "deno/testRun",
+    json!({
+      "id": 2,
+      "kind": "coverage",
+    }),
+  );
+  assert_eq!(res.enqueued.len(), 1);
+
+  loop {
+    let notification =
+      client.read_notification_with_method::<Value>("deno/testRunProgress");
+    let notification = notification.unwrap();
+    let message_type = notification
+      .as_object()
+      .unwrap()
+      .get("message")
+      .unwrap()
+      .as_object()
+      .unwrap()
+      .get("type")
+      .unwrap()
+      .as_str()
+      .unwrap();
+    if message_type == "end" {
+      break;
+    }
+  }
+
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testCoverage");
+  let notification = notification.unwrap();
+  assert_eq!(notification.get("id"), Some(&json!(2)));
+  let files = notification
+    .get("files")
+    .and_then(|value| value.as_array())
+    .unwrap();
+  let file = files
+    .iter()
+    .find(|file| {
+      file.get("textDocument").and_then(|value| value.get("uri"))
+        == Some(&json!(mod_uri))
+    })
+    .unwrap();
+  let lines = file
+    .get("lines")
+    .and_then(|value| value.as_array())
+    .unwrap();
+  assert!(!lines.is_empty());
+  assert!(lines.iter().any(|line| {
+    line
+      .get("count")
+      .and_then(|value| value.as_u64())
+      .unwrap_or_default()
+      > 0
+  }));
+
+  client.shutdown();
+}
+
+#[test(timeout = 300)]
 fn lsp_testing_api_failure() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let temp_dir = context.temp_dir();


### PR DESCRIPTION
This adds coverage reporting for LSP test runs.

Changes:
- runs `TestRunKind::Coverage` with a unique temporary raw coverage directory
- exposes a `deno/testCoverage` notification with per-file line hit counts
- reuses the existing CLI coverage report generation path for source maps and ignore directives
- adds an LSP integration test covering the notification payload

The notification shape reports `{ line, count }` entries instead of separate covered/uncovered arrays, so clients can derive gutter state while preserving hit-count information.

Fixes #18147.

AI-assisted contribution disclosure: this PR was prepared with AI assistance and manually validated locally.

Tests:
- `CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=/tmp/deno-cc-strip-lld cargo test -p deno --lib lsp::testing::execution::tests`
- `CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=/tmp/deno-cc-strip-lld cargo test -p deno --lib tools::coverage`
- `CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=/tmp/deno-cc-strip-lld cargo test -p integration_tests --test integration -- lsp::lsp_testing_api_coverage`
- `cargo fmt --all -- --check`
- `git diff --check`
