### PR TITLE
fix(task): preserve trailing backslashes in task arguments

### DIFF
--- a/cli/task_runner.rs
+++ b/cli/task_runner.rs
@@ -30,16 +30,11 @@ use crate::util::fs::canonicalize_path;
 pub fn get_script_with_args(script: &str, argv: &[String]) -> String {
   let additional_args = argv
     .iter()
-    // surround all the additional arguments in double quotes
-    // and sanitize any command substitution
-    .map(|a| {
-      format!(
-        "\"{}\"",
-        a.replace('"', "\\\"")
-          .replace('$', "\\$")
-          .replace('`', "\\`")
-      )
-    })
+    // Wrap each argument in single quotes so the shell preserves the
+    // content literally (including backslashes, $, `, etc.). For an
+    // argument containing a single quote, splice in a double-quoted `'`
+    // using the POSIX idiom `'foo'"'"'bar'`.
+    .map(|a| format!("'{}'", a.replace('\'', "'\"'\"'")))
     .collect::<Vec<_>>()
     .join(" ");
 
@@ -731,5 +726,27 @@ mod test {
       env_vars,
       HashMap::from([("PATH".into(), "/example".into())])
     );
+  }
+
+  #[test]
+  fn test_get_script_with_args() {
+    let cases: &[(&[&str], &str)] = &[
+      (&[], "echo"),
+      (&["hello"], "echo 'hello'"),
+      (&["hello", "world"], "echo 'hello' 'world'"),
+      // Windows path with trailing backslash (issue #31453).
+      (&[".\\dist\\"], "echo '.\\dist\\'"),
+      // Dollar sign and backtick must not be expanded.
+      (&["$HOME"], "echo '$HOME'"),
+      (&["`cmd`"], "echo '`cmd`'"),
+      // Double quotes pass through literally.
+      (&["foo\"bar"], "echo 'foo\"bar'"),
+      // Single quote uses the POSIX `'"'"'` idiom.
+      (&["it's"], "echo 'it'\"'\"'s'"),
+    ];
+    for (argv, expected) in cases {
+      let argv: Vec<String> = argv.iter().map(|s| s.to_string()).collect();
+      assert_eq!(get_script_with_args("echo", &argv), *expected);
+    }
   }
 }

--- a/cli/task_runner.rs
+++ b/cli/task_runner.rs
@@ -30,26 +30,11 @@ use crate::util::fs::canonicalize_path;
 pub fn get_script_with_args(script: &str, argv: &[String]) -> String {
   let additional_args = argv
     .iter()
-    .map(|a| {
-      // Arguments containing a backslash can't be safely wrapped in
-      // double quotes: a trailing `\` escapes the closing quote, and
-      // the task shell accumulates `was_escape` across consecutive
-      // backslashes (issue #31453). Fall back to single quotes, which
-      // preserve their contents literally. The POSIX `'"'"'` idiom
-      // handles embedded single quotes.
-      if a.contains('\\') {
-        format!("'{}'", a.replace('\'', "'\"'\"'"))
-      } else {
-        // Surround in double quotes and sanitize any command
-        // substitution.
-        format!(
-          "\"{}\"",
-          a.replace('"', "\\\"")
-            .replace('$', "\\$")
-            .replace('`', "\\`")
-        )
-      }
-    })
+    // Wrap each argument in single quotes so the shell preserves the
+    // content literally (including backslashes, $, `, etc.). For an
+    // argument containing a single quote, splice in a double-quoted `'`
+    // using the POSIX idiom `'foo'"'"'bar'`.
+    .map(|a| format!("'{}'", a.replace('\'', "'\"'\"'")))
     .collect::<Vec<_>>()
     .join(" ");
 
@@ -747,17 +732,17 @@ mod test {
   fn test_get_script_with_args() {
     let cases: &[(&[&str], &str)] = &[
       (&[], "echo"),
-      (&["hello"], "echo \"hello\""),
-      (&["hello", "world"], "echo \"hello\" \"world\""),
-      // Backslash-free args keep the original double-quoted form and
-      // escape command-substitution metacharacters.
-      (&["$HOME"], "echo \"\\$HOME\""),
-      (&["`cmd`"], "echo \"\\`cmd\\`\""),
-      (&["a\"b"], "echo \"a\\\"b\""),
-      // Args containing a backslash (e.g. Windows paths, issue #31453)
-      // fall back to single quotes so trailing `\` is preserved.
+      (&["hello"], "echo 'hello'"),
+      (&["hello", "world"], "echo 'hello' 'world'"),
+      // Windows path with trailing backslash (issue #31453).
       (&[".\\dist\\"], "echo '.\\dist\\'"),
-      (&["a\\b'c"], "echo 'a\\b'\"'\"'c'"),
+      // Dollar sign and backtick must not be expanded.
+      (&["$HOME"], "echo '$HOME'"),
+      (&["`cmd`"], "echo '`cmd`'"),
+      // Double quotes pass through literally.
+      (&["foo\"bar"], "echo 'foo\"bar'"),
+      // Single quote uses the POSIX `'"'"'` idiom.
+      (&["it's"], "echo 'it'\"'\"'s'"),
     ];
     for (argv, expected) in cases {
       let argv: Vec<String> = argv.iter().map(|s| s.to_string()).collect();

--- a/cli/task_runner.rs
+++ b/cli/task_runner.rs
@@ -30,11 +30,26 @@ use crate::util::fs::canonicalize_path;
 pub fn get_script_with_args(script: &str, argv: &[String]) -> String {
   let additional_args = argv
     .iter()
-    // Wrap each argument in single quotes so the shell preserves the
-    // content literally (including backslashes, $, `, etc.). For an
-    // argument containing a single quote, splice in a double-quoted `'`
-    // using the POSIX idiom `'foo'"'"'bar'`.
-    .map(|a| format!("'{}'", a.replace('\'', "'\"'\"'")))
+    .map(|a| {
+      // Arguments containing a backslash can't be safely wrapped in
+      // double quotes: a trailing `\` escapes the closing quote, and
+      // the task shell accumulates `was_escape` across consecutive
+      // backslashes (issue #31453). Fall back to single quotes, which
+      // preserve their contents literally. The POSIX `'"'"'` idiom
+      // handles embedded single quotes.
+      if a.contains('\\') {
+        format!("'{}'", a.replace('\'', "'\"'\"'"))
+      } else {
+        // Surround in double quotes and sanitize any command
+        // substitution.
+        format!(
+          "\"{}\"",
+          a.replace('"', "\\\"")
+            .replace('$', "\\$")
+            .replace('`', "\\`")
+        )
+      }
+    })
     .collect::<Vec<_>>()
     .join(" ");
 
@@ -732,17 +747,17 @@ mod test {
   fn test_get_script_with_args() {
     let cases: &[(&[&str], &str)] = &[
       (&[], "echo"),
-      (&["hello"], "echo 'hello'"),
-      (&["hello", "world"], "echo 'hello' 'world'"),
-      // Windows path with trailing backslash (issue #31453).
+      (&["hello"], "echo \"hello\""),
+      (&["hello", "world"], "echo \"hello\" \"world\""),
+      // Backslash-free args keep the original double-quoted form and
+      // escape command-substitution metacharacters.
+      (&["$HOME"], "echo \"\\$HOME\""),
+      (&["`cmd`"], "echo \"\\`cmd\\`\""),
+      (&["a\"b"], "echo \"a\\\"b\""),
+      // Args containing a backslash (e.g. Windows paths, issue #31453)
+      // fall back to single quotes so trailing `\` is preserved.
       (&[".\\dist\\"], "echo '.\\dist\\'"),
-      // Dollar sign and backtick must not be expanded.
-      (&["$HOME"], "echo '$HOME'"),
-      (&["`cmd`"], "echo '`cmd`'"),
-      // Double quotes pass through literally.
-      (&["foo\"bar"], "echo 'foo\"bar'"),
-      // Single quote uses the POSIX `'"'"'` idiom.
-      (&["it's"], "echo 'it'\"'\"'s'"),
+      (&["a\\b'c"], "echo 'a\\b'\"'\"'c'"),
     ];
     for (argv, expected) in cases {
       let argv: Vec<String> = argv.iter().map(|s| s.to_string()).collect();

--- a/tests/specs/task/additional_args_trailing_backslash/__test__.jsonc
+++ b/tests/specs/task/additional_args_trailing_backslash/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "task -q --config deno.json echo .\\dist\\",
+  "output": ".\\dist\\\n"
+}

--- a/tests/specs/task/additional_args_trailing_backslash/deno.json
+++ b/tests/specs/task/additional_args_trailing_backslash/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "echo": "echo"
+  }
+}

--- a/tests/specs/task/bin_pkg_with_scope_auto/bin_auto.out
+++ b/tests/specs/task/bin_pkg_with_scope_auto/bin_auto.out
@@ -5,7 +5,7 @@ Initialize @denotest/bin@0.5.0
 Download http://localhost:4260/@denotest/bin/1.0.0.tgz
 Initialize @denotest/bin@1.0.0
 [UNORDERED_END]
-Task bin bin hi && cli-esm testing this out && npx cli-cjs test "extra"
+Task bin bin hi && cli-esm testing this out && npx cli-cjs test 'extra'
 hi
 testing
 this

--- a/tests/specs/task/bin_pkg_with_scope_none/bin_none.out
+++ b/tests/specs/task/bin_pkg_with_scope_none/bin_none.out
@@ -3,7 +3,7 @@ Download http://localhost:4260/@denotest%2fbin
 Download http://localhost:4260/@denotest/bin/0.5.0.tgz
 Download http://localhost:4260/@denotest/bin/1.0.0.tgz
 [UNORDERED_END]
-Task bin bin hi && cli-esm testing this out && npx cli-cjs test "extra"
+Task bin bin hi && cli-esm testing this out && npx cli-cjs test 'extra'
 hi
 testing
 this

--- a/tests/specs/task/both_package_json_selected/package_json_selected.out
+++ b/tests/specs/task/both_package_json_selected/package_json_selected.out
@@ -1,4 +1,4 @@
-Task bin cli-esm testing this out "asdf"
+Task bin cli-esm testing this out 'asdf'
 testing
 this
 out

--- a/tests/specs/task/both_prefers_deno/prefers_deno.out
+++ b/tests/specs/task/both_prefers_deno/prefers_deno.out
@@ -1,2 +1,2 @@
-Task output deno eval 'console.log(1)' "some" "text"
+Task output deno eval 'console.log(1)' 'some' 'text'
 1

--- a/tests/specs/task/dependencies/arg_task_with_deps.out
+++ b/tests/specs/task/dependencies/arg_task_with_deps.out
@@ -1,4 +1,4 @@
 Task b echo 'b'
 b
-Task a echo "a"
+Task a echo 'a'
 a

--- a/tests/specs/task/npm_run/task_test.out
+++ b/tests/specs/task/npm_run/task_test.out
@@ -1,3 +1,3 @@
 Task test npm run echo hi there
-Task echo echo "hi" "there"
+Task echo echo 'hi' 'there'
 hi there

--- a/tests/specs/task/package_json_npm_bin/task.out
+++ b/tests/specs/task/package_json_npm_bin/task.out
@@ -1,4 +1,4 @@
-Task bin bin hi && cli-esm testing this out && npx cli-cjs test "extra"
+Task bin bin hi && cli-esm testing this out && npx cli-cjs test 'extra'
 hi
 testing
 this


### PR DESCRIPTION
Running `deno task <name> <args...>` failed with an "Expected closing
double quote" parse error when an argument ended in a backslash, which
is a common shape for Windows paths like `.\dist\`. The argv wrapper in
`get_script_with_args` double-quoted each argument and only escaped `"`,
`$`, and `` ` ``, so a trailing `\` ended up escaping the closing quote.
The task shell's double-quoted-string scanner also accumulates its
`was_escape` flag across consecutive backslashes, so there is no way to
safely terminate a double-quoted string ending in backslashes from the
caller side.

Wrap each argument in single quotes instead. Single-quoted strings in
`deno_task_shell` preserve their contents literally, so backslashes,
dollar signs, and backticks all pass through without interpretation.
Embedded single quotes use the POSIX `'"'"'` idiom (close, double-quoted
`'`, reopen).

Fixes #31453