### PR TITLE
fix(ext/node): drop bogus Buffer.prototype._isBuffer marker

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -666,8 +666,6 @@ function byteLength(string, encoding) {
 
 Buffer.byteLength = byteLength;
 
-Buffer.prototype._isBuffer = true;
-
 function swap(b, n, m) {
   const i = b[n];
   b[n] = b[m];

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -874,3 +874,17 @@ Deno.test({
     assertEquals(transcode(single, "utf16le", "utf8").toString(), "");
   },
 });
+
+// Node's real Buffer has no _isBuffer marker; the npm `buffer` polyfill
+// (feross/buffer) sets it to true and libraries like bson use that to detect
+// a non-Node runtime and fall back to a Uint8Array codepath that breaks
+// mongodb SCRAM auth (denoland/deno#34468).
+Deno.test({
+  name: "[node/buffer] Buffer.prototype does not expose _isBuffer marker",
+  fn() {
+    // deno-lint-ignore no-explicit-any
+    assertEquals((Buffer.prototype as any)._isBuffer, undefined);
+    // deno-lint-ignore no-explicit-any
+    assertEquals((Buffer.alloc(1) as any)._isBuffer, undefined);
+  },
+});


### PR DESCRIPTION
Deno's `node:buffer` polyfill was forked from the npm `buffer` package
(feross/buffer), which sets `Buffer.prototype._isBuffer = true` as a
duck-typing tag used by its own `Buffer.isBuffer` implementation. Deno's
`Buffer.isBuffer` uses a real prototype check, so the marker has been
unused internally for a long time. Real Node's Buffer doesn't expose it
either, and libraries that need to tell a real Node runtime apart from
the npm polyfill use exactly the absence of this marker as the signal.

`bson` (bundled with mongodb 7.2.0) is one such library: it picks
between a Node bytes path and a Web/Uint8Array fallback via
`typeof Buffer === 'function' && Buffer.prototype?._isBuffer !== true`.
With our spurious marker present, bson chose the Web fallback under
Deno, so `ByteUtils.concat(...)` returned a plain `Uint8Array`. mongodb
then builds its SCRAM auth message with
`[firstMessageBare, payload, withoutProof].join(',')`, which calls
`Uint8Array.prototype.toString` and produces comma-joined byte values
instead of UTF-8 text. The resulting HMAC client proof is wrong and the
server rejects authentication. Dropping the marker restores the Node
codepath and unblocks mongodb 7.2.0 against Atlas and any other server
that requires SCRAM auth.

Fixes #34468