### PR TITLE
fix(core): keep lazy_loaded_esm sources across concurrent loads

### DIFF
--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -2710,21 +2710,31 @@ impl ModuleMap {
       .contains(specifier)
   }
 
-  /// Try to take a lazy-loaded ESM source by specifier. Returns the source
-  /// code if found, removing it from the lazy sources map.
+  /// Get a lazy-loaded ESM source by specifier. Returns a cheap clone of the
+  /// source code if found, keeping it in the lazy sources map so concurrent
+  /// loads of the same lazy specifier from independent `RecursiveModuleLoad`
+  /// instances each get their own copy. The duplicate `ModuleSource`s are
+  /// deduplicated by `new_module_with_pending`'s `get_id` check at register
+  /// time.
   pub(crate) fn take_lazy_esm_source(
     &self,
     specifier: &str,
   ) -> Option<ModuleCodeString> {
     let data = self.data.borrow();
-    let source = data.lazy_esm_sources.borrow_mut().remove(specifier);
-    if source.is_some() {
-      data
-        .consumed_lazy_specifiers
-        .borrow_mut()
-        .insert(specifier.to_string());
-    }
-    source
+    let mut sources = data.lazy_esm_sources.borrow_mut();
+    let entry = sources.get_mut(specifier)?;
+    // `into_cheap_copy` always returns two cheap handles to the same backing
+    // storage (Arc or Static), so we can keep one in the map and return the
+    // other. The Owned variant gets promoted to Arc in the process.
+    let placeholder = ModuleCodeString::from_static("");
+    let owned = std::mem::replace(entry, placeholder);
+    let (keep, give) = owned.into_cheap_copy();
+    *entry = keep;
+    data
+      .consumed_lazy_specifiers
+      .borrow_mut()
+      .insert(specifier.to_string());
+    Some(give)
   }
 
   pub(crate) fn add_lazy_loaded_esm_source(

--- a/libs/core/modules/testdata/lazy_loaded_concurrent_a.js
+++ b/libs/core/modules/testdata/lazy_loaded_concurrent_a.js
@@ -1,0 +1,3 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+import { value } from "custom:lazy_shared";
+export const a = value;

--- a/libs/core/modules/testdata/lazy_loaded_concurrent_b.js
+++ b/libs/core/modules/testdata/lazy_loaded_concurrent_b.js
@@ -1,0 +1,3 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+import { value } from "custom:lazy_shared";
+export const b = value;

--- a/libs/core/modules/testdata/lazy_loaded_concurrent_main.js
+++ b/libs/core/modules/testdata/lazy_loaded_concurrent_main.js
@@ -1,0 +1,16 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Two concurrent dynamic imports that both transitively depend on the same
+// lazy-loaded ESM module ("custom:lazy_shared"). Each import() spawns its
+// own RecursiveModuleLoad, and the per-load `visited` set does not dedupe
+// across loads.
+const [a, b] = await Promise.all([
+  import("./lazy_loaded_concurrent_a.js"),
+  import("./lazy_loaded_concurrent_b.js"),
+]);
+if (a.a !== "shared") {
+  throw new Error("expected a.a to be 'shared', got: " + a.a);
+}
+if (b.b !== "shared") {
+  throw new Error("expected b.b to be 'shared', got: " + b.b);
+}

--- a/libs/core/modules/testdata/lazy_loaded_shared.js
+++ b/libs/core/modules/testdata/lazy_loaded_shared.js
@@ -1,0 +1,2 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+export const value = "shared";

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -661,6 +661,59 @@ async fn test_lazy_load_esm_evaluates_pre_instantiated_sibling() {
   result.await.unwrap();
 }
 
+/// Regression test for https://github.com/denoland/deno/issues/34307
+///
+/// Two concurrent dynamic `import()` calls each spawn their own
+/// `RecursiveModuleLoad`. If both transitively depend on the same
+/// `lazy_loaded_esm` module, their per-load `visited`/`get_id` dedup misses
+/// (the first hasn't registered the module yet) and both queue load futures
+/// for the same lazy specifier. The first wins `take_lazy_esm_source`; the
+/// second used to get `None` and fall through to `loader.load()`, which
+/// surfaces "Unsupported scheme" for `node:` builtins in the wild (vite 8
+/// + react-router 7.15 under a CJS bin).
+#[tokio::test]
+async fn test_lazy_loaded_esm_concurrent_loads() {
+  deno_core::extension!(
+    test_ext,
+    lazy_loaded_esm = [
+      dir "modules/testdata",
+      "custom:lazy_shared" = "lazy_loaded_shared.js",
+    ]
+  );
+
+  let main =
+    ModuleSpecifier::parse("file:///lazy_loaded_concurrent_main.js").unwrap();
+  let a =
+    ModuleSpecifier::parse("file:///lazy_loaded_concurrent_a.js").unwrap();
+  let b =
+    ModuleSpecifier::parse("file:///lazy_loaded_concurrent_b.js").unwrap();
+  let loader = Rc::new(StaticModuleLoader::new([
+    (
+      main.clone(),
+      crate::ascii_str_include!("testdata/lazy_loaded_concurrent_main.js"),
+    ),
+    (
+      a,
+      crate::ascii_str_include!("testdata/lazy_loaded_concurrent_a.js"),
+    ),
+    (
+      b,
+      crate::ascii_str_include!("testdata/lazy_loaded_concurrent_b.js"),
+    ),
+  ]));
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![test_ext::init()],
+    module_loader: Some(loader),
+    ..Default::default()
+  });
+
+  let mod_id = runtime.load_main_es_module(&main).await.unwrap();
+  let result = runtime.mod_evaluate(mod_id);
+  runtime.run_event_loop(Default::default()).await.unwrap();
+  result.await.unwrap();
+}
+
 #[test]
 fn test_lazy_loaded_script() {
   deno_core::extension!(


### PR DESCRIPTION
Two concurrent dynamic imports that both transitively depend on the same
lazy-loaded ESM module (e.g. `node:assert`) could fail with `Unsupported
scheme "node"`. Each `import()` spawns its own `RecursiveModuleLoad`, and
the per-load `visited`/`get_id` dedup misses across loads — both queue a
load future for the lazy specifier. `take_lazy_esm_source` removed the
source on first call, so the second future got `None` and fell through to
`loader.load()`, which doesn't handle `node:` builtins. This manifests
on vite 8 + react-router 7.15 under their CJS bin, where prettier
(loaded via `require`) and vite's `chunks/node.js` both import
`node:assert`.

Return a cheap clone (via `FastString::into_cheap_copy`) instead of
removing the entry. The duplicate `ModuleSource`s are deduplicated by
`new_module_with_pending`'s existing `get_id` check at register time.

Fixes #34307