### PR TITLE
fix(config): don't panic when --config path can't be converted to URL

### DIFF
--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -5577,6 +5577,26 @@ pub mod test {
   }
 
   #[test]
+  fn test_config_file_path_not_convertible_to_url() {
+    // Regression test for https://github.com/denoland/deno/issues/34308 -
+    // passing a path whose parent can't be converted to a `file://` URL
+    // (e.g. a `file:///D:/deno.json` argument joined with cwd on Windows)
+    // used to panic. It should return an error instead.
+    let sys = InMemorySys::default();
+    let path = PathBuf::from("deno.json"); // relative path; parent is ""
+    let err = WorkspaceDirectory::discover(
+      &sys,
+      WorkspaceDiscoverStart::ConfigFile(&path),
+      &WorkspaceDiscoverOptions::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+      err.as_kind(),
+      WorkspaceDiscoverErrorKind::PathToUrl(_)
+    ));
+  }
+
+  #[test]
   fn test_config_workspace() {
     let sys = InMemorySys::default();
     let root_config_path = root_dir().join("deno.json");

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -1792,18 +1792,15 @@ impl WorkspaceDirectory {
             // so this is ok for now
             let path = &paths[0];
             match sys.fs_is_dir(path) {
-              Ok(is_dir) => Ok(
-                url_from_directory_path(if is_dir {
-                  path
-                } else {
-                  path.parent().unwrap()
-                })
-                .unwrap(),
-              ),
+              Ok(is_dir) => Ok(url_from_directory_path(if is_dir {
+                path
+              } else {
+                path.parent().unwrap()
+              })?),
               Err(_err) => {
                 // assume the parent is a directory
                 match path.parent() {
-                  Some(parent) => Ok(url_from_directory_path(parent).unwrap()),
+                  Some(parent) => Ok(url_from_directory_path(parent)?),
                   None => Err(
                     WorkspaceDiscoverErrorKind::FailedResolvingStartDirectory(
                       FailedResolvingStartDirectoryError::CouldNotResolvePath(
@@ -1825,7 +1822,7 @@ impl WorkspaceDirectory {
               ),
             )
           })?;
-          Ok(url_from_directory_path(parent).unwrap())
+          Ok(url_from_directory_path(parent)?)
         }
       }
     }


### PR DESCRIPTION
Passing a `file://` URL (or any other path whose parent can't be turned
into a file URL on the host platform) to `--config` was panicking inside
`resolve_start_dir` at `url_from_directory_path(...).unwrap()`. On
Windows, `--config file:///D:/deno.json` joined with the cwd produced a
parent path that the URL conversion rejected, and the unwrap turned that
into a Deno panic instead of a user-facing error.

This swaps the three unwraps in `resolve_start_dir` for `?` so the
failure is propagated through the existing
`WorkspaceDiscoverError::PathToUrl` variant. Behavior on platforms where
the join already produced a valid path (macOS, Linux) is unchanged.

Fixes #34308