### PR TITLE
fix(ext/node): allow omitting arguments in base64Slice

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -1021,6 +1021,14 @@ Buffer.prototype.base64Slice = function base64Slice(
   offset,
   length,
 ) {
+  if (offset === undefined) {
+    offset = 0;
+  }
+
+  if (length === undefined) {
+    length = this.length;
+  }
+
   // Use op_base64_encode (#[string] return) for small buffers where
   // the lighter-weight op2 string path is faster.
   // Use op_base64_encode_from_buffer (v8::String::new_external_onebyte) for

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -645,6 +645,29 @@ Deno.test({
   },
 });
 
+// https://github.com/denoland/deno/issues/34286
+Deno.test({
+  name: "[node/buffer] base64Slice allows omitting arguments",
+  fn() {
+    const buf = Buffer.of(1, 2, 3);
+    // @ts-expect-error Buffer.prototype.base64Slice is an undocumented API
+    assertEquals(buf.base64Slice(), "AQID");
+    // @ts-expect-error Buffer.prototype.base64Slice is an undocumented API
+    assertEquals(buf.base64Slice(0, 3), "AQID");
+  },
+});
+
+Deno.test({
+  name: "[node/buffer] base64urlSlice allows omitting arguments",
+  fn() {
+    const buf = Buffer.of(1, 2, 3);
+    // @ts-expect-error Buffer.prototype.base64urlSlice is an undocumented API
+    assertEquals(buf.base64urlSlice(), "AQID");
+    // @ts-expect-error Buffer.prototype.base64urlSlice is an undocumented API
+    assertEquals(buf.base64urlSlice(0, 3), "AQID");
+  },
+});
+
 Deno.test({
   name: "[node/buffer] isEncoding returns true for valid encodings",
   fn() {


### PR DESCRIPTION
Closes #34286

## Summary

The `offset` and `length` parameters are optional and default to `0` and `buffer.length()`, respectively, as defined in [node source code](https://github.com/nodejs/node/blob/e11b9459d1a4518971d26d50c74af587e335f888/src/node_buffer.cc#L575). This PR adds default values to these parameters to match Node.js behavior.

Followed @bddjr recommendations.