### PR TITLE
fix(ext/node): attach register as static on Module

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -3094,6 +3094,7 @@ export function registerHooks(hooks) {
 }
 
 Module.registerHooks = registerHooks;
+Module.register = register;
 
 let initialized = false;
 

--- a/tests/unit_node/module_test.ts
+++ b/tests/unit_node/module_test.ts
@@ -110,6 +110,20 @@ Deno.test("[node/module register] is a function", () => {
   assertEquals(register("foo"), undefined);
 });
 
+// Regression test: tsx and other tools probe `Module.register` (the default
+// export of `node:module`) to decide whether the host supports module loader
+// hooks. Make sure both `Module.register` and `Module.registerHooks` are
+// attached as static methods so `import M from "node:module"; M.register`
+// resolves to the stub instead of `undefined`.
+Deno.test("[node/module] Module.register and Module.registerHooks are exposed", () => {
+  // @ts-ignore Not in our bundled @types/node yet.
+  assertEquals(typeof Module.register, "function");
+  // @ts-ignore Not in our bundled @types/node yet.
+  assertEquals(typeof Module.registerHooks, "function");
+  // @ts-ignore Stub returns undefined.
+  assertEquals(Module.register("foo"), undefined);
+});
+
 Deno.test("[node/module] overriding Module._compile is possible and Node globals work", () => {
   // @ts-ignore Not documented but available
   const originalCompile = Module.prototype._compile;


### PR DESCRIPTION
Tools like tsx do `import M from "node:module"; M.register` to decide
whether the host supports module loader hooks. The named `register`
export (a stub that returns `undefined`) was already present, but the
revert and re-land of the module loader hooks stack lost the line that
attaches it as a static on `Module`, so `M.register` came back as
`undefined`. tsx then falls through to its `registerHooks` feature
gate, which requires Node `>= 24.11.1` while Deno reports `24.2.0`, so
it throws "This version of Node.js does not support module.register()".

Re-attaching `Module.register = register;` next to
`Module.registerHooks = registerHooks;` is enough to make the stub
visible again and unblocks tsx.