### PR TITLE
feat(bundle): support `browser` field map in package.json

### DIFF
--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -851,6 +851,10 @@ pub struct DeferredResolveError {
   error: ResolveWithGraphError,
 }
 
+/// Path prefix used to mark modules disabled via a `browser` map (`"foo": false`).
+/// `\0` keeps it from colliding with any real filesystem path.
+const BROWSER_DISABLED_PREFIX: &str = "\0deno-browser-disabled:";
+
 pub struct DenoPluginHandler {
   file_fetcher: Arc<CliFileFetcher>,
   resolver: Arc<CliResolver>,
@@ -1013,6 +1017,17 @@ impl esbuild_client::PluginHandler for DenoPluginHandler {
     let result = match result {
       Ok(r) => r,
       Err(e) => {
+        // A `browser` map entry of `false` disables the module: return a
+        // sentinel path that `on_load` recognizes and turns into an empty
+        // module, rather than surfacing the resolver error.
+        if let Some(orig) = browser_map_disabled_specifier(&e) {
+          return Ok(Some(esbuild_client::OnResolveResult {
+            path: Some(format!("{BROWSER_DISABLED_PREFIX}{orig}")),
+            namespace: Some("deno".into()),
+            plugin_name: Some("deno".to_string()),
+            ..Default::default()
+          }));
+        }
         return Ok(Some(esbuild_client::OnResolveResult {
           errors: Some(vec![esbuild_client::protocol::PartialMessage {
             id: "deno_error".into(),
@@ -1068,6 +1083,13 @@ impl esbuild_client::PluginHandler for DenoPluginHandler {
     args: esbuild_client::OnLoadArgs,
   ) -> Result<Option<esbuild_client::OnLoadResult>, AnyError> {
     log::debug!("{}: {args:?}", deno_terminal::colors::cyan("on_load"));
+    if args.path.starts_with(BROWSER_DISABLED_PREFIX) {
+      return Ok(Some(esbuild_client::OnLoadResult {
+        contents: Some(b"module.exports = {};\n".to_vec()),
+        loader: Some(esbuild_client::BuiltinLoader::Js),
+        ..Default::default()
+      }));
+    }
     if let Some(virtual_modules) = &self.virtual_modules
       && let Some(module) = virtual_modules.get(&args.path)
     {
@@ -1213,6 +1235,29 @@ impl BundleLoadError {
       _ => false,
     }
   }
+}
+
+/// Walk a `BundleError` looking for a `BrowserMapDisabled` error returned
+/// by `node_resolver`. Returns the original specifier so the bundle can
+/// emit an empty-module stub in place of the resolution.
+fn browser_map_disabled_specifier(error: &BundleError) -> Option<String> {
+  let BundleErrorKind::Resolver(resolve_err) = error.as_kind() else {
+    return None;
+  };
+  let deno_resolver::graph::ResolveWithGraphErrorKind::Resolve(e) =
+    resolve_err.as_kind()
+  else {
+    return None;
+  };
+  let deno_resolver::DenoResolveErrorKind::Node(node_err) = e.as_kind() else {
+    return None;
+  };
+  let node_resolver::errors::NodeResolveErrorKind::BrowserMapDisabled(disabled) =
+    node_err.as_kind()
+  else {
+    return None;
+  };
+  Some(disabled.specifier.clone())
 }
 
 fn maybe_ignorable_resolution_error(

--- a/libs/node_resolver/errors.rs
+++ b/libs/node_resolver/errors.rs
@@ -227,6 +227,9 @@ impl NodeJsErrorCoded for PackageSubpathFromDenoModuleResolveError {
       PackageSubpathFromDenoModuleResolveErrorKind::FinalizeResolution(e) => {
         e.code()
       }
+      PackageSubpathFromDenoModuleResolveErrorKind::BrowserMapDisabled(_) => {
+        NodeJsErrorCode::ERR_MODULE_NOT_FOUND
+      }
     }
   }
 }
@@ -240,6 +243,9 @@ impl PackageSubpathFromDenoModuleResolveError {
       PackageSubpathFromDenoModuleResolveErrorKind::FinalizeResolution(e) => {
         e.as_types_not_found()
       }
+      PackageSubpathFromDenoModuleResolveErrorKind::BrowserMapDisabled(_) => {
+        None
+      }
     }
   }
 
@@ -250,6 +256,9 @@ impl PackageSubpathFromDenoModuleResolveError {
       }
       PackageSubpathFromDenoModuleResolveErrorKind::FinalizeResolution(e) => {
         e.maybe_specifier()
+      }
+      PackageSubpathFromDenoModuleResolveErrorKind::BrowserMapDisabled(_) => {
+        None
       }
     }
   }
@@ -264,6 +273,9 @@ impl PackageSubpathFromDenoModuleResolveError {
       PackageSubpathFromDenoModuleResolveErrorKind::FinalizeResolution(e) => {
         NodeResolveErrorKind::FinalizeResolution(e)
       }
+      PackageSubpathFromDenoModuleResolveErrorKind::BrowserMapDisabled(e) => {
+        NodeResolveErrorKind::BrowserMapDisabled(e)
+      }
     }
     .into_box()
   }
@@ -277,6 +289,9 @@ pub enum PackageSubpathFromDenoModuleResolveErrorKind {
   #[class(inherit)]
   #[error(transparent)]
   FinalizeResolution(#[from] FinalizeResolutionError),
+  #[class(inherit)]
+  #[error(transparent)]
+  BrowserMapDisabled(#[from] BrowserMapDisabledError),
 }
 
 #[derive(Debug, Boxed, JsError)]
@@ -691,6 +706,17 @@ pub struct DataUrlReferrerError {
   pub source: url::ParseError,
 }
 
+/// A module was disabled by the importer's `package.json` `browser` map
+/// (`{"name": false}`). The bundler turns this into an empty stub; other
+/// callers treat it as a resolution failure.
+#[derive(Debug, Error, JsError)]
+#[class(generic)]
+#[error("Module `{specifier}` is disabled by the `browser` field in `{}`.", pkg_json_path.display())]
+pub struct BrowserMapDisabledError {
+  pub specifier: String,
+  pub pkg_json_path: PathBuf,
+}
+
 #[derive(Debug, Boxed, JsError)]
 pub struct NodeResolveError(pub Box<NodeResolveErrorKind>);
 
@@ -714,7 +740,8 @@ impl NodeResolveError {
       NodeResolveErrorKind::FinalizeResolution(err) => err.maybe_specifier(),
       NodeResolveErrorKind::UnsupportedEsmUrlScheme(_)
       | NodeResolveErrorKind::DataUrlReferrer(_)
-      | NodeResolveErrorKind::RelativeJoin(_) => None,
+      | NodeResolveErrorKind::RelativeJoin(_)
+      | NodeResolveErrorKind::BrowserMapDisabled(_) => None,
     }
   }
 }
@@ -751,6 +778,9 @@ pub enum NodeResolveErrorKind {
   #[class(inherit)]
   #[error(transparent)]
   FinalizeResolution(#[from] FinalizeResolutionError),
+  #[class(inherit)]
+  #[error(transparent)]
+  BrowserMapDisabled(#[from] BrowserMapDisabledError),
 }
 
 impl NodeResolveErrorKind {
@@ -769,6 +799,7 @@ impl NodeResolveErrorKind {
       | NodeResolveErrorKind::RelativeJoin(_)
       | NodeResolveErrorKind::PathToUrl(_)
       | NodeResolveErrorKind::UnknownBuiltInNodeModule(_)
+      | NodeResolveErrorKind::BrowserMapDisabled(_)
       | NodeResolveErrorKind::UrlToFilePath(_) => None,
     }
   }
@@ -785,6 +816,7 @@ impl NodeResolveErrorKind {
       NodeResolveErrorKind::TypesNotFound(e) => Some(e.code()),
       NodeResolveErrorKind::UnknownBuiltInNodeModule(e) => Some(e.code()),
       NodeResolveErrorKind::FinalizeResolution(e) => Some(e.code()),
+      NodeResolveErrorKind::BrowserMapDisabled(_) => None,
     }
   }
 }

--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use anyhow::Error as AnyError;
 use anyhow::bail;
 use deno_media_type::MediaType;
+use deno_package_json::BrowserMapEntry;
 use deno_package_json::PackageJson;
 use deno_package_json::PackageJsonRc;
 use deno_path_util::url_to_file_path;
@@ -37,6 +38,7 @@ use crate::PackageJsonResolverRc;
 use crate::PathClean;
 use crate::cache::NodeResolutionSys;
 use crate::errors;
+use crate::errors::BrowserMapDisabledError;
 use crate::errors::DataUrlReferrerError;
 use crate::errors::FinalizeResolutionError;
 use crate::errors::InvalidModuleSpecifierError;
@@ -260,6 +262,12 @@ pub struct NodeResolverOptions {
   pub typescript_version: Option<Version>,
 }
 
+/// Result of consulting the `browser` map on a `package.json`.
+struct BrowserMapMatch {
+  entry: BrowserMapEntry,
+  pkg_json: PackageJsonRc,
+}
+
 #[derive(Debug)]
 struct ResolutionConfig {
   pub bundle_mode: bool,
@@ -386,8 +394,38 @@ impl<
     resolution_mode: ResolutionMode,
     resolution_kind: NodeResolutionKind,
   ) -> Result<NodeResolution, NodeResolveError> {
+    self.resolve_internal(
+      specifier,
+      referrer,
+      resolution_mode,
+      resolution_kind,
+      true,
+    )
+  }
+
+  fn resolve_internal(
+    &self,
+    specifier: &str,
+    referrer: &Url,
+    resolution_mode: ResolutionMode,
+    resolution_kind: NodeResolutionKind,
+    apply_browser_pre: bool,
+  ) -> Result<NodeResolution, NodeResolveError> {
     // Note: if we are here, then the referrer is an esm module
     // TODO(bartlomieju): skipped "policy" part as we don't plan to support it
+
+    if apply_browser_pre
+      && self.resolution_config.prefer_browser_field
+      && let Some(action) = self.lookup_browser_map_pre(specifier, referrer)?
+    {
+      return self.apply_browser_pre_action(
+        specifier,
+        referrer,
+        resolution_mode,
+        resolution_kind,
+        action,
+      );
+    }
 
     if self.is_builtin_node_module(specifier) {
       return Ok(NodeResolution::BuiltIn(specifier.to_string()));
@@ -425,10 +463,10 @@ impl<
     }
 
     let conditions = self.condition_resolver.resolve(resolution_mode);
-    let referrer = UrlOrPathRef::from_url(referrer);
+    let referrer_ref = UrlOrPathRef::from_url(referrer);
     let (url, resolved_kind) = self.module_resolve(
       specifier,
-      &referrer,
+      &referrer_ref,
       resolution_mode,
       conditions,
       resolution_kind,
@@ -440,8 +478,16 @@ impl<
       resolution_mode,
       conditions,
       resolution_kind,
-      Some(&referrer),
+      Some(&referrer_ref),
     )?;
+
+    if self.resolution_config.prefer_browser_field
+      && let Some(action) = self.lookup_browser_map_post(&url_or_path)
+      && let Some(res) = self.apply_browser_post_action(specifier, action)?
+    {
+      return Ok(res);
+    }
+
     let resolve_response = NodeResolution::Module(url_or_path);
     // TODO(bartlomieju): skipped checking errors for commonJS resolution and
     // "preserveSymlinksMain"/"preserveSymlinks" options.
@@ -462,10 +508,10 @@ impl<
     resolution_kind: NodeResolutionKind,
   ) -> Result<NodeResolution, NodeResolveError> {
     let conditions = self.condition_resolver.resolve(resolution_mode);
-    let referrer = UrlOrPathRef::from_url(referrer);
+    let referrer_ref = UrlOrPathRef::from_url(referrer);
     let (url, resolved_kind) = self.module_resolve(
       specifier,
-      &referrer,
+      &referrer_ref,
       resolution_mode,
       conditions,
       resolution_kind,
@@ -477,9 +523,165 @@ impl<
       resolution_mode,
       conditions,
       resolution_kind,
-      Some(&referrer),
+      Some(&referrer_ref),
     )?;
+
+    if self.resolution_config.prefer_browser_field
+      && let Some(action) = self.lookup_browser_map_post(&url_or_path)
+      && let Some(res) = self.apply_browser_post_action(specifier, action)?
+    {
+      return Ok(res);
+    }
     Ok(NodeResolution::Module(url_or_path))
+  }
+
+  /// Pre-resolution `browser` map lookup. Matches bare-specifier keys
+  /// ("fs", "foo") against the importer's nearest `package.json`. The
+  /// `node:` prefix is stripped before lookup.
+  fn lookup_browser_map_pre(
+    &self,
+    specifier: &str,
+    referrer: &Url,
+  ) -> Result<Option<BrowserMapMatch>, NodeResolveError> {
+    if specifier.starts_with("./")
+      || specifier.starts_with("../")
+      || specifier.starts_with('/')
+    {
+      return Ok(None);
+    }
+    let Ok(referrer_path) = url_to_file_path(referrer) else {
+      return Ok(None);
+    };
+    let probe = if self.sys.is_dir(Cow::Borrowed(&referrer_path)) {
+      referrer_path.join("__")
+    } else {
+      referrer_path
+    };
+    let pkg_json = match self.pkg_json_resolver.get_closest_package_json(&probe)
+    {
+      Ok(Some(pkg)) => pkg,
+      _ => return Ok(None),
+    };
+    let Some(map) = pkg_json.browser_map.as_ref() else {
+      return Ok(None);
+    };
+    let lookup_key = specifier.strip_prefix("node:").unwrap_or(specifier);
+    let entry = map.get(specifier).or_else(|| map.get(lookup_key));
+    Ok(entry.map(|e| BrowserMapMatch {
+      entry: e.clone(),
+      pkg_json: pkg_json.clone(),
+    }))
+  }
+
+  /// Post-resolution `browser` map lookup. Matches relative-path keys
+  /// ("./bar.js") against the resolved file's nearest `package.json`.
+  fn lookup_browser_map_post(
+    &self,
+    resolved: &UrlOrPath,
+  ) -> Option<BrowserMapMatch> {
+    let resolved_path = match resolved {
+      UrlOrPath::Path(p) => p.clone(),
+      UrlOrPath::Url(u) if u.scheme() == "file" => url_to_file_path(u).ok()?,
+      _ => return None,
+    };
+    let resolved_clean =
+      deno_path_util::normalize_path(Cow::Borrowed(resolved_path.as_path()));
+    let pkg_json = self
+      .pkg_json_resolver
+      .get_closest_package_json(&resolved_path)
+      .ok()
+      .flatten()?;
+    let map = pkg_json.browser_map.as_ref()?;
+    let pkg_dir = pkg_json.path.parent()?;
+    for (key, entry) in map {
+      if !key.starts_with("./") && !key.starts_with("../") {
+        continue;
+      }
+      let joined = pkg_dir.join(key);
+      let key_path =
+        deno_path_util::normalize_path(Cow::Borrowed(joined.as_path()));
+      if key_path == resolved_clean {
+        return Some(BrowserMapMatch {
+          entry: entry.clone(),
+          pkg_json: pkg_json.clone(),
+        });
+      }
+    }
+    None
+  }
+
+  fn apply_browser_pre_action(
+    &self,
+    specifier: &str,
+    referrer: &Url,
+    resolution_mode: ResolutionMode,
+    resolution_kind: NodeResolutionKind,
+    action: BrowserMapMatch,
+  ) -> Result<NodeResolution, NodeResolveError> {
+    match action.entry {
+      BrowserMapEntry::Disabled => Err(
+        BrowserMapDisabledError {
+          specifier: specifier.to_string(),
+          pkg_json_path: action.pkg_json.path.clone(),
+        }
+        .into(),
+      ),
+      BrowserMapEntry::Replace(replacement) => {
+        if replacement.starts_with("./") || replacement.starts_with("../") {
+          // Relative to the package containing the map.
+          let pkg_dir = action
+            .pkg_json
+            .path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("/"));
+          let abs = deno_path_util::normalize_path(Cow::Owned(
+            pkg_dir.join(&replacement),
+          ));
+          Ok(NodeResolution::Module(UrlOrPath::Path(abs.into_owned())))
+        } else {
+          // Bare module name — resolve normally. Skip pre-check to avoid
+          // self-referential loops like `{"foo": "foo"}`.
+          self.resolve_internal(
+            &replacement,
+            referrer,
+            resolution_mode,
+            resolution_kind,
+            false,
+          )
+        }
+      }
+    }
+  }
+
+  fn apply_browser_post_action(
+    &self,
+    original_specifier: &str,
+    action: BrowserMapMatch,
+  ) -> Result<Option<NodeResolution>, NodeResolveError> {
+    match action.entry {
+      BrowserMapEntry::Disabled => Err(
+        BrowserMapDisabledError {
+          specifier: original_specifier.to_string(),
+          pkg_json_path: action.pkg_json.path.clone(),
+        }
+        .into(),
+      ),
+      BrowserMapEntry::Replace(replacement) => {
+        // Relative-key replacements only fire post-resolve; the value
+        // should likewise be relative to the package directory.
+        let pkg_dir = action
+          .pkg_json
+          .path
+          .parent()
+          .unwrap_or_else(|| std::path::Path::new("/"));
+        let abs = deno_path_util::normalize_path(Cow::Owned(
+          pkg_dir.join(&replacement),
+        ));
+        Ok(Some(NodeResolution::Module(UrlOrPath::Path(
+          abs.into_owned(),
+        ))))
+      }
+    }
   }
 
   fn module_resolve(
@@ -786,6 +988,31 @@ impl<
       resolution_kind,
       maybe_referrer.as_ref(),
     )?;
+    if self.resolution_config.prefer_browser_field
+      && let Some(action) = self.lookup_browser_map_post(&url_or_path)
+    {
+      let pkg_json_path = action.pkg_json.path.clone();
+      match action.entry {
+        BrowserMapEntry::Disabled => {
+          return Err(
+            BrowserMapDisabledError {
+              specifier: package_subpath.into_owned(),
+              pkg_json_path,
+            }
+            .into(),
+          );
+        }
+        BrowserMapEntry::Replace(replacement) => {
+          let pkg_dir = pkg_json_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("/"));
+          let abs = deno_path_util::normalize_path(Cow::Owned(
+            pkg_dir.join(&replacement),
+          ));
+          return Ok(UrlOrPath::Path(abs.into_owned()));
+        }
+      }
+    }
     Ok(url_or_path)
   }
 

--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -268,6 +268,34 @@ struct BrowserMapMatch {
   pkg_json: PackageJsonRc,
 }
 
+/// Extensions probed when matching a relative-path `browser` map key against a
+/// resolved file path. Mirrors the suffixes Node's `require()` algorithm tries
+/// after the bare path, so an entry like `"./foo": false` also catches
+/// `./foo.js`, `./foo.cjs`, `./foo/index.js`, etc.
+const BROWSER_MAP_PROBE_EXTS: &[&str] =
+  &[".js", ".mjs", ".cjs", ".json", ".node"];
+
+fn browser_map_key_matches(key_path: &Path, resolved_path: &Path) -> bool {
+  if key_path == resolved_path {
+    return true;
+  }
+  for ext in BROWSER_MAP_PROBE_EXTS {
+    // strip the leading '.' so OsString::push("js") gives "foo.js".
+    let ext = &ext[1..];
+    let mut with_ext = key_path.as_os_str().to_owned();
+    with_ext.push(".");
+    with_ext.push(ext);
+    if Path::new(&with_ext) == resolved_path {
+      return true;
+    }
+    let index_path = key_path.join("index").with_extension(ext);
+    if index_path == resolved_path {
+      return true;
+    }
+  }
+  false
+}
+
 #[derive(Debug)]
 struct ResolutionConfig {
   pub bundle_mode: bool,
@@ -600,7 +628,11 @@ impl<
       let joined = pkg_dir.join(key);
       let key_path =
         deno_path_util::normalize_path(Cow::Borrowed(joined.as_path()));
-      if key_path == resolved_clean {
+      // Per the proposal, relative-path keys are matched after node-style
+      // probing — `"./foo": false` should disable `./foo.js`, `./foo/index.js`,
+      // etc. Compare the resolved file against the key plus the same extension
+      // and `/index.*` variants `require()` would try.
+      if browser_map_key_matches(&key_path, &resolved_clean) {
         return Some(BrowserMapMatch {
           entry: entry.clone(),
           pkg_json: pkg_json.clone(),

--- a/libs/package_json/lib.rs
+++ b/libs/package_json/lib.rs
@@ -62,6 +62,17 @@ pub enum PackageJsonSideEffects {
   Patterns(Vec<String>),
 }
 
+/// An entry in the object form of `package.json`'s `browser` field.
+///
+/// A string value remaps the key to a different specifier; `false` marks the
+/// key as disabled (bundlers should substitute an empty module).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum BrowserMapEntry {
+  Replace(String),
+  Disabled,
+}
+
 #[derive(Debug, Clone, Error, JsError, PartialEq, Eq)]
 #[class(generic)]
 #[error("'{}' did not have a name", pkg_json_path.display())]
@@ -295,6 +306,8 @@ pub struct PackageJson {
   pub main: Option<String>,
   pub module: Option<String>,
   pub browser: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub browser_map: Option<IndexMap<String, BrowserMapEntry>>,
   pub name: Option<String>,
   pub version: Option<String>,
   #[serde(skip)]
@@ -376,6 +389,7 @@ impl PackageJson {
         version: None,
         module: None,
         browser: None,
+        browser_map: None,
         typ: "none".to_string(),
         types: None,
         types_versions: None,
@@ -494,7 +508,29 @@ impl PackageJson {
     let name = name_val.and_then(map_string);
     let version = version_val.and_then(map_string);
     let module = module_val.and_then(map_string);
-    let browser = browser_val.and_then(map_string);
+    let (browser, browser_map) = match browser_val {
+      Some(Value::String(s)) => (Some(s), None),
+      Some(Value::Object(map)) => {
+        let mut entries = IndexMap::with_capacity(map.len());
+        for (k, v) in map {
+          match v {
+            Value::String(s) => {
+              entries.insert(k, BrowserMapEntry::Replace(s));
+            }
+            Value::Bool(false) => {
+              entries.insert(k, BrowserMapEntry::Disabled);
+            }
+            _ => {}
+          }
+        }
+        if entries.is_empty() {
+          (None, None)
+        } else {
+          (None, Some(entries))
+        }
+      }
+      _ => (None, None),
+    };
 
     let dependencies = package_json
       .remove("dependencies")
@@ -610,6 +646,7 @@ impl PackageJson {
       version,
       module,
       browser,
+      browser_map,
       typ,
       types,
       types_versions,

--- a/libs/resolver/npm/mod.rs
+++ b/libs/resolver/npm/mod.rs
@@ -586,6 +586,7 @@ impl<
           | NodeResolveErrorKind::UrlToFilePath(_)
           | NodeResolveErrorKind::TypesNotFound(_)
           | NodeResolveErrorKind::UnknownBuiltInNodeModule(_)
+          | NodeResolveErrorKind::BrowserMapDisabled(_)
           | NodeResolveErrorKind::FinalizeResolution(_) => Err(
             ResolveIfForNpmPackageErrorKind::NodeResolve(err.into()).into_box(),
           ),

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/dir-extensionless/index.js
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/dir-extensionless/index.js
@@ -1,0 +1,1 @@
+export const dirExtensionless = "node-dir-extensionless";

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/extensionless.js
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/extensionless.js
@@ -1,0 +1,1 @@
+export const extensionless = "node-extensionless";

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/main.browser.js
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/main.browser.js
@@ -1,0 +1,5 @@
+import { greet } from "./util.js";
+import fs from "fs";
+import foo from "foo";
+export const hello = () =>
+  "browser: " + greet() + " fs=" + typeof fs + " foo=" + foo;

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/main.browser.js
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/main.browser.js
@@ -1,5 +1,11 @@
 import { greet } from "./util.js";
 import fs from "fs";
 import foo from "foo";
+import * as ext from "./extensionless.js";
+import * as dirext from "./dir-extensionless/index.js";
 export const hello = () =>
-  "browser: " + greet() + " fs=" + typeof fs + " foo=" + foo;
+  "browser: " + greet() +
+  " fs=" + typeof fs +
+  " foo=" + foo +
+  " ext=" + JSON.stringify(ext) +
+  " dirext=" + JSON.stringify(dirext);

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/main.js
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/main.js
@@ -1,0 +1,2 @@
+import { greet } from "./util.js";
+export const hello = () => "node: " + greet();

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/package.json
@@ -5,6 +5,8 @@
   "browser": {
     "./main.js": "./main.browser.js",
     "./util.js": "./util.browser.js",
+    "./extensionless": false,
+    "./dir-extensionless": false,
     "fs": false,
     "foo": "./shims/foo.js"
   },

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@denotest/browser-field-map",
+  "version": "1.0.0",
+  "main": "main.js",
+  "browser": {
+    "./main.js": "./main.browser.js",
+    "./util.js": "./util.browser.js",
+    "fs": false,
+    "foo": "./shims/foo.js"
+  },
+  "type": "module"
+}

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/shims/foo.js
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/shims/foo.js
@@ -1,0 +1,1 @@
+export default "foo-shim";

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/util.browser.js
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/util.browser.js
@@ -1,0 +1,1 @@
+export const greet = () => "util-browser";

--- a/tests/registry/npm/@denotest/browser-field-map/1.0.0/util.js
+++ b/tests/registry/npm/@denotest/browser-field-map/1.0.0/util.js
@@ -1,0 +1,1 @@
+export const greet = () => "util-node";

--- a/tests/specs/bundle/browser_platform_map/__test__.jsonc
+++ b/tests/specs/bundle/browser_platform_map/__test__.jsonc
@@ -13,7 +13,7 @@
         },
         {
           "args": "run -A bundled.js",
-          "output": "browser: util-browser fs=object foo=foo-shim\n"
+          "output": "browser: util-browser fs=object foo=foo-shim ext={\"default\":{}} dirext={\"default\":{}}\n"
         }
       ]
     }

--- a/tests/specs/bundle/browser_platform_map/__test__.jsonc
+++ b/tests/specs/bundle/browser_platform_map/__test__.jsonc
@@ -1,0 +1,21 @@
+{
+  "tempDir": true,
+  "tests": {
+    "applies_browser_map": {
+      "steps": [
+        {
+          "args": "run -A entry.ts",
+          "output": "[WILDCARD]node: util-node\n"
+        },
+        {
+          "args": "bundle --platform browser --output bundled.js entry.ts",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run -A bundled.js",
+          "output": "browser: util-browser fs=object foo=foo-shim\n"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/bundle/browser_platform_map/entry.ts
+++ b/tests/specs/bundle/browser_platform_map/entry.ts
@@ -1,0 +1,2 @@
+import { hello } from "npm:@denotest/browser-field-map";
+console.log(hello());


### PR DESCRIPTION
Closes #30024

## Summary

Implements the object form of the npm `browser` field for `deno bundle --platform browser`. The simple string form was already supported; the mapped form was silently dropped.

```json
"browser": {
  "./bar.js": "./bar.browser.js",
  "crypto": false,
  "foo": "./shims/foo.js"
}
```

- relative-path keys remap the resolved file (`./bar.js` → `./bar.browser.js`)
- bare-name keys remap an import specifier (`foo` → `./shims/foo.js`), with `node:` prefix stripped before lookup so `import "node:crypto"` matches a `"crypto"` key
- a value of `false` disables the module — the bundler substitutes an empty stub

Esbuild's built-in browser-map handling is bypassed because Deno's `on_resolve` plugin claims every resolve with filter `.*`, so we have to apply the mapping ourselves.

## Where the logic lives

- **`libs/package_json`** — parses the object form into `browser_map: Option<IndexMap<String, BrowserMapEntry>>` (`Replace(String) | Disabled`). The string form keeps populating the existing `browser` field.
- **`libs/node_resolver`** — substitution happens here, gated on the existing `prefer_browser_field` flag (only set when bundling with `--platform browser`). Hooks in `resolve`, `resolve_package`, and `resolve_package_subpath_from_deno_module`. A new `BrowserMapDisabledError` propagates `false` entries up to the caller.
- **`cli/tools/bundle/mod.rs`** — only catches `BrowserMapDisabledError` from the resolver, returns a `\0deno-browser-disabled:<orig>` sentinel path, and the `on_load` hook turns it into `module.exports = {}`.

## Test plan

- [x] New spec `tests/specs/bundle/browser_platform_map` covers all four cases (relative remap, bare remap, bare disabled, transitive within-package import) using new npm fixture `@denotest/browser-field-map`
- [x] All 49 existing `bundle::*` spec tests still pass
- [x] `node_resolver` unit tests still pass
- [x] `--platform deno` bundles are unchanged (gate is `prefer_browser_field`)