### PR TITLE
ci: get npm_publish working under pnpm 11

### DIFF
--- a/.github/workflows/npm_publish.generated.yml
+++ b/.github/workflows/npm_publish.generated.yml
@@ -196,7 +196,7 @@ jobs:
         run: |-
           EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"
           pnpm install -g --ignore-scripts deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
-          ACTUAL="$(node "$(pnpm root -g)/deno/bin.cjs" -v)"
+          ACTUAL="$(deno -v)"
           echo "$ACTUAL"
           [ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected '$EXPECTED_VERSION', got '$ACTUAL'"; exit 1; }
           pnpm uninstall -g deno

--- a/.github/workflows/npm_publish.generated.yml
+++ b/.github/workflows/npm_publish.generated.yml
@@ -206,15 +206,19 @@ jobs:
           mkdir -p "$TEST_DIR"
           cd "$TEST_DIR"
           npm init -y
+          echo 'onlyBuiltDependencies: [deno]' > pnpm-workspace.yaml
           EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"
-          pnpm install --config.onlyBuiltDependencies='["deno"]' deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
+          pnpm install deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
           ACTUAL="$(pnpm exec deno -v)"
           echo "$ACTUAL"
           [ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected '$EXPECTED_VERSION', got '$ACTUAL'"; exit 1; }
       - name: Test pnpm global install deno (with postinstall)
         run: |-
+          GLOBAL_DIR="$(pnpm root -g)"
+          mkdir -p "$GLOBAL_DIR"
+          echo 'onlyBuiltDependencies: [deno]' > "$GLOBAL_DIR/pnpm-workspace.yaml"
           EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"
-          pnpm install -g --config.onlyBuiltDependencies='["deno"]' deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
+          pnpm install -g deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
           ACTUAL="$(deno -v)"
           echo "$ACTUAL"
           [ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected '$EXPECTED_VERSION', got '$ACTUAL'"; exit 1; }

--- a/.github/workflows/npm_publish.generated.yml
+++ b/.github/workflows/npm_publish.generated.yml
@@ -200,8 +200,6 @@ jobs:
           echo "$ACTUAL"
           [ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected '$EXPECTED_VERSION', got '$ACTUAL'"; exit 1; }
           pnpm uninstall -g deno
-      - name: Allow pnpm build scripts
-        run: 'pnpm config set --global onlyBuiltDependencies ''["*"]'''
       - name: Test pnpm local install deno (with postinstall)
         run: |-
           TEST_DIR="${{ runner.temp }}/pnpm-test"
@@ -209,14 +207,14 @@ jobs:
           cd "$TEST_DIR"
           npm init -y
           EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"
-          pnpm install deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
+          pnpm install --config.onlyBuiltDependencies='["deno"]' deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
           ACTUAL="$(pnpm exec deno -v)"
           echo "$ACTUAL"
           [ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected '$EXPECTED_VERSION', got '$ACTUAL'"; exit 1; }
       - name: Test pnpm global install deno (with postinstall)
         run: |-
           EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"
-          pnpm install -g deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
+          pnpm install -g --config.onlyBuiltDependencies='["deno"]' deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
           ACTUAL="$(deno -v)"
           echo "$ACTUAL"
           [ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected '$EXPECTED_VERSION', got '$ACTUAL'"; exit 1; }

--- a/.github/workflows/npm_publish.generated.yml
+++ b/.github/workflows/npm_publish.generated.yml
@@ -196,7 +196,7 @@ jobs:
         run: |-
           EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"
           pnpm install -g --ignore-scripts deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
-          ACTUAL="$(node "$PNPM_HOME/global/5/node_modules/deno/bin.cjs" -v)"
+          ACTUAL="$(node "$(pnpm root -g)/deno/bin.cjs" -v)"
           echo "$ACTUAL"
           [ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected '$EXPECTED_VERSION', got '$ACTUAL'"; exit 1; }
           pnpm uninstall -g deno

--- a/.github/workflows/npm_publish.generated.yml
+++ b/.github/workflows/npm_publish.generated.yml
@@ -206,7 +206,7 @@ jobs:
           mkdir -p "$TEST_DIR"
           cd "$TEST_DIR"
           npm init -y
-          echo 'onlyBuiltDependencies: [deno]' > pnpm-workspace.yaml
+          printf 'allowBuilds:\n  deno: true\n' > pnpm-workspace.yaml
           EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"
           pnpm install deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
           ACTUAL="$(pnpm exec deno -v)"
@@ -216,7 +216,7 @@ jobs:
         run: |-
           GLOBAL_DIR="$(pnpm root -g)"
           mkdir -p "$GLOBAL_DIR"
-          echo 'onlyBuiltDependencies: [deno]' > "$GLOBAL_DIR/pnpm-workspace.yaml"
+          printf 'allowBuilds:\n  deno: true\n' > "$GLOBAL_DIR/pnpm-workspace.yaml"
           EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"
           pnpm install -g deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/
           ACTUAL="$(deno -v)"

--- a/.github/workflows/npm_publish.ts
+++ b/.github/workflows/npm_publish.ts
@@ -264,12 +264,7 @@ const testPnpmGlobalNoScripts = step.dependsOn(testPnpmLocalNoScripts)({
   ],
 });
 
-const allowPnpmBuildScripts = step.dependsOn(testPnpmGlobalNoScripts)({
-  name: "Allow pnpm build scripts",
-  run: "pnpm config set --global onlyBuiltDependencies '[\"*\"]'",
-});
-
-const testPnpmLocalWithScripts = step.dependsOn(allowPnpmBuildScripts)({
+const testPnpmLocalWithScripts = step.dependsOn(testPnpmGlobalNoScripts)({
   name: "Test pnpm local install deno (with postinstall)",
   run: [
     'TEST_DIR="${{ runner.temp }}/pnpm-test"',
@@ -277,7 +272,7 @@ const testPnpmLocalWithScripts = step.dependsOn(allowPnpmBuildScripts)({
     'cd "$TEST_DIR"',
     "npm init -y",
     'EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"',
-    "pnpm install deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
+    "pnpm install --config.onlyBuiltDependencies='[\"deno\"]' deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
     'ACTUAL="$(pnpm exec deno -v)"',
     'echo "$ACTUAL"',
     '[ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected \'$EXPECTED_VERSION\', got \'$ACTUAL\'"; exit 1; }',
@@ -288,7 +283,7 @@ const testPnpmGlobalWithScripts = step.dependsOn(testPnpmLocalWithScripts)({
   name: "Test pnpm global install deno (with postinstall)",
   run: [
     'EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"',
-    "pnpm install -g deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
+    "pnpm install -g --config.onlyBuiltDependencies='[\"deno\"]' deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
     'ACTUAL="$(deno -v)"',
     'echo "$ACTUAL"',
     '[ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected \'$EXPECTED_VERSION\', got \'$ACTUAL\'"; exit 1; }',

--- a/.github/workflows/npm_publish.ts
+++ b/.github/workflows/npm_publish.ts
@@ -257,7 +257,7 @@ const testPnpmGlobalNoScripts = step.dependsOn(testPnpmLocalNoScripts)({
   run: [
     'EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"',
     "pnpm install -g --ignore-scripts deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
-    'ACTUAL="$(node "$PNPM_HOME/global/5/node_modules/deno/bin.cjs" -v)"',
+    'ACTUAL="$(node "$(pnpm root -g)/deno/bin.cjs" -v)"',
     'echo "$ACTUAL"',
     '[ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected \'$EXPECTED_VERSION\', got \'$ACTUAL\'"; exit 1; }',
     "pnpm uninstall -g deno",

--- a/.github/workflows/npm_publish.ts
+++ b/.github/workflows/npm_publish.ts
@@ -257,7 +257,7 @@ const testPnpmGlobalNoScripts = step.dependsOn(testPnpmLocalNoScripts)({
   run: [
     'EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"',
     "pnpm install -g --ignore-scripts deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
-    'ACTUAL="$(node "$(pnpm root -g)/deno/bin.cjs" -v)"',
+    'ACTUAL="$(deno -v)"',
     'echo "$ACTUAL"',
     '[ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected \'$EXPECTED_VERSION\', got \'$ACTUAL\'"; exit 1; }',
     "pnpm uninstall -g deno",

--- a/.github/workflows/npm_publish.ts
+++ b/.github/workflows/npm_publish.ts
@@ -271,7 +271,7 @@ const testPnpmLocalWithScripts = step.dependsOn(testPnpmGlobalNoScripts)({
     'mkdir -p "$TEST_DIR"',
     'cd "$TEST_DIR"',
     "npm init -y",
-    "echo 'onlyBuiltDependencies: [deno]' > pnpm-workspace.yaml",
+    "printf 'allowBuilds:\\n  deno: true\\n' > pnpm-workspace.yaml",
     'EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"',
     "pnpm install deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
     'ACTUAL="$(pnpm exec deno -v)"',
@@ -285,7 +285,7 @@ const testPnpmGlobalWithScripts = step.dependsOn(testPnpmLocalWithScripts)({
   run: [
     'GLOBAL_DIR="$(pnpm root -g)"',
     'mkdir -p "$GLOBAL_DIR"',
-    "echo 'onlyBuiltDependencies: [deno]' > \"$GLOBAL_DIR/pnpm-workspace.yaml\"",
+    "printf 'allowBuilds:\\n  deno: true\\n' > \"$GLOBAL_DIR/pnpm-workspace.yaml\"",
     'EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"',
     "pnpm install -g deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
     'ACTUAL="$(deno -v)"',

--- a/.github/workflows/npm_publish.ts
+++ b/.github/workflows/npm_publish.ts
@@ -271,8 +271,9 @@ const testPnpmLocalWithScripts = step.dependsOn(testPnpmGlobalNoScripts)({
     'mkdir -p "$TEST_DIR"',
     'cd "$TEST_DIR"',
     "npm init -y",
+    "echo 'onlyBuiltDependencies: [deno]' > pnpm-workspace.yaml",
     'EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"',
-    "pnpm install --config.onlyBuiltDependencies='[\"deno\"]' deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
+    "pnpm install deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
     'ACTUAL="$(pnpm exec deno -v)"',
     'echo "$ACTUAL"',
     '[ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected \'$EXPECTED_VERSION\', got \'$ACTUAL\'"; exit 1; }',
@@ -282,8 +283,11 @@ const testPnpmLocalWithScripts = step.dependsOn(testPnpmGlobalNoScripts)({
 const testPnpmGlobalWithScripts = step.dependsOn(testPnpmLocalWithScripts)({
   name: "Test pnpm global install deno (with postinstall)",
   run: [
+    'GLOBAL_DIR="$(pnpm root -g)"',
+    'mkdir -p "$GLOBAL_DIR"',
+    "echo 'onlyBuiltDependencies: [deno]' > \"$GLOBAL_DIR/pnpm-workspace.yaml\"",
     'EXPECTED_VERSION="deno ${{ steps.publish-verdaccio.outputs.version }}"',
-    "pnpm install -g --config.onlyBuiltDependencies='[\"deno\"]' deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
+    "pnpm install -g deno@${{ steps.publish-verdaccio.outputs.version }} --registry http://localhost:4873/",
     'ACTUAL="$(deno -v)"',
     'echo "$ACTUAL"',
     '[ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected \'$EXPECTED_VERSION\', got \'$ACTUAL\'"; exit 1; }',


### PR DESCRIPTION
Follow-up to #34445 and #34449. After those fixes the `test` job got
further into the pnpm steps and tripped two more pnpm 11 strictness
changes that had been masked. With this PR the full matrix passes and
2.8.0 / 2.8.1 publish to npm.

The `(without postinstall)` step verified the install by running
`node $PNPM_HOME/global/5/node_modules/deno/bin.cjs -v`. The `5` is
pnpm's internal global-store version segment, which moved under pnpm
11, so the path no longer existed and the step failed with
`MODULE_NOT_FOUND`. Drop the hard-coded path and call `deno -v`
directly — `$PNPM_HOME/bin` is on `$PATH` (from #34449), and under
`--ignore-scripts` the global bin entry points at `bin.cjs`, so this
still exercises the same fallback the test was checking. Matches the
npm `--ignore-scripts` step pattern.

The `Allow pnpm build scripts` step ran `pnpm config set --global
onlyBuiltDependencies '["*"]'`. pnpm 11 rejects that with
`ERR_PNPM_CONFIG_SET_UNSUPPORTED_YAML_CONFIG_KEY` — and more
importantly, `onlyBuiltDependencies` is itself deprecated. pnpm 11
reads `allowBuilds: { <pkg>: true }` from `pnpm-workspace.yaml`
instead (pnpm writes that exact skeleton itself on first failure).
Drop the global-config step and pre-write a minimal workspace yaml
into the local `TEST_DIR` and into `$(pnpm root -g)` before the two
`(with postinstall)` installs. Reproduced and verified locally against
a fresh Verdaccio with all seven `deno`+`@deno/*` tarballs and
pnpm 11.4.0; lifecycle log confirms postinstall actually runs
(`stage=postinstall, exitCode=0`).