### PR TITLE
feat(ext/http): deprecation warning for legacy request abort

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -103,6 +103,8 @@ const {
 
 const _upgraded = Symbol("_upgraded");
 
+let legacyAbortWarned = false;
+
 function internalServerError() {
   // "Internal Server Error"
   return new Response(
@@ -171,6 +173,7 @@ class InnerRequest {
   #upgraded;
   #urlValue;
   #completed;
+  #signalAccessed;
   request;
 
   constructor(external, context) {
@@ -178,6 +181,7 @@ class InnerRequest {
     this.#context = context;
     this.#upgraded = false;
     this.#completed = undefined;
+    this.#signalAccessed = false;
   }
 
   close(success = true) {
@@ -195,6 +199,13 @@ class InnerRequest {
       }
     }
     if (this.#context.legacyAbort) {
+      if (success && this.#signalAccessed && !legacyAbortWarned) {
+        legacyAbortWarned = true;
+        // deno-lint-ignore no-console
+        console.warn(
+          "Deno.serve: request.signal aborts on successful responses (legacy behavior, see https://github.com/denoland/deno/issues/29111). Move cleanup to the handler's return path, or opt in to the new behavior with --unstable-no-legacy-abort. See https://docs.deno.com/runtime/reference/migrate-deprecations/",
+        );
+      }
       abortRequest(this.request);
     }
     this.#external = null;
@@ -419,6 +430,7 @@ class InnerRequest {
   }
 
   onCancel(callback) {
+    this.#signalAccessed = true;
     if (this.#external === null) {
       if (this.#context.legacyAbort) callback();
       return;
@@ -1157,6 +1169,9 @@ internals.upgradeHttpRaw = upgradeHttpRaw;
 internals.upgradeHttpRawConnect = upgradeHttpRawConnect;
 internals.serveHttpOnListener = serveHttpOnListener;
 internals.serveHttpOnConnection = serveHttpOnConnection;
+internals.resetLegacyAbortWarning = () => {
+  legacyAbortWarned = false;
+};
 
 function registerDeclarativeServer(exports) {
   if (!ObjectHasOwn(exports, "fetch")) return;

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -30,6 +30,7 @@ const {
   serveHttpOnListener,
   serveHttpOnConnection,
   getCachedAbortSignal,
+  resetLegacyAbortWarning,
   // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
 } = Deno[Deno.internal];
 
@@ -4540,5 +4541,106 @@ Deno.test(
     await serverWebSocketClosed.promise;
     ac.abort();
     await server.finished;
+  },
+);
+
+async function captureLegacyAbortWarnings(
+  fn: () => Promise<void>,
+): Promise<string[]> {
+  resetLegacyAbortWarning();
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    if (typeof args[0] === "string" && args[0].includes("request.signal")) {
+      warnings.push(args[0]);
+      return;
+    }
+    originalWarn(...args);
+  };
+  try {
+    await fn();
+  } finally {
+    console.warn = originalWarn;
+    resetLegacyAbortWarning();
+  }
+  return warnings;
+}
+
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerLegacyAbortWarningFiresOnce() {
+    const warnings = await captureLegacyAbortWarnings(async () => {
+      const { finished, shutdown } = await makeServer((req) => {
+        req.signal.addEventListener("abort", () => {});
+        return new Response("ok");
+      });
+      for (let i = 0; i < 3; i++) {
+        await (await fetch(`http://localhost:${servePort}`)).text();
+      }
+      await shutdown();
+      await finished;
+    });
+    assertEquals(warnings.length, 1);
+    assertStringIncludes(warnings[0], "request.signal");
+    assertStringIncludes(warnings[0], "--unstable-no-legacy-abort");
+  },
+);
+
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerLegacyAbortWarningSkipsWhenSignalUntouched() {
+    const warnings = await captureLegacyAbortWarnings(async () => {
+      const { finished, shutdown } = await makeServer(() => {
+        return new Response("ok");
+      });
+      for (let i = 0; i < 3; i++) {
+        await (await fetch(`http://localhost:${servePort}`)).text();
+      }
+      await shutdown();
+      await finished;
+    });
+    assertEquals(warnings.length, 0);
+  },
+);
+
+Deno.test(
+  { permissions: { net: true, run: true, read: true } },
+  async function httpServerLegacyAbortWarningSilentUnderUnstableFlag() {
+    const subprocessPort = servePort + 1;
+    const code = `
+      const originalWarn = console.warn;
+      let warned = false;
+      console.warn = (...args) => {
+        if (typeof args[0] === "string" && args[0].includes("request.signal")) {
+          warned = true;
+        }
+        originalWarn(...args);
+      };
+      const { promise, resolve } = Promise.withResolvers();
+      const server = Deno.serve({
+        port: ${subprocessPort},
+        handler: (req) => {
+          req.signal.addEventListener("abort", () => {});
+          return new Response("ok");
+        },
+        onListen: resolve,
+      });
+      await promise;
+      for (let i = 0; i < 3; i++) {
+        await (await fetch("http://localhost:${subprocessPort}")).text();
+      }
+      console.log(warned ? "WARNED" : "QUIET");
+      await server.shutdown();
+    `;
+    const command = new Deno.Command(Deno.execPath(), {
+      args: ["eval", "--unstable-no-legacy-abort", code],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { code: exitCode, stdout } = await command.output();
+    const output = new TextDecoder().decode(stdout);
+    assertEquals(exitCode, 0);
+    assertStringIncludes(output, "QUIET");
+    assert(!output.includes("WARNED"));
   },
 );


### PR DESCRIPTION
Deno.serve currently fires `abort` on `request.signal` even when the
handler returns a successful response. This breaks common Node proxy
libraries (Vite's http-proxy, http-proxy-middleware) which treat the
upstream abort as a real failure. The opt-in `--unstable-no-legacy-abort`
flag landed ~14 months ago to fix this but has seen almost no adoption,
so before flipping the default in an upcoming minor release we want a
deprecation warning so affected users discover the issue first.

This emits a single `console.warn` per worker process when legacyAbort
is the active mode, the handler accessed `request.signal`, and the
request completed successfully. Signal access is detected by flagging
`InnerRequest.onCancel`, which the `request.signal` getter invokes on
first read, so handlers that never touch the signal pay no extra cost.
The warning suggests moving cleanup to the handler's return path or
opting in to `--unstable-no-legacy-abort` today.

Refs #28850, #29111