### PR TITLE
test(node_compat): disable flaky test-dns-any.js

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4496,7 +4496,7 @@
       "darwin": false,
       "reason": "Responses were not received within 5000 ms"
     },
-    "internet/test-dns-any.js": {},
+    // "internet/test-dns-any.js": {}, // really flaky in CI
     "internet/test-dns-getDefaultResultOrder.js": {},
     "internet/test-dns-idna2008.js": {},
     "internet/test-dns-lookup.js": {},


### PR DESCRIPTION
`internet/test-dns-any.js` is really flaky in CI, so this disables it in the node_compat config.