### PR TITLE
fix(ext/node): reset req.reusedSocket on transparent retry

### DIFF
--- a/ext/node/polyfills/_http_client.js
+++ b/ext/node/polyfills/_http_client.js
@@ -840,6 +840,11 @@ function maybeRetryRequest(req, socket) {
   req._headerSent = false;
   req.destroyed = false;
   req._closed = false;
+  // The first attempt set reusedSocket on the stale socket. The retry runs
+  // through addRequest again, which will call agent.reuseSocket() if it
+  // happens to land on another pooled free socket. Otherwise the request
+  // goes to a brand-new connection and the flag must stay false.
+  req.reusedSocket = false;
 
   // Restore output data saved before the first flush attempt
   if (req[kRetryData]) {

--- a/tests/specs/node/http_agent_reused_socket_after_retry/__test__.jsonc
+++ b/tests/specs/node/http_agent_reused_socket_after_retry/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run -A main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/node/http_agent_reused_socket_after_retry/main.out
+++ b/tests/specs/node/http_agent_reused_socket_after_retry/main.out
@@ -1,0 +1,3 @@
+R1 reused: false
+R2 reused: false
+connections: 2

--- a/tests/specs/node/http_agent_reused_socket_after_retry/main.ts
+++ b/tests/specs/node/http_agent_reused_socket_after_retry/main.ts
@@ -1,0 +1,57 @@
+// Regression test for https://github.com/denoland/deno/issues/34370
+//
+// When an http.Agent picks a stale socket out of freeSockets, addRequest
+// sets req.reusedSocket = true before the write fails. maybeRetryRequest
+// then opens a fresh TCP connection and re-sends the request. The retry
+// must reset req.reusedSocket to false; otherwise userland code that
+// branches on the flag sees a misleading "true" for a brand-new socket.
+import http from "node:http";
+import { strictEqual } from "node:assert";
+
+const agent = new http.Agent({ keepAlive: true });
+
+const server = http.createServer((_req, res) => {
+  res.writeHead(200);
+  res.end("hi");
+});
+
+let connectionCount = 0;
+server.on("connection", () => connectionCount++);
+
+await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+const port = (server.address() as { port: number }).port;
+
+function doRequest(): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, path: "/", agent });
+    let reused = false;
+    req.on("socket", () => {
+      reused = req.reusedSocket;
+    });
+    req.on("error", reject);
+    req.on("response", (res) => {
+      res.on("data", () => {});
+      res.on("end", () => resolve(reused));
+    });
+    req.end();
+  });
+}
+
+const r1 = await doRequest();
+strictEqual(r1, false, "R1 should not reuse socket");
+console.log("R1 reused:", r1);
+
+// Let the socket land in freeSockets, then FIN the idle connection from
+// the server side. Fire R2 synchronously before Deno processes the FIN,
+// so addRequest still sees the stale socket in the free pool.
+await Promise.resolve();
+server.closeAllConnections();
+
+const r2 = await doRequest();
+strictEqual(r2, false, "R2 must report reusedSocket=false after retry");
+console.log("R2 reused:", r2);
+strictEqual(connectionCount, 2, "server should see 2 TCP connections");
+console.log("connections:", connectionCount);
+
+agent.destroy();
+server.close();


### PR DESCRIPTION
When an http.Agent picks a stale keep-alive socket out of freeSockets,
addRequest sets req.reusedSocket = true before the write fails.
maybeRetryRequest then opens a fresh TCP connection and re-sends the
request, but the flag was never reset alongside the other request state.
Userland code that branches on reusedSocket (e.g. capturing
socket.remoteAddress only on initial connect) saw a misleading "true"
for what was actually a brand-new connection.

Fixes #34370