### PR TITLE
fix(inspector): emit NodeWorker.attachedToWorker for late workers

### DIFF
--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -627,6 +627,19 @@ impl JsRuntimeInspectorState {
                     }),
                   ));
                 }
+
+                if self.nodeworker_enabled.get() {
+                  (main_session.state.send)(InspectorMsg::notification(
+                    json!({
+                      "method": "NodeWorker.attachedToWorker",
+                      "params": {
+                        "sessionId": ts.session_id,
+                        "workerInfo": ts.worker_info(),
+                        "waitingForDebugger": false
+                      }
+                    }),
+                  ));
+                }
               }
 
               continue;

--- a/tests/unit/inspector_test.ts
+++ b/tests/unit/inspector_test.ts
@@ -855,6 +855,58 @@ Deno.test("inspector_worker_target_discovery", async () => {
   }
 });
 
+// Regression test for https://github.com/denoland/deno/issues/34291
+// vscode-js-debug calls NodeWorker.enable before the user script runs, so
+// any Worker constructor fires *after* NodeWorker.enable has been processed.
+// Previously these later workers were not announced — NodeWorker.enable
+// only walked existing workers, and the new-worker registration path only
+// emitted Target.* events. Now NodeWorker.attachedToWorker fires for both.
+Deno.test("inspector_node_worker_attached_after_enable", async () => {
+  const script = `${testdataPath}/worker_main.js`;
+  const tester = await InspectorTester.create(
+    ["run", "-A", "--inspect-brk=0", script],
+    { notificationFilter: ignoreScriptParsed },
+  );
+
+  try {
+    await tester.assertStderrForInspectBrk();
+
+    tester.sendMany([
+      { id: 1, method: "Runtime.enable" },
+      { id: 2, method: "Debugger.enable" },
+      {
+        id: 3,
+        method: "NodeWorker.enable",
+        params: { waitForDebuggerOnStart: false },
+      },
+      { id: 4, method: "Runtime.runIfWaitingForDebugger" },
+    ]);
+
+    await tester.expectResponse(1);
+    await tester.expectResponse(2);
+    await tester.expectResponse(3);
+    await tester.expectResponse(4);
+    await tester.expectNotification("Runtime.executionContextCreated");
+    await tester.expectNotification("Debugger.paused");
+
+    tester.send({ id: 5, method: "Debugger.resume" });
+    await tester.expectResponse(5);
+
+    const attached = await tester.expectNotification(
+      "NodeWorker.attachedToWorker",
+    );
+    const params = attached.params as Record<string, unknown>;
+    assert(params.sessionId, "attachedToWorker should include sessionId");
+    const workerInfo = params.workerInfo as Record<string, unknown>;
+    assert(workerInfo, "attachedToWorker should include workerInfo");
+    assertEquals(workerInfo.type, "node_worker");
+  } finally {
+    await tester.close();
+    tester.kill();
+    await tester.waitForExit();
+  }
+});
+
 Deno.test("inspector_node_worker_enable", async () => {
   const script = `${testdataPath}/worker_main.js`;
   const tester = await InspectorTester.create(


### PR DESCRIPTION
vscode-js-debug uses the `NodeWorker.*` CDP domain and sends
`NodeWorker.enable` before `Runtime.runIfWaitingForDebugger`, so every
`Worker` created by the user script is registered *after* the inspector
has been enabled. Previously `NodeWorker.enable` only walked workers
that already existed at the time of the call, and the new-worker
registration path only emitted `Target.targetCreated` /
`Target.attachedToTarget` (used by Chrome DevTools via
`Target.setAutoAttach`). As a result the VSCode debugger never saw any
Worker created during a debug session — it failed to attach to them and
breakpoints inside the worker were silently ignored.

Mirror the existing `Target.*` branches in the worker registration path
so a `NodeWorker.attachedToWorker` notification is emitted whenever a
new worker is registered and `NodeWorker.enable` is active.

Fixes #34291