### PR TITLE
test: disable flaky test-cluster-send-deadlock

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -573,7 +573,10 @@
     "parallel/test-cluster-rr-handle-keep-loop-alive.js": { "windows": false },
     "parallel/test-cluster-rr-handle-ref-unref.js": { "windows": false },
     "parallel/test-cluster-rr-ref.js": { "windows": false },
-    "parallel/test-cluster-send-deadlock.js": { "windows": false },
+    "parallel/test-cluster-send-deadlock.js": {
+      "ignore": true,
+      "reason": "Flaky: intermittent cluster worker message deadlock on Linux, see #34180"
+    },
     "parallel/test-cluster-send-socket-to-worker-http-server.js": {
       "windows": false
     },


### PR DESCRIPTION
Disables `node_compat::parallel::test-cluster-send-deadlock.js` after it failed on main CI run https://github.com/denoland/deno/actions/runs/26327482805/job/77509473920 with `ChildProcess.send with non-TCP net.Socket handle`.

This test is already tracked as flaky in denoland/deno#34180 and has also timed out on main.

Closes denoland/deno#34180
Refs bartlomieju/orchid-inbox#4