### PR TITLE
fix(ext/node): require env permission for process.loadEnvFile

### DIFF
--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -113,8 +113,11 @@ fn op_node_load_env_file(
   #[string] path: &str,
 ) -> Result<(), DotEnvLoadErr> {
   let fs = state.borrow::<deno_fs::FileSystemRc>().clone();
-  let path = state
-    .borrow::<PermissionsContainer>()
+  let permissions = state.borrow::<PermissionsContainer>().clone();
+  permissions
+    .check_env_all()
+    .map_err(DotEnvLoadErr::Permission)?;
+  let path = permissions
     .check_open(
       Cow::Borrowed(Path::new(path)),
       OpenAccessKind::ReadNoFollow,

--- a/tests/specs/run/process_env_load/__test__.jsonc
+++ b/tests/specs/run/process_env_load/__test__.jsonc
@@ -3,6 +3,16 @@
     "env_load_file": {
       "args": "run --allow-env --allow-read env_file.ts",
       "output": "env_file.out"
+    },
+    "env_load_file_without_env_permission": {
+      "args": "run --allow-read --no-prompt env_file.ts",
+      "output": "env_file_no_env_perm.out",
+      "exitCode": 1
+    },
+    "env_load_file_with_partial_env_permission": {
+      "args": "run --allow-read --allow-env=FOO --no-prompt env_file.ts",
+      "output": "env_file_no_env_perm.out",
+      "exitCode": 1
     }
   }
 }

--- a/tests/specs/run/process_env_load/env_file_no_env_perm.out
+++ b/tests/specs/run/process_env_load/env_file_no_env_perm.out
@@ -1,0 +1,1 @@
+[WILDCARD]NotCapable: Requires env access, run again with the --allow-env flag[WILDCARD]


### PR DESCRIPTION
process.loadEnvFile() checked only read permission for the dotenv file
and then wrote each parsed key into the process environment via
env::set_var, making it the only env-mutation API in the runtime that
didn't go through the --allow-env gate. Add a check_env_all() call
upfront so the call fails before any mutation when env access is denied,
keeping loadEnvFile consistent with Deno.env.set and friends.

The check is all-or-nothing rather than per-key — partial-grant shapes
like --allow-env=FOO no longer satisfy loadEnvFile even when FOO is the
only key in the file. The simpler behavior matches how dotenv files are
conventionally used (you either want the whole file applied or you
don't) and avoids the partial-mutation edge case where one denied key
would leave the env half-populated.