### PR TITLE
fix(install): resolve global install --import-map against user cwd

### DIFF
--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -160,6 +160,7 @@ pub async fn install_global(
     setup_config_dir(
       &name_and_url,
       &flags,
+      cli_options.initial_cwd(),
       &installation_dir,
       Some(&jsr_lockfile_fetcher),
       install_flags_global.force,
@@ -397,6 +398,7 @@ async fn install_global_compiled(
 async fn setup_config_dir(
   bin_name_and_url: &BinaryNameAndUrl,
   flags: &Flags,
+  cwd: &Path,
   installation_dir: &Path,
   jsr_lockfile_fetcher: Option<&JsrLockfileFetcher<'_>>,
   force: bool,
@@ -499,6 +501,13 @@ async fn setup_config_dir(
 
   // create cloned flags to run cache_top_level_deps
   let mut new_flags = flags.clone();
+  // Pre-resolve cwd-relative paths against the user's original cwd before
+  // switching `initial_cwd` to the generated install dir, otherwise they'd
+  // be re-resolved against `dir` and point at non-existent files.
+  if let Some(import_map_path) = &flags.import_map_path {
+    new_flags.import_map_path =
+      Some(resolve_url_or_path(import_map_path, cwd)?.to_string());
+  }
   new_flags.initial_cwd = Some(dir.clone());
   new_flags.node_modules_dir = flags.node_modules_dir;
   new_flags.internal.root_node_modules_dir_override =
@@ -1246,6 +1255,7 @@ mod tests {
     super::setup_config_dir(
       &binary_name_and_url,
       flags,
+      &cwd,
       &installation_dir,
       None,
       install_flags_global.force,

--- a/tests/integration/install_tests.rs
+++ b/tests/integration/install_tests.rs
@@ -177,6 +177,52 @@ fn install_basic_global() {
   assert!(!file_path.exists());
 }
 
+// Regression test for #32798: a relative `--import-map` passed to a global
+// install (typically via `deno task`) must resolve against the user's cwd,
+// not the generated `~/.deno/bin/.<name>/` install dir.
+#[test]
+fn install_global_from_task_with_relative_import_map() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+
+  temp_dir.write(
+    "deno.json",
+    r#"{
+  "tasks": {
+    "install": "deno install -A --global --root ./root --import-map imports.json -n test main.ts"
+  }
+}
+"#,
+  );
+  temp_dir.write(
+    "imports.json",
+    r#"{
+  "imports": {
+    "@fixture": "./fixture.ts"
+  }
+}
+"#,
+  );
+  temp_dir.write("fixture.ts", "export const value = 1;\n");
+  temp_dir.write(
+    "main.ts",
+    "import { value } from \"@fixture\";\nconsole.log(value);\n",
+  );
+
+  let output = context.new_command().args("task install").run();
+
+  output.assert_exit_code(0);
+  let output_text = output.combined_output();
+  assert_contains!(output_text, "✅ Successfully installed test");
+  assert_not_contains!(output_text, ".test/imports.json");
+
+  let mut file_path = temp_dir.path().join("root/bin/test");
+  if cfg!(windows) {
+    file_path = file_path.with_extension("cmd");
+  }
+  assert!(file_path.exists());
+}
+
 #[test]
 fn install_custom_dir_env_var() {
   let context = TestContext::with_http_server();


### PR DESCRIPTION
`setup_config_dir` clones the user's flags and then switches
`new_flags.initial_cwd` to the generated `~/.deno/bin/.<name>/`
install dir before running `install_from_entrypoints`. A relative
`--import-map` path then resolves against that generated dir instead
of the user's project, surfacing as e.g.

    error: Unable to load 'file:///…/.deno/bin/.test/imports.json' import map

The regression came in with #32341, which moved the global install
flow onto `install_from_entrypoints` — the old top-level dependency
caching path didn't try to load the import map at all.

Fix: pre-resolve `flags.import_map_path` to an absolute URL against
the original cwd before switching `initial_cwd`. The downstream
consumer (`resolve_import_map_specifier`) goes through
`deno_path_util::resolve_url_or_path`, which round-trips an already
absolute URL unchanged.

Includes an integration regression test that exercises the exact
shape from the issue: a `deno task` invoking `deno install --global`
with a relative `--import-map`.

Closes #32798.

Supersedes #34165 (alternative, AI-generated fix by an external bot).