### PR TITLE
fix(lsp): surface CSS imports as .js to TypeScript

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4927,10 +4927,12 @@ fn op_resolve_inner(
       o.map(|(s, mt)| {
         (
           state.specifier_map.denormalize(&s, mt),
-          if matches!(mt, MediaType::Unknown) {
-            None
-          } else {
-            Some(mt.as_ts_extension().to_string())
+          match mt {
+            MediaType::Unknown => None,
+            // surface these as .js for typescript so side-effect imports
+            // (e.g. `import "./styles.css"`) don't trigger TS6263
+            MediaType::Css => Some(".js".to_string()),
+            _ => Some(mt.as_ts_extension().to_string()),
           },
         )
       })

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -19264,6 +19264,22 @@ fn lsp_skip_lib_check_graph_errors() {
 }
 
 #[test(timeout = 300)]
+fn lsp_css_side_effect_import() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write("styles.css", "body { background: red; }\n");
+  let file = temp_dir.source_file(
+    "main.ts",
+    "import \"./styles.css\";\nconsole.log(\"hello\");\n",
+  );
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  let diagnostics = client.did_open_file(&file);
+  assert_eq!(json!(diagnostics.all()), json!([]));
+  client.shutdown();
+}
+
+#[test(timeout = 300)]
 fn lsp_import_json_module_import_attribute_variations() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let temp_dir = context.temp_dir().path();


### PR DESCRIPTION
The LSP's `op_resolve` reported `.css` modules to TypeScript with the
`.css` extension, so TypeScript emitted `TS6263` ("Module ... was
resolved to ..., but importing these modules is not supported") on bare
side-effect imports like `import "./styles.css";`. This shows up in
editors as a red squiggle even though `deno check` and `deno bundle`
both accept the same code without complaint.

The CLI typecheck path in `cli/tsc/mod.rs` already maps `MediaType::Css`
to `.js` when reporting resolutions back to TypeScript, with a comment
explaining the workaround. The LSP's parallel resolver never got the
same treatment. This change mirrors it so the two paths agree.

Fixes #34414