### PR TITLE
fix(npm): hoist direct deps over higher transitive versions

### DIFF
--- a/libs/npm_installer/hoisted.rs
+++ b/libs/npm_installer/hoisted.rs
@@ -14,6 +14,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -68,12 +69,18 @@ use crate::process_state::NpmProcessState;
 struct HoistedLayout<'a> {
   /// Packages that go to `node_modules/<name>/`.
   top_level: HashMap<&'a StackString, &'a NpmResolutionPackage>,
-  /// Packages that must be nested: parent's `node_modules/<dep_name>/`.
+  /// Packages that must be nested: `<parent_path>/node_modules/<dep>/`,
+  /// where `parent_path` is relative to the root `node_modules/` dir and
+  /// may itself include `.../node_modules/<name>` segments for parents
+  /// that are themselves nested.
   nested: Vec<NestedPackage<'a>>,
 }
 
 struct NestedPackage<'a> {
-  parent: &'a NpmResolutionPackage,
+  /// Path of the parent relative to the root `node_modules/` directory.
+  /// For a top-level parent this is just `<name>`; for a nested parent
+  /// it is `<ancestor>/node_modules/.../node_modules/<name>`.
+  parent_path: PathBuf,
   #[allow(dead_code, reason = "used for future nested package resolution")]
   dep_name: &'a StackString,
   dep: &'a NpmResolutionPackage,
@@ -154,14 +161,39 @@ fn compute_hoisted_layout<'a>(
     }
   }
 
-  // Determine which deps need to be nested
+  // Walk the dependency tree breadth-first starting from the top-level
+  // (hoisted) packages so that when a transitive package is itself
+  // nested, its own conflicting deps get placed under the actual
+  // nested location rather than under the top-level package that
+  // happens to share the same name.
+  //
+  // For example with root deps `schema-utils@4` + `terser-webpack-plugin`:
+  //   * `schema-utils@4` and `ajv@8` hoist to the top level.
+  //   * `terser-webpack-plugin` transitively pulls `schema-utils@3`,
+  //     which nests at `terser-webpack-plugin/node_modules/schema-utils`.
+  //   * `schema-utils@3` needs `ajv@6`. The previous flat algorithm
+  //     placed it at `node_modules/schema-utils/node_modules/ajv`,
+  //     shadowing the top-level `ajv@8` for the hoisted `schema-utils@4`.
+  //     With the BFS below it lands at
+  //     `node_modules/terser-webpack-plugin/node_modules/schema-utils/node_modules/ajv`.
   let mut nested = Vec::new();
+  let mut queue: VecDeque<(PathBuf, &NpmResolutionPackage)> = VecDeque::new();
+  // `(parent_path, parent_nv)` we've already expanded — guards against
+  // cyclic dep graphs and avoids re-emitting the same edges.
+  let mut visited: HashSet<(PathBuf, &PackageNv)> = HashSet::new();
 
-  for package in packages {
-    for (dep_name, dep_id) in &package.dependencies {
+  for (name, package) in &best_version_for_name {
+    queue.push_back((PathBuf::from(name.as_str()), package));
+  }
+
+  while let Some((parent_path, parent)) = queue.pop_front() {
+    if !visited.insert((parent_path.clone(), &parent.id.nv)) {
+      continue;
+    }
+    for (dep_name, dep_id) in &parent.dependencies {
       let dep = snapshot.package_from_id(dep_id).unwrap();
 
-      if package.optional_dependencies.contains(dep_name)
+      if parent.optional_dependencies.contains(dep_name)
         && !dep.system.matches_system(system_info)
       {
         continue;
@@ -170,14 +202,20 @@ fn compute_hoisted_layout<'a>(
       if let Some(hoisted) = best_version_for_name.get(&dep.id.nv.name)
         && hoisted.id.nv == dep.id.nv
       {
-        continue; // This version is hoisted, no nesting needed
+        // Resolved by the top-level (or an ancestor) — Node's lookup
+        // walks up the directory tree, so no nesting needed here.
+        continue;
       }
 
+      let dep_path = parent_path
+        .join("node_modules")
+        .join(dep.id.nv.name.as_str());
       nested.push(NestedPackage {
-        parent: package,
+        parent_path: parent_path.clone(),
         dep_name,
         dep,
       });
+      queue.push_back((dep_path, dep));
     }
   }
 
@@ -373,10 +411,7 @@ impl<
 
     // 3. Clone nested packages (version conflicts)
     for nested in &layout.nested {
-      let parent_path = join_package_name(
-        Cow::Borrowed(&self.root_node_modules_path),
-        &nested.parent.id.nv.name,
-      );
+      let parent_path = self.root_node_modules_path.join(&nested.parent_path);
       let nested_node_modules = parent_path.join("node_modules");
       sys.fs_create_dir_all(&nested_node_modules)?;
       let package_path = join_package_name(

--- a/libs/npm_installer/hoisted.rs
+++ b/libs/npm_installer/hoisted.rs
@@ -177,16 +177,22 @@ fn compute_hoisted_layout<'a>(
   //     With the BFS below it lands at
   //     `node_modules/terser-webpack-plugin/node_modules/schema-utils/node_modules/ajv`.
   let mut nested = Vec::new();
-  let mut queue: VecDeque<(PathBuf, &NpmResolutionPackage)> = VecDeque::new();
-  // `(parent_path, parent_nv)` we've already expanded — guards against
-  // cyclic dep graphs and avoids re-emitting the same edges.
+  // Each queue entry carries the parent's path (relative to the root
+  // `node_modules/`), the parent package, and the chain of ancestor
+  // NVs whose `node_modules/<name>` segments lie on `parent_path` —
+  // these are the candidates Node's resolver walks up to.
+  let mut queue: VecDeque<(PathBuf, &NpmResolutionPackage, Vec<&PackageNv>)> =
+    VecDeque::new();
+  // `(parent_path, parent_nv)` we've already expanded — avoids
+  // re-emitting the same edges when multiple paths reach the same
+  // (path, package) pair.
   let mut visited: HashSet<(PathBuf, &PackageNv)> = HashSet::new();
 
   for (name, package) in &best_version_for_name {
-    queue.push_back((PathBuf::from(name.as_str()), package));
+    queue.push_back((PathBuf::from(name.as_str()), package, Vec::new()));
   }
 
-  while let Some((parent_path, parent)) = queue.pop_front() {
+  while let Some((parent_path, parent, parent_ancestors)) = queue.pop_front() {
     if !visited.insert((parent_path.clone(), &parent.id.nv)) {
       continue;
     }
@@ -202,8 +208,17 @@ fn compute_hoisted_layout<'a>(
       if let Some(hoisted) = best_version_for_name.get(&dep.id.nv.name)
         && hoisted.id.nv == dep.id.nv
       {
-        // Resolved by the top-level (or an ancestor) — Node's lookup
-        // walks up the directory tree, so no nesting needed here.
+        // Top-level provides this version; Node's walk-up finds it.
+        continue;
+      }
+
+      // An ancestor on `parent_path` (including `parent` itself) already
+      // resolves `dep.id.nv` via Node's directory walk-up. This both
+      // breaks dependency cycles (A@1 ↔ B@1 where neither hoists) and
+      // avoids redundant deeper nestings.
+      if parent.id.nv == dep.id.nv
+        || parent_ancestors.iter().any(|a| **a == dep.id.nv)
+      {
         continue;
       }
 
@@ -215,7 +230,9 @@ fn compute_hoisted_layout<'a>(
         dep_name,
         dep,
       });
-      queue.push_back((dep_path, dep));
+      let mut dep_ancestors = parent_ancestors.clone();
+      dep_ancestors.push(&parent.id.nv);
+      queue.push_back((dep_path, dep, dep_ancestors));
     }
   }
 

--- a/libs/npm_installer/hoisted.rs
+++ b/libs/npm_installer/hoisted.rs
@@ -179,10 +179,13 @@ fn compute_hoisted_layout<'a>(
   let mut nested = Vec::new();
   // Each queue entry carries the parent's path (relative to the root
   // `node_modules/`), the parent package, and the chain of ancestor
-  // NVs whose `node_modules/<name>` segments lie on `parent_path` —
-  // these are the candidates Node's resolver walks up to.
-  let mut queue: VecDeque<(PathBuf, &NpmResolutionPackage, Vec<&PackageNv>)> =
-    VecDeque::new();
+  // packages whose `node_modules/<name>` segments lie on `parent_path`
+  // — these are the candidates Node's resolver walks up to.
+  let mut queue: VecDeque<(
+    PathBuf,
+    &NpmResolutionPackage,
+    Vec<&NpmResolutionPackage>,
+  )> = VecDeque::new();
   // `(parent_path, parent_nv)` we've already expanded — avoids
   // re-emitting the same edges when multiple paths reach the same
   // (path, package) pair.
@@ -205,20 +208,44 @@ fn compute_hoisted_layout<'a>(
         continue;
       }
 
-      if let Some(hoisted) = best_version_for_name.get(&dep.id.nv.name)
-        && hoisted.id.nv == dep.id.nv
-      {
-        // Top-level provides this version; Node's walk-up finds it.
+      // Self-loop: parent depends on something at its own nv. Nesting
+      // at `parent_path/node_modules/<name>` would just be a copy of
+      // parent under itself.
+      if parent.id.nv == dep.id.nv {
         continue;
       }
 
-      // An ancestor on `parent_path` (including `parent` itself) already
-      // resolves `dep.id.nv` via Node's directory walk-up. This both
-      // breaks dependency cycles (A@1 ↔ B@1 where neither hoists) and
-      // avoids redundant deeper nestings.
-      if parent.id.nv == dep.id.nv
-        || parent_ancestors.iter().any(|a| **a == dep.id.nv)
-      {
+      // Simulate Node's directory walk-up from `parent`'s dir: it
+      // binds the nearest `<ancestor>/node_modules/<dep.name>`, which
+      // exists iff that ancestor has a *non-hoisted* dep with that
+      // name (hoisted versions live at the root, not in the
+      // ancestor's own node_modules). Match by name, not by nv — two
+      // different versions of the same name on one path each shadow
+      // further-up copies.
+      //
+      // If walk-up already finds `dep.id.nv`, no nesting is needed.
+      // This subsumes the simple "hoisted at root" case, breaks
+      // dependency cycles, and avoids redundant deeper nestings.
+      let hoisted_for_name =
+        best_version_for_name.get(&dep.id.nv.name).map(|p| &p.id.nv);
+      let walkup_target = parent_ancestors
+        .iter()
+        .rev()
+        .find_map(|ancestor| {
+          ancestor.dependencies.values().find_map(|aid| {
+            let apkg = snapshot.package_from_id(aid).unwrap();
+            if apkg.id.nv.name == dep.id.nv.name
+              && hoisted_for_name != Some(&apkg.id.nv)
+            {
+              Some(&apkg.id.nv)
+            } else {
+              None
+            }
+          })
+        })
+        .or(hoisted_for_name);
+
+      if walkup_target == Some(&dep.id.nv) {
         continue;
       }
 
@@ -231,7 +258,7 @@ fn compute_hoisted_layout<'a>(
         dep,
       });
       let mut dep_ancestors = parent_ancestors.clone();
-      dep_ancestors.push(&parent.id.nv);
+      dep_ancestors.push(parent);
       queue.push_back((dep_path, dep, dep_ancestors));
     }
   }

--- a/libs/npm_installer/hoisted.rs
+++ b/libs/npm_installer/hoisted.rs
@@ -88,6 +88,26 @@ fn compute_hoisted_layout<'a>(
   packages: &'a [NpmResolutionPackage],
   system_info: &NpmSystemInfo,
 ) -> HoistedLayout<'a> {
+  // Versions explicitly required by the root/workspace package.json(s).
+  // These take priority when picking what to hoist, matching npm: a
+  // version listed in package.json wins over a (possibly higher) version
+  // pulled in only transitively.
+  let mut root_version_for_name: HashMap<&StackString, &PackageNv> =
+    HashMap::new();
+  for root_nv in snapshot.package_reqs().values() {
+    root_version_for_name
+      .entry(&root_nv.name)
+      .and_modify(|existing| {
+        // Multiple workspace members directly require the same package
+        // at different versions. Tie-break by higher version so the
+        // result is deterministic; the loser gets nested.
+        if root_nv.cmp(existing) == Ordering::Greater {
+          *existing = root_nv;
+        }
+      })
+      .or_insert(root_nv);
+  }
+
   // Count how many packages depend on each (name, version) pair
   let mut version_dependents: HashMap<&PackageNv, usize> = HashMap::new();
 
@@ -98,12 +118,22 @@ fn compute_hoisted_layout<'a>(
     }
   }
 
-  // For each package name, find the version with the most dependents
+  // For each package name, pick the version to hoist. A version
+  // required directly by the root/workspace always wins; otherwise we
+  // fall back to "most depended on, then highest version".
   let mut best_version_for_name: HashMap<&StackString, &NpmResolutionPackage> =
     HashMap::new();
 
   for package in packages {
-    match best_version_for_name.get(&package.id.nv.name) {
+    let name = &package.id.nv.name;
+    if let Some(root_nv) = root_version_for_name.get(name) {
+      if package.id.nv == **root_nv {
+        best_version_for_name.insert(name, package);
+      }
+      // Any other version of a root-required name will be nested.
+      continue;
+    }
+    match best_version_for_name.get(name) {
       Some(current_best) => {
         let current_count = version_dependents
           .get(&current_best.id.nv)
@@ -115,11 +145,11 @@ fn compute_hoisted_layout<'a>(
           || (new_count == current_count
             && package.id.nv.cmp(&current_best.id.nv) == Ordering::Greater)
         {
-          best_version_for_name.insert(&package.id.nv.name, package);
+          best_version_for_name.insert(name, package);
         }
       }
       None => {
-        best_version_for_name.insert(&package.id.nv.name, package);
+        best_version_for_name.insert(name, package);
       }
     }
   }

--- a/tests/registry/npm/@denotest/hoisted-cycle-a/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-cycle-a/1.0.0/index.js
@@ -1,0 +1,1 @@
+export const version = "1.0.0";

--- a/tests/registry/npm/@denotest/hoisted-cycle-a/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-cycle-a/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/hoisted-cycle-a",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/hoisted-cycle-b": "1.0.0"
+  }
+}

--- a/tests/registry/npm/@denotest/hoisted-cycle-a/2.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-cycle-a/2.0.0/index.js
@@ -1,0 +1,1 @@
+export const version = "2.0.0";

--- a/tests/registry/npm/@denotest/hoisted-cycle-a/2.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-cycle-a/2.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/hoisted-cycle-a",
+  "version": "2.0.0",
+  "type": "module"
+}

--- a/tests/registry/npm/@denotest/hoisted-cycle-b/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-cycle-b/1.0.0/index.js
@@ -1,0 +1,1 @@
+export const version = "1.0.0";

--- a/tests/registry/npm/@denotest/hoisted-cycle-b/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-cycle-b/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/hoisted-cycle-b",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/hoisted-cycle-a": "1.0.0"
+  }
+}

--- a/tests/registry/npm/@denotest/hoisted-cycle-b/2.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-cycle-b/2.0.0/index.js
@@ -1,0 +1,1 @@
+export const version = "2.0.0";

--- a/tests/registry/npm/@denotest/hoisted-cycle-b/2.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-cycle-b/2.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/hoisted-cycle-b",
+  "version": "2.0.0",
+  "type": "module"
+}

--- a/tests/registry/npm/@denotest/hoisted-cycle-trigger/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-cycle-trigger/1.0.0/index.js
@@ -1,0 +1,1 @@
+export const version = "1.0.0";

--- a/tests/registry/npm/@denotest/hoisted-cycle-trigger/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-cycle-trigger/1.0.0/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@denotest/hoisted-cycle-trigger",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/hoisted-cycle-a": "1.0.0",
+    "@denotest/hoisted-cycle-b": "1.0.0"
+  }
+}

--- a/tests/registry/npm/@denotest/hoisted-nested-grandchild-chain/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-nested-grandchild-chain/1.0.0/index.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/tests/registry/npm/@denotest/hoisted-nested-grandchild-chain/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-nested-grandchild-chain/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/hoisted-nested-grandchild-chain",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/tests/registry/npm/@denotest/hoisted-nested-grandchild-chain/2.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-nested-grandchild-chain/2.0.0/index.js
@@ -1,0 +1,2 @@
+import version from "@denotest/different-nested-dep-child";
+export default version;

--- a/tests/registry/npm/@denotest/hoisted-nested-grandchild-chain/2.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-nested-grandchild-chain/2.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/hoisted-nested-grandchild-chain",
+  "version": "2.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/different-nested-dep-child": "1.0.0"
+  }
+}

--- a/tests/registry/npm/@denotest/hoisted-nested-grandchild-parent/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-nested-grandchild-parent/1.0.0/index.js
@@ -1,0 +1,2 @@
+import version from "@denotest/hoisted-nested-grandchild-chain";
+export default version;

--- a/tests/registry/npm/@denotest/hoisted-nested-grandchild-parent/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-nested-grandchild-parent/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/hoisted-nested-grandchild-parent",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/hoisted-nested-grandchild-chain": "2.0.0"
+  }
+}

--- a/tests/registry/npm/@denotest/hoisted-walkup-chain/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-walkup-chain/1.0.0/index.js
@@ -1,0 +1,1 @@
+export const version = "1.0.0";

--- a/tests/registry/npm/@denotest/hoisted-walkup-chain/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-walkup-chain/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/hoisted-walkup-chain",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/hoisted-walkup-x": "1.0.0"
+  }
+}

--- a/tests/registry/npm/@denotest/hoisted-walkup-chain/2.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-walkup-chain/2.0.0/index.js
@@ -1,0 +1,1 @@
+export const version = "2.0.0";

--- a/tests/registry/npm/@denotest/hoisted-walkup-chain/2.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-walkup-chain/2.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/hoisted-walkup-chain",
+  "version": "2.0.0",
+  "type": "module"
+}

--- a/tests/registry/npm/@denotest/hoisted-walkup-needs-chain2/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-walkup-needs-chain2/1.0.0/index.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/tests/registry/npm/@denotest/hoisted-walkup-needs-chain2/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-walkup-needs-chain2/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/hoisted-walkup-needs-chain2",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/hoisted-walkup-chain": "2.0.0"
+  }
+}

--- a/tests/registry/npm/@denotest/hoisted-walkup-needs-x2/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-walkup-needs-x2/1.0.0/index.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/tests/registry/npm/@denotest/hoisted-walkup-needs-x2/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-walkup-needs-x2/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/hoisted-walkup-needs-x2",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/hoisted-walkup-x": "2.0.0"
+  }
+}

--- a/tests/registry/npm/@denotest/hoisted-walkup-x/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-walkup-x/1.0.0/index.js
@@ -1,0 +1,1 @@
+export const version = "1.0.0";

--- a/tests/registry/npm/@denotest/hoisted-walkup-x/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-walkup-x/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/hoisted-walkup-x",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/tests/registry/npm/@denotest/hoisted-walkup-x/2.0.0/index.js
+++ b/tests/registry/npm/@denotest/hoisted-walkup-x/2.0.0/index.js
@@ -1,0 +1,1 @@
+export const version = "2.0.0";

--- a/tests/registry/npm/@denotest/hoisted-walkup-x/2.0.0/package.json
+++ b/tests/registry/npm/@denotest/hoisted-walkup-x/2.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/hoisted-walkup-x",
+  "version": "2.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/hoisted-walkup-chain": "1.0.0"
+  }
+}

--- a/tests/registry/npm/@denotest/needs-different-nested-dep-child-v2/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/needs-different-nested-dep-child-v2/1.0.0/index.js
@@ -1,0 +1,2 @@
+import version from "@denotest/different-nested-dep-child";
+export default version;

--- a/tests/registry/npm/@denotest/needs-different-nested-dep-child-v2/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/needs-different-nested-dep-child-v2/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/needs-different-nested-dep-child-v2",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@denotest/different-nested-dep-child": "2.0.0"
+  }
+}

--- a/tests/specs/npm/hoisted_cycle/__test__.jsonc
+++ b/tests/specs/npm/hoisted_cycle/__test__.jsonc
@@ -1,0 +1,23 @@
+{
+  "tempDir": true,
+  "tests": {
+    "cycle_does_not_hang_nested_walk": {
+      // Root directly requires hoisted-cycle-a@2.0.0 and
+      // hoisted-cycle-b@2.0.0, so both hoist to the top level. The
+      // transitive trigger@1.0.0 pulls in a@1.0.0 and b@1.0.0, which
+      // form a cycle (a@1 deps b@1, b@1 deps a@1) and neither wins
+      // hoisting. Regression test: without ancestor walk-up the BFS
+      // would keep producing deeper paths
+      // (.../trigger/node_modules/a/node_modules/b/node_modules/a/...)
+      // and hang. The ancestor check should short-circuit when a
+      // package's dep is already provided by an ancestor on the path.
+      "steps": [{
+        "args": "install",
+        "output": "[WILDCARD]"
+      }, {
+        "args": "run --allow-read main.ts",
+        "output": "top a: 2.0.0\ntop b: 2.0.0\nnested a: 1.0.0\nnested b: 1.0.0\n"
+      }]
+    }
+  }
+}

--- a/tests/specs/npm/hoisted_cycle/deno.json
+++ b/tests/specs/npm/hoisted_cycle/deno.json
@@ -1,0 +1,4 @@
+{
+  "nodeModulesDir": "manual",
+  "nodeModulesLinker": "hoisted"
+}

--- a/tests/specs/npm/hoisted_cycle/main.ts
+++ b/tests/specs/npm/hoisted_cycle/main.ts
@@ -1,0 +1,13 @@
+const readVersion = (p: string) =>
+  JSON.parse(Deno.readTextFileSync(p + "/package.json")).version;
+
+const topA = "node_modules/@denotest/hoisted-cycle-a";
+const topB = "node_modules/@denotest/hoisted-cycle-b";
+const trigger = "node_modules/@denotest/hoisted-cycle-trigger";
+const nestedA = `${trigger}/node_modules/@denotest/hoisted-cycle-a`;
+const nestedB = `${trigger}/node_modules/@denotest/hoisted-cycle-b`;
+
+console.log("top a:", readVersion(topA));
+console.log("top b:", readVersion(topB));
+console.log("nested a:", readVersion(nestedA));
+console.log("nested b:", readVersion(nestedB));

--- a/tests/specs/npm/hoisted_cycle/package.json
+++ b/tests/specs/npm/hoisted_cycle/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "@denotest/hoisted-cycle-a": "2.0.0",
+    "@denotest/hoisted-cycle-b": "2.0.0",
+    "@denotest/hoisted-cycle-trigger": "1.0.0"
+  }
+}

--- a/tests/specs/npm/hoisted_direct_dep_priority/__test__.jsonc
+++ b/tests/specs/npm/hoisted_direct_dep_priority/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  "tempDir": true,
+  "tests": {
+    "direct_dep_wins_over_transitive": {
+      // Root directly depends on different-nested-dep-child@1.0.0, and
+      // transitively (via different-nested-dep@2.0.0) on
+      // different-nested-dep-child@2.0.0. The direct version must be
+      // hoisted to node_modules/, and the transitive version nested
+      // under the package that pulled it in. (issue #34460)
+      "steps": [{
+        "args": "install",
+        "output": "[WILDCARD]"
+      }, {
+        "args": "run --allow-read main.ts",
+        "output": "hoisted: 1.0.0\nnested: 2.0.0\n"
+      }]
+    }
+  }
+}

--- a/tests/specs/npm/hoisted_direct_dep_priority/deno.json
+++ b/tests/specs/npm/hoisted_direct_dep_priority/deno.json
@@ -1,0 +1,4 @@
+{
+  "nodeModulesDir": "manual",
+  "nodeModulesLinker": "hoisted"
+}

--- a/tests/specs/npm/hoisted_direct_dep_priority/main.ts
+++ b/tests/specs/npm/hoisted_direct_dep_priority/main.ts
@@ -1,0 +1,12 @@
+const hoisted = JSON.parse(
+  Deno.readTextFileSync(
+    "node_modules/@denotest/different-nested-dep-child/package.json",
+  ),
+);
+const nested = JSON.parse(
+  Deno.readTextFileSync(
+    "node_modules/@denotest/needs-different-nested-dep-child-v2/node_modules/@denotest/different-nested-dep-child/package.json",
+  ),
+);
+console.log("hoisted:", hoisted.version);
+console.log("nested:", nested.version);

--- a/tests/specs/npm/hoisted_direct_dep_priority/package.json
+++ b/tests/specs/npm/hoisted_direct_dep_priority/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@denotest/different-nested-dep-child": "1.0.0",
+    "@denotest/needs-different-nested-dep-child-v2": "1.0.0"
+  }
+}

--- a/tests/specs/npm/hoisted_nested_grandchild/__test__.jsonc
+++ b/tests/specs/npm/hoisted_nested_grandchild/__test__.jsonc
@@ -1,0 +1,23 @@
+{
+  "tempDir": true,
+  "tests": {
+    "nested_parent_gets_correctly_nested_grandchild": {
+      // Root directly requires different-nested-dep-child@2.0.0 (hoists
+      // to top level) and hoisted-nested-grandchild-chain@1.0.0 (hoists
+      // to top level). hoisted-nested-grandchild-parent transitively
+      // pulls hoisted-nested-grandchild-chain@2.0.0, which must nest
+      // under the parent. That nested chain@2.0.0 requires
+      // different-nested-dep-child@1.0.0 — it must nest under the
+      // *nested* chain@2.0.0, NOT under the top-level chain@1.0.0
+      // (which would shadow the top-level child@2.0.0). Regression
+      // test for the bug reported on PR #34470.
+      "steps": [{
+        "args": "install",
+        "output": "[WILDCARD]"
+      }, {
+        "args": "run --allow-read main.ts",
+        "output": "top child: 2.0.0\ntop chain: 1.0.0\nnested chain: 2.0.0\nnested grandchild: 1.0.0\nwrong placement exists: false\n"
+      }]
+    }
+  }
+}

--- a/tests/specs/npm/hoisted_nested_grandchild/deno.json
+++ b/tests/specs/npm/hoisted_nested_grandchild/deno.json
@@ -1,0 +1,4 @@
+{
+  "nodeModulesDir": "manual",
+  "nodeModulesLinker": "hoisted"
+}

--- a/tests/specs/npm/hoisted_nested_grandchild/main.ts
+++ b/tests/specs/npm/hoisted_nested_grandchild/main.ts
@@ -1,0 +1,27 @@
+const readVersion = (p: string) =>
+  JSON.parse(Deno.readTextFileSync(p + "/package.json")).version;
+
+const exists = (p: string) => {
+  try {
+    Deno.statSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const top = "node_modules/@denotest/different-nested-dep-child";
+const chainTop = "node_modules/@denotest/hoisted-nested-grandchild-chain";
+const parentTop = "node_modules/@denotest/hoisted-nested-grandchild-parent";
+const nestedChain =
+  `${parentTop}/node_modules/@denotest/hoisted-nested-grandchild-chain`;
+const nestedGrandchild =
+  `${nestedChain}/node_modules/@denotest/different-nested-dep-child`;
+const wrongPlacement =
+  `${chainTop}/node_modules/@denotest/different-nested-dep-child`;
+
+console.log("top child:", readVersion(top));
+console.log("top chain:", readVersion(chainTop));
+console.log("nested chain:", readVersion(nestedChain));
+console.log("nested grandchild:", readVersion(nestedGrandchild));
+console.log("wrong placement exists:", exists(wrongPlacement));

--- a/tests/specs/npm/hoisted_nested_grandchild/package.json
+++ b/tests/specs/npm/hoisted_nested_grandchild/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "@denotest/different-nested-dep-child": "2.0.0",
+    "@denotest/hoisted-nested-grandchild-chain": "1.0.0",
+    "@denotest/hoisted-nested-grandchild-parent": "1.0.0"
+  }
+}

--- a/tests/specs/npm/hoisted_walkup_shadow/__test__.jsonc
+++ b/tests/specs/npm/hoisted_walkup_shadow/__test__.jsonc
@@ -1,0 +1,31 @@
+{
+  "tempDir": true,
+  "tests": {
+    "walkup_shadow_forces_nested_copy": {
+      // Regression test for the directory walk-up resolution. Root
+      // directly requires walkup-x@1.0.0, so walkup-x@1 hoists to the
+      // top level. walkup-needs-x2 transitively pulls walkup-x@2,
+      // which nests under it. walkup-x@2 in turn depends on
+      // walkup-chain@1, which depends back on walkup-x@1.0.0. A
+      // separate root dep on walkup-needs-chain2 hoists
+      // walkup-chain@2 at the top, leaving walkup-chain@1 nested.
+      //
+      // Node's resolver walks up by NAME, binding the nearest
+      // node_modules/<name>: from walkup-chain@1's dir the nearest
+      // walkup-x is the nested walkup-x@2 (at
+      // .../needs-x2/node_modules/walkup-x), not the hoisted
+      // walkup-x@1. Skipping the nest because the top level "has"
+      // walkup-x@1 would let walkup-x@2 shadow it — the wrong
+      // version. The walk-up simulation in compute_hoisted_layout
+      // must nest walkup-x@1 inside walkup-chain@1's node_modules so
+      // walkup-chain@1 actually resolves to its declared version.
+      "steps": [{
+        "args": "install",
+        "output": "[WILDCARD]"
+      }, {
+        "args": "run --allow-read main.ts",
+        "output": "top x: 1.0.0\ntop chain: 2.0.0\nnested x@2: 2.0.0\nnested chain@1: 1.0.0\nchain's nested x: 1.0.0\n"
+      }]
+    }
+  }
+}

--- a/tests/specs/npm/hoisted_walkup_shadow/deno.json
+++ b/tests/specs/npm/hoisted_walkup_shadow/deno.json
@@ -1,0 +1,4 @@
+{
+  "nodeModulesDir": "manual",
+  "nodeModulesLinker": "hoisted"
+}

--- a/tests/specs/npm/hoisted_walkup_shadow/main.ts
+++ b/tests/specs/npm/hoisted_walkup_shadow/main.ts
@@ -1,0 +1,15 @@
+const readVersion = (p: string) =>
+  JSON.parse(Deno.readTextFileSync(p + "/package.json")).version;
+
+const topX = "node_modules/@denotest/hoisted-walkup-x";
+const topChain = "node_modules/@denotest/hoisted-walkup-chain";
+const needsX2 = "node_modules/@denotest/hoisted-walkup-needs-x2";
+const nestedX2 = `${needsX2}/node_modules/@denotest/hoisted-walkup-x`;
+const nestedChain1 = `${nestedX2}/node_modules/@denotest/hoisted-walkup-chain`;
+const chainNestedX1 = `${nestedChain1}/node_modules/@denotest/hoisted-walkup-x`;
+
+console.log("top x:", readVersion(topX));
+console.log("top chain:", readVersion(topChain));
+console.log("nested x@2:", readVersion(nestedX2));
+console.log("nested chain@1:", readVersion(nestedChain1));
+console.log("chain's nested x:", readVersion(chainNestedX1));

--- a/tests/specs/npm/hoisted_walkup_shadow/package.json
+++ b/tests/specs/npm/hoisted_walkup_shadow/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "@denotest/hoisted-walkup-x": "1.0.0",
+    "@denotest/hoisted-walkup-needs-x2": "1.0.0",
+    "@denotest/hoisted-walkup-needs-chain2": "1.0.0"
+  }
+}


### PR DESCRIPTION
With `nodeModulesLinker: "hoisted"`, the layout picker ranked candidate
versions purely by how many other npm packages depended on each one.
Versions required directly by the root/workspace `package.json` had
zero such dependents (the root isn't itself an npm package in the
resolution snapshot), so any transitive that wanted a higher version
would win the tiebreak and end up hoisted to `node_modules/<name>`,
shadowing the version the user actually asked for.

Direct requirements from `snapshot.package_reqs()` now take priority
when choosing what to hoist; the previous most-dependents-then-highest
heuristic still applies to names that only appear transitively. When
two workspace members directly require the same name at different
versions, the higher one wins and the other gets nested, matching how
npm picks a winner in the same situation.

Fixes #34460