### PR TITLE
build: disable incremental compilation for release/bench profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -462,7 +462,7 @@ winres = "=0.1.12"
 # NB: the `bench` and `release` profiles must remain EXACTLY the same.
 [profile.release]
 codegen-units = 1
-incremental = true
+incremental = false
 lto = true
 opt-level = 'z' # Optimize for size
 split-debuginfo = "packed"
@@ -472,7 +472,7 @@ panic = "abort"
 # NB: the `bench` and `release` profiles must remain EXACTLY the same.
 [profile.bench]
 codegen-units = 1
-incremental = true
+incremental = false
 lto = true
 opt-level = 'z' # Optimize for size
 split-debuginfo = "packed"
@@ -487,6 +487,9 @@ debug = true
 # Faster to compile than `release` but with similar performance.
 [profile.release-lite]
 inherits = "release"
+# Re-enable incremental here (release/bench are non-incremental for deterministic
+# codegen layout); release-lite is the local iteration profile, so keep it fast.
+incremental = true
 codegen-units = 128
 lto = "thin"
 


### PR DESCRIPTION
The `release` and `bench` profiles set `codegen-units = 1` (for maximum optimization) but also `incremental = true`. Incremental compilation re-partitions the crate into many independently-cacheable codegen units, which:

1. **partly defeats `codegen-units = 1`** (the whole point of which is to optimize as a single unit), and
2. **produces non-deterministic function layout** between builds — two binaries with byte-identical `__text` were observed to differ by ~5 MB in resident memory purely from layout, and benchmark numbers can move the same way on layout luck.

CI already builds release with `CARGO_PROFILE_RELEASE_INCREMENTAL=false`, so this only aligns **local** `release`/`bench` builds with what actually ships.

### Changes
- `[profile.release]` and `[profile.bench]`: `incremental = false` (kept identical, per the existing `NB`).
- `[profile.release-lite]`: explicitly `incremental = true` — it `inherits = "release"`, and it's the local iteration profile, so keep its rebuilds fast.

### Tradeoff
Local `release`/`bench` rebuilds lose incremental caching (slower full recompiles), but those profiles are for final/measurement builds — iterate on `release-lite`, which is unchanged.