### PR TITLE
refactor(lsp): remove unwrap() in PerformanceScopeMark drop

### DIFF
--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -80,11 +80,9 @@ pub struct PerformanceScopeMark {
 
 impl Drop for PerformanceScopeMark {
   fn drop(&mut self) {
-    self
-      .performance
-      .0
-      .lock()
-      .measure(self.inner.take().unwrap());
+    if let Some(mark) = self.inner.take() {
+      self.performance.0.lock().measure(mark);
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Replace `unwrap()` with `if let Some()` in the `Drop` implementation of `PerformanceScopeMark`. This makes the code more robust by gracefully handling the case where `inner` is `None`, rather than panicking.

The `inner` field can be `None` if `take()` is called before `drop`, or if the struct is constructed incorrectly. Using `if let Some()` is safer and follows Rust best practices.

## Changes
- Replaced `self.inner.take().unwrap()` with `if let Some(mark) = self.inner.take()`

## Checklist
- [x] Code follows the project's style guidelines
- [x] Changes are minimal and focused