### PR TITLE
fix: support npm: specifiers in --preload and --import

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -711,13 +711,28 @@ impl CliOptions {
   }
 
   pub fn preload_modules(&self) -> Result<Vec<ModuleSpecifier>, AnyError> {
+    self.preload_modules_with_resolver(None)
+  }
+
+  pub fn preload_modules_with_resolver(
+    &self,
+    resolver: Option<&WorkspaceMainModuleResolver>,
+  ) -> Result<Vec<ModuleSpecifier>, AnyError> {
     if self.flags.preload.is_empty() {
       return Ok(vec![]);
     }
 
     let mut modules = Vec::with_capacity(self.flags.preload.len());
     for preload_specifier in self.flags.preload.iter() {
-      modules.push(resolve_url_or_path(preload_specifier, self.initial_cwd())?);
+      let default_resolve = || {
+        resolve_url_or_path(preload_specifier, self.initial_cwd())
+          .map_err(|e| e.into())
+      };
+      modules.push(self.resolve_main_module_with_resolver_if_bare(
+        preload_specifier,
+        resolver,
+        default_resolve,
+      )?);
     }
 
     Ok(modules)

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -79,13 +79,14 @@ pub async fn run_script(
     deno_dir.upgrade_check_file_path(),
   );
 
-  let main_module = cli_options.resolve_main_module_with_resolver(Some(
-    &crate::args::WorkspaceMainModuleResolver::new(
-      workspace_resolver.clone(),
-      node_resolver.clone(),
-    ),
-  ))?;
-  let preload_modules = cli_options.preload_modules()?;
+  let main_module_resolver = crate::args::WorkspaceMainModuleResolver::new(
+    workspace_resolver.clone(),
+    node_resolver.clone(),
+  );
+  let main_module = cli_options
+    .resolve_main_module_with_resolver(Some(&main_module_resolver))?;
+  let preload_modules =
+    cli_options.preload_modules_with_resolver(Some(&main_module_resolver))?;
   let require_modules = cli_options.require_modules()?;
 
   if main_module.scheme() == "npm" {

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -459,28 +459,41 @@ impl CliMainWorkerFactory {
     stdio: deno_runtime::deno_io::Stdio,
     unconfigured_runtime: Option<deno_runtime::UnconfiguredRuntime>,
   ) -> Result<CliMainWorker, CreateCustomWorkerError> {
-    let main_module = match NpmPackageReqReference::from_specifier(&main_module)
-    {
-      Ok(package_ref) => {
-        if let Some(npm_installer) = &self.npm_installer {
-          let _clear_guard = self.progress_bar.deferred_keep_initialize_alive();
-          let reqs = &[package_ref.req().clone()];
-          npm_installer
-            .add_package_reqs(
-              reqs,
-              if matches!(
-                self.default_npm_caching_strategy,
-                NpmCachingStrategy::Lazy
-              ) {
-                PackageCaching::Only(reqs.into())
-              } else {
-                PackageCaching::All
-              },
-            )
-            .await
-            .map_err(CreateCustomWorkerError::NpmPackageReq)?;
-        }
+    let main_module_npm_ref =
+      NpmPackageReqReference::from_specifier(&main_module).ok();
+    let mut npm_reqs = Vec::new();
+    if let Some(package_ref) = &main_module_npm_ref {
+      npm_reqs.push(package_ref.req().clone());
+    }
+    for specifier in preload_modules.iter().chain(require_modules.iter()) {
+      if let Ok(package_ref) = NpmPackageReqReference::from_specifier(specifier)
+      {
+        npm_reqs.push(package_ref.req().clone());
+      }
+    }
 
+    if !npm_reqs.is_empty()
+      && let Some(npm_installer) = &self.npm_installer
+    {
+      let _clear_guard = self.progress_bar.deferred_keep_initialize_alive();
+      npm_installer
+        .add_package_reqs(
+          &npm_reqs,
+          if matches!(
+            self.default_npm_caching_strategy,
+            NpmCachingStrategy::Lazy
+          ) {
+            PackageCaching::Only(npm_reqs.as_slice().into())
+          } else {
+            PackageCaching::All
+          },
+        )
+        .await
+        .map_err(CreateCustomWorkerError::NpmPackageReq)?;
+    }
+
+    let main_module = match main_module_npm_ref {
+      Some(package_ref) => {
         // use a fake referrer that can be used to discover the package.json if necessary
         let referrer = self.shared.initial_cwd.join("package.json")?;
         let package_folder =
@@ -503,7 +516,7 @@ impl CliMainWorkerFactory {
 
         main_module
       }
-      _ => main_module,
+      None => main_module,
     };
 
     let mut worker = self.lib_main_worker_factory.create_custom_worker(

--- a/tests/specs/run/preload_modules_npm/__test__.jsonc
+++ b/tests/specs/run/preload_modules_npm/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  "tests": {
+    "import_npm": {
+      "args": "run --quiet --import npm:@denotest/say-hello main.ts",
+      "output": "main.out"
+    },
+    "preload_npm": {
+      "args": "run --quiet --preload npm:@denotest/say-hello main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/run/preload_modules_npm/main.out
+++ b/tests/specs/run/preload_modules_npm/main.out
@@ -1,0 +1,1 @@
+@denotest/say-hello says hello!

--- a/tests/specs/run/preload_modules_npm/main.ts
+++ b/tests/specs/run/preload_modules_npm/main.ts
@@ -1,0 +1,2 @@
+import { sayHello } from "npm:@denotest/say-hello";
+console.log(sayHello());


### PR DESCRIPTION
`deno run --preload npm:foo` and `deno run --import npm:foo` previously
failed with `Could not find constraint 'foo' in the list of packages`,
because the npm package referenced by the preload/import flag was never
installed before the preload module list was resolved. Bare specifiers
that mapped to an npm package via an import map or `package.json`
dependency were also unresolved, since the preload pipeline did not run
them through the workspace resolver.

This change threads the `WorkspaceMainModuleResolver` into
`preload_modules_with_resolver` so bare specifiers in `--import` /
`--preload` resolve the same way as the main module. It also moves npm
package collection inside `CliMainWorkerFactory::create_custom_worker`
to gather requirements from the main module, preload list, and require
list together, and installs them in one batch before resolution
proceeds.

Spec test coverage is added in `tests/specs/run/preload_modules_npm`
exercising both `--import npm:` and `--preload npm:`.

Fixes #34303