### PR TITLE
fix(core): TLA hang on dyn import when async dep triggers lazy ESM load

### DIFF
--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -2076,7 +2076,17 @@ impl ModuleMap {
     tc_scope.set_continuation_preserved_embedder_data(cped);
 
     let module = v8::Local::new(tc_scope, &module_handle);
+    // Set `evaluating_top_level` so that any nested `lazy_load_esm_module`
+    // calls (triggered e.g. by CJS `require()` chains under
+    // `npm:` packages) skip their post-evaluate `perform_microtask_checkpoint`.
+    // Draining microtasks while V8 is inside `module.evaluate()` on an
+    // async module graph leaves the evaluation promise permanently
+    // Pending — V8 advances AsyncModuleExecutionFulfilled for the resumed
+    // TLA dep but cannot then run `ExecuteModule` on the still-evaluating
+    // parent.
+    self.evaluating_top_level.set(true);
     let maybe_value = module.evaluate(tc_scope);
+    self.evaluating_top_level.set(false);
 
     // Update status after evaluating.
     let status = module.get_status();

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -2958,3 +2958,98 @@ async fn test_tla_with_tick_scheduled_no_hang() {
   runtime.run_event_loop(Default::default()).await.unwrap();
   receiver.await.unwrap();
 }
+
+/// Regression test for https://github.com/denoland/deno/issues/34466
+///
+/// When a dynamic import evaluates an async module graph whose
+/// dependencies trigger nested `lazy_load_esm_module` calls (e.g. an npm
+/// CJS package whose `require()` chain pulls in a now-lazy `node:*`
+/// polyfill), the inner `perform_microtask_checkpoint` was firing while
+/// V8 was still inside the outer `module.evaluate()` on the async graph.
+/// That drained the TLA dependency's await-resume microtask too early
+/// and wedged V8's async module state machine — the parent module's
+/// evaluation promise stayed Pending forever and the runtime reported
+/// "Top-level await promise never resolved" at the dynamic import site.
+///
+/// The fix is to mark `evaluating_top_level` true around
+/// `module.evaluate()` in `dynamic_import_module_evaluate`, matching
+/// `mod_evaluate`, so nested lazy ESM loads skip their post-evaluate
+/// microtask checkpoint.
+#[tokio::test]
+async fn test_dyn_import_async_graph_with_lazy_esm_no_stall() {
+  deno_core::extension!(
+    test_ext,
+    lazy_loaded_esm = [
+      dir "modules/testdata",
+      "lazy_loaded.js",
+    ]
+  );
+
+  // mod.js mimics an npm package side-effect import: it has a TLA dep
+  // (tla.js) and a sibling that triggers a lazy ESM load (the CJS
+  // require-of-node:* case in the original bug).
+  struct Loader;
+  impl ModuleLoader for Loader {
+    fn resolve(
+      &self,
+      specifier: &str,
+      referrer: &str,
+      _kind: ResolutionKind,
+    ) -> Result<ModuleSpecifier, ModuleLoaderError> {
+      resolve_import(specifier, referrer)
+        .map_err(|e| deno_error::JsErrorBox::generic(e.to_string()))
+    }
+    fn load(
+      &self,
+      module_specifier: &ModuleSpecifier,
+      _maybe_referrer: Option<&ModuleLoadReferrer>,
+      _options: ModuleLoadOptions,
+    ) -> ModuleLoadResponse {
+      let s = module_specifier.as_str();
+      let code = match s {
+        "file:///main.js" => {
+          r#"await import("./mod.js"); globalThis.done = true;"#
+        }
+        // mod.js mirrors the npm-package shape from the original bug:
+        // a TLA dep imported first, then a sibling whose evaluation
+        // triggers a `lazy_load_esm_module` call (the CJS-require-of-a-
+        // now-lazy-node:*-polyfill case).
+        "file:///mod.js" => r#"import "./tla.js"; import "./helper.js";"#,
+        "file:///tla.js" => r#"await Promise.resolve();"#,
+        "file:///helper.js" => {
+          r#"
+          const lazy = Deno.core.createLazyLoader("ext:test_ext/lazy_loaded.js")();
+          if (lazy.foo !== "foo") throw new Error("lazy.foo: " + lazy.foo);
+          "#
+        }
+        _ => panic!("unexpected: {s}"),
+      };
+      ModuleLoadResponse::Sync(Ok(ModuleSource::new(
+        ModuleType::JavaScript,
+        ModuleSourceCode::String(FastString::from_static(code)),
+        module_specifier,
+        None,
+      )))
+    }
+  }
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![test_ext::init()],
+    module_loader: Some(Rc::new(Loader)),
+    ..Default::default()
+  });
+
+  let main_url = Url::parse("file:///main.js").unwrap();
+  let mod_id = runtime.load_main_es_module(&main_url).await.unwrap();
+  let receiver = runtime.mod_evaluate(mod_id);
+  runtime.run_event_loop(Default::default()).await.unwrap();
+  receiver.await.unwrap();
+
+  // Confirm main.js's TLA actually completed (not just that we didn't
+  // hit a stall error).
+  deno_core::scope!(scope, runtime);
+  let g = scope.get_current_context().global(scope);
+  let key = v8::String::new(scope, "done").unwrap();
+  let v = g.get(scope, key.into()).unwrap();
+  assert!(v.is_true(), "main.js await import never resolved");
+}


### PR DESCRIPTION
A dynamic `import()` of an async module graph could hang and then exit
with "Top-level await promise never resolved" when one of the graph's
sibling deps triggered a nested lazy ESM load — the shape that npm CJS
packages routinely hit since #34061 moved many `node:*` polyfills behind
`createLazyLoader`. Minimal repro: `await import("./mod.ts")` where
`mod.ts` is `import "./tla.ts"; import "npm:undici";` and `tla.ts` is
`await Promise.resolve();`.

`lazy_load_esm_module` runs a `perform_microtask_checkpoint()` after
evaluating the lazy module, gated by `!evaluating_top_level`. That flag
was only set in `mod_evaluate` (main module path), not in
`dynamic_import_module_evaluate`, so during a dyn-imported async graph
the checkpoint would fire while V8 was still inside the outer
`module.evaluate()`. V8 would drain the TLA dep's await-resume and run
`AsyncModuleExecutionFulfilled`, but couldn't then run `ExecuteModule`
on the still-evaluating parent — leaving the parent's evaluation promise
stuck in Pending and V8 reporting the user-facing top-level `await
import(...)` as stalled. This commit sets `evaluating_top_level` around
`module.evaluate()` in the dynamic import path too, matching
`mod_evaluate`, so nested lazy ESM loads skip their post-evaluate
checkpoint.

Fixes #34466