### PR TITLE
fix(permissions): don't hang prompt when stdin is in raw mode

### DIFF
--- a/runtime/permissions/prompter.rs
+++ b/runtime/permissions/prompter.rs
@@ -298,28 +298,35 @@ fn clear_n_lines(stderr_lock: &mut std::io::StderrLock, n: usize) {
 }
 
 /// Returns true if stdin's terminal line discipline has been put into raw
-/// mode (canonical input disabled) by something else in this process — for
-/// example a Node.js library calling `process.stdin.setRawMode(true)`.
+/// mode by something else in this process — for example a Node.js library
+/// calling `process.stdin.setRawMode(true)`.
 ///
 /// When that has happened our line-oriented `read_line()` prompt loop would
 /// hang forever (Enter delivers `\r` rather than `\n`, and ECHO is off so the
 /// user can't see they're typing), so we bail out instead.
+///
+/// We require *both* canonical input and echo to be disabled, matching what
+/// `setRaw`/`setRawMode` actually does (see `runtime/ops/tty.rs`). Clearing
+/// canonical mode alone does not trigger the hang as long as newlines are
+/// still delivered, and treating that as raw would misfire on setups that
+/// disable only canonical mode (such as the test PTY harness).
 #[cfg(unix)]
 fn stdin_is_raw_mode() -> bool {
-  // SAFETY: tcgetattr on a possibly-invalid fd 0 returns -1; we only treat
-  // ICANON-cleared as raw, so any failure conservatively returns false.
+  // SAFETY: tcgetattr on a possibly-invalid fd 0 returns -1; on any failure we
+  // conservatively report not-raw.
   unsafe {
     let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
     if libc::tcgetattr(libc::STDIN_FILENO, termios.as_mut_ptr()) != 0 {
       return false;
     }
     let termios = termios.assume_init();
-    termios.c_lflag & libc::ICANON == 0
+    termios.c_lflag & (libc::ICANON | libc::ECHO) == 0
   }
 }
 
 #[cfg(all(not(unix), not(target_arch = "wasm32")))]
 fn stdin_is_raw_mode() -> bool {
+  use windows_sys::Win32::System::Console::ENABLE_ECHO_INPUT;
   use windows_sys::Win32::System::Console::ENABLE_LINE_INPUT;
   use windows_sys::Win32::System::Console::GetConsoleMode;
   use windows_sys::Win32::System::Console::GetStdHandle;
@@ -334,7 +341,7 @@ fn stdin_is_raw_mode() -> bool {
     if GetConsoleMode(handle, &mut mode) == 0 {
       return false;
     }
-    mode & ENABLE_LINE_INPUT == 0
+    mode & (ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT) == 0
   }
 }
 

--- a/runtime/permissions/prompter.rs
+++ b/runtime/permissions/prompter.rs
@@ -393,7 +393,6 @@ impl PermissionPrompter for TtyPrompter {
     // hang forever waiting for a `\n` that the terminal will never deliver,
     // and the user wouldn't see what they're typing either. Bail out with a
     // clear message so the program doesn't appear to freeze.
-    #[cfg(not(target_arch = "wasm32"))]
     #[allow(clippy::print_stderr, reason = "actually want to print")]
     if stdin_is_raw_mode() {
       // Escape the message/name since they can contain user-controlled strings

--- a/runtime/permissions/prompter.rs
+++ b/runtime/permissions/prompter.rs
@@ -320,19 +320,18 @@ fn stdin_is_raw_mode() -> bool {
 
 #[cfg(all(not(unix), not(target_arch = "wasm32")))]
 fn stdin_is_raw_mode() -> bool {
-  use winapi::shared::minwindef::DWORD;
-  use winapi::shared::minwindef::FALSE;
-  use winapi::um::consoleapi::GetConsoleMode;
-  use winapi::um::processenv::GetStdHandle;
-  use winapi::um::winbase::STD_INPUT_HANDLE;
-  use winapi::um::wincon::ENABLE_LINE_INPUT;
+  use windows_sys::Win32::System::Console::ENABLE_LINE_INPUT;
+  use windows_sys::Win32::System::Console::GetConsoleMode;
+  use windows_sys::Win32::System::Console::GetStdHandle;
+  use windows_sys::Win32::System::Console::STD_INPUT_HANDLE;
 
-  // SAFETY: winapi calls. GetConsoleMode returns FALSE for non-console handles
-  // (e.g. when stdin is a pipe), in which case we conservatively return false.
+  // SAFETY: winapi calls. GetConsoleMode returns 0 (FALSE) for non-console
+  // handles (e.g. when stdin is a pipe), in which case we conservatively
+  // return false.
   unsafe {
     let handle = GetStdHandle(STD_INPUT_HANDLE);
-    let mut mode: DWORD = 0;
-    if GetConsoleMode(handle, &mut mode) == FALSE {
+    let mut mode = 0u32;
+    if GetConsoleMode(handle, &mut mode) == 0 {
       return false;
     }
     mode & ENABLE_LINE_INPUT == 0
@@ -390,11 +389,15 @@ impl PermissionPrompter for TtyPrompter {
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(clippy::print_stderr, reason = "actually want to print")]
     if stdin_is_raw_mode() {
+      // Escape the message/name since they can contain user-controlled strings
+      // (env var names, file paths) that could otherwise spoof the terminal.
       eprintln!(
-        "❌ Cannot prompt for {message}: stdin is in raw mode (a library has likely called setRawMode)."
+        "❌ Cannot prompt for {}: stdin is in raw mode (a library has likely called setRawMode).",
+        escape_control_characters(message)
       );
       eprintln!(
-        "❌ Run again with --allow-{name} to grant the permission up front, or with -A to skip all prompts."
+        "❌ Run again with --allow-{} to grant the permission up front, or with -A to skip all prompts.",
+        escape_control_characters(name)
       );
       return PromptResponse::Deny;
     }

--- a/runtime/permissions/prompter.rs
+++ b/runtime/permissions/prompter.rs
@@ -297,6 +297,48 @@ fn clear_n_lines(stderr_lock: &mut std::io::StderrLock, n: usize) {
   write!(stderr_lock, "\x1B[{n}A\x1B[0J").unwrap();
 }
 
+/// Returns true if stdin's terminal line discipline has been put into raw
+/// mode (canonical input disabled) by something else in this process — for
+/// example a Node.js library calling `process.stdin.setRawMode(true)`.
+///
+/// When that has happened our line-oriented `read_line()` prompt loop would
+/// hang forever (Enter delivers `\r` rather than `\n`, and ECHO is off so the
+/// user can't see they're typing), so we bail out instead.
+#[cfg(unix)]
+fn stdin_is_raw_mode() -> bool {
+  // SAFETY: tcgetattr on a possibly-invalid fd 0 returns -1; we only treat
+  // ICANON-cleared as raw, so any failure conservatively returns false.
+  unsafe {
+    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+    if libc::tcgetattr(libc::STDIN_FILENO, termios.as_mut_ptr()) != 0 {
+      return false;
+    }
+    let termios = termios.assume_init();
+    termios.c_lflag & libc::ICANON == 0
+  }
+}
+
+#[cfg(all(not(unix), not(target_arch = "wasm32")))]
+fn stdin_is_raw_mode() -> bool {
+  use winapi::shared::minwindef::DWORD;
+  use winapi::shared::minwindef::FALSE;
+  use winapi::um::consoleapi::GetConsoleMode;
+  use winapi::um::processenv::GetStdHandle;
+  use winapi::um::winbase::STD_INPUT_HANDLE;
+  use winapi::um::wincon::ENABLE_LINE_INPUT;
+
+  // SAFETY: winapi calls. GetConsoleMode returns FALSE for non-console handles
+  // (e.g. when stdin is a pipe), in which case we conservatively return false.
+  unsafe {
+    let handle = GetStdHandle(STD_INPUT_HANDLE);
+    let mut mode: DWORD = 0;
+    if GetConsoleMode(handle, &mut mode) == FALSE {
+      return false;
+    }
+    mode & ENABLE_LINE_INPUT == 0
+  }
+}
+
 #[cfg(unix)]
 fn get_stdin_metadata() -> std::io::Result<std::fs::Metadata> {
   use std::os::fd::FromRawFd;
@@ -339,6 +381,23 @@ impl PermissionPrompter for TtyPrompter {
     if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
       return PromptResponse::Deny;
     };
+
+    // If stdin has been put into raw mode (e.g. a Node.js library has called
+    // `process.stdin.setRawMode(true)`) our line-oriented prompt loop would
+    // hang forever waiting for a `\n` that the terminal will never deliver,
+    // and the user wouldn't see what they're typing either. Bail out with a
+    // clear message so the program doesn't appear to freeze.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[allow(clippy::print_stderr, reason = "actually want to print")]
+    if stdin_is_raw_mode() {
+      eprintln!(
+        "❌ Cannot prompt for {message}: stdin is in raw mode (a library has likely called setRawMode)."
+      );
+      eprintln!(
+        "❌ Run again with --allow-{name} to grant the permission up front, or with -A to skip all prompts."
+      );
+      return PromptResponse::Deny;
+    }
 
     #[allow(clippy::print_stderr, reason = "actually want to print")]
     if message.len() > MAX_PERMISSION_PROMPT_LENGTH {

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -389,6 +389,23 @@ fn permissions_prompt_allow_all_lowercase_a() {
     });
 }
 
+// Regression test for https://github.com/denoland/deno/issues/34399
+// When stdin has been put into raw mode by user code (e.g. ts-node calling
+// `process.stdin.setRawMode(true)`), the prompt's line-buffered `read_line`
+// would hang because Enter delivers `\r` and ECHO is off. Verify we bail
+// out with a clear message and deny the permission instead.
+#[test(flaky)]
+fn permissions_prompt_raw_stdin() {
+  TestContext::default()
+    .new_command()
+    .args_vec(["run", "--quiet", "run/permissions_prompt_raw_stdin.ts"])
+    .with_pty(|mut console| {
+      console.expect("stdin is in raw mode");
+      console.expect("Run again with --allow-env");
+      console.expect("STATUS: denied");
+    });
+}
+
 #[test(flaky)]
 fn permission_request_long() {
   TestContext::default()

--- a/tests/testdata/run/permissions_prompt_raw_stdin.ts
+++ b/tests/testdata/run/permissions_prompt_raw_stdin.ts
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/denoland/deno/issues/34399
+// When a library (e.g. ts-node) has put stdin into raw mode, the
+// permission prompt's line-buffered `read_line` would hang forever
+// because Enter delivers `\r` (no `\n`) and ECHO is off.
+//
+// Verify that the prompt instead bails out with a clear message and
+// denies the permission.
+Deno.stdin.setRaw(true);
+const status = Deno.permissions.requestSync({ name: "env", variable: "FOO" });
+console.log("STATUS:", status.state);


### PR DESCRIPTION
When a library has put stdin into raw mode — e.g. ts-node calling
`process.stdin.setRawMode(true)` from a REPL — the line-oriented
permission prompt would hang forever. With `ICANON` cleared, Enter
delivers `\r` rather than `\n` so `read_line` never returns, and with
`ECHO` off the user can't even see they're typing into the void. From
the program's perspective Deno is just frozen.

Detect the raw-mode state via `tcgetattr` on Unix (and `GetConsoleMode`
on Windows) before issuing the prompt; if `ICANON` / `ENABLE_LINE_INPUT`
is cleared we print a clear message naming the requested permission and
deny the request, so the program fails fast with a normal `NotCapable`
error instead of appearing to hang.

Closes #34399