### PR TITLE
ci: put $PNPM_HOME/bin on PATH for npm_publish global install steps

### DIFF
--- a/.github/workflows/npm_publish.generated.yml
+++ b/.github/workflows/npm_publish.generated.yml
@@ -110,7 +110,7 @@ jobs:
           PNPM_HOME="${{ runner.temp }}/pnpm-global"
           mkdir -p "$PNPM_HOME"
           echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
-          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          echo "$PNPM_HOME/bin" >> "$GITHUB_PATH"
       - name: Configure npm to use Verdaccio
         run: |-
           npm config set registry http://localhost:4873/

--- a/.github/workflows/npm_publish.ts
+++ b/.github/workflows/npm_publish.ts
@@ -134,7 +134,7 @@ const installPnpm = step.dependsOn(startVerdaccio)({
     'PNPM_HOME="${{ runner.temp }}/pnpm-global"',
     'mkdir -p "$PNPM_HOME"',
     'echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"',
-    'echo "$PNPM_HOME" >> "$GITHUB_PATH"',
+    'echo "$PNPM_HOME/bin" >> "$GITHUB_PATH"',
   ],
 });
 


### PR DESCRIPTION
pnpm's global bin directory lives at `$PNPM_HOME/bin`, but the `Install
pnpm` step in `npm_publish` was appending `$PNPM_HOME` itself to
`$GITHUB_PATH`. Under pnpm 9 that mismatch produced only a warning, so
the global install steps kept working. Under pnpm 10 it became a hard
error — `[ERROR] The configured global bin directory ... is not in
PATH` — which fails the `Test pnpm global install deno (without
postinstall)` step and, by extension, the whole `test` job that gates
`publish`. This is the second pnpm 10 strictness ratchet uncovered
after #34445; once the local install passed, the global install
started erroring on PATH.

Closes #34442