### PR TITLE
fix(core): disable include_icu_data feature

### DIFF
--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -14,7 +14,7 @@ description = "A modern JavaScript/TypeScript runtime built with V8, Rust, and T
 path = "lib.rs"
 
 [features]
-default = ["include_icu_data", "v8_use_custom_libcxx", "reactor-tokio"]
+default = ["v8_use_custom_libcxx", "reactor-tokio"]
 reactor-tokio = []
 include_icu_data = ["deno_core_icudata"]
 v8_use_custom_libcxx = ["v8/use_custom_libcxx"]


### PR DESCRIPTION
This change https://github.com/denoland/rusty_v8/commit/12d7ef1dba08d2023b3a5dd1df275d2cac401bd7#diff-b2b1f3ec619c03c5bba2f171beab1301d960e1dcac6a17a99ce02326ce9c49b4R83

made it so icu data is bundled in with v8 unconditionally, so we don't need to include the copy from deno_core anymore. 

Resolves a roughly 11MB regression in binary size with the v8 upgrade.