### PR TITLE
feat(install): default to npm for `deno install -g` unprefixed packages

### DIFF
--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -48,7 +48,6 @@ use crate::file_fetcher::CliFileFetcher;
 use crate::file_fetcher::CreateCliFileFetcherOptions;
 use crate::file_fetcher::create_cli_file_fetcher;
 use crate::jsr::JsrFetchResolver;
-use crate::npm::NpmFetchResolver;
 use crate::util::env::resolve_cwd;
 use crate::util::fs::canonicalize_path_maybe_not_exists;
 
@@ -80,17 +79,6 @@ pub async fn install_global(
 
   let npmrc = factory.npmrc()?;
 
-  let deps_file_fetcher = create_deps_file_fetcher(log::Level::Trace);
-  let jsr_resolver = Arc::new(JsrFetchResolver::new(
-    deps_file_fetcher.clone(),
-    factory.jsr_version_resolver()?.clone(),
-  ));
-  let npm_resolver = Arc::new(NpmFetchResolver::new(
-    deps_file_fetcher,
-    npmrc.clone(),
-    factory.npm_version_resolver()?.clone(),
-  ));
-
   if matches!(flags.config_flag, ConfigFlag::Discover)
     && cli_options.workspace().deno_jsons().next().is_some()
   {
@@ -105,10 +93,20 @@ pub async fn install_global(
       .await;
   }
 
-  for (i, module_url) in install_flags_global.module_urls.iter().enumerate() {
-    let entry_text = module_url;
-    if !cli_options.initial_cwd().join(entry_text).exists() {
-      // provide a helpful error message for users migrating from Deno < 3.0
+  // Validate every entry and default unprefixed bare package names to the npm
+  // registry (matching `deno add` and local `deno install`) before installing
+  // anything, so an error on entry N doesn't leave entries < N installed.
+  let module_urls: Vec<String> = install_flags_global
+    .module_urls
+    .iter()
+    .enumerate()
+    .map(|(i, module_url)| -> Result<String, AnyError> {
+      let entry_text = module_url;
+      if cli_options.initial_cwd().join(entry_text).exists() {
+        return Ok(module_url.clone());
+      }
+      // Migration error for users coming from Deno < 3.0 who passed script
+      // args without `--`.
       if i == 1
         && install_flags_global.args.is_empty()
         && Url::parse(entry_text).is_err()
@@ -121,39 +119,18 @@ pub async fn install_global(
           entry_text,
           &install_flags_global.module_urls[0],
           install_flags_global.module_urls[1..].join(" "),
-        )
+        );
       }
-      // check for package requirement missing prefix
       if let Ok(Err(package_req)) =
         crate::tools::pm::AddRmPackageReq::parse(entry_text, None)
       {
-        if package_req.name.starts_with("@")
-          && jsr_resolver
-            .req_to_nv(&package_req)
-            .await
-            .ok()
-            .flatten()
-            .is_some()
-        {
-          bail!(
-            "{entry_text} is missing a prefix. Did you mean `{}`?",
-            crate::colors::yellow(format!("deno install -g jsr:{package_req}"))
-          );
-        } else if npm_resolver
-          .req_to_nv(&package_req)
-          .await
-          .ok()
-          .flatten()
-          .is_some()
-        {
-          bail!(
-            "{entry_text} is missing a prefix. Did you mean `{}`?",
-            crate::colors::yellow(format!("deno install -g npm:{package_req}"))
-          );
-        }
+        return Ok(format!("npm:{package_req}"));
       }
-    }
+      Ok(module_url.clone())
+    })
+    .collect::<Result<_, _>>()?;
 
+  for module_url in &module_urls {
     let (name_and_url, extra_bin_entries) = BinaryNameAndUrl::resolve(
       &factory.bin_name_resolver()?,
       cli_options.initial_cwd(),

--- a/tests/integration/install_tests.rs
+++ b/tests/integration/install_tests.rs
@@ -417,7 +417,9 @@ fn check_local_by_default2() {
 }
 
 #[test]
-fn show_prefix_hint_on_global_install() {
+fn unprefixed_global_install_defaults_to_npm() {
+  // Unprefixed package names in `deno install -g` default to the npm
+  // registry, matching `deno add` and local `deno install`.
   let context = TestContextBuilder::new()
     .add_npm_env_vars()
     .add_jsr_env_vars()
@@ -433,45 +435,27 @@ fn show_prefix_hint_on_global_install() {
     ("DENO_INSTALL_ROOT", ""),
   ];
 
-  for pkg_req in ["npm:@denotest/bin", "jsr:@denotest/add"] {
-    let name = pkg_req.split_once('/').unwrap().1;
-    let pkg = pkg_req.split_once(':').unwrap().1;
+  // Bare npm name (no prefix) installs successfully from npm.
+  context
+    .new_command()
+    .args_vec(["install", "-g", "--name", "bin", "@denotest/bin"])
+    .envs(env_vars)
+    .run()
+    .skip_output_check()
+    .assert_exit_code(0);
 
-    // try with prefix and ensure that the installation succeeds
-    context
-      .new_command()
-      .args_vec(["install", "-g", "--name", name, pkg_req])
-      .envs(env_vars)
-      .run()
-      .skip_output_check()
-      .assert_exit_code(0);
-
-    // try without the prefix and ensure that the installation fails with the appropriate error
-    // message
-    let output = context
-      .new_command()
-      .args_vec(["install", "-g", "--name", name, pkg])
-      .envs(env_vars)
-      .run();
-    output.assert_exit_code(1);
-
-    let output_text = output.combined_output();
-    let expected_text = format!(
-      "error: {pkg} is missing a prefix. Did you mean `deno install -g {pkg_req}`?"
-    );
-    assert_contains!(output_text, &expected_text);
-  }
-
-  // try a pckage not in npm and jsr to make sure the appropriate error message still appears
+  // A package that doesn't exist on npm produces the npm "does not exist"
+  // error rather than the legacy "missing a prefix" hint.
   let output = context
     .new_command()
     .args_vec(["install", "-g", "package-that-does-not-exist"])
     .envs(env_vars)
     .run();
   output.assert_exit_code(1);
-
-  let output_text = output.combined_output();
-  assert_contains!(output_text, "error: Module not found");
+  assert_contains!(
+    output.combined_output(),
+    "npm package 'package-that-does-not-exist' does not exist"
+  );
 }
 
 #[test]
@@ -504,14 +488,16 @@ fn installer_second_module_looks_like_script_argument() {
     .use_http_server()
     .use_temp_cwd()
     .build();
-  // in Deno < 3.0, we didn't require `--` before script arguments, so we try to provide a helpful
-  // error message for people migrating
+  // in Deno < 3.0, we didn't require `--` before script arguments, so we try
+  // to provide a helpful error message for people migrating. Validation
+  // happens up-front for the whole entry list, so the migration error fires
+  // before any entry is installed.
   context
     .new_command()
     .args("install --root ./root -g http://localhost:4545/echo.ts non_existent")
     .run()
     .assert_matches_text(concat!(
-      "[WILDCARD]Successfully installed echo[WILDCARD]error: non_existent is missing a prefix. ",
+      "error: non_existent is missing a prefix. ",
       "Deno 3.0 requires `--` before script arguments in `deno install -g`. ",
       "Did you mean `deno install -g http://localhost:4545/echo.ts -- non_existent`? ",
       "Or maybe provide a `jsr:` or `npm:` prefix?\n"

--- a/tests/specs/install/global/bare_name_defaults_to_npm/__test__.jsonc
+++ b/tests/specs/install/global/bare_name_defaults_to_npm/__test__.jsonc
@@ -1,0 +1,32 @@
+{
+  "tempDir": true,
+  "tests": {
+    // Bare scoped package name (no `npm:` prefix) — should resolve to the
+    // npm registry, matching the behavior of `deno add` / local `deno install`.
+    "scoped": {
+      "steps": [{
+        "if": "unix",
+        "args": "install -g --allow-env --root ./bins @denotest/cli-with-permissions",
+        "output": "install_scoped.out"
+      }, {
+        "if": "unix",
+        "commandName": "./bins/bin/cli-with-permissions",
+        "args": [],
+        "envs": { "DENO_HELLO": "world" },
+        "output": "run.out",
+        "exitCode": 0
+      }, {
+        "if": "windows",
+        "args": "install -g --allow-env --root ./bins @denotest/cli-with-permissions",
+        "output": "install_scoped.out"
+      }, {
+        "if": "windows",
+        "commandName": "./bins/bin/cli-with-permissions.cmd",
+        "args": [],
+        "envs": { "DENO_HELLO": "world" },
+        "output": "run.out",
+        "exitCode": 0
+      }]
+    }
+  }
+}

--- a/tests/specs/install/global/bare_name_defaults_to_npm/install_scoped.out
+++ b/tests/specs/install/global/bare_name_defaults_to_npm/install_scoped.out
@@ -1,0 +1,2 @@
+[WILDCARD]✅ Successfully installed cli-with-permissions
+[WILDCARD]

--- a/tests/specs/install/global/bare_name_defaults_to_npm/run.out
+++ b/tests/specs/install/global/bare_name_defaults_to_npm/run.out
@@ -1,0 +1,3 @@
+Hello in CLI with permissions
+Reading DENO_HELLO env var...
+world

--- a/tests/specs/install/global/pkg_name_same_as_file/__test__.jsonc
+++ b/tests/specs/install/global/pkg_name_same_as_file/__test__.jsonc
@@ -12,7 +12,12 @@
       }]
     },
     "file_not_exists": {
-      "args": "install --root ./bins -g --name my-cli cli.ts",
+      // No local cli.ts file: the entry is treated as an npm package
+      // (defaulting to the npm registry, like `deno add`). The mock npm
+      // registry doesn't have this name, so install fails with a clear
+      // "package does not exist" error rather than the legacy
+      // "missing a prefix" hint.
+      "args": "install --root ./bins -g --name my-cli nonexistent-pkg-name-xyz123",
       "output": "file_not_exists.out",
       "exitCode": 1
     }

--- a/tests/specs/install/global/pkg_name_same_as_file/file_not_exists.out
+++ b/tests/specs/install/global/pkg_name_same_as_file/file_not_exists.out
@@ -1,1 +1,1 @@
-error: cli.ts is missing a prefix. Did you mean `deno install -g npm:cli.ts`?
+[WILDCARD]error: npm package 'nonexistent-pkg-name-xyz123' does not exist.


### PR DESCRIPTION
`deno install -g @earendil-works/pi-coding-agent` previously bailed with a
"missing a prefix" error and asked the user to retype it with `npm:`,
while `deno add @earendil-works/pi-coding-agent` and local
`deno install @earendil-works/pi-coding-agent` have defaulted to the npm
registry since #33246. The global install path lives in
`cli/tools/installer/global.rs` and was missed in that change.

This applies the same default: an unprefixed bare package name in
`deno install -g` is resolved against the npm registry, matching `deno add`
and local `deno install`. Explicit `npm:` / `jsr:` prefixes and URL /
local-file forms continue to work unchanged.

While here, validation is hoisted into a single pre-pass over the entry
list so an error on the Nth entry no longer leaves entries `< N` already
installed (the previous loop ran the prefix check and the install
side-by-side per iteration).