### PR TITLE
fix(fmt): align singleBodyPosition schema values

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -743,7 +743,7 @@
         },
         "singleBodyPosition": {
           "description": "The position of the body in single body blocks in JavaScript and TypeScript.",
-          "default": "sameLine",
+          "default": "maintain",
           "enum": [
             "maintain",
             "sameLine",

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -743,12 +743,11 @@
         },
         "singleBodyPosition": {
           "description": "The position of the body in single body blocks in JavaScript and TypeScript.",
-          "default": "sameLineUnlessHanging",
+          "default": "sameLine",
           "enum": [
             "maintain",
             "sameLine",
-            "nextLine",
-            "sameLineUnlessHanging"
+            "nextLine"
           ]
         },
         "nextControlFlowPosition": {


### PR DESCRIPTION
Fixes #34289

## Summary
- remove the unsupported `sameLineUnlessHanging` value from the `fmt.singleBodyPosition` JSON schema enum
- change the schema default to `sameLine`, which is accepted by the config parser

## Tests
- `jq empty cli/schemas/config-file.v1.json`
- `deno fmt --check cli/schemas/config-file.v1.json`
- `jq -e '.properties.fmt.properties.singleBodyPosition.default == "sameLine" and ((.properties.fmt.properties.singleBodyPosition.enum | index("sameLineUnlessHanging")) == null)' cli/schemas/config-file.v1.json`\n- `cargo test -p deno_config deno_json::tests::test_parse_config`\n\n## AI assistance\nThis PR was prepared with assistance from OpenAI Codex.