### PR TITLE
fix(ext/node): re-export inner spec for module.exports = require(X).Y

### DIFF
--- a/cli/cache/node.rs
+++ b/cli/cache/node.rs
@@ -165,6 +165,7 @@ mod test {
     let cjs_analysis = DenoCjsAnalysis::Cjs(ModuleExportsAndReExports {
       exports: vec!["export1".to_string()],
       reexports: vec!["re-export1".to_string()],
+      member_reexports: vec![],
     });
     cache
       .set_cjs_analysis("file.js", CacheDBHash::new(2), &cjs_analysis)

--- a/cli/rt/node.rs
+++ b/cli/rt/node.rs
@@ -79,6 +79,7 @@ impl CjsCodeAnalyzer {
       return Ok(CjsAnalysis::Cjs(CjsAnalysisExports {
         exports: vec![],
         reexports: vec![],
+        member_reexports: vec![],
       }));
     }
 
@@ -105,6 +106,7 @@ impl CjsCodeAnalyzer {
               CjsAnalysis::Cjs(CjsAnalysisExports {
                 exports,
                 reexports: Vec::new(), // already resolved
+                member_reexports: Vec::new(),
               })
             }
             CjsExportAnalysisEntry::Error(err) => {
@@ -161,16 +163,31 @@ impl node_resolver::analyze::CjsCodeAnalyzer for CjsCodeAnalyzer {
             return Ok(CjsAnalysis::Cjs(CjsAnalysisExports {
               exports: vec![],
               reexports: vec![],
+              member_reexports: vec![],
             }));
           }
         } else {
           return Ok(CjsAnalysis::Cjs(CjsAnalysisExports {
             exports: vec![],
             reexports: vec![],
+            member_reexports: vec![],
           }));
         }
       }
     };
     self.inner_cjs_analysis(specifier, source)
+  }
+
+  async fn analyze_cjs_member_props<'a>(
+    &self,
+    _specifier: &Url,
+    _maybe_source: Option<Cow<'a, str>>,
+    _member: &str,
+  ) -> Result<Option<Vec<String>>, JsErrorBox> {
+    // The compiled runtime does not have access to swc; CJS export
+    // analysis is precomputed at compile time. Member-shape narrowing
+    // is therefore unavailable here, and the wrapper falls back to
+    // advertising only the default and module.exports.
+    Ok(None)
   }
 }

--- a/libs/node_resolver/analyze.rs
+++ b/libs/node_resolver/analyze.rs
@@ -239,7 +239,7 @@ impl<
   }
 
   /// For each `module.exports = require(X).MEMBER` shape recorded on
-  /// `entry_specifier`, resolve `X`, ask the analyzer for the property
+  /// `referrer`, resolve `X`, ask the analyzer for the property
   /// names attached to the value of `exports.MEMBER` inside `X`, and
   /// surface those (and only those) as names on the wrapper. This is
   /// strictly narrower than treating `X` as a wildcard re-export: only
@@ -251,7 +251,7 @@ impl<
   )]
   async fn resolve_member_reexports<'a>(
     &'a self,
-    entry_specifier: &Url,
+    referrer: &Url,
     member_reexports: &[CjsMemberReExport],
     all_exports: &mut BTreeSet<String>,
     errors: &mut Vec<JsErrorBox>,
@@ -260,7 +260,7 @@ impl<
       let result = self
         .resolve(
           &entry.specifier,
-          entry_specifier,
+          referrer,
           &[
             Cow::Borrowed("deno"),
             Cow::Borrowed("node"),
@@ -425,6 +425,17 @@ impl<
               &mut analyze_futures,
               errors,
             );
+          }
+
+          if !analysis.member_reexports.is_empty() {
+            self
+              .resolve_member_reexports(
+                &reexport_specifier,
+                &analysis.member_reexports,
+                all_exports,
+                errors,
+              )
+              .await;
           }
 
           all_exports.extend(

--- a/libs/node_resolver/analyze.rs
+++ b/libs/node_resolver/analyze.rs
@@ -43,6 +43,18 @@ pub enum CjsAnalysis<'a> {
 pub struct CjsAnalysisExports {
   pub exports: Vec<String>,
   pub reexports: Vec<String>,
+  /// Re-exports that pin down a specific member of the inner module
+  /// (the shape `module.exports = require(X).MEMBER`). For these, only
+  /// names statically attached to that member in the inner module are
+  /// surfaced as exports of the wrapper.
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub member_reexports: Vec<CjsMemberReExport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CjsMemberReExport {
+  pub specifier: String,
+  pub member: String,
 }
 
 /// What parts of an ES module should be analyzed.
@@ -68,6 +80,21 @@ pub trait CjsCodeAnalyzer {
     maybe_source: Option<Cow<'a, str>>,
     esm_analysis_mode: EsmAnalysisMode,
   ) -> Result<CjsAnalysis<'a>, JsErrorBox>;
+
+  /// For `module.exports = require(X).MEMBER` shapes, return the names
+  /// statically attached as properties of the value bound to
+  /// `exports.MEMBER` in the module at `specifier`. Used by callers to
+  /// narrow the wrapper's named exports to names the inner module
+  /// actually exposes on that specific member, rather than the entire
+  /// inner module. Returns `None` if the member's value can't be
+  /// statically resolved to such an identifier, in which case the
+  /// caller should advertise no names under the member shape.
+  async fn analyze_cjs_member_props<'a>(
+    &self,
+    specifier: &Url,
+    maybe_source: Option<Cow<'a, str>>,
+    member: &str,
+  ) -> Result<Option<Vec<String>>, JsErrorBox>;
 }
 
 pub enum ResolvedCjsAnalysis<'a> {
@@ -192,7 +219,89 @@ impl<
       }
     }
 
+    if !analysis.member_reexports.is_empty() {
+      let mut errors = Vec::new();
+      self
+        .resolve_member_reexports(
+          entry_specifier,
+          &analysis.member_reexports,
+          &mut all_exports,
+          &mut errors,
+        )
+        .await;
+      if !errors.is_empty() {
+        errors.sort_by_cached_key(|e| e.to_string());
+        return Err(TranslateCjsToEsmError::ExportAnalysis(errors.remove(0)));
+      }
+    }
+
     Ok(ResolvedCjsAnalysis::Cjs(all_exports))
+  }
+
+  /// For each `module.exports = require(X).MEMBER` shape recorded on
+  /// `entry_specifier`, resolve `X`, ask the analyzer for the property
+  /// names attached to the value of `exports.MEMBER` inside `X`, and
+  /// surface those (and only those) as names on the wrapper. This is
+  /// strictly narrower than treating `X` as a wildcard re-export: only
+  /// names the inner module statically attaches to the specific member
+  /// are advertised, so unrelated names from `X` don't leak through.
+  #[allow(
+    clippy::needless_lifetimes,
+    reason = "explicit lifetimes improve clarity"
+  )]
+  async fn resolve_member_reexports<'a>(
+    &'a self,
+    entry_specifier: &Url,
+    member_reexports: &[CjsMemberReExport],
+    all_exports: &mut BTreeSet<String>,
+    errors: &mut Vec<JsErrorBox>,
+  ) {
+    for entry in member_reexports {
+      let result = self
+        .resolve(
+          &entry.specifier,
+          entry_specifier,
+          &[
+            Cow::Borrowed("deno"),
+            Cow::Borrowed("node"),
+            Cow::Borrowed("require"),
+            Cow::Borrowed("default"),
+          ],
+          NodeResolutionKind::Execution,
+        )
+        .and_then(|value| {
+          value
+            .map(|url_or_path| url_or_path.into_url())
+            .transpose()
+            .map_err(JsErrorBox::from_err)
+        });
+      let inner_specifier = match result {
+        Ok(Some(spec)) => spec,
+        Ok(None) => continue,
+        Err(err) => {
+          errors.push(err);
+          continue;
+        }
+      };
+      let props = match self
+        .cjs_code_analyzer
+        .analyze_cjs_member_props(&inner_specifier, None, &entry.member)
+        .await
+      {
+        Ok(Some(props)) => props,
+        Ok(None) => continue,
+        Err(err) => {
+          errors.push(err);
+          continue;
+        }
+      };
+      for prop in props {
+        if prop == "default" {
+          continue;
+        }
+        all_exports.insert(prop);
+      }
+    }
   }
 
   #[allow(

--- a/libs/resolver/cjs/analyzer/deno_ast.rs
+++ b/libs/resolver/cjs/analyzer/deno_ast.rs
@@ -2,6 +2,17 @@
 
 use deno_ast::MediaType;
 use deno_ast::ParsedSource;
+use deno_ast::ProgramRef;
+use deno_ast::swc::ast::AssignOp;
+use deno_ast::swc::ast::AssignTarget;
+use deno_ast::swc::ast::CallExpr;
+use deno_ast::swc::ast::Expr;
+use deno_ast::swc::ast::Lit;
+use deno_ast::swc::ast::MemberExpr;
+use deno_ast::swc::ast::MemberProp;
+use deno_ast::swc::ast::ModuleItem;
+use deno_ast::swc::ast::SimpleAssignTarget;
+use deno_ast::swc::ast::Stmt;
 use deno_error::JsErrorBox;
 use deno_graph::ast::ParsedSourceStore;
 use url::Url;
@@ -64,10 +75,24 @@ impl super::ModuleForExportAnalysis for ParsedSource {
 
   fn analyze_cjs(&self) -> super::ModuleExportsAndReExports {
     let analysis = ParsedSource::analyze_cjs(self);
-    super::ModuleExportsAndReExports {
-      exports: analysis.exports,
-      reexports: analysis.reexports,
+    let exports = analysis.exports;
+    let mut reexports = analysis.reexports;
+
+    // Fallback for the shape `module.exports = require("./inner").IDENT;`
+    // (e.g. graphql-tag@2's main entry). deno_ast's CJS analyzer
+    // recognizes the bare-call form but not the member-access form, so
+    // it surfaces no exports here. Detect this top-level pattern and
+    // emit the inner specifier as a re-export; the existing recursive
+    // re-export machinery then picks up the inner module's named
+    // exports.
+    if exports.is_empty()
+      && reexports.is_empty()
+      && let Some(spec) = find_module_exports_require_member(self)
+    {
+      reexports.push(spec);
     }
+
+    super::ModuleExportsAndReExports { exports, reexports }
   }
 
   fn analyze_es_runtime_exports(&self) -> super::ModuleExportsAndReExports {
@@ -76,5 +101,77 @@ impl super::ModuleForExportAnalysis for ParsedSource {
       exports: analysis.exports,
       reexports: analysis.reexports,
     }
+  }
+}
+
+fn find_module_exports_require_member(ps: &ParsedSource) -> Option<String> {
+  match ps.program_ref() {
+    ProgramRef::Module(m) => m.body.iter().find_map(|item| match item {
+      ModuleItem::Stmt(stmt) => match_module_exports_require_member(stmt),
+      ModuleItem::ModuleDecl(_) => None,
+    }),
+    ProgramRef::Script(s) => {
+      s.body.iter().find_map(match_module_exports_require_member)
+    }
+  }
+}
+
+fn match_module_exports_require_member(stmt: &Stmt) -> Option<String> {
+  let assign = match stmt {
+    Stmt::Expr(e) => e.expr.as_assign()?,
+    _ => return None,
+  };
+  if assign.op != AssignOp::Assign {
+    return None;
+  }
+  let target_member = match &assign.left {
+    AssignTarget::Simple(SimpleAssignTarget::Member(m)) => m,
+    _ => return None,
+  };
+  if !is_module_exports_member(target_member) {
+    return None;
+  }
+  // RHS shape: zero or more `.IDENT` member accesses wrapping a
+  // `require("…")` call. Walk down to the call.
+  let mut current: &Expr = &assign.right;
+  loop {
+    match current {
+      Expr::Call(call) => return call_expr_require_spec(call),
+      Expr::Member(m) => current = &m.obj,
+      _ => return None,
+    }
+  }
+}
+
+fn is_module_exports_member(m: &MemberExpr) -> bool {
+  let Expr::Ident(obj_ident) = &*m.obj else {
+    return false;
+  };
+  if &*obj_ident.sym != "module" {
+    return false;
+  }
+  match &m.prop {
+    MemberProp::Ident(i) => &*i.sym == "exports",
+    MemberProp::Computed(c) => matches!(
+      &*c.expr,
+      Expr::Lit(Lit::Str(s)) if s.value.as_str() == Some("exports"),
+    ),
+    MemberProp::PrivateName(_) => false,
+  }
+}
+
+fn call_expr_require_spec(call: &CallExpr) -> Option<String> {
+  let callee_expr = call.callee.as_expr()?;
+  let ident = callee_expr.as_ident()?;
+  if &*ident.sym != "require" {
+    return None;
+  }
+  let arg = call.args.first()?;
+  if arg.spread.is_some() {
+    return None;
+  }
+  match arg.expr.as_lit()? {
+    Lit::Str(s) => s.value.as_str().map(|s| s.to_string()),
+    _ => None,
   }
 }

--- a/libs/resolver/cjs/analyzer/deno_ast.rs
+++ b/libs/resolver/cjs/analyzer/deno_ast.rs
@@ -76,23 +76,30 @@ impl super::ModuleForExportAnalysis for ParsedSource {
   fn analyze_cjs(&self) -> super::ModuleExportsAndReExports {
     let analysis = ParsedSource::analyze_cjs(self);
     let exports = analysis.exports;
-    let mut reexports = analysis.reexports;
+    let reexports = analysis.reexports;
+    let mut member_reexports = Vec::new();
 
-    // Fallback for the shape `module.exports = require("./inner").IDENT;`
+    // Fallback for the shape `module.exports = require("./inner").MEMBER;`
     // (e.g. graphql-tag@2's main entry). deno_ast's CJS analyzer
     // recognizes the bare-call form but not the member-access form, so
     // it surfaces no exports here. Detect this top-level pattern and
-    // emit the inner specifier as a re-export; the existing recursive
-    // re-export machinery then picks up the inner module's named
-    // exports.
+    // record it as a member-scoped re-export. The recursive analyzer
+    // then narrows the inner module's exports to those statically
+    // attached to MEMBER, so unrelated names from the inner module
+    // are not advertised by the wrapper.
     if exports.is_empty()
       && reexports.is_empty()
-      && let Some(spec) = find_module_exports_require_member(self)
+      && let Some((specifier, member)) =
+        find_module_exports_require_member(self)
     {
-      reexports.push(spec);
+      member_reexports.push(super::MemberReExport { specifier, member });
     }
 
-    super::ModuleExportsAndReExports { exports, reexports }
+    super::ModuleExportsAndReExports {
+      exports,
+      reexports,
+      member_reexports,
+    }
   }
 
   fn analyze_es_runtime_exports(&self) -> super::ModuleExportsAndReExports {
@@ -100,11 +107,41 @@ impl super::ModuleForExportAnalysis for ParsedSource {
     super::ModuleExportsAndReExports {
       exports: analysis.exports,
       reexports: analysis.reexports,
+      member_reexports: Vec::new(),
     }
+  }
+
+  fn analyze_member_export_props(&self, member: &str) -> Option<Vec<String>> {
+    let stmts: Vec<&Stmt> = match self.program_ref() {
+      ProgramRef::Module(m) => m
+        .body
+        .iter()
+        .filter_map(|item| match item {
+          ModuleItem::Stmt(stmt) => Some(stmt),
+          ModuleItem::ModuleDecl(_) => None,
+        })
+        .collect(),
+      ProgramRef::Script(s) => s.body.iter().collect(),
+    };
+
+    // Resolve `exports.MEMBER = <value>` to a top-level identifier.
+    let ident = find_member_value_ident(&stmts, member)?;
+
+    // Collect property names statically assigned to that identifier
+    // at the top level: `IDENT.X = ...`.
+    let mut props: Vec<String> = stmts
+      .iter()
+      .filter_map(|stmt| match_identifier_property_assignment(stmt, &ident))
+      .collect();
+    props.sort();
+    props.dedup();
+    Some(props)
   }
 }
 
-fn find_module_exports_require_member(ps: &ParsedSource) -> Option<String> {
+fn find_module_exports_require_member(
+  ps: &ParsedSource,
+) -> Option<(String, String)> {
   match ps.program_ref() {
     ProgramRef::Module(m) => m.body.iter().find_map(|item| match item {
       ModuleItem::Stmt(stmt) => match_module_exports_require_member(stmt),
@@ -116,7 +153,9 @@ fn find_module_exports_require_member(ps: &ParsedSource) -> Option<String> {
   }
 }
 
-fn match_module_exports_require_member(stmt: &Stmt) -> Option<String> {
+fn match_module_exports_require_member(
+  stmt: &Stmt,
+) -> Option<(String, String)> {
   let assign = match stmt {
     Stmt::Expr(e) => e.expr.as_assign()?,
     _ => return None,
@@ -131,15 +170,101 @@ fn match_module_exports_require_member(stmt: &Stmt) -> Option<String> {
   if !is_module_exports_member(target_member) {
     return None;
   }
-  // RHS shape: zero or more `.IDENT` member accesses wrapping a
-  // `require("…")` call. Walk down to the call.
-  let mut current: &Expr = &assign.right;
-  loop {
-    match current {
-      Expr::Call(call) => return call_expr_require_spec(call),
-      Expr::Member(m) => current = &m.obj,
+  // RHS shape: exactly one `.MEMBER` member access wrapping a
+  // `require("…")` call. Narrower than the previous walk (which
+  // accepted nested member accesses) because the narrowing in
+  // `analyze_member_export_props` only resolves a single hop.
+  let outer_member = match &*assign.right {
+    Expr::Member(m) => m,
+    _ => return None,
+  };
+  let member_name = match &outer_member.prop {
+    MemberProp::Ident(i) => i.sym.to_string(),
+    MemberProp::Computed(c) => match &*c.expr {
+      Expr::Lit(Lit::Str(s)) => s.value.as_str()?.to_string(),
       _ => return None,
+    },
+    MemberProp::PrivateName(_) => return None,
+  };
+  let call = match &*outer_member.obj {
+    Expr::Call(c) => c,
+    _ => return None,
+  };
+  let spec = call_expr_require_spec(call)?;
+  Some((spec, member_name))
+}
+
+/// In `stmts`, find `exports.MEMBER = IDENT` (or
+/// `module.exports.MEMBER = IDENT`) and return IDENT's name.
+fn find_member_value_ident(stmts: &[&Stmt], member: &str) -> Option<String> {
+  stmts.iter().find_map(|stmt| {
+    let assign = match stmt {
+      Stmt::Expr(e) => e.expr.as_assign()?,
+      _ => return None,
+    };
+    if assign.op != AssignOp::Assign {
+      return None;
     }
+    let target_member = match &assign.left {
+      AssignTarget::Simple(SimpleAssignTarget::Member(m)) => m,
+      _ => return None,
+    };
+    if !is_exports_member(target_member, member) {
+      return None;
+    }
+    let ident = assign.right.as_ident()?;
+    Some(ident.sym.to_string())
+  })
+}
+
+/// Match `IDENT.X = …` and return `X`.
+fn match_identifier_property_assignment(
+  stmt: &Stmt,
+  ident: &str,
+) -> Option<String> {
+  let assign = match stmt {
+    Stmt::Expr(e) => e.expr.as_assign()?,
+    _ => return None,
+  };
+  if assign.op != AssignOp::Assign {
+    return None;
+  }
+  let m = match &assign.left {
+    AssignTarget::Simple(SimpleAssignTarget::Member(m)) => m,
+    _ => return None,
+  };
+  let obj_ident = m.obj.as_ident()?;
+  if &*obj_ident.sym != ident {
+    return None;
+  }
+  match &m.prop {
+    MemberProp::Ident(i) => Some(i.sym.to_string()),
+    MemberProp::Computed(c) => match &*c.expr {
+      Expr::Lit(Lit::Str(s)) => s.value.as_str().map(|s| s.to_string()),
+      _ => None,
+    },
+    MemberProp::PrivateName(_) => None,
+  }
+}
+
+/// True if `m` is `exports.NAME` or `module.exports.NAME` matching
+/// `name`.
+fn is_exports_member(m: &MemberExpr, name: &str) -> bool {
+  let prop_matches = match &m.prop {
+    MemberProp::Ident(i) => &*i.sym == name,
+    MemberProp::Computed(c) => matches!(
+      &*c.expr,
+      Expr::Lit(Lit::Str(s)) if s.value.as_str() == Some(name),
+    ),
+    MemberProp::PrivateName(_) => false,
+  };
+  if !prop_matches {
+    return false;
+  }
+  match &*m.obj {
+    Expr::Ident(i) => &*i.sym == "exports",
+    Expr::Member(inner) => is_module_exports_member(inner),
+    _ => false,
   }
 }
 

--- a/libs/resolver/cjs/analyzer/mod.rs
+++ b/libs/resolver/cjs/analyzer/mod.rs
@@ -9,6 +9,7 @@ use deno_media_type::MediaType;
 use node_resolver::analyze::CjsAnalysis as ExtNodeCjsAnalysis;
 use node_resolver::analyze::CjsAnalysisExports;
 use node_resolver::analyze::CjsCodeAnalyzer;
+use node_resolver::analyze::CjsMemberReExport;
 use node_resolver::analyze::EsmAnalysisMode;
 use serde::Deserialize;
 use serde::Serialize;
@@ -27,6 +28,19 @@ pub use deno_ast::DenoAstModuleExportAnalyzer;
 pub struct ModuleExportsAndReExports {
   pub exports: Vec<String>,
   pub reexports: Vec<String>,
+  /// Re-exports that pin down a specific member of the inner module.
+  /// Set when the analyzer detects a `module.exports = require("X").MEMBER`
+  /// shape. Downstream analysis filters the inner module's exports to
+  /// those statically attached to `MEMBER` rather than treating the
+  /// whole inner module as the re-export source.
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub member_reexports: Vec<MemberReExport>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemberReExport {
+  pub specifier: String,
+  pub member: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -96,6 +110,13 @@ pub trait ModuleForExportAnalysis {
   fn compute_is_script(&self) -> bool;
   fn analyze_cjs(&self) -> ModuleExportsAndReExports;
   fn analyze_es_runtime_exports(&self) -> ModuleExportsAndReExports;
+  /// For the shape `module.exports = require(X).MEMBER`, return the
+  /// property names that this module statically attaches to the value
+  /// bound to `exports.MEMBER`. Returns `None` if the member cannot be
+  /// statically resolved to an identifier whose property assignments
+  /// are visible at the top level (in which case callers must not
+  /// advertise any names from this module under the member shape).
+  fn analyze_member_export_props(&self, member: &str) -> Option<Vec<String>>;
 }
 
 #[allow(clippy::disallowed_types, reason = "definition")]
@@ -253,12 +274,14 @@ impl<TSys: DenoCjsCodeAnalyzerSys> CjsCodeAnalyzer
             return Ok(ExtNodeCjsAnalysis::Cjs(CjsAnalysisExports {
               exports: vec![],
               reexports: vec![],
+              member_reexports: vec![],
             }));
           }
         } else {
           return Ok(ExtNodeCjsAnalysis::Cjs(CjsAnalysisExports {
             exports: vec![],
             reexports: vec![],
+            member_reexports: vec![],
           }));
         }
       }
@@ -270,17 +293,68 @@ impl<TSys: DenoCjsCodeAnalyzerSys> CjsCodeAnalyzer
       DenoCjsAnalysis::Esm => Ok(ExtNodeCjsAnalysis::Esm(source, None)),
       DenoCjsAnalysis::EsmAnalysis(analysis) => Ok(ExtNodeCjsAnalysis::Esm(
         source,
-        Some(CjsAnalysisExports {
-          exports: analysis.exports,
-          reexports: analysis.reexports,
-        }),
+        Some(to_ext_cjs_analysis_exports(analysis)),
       )),
-      DenoCjsAnalysis::Cjs(analysis) => {
-        Ok(ExtNodeCjsAnalysis::Cjs(CjsAnalysisExports {
-          exports: analysis.exports,
-          reexports: analysis.reexports,
-        }))
-      }
+      DenoCjsAnalysis::Cjs(analysis) => Ok(ExtNodeCjsAnalysis::Cjs(
+        to_ext_cjs_analysis_exports(analysis),
+      )),
     }
+  }
+
+  async fn analyze_cjs_member_props<'a>(
+    &self,
+    specifier: &Url,
+    maybe_source: Option<Cow<'a, str>>,
+    member: &str,
+  ) -> Result<Option<Vec<String>>, JsErrorBox> {
+    let source = match maybe_source {
+      Some(source) => source,
+      None => match deno_path_util::url_to_file_path(specifier) {
+        Ok(path) => match self.sys.fs_read_to_string_lossy(path) {
+          Ok(source_from_file) => source_from_file,
+          Err(_) => return Ok(None),
+        },
+        Err(_) => return Ok(None),
+      },
+    };
+    let source = source.strip_prefix('\u{FEFF}').unwrap_or(&source);
+    let media_type = MediaType::from_specifier(specifier);
+    if media_type == MediaType::Json {
+      return Ok(None);
+    }
+    let module_export_analyzer = self.module_export_analyzer.clone();
+    let specifier = specifier.clone();
+    let source_arc: ArcStr = source.into();
+    let member = member.to_string();
+    let analyze = move || -> Result<Option<Vec<String>>, JsErrorBox> {
+      let parsed = module_export_analyzer
+        .parse_module(specifier, media_type, source_arc)?;
+      Ok(parsed.analyze_member_export_props(&member))
+    };
+    #[cfg(feature = "sync")]
+    {
+      crate::rt::spawn_blocking(analyze).await.unwrap()
+    }
+    #[cfg(not(feature = "sync"))]
+    {
+      analyze()
+    }
+  }
+}
+
+fn to_ext_cjs_analysis_exports(
+  analysis: ModuleExportsAndReExports,
+) -> CjsAnalysisExports {
+  CjsAnalysisExports {
+    exports: analysis.exports,
+    reexports: analysis.reexports,
+    member_reexports: analysis
+      .member_reexports
+      .into_iter()
+      .map(|m| CjsMemberReExport {
+        specifier: m.specifier,
+        member: m.member,
+      })
+      .collect(),
   }
 }

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-narrow/1.0.0/lib/inner.js
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-narrow/1.0.0/lib/inner.js
@@ -1,0 +1,18 @@
+function safe() {
+  return "safe";
+}
+function unrelated() {
+  return "unrelated";
+}
+
+// Only `attached` is attached to `safe`. `loose` is exported by
+// inner.js but NOT a property of `safe`. The wrapper does
+// `module.exports = require('./lib/inner.js').safe`, so the
+// wrapper's named exports should be limited to `safe`'s own
+// properties, not all of inner's named exports.
+safe.attached = function attached() {
+  return "attached";
+};
+
+exports.safe = safe;
+exports.loose = unrelated;

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-narrow/1.0.0/main.js
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-narrow/1.0.0/main.js
@@ -1,0 +1,6 @@
+// `module.exports = require(X).MEMBER` shape, but inner.js
+// deliberately exposes a named export (`loose`) that is NOT a
+// property of the re-exported member (`safe`). The wrapper must
+// not advertise `loose` since `mod.loose` would be undefined at
+// runtime.
+module.exports = require("./lib/inner.js").safe;

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-narrow/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-narrow/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/cjs-module-exports-require-member-narrow",
+  "version": "1.0.0",
+  "main": "./main.js"
+}

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-nested/1.0.0/lib/inner.js
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-nested/1.0.0/lib/inner.js
@@ -1,0 +1,18 @@
+function safe() {
+  return "safe";
+}
+function unrelated() {
+  return "unrelated";
+}
+
+// Only `attached` is attached to `safe`. `loose` is exported by
+// inner.js but NOT a property of `safe`. The wrapper does
+// `module.exports = require('./inner.js').safe`, so when the entry
+// module re-exports the wrapper, only `safe`'s own properties should
+// be advertised on the entry.
+safe.attached = function attached() {
+  return "attached";
+};
+
+exports.safe = safe;
+exports.loose = unrelated;

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-nested/1.0.0/lib/wrapper.js
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-nested/1.0.0/lib/wrapper.js
@@ -1,0 +1,4 @@
+// Member-shape re-export reached through the entry module's normal
+// re-export. The wrapper's named exports should be limited to
+// properties of `safe` in `./inner.js`.
+module.exports = require("./inner.js").safe;

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-nested/1.0.0/main.js
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-nested/1.0.0/main.js
@@ -1,0 +1,6 @@
+// The entry module is a plain `module.exports = require(X)` re-export
+// of a wrapper module that itself uses the member-shape re-export.
+// Exercises the recursive path: member-shaped re-exports reached
+// through normal CJS re-exports must still resolve to the inner
+// member's properties.
+module.exports = require("./lib/wrapper.js");

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-nested/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-nested/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/cjs-module-exports-require-member-nested",
+  "version": "1.0.0",
+  "main": "./main.js"
+}

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member/1.0.0/lib/inner.js
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member/1.0.0/lib/inner.js
@@ -1,0 +1,23 @@
+function gql() {
+  return "gql-result";
+}
+function resetCaches() {
+  return "reset";
+}
+function disableFragmentWarnings() {
+  return "disabled";
+}
+
+// Attach the named helpers as properties of `gql` so that
+// `require('./inner.js').gql` is a function carrying all named exports.
+gql.gql = gql;
+gql.resetCaches = resetCaches;
+gql.disableFragmentWarnings = disableFragmentWarnings;
+gql.default = gql;
+
+exports.default = gql;
+exports.gql = gql;
+exports.resetCaches = resetCaches;
+exports.disableFragmentWarnings = disableFragmentWarnings;
+
+Object.defineProperty(exports, '__esModule', { value: true });

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member/1.0.0/main.js
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member/1.0.0/main.js
@@ -1,0 +1,5 @@
+// Mirrors the shape of graphql-tag@2's main entry: re-exports a single
+// named property of an inner module as the whole `module.exports`. The
+// inner module attaches the other named exports as properties of that
+// same function value.
+module.exports = require('./lib/inner.js').gql;

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/cjs-module-exports-require-member",
+  "version": "1.0.0",
+  "main": "./main.js"
+}

--- a/tests/specs/npm/cjs_module_exports_require_member/__test__.jsonc
+++ b/tests/specs/npm/cjs_module_exports_require_member/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run -A --quiet main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/npm/cjs_module_exports_require_member/main.out
+++ b/tests/specs/npm/cjs_module_exports_require_member/main.out
@@ -1,0 +1,3 @@
+gql-result
+reset
+disabled

--- a/tests/specs/npm/cjs_module_exports_require_member/main.ts
+++ b/tests/specs/npm/cjs_module_exports_require_member/main.ts
@@ -1,0 +1,15 @@
+// Regression test for #25311: when a CJS main file is
+//   module.exports = require("./inner").IDENT;
+// the static CJS analyzer fails to surface the inner module's named
+// exports, so `import { gql }` would throw "does not provide an export
+// named 'gql'". The fallback in libs/resolver/cjs/analyzer detects this
+// pattern and surfaces the inner specifier as a re-export.
+import {
+  disableFragmentWarnings,
+  gql,
+  resetCaches,
+} from "npm:@denotest/cjs-module-exports-require-member";
+
+console.log(gql());
+console.log(resetCaches());
+console.log(disableFragmentWarnings());

--- a/tests/specs/npm/cjs_module_exports_require_member_narrow/__test__.jsonc
+++ b/tests/specs/npm/cjs_module_exports_require_member_narrow/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tests": {
+    "attached_works": {
+      "args": "run -A --quiet main.ts",
+      "output": "main.out"
+    },
+    "loose_is_not_advertised": {
+      "args": "run -A --quiet loose.ts",
+      "output": "loose.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/npm/cjs_module_exports_require_member_narrow/loose.out
+++ b/tests/specs/npm/cjs_module_exports_require_member_narrow/loose.out
@@ -1,0 +1,1 @@
+[WILDCARD]does not provide an export named 'loose'[WILDCARD]

--- a/tests/specs/npm/cjs_module_exports_require_member_narrow/loose.ts
+++ b/tests/specs/npm/cjs_module_exports_require_member_narrow/loose.ts
@@ -1,0 +1,6 @@
+// `loose` is a named export of the inner module but is NOT a
+// property of the member that the wrapper re-exports. The wrapper
+// must not advertise it, so `deno check` should fail here.
+import { loose } from "npm:@denotest/cjs-module-exports-require-member-narrow";
+
+console.log(loose);

--- a/tests/specs/npm/cjs_module_exports_require_member_narrow/main.out
+++ b/tests/specs/npm/cjs_module_exports_require_member_narrow/main.out
@@ -1,0 +1,2 @@
+safe
+attached

--- a/tests/specs/npm/cjs_module_exports_require_member_narrow/main.ts
+++ b/tests/specs/npm/cjs_module_exports_require_member_narrow/main.ts
@@ -1,0 +1,9 @@
+// Properties statically attached to the re-exported member ARE
+// advertised by the wrapper. Confirms the member-shape fallback is
+// still active for safe shapes.
+import safe, {
+  attached,
+} from "npm:@denotest/cjs-module-exports-require-member-narrow";
+
+console.log(safe());
+console.log(attached());

--- a/tests/specs/npm/cjs_module_exports_require_member_nested/__test__.jsonc
+++ b/tests/specs/npm/cjs_module_exports_require_member_nested/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tests": {
+    "attached_works": {
+      "args": "run -A --quiet main.ts",
+      "output": "main.out"
+    },
+    "loose_is_not_advertised": {
+      "args": "run -A --quiet loose.ts",
+      "output": "loose.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/npm/cjs_module_exports_require_member_nested/loose.out
+++ b/tests/specs/npm/cjs_module_exports_require_member_nested/loose.out
@@ -1,0 +1,1 @@
+[WILDCARD]does not provide an export named 'loose'[WILDCARD]

--- a/tests/specs/npm/cjs_module_exports_require_member_nested/loose.ts
+++ b/tests/specs/npm/cjs_module_exports_require_member_nested/loose.ts
@@ -1,0 +1,7 @@
+// `loose` is a named export of the inner module but is NOT a
+// property of the member the wrapper re-exports. The entry module
+// re-exports the wrapper, so `loose` must not be advertised through
+// the recursive re-export chain either.
+import { loose } from "npm:@denotest/cjs-module-exports-require-member-nested";
+
+console.log(loose);

--- a/tests/specs/npm/cjs_module_exports_require_member_nested/main.out
+++ b/tests/specs/npm/cjs_module_exports_require_member_nested/main.out
@@ -1,0 +1,2 @@
+safe
+attached

--- a/tests/specs/npm/cjs_module_exports_require_member_nested/main.ts
+++ b/tests/specs/npm/cjs_module_exports_require_member_nested/main.ts
@@ -1,0 +1,10 @@
+// The entry module re-exports a wrapper module whose body is a
+// member-shape re-export. Properties statically attached to the
+// re-exported member must still be advertised through the recursive
+// re-export chain.
+import safe, {
+  attached,
+} from "npm:@denotest/cjs-module-exports-require-member-nested";
+
+console.log(safe());
+console.log(attached());


### PR DESCRIPTION
deno_ast's CJS analyzer recognizes the bare-call form
`module.exports = require("./inner")` and surfaces the inner specifier as
a re-export, but the very common member-access form
`module.exports = require("./inner").Y` falls through unhandled. As a
result, packages whose main entry has that shape (graphql-tag@2 is the
canonical example) expose no named exports — `import { gql } from
"npm:graphql-tag"` fails with "does not provide an export named 'gql'".

When static analysis comes back with no exports and no re-exports, walk
the program's top-level statements looking for the
`module.exports = require(LIT)[.IDENT]*` pattern and treat the require
specifier as a re-export. The existing recursive re-export machinery
then resolves the inner module and picks up its named exports, which
produces the same set of names Node exposes for these packages.

Fixes #25311