### PR TITLE
chore: relax twox-hash version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,7 +324,7 @@ tower-service = "0.3.2"
 tracing = "0.1"
 tracing-opentelemetry = "0.28.0"
 tracing-subscriber = "0.3.20"
-twox-hash = { version = "=2.1.0", features = ["std", "xxhash64"], default-features = false }
+twox-hash = { version = "2.1.0", features = ["std", "xxhash64"], default-features = false }
 typed-arena = "=2.0.2"
 url = { version = "2.5", features = ["serde", "expose_internals"] }
 urlpattern = "=0.4.2"


### PR DESCRIPTION
Relax the workspace `twox-hash` dependency from an exact `=2.1.0` requirement to Cargo's default caret requirement.

This keeps the current locked version unchanged while allowing downstream dependency graphs to resolve compatible `twox-hash` 2.x patch releases.

Closes #34274