### PR TITLE
perf: use panic=abort in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -480,6 +480,7 @@ lto = true
 opt-level = 'z' # Optimize for size
 split-debuginfo = "packed"
 debug = "line-tables-only"
+panic = "abort"
 
 # Build release with debug symbols: cargo build --profile=release-with-debug
 [profile.release-with-debug]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -470,6 +470,7 @@ lto = true
 opt-level = 'z' # Optimize for size
 split-debuginfo = "packed"
 debug = "line-tables-only"
+panic = "abort"
 
 # NB: the `bench` and `release` profiles must remain EXACTLY the same.
 [profile.bench]


### PR DESCRIPTION
We already have our own panic hook and strip the binaries, this shaves off another roughly 10MB from the release binaries. I don't think we have any cases where we rely on destructors being run, and we don't catch unwinds anywhere, so I believe this is safe.