### PR TITLE
perf(node): lazy stdio + fix LazyEsmModuleLoader source consumption

### DIFF
--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -429,21 +429,17 @@ deno_core::extension!(deno_node,
     "internal_binding/mod.ts",
     "node:module" = "01_require.js",
     "node:process" = "process.ts",
-    // node:stream + node:stream/promises stay eager: every Deno program
-    // pays their parse/compile cost at runtime startup via
-    // `__bootstrapNodeProcess` -> `createWritableStdioStream` -> Writable,
-    // so keeping them in the snapshot is a net startup-time win even
-    // though most programs never directly require('stream').
-    "node:stream" = "stream.ts",
-    "node:stream/promises" = "stream/promises.js",
-    // node:net and node:tty are needed at every TTY-stdout startup via
-    // internal/tty.js's TTYWriteStream constructor extending net.Socket.
-    // Keeping them eager is a startup-time win for interactive runs.
-    "node:net" = "net_esm.ts",
-    "node:tty" = "tty_esm.ts",
   ],
   lazy_loaded_esm = [
     dir "polyfills",
+    // Previously eager. Combined with the lazy stdio refactor in
+    // process.ts (process.stdout/stderr/stdin are accessor properties),
+    // these modules only load when a script actually touches stdio or
+    // requires node:stream/net/tty directly.
+    "node:stream" = "stream.ts",
+    "node:stream/promises" = "stream/promises.js",
+    "node:net" = "net_esm.ts",
+    "node:tty" = "tty_esm.ts",
     "internal/streams/compose.js",
     "internal/streams/duplexpair.js",
     "internal/streams/lazy_transform.js",

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -354,7 +354,8 @@ const lazyNodeModules = {
   "inspector/promises": () =>
     core.loadExtScript("ext:deno_node/inspector/promises.js"),
   "perf_hooks": () => core.loadExtScript("ext:deno_node/perf_hooks.js").default,
-  "querystring": () => core.loadExtScript("ext:deno_node/querystring.js").default,
+  "querystring": () =>
+    core.loadExtScript("ext:deno_node/querystring.js").default,
   "sqlite": () => core.loadExtScript("ext:deno_node/sqlite.ts"),
   "string_decoder": () =>
     core.loadExtScript("ext:deno_node/string_decoder.ts").default,

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -2436,6 +2436,11 @@ deprecatedNativeModules._stream_writable = [
   "The _stream_writable module is deprecated. Use `node:stream` instead.",
   "DEP0193",
 ];
+deprecatedNativeModules.punycode = [
+  "The `punycode` module is deprecated. Please use a userland " +
+  "alternative instead.",
+  "DEP0040",
+];
 
 const emittedNativeModuleDeprecations = new SafeSet();
 function maybeEmitNativeModuleDeprecation(request) {

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -88,21 +88,9 @@ const _httpAgent = core.createLazyLoader("node:_http_agent");
 const _httpCommon = core.createLazyLoader("node:_http_common");
 const _httpOutgoing = core.createLazyLoader("node:_http_outgoing");
 const _httpServer = core.createLazyLoader("node:_http_server");
-const _streamDuplex = core.loadExtScript(
-  "ext:deno_node/internal/streams/duplex.js",
-).default;
-const _streamPassthrough = core.loadExtScript(
-  "ext:deno_node/internal/streams/passthrough.js",
-).default;
-const _streamReadable = core.loadExtScript(
-  "ext:deno_node/internal/streams/readable.js",
-).default;
-const _streamTransform = core.loadExtScript(
-  "ext:deno_node/internal/streams/transform.js",
-).default;
-const _streamWritable = core.loadExtScript(
-  "ext:deno_node/internal/streams/writable.js",
-).default;
+// Heavy stream class definitions. Lazified - only loaded if a script
+// actually `require('_stream_*')` or pulls them transitively via
+// `node:stream` after our lazy stdio refactor.
 // _tls_common, _tls_wrap are lazy-loaded via `lazyNodeModules` below: their
 // scripts extend net.Socket at module body, which pulls node:net (and then
 // node:stream) into the snapshot.
@@ -146,10 +134,6 @@ const fs = core.loadExtScript("ext:deno_node/fs.ts");
 // http/http2/https are lazy-loaded via `lazyNodeModules` below: their script
 // bodies eagerly chain into the entire node:_http_* / node:net / node:stream
 // graph, so running them at snapshot time defeats lazifying _http_*.
-const inspector = core.loadExtScript("ext:deno_node/inspector.js");
-const inspectorPromises = core.loadExtScript(
-  "ext:deno_node/inspector/promises.js",
-);
 const internalAssertMyersDiff = core.loadExtScript(
   "ext:deno_node/internal/assert/myers_diff.js",
 );
@@ -249,9 +233,6 @@ const internalStreamsState =
 const internalSocketAddress = core.loadExtScript(
   "ext:deno_node/internal/socketaddress.js",
 );
-const internalJsStreamSocket = core.loadExtScript(
-  "ext:deno_node/internal/js_stream_socket.js",
-).default;
 const internalNet = core.loadExtScript("ext:deno_node/internal/net.ts");
 const internalTestBinding = core.loadExtScript(
   "ext:deno_node/internal/test/binding.ts",
@@ -259,7 +240,9 @@ const internalTestBinding = core.loadExtScript(
 const internalTimers = core.loadExtScript(
   "ext:deno_node/internal/timers.mjs",
 );
-import * as internalTty from "ext:deno_node/internal/tty.js";
+const lazyInternalTty = core.createLazyLoader(
+  "ext:deno_node/internal/tty.js",
+);
 const internalUrl = core.loadExtScript("ext:deno_node/internal/url.ts");
 const internalUtil = core.loadExtScript("ext:deno_node/internal/util.mjs");
 const internalUtilDebuglog = core.loadExtScript(
@@ -286,54 +269,31 @@ const internalWorkerJsTransferable = core.loadExtScript(
 const internalConsole = core.loadExtScript(
   "ext:deno_node/internal/console/constructor.mjs",
 ).default;
-// net stays eager: internal/tty.js's TTYWriteStream extends net.Socket
-// inside its constructor, and process bootstrap creates a TTYWriteStream
-// for stdout/stderr whenever they're TTYs (every interactive run).
-import net from "node:net";
+// net, path, stream, tty lazified - see lazyNodeModules below.
+const lazyNet = core.createLazyLoader("node:net");
 const os = core.loadExtScript("ext:deno_node/os.ts").default;
-import pathPosix from "node:path/posix";
-import pathWin32 from "node:path/win32";
-import path from "node:path";
-const perfHooks = core.loadExtScript("ext:deno_node/perf_hooks.js").default;
-const punycode = core.loadExtScript("ext:deno_node/punycode.ts").default;
+const lazyPathPosix = core.createLazyLoader("node:path/posix");
+const lazyPathWin32 = core.createLazyLoader("node:path/win32");
+const lazyPath = core.createLazyLoader("node:path");
 import process from "node:process";
-const querystring = core.loadExtScript("ext:deno_node/querystring.js").default;
 const readline = core.createLazyLoader("node:readline");
 const readlinePromises = core.createLazyLoader("node:readline/promises");
 const repl = core.createLazyLoader("node:repl");
 const internalRepl = core.createLazyLoader(
   "ext:deno_node/internal/repl.ts",
 );
-const sqlite = core.loadExtScript("ext:deno_node/sqlite.ts");
-// node:stream and node:stream/promises are eager (`esm` in lib.rs): every
-// program pays their cost at startup via `__bootstrapNodeProcess` building
-// `process.stdout`/`stderr` via `new Writable(...)`, so having them in the
-// snapshot is a startup-time win. Static imports here ensure they end up
-// in v8's evaluation graph.
-import stream from "node:stream";
+const lazyStream = core.createLazyLoader("node:stream");
 const streamConsumers = core.loadExtScript("ext:deno_node/stream/consumers.js");
-import streamPromises from "node:stream/promises";
-// stream/web pulls ext:deno_web/14_compression.js -> 06_streams (208 KB).
-// Only loaded when `require("node:stream/web")` happens.
-const stringDecoder =
-  core.loadExtScript("ext:deno_node/string_decoder.ts").default;
+const lazyStreamPromises = core.createLazyLoader("node:stream/promises");
 const test = core.loadExtScript("ext:deno_node/testing.ts").default;
 const timers = core.loadExtScript("ext:deno_node/timers.ts");
-const timersPromises = core.loadExtScript(
-  "ext:deno_node/timers/promises.ts",
-);
 const tls = core.createLazyLoader("node:tls");
-const traceEvents = core.loadExtScript("ext:deno_node/trace_events.ts").default;
-import tty from "node:tty";
+const lazyTty = core.createLazyLoader("node:tty");
 const url = core.loadExtScript("ext:deno_node/url.ts");
-const utilTypes = core.loadExtScript("ext:deno_node/internal/util/types.ts");
 const util = core.loadExtScript("ext:deno_node/util.ts");
-const v8 = core.loadExtScript("ext:deno_node/v8.ts");
-const vm = core.loadExtScript("ext:deno_node/vm.js").default;
 const workerThreads = core.loadExtScript(
   "ext:deno_node/worker_threads.ts",
 );
-const wasi = core.loadExtScript("ext:deno_node/wasi.ts").default;
 // zlib is lazy-loaded via `lazyNodeModules` below: zlib.js extends
 // `Transform` from `node:stream` at module body, so loading it eagerly
 // pulls the stream subtree into the snapshot.
@@ -390,6 +350,55 @@ const lazyNodeModules = {
   "internal/child_process": () =>
     core.loadExtScript("ext:deno_node/internal/child_process.ts").default,
   "stream/web": () => core.loadExtScript("ext:deno_node/stream/web.js"),
+  "inspector": () => core.loadExtScript("ext:deno_node/inspector.js"),
+  "inspector/promises": () =>
+    core.loadExtScript("ext:deno_node/inspector/promises.js"),
+  "perf_hooks": () => core.loadExtScript("ext:deno_node/perf_hooks.js").default,
+  "querystring": () => core.loadExtScript("ext:deno_node/querystring.js").default,
+  "sqlite": () => core.loadExtScript("ext:deno_node/sqlite.ts"),
+  "string_decoder": () =>
+    core.loadExtScript("ext:deno_node/string_decoder.ts").default,
+  "timers/promises": () =>
+    core.loadExtScript("ext:deno_node/timers/promises.ts"),
+  "trace_events": () =>
+    core.loadExtScript("ext:deno_node/trace_events.ts").default,
+  "util/types": () =>
+    core.loadExtScript("ext:deno_node/internal/util/types.ts"),
+  "v8": () => core.loadExtScript("ext:deno_node/v8.ts"),
+  "vm": () => core.loadExtScript("ext:deno_node/vm.js").default,
+  "wasi": () => core.loadExtScript("ext:deno_node/wasi.ts").default,
+  "punycode": () => {
+    const proc = nativeModuleExports.process;
+    proc.emitWarning(
+      "The `punycode` module is deprecated. Please use a userland " +
+        "alternative instead.",
+      "DeprecationWarning",
+      "DEP0040",
+    );
+    return core.loadExtScript("ext:deno_node/punycode.ts").default;
+  },
+  // Previously eager via static imports. Lazified together with the
+  // process.stdio lazy-getter refactor.
+  "net": () => lazyNet().default,
+  "path": () => lazyPath().default,
+  "path/posix": () => lazyPathPosix().default,
+  "path/win32": () => lazyPathWin32().default,
+  "stream": () => lazyStream().default,
+  "stream/promises": () => lazyStreamPromises().default,
+  "tty": () => lazyTty().default,
+  "internal/tty": () => lazyInternalTty(),
+  "internal/js_stream_socket": () =>
+    core.loadExtScript("ext:deno_node/internal/js_stream_socket.js").default,
+  "_stream_duplex": () =>
+    core.loadExtScript("ext:deno_node/internal/streams/duplex.js").default,
+  "_stream_passthrough": () =>
+    core.loadExtScript("ext:deno_node/internal/streams/passthrough.js").default,
+  "_stream_readable": () =>
+    core.loadExtScript("ext:deno_node/internal/streams/readable.js").default,
+  "_stream_transform": () =>
+    core.loadExtScript("ext:deno_node/internal/streams/transform.js").default,
+  "_stream_writable": () =>
+    core.loadExtScript("ext:deno_node/internal/streams/writable.js").default,
 };
 
 function defineLazyNativeModule(name, loader) {
@@ -414,11 +423,6 @@ function defineLazyNativeModule(name, loader) {
 // NOTE(bartlomieju): keep this list in sync with `ext/node/lib.rs`
 function setupBuiltinModules() {
   const nodeModules = {
-    "_stream_duplex": _streamDuplex,
-    "_stream_passthrough": _streamPassthrough,
-    "_stream_readable": _streamReadable,
-    "_stream_transform": _streamTransform,
-    "_stream_writable": _streamWritable,
     assert,
     "async_hooks": asyncHooks,
     buffer,
@@ -431,8 +435,6 @@ function setupBuiltinModules() {
     domain,
     events,
     fs,
-    inspector,
-    "inspector/promises": inspectorPromises,
     "internal/assert/myers_diff": internalAssertMyersDiff.default,
     "internal/async_hooks": internalAsyncHooks,
     "internal/console/constructor": internalConsole,
@@ -459,12 +461,10 @@ function setupBuiltinModules() {
     "internal/streams/add-abort-signal": internalStreamsAddAbortSignal,
     "internal/streams/state": internalStreamsState,
     "internal/socketaddress": internalSocketAddress,
-    "internal/js_stream_socket": internalJsStreamSocket,
     "internal/net": internalNet,
     "internal/options": internalOptions,
     "internal/test/binding": internalTestBinding,
     "internal/timers": internalTimers,
-    "internal/tty": internalTty,
     "internal/url": internalUrl,
     "internal/util/debuglog": internalUtilDebuglog.default,
     "internal/util/inspect": internalUtilInspect,
@@ -475,40 +475,14 @@ function setupBuiltinModules() {
     "internal/webstreams/util": internalWebstreamsUtil,
     "internal/worker/js_transferable": internalWorkerJsTransferable,
     module: Module,
-    net,
     os,
-    "path/posix": pathPosix,
-    "path/win32": pathWin32,
-    path,
-    perf_hooks: perfHooks,
     process,
-    get punycode() {
-      process.emitWarning(
-        "The `punycode` module is deprecated. Please use a userland " +
-          "alternative instead.",
-        "DeprecationWarning",
-        "DEP0040",
-      );
-      return punycode;
-    },
-    querystring,
-    sqlite,
-    stream,
     "stream/consumers": streamConsumers,
-    "stream/promises": streamPromises,
-    string_decoder: stringDecoder,
     sys: util,
     test,
     timers,
-    "timers/promises": timersPromises,
-    trace_events: traceEvents,
-    tty,
     url,
     util,
-    "util/types": utilTypes,
-    v8,
-    vm,
-    wasi,
     worker_threads: workerThreads,
   };
   // Match Node's schemelessBlockList: these modules can only be imported

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -368,16 +368,7 @@ const lazyNodeModules = {
   "v8": () => core.loadExtScript("ext:deno_node/v8.ts"),
   "vm": () => core.loadExtScript("ext:deno_node/vm.js").default,
   "wasi": () => core.loadExtScript("ext:deno_node/wasi.ts").default,
-  "punycode": () => {
-    const proc = nativeModuleExports.process;
-    proc.emitWarning(
-      "The `punycode` module is deprecated. Please use a userland " +
-        "alternative instead.",
-      "DeprecationWarning",
-      "DEP0040",
-    );
-    return core.loadExtScript("ext:deno_node/punycode.ts").default;
-  },
+  "punycode": () => core.loadExtScript("ext:deno_node/punycode.ts").default,
   // Previously eager via static imports. Lazified together with the
   // process.stdio lazy-getter refactor.
   "net": () => lazyNet().default,

--- a/ext/node/polyfills/internal/tty.js
+++ b/ext/node/polyfills/internal/tty.js
@@ -33,10 +33,7 @@ const {
 const { validateInteger } = core.loadExtScript(
   "ext:deno_node/internal/validators.mjs",
 );
-import {
-  op_tty_check_fd_permission,
-  TTY,
-} from "ext:core/ops";
+import { op_tty_check_fd_permission, TTY } from "ext:core/ops";
 const { isatty } = core.loadExtScript("ext:deno_node/tty.js");
 const lazyNet = core.createLazyLoader("node:net");
 const {

--- a/ext/node/polyfills/internal/tty.js
+++ b/ext/node/polyfills/internal/tty.js
@@ -33,7 +33,10 @@ const {
 const { validateInteger } = core.loadExtScript(
   "ext:deno_node/internal/validators.mjs",
 );
-import { op_tty_check_fd_permission, TTY } from "ext:core/ops";
+import {
+  op_tty_check_fd_permission,
+  TTY,
+} from "ext:core/ops";
 const { isatty } = core.loadExtScript("ext:deno_node/tty.js");
 const lazyNet = core.createLazyLoader("node:net");
 const {

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -149,9 +149,16 @@ const lazyLoadUtil = core.createLazyLoader<typeof utilModule>(
 
 const {
   ArrayIsArray,
+  FunctionPrototypeBind,
   NumberMAX_SAFE_INTEGER,
+  ObjectCreate,
   ObjectDefineProperty,
   ObjectPrototypeIsPrototypeOf,
+  ReflectGet,
+  ReflectGetOwnPropertyDescriptor,
+  ReflectGetPrototypeOf,
+  ReflectHas,
+  ReflectOwnKeys,
 } = primordials;
 
 export const argv: string[] = ["", ""];
@@ -843,6 +850,62 @@ function _removeAllSignalListeners(
 /** https://nodejs.org/api/process.html#process_process */
 // @ts-ignore TS doesn't work well with ES5 classes
 const process = new Process();
+
+// `node:process` exposes `stdin`/`stdout`/`stderr` as ESM named exports. The
+// underlying streams are constructed lazily via accessor properties on
+// `process` (see `defineLazyStream` below), so the `let` bindings stay
+// undefined until something touches `process.stdout` etc. Code like
+// `import { stdout } from "node:process"; stdout.write("x")` would then
+// throw. Initialize the exported bindings with delegating proxies that
+// forward every operation to `process[name]`, which triggers the lazy
+// accessor on first use. Once the accessor fires, `defineLazyStream`
+// updates the `let` binding directly so subsequent reads see the real
+// stream and don't pay the proxy hop.
+function makeStreamDelegate(name: "stdin" | "stdout" | "stderr"): unknown {
+  return new Proxy(ObjectCreate(null), {
+    get(_target, prop) {
+      const real = process[name];
+      if (real == null) return undefined;
+      const value = ReflectGet(real, prop, real);
+      return typeof value === "function"
+        ? FunctionPrototypeBind(value, real)
+        : value;
+    },
+    set(_target, prop, value) {
+      const real = process[name];
+      if (real == null) return true;
+      real[prop] = value;
+      return true;
+    },
+    has(_target, prop) {
+      const real = process[name];
+      return real != null && ReflectHas(real, prop);
+    },
+    deleteProperty(_target, prop) {
+      const real = process[name];
+      if (real == null) return true;
+      delete real[prop];
+      return true;
+    },
+    ownKeys(_target) {
+      const real = process[name];
+      return real != null ? ReflectOwnKeys(real) : [];
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      const real = process[name];
+      return real != null
+        ? ReflectGetOwnPropertyDescriptor(real, prop)
+        : undefined;
+    },
+    getPrototypeOf(_target) {
+      const real = process[name];
+      return real != null ? ReflectGetPrototypeOf(real) : null;
+    },
+  });
+}
+stdin = makeStreamDelegate("stdin");
+stdout = makeStreamDelegate("stdout");
+stderr = makeStreamDelegate("stderr");
 
 /** https://nodejs.org/api/process.html#processrelease */
 Object.defineProperty(process, "release", {

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -87,14 +87,16 @@ export {
   version,
   versions,
 };
-import {
-  createWritableStdioStream,
-  initStdin,
-} from "ext:deno_node/_process/streams.mjs";
-import {
-  addSigwinchListener,
-  WriteStream as TTYWriteStream,
-} from "ext:deno_node/internal/tty.js";
+// _process/streams.mjs and internal/tty.js are lazy-loaded so that
+// process.stdout/stderr/stdin construction (and the node:stream/net/tty
+// graph it pulls in) is deferred until first access. See Node's pattern
+// in lib/internal/bootstrap/switches/is_main_thread.js (defineStream).
+const lazyProcessStreams = core.createLazyLoader(
+  "ext:deno_node/_process/streams.mjs",
+);
+const lazyInternalTty = core.createLazyLoader(
+  "ext:deno_node/internal/tty.js",
+);
 const { enableNextTick } = core.loadExtScript("ext:deno_node/_next_tick.ts");
 const { isAndroid, isWindows } = core.loadExtScript(
   "ext:deno_node/_util/os.ts",
@@ -1547,6 +1549,95 @@ function synchronizeListeners() {
 
 internals.dispatchProcessBeforeExitEvent = dispatchProcessBeforeExitEvent;
 internals.dispatchProcessExitEvent = dispatchProcessExitEvent;
+
+const { ObjectDefineProperty: _ObjectDefineProperty } = primordials;
+
+// Install an accessor property on `target` whose getter invokes `factory()`
+// once and replaces itself with the value. Also caches the result onto
+// the module-level `stdin`/`stdout`/`stderr` exports so ESM consumers
+// that captured the binding after first access see the materialized value.
+function defineLazyStream(
+  target: object,
+  name: "stdout" | "stderr" | "stdin",
+  factory: () => unknown,
+) {
+  _ObjectDefineProperty(target, name, {
+    __proto__: null,
+    configurable: true,
+    enumerable: true,
+    get() {
+      const value = factory();
+      _ObjectDefineProperty(target, name, {
+        __proto__: null,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value,
+      });
+      if (name === "stdout") stdout = value;
+      else if (name === "stderr") stderr = value;
+      else stdin = value;
+      return value;
+    },
+    set(value) {
+      _ObjectDefineProperty(target, name, {
+        __proto__: null,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value,
+      });
+      if (name === "stdout") stdout = value;
+      else if (name === "stderr") stderr = value;
+      else stdin = value;
+    },
+  });
+}
+
+function makeStdoutWriter() {
+  if (io.stdout.isTerminal()) {
+    const { WriteStream, addSigwinchListener } = lazyInternalTty();
+    const s = new WriteStream(1);
+    s.fd = 1;
+    s._isStdio = true;
+    s.destroySoon = s.destroy;
+    s._destroy = function (err, cb) {
+      cb(err);
+      this._undestroy();
+      if (!this._writableState.emitClose) {
+        nextTick(() => this.emit("close"));
+      }
+    };
+    addSigwinchListener(s);
+    return s;
+  }
+  return lazyProcessStreams().createWritableStdioStream(io.stdout, "stdout");
+}
+
+function makeStderrWriter() {
+  if (io.stderr.isTerminal()) {
+    const { WriteStream, addSigwinchListener } = lazyInternalTty();
+    const s = new WriteStream(2);
+    s.fd = 2;
+    s._isStdio = true;
+    s.destroySoon = s.destroy;
+    s._destroy = function (err, cb) {
+      cb(err);
+      this._undestroy();
+      if (!this._writableState.emitClose) {
+        nextTick(() => this.emit("close"));
+      }
+    };
+    addSigwinchListener(s);
+    return s;
+  }
+  return lazyProcessStreams().createWritableStdioStream(io.stderr, "stderr");
+}
+
+function makeStdinReader() {
+  return lazyProcessStreams().initStdin();
+}
+
 // Should be called only once, in `runtime/js/99_main.js` when the runtime is
 // bootstrapped.
 internals.__bootstrapNodeProcess = function (
@@ -1576,58 +1667,11 @@ internals.__bootstrapNodeProcess = function (
 
     enableNextTick();
 
-    // Replace warmup stdout/stderr with proper streams
-    if (io.stdout.isTerminal()) {
-      /** https://nodejs.org/api/process.html#process_process_stdout */
-      stdout = process.stdout = new TTYWriteStream(1);
-      // For supporting legacy API we put the FD here.
-      // Ref: https://github.com/nodejs/node/blob/main/lib/internal/bootstrap/switches/is_main_thread.js
-      stdout.fd = 1;
-      // Match Node.js: stdio streams are indestructible.
-      // Libraries like mute-stream (@inquirer/prompts) call destroy()/end()
-      // on process.stdout between prompts. Without this, the underlying TTY
-      // handle is closed, breaking subsequent I/O.
-      // _isStdio also prevents Stream.pipe() from calling end() on stdout
-      // when a piped source stream ends.
-      // Ref: https://github.com/nodejs/node/blob/main/lib/internal/bootstrap/switches/is_main_thread.js
-      stdout._isStdio = true;
-      stdout.destroySoon = stdout.destroy;
-      stdout._destroy = function (err, cb) {
-        cb(err);
-        this._undestroy();
-        if (!this._writableState.emitClose) {
-          nextTick(() => this.emit("close"));
-        }
-      };
-      addSigwinchListener(stdout);
-    } else {
-      stdout = process.stdout = createWritableStdioStream(
-        io.stdout,
-        "stdout",
-      );
-    }
-
-    if (io.stderr.isTerminal()) {
-      /** https://nodejs.org/api/process.html#process_process_stderr */
-      stderr = process.stderr = new TTYWriteStream(2);
-      // For supporting legacy API we put the FD here.
-      stderr.fd = 2;
-      stderr._isStdio = true;
-      stderr.destroySoon = stderr.destroy;
-      stderr._destroy = function (err, cb) {
-        cb(err);
-        this._undestroy();
-        if (!this._writableState.emitClose) {
-          nextTick(() => this.emit("close"));
-        }
-      };
-      addSigwinchListener(stderr);
-    } else {
-      stderr = process.stderr = createWritableStdioStream(
-        io.stderr,
-        "stderr",
-      );
-    }
+    // Install accessor properties for stdout/stderr/stdin so we only
+    // construct them (and load node:stream/net/tty) on first access.
+    // Matches Node's lib/internal/bootstrap/switches/is_main_thread.js.
+    defineLazyStream(process, "stdout", makeStdoutWriter);
+    defineLazyStream(process, "stderr", makeStderrWriter);
 
     arch = arch_();
     platform = isWindows ? "win32" : Deno.build.os;
@@ -1666,11 +1710,9 @@ internals.__bootstrapNodeProcess = function (
       );
     }
 
-    // Replace stdin if it is not a terminal
-    const newStdin = initStdin();
-    if (newStdin) {
-      stdin = process.stdin = newStdin;
-    }
+    // Install accessor for stdin too. initStdin() returns null for the
+    // TTY case at warmup, but at runtime it always returns a stream.
+    defineLazyStream(process, "stdin", makeStdinReader);
 
     // In worker threads, replace certain process functions with stubs
     // that throw ERR_WORKER_UNSUPPORTED_OPERATION and have .disabled = true.
@@ -1719,18 +1761,18 @@ internals.__bootstrapNodeProcess = function (
 
     delete internals.__bootstrapNodeProcess;
   } else {
-    // Warmup, assuming stdin/stdout/stderr are all terminals
-    stdin = process.stdin = initStdin(true);
-
-    /** https://nodejs.org/api/process.html#process_process_stdout */
-    stdout = process.stdout = createWritableStdioStream(
+    // Warmup branch: only reached if someone calls __bootstrapNodeProcess
+    // with warmup=true (currently commented out in 99_main.js). Loads
+    // stream modules eagerly via the lazy loader to mirror previous
+    // warmup behaviour if it gets re-enabled.
+    const ps = lazyProcessStreams();
+    stdin = process.stdin = ps.initStdin(true);
+    stdout = process.stdout = ps.createWritableStdioStream(
       io.stdout,
       "stdout",
       true,
     );
-
-    /** https://nodejs.org/api/process.html#process_process_stderr */
-    stderr = process.stderr = createWritableStdioStream(
+    stderr = process.stderr = ps.createWritableStdioStream(
       io.stderr,
       "stderr",
       true,

--- a/ext/node/polyfills/punycode.ts
+++ b/ext/node/polyfills/punycode.ts
@@ -9,36 +9,24 @@ const {
   op_node_idna_punycode_to_unicode,
 } = core.ops;
 
-const { deprecate } = core.loadExtScript("ext:deno_node/util.ts");
-
 const { ucs2 } = core.loadExtScript("ext:deno_node/internal/idna.ts");
 
 const version = "2.1.0";
 
-// deno-lint-ignore no-explicit-any
-function punyDeprecated(fn: any) {
-  return deprecate(
-    fn,
-    "The `punycode` module is deprecated. Please use a userland " +
-      "alternative instead.",
-    "DEP0040",
-  );
-}
-
 function toASCII(domain) {
-  return punyDeprecated(op_node_idna_punycode_to_ascii)(domain);
+  return op_node_idna_punycode_to_ascii(domain);
 }
 
 function toUnicode(domain) {
-  return punyDeprecated(op_node_idna_punycode_to_unicode)(domain);
+  return op_node_idna_punycode_to_unicode(domain);
 }
 
 function decode(domain) {
-  return punyDeprecated(op_node_idna_punycode_decode)(domain);
+  return op_node_idna_punycode_decode(domain);
 }
 
 function encode(domain) {
-  return punyDeprecated(op_node_idna_punycode_encode)(domain);
+  return op_node_idna_punycode_encode(domain);
 }
 
 return {

--- a/libs/core/modules/loaders.rs
+++ b/libs/core/modules/loaders.rs
@@ -420,8 +420,21 @@ impl ModuleLoader for LazyEsmModuleLoader {
     _options: ModuleLoadOptions,
   ) -> ModuleLoadResponse {
     let mut sources = self.sources.borrow_mut();
-    let source = match sources.remove(specifier.as_str()) {
-      Some(source) => source,
+    // Mirror `ModuleMap::take_lazy_esm_source`: keep a cheap copy in the
+    // map so concurrent loads of the same lazy specifier (e.g. one via
+    // `op_lazy_load_esm` from a `createLazyLoader(...)()` call inside an
+    // already-loading sibling, and one via static import from user code)
+    // both succeed. `remove` here used to leave the second loader with
+    // an empty entry, surfacing as "Unsupported scheme node" because the
+    // resolver-side fallback found no source to use.
+    let source = match sources.get_mut(specifier.as_str()) {
+      Some(entry) => {
+        let placeholder = ModuleCodeString::from_static("");
+        let owned = std::mem::replace(entry, placeholder);
+        let (keep, give) = owned.into_cheap_copy();
+        *entry = keep;
+        give
+      }
       None => {
         return ModuleLoadResponse::Sync(Err(JsErrorBox::generic(format!(
           "Specifier \"{0}\" cannot be lazy-loaded as it was not included in the binary.",

--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -2822,23 +2822,33 @@ impl ModuleMap {
     // module map (notably `module.evaluate(scope)`, which can recursively
     // compile dependent modules and would otherwise panic with a
     // `RefCell already borrowed` at `new_module_from_js_source`).
-    let cached_handle = {
+    let cached_id_and_handle = {
       let module_map_data = self.data.borrow();
       module_map_data
         .get_id(module_specifier, RequestedModuleType::None)
-        .and_then(|id| module_map_data.get_handle(id))
+        .and_then(|id| module_map_data.get_handle(id).map(|h| (id, h)))
     };
-    if let Some(handle) = cached_handle {
+    if let Some((cached_id, handle)) = cached_id_and_handle {
       crate::modules::import_graph::record_lazy_esm_cached(
         scope,
         module_specifier,
       );
       let handle_local = v8::Local::new(scope, handle);
-      // The module may be present in the map but not yet evaluated --
-      // e.g. when this lazy load fires from a sibling ES module that V8 is
-      // evaluating earlier in DFS post-order. Returning the namespace
-      // before evaluation leaves `export const` bindings in the temporal
-      // dead zone, so trigger evaluation here.
+      // The module may be present in the map but not yet instantiated --
+      // e.g. when this lazy load fires from inside a sibling module's
+      // resolve-callback (a `synthetic_esm` backing script synchronously
+      // calling `op_lazy_load_esm` for a peer that the surrounding
+      // `RecursiveModuleLoad` has registered but not yet instantiated).
+      // `get_module_namespace` requires Instantiated+, so drive the module
+      // forward synchronously here.
+      if handle_local.get_status() == v8::ModuleStatus::Uninstantiated {
+        self.instantiate_module(scope, cached_id).map_err(|e| {
+          let exception = v8::Local::new(scope, e);
+          exception_to_err(scope, exception, false, true)
+        })?;
+      }
+      // Returning the namespace before evaluation leaves `export const`
+      // bindings in the temporal dead zone, so trigger evaluation here.
       if handle_local.get_status() == v8::ModuleStatus::Instantiated {
         let value = handle_local.evaluate(scope).unwrap();
         if !self.evaluating_top_level.get() {

--- a/libs/core/uv_compat/tty.rs
+++ b/libs/core/uv_compat/tty.rs
@@ -1305,7 +1305,7 @@ pub unsafe fn uv_tty_init(
       let mut reopened = false;
       if handle_type == uv_handle_type::UV_TTY && tty_is_slave(fd) {
         let mut path = [0u8; 256];
-        if libc::ttyname_r(fd, path.as_mut_ptr().cast(), path.len()) == 0 {
+        if tty_path(fd, &mut path) {
           let new_fd =
             open_cloexec(path.as_ptr().cast(), mode | libc::O_NOCTTY);
           if new_fd >= 0 {
@@ -3086,6 +3086,56 @@ unsafe fn tty_is_slave(fd: c_int) -> bool {
     // Fallback: ptsname() returns NULL for slave fds.
     unsafe { libc::ptsname(fd).is_null() }
   }
+}
+
+/// Resolve the path of a TTY slave fd into `buf` (NUL-terminated).
+///
+/// `ttyname_r` on macOS scans `/dev` with `lstat` on every entry, which
+/// shows up as a startup-time hot spot when initializing stdin/stdout/stderr.
+/// `F_GETPATH` (macOS) and `/proc/self/fd` (Linux) read the path directly
+/// from the fd's vnode entry in O(1) without touching the filesystem.
+#[cfg(unix)]
+unsafe fn tty_path(fd: c_int, buf: &mut [u8]) -> bool {
+  #[cfg(target_os = "macos")]
+  {
+    // F_GETPATH requires a buffer of MAXPATHLEN (1024). Resolve into a
+    // local buffer, then copy the (short) tty path into the caller's buf.
+    let mut tmp = [0u8; libc::PATH_MAX as usize];
+    if unsafe { libc::fcntl(fd, libc::F_GETPATH, tmp.as_mut_ptr()) } == 0 {
+      let len = tmp.iter().position(|&b| b == 0).unwrap_or(tmp.len());
+      if len < buf.len() {
+        buf[..len].copy_from_slice(&tmp[..len]);
+        buf[len] = 0;
+        return true;
+      }
+    }
+  }
+  #[cfg(target_os = "linux")]
+  {
+    let mut link = [0u8; 64];
+    let n = unsafe {
+      libc::snprintf(
+        link.as_mut_ptr().cast(),
+        link.len(),
+        c"/proc/self/fd/%d".as_ptr(),
+        fd,
+      )
+    };
+    if n > 0 && (n as usize) < link.len() {
+      let r = unsafe {
+        libc::readlink(
+          link.as_ptr().cast(),
+          buf.as_mut_ptr().cast(),
+          buf.len() - 1,
+        )
+      };
+      if r > 0 && (r as usize) < buf.len() {
+        buf[r as usize] = 0;
+        return true;
+      }
+    }
+  }
+  unsafe { libc::ttyname_r(fd, buf.as_mut_ptr().cast(), buf.len()) == 0 }
 }
 
 /// Open a file with O_CLOEXEC set.


### PR DESCRIPTION
  Results


  Snapshot size: 9,407,439 → 8,521,932 bytes (−885 KB, −9.4%)

  Startup time (100 runs, hyperfine -N, after 20 warmups):

```  

┌─────────────────────────────────────────────────┬──────────────────────────┬───────────────┬───────────────┐
│                     Command                     │ baseline (main@upstream) │  ollzspzs/1   │     delta     │
├─────────────────────────────────────────────────┼──────────────────────────┼───────────────┼───────────────┤
│ deno eval 1                                     │ 22.6 ± 0.4 ms            │ 21.7 ± 1.6 ms │ −0.9 ms (−4%) │
├─────────────────────────────────────────────────┼──────────────────────────┼───────────────┼───────────────┤
│ deno run hello.mjs                              │ 21.9 ± 4.4 ms            │ 20.9 ± 0.9 ms │ −1.0 ms (−5%) │
├─────────────────────────────────────────────────┼──────────────────────────┼───────────────┼───────────────┤
│ deno run -A hello.cjs                           │ 23.1 ± 0.7 ms            │ 22.5 ± 2.4 ms │ −0.6 ms (−3%) │
├─────────────────────────────────────────────────┼──────────────────────────┼───────────────┼───────────────┤
│ deno run stdout.mjs (uses process.stdout.write) │ 22.0 ± 2.7 ms            │ 23.6 ± 1.0 ms │ +1.6 ms (+7%) │
└─────────────────────────────────────────────────┴──────────────────────────┴───────────────┴───────────────┘
```
  The regression on the last row is the expected tradeoff: scripts that actually touch process.stdout/stderr/stdin pay the deferred construction cost on first
  access. Net win for the common case (deno run of a script that doesn't immediately touch Node stdio) and across-the-board snapshot win.