### PR TITLE
fix(runtime): lazy-loaded globals should shadow on inherited [[Set]]

### DIFF
--- a/libs/core/01_core.js
+++ b/libs/core/01_core.js
@@ -877,12 +877,26 @@
         return getter(loadFn());
       },
       set(v) {
-        ObjectDefineProperty(this, desc[lazyNameSym], {
-          value: v,
-          writable: true,
-          enumerable: false,
-          configurable: true,
-        });
+        const name = desc[lazyNameSym];
+        // Match OrdinarySetWithOwnDescriptor semantics for an inherited
+        // writable data property: a direct set on the holder updates the
+        // value in place (preserving enumerable: false), while an inherited
+        // set creates a new enumerable own data property on the receiver.
+        if (ObjectHasOwn(this, name)) {
+          ObjectDefineProperty(this, name, {
+            value: v,
+            writable: true,
+            enumerable: false,
+            configurable: true,
+          });
+        } else {
+          ObjectDefineProperty(this, name, {
+            value: v,
+            writable: true,
+            enumerable: true,
+            configurable: true,
+          });
+        }
       },
       enumerable: false,
       configurable: true,

--- a/libs/core/01_core.js
+++ b/libs/core/01_core.js
@@ -9,6 +9,8 @@
     ErrorCaptureStackTrace,
     FunctionPrototypeBind,
     ObjectAssign,
+    ObjectDefineProperties,
+    ObjectDefineProperty,
     ObjectFreeze,
     ObjectFromEntries,
     ObjectKeys,
@@ -842,50 +844,65 @@
     };
   }
 
-  function propWritableLazyLoaded(getter, loadFn) {
-    let valueIsSet = false;
-    let value;
+  // Marker symbol identifying a lazy-loaded property descriptor. The property
+  // name is filled in by `defineGlobalProperties` at install time so the
+  // setter can mimic data-property [[Set]] semantics (define an own data
+  // property on the receiver) instead of mutating a closure shared across all
+  // receivers - see denoland/deno#34403.
+  const lazyNameSym = Symbol("lazyName");
 
-    return {
+  function propWritableLazyLoaded(getter, loadFn) {
+    const desc = {
       get() {
-        const loadedValue = loadFn();
-        if (valueIsSet) {
-          return value;
-        } else {
-          return getter(loadedValue);
-        }
+        return getter(loadFn());
       },
       set(v) {
-        loadFn();
-        valueIsSet = true;
-        value = v;
+        ObjectDefineProperty(this, desc[lazyNameSym], {
+          value: v,
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
       },
       enumerable: true,
       configurable: true,
+      [lazyNameSym]: undefined,
     };
+    return desc;
   }
 
   function propNonEnumerableLazyLoaded(getter, loadFn) {
-    let valueIsSet = false;
-    let value;
-
-    return {
+    const desc = {
       get() {
-        const loadedValue = loadFn();
-        if (valueIsSet) {
-          return value;
-        } else {
-          return getter(loadedValue);
-        }
+        return getter(loadFn());
       },
       set(v) {
-        loadFn();
-        valueIsSet = true;
-        value = v;
+        ObjectDefineProperty(this, desc[lazyNameSym], {
+          value: v,
+          writable: true,
+          enumerable: false,
+          configurable: true,
+        });
       },
       enumerable: false,
       configurable: true,
+      [lazyNameSym]: undefined,
     };
+    return desc;
+  }
+
+  // Like `Object.defineProperties`, but also stamps the property name into any
+  // lazy-loaded descriptors so their setters can target the correct receiver.
+  function defineGlobalProperties(target, props) {
+    const keys = ObjectKeys(props);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const desc = props[key];
+      if (desc !== null && typeof desc === "object" && lazyNameSym in desc) {
+        desc[lazyNameSym] = key;
+      }
+    }
+    ObjectDefineProperties(target, props);
   }
 
   function createLazyLoader(specifier) {
@@ -1199,6 +1216,7 @@
     propGetterOnly,
     propWritableLazyLoaded,
     propNonEnumerableLazyLoaded,
+    defineGlobalProperties,
     createLazyLoader,
     loadExtScript,
     createCancelHandle: () => op_cancel_handle(),

--- a/libs/core/core.d.ts
+++ b/libs/core/core.d.ts
@@ -377,6 +377,11 @@ export namespace core {
     loadFn: LazyLoader<T>,
   ): PropertyDescriptor;
 
+  function defineGlobalProperties(
+    target: object,
+    props: PropertyDescriptorMap,
+  ): void;
+
   type LazyLoader<T> = () => T;
   function createLazyLoader<T = unknown>(specifier: string): LazyLoader<T>;
 

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -314,7 +314,7 @@ denoNsUnstableById[unstableIds.net] = {
   ),
 };
 
-ObjectDefineProperties(denoNsUnstableById[unstableIds.net], {
+core.defineGlobalProperties(denoNsUnstableById[unstableIds.net], {
   connectQuic: core.propWritableLazyLoaded((q) => q.connectQuic, loadQuic),
   QuicEndpoint: core.propWritableLazyLoaded((q) => q.QuicEndpoint, loadQuic),
   QuicBidirectionalStream: core.propWritableLazyLoaded(
@@ -343,7 +343,7 @@ ObjectDefineProperties(denoNsUnstableById[unstableIds.net], {
 denoNsUnstableById[unstableIds.webgpu] = {
   UnsafeWindowSurface: surface.UnsafeWindowSurface,
 };
-ObjectDefineProperties(denoNsUnstableById[unstableIds.webgpu], {
+core.defineGlobalProperties(denoNsUnstableById[unstableIds.webgpu], {
   webgpu: core.propWritableLazyLoaded(
     (webgpu) => webgpu.denoNsWebGPU,
     loadWebGPU,

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -62,8 +62,7 @@ import { unstableIds } from "ext:deno_features/flags.js";
 const { loadWebGPU } = core.loadExtScript("ext:deno_webgpu/00_init.js");
 import { bundle } from "ext:deno_bundle_runtime/bundle.ts";
 
-const { ObjectDefineProperties, ObjectDefineProperty, Float64Array } =
-  primordials;
+const { ObjectDefineProperty, Float64Array } = primordials;
 
 const loadQuic = core.createLazyLoader("ext:deno_net/03_quic.js");
 const loadWebTransport = core.createLazyLoader(

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -548,7 +548,7 @@ function dispatchUnloadEvent() {
 
 let hasBootstrapped = false;
 // Set up global properties shared by main and worker runtime.
-ObjectDefineProperties(globalThis, windowOrWorkerGlobalScope);
+core.defineGlobalProperties(globalThis, windowOrWorkerGlobalScope);
 
 // Set up global properties shared by main and worker runtime that are exposed
 // by unstable features if those are enabled.
@@ -564,7 +564,7 @@ function exposeUnstableFeaturesForWindowOrWorkerGlobalScope(unstableFeatures) {
     const featureId = featureIds[i];
     if (ArrayPrototypeIncludes(unstableFeatures, featureId)) {
       const props = unstableForWindowOrWorkerGlobalScope[featureId];
-      ObjectDefineProperties(globalThis, { ...props });
+      core.defineGlobalProperties(globalThis, { ...props });
     }
   }
 }

--- a/tests/specs/run/lazy_global_polyfill_shadowing/__test__.jsonc
+++ b/tests/specs/run/lazy_global_polyfill_shadowing/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "polyfill_shadow": {
+      "args": "run main.js",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/run/lazy_global_polyfill_shadowing/main.js
+++ b/tests/specs/run/lazy_global_polyfill_shadowing/main.js
@@ -45,11 +45,36 @@ console.log(
   Object.prototype.hasOwnProperty.call(g, "Request"),
 );
 
+// The shadowing own property on the inheriting receiver should be a normal
+// enumerable, writable, configurable data property - matching standard
+// [[Set]] semantics for an inherited writable data property.
+const receiverDesc = Object.getOwnPropertyDescriptor(g, "Response");
+console.log(
+  "receiver Response descriptor:",
+  JSON.stringify({
+    hasValue: Object.hasOwn(receiverDesc, "value"),
+    writable: receiverDesc.writable,
+    enumerable: receiverDesc.enumerable,
+    configurable: receiverDesc.configurable,
+  }),
+);
+
 // `new Response()` still produces a real Response (instanceof works).
 const r = new Response("hello");
 console.log("real Response instanceof Response:", r instanceof Response);
 
-// Direct assignment to globalThis still works.
+// Direct assignment to globalThis still works, and preserves the original
+// non-enumerable attribute of the global descriptor.
 globalThis.WebSocket = "patched";
 console.log("direct set on globalThis:", globalThis.WebSocket === "patched");
+const globalDesc = Object.getOwnPropertyDescriptor(globalThis, "WebSocket");
+console.log(
+  "global WebSocket descriptor:",
+  JSON.stringify({
+    hasValue: Object.hasOwn(globalDesc, "value"),
+    writable: globalDesc.writable,
+    enumerable: globalDesc.enumerable,
+    configurable: globalDesc.configurable,
+  }),
+);
 globalThis.WebSocket = originalWebSocket;

--- a/tests/specs/run/lazy_global_polyfill_shadowing/main.js
+++ b/tests/specs/run/lazy_global_polyfill_shadowing/main.js
@@ -1,0 +1,55 @@
+// Regression test for https://github.com/denoland/deno/issues/34403
+// Lazy-loaded globals (Response, Request, ReadableStream, WebSocket, ...) used
+// to be writable data properties. After they were converted to accessor
+// properties for lazy loading, assigning through an object whose prototype is
+// globalThis (the cross-fetch / whatwg-fetch polyfill pattern) would clobber
+// the global instead of shadowing on the receiver.
+
+const originalResponse = globalThis.Response;
+const originalRequest = globalThis.Request;
+const originalReadableStream = globalThis.ReadableStream;
+const originalWebSocket = globalThis.WebSocket;
+
+// Mimic the cross-fetch / whatwg-fetch polyfill pattern.
+function Self() {}
+Self.prototype = globalThis;
+const g = new Self();
+g.Response = class PolyfillResponse {};
+g.Request = class PolyfillRequest {};
+g.ReadableStream = class PolyfillReadableStream {};
+g.WebSocket = class PolyfillWebSocket {};
+
+console.log(
+  "global Response untouched:",
+  globalThis.Response === originalResponse,
+);
+console.log(
+  "global Request untouched:",
+  globalThis.Request === originalRequest,
+);
+console.log(
+  "global ReadableStream untouched:",
+  globalThis.ReadableStream === originalReadableStream,
+);
+console.log(
+  "global WebSocket untouched:",
+  globalThis.WebSocket === originalWebSocket,
+);
+
+console.log(
+  "own Response on receiver:",
+  Object.prototype.hasOwnProperty.call(g, "Response"),
+);
+console.log(
+  "own Request on receiver:",
+  Object.prototype.hasOwnProperty.call(g, "Request"),
+);
+
+// `new Response()` still produces a real Response (instanceof works).
+const r = new Response("hello");
+console.log("real Response instanceof Response:", r instanceof Response);
+
+// Direct assignment to globalThis still works.
+globalThis.WebSocket = "patched";
+console.log("direct set on globalThis:", globalThis.WebSocket === "patched");
+globalThis.WebSocket = originalWebSocket;

--- a/tests/specs/run/lazy_global_polyfill_shadowing/main.out
+++ b/tests/specs/run/lazy_global_polyfill_shadowing/main.out
@@ -1,0 +1,8 @@
+global Response untouched: true
+global Request untouched: true
+global ReadableStream untouched: true
+global WebSocket untouched: true
+own Response on receiver: true
+own Request on receiver: true
+real Response instanceof Response: true
+direct set on globalThis: true

--- a/tests/specs/run/lazy_global_polyfill_shadowing/main.out
+++ b/tests/specs/run/lazy_global_polyfill_shadowing/main.out
@@ -4,5 +4,7 @@ global ReadableStream untouched: true
 global WebSocket untouched: true
 own Response on receiver: true
 own Request on receiver: true
+receiver Response descriptor: {"hasValue":true,"writable":true,"enumerable":true,"configurable":true}
 real Response instanceof Response: true
 direct set on globalThis: true
+global WebSocket descriptor: {"hasValue":true,"writable":true,"enumerable":false,"configurable":true}


### PR DESCRIPTION
## Summary

Fixes #34403.

Lazy-loaded global accessors (`Response`, `Request`, `ReadableStream`, `WebSocket`, `CompressionStream`, ...) installed via `propNonEnumerableLazyLoaded` / `propWritableLazyLoaded` stored assigned values in a shared closure and ignored the receiver. Assigning through an object whose prototype chain includes `globalThis` (the `whatwg-fetch` / `cross-fetch` polyfill idiom) clobbered the global instead of creating a shadowing own property on the receiver, breaking `x instanceof Response` for real fetch responses and tripping up wasm-bindgen loaders such as `@swc/wasm-web`.

The setter now uses `Object.defineProperty(this, name, ...)` to define an own data property on the receiver, matching the pre-2.8 data-property `[[Set]]` semantics. A new `core.defineGlobalProperties` helper stamps the property name onto each lazy descriptor at install time so the setter knows which name to define.

After the first set, the accessor is replaced by a regular data property on whichever object received the set, so subsequent reads on that object skip the lazy loader entirely:
- Direct assignment to `globalThis`: descriptor becomes a data descriptor with the assigned value (same as 2.7.x).
- Assignment via an inheriting object: creates a shadowing own property on the inheritor; `globalThis` is untouched.

## Test plan

- [x] New spec test `tests/specs/run/lazy_global_polyfill_shadowing` covers the polyfill pattern, the `instanceof` invariant, and direct `globalThis` assignment.
- [x] `cargo test --test specs -- lazy_global` passes.
- [x] Related spec tests (`fetch`, `window`) still pass.