### PR TITLE
fix(install): vendor type-only imports during `deno ci`

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -580,6 +580,7 @@ impl CliOptions {
       DenoSubcommand::Add(_) => GraphKind::All,
       DenoSubcommand::Cache(_) => GraphKind::All,
       DenoSubcommand::Check(_) => GraphKind::TypesOnly,
+      DenoSubcommand::Ci(_) => GraphKind::All,
       DenoSubcommand::Install(InstallFlags::Local(
         InstallFlagsLocal::Entrypoints(flags),
         _,

--- a/tests/specs/install/ci_vendor_type_only_import/__test__.jsonc
+++ b/tests/specs/install/ci_vendor_type_only_import/__test__.jsonc
@@ -1,0 +1,35 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": [
+      "eval",
+      "import fs from 'node:fs'; fs.writeFileSync('deno.json', JSON.stringify({ vendor: true, imports: { 'type-only': 'jsr:@denotest/type-only-import@1.0.0' } }))"
+    ],
+    "output": ""
+  }, {
+    "args": [
+      "eval",
+      "import fs from 'node:fs'; fs.writeFileSync('main.ts', \"import { foo } from 'type-only'; console.log(foo.bar);\")"
+    ],
+    "output": ""
+  }, {
+    // create the lockfile first
+    "args": "install",
+    "output": "[WILDCARD]"
+  }, {
+    // clean vendor and cache so ci re-populates from scratch
+    "args": [
+      "eval",
+      "import fs from 'node:fs'; fs.rmSync('vendor', { recursive: true, force: true })"
+    ],
+    "output": ""
+  }, {
+    "args": "ci",
+    "output": "[WILDCARD]"
+  }, {
+    // foo.ts is referenced via `import type` from mod.ts — must still be
+    // vendored so that --cached-only / type checking can find it.
+    "args": "run --cached-only main.ts",
+    "output": "foo\n"
+  }]
+}


### PR DESCRIPTION
`deno ci` was using `GraphKind::CodeOnly` when walking the module graph,
because it never sets a type-check mode and so falls through to the
default. `deno install` uses `GraphKind::All`. Files referenced only via
`import type` (e.g. `@std/internal/build_message.ts` importing
`./types.ts`) were therefore skipped during `deno ci` and never written
to the `vendor/` folder, and a subsequent `deno test --cached-only`
would fail with `Specifier not found in cache`.

Fix is a one-line addition to `CliOptions::graph_kind()` so `ci` gets
the same `GraphKind::All` treatment as `install`. The new spec test
uses the existing `@denotest/type-only-import` JSR fixture to guard the
regression.

Closes #34436