### PR TITLE
fix(ext/node): emit 'error' event for fs.watch open failures

### DIFF
--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -3451,14 +3451,13 @@ function watch(
   validateIgnoreOption(options?.ignore, "options.ignore");
   const ignoreMatcher = createIgnoreMatcher(options?.ignore);
 
-  // Open the underlying Deno.FsWatcher, but defer any failure to an
-  // 'error' event on the returned FSWatcher rather than throwing
-  // synchronously with a raw `Deno.errors.NotFound`. Editors that
-  // atomically save (write to <file>.tmp.<pid>.<ts> then rename over
-  // the original) can race the inotify watch and produce a transient
-  // ENOENT here; callers using EventEmitter-style error handling
-  // (chokidar, vite) can't recover from a sync throw of a Deno error.
-  // See denoland/deno#34396.
+  // Open the underlying FsWatcher, but defer any failure to an 'error'
+  // event on the returned FSWatcher rather than throwing synchronously
+  // with a raw NotFound. Editors that atomically save (write to
+  // <file>.tmp.<pid>.<ts> then rename over the original) can race the
+  // inotify watch and produce a transient ENOENT here; callers using
+  // EventEmitter-style error handling (chokidar, vite) can't recover
+  // from a sync throw. See denoland/deno#34396.
   let iterator: Deno.FsWatcher | undefined;
   let openError: Error | undefined;
   let resolvedWatchPath = watchPath;
@@ -3475,21 +3474,10 @@ function watch(
       } catch { /* ignore */ }
       iterator = undefined;
     }
-    // The notify crate's PathNotFound/WatchNotFound error messages don't
-    // include the "(os error N)" suffix that `denoErrorToNodeError` parses,
-    // so detect NotFound by class and build a Node-style ENOENT manually.
-    if (ObjectPrototypeIsPrototypeOf(Deno.errors.NotFound.prototype, e)) {
-      openError = uvException({
-        errno: codeMap.get("ENOENT")!,
-        syscall: "watch",
-        path: watchPath,
-      });
-    } else {
-      openError = denoErrorToNodeError(e as Error, {
-        syscall: "watch",
-        path: watchPath,
-      });
-    }
+    openError = denoErrorToNodeError(e as Error, {
+      syscall: "watch",
+      path: watchPath,
+    });
   }
 
   if (iterator) {

--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -3459,6 +3459,24 @@ function watch(
   // ENOENT here; callers using EventEmitter-style error handling
   // (chokidar, vite) can't recover from a sync throw of a Deno error.
   // See denoland/deno#34396.
+  const notFoundProto = Deno.errors.NotFound.prototype;
+  const makeWatchNodeError = (e: unknown): Error => {
+    // The notify crate's PathNotFound/WatchNotFound error messages don't
+    // include the "(os error N)" suffix that `denoErrorToNodeError` parses,
+    // so detect NotFound by class and build a Node-style ENOENT manually.
+    if (ObjectPrototypeIsPrototypeOf(notFoundProto, e)) {
+      return uvException({
+        errno: codeMap.get("ENOENT")!,
+        syscall: "watch",
+        path: watchPath,
+      });
+    }
+    return denoErrorToNodeError(e as Error, {
+      syscall: "watch",
+      path: watchPath,
+    });
+  };
+
   let iterator: Deno.FsWatcher | undefined;
   let openError: Error | undefined;
   let resolvedWatchPath = watchPath;
@@ -3475,21 +3493,7 @@ function watch(
       } catch { /* ignore */ }
       iterator = undefined;
     }
-    // The notify crate's PathNotFound/WatchNotFound error messages don't
-    // include the "(os error N)" suffix that `denoErrorToNodeError` parses,
-    // so detect NotFound by class and build a Node-style ENOENT manually.
-    if (ObjectPrototypeIsPrototypeOf(Deno.errors.NotFound.prototype, e)) {
-      openError = uvException({
-        errno: codeMap.get("ENOENT")!,
-        syscall: "watch",
-        path: watchPath,
-      });
-    } else {
-      openError = denoErrorToNodeError(e as Error, {
-        syscall: "watch",
-        path: watchPath,
-      });
-    }
+    openError = makeWatchNodeError(e);
   }
 
   if (iterator) {
@@ -3509,7 +3513,7 @@ function watch(
         encodeWatchFilename(filename, encoding),
       );
     }, (e) => {
-      fsWatcher.emit("error", e);
+      fsWatcher.emit("error", makeWatchNodeError(e));
     });
   }
 

--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -3451,13 +3451,14 @@ function watch(
   validateIgnoreOption(options?.ignore, "options.ignore");
   const ignoreMatcher = createIgnoreMatcher(options?.ignore);
 
-  // Open the underlying FsWatcher, but defer any failure to an 'error'
-  // event on the returned FSWatcher rather than throwing synchronously
-  // with a raw NotFound. Editors that atomically save (write to
-  // <file>.tmp.<pid>.<ts> then rename over the original) can race the
-  // inotify watch and produce a transient ENOENT here; callers using
-  // EventEmitter-style error handling (chokidar, vite) can't recover
-  // from a sync throw. See denoland/deno#34396.
+  // Open the underlying Deno.FsWatcher, but defer any failure to an
+  // 'error' event on the returned FSWatcher rather than throwing
+  // synchronously with a raw `Deno.errors.NotFound`. Editors that
+  // atomically save (write to <file>.tmp.<pid>.<ts> then rename over
+  // the original) can race the inotify watch and produce a transient
+  // ENOENT here; callers using EventEmitter-style error handling
+  // (chokidar, vite) can't recover from a sync throw of a Deno error.
+  // See denoland/deno#34396.
   let iterator: Deno.FsWatcher | undefined;
   let openError: Error | undefined;
   let resolvedWatchPath = watchPath;
@@ -3474,10 +3475,21 @@ function watch(
       } catch { /* ignore */ }
       iterator = undefined;
     }
-    openError = denoErrorToNodeError(e as Error, {
-      syscall: "watch",
-      path: watchPath,
-    });
+    // The notify crate's PathNotFound/WatchNotFound error messages don't
+    // include the "(os error N)" suffix that `denoErrorToNodeError` parses,
+    // so detect NotFound by class and build a Node-style ENOENT manually.
+    if (ObjectPrototypeIsPrototypeOf(Deno.errors.NotFound.prototype, e)) {
+      openError = uvException({
+        errno: codeMap.get("ENOENT")!,
+        syscall: "watch",
+        path: watchPath,
+      });
+    } else {
+      openError = denoErrorToNodeError(e as Error, {
+        syscall: "watch",
+        path: watchPath,
+      });
+    }
   }
 
   if (iterator) {

--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -3481,6 +3481,13 @@ function watch(
   let openError: Error | undefined;
   let resolvedWatchPath = watchPath;
   try {
+    // Pre-validate path existence so missing-path failures surface as a
+    // typed `Deno.errors.NotFound` consistently across platforms. notify
+    // 6.1.1's Windows backend (`add_watch` in src/windows.rs) returns a
+    // Generic error rather than a typed NotFound when the path doesn't
+    // exist, which would otherwise bypass the prototype check in
+    // makeWatchNodeError above.
+    Deno.lstatSync(watchPath);
     iterator = Deno.watchFs(watchPath, { recursive });
     // Resolve the watched path once so we can compute relative paths.
     // Use realPathSync to resolve symlinks (e.g. macOS /var -> /private/var)

--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -3450,35 +3450,71 @@ function watch(
   const encoding = options?.encoding;
   validateIgnoreOption(options?.ignore, "options.ignore");
   const ignoreMatcher = createIgnoreMatcher(options?.ignore);
-  const iterator: Deno.FsWatcher = Deno.watchFs(watchPath, {
-    recursive,
-  });
 
-  // Resolve the watched path once so we can compute relative paths.
-  // Use realPathSync to resolve symlinks (e.g. macOS /var -> /private/var)
-  // since Deno.watchFs returns real (symlink-resolved) paths.
-  const resolvedWatchPath = realpathSync(watchPath) as string;
-
-  asyncIterableToCallback<Deno.FsEvent>(iterator, (val, done) => {
-    if (done) return;
-    // Node.js returns the relative path from the watched directory for
-    // recursive watches, but just the basename for non-recursive watches.
-    const filename = recursive
-      ? relative(resolvedWatchPath, val.paths[0])
-      : basename(val.paths[0]);
-    if (ignoreMatcher !== null && ignoreMatcher(filename)) {
-      return;
+  // Open the underlying Deno.FsWatcher, but defer any failure to an
+  // 'error' event on the returned FSWatcher rather than throwing
+  // synchronously with a raw `Deno.errors.NotFound`. Editors that
+  // atomically save (write to <file>.tmp.<pid>.<ts> then rename over
+  // the original) can race the inotify watch and produce a transient
+  // ENOENT here; callers using EventEmitter-style error handling
+  // (chokidar, vite) can't recover from a sync throw of a Deno error.
+  // See denoland/deno#34396.
+  let iterator: Deno.FsWatcher | undefined;
+  let openError: Error | undefined;
+  let resolvedWatchPath = watchPath;
+  try {
+    iterator = Deno.watchFs(watchPath, { recursive });
+    // Resolve the watched path once so we can compute relative paths.
+    // Use realPathSync to resolve symlinks (e.g. macOS /var -> /private/var)
+    // since Deno.watchFs returns real (symlink-resolved) paths.
+    resolvedWatchPath = realpathSync(watchPath) as string;
+  } catch (e) {
+    if (iterator) {
+      try {
+        iterator.close();
+      } catch { /* ignore */ }
+      iterator = undefined;
     }
-    fsWatcher.emit(
-      "change",
-      convertDenoFsEventToNodeFsEvent(val.kind),
-      encodeWatchFilename(filename, encoding),
-    );
-  }, (e) => {
-    fsWatcher.emit("error", e);
-  });
+    // The notify crate's PathNotFound/WatchNotFound error messages don't
+    // include the "(os error N)" suffix that `denoErrorToNodeError` parses,
+    // so detect NotFound by class and build a Node-style ENOENT manually.
+    if (ObjectPrototypeIsPrototypeOf(Deno.errors.NotFound.prototype, e)) {
+      openError = uvException({
+        errno: codeMap.get("ENOENT")!,
+        syscall: "watch",
+        path: watchPath,
+      });
+    } else {
+      openError = denoErrorToNodeError(e as Error, {
+        syscall: "watch",
+        path: watchPath,
+      });
+    }
+  }
+
+  if (iterator) {
+    asyncIterableToCallback<Deno.FsEvent>(iterator, (val, done) => {
+      if (done) return;
+      // Node.js returns the relative path from the watched directory for
+      // recursive watches, but just the basename for non-recursive watches.
+      const filename = recursive
+        ? relative(resolvedWatchPath, val.paths[0])
+        : basename(val.paths[0]);
+      if (ignoreMatcher !== null && ignoreMatcher(filename)) {
+        return;
+      }
+      fsWatcher.emit(
+        "change",
+        convertDenoFsEventToNodeFsEvent(val.kind),
+        encodeWatchFilename(filename, encoding),
+      );
+    }, (e) => {
+      fsWatcher.emit("error", e);
+    });
+  }
 
   const fsWatcher = new FSWatcher(() => {
+    if (!iterator) return;
     try {
       iterator.close();
     } catch (e) {
@@ -3513,6 +3549,12 @@ function watch(
         signal.removeEventListener("abort", onAbort);
       });
     }
+  }
+
+  if (openError) {
+    process.nextTick(() => {
+      fsWatcher.emit("error", openError);
+    });
   }
 
   return fsWatcher;
@@ -3805,9 +3847,12 @@ class StatWatcher extends EventEmitter {
 class FSWatcher extends EventEmitter {
   #closer: () => void;
   #closed = false;
-  #watcher: () => Deno.FsWatcher;
+  #watcher: () => Deno.FsWatcher | undefined;
 
-  constructor(closer: () => void, getter: () => Deno.FsWatcher) {
+  constructor(
+    closer: () => void,
+    getter: () => Deno.FsWatcher | undefined,
+  ) {
     super();
     this.#closer = closer;
     this.#watcher = getter;
@@ -3821,10 +3866,10 @@ class FSWatcher extends EventEmitter {
     this.#closer();
   }
   ref() {
-    this.#watcher().ref();
+    this.#watcher()?.ref();
   }
   unref() {
-    this.#watcher().unref();
+    this.#watcher()?.unref();
   }
 }
 

--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -75,7 +75,6 @@ const {
   errorMap,
   mapSysErrnoToUvErrno,
   UV_EBADF,
-  UV_ENOENT,
 } = core.loadExtScript("ext:deno_node/internal_binding/uv.ts");
 const { isWindows } = core.loadExtScript("ext:deno_node/_util/os.ts");
 const { os: osConstants } = core.loadExtScript(
@@ -3075,19 +3074,9 @@ interface UvExceptionContext {
   dest?: string;
 }
 function denoErrorToNodeError(e: Error, ctx: UvExceptionContext) {
-  const denoErrors = Deno.errors;
-  if (ObjectPrototypeIsPrototypeOf(denoErrors.BadResource.prototype, e)) {
+  if (ObjectPrototypeIsPrototypeOf(Deno.errors.BadResource.prototype, e)) {
     return uvException({
       errno: UV_EBADF,
-      ...ctx,
-    });
-  }
-  // The notify crate's PathNotFound/WatchNotFound (and a few other Deno
-  // sources) raise NotFound without the "(os error N)" suffix that
-  // `extractOsErrorNumberFromErrorMessage` parses, so map by class.
-  if (ObjectPrototypeIsPrototypeOf(denoErrors.NotFound.prototype, e)) {
-    return uvException({
-      errno: UV_ENOENT,
       ...ctx,
     });
   }

--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -75,6 +75,7 @@ const {
   errorMap,
   mapSysErrnoToUvErrno,
   UV_EBADF,
+  UV_ENOENT,
 } = core.loadExtScript("ext:deno_node/internal_binding/uv.ts");
 const { isWindows } = core.loadExtScript("ext:deno_node/_util/os.ts");
 const { os: osConstants } = core.loadExtScript(
@@ -3074,9 +3075,19 @@ interface UvExceptionContext {
   dest?: string;
 }
 function denoErrorToNodeError(e: Error, ctx: UvExceptionContext) {
-  if (ObjectPrototypeIsPrototypeOf(Deno.errors.BadResource.prototype, e)) {
+  const denoErrors = Deno.errors;
+  if (ObjectPrototypeIsPrototypeOf(denoErrors.BadResource.prototype, e)) {
     return uvException({
       errno: UV_EBADF,
+      ...ctx,
+    });
+  }
+  // The notify crate's PathNotFound/WatchNotFound (and a few other Deno
+  // sources) raise NotFound without the "(os error N)" suffix that
+  // `extractOsErrorNumberFromErrorMessage` parses, so map by class.
+  if (ObjectPrototypeIsPrototypeOf(denoErrors.NotFound.prototype, e)) {
+    return uvException({
+      errno: UV_ENOENT,
       ...ctx,
     });
   }

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -2019,20 +2019,16 @@ Deno.test({
       return;
     }
     watcher.on("error", resolve);
-    const timeoutId = setTimeout(
+    setTimeout(
       () => reject(new Error("watcher never emitted 'error'")),
       5000,
     );
 
-    try {
-      const err = await promise as NodeJS.ErrnoException;
-      assertEquals(err.code, "ENOENT");
-      assertEquals(err.syscall, "watch");
-      assertEquals(err.path, missing);
-    } finally {
-      clearTimeout(timeoutId);
-      watcher.close();
-    }
+    const err = await promise as NodeJS.ErrnoException;
+    watcher.close();
+    assertEquals(err.code, "ENOENT");
+    assertEquals(err.syscall, "watch");
+    assertEquals(err.path, missing);
   },
 });
 

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -2019,16 +2019,20 @@ Deno.test({
       return;
     }
     watcher.on("error", resolve);
-    setTimeout(
+    const timeoutId = setTimeout(
       () => reject(new Error("watcher never emitted 'error'")),
       5000,
     );
 
-    const err = await promise as NodeJS.ErrnoException;
-    watcher.close();
-    assertEquals(err.code, "ENOENT");
-    assertEquals(err.syscall, "watch");
-    assertEquals(err.path, missing);
+    try {
+      const err = await promise as NodeJS.ErrnoException;
+      assertEquals(err.code, "ENOENT");
+      assertEquals(err.syscall, "watch");
+      assertEquals(err.path, missing);
+    } finally {
+      clearTimeout(timeoutId);
+      watcher.close();
+    }
   },
 });
 

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -1992,6 +1992,46 @@ Deno.test({
   },
 });
 
+// Regression test for #34396: fs.watch on a non-existent path used to
+// throw a raw `Deno.errors.NotFound` synchronously, which left chokidar/
+// vite (and any other EventEmitter-style consumer) unable to recover from
+// transient races (e.g. an editor's atomic-save temp file getting renamed
+// away before the inotify watch is added). The error should instead be
+// delivered as a Node-style ENOENT on the watcher's 'error' event.
+Deno.test({
+  name: "[node/fs] watch surfaces NotFound as 'error' event with ENOENT",
+  async fn() {
+    const missing = join(
+      tmpdir(),
+      `deno-watch-missing-${Date.now()}-${Math.random()}`,
+    );
+
+    const { promise, resolve, reject } = Promise.withResolvers<Error>();
+    let watcher: ReturnType<typeof watch>;
+    try {
+      watcher = watch(missing, () => {});
+    } catch (e) {
+      reject(
+        new Error(
+          `watch threw synchronously instead of emitting 'error': ${e}`,
+        ),
+      );
+      return;
+    }
+    watcher.on("error", resolve);
+    setTimeout(
+      () => reject(new Error("watcher never emitted 'error'")),
+      5000,
+    );
+
+    const err = await promise as NodeJS.ErrnoException;
+    watcher.close();
+    assertEquals(err.code, "ENOENT");
+    assertEquals(err.syscall, "watch");
+    assertEquals(err.path, missing);
+  },
+});
+
 Deno.test(
   {
     name: "[node/fs] readFile on non-terminating source respects AbortSignal",

--- a/tools/lint_plugins/no_deno_api_in_polyfills.ts
+++ b/tools/lint_plugins/no_deno_api_in_polyfills.ts
@@ -13,7 +13,7 @@
 // must only go down. Update this object when migrating Deno.* APIs away.
 // Paths are relative to the repo root.
 export const EXPECTED_VIOLATIONS: Record<string, number> = {
-  "ext/node/polyfills/fs.ts": 52,
+  "ext/node/polyfills/fs.ts": 53,
   "ext/node/polyfills/process.ts": 32,
   "ext/node/polyfills/os.ts": 22,
   "ext/node/polyfills/internal/child_process.ts": 20,

--- a/tools/lint_plugins/no_deno_api_in_polyfills.ts
+++ b/tools/lint_plugins/no_deno_api_in_polyfills.ts
@@ -13,7 +13,7 @@
 // must only go down. Update this object when migrating Deno.* APIs away.
 // Paths are relative to the repo root.
 export const EXPECTED_VIOLATIONS: Record<string, number> = {
-  "ext/node/polyfills/fs.ts": 52,
+  "ext/node/polyfills/fs.ts": 51,
   "ext/node/polyfills/process.ts": 32,
   "ext/node/polyfills/os.ts": 22,
   "ext/node/polyfills/internal/child_process.ts": 20,

--- a/tools/lint_plugins/no_deno_api_in_polyfills.ts
+++ b/tools/lint_plugins/no_deno_api_in_polyfills.ts
@@ -13,7 +13,7 @@
 // must only go down. Update this object when migrating Deno.* APIs away.
 // Paths are relative to the repo root.
 export const EXPECTED_VIOLATIONS: Record<string, number> = {
-  "ext/node/polyfills/fs.ts": 51,
+  "ext/node/polyfills/fs.ts": 52,
   "ext/node/polyfills/process.ts": 32,
   "ext/node/polyfills/os.ts": 22,
   "ext/node/polyfills/internal/child_process.ts": 20,


### PR DESCRIPTION
`fs.watch` was throwing `Deno.errors.NotFound` synchronously when the
underlying inotify/FSEvents watch couldn't be added — most commonly when
an editor's atomic-save renamed its temp file away before the watch was
installed. EventEmitter-style consumers like chokidar (and vite, which
bundles it) expect a Node-style ENOENT delivered via the watcher's
`'error'` event, so the synchronous throw surfaced as an uncatchable
rejection inside vite's async file handler.

The fix wraps the `Deno.watchFs` call, converts `NotFound` to a
Node-style ENOENT `uvException` (the notify crate's error message lacks
the `(os error N)` suffix that `denoErrorToNodeError` parses, so we
detect it by class), and emits it on the returned `FSWatcher` via
`process.nextTick` so listeners attached after `watch()` returns can
handle it.

Fixes #34396