### PR TITLE
fix(ext/node): TLSSocket.authorized=false when client presents no cert

### DIFF
--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -1147,6 +1147,14 @@ function onServerSocketSecure() {
         this.destroy();
         return;
       }
+    } else if (this._handle.getPeerCertificate(false) == null) {
+      // `rejectUnauthorized: false` lets the handshake complete even when
+      // the client presented no certificate. rustls only invokes the
+      // client cert verifier when a cert is actually presented, so
+      // `verifyError()` is empty in this case. Match Node's behaviour
+      // and surface "no client cert" as an authorization error rather
+      // than reporting `authorized = true`.
+      this.authorizationError = "UNABLE_TO_GET_ISSUER_CERT";
     } else {
       this.authorized = true;
     }

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -576,6 +576,62 @@ Deno.test("mTLS client certificate authentication", async () => {
   await new Promise<void>((resolve) => server.on("close", resolve));
 });
 
+Deno.test(
+  "requestCert + rejectUnauthorized:false: no client cert => authorized=false",
+  async () => {
+    const server = tls.createServer({
+      key,
+      cert,
+      ca: [rootCaCert],
+      requestCert: true,
+      rejectUnauthorized: false,
+    }, (socket) => {
+      // deno-lint-ignore no-explicit-any
+      const s = socket as any;
+      socket.write(
+        JSON.stringify({
+          authorized: s.authorized,
+          authorizationError: s.authorizationError?.code ??
+            s.authorizationError,
+          peerCertSubject: socket.getPeerCertificate()?.subject,
+        }),
+      );
+      socket.end();
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+
+    server.listen(0, () => {
+      // deno-lint-ignore no-explicit-any
+      const port = (server.address() as any)?.port;
+
+      const client = tls.connect({
+        host: "localhost",
+        port,
+        ca: rootCaCert,
+      });
+
+      client.setEncoding("utf8");
+      let data = "";
+      client.on("data", (chunk) => {
+        data += chunk;
+      });
+      client.on("end", () => {
+        client.destroy();
+        resolve(data);
+      });
+      client.on("error", (err) => reject(err));
+    });
+
+    const result = JSON.parse(await promise);
+    assertEquals(result.authorized, false);
+    assertEquals(result.authorizationError, "UNABLE_TO_GET_ISSUER_CERT");
+    assertEquals(result.peerCertSubject, undefined);
+    server.close();
+    await new Promise<void>((resolve) => server.on("close", resolve));
+  },
+);
+
 Deno.test("tls.getCACertificates returns bundled certificates", () => {
   const certs = tls.getCACertificates("bundled");
   assert(Array.isArray(certs));


### PR DESCRIPTION
A `node:tls` server with `requestCert: true, rejectUnauthorized: false`
was incorrectly reporting `socket.authorized === true` and a null
`authorizationError` when the client connected without presenting any
client certificate. Node reports `authorized = false` with
`authorizationError = "UNABLE_TO_GET_ISSUER_CERT"` in this case, so
application code that gates trust on `socket.authorized` was treating
unauthenticated connections as authenticated.

rustls only invokes the `ClientCertVerifier` when the client actually
sends a certificate, and `client_auth_mandatory` returns the
`reject_unauthorized` flag — so with `rejectUnauthorized: false` the
verifier never runs and the shared `verifyError` slot stays empty.
`onServerSocketSecure` then fell into the `authorized = true` branch.
Detect the no-cert case explicitly via `getPeerCertificate(false) ==
null` and surface it as the matching Node authorization code.

Fixes #34366