### PR TITLE
fix(ext/node): prevent panic on `node:sqlite` aggregate method

### DIFF
--- a/ext/node_sqlite/database.rs
+++ b/ext/node_sqlite/database.rs
@@ -2386,24 +2386,12 @@ unsafe extern "C" fn custom_aggregate_xvalue(
 
 unsafe extern "C" fn custom_aggregate_xdestroy(data: *mut c_void) {
   // SAFETY: `data` is a valid pointer to CustomAggregate.
-  // The v8 handles are properly dropped here.
+  // We intentionally do not re-enter V8 here. SQLite may invoke this
+  // destructor while the isolate is already tearing down, so creating a
+  // callback scope can panic. The raw V8 handles are allowed to leak in that
+  // case, matching the custom function destroy path.
   unsafe {
-    let data = Box::from_raw(data as *mut CustomAggregate);
-    let context_local: v8::Local<v8::Context> =
-      std::mem::transmute(data.context.as_ptr());
-
-    v8::callback_scope!(unsafe cb_scope, context_local);
-    v8::scope!(scope, cb_scope);
-
-    let _ = v8::Global::from_raw(scope, data.context);
-    let _ = v8::Global::from_raw(scope, data.start);
-    let _ = v8::Global::from_raw(scope, data.step_fn);
-    if let Some(inverse_ptr) = data.inverse_fn {
-      let _ = v8::Global::from_raw(scope, inverse_ptr);
-    }
-    if let Some(final_ptr) = data.final_fn {
-      let _ = v8::Global::from_raw(scope, final_ptr);
-    }
+    let _ = Box::from_raw(data as *mut CustomAggregate);
   }
 }
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3292,6 +3292,7 @@
     // TODO(bartlomieju): disabled during work on `node:inspector`, this test didn't actualy run before
     // "parallel/test-source-map-enable.js": {},
     "parallel/test-socket-write-after-fin.js": {},
+    "parallel/test-sqlite-aggregate-function.mjs": {},
     "parallel/test-sqlite-authz.js": {},
     "parallel/test-sqlite-config.js": {},
     "parallel/test-sqlite-custom-functions.js": {},


### PR DESCRIPTION
This implementation was written by AI.

Previously, the SQLite xDestroy callback re-entered V8 during SQLite cleanup, when the isolate may already be tearing down and V8’s isolate annex is no longer available. This change makes Deno’s aggregate teardown behave like Node’s safer cleanup path. It no longer creates a V8 callback scope or tries to drop V8 globals during destructor execution.

Similar behavior found on [#33422](https://github.com/denoland/deno/pull/33422/changes#diff-adc24d66fd68f964625b38168b1f0a129fe6186c1ca62df4f5bf76cd5f05bfb5). This allows https://github.com/nodejs/node/blob/v25.8.1/test/parallel/test-sqlite-aggregate-function.mjs to pass.