### PR TITLE
fix(transpile): preserve newlines after multi-line block comments

### DIFF
--- a/cli/tools/transpile.rs
+++ b/cli/tools/transpile.rs
@@ -174,7 +174,16 @@ pub async fn transpile(
     )?;
 
     let emitted = transpile_result.into_source();
-    let js_text = &emitted.text;
+    // Skip the newline restoration pass when source maps are requested,
+    // since inserting newlines would shift line numbers in the generated
+    // output without a corresponding adjustment to the mappings.
+    let emitted_text;
+    let js_text = if matches!(source_map_option, SourceMapOption::None) {
+      emitted_text = restore_block_comment_newlines(&emitted.text);
+      &emitted_text
+    } else {
+      &emitted.text
+    };
     let source_map_text = &emitted.source_map;
 
     // Determine output path
@@ -366,6 +375,152 @@ fn resolve_dts_output_path(
     // No output specified: place next to source file
     Ok(path)
   }
+}
+
+/// SWC's code generator always writes a single space after a block
+/// comment's closing `*/`, regardless of whether the original source had a
+/// newline. For multi-line block comments (typically JSDoc) this collapses
+/// the comment onto the same line as the following statement. This function
+/// walks the emitted source and replaces that single space with a newline
+/// (plus the comment's own leading indentation) when the preceding block
+/// comment spans multiple lines.
+fn restore_block_comment_newlines(input: &str) -> String {
+  let bytes = input.as_bytes();
+  let n = bytes.len();
+  let mut out: Vec<u8> = Vec::with_capacity(n);
+  let mut i = 0;
+
+  // Stack of brace depths at which template-literal substitutions started.
+  // When `}` is reached at the top of the stack, we re-enter the template.
+  let mut template_stack: Vec<u32> = Vec::new();
+  let mut brace_depth: u32 = 0;
+
+  // 0 = code, 1 = single-quote string, 2 = double-quote string,
+  // 3 = template literal.
+  let mut mode: u8 = 0;
+
+  while i < n {
+    let c = bytes[i];
+    match mode {
+      0 => match c {
+        b'\'' => {
+          out.push(c);
+          mode = 1;
+          i += 1;
+        }
+        b'"' => {
+          out.push(c);
+          mode = 2;
+          i += 1;
+        }
+        b'`' => {
+          out.push(c);
+          mode = 3;
+          i += 1;
+        }
+        b'{' => {
+          brace_depth += 1;
+          out.push(c);
+          i += 1;
+        }
+        b'}' => {
+          if template_stack.last() == Some(&brace_depth) {
+            template_stack.pop();
+            mode = 3;
+          }
+          brace_depth = brace_depth.saturating_sub(1);
+          out.push(c);
+          i += 1;
+        }
+        b'/' if i + 1 < n && bytes[i + 1] == b'/' => {
+          // Line comment: copy through end of line.
+          while i < n && bytes[i] != b'\n' {
+            out.push(bytes[i]);
+            i += 1;
+          }
+        }
+        b'/' if i + 1 < n && bytes[i + 1] == b'*' => {
+          // Block comment: copy through `*/`, then maybe restore newline.
+          let start = i;
+          out.push(bytes[i]);
+          out.push(bytes[i + 1]);
+          i += 2;
+          let mut has_newline = false;
+          while i + 1 < n && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+            if bytes[i] == b'\n' {
+              has_newline = true;
+            }
+            out.push(bytes[i]);
+            i += 1;
+          }
+          if i + 1 < n {
+            out.push(b'*');
+            out.push(b'/');
+            i += 2;
+          }
+          // If multi-line and SWC emitted the trailing space, replace it
+          // with a newline + the comment's own indentation. We only act
+          // when the comment is indented by pure whitespace on its line;
+          // otherwise leave the output untouched to avoid breaking layout.
+          if has_newline && i < n && bytes[i] == b' ' {
+            // Locate the start of the line containing the comment.
+            let mut line_start = start;
+            while line_start > 0 && bytes[line_start - 1] != b'\n' {
+              line_start -= 1;
+            }
+            let indent = &bytes[line_start..start];
+            if indent.iter().all(|&b| b == b' ' || b == b'\t') {
+              out.push(b'\n');
+              out.extend_from_slice(indent);
+              i += 1; // skip the space SWC wrote
+            }
+          }
+        }
+        _ => {
+          out.push(c);
+          i += 1;
+        }
+      },
+      1 | 2 => {
+        let quote = if mode == 1 { b'\'' } else { b'"' };
+        out.push(c);
+        i += 1;
+        if c == b'\\' && i < n {
+          out.push(bytes[i]);
+          i += 1;
+        } else if c == quote {
+          mode = 0;
+        }
+      }
+      3 => {
+        if c == b'\\' && i + 1 < n {
+          out.push(c);
+          out.push(bytes[i + 1]);
+          i += 2;
+        } else if c == b'`' {
+          out.push(c);
+          mode = 0;
+          i += 1;
+        } else if c == b'$' && i + 1 < n && bytes[i + 1] == b'{' {
+          out.push(c);
+          out.push(b'{');
+          brace_depth += 1;
+          template_stack.push(brace_depth);
+          mode = 0;
+          i += 2;
+        } else {
+          out.push(c);
+          i += 1;
+        }
+      }
+      _ => unreachable!(),
+    }
+  }
+
+  // Safety: input is valid UTF-8 and we only branch on ASCII bytes; the
+  // newlines and spaces we insert are ASCII. Multi-byte UTF-8 sequences are
+  // copied byte-for-byte so the output remains valid UTF-8.
+  String::from_utf8(out).expect("post-processed text must remain valid UTF-8")
 }
 
 fn js_extension_for_media_type(media_type: MediaType) -> &'static str {

--- a/tests/specs/transpile/__test__.jsonc
+++ b/tests/specs/transpile/__test__.jsonc
@@ -5,6 +5,10 @@
       "args": "transpile main.ts",
       "output": "basic_stdout.out"
     },
+    "jsdoc_newline": {
+      "args": "transpile jsdoc.ts",
+      "output": "jsdoc.out"
+    },
     "output_flag": {
       "steps": [
         {

--- a/tests/specs/transpile/jsdoc.out
+++ b/tests/specs/transpile/jsdoc.out
@@ -1,0 +1,9 @@
+[WILDCARD]deno transpile is experimental and subject to changes
+/**
+ * Greets the user and shows their balance.
+ * @param user - The user to greet.
+ * @returns A greeting message with the user's name and balance.
+ */
+export function greet(user) {
+  return `Hello ${user.name}, you have $${user.balance.toFixed(2)}`;
+}

--- a/tests/specs/transpile/jsdoc.ts
+++ b/tests/specs/transpile/jsdoc.ts
@@ -1,0 +1,13 @@
+interface User {
+  name: string;
+  balance: number;
+}
+
+/**
+ * Greets the user and shows their balance.
+ * @param user - The user to greet.
+ * @returns A greeting message with the user's name and balance.
+ */
+export function greet(user: User): string {
+  return `Hello ${user.name}, you have $${user.balance.toFixed(2)}`;
+}


### PR DESCRIPTION
SWC's code generator always writes a single space after a block
comment's closing `*/`, regardless of what the original source had there.
For multi-line JSDoc this collapses the comment onto the same line as the
following statement, producing awkward output like `*/ export function
greet(...)`. Restore the newline (plus the comment's leading indentation)
as a post-process pass on the emitted text.

The pass uses a small state machine that tracks string, template-literal,
and substitution contexts so `*/` appearing inside literals is left
untouched. It is skipped when `--source-map` is requested, since
inserting newlines would shift line numbers in the generated output
without a corresponding adjustment to the mappings.

Fixes #34317