### PR TITLE
feat(task): support --env-file flag

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -4521,6 +4521,7 @@ Evaluate a task from string:
           )
           .action(ArgAction::SetTrue),
       )
+      .arg(env_file_arg())
       .arg(node_modules_dir_arg())
       .arg(node_modules_linker_arg())
       .arg(tunnel_arg())
@@ -7781,6 +7782,7 @@ fn task_parse(
   node_modules_arg_parse(flags, matches);
   node_modules_linker_arg_parse(flags, matches);
   lock_args_parse(flags, matches);
+  env_file_arg_parse(flags, matches);
 
   let mut recursive = matches.get_flag("recursive");
   let filter = if let Some(filter) = matches.remove_one::<String>("filter") {
@@ -14006,6 +14008,51 @@ mod tests {
     assert_eq!(
       r.unwrap_err().kind(),
       clap::error::ErrorKind::UnknownArgument
+    );
+  }
+
+  #[test]
+  fn task_subcommand_env_file() {
+    let r = flags_from_vec(svec!["deno", "task", "--env-file", "build"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Task(TaskFlags {
+          cwd: None,
+          task: Some("build".to_string()),
+          is_run: false,
+          recursive: false,
+          filter: None,
+          eval: false,
+          no_prefix: false,
+        }),
+        env_file: Some(vec![".env".to_owned()]),
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec![
+      "deno",
+      "task",
+      "--env-file=.env.dev",
+      "--env-file=.env.local",
+      "build"
+    ]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Task(TaskFlags {
+          cwd: None,
+          task: Some("build".to_string()),
+          is_run: false,
+          recursive: false,
+          filter: None,
+          eval: false,
+          no_prefix: false,
+        }),
+        env_file: Some(vec![".env.dev".to_owned(), ".env.local".to_owned()]),
+        ..Flags::default()
+      }
     );
   }
 

--- a/tests/specs/task/env_file/.env
+++ b/tests/specs/task/env_file/.env
@@ -1,0 +1,2 @@
+FOO=hello_from_env
+BAR=world

--- a/tests/specs/task/env_file/.env.dev
+++ b/tests/specs/task/env_file/.env.dev
@@ -1,0 +1,1 @@
+FOO=dev_env

--- a/tests/specs/task/env_file/__test__.jsonc
+++ b/tests/specs/task/env_file/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  "tests": {
+    "default_env_file": {
+      "args": "task -q --env-file show",
+      "output": "default.out",
+      "exitCode": 0
+    },
+    "specific_env_file": {
+      "args": "task -q --env-file=.env.dev show",
+      "output": "specific.out",
+      "exitCode": 0
+    },
+    "multiple_env_files": {
+      "args": "task -q --env-file=.env --env-file=.env.dev show",
+      "output": "multiple.out",
+      "exitCode": 0
+    }
+  }
+}

--- a/tests/specs/task/env_file/default.out
+++ b/tests/specs/task/env_file/default.out
@@ -1,0 +1,1 @@
+FOO=hello_from_env BAR=world

--- a/tests/specs/task/env_file/deno.json
+++ b/tests/specs/task/env_file/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "show": "echo FOO=$FOO BAR=$BAR"
+  }
+}

--- a/tests/specs/task/env_file/multiple.out
+++ b/tests/specs/task/env_file/multiple.out
@@ -1,0 +1,1 @@
+FOO=dev_env BAR=world

--- a/tests/specs/task/env_file/specific.out
+++ b/tests/specs/task/env_file/specific.out
@@ -1,0 +1,1 @@
+FOO=dev_env BAR=


### PR DESCRIPTION
`deno task` had no `--env-file` flag, so loading dotenv files into a
task's shell environment required forwarding `--env-file` through every
individual `deno run`/`deno install`/etc. inside the task body. This adds
the flag at the task level, matching how `run`, `eval`, `test`, `serve`,
and other runtime subcommands already accept it.

The loader machinery is already global (`cli/lib.rs` reads `flags.env_file`
at startup and mutates the process env), so the spawned task shell
inherits the variables for free. The flag accepts a default path (`.env`),
an explicit path, or multiple paths with later files taking precedence,
consistent with the other subcommands.

Closes #27236