### PR TITLE
test: disable flaky cluster deadlock test

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -573,7 +573,10 @@
     "parallel/test-cluster-rr-handle-keep-loop-alive.js": { "windows": false },
     "parallel/test-cluster-rr-handle-ref-unref.js": { "windows": false },
     "parallel/test-cluster-rr-ref.js": { "windows": false },
-    "parallel/test-cluster-send-deadlock.js": { "windows": false },
+    "parallel/test-cluster-send-deadlock.js": {
+      "ignore": true,
+      "reason": "Flaky in CI, tracked in denoland/deno#34180"
+    },
     "parallel/test-cluster-send-socket-to-worker-http-server.js": {
       "windows": false
     },


### PR DESCRIPTION
## Summary\n- Disable node compat test  because it is flaky in CI\n- Link the skip reason to denoland/deno#34180\n\n## Validation\n-

Closes bartlomieju/orchid-inbox#146
