### PR TITLE
feat(types): add Math.sumPrecise and Intl.Locale.prototype.variants

### DIFF
--- a/cli/tsc/dts/lib.deno.shared_globals.d.ts
+++ b/cli/tsc/dts/lib.deno.shared_globals.d.ts
@@ -884,3 +884,28 @@ declare function fetch(
   input: RequestInfo | URL,
   init?: RequestInit & { client?: Deno.HttpClient },
 ): Promise<Response>;
+
+/** @category Platform */
+interface Math {
+  /**
+   * Returns the sum of the given values using a more precise algorithm than a
+   * naive `+`-based reduction, avoiding the floating-point rounding errors
+   * that accumulate when summing many numbers.
+   *
+   * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sumPrecise)
+   */
+  sumPrecise(values: Iterable<number>): number;
+}
+
+declare namespace Intl {
+  interface Locale {
+    /**
+     * Returns the variant subtags of the locale as a single string, with
+     * subtags separated by `-`. Returns an empty string if the locale has no
+     * variant subtags.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/variants)
+     */
+    readonly variants: string;
+  }
+}

--- a/cli/tsc/dts/lib.deno.shared_globals.d.ts
+++ b/cli/tsc/dts/lib.deno.shared_globals.d.ts
@@ -897,8 +897,10 @@ interface Math {
   sumPrecise(values: Iterable<number>): number;
 }
 
+/** @category Intl */
 declare namespace Intl {
-  interface Locale {
+  /** @category Intl */
+  export interface Locale {
     /**
      * Returns the variant subtags of the locale as a single string, with
      * subtags separated by `-`. Returns an empty string if the locale has no

--- a/cli/tsc/dts/lib.deno.shared_globals.d.ts
+++ b/cli/tsc/dts/lib.deno.shared_globals.d.ts
@@ -903,11 +903,11 @@ declare namespace Intl {
   export interface Locale {
     /**
      * Returns the variant subtags of the locale as a single string, with
-     * subtags separated by `-`. Returns an empty string if the locale has no
+     * subtags separated by `-`. Returns `undefined` if the locale has no
      * variant subtags.
      *
      * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/variants)
      */
-    readonly variants: string;
+    readonly variants: string | undefined;
   }
 }

--- a/tests/unit/esnext_test.ts
+++ b/tests/unit/esnext_test.ts
@@ -57,3 +57,25 @@ Deno.test(function float16Array() {
   assertEquals(sorted[2], 2);
   assertEquals(sorted[3], 11.25);
 });
+
+Deno.test(function mathSumPrecise() {
+  assertEquals(Math.sumPrecise([1, 2, 3]), 6);
+  assertEquals(Math.sumPrecise([]), -0);
+  // Avoids the accumulated rounding error from naive `+` reduction:
+  // `0.1 + 0.2 + 0.3` is `0.6000000000000001`.
+  assertEquals(Math.sumPrecise([0.1, 0.2, 0.3]), 0.6);
+  // Accepts arbitrary iterables.
+  function* gen() {
+    yield 1.5;
+    yield 2.5;
+    yield 3.5;
+  }
+  assertEquals(Math.sumPrecise(gen()), 7.5);
+});
+
+Deno.test(function intlLocaleVariants() {
+  const variants: string | undefined =
+    new Intl.Locale("de-DE-1996-fonipa").variants;
+  assertEquals(variants, "1996-fonipa");
+  assertEquals(new Intl.Locale("en-US").variants, undefined);
+});


### PR DESCRIPTION
Both `Math.sumPrecise` and `Intl.Locale.prototype.variants` are available
at runtime via V8, but our bundled TypeScript libs (currently on 6.0)
don't yet declare them, so `deno check` errors with TS2339 whenever user
code references either API. This adds the missing typings to
`lib.deno.shared_globals.d.ts` so both stable and worker contexts pick
them up. `variants` is typed as `string` to match the spec, which
returns the variant subtags joined by `-` (e.g. `"1996-fonipa"`).