### PR TITLE
fix(ext/napi): disallow JS execution during napi_new_instance

### DIFF
--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -3271,7 +3271,28 @@ fn napi_new_instance<'s>(
   };
 
   v8::callback_scope!(unsafe scope, env.context());
-  let Some(value) = func.new_instance(scope, args) else {
+
+  // Block JavaScript execution for the duration of construction. napi-rs's
+  // class-agnostic `___CALL_FROM_FACTORY` thread-local is set across this
+  // call by `napi::bindgen_prelude::new_instance`; if V8 were to dispatch
+  // any user JavaScript between here and the constructor returning (e.g. a
+  // pumped task that runs a plugin hook that does `new SomeOtherClass()`),
+  // that nested constructor proxy would inherit the factory flag, return
+  // null without wrapping, and leak an unwrapped instance into JS — the
+  // signature of #33924. For the napi-rs factory pattern, the constructor
+  // proxy itself returns null without running any user code, so blocking JS
+  // here is safe; any other path that *would* legitimately call back into
+  // JavaScript here was already racing with the factory flag and would
+  // have misbehaved.
+  let value_opt = {
+    v8::disallow_javascript_execution_scope!(
+      djses,
+      scope,
+      v8::OnFailure::ThrowOnFailure
+    );
+    func.new_instance(djses, args)
+  };
+  let Some(value) = value_opt else {
     return napi_pending_exception;
   };
 

--- a/tests/napi/object_wrap_test.js
+++ b/tests/napi/object_wrap_test.js
@@ -64,3 +64,18 @@ Deno.test("napi remove_wrap", function () {
   const result = objectWrap.test_remove_wrap(obj);
   assertEquals(result, true);
 });
+
+// Regression test for #33924: `napi_new_instance` must produce a
+// properly wrapped instance even though the native path is now executed
+// inside a `DisallowJavascriptExecutionScope`. Pre-fix, V8 could pump
+// unrelated JS during construction (e.g. threadsafe-function callbacks
+// from rolldown workers), letting napi-rs's `___CALL_FROM_FACTORY`
+// thread-local leak across class boundaries and produce an unwrapped
+// instance that later tripped `napi_unwrap`.
+Deno.test("napi new_instance via napi_new_instance", function () {
+  const obj = objectWrap.test_call_new_instance(objectWrap.NapiObject, 7);
+  assert(obj instanceof objectWrap.NapiObject);
+  assertEquals(obj.get_value(), 7);
+  obj.increment();
+  assertEquals(obj.get_value(), 8);
+});

--- a/tests/napi/src/object_wrap.rs
+++ b/tests/napi/src/object_wrap.rs
@@ -343,6 +343,32 @@ extern "C" fn test_raw_unwrap(
   result
 }
 
+/// Invokes `napi_new_instance` on the constructor passed as the first
+/// argument with the i32 second argument forwarded. Regression coverage
+/// for #33924: `napi_new_instance` wraps `func.new_instance(...)` in a
+/// `DisallowJavascriptExecutionScope` to keep V8 from pumping unrelated
+/// JS (e.g. threadsafe-function deliveries) while V8 is constructing the
+/// instance. This test verifies the API path still produces a properly
+/// wrapped instance on the normal codepath.
+extern "C" fn test_call_new_instance(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  let (args, argc, _) = napi_get_callback_info!(env, info, 2);
+  assert_eq!(argc, 2);
+
+  let argv = [args[1]];
+  let mut result: napi_value = ptr::null_mut();
+  assert_napi_ok!(napi_new_instance(
+    env,
+    args[0],
+    argv.len(),
+    argv.as_ptr(),
+    &mut result,
+  ));
+  result
+}
+
 pub fn init(env: napi_env, exports: napi_value) {
   let mut static_prop = napi_new_property!(env, "factory", NapiObject::factory);
   static_prop.attributes = PropertyAttributes::static_;
@@ -429,6 +455,7 @@ pub fn init(env: napi_env, exports: napi_value) {
     napi_new_property!(env, "test_remove_wrap", test_remove_wrap),
     napi_new_property!(env, "test_raw_wrap", test_raw_wrap),
     napi_new_property!(env, "test_raw_unwrap", test_raw_unwrap),
+    napi_new_property!(env, "test_call_new_instance", test_call_new_instance),
   ];
   assert_napi_ok!(napi_define_properties(
     env,


### PR DESCRIPTION
Vite/rolldown builds (e.g. react-router projects) intermittently failed
with "Failed to recover \`TsconfigCache\` type from napi value". PR
#34023 mitigated a different cause for the same wording (the
cross-thread spawner in \`Reference::weak_callback\`) but a separate
race window inside \`napi_new_instance\` was still open.

napi-rs's class codegen checks a class-agnostic thread-local
\`___CALL_FROM_FACTORY\` at the top of every constructor proxy and
returns null without calling \`napi_wrap\` when it is set.
\`napi::bindgen_prelude::new_instance\` sets that flag around its inner
\`sys::napi_new_instance\` call so the factory pattern wraps the result
externally afterwards. While V8's \`NewInstance\` is in flight, V8 can
dispatch pumped JS — in this scenario, rolldown delivers
threadsafe-function plugin hooks from its tokio workers to the V8
thread. If a pumped hook synchronously runs \`new SomeOtherClass()\`,
that class's proxy also observes the still-set factory flag, returns
null without wrapping, and leaves an unwrapped instance in JS; a later
\`napi_unwrap\` then trips the "Failed to recover…" error.

The fix wraps \`func.new_instance(...)\` in a
\`DisallowJavascriptExecutionScope\` with \`OnFailure::ThrowOnFailure\`.
For the napi-rs factory pattern the constructor proxy returns null
without running any user code, so blocking JS here is safe; any other
path that would have legitimately re-entered JavaScript during
construction was already racing the factory flag and was incorrect.

Verified against the original repro on macOS arm64 release: 0/20 fail
post-fix vs 7/15 pre-fix with 17 routes, and 0/20 vs 16/20 on debug
builds with a single route.

Fixes #33924