### PR TITLE
refactor(ext/web): build timers directly on core.createTimer

### DIFF
--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -1,27 +1,40 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-// Web timers (setTimeout/setInterval) built on top of Node's Timeout class.
-// The Node Timeout class is the canonical timer implementation that wraps
-// core.createTimer. Web timers add WHATWG-specific behavior on top:
+// Web timers (setTimeout/setInterval) built directly on core.createTimer.
+// Adds WHATWG-specific behavior on top:
 // - webidl type coercion
 // - string callback eval (WHATWG spec)
 // - timer nesting depth tracking (WHATWG spec)
-// - numeric timer IDs (vs Node's Timeout objects)
+// - numeric timer IDs
+// - AsyncContext propagation across the callback boundary
 
 (function () {
 const { core, primordials } = __bootstrap;
 const { op_defer } = core.ops;
 const {
+  createTimer,
+  cancelTimer,
+  refTimer: coreRefTimer,
+  unrefTimer: coreUnrefTimer,
+  getAsyncContext,
+  setAsyncContext,
+} = core;
+const {
+  MapPrototypeDelete,
+  MapPrototypeGet,
+  MapPrototypeSet,
   PromisePrototypeThen,
+  ReflectApply,
+  SafeMap,
   TypeError,
   indirectEval,
-  ReflectApply,
 } = primordials;
 
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
 
-const loadNodeTimers = () =>
-  core.loadExtScript("ext:deno_node/internal/timers.mjs");
+// Map numeric timer IDs to internal core timer objects so clearTimeout /
+// clearInterval / refTimer / unrefTimer can look them up by id.
+const activeTimers = new SafeMap();
 
 // WHATWG timer nesting depth tracking.
 let timerDepth = 0;
@@ -42,20 +55,27 @@ function setTimeout(callback, timeout = 0, ...args) {
     callback = () => indirectEval(unboundCallback);
   }
   const unboundCallback = callback;
+  const asyncContext = getAsyncContext();
   const depth = timerDepth;
+  let id = 0;
   const wrappedCallback = function () {
+    const oldContext = getAsyncContext();
     const prevDepth = timerDepth;
     try {
+      setAsyncContext(asyncContext);
       timerDepth = depth + 1;
       ReflectApply(unboundCallback, globalThis, args);
     } finally {
       timerDepth = prevDepth;
+      setAsyncContext(oldContext);
+      MapPrototypeDelete(activeTimers, id);
     }
   };
   timeout = webidl.converters.long(timeout);
-  const { Timeout, kTimerId } = loadNodeTimers();
-  const t = new Timeout(wrappedCallback, timeout, undefined, false, true);
-  return t[kTimerId];
+  const timer = createTimer(wrappedCallback, timeout, undefined, false, true);
+  id = timer._timerId;
+  MapPrototypeSet(activeTimers, id, timer);
+  return id;
 }
 
 /**
@@ -68,20 +88,25 @@ function setInterval(callback, timeout = 0, ...args) {
     callback = () => indirectEval(unboundCallback);
   }
   const unboundCallback = callback;
+  const asyncContext = getAsyncContext();
   const depth = timerDepth;
   const wrappedCallback = function () {
+    const oldContext = getAsyncContext();
     const prevDepth = timerDepth;
     try {
+      setAsyncContext(asyncContext);
       timerDepth = depth + 1;
       ReflectApply(unboundCallback, globalThis, args);
     } finally {
       timerDepth = prevDepth;
+      setAsyncContext(oldContext);
     }
   };
   timeout = webidl.converters.long(timeout);
-  const { Timeout, kTimerId } = loadNodeTimers();
-  const t = new Timeout(wrappedCallback, timeout, undefined, true, true);
-  return t[kTimerId];
+  const timer = createTimer(wrappedCallback, timeout, undefined, true, true);
+  const id = timer._timerId;
+  MapPrototypeSet(activeTimers, id, timer);
+  return id;
 }
 
 /**
@@ -90,10 +115,10 @@ function setInterval(callback, timeout = 0, ...args) {
 function clearTimeout(id = 0) {
   checkThis(this);
   id = webidl.converters.long(id);
-  const { getActiveTimer, kDestroy } = loadNodeTimers();
-  const timer = getActiveTimer(id);
+  const timer = MapPrototypeGet(activeTimers, id);
   if (timer) {
-    timer[kDestroy]();
+    cancelTimer(timer);
+    MapPrototypeDelete(activeTimers, id);
   }
 }
 
@@ -103,10 +128,10 @@ function clearTimeout(id = 0) {
 function clearInterval(id = 0) {
   checkThis(this);
   id = webidl.converters.long(id);
-  const { getActiveTimer, kDestroy } = loadNodeTimers();
-  const timer = getActiveTimer(id);
+  const timer = MapPrototypeGet(activeTimers, id);
   if (timer) {
-    timer[kDestroy]();
+    cancelTimer(timer);
+    MapPrototypeDelete(activeTimers, id);
   }
 }
 
@@ -114,13 +139,14 @@ function clearInterval(id = 0) {
  * Mark a timer as not blocking event loop exit.
  */
 function unrefTimer(id) {
-  const { getActiveTimer, kTimerId } = loadNodeTimers();
   if (typeof id !== "number") {
-    id = id[kTimerId];
+    // NodeJS.Timeout (or compatible): delegate to its own unref().
+    id?.unref?.();
+    return;
   }
-  const timer = getActiveTimer(id);
+  const timer = MapPrototypeGet(activeTimers, id);
   if (timer) {
-    timer.unref();
+    coreUnrefTimer(timer);
   }
 }
 
@@ -128,13 +154,13 @@ function unrefTimer(id) {
  * Mark a timer as blocking event loop exit.
  */
 function refTimer(id) {
-  const { getActiveTimer, kTimerId } = loadNodeTimers();
   if (typeof id !== "number") {
-    id = id[kTimerId];
+    id?.ref?.();
+    return;
   }
-  const timer = getActiveTimer(id);
+  const timer = MapPrototypeGet(activeTimers, id);
   if (timer) {
-    timer.ref();
+    coreRefTimer(timer);
   }
 }
 


### PR DESCRIPTION
Web `setTimeout` / `setInterval` / `clearTimeout` / `clearInterval` /
`Deno.refTimer` / `Deno.unrefTimer` previously routed through the Node
`Timeout` class in `ext:deno_node/internal/timers.mjs` (added in #32843).
That class itself just wraps `core.createTimer`, so for the web side it
was pure indirection — and it forced an `ext/web` → `ext/node` load that
this layer otherwise doesn't need.

This calls `core.createTimer` / `cancelTimer` / `refTimer` / `unrefTimer`
directly and keeps a small numeric-id → timer map locally, the same
shape the file had before #32843. The WHATWG-specific bits (webidl
coercion, string-callback eval, nesting-depth tracking, numeric ids)
stay in place, and AsyncContext capture/restore now happens in the
wrapped callback here instead of being inherited from Node's `Timeout`.
The Node global `setTimeout` (which is what user code reaches via
`globalThis.setTimeout`) is unaffected and continues to go through
`node:timers`.