### PR TITLE
fix: panic in deno test --parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11296,9 +11296,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "149.0.0"
+version = "149.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55897294cf631f99d5ff57c6a0611648861645ed7c8f251579161e0768812840"
+checksum = "46dccf61a364b61bbaac70a8ba64a1a1006e87123b7d62eaeec999a3ba31ecdb"
 dependencies = [
  "bindgen 0.72.1",
  "bitflags 2.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ deno_task_shell = "=0.32.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"
-v8 = { version = "149.0.0", default-features = false, features = ["simdutf"] }
+v8 = { version = "149.2.0", default-features = false, features = ["simdutf"] }
 
 denokv_proto = "0.13.0"
 denokv_remote = "0.13.0"


### PR DESCRIPTION
Bumps rusty_v8 from 149.0.0 to 149.2.0. The V8 14.6 -> 14.9 upgrade
(#34226) introduced a regression where running tests with
\`deno test --parallel\` consistently panics on the isolate annex
assertion (\`assertion failed: !annex_ptr.is_null()\` in
\`v8-149.0.0/src/isolate.rs:1041\`) across multiple
\`tokio-runtime-worker\` threads. The new rusty_v8 release contains the
upstream fix.

Closes #34311