### PR TITLE
feat(ext/node): auto-instrument node:http2 with OpenTelemetry

### DIFF
--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -535,7 +535,7 @@ function setOtelServerStatus(stream, statusCode) {
   span.setAttribute("http.response.status_code", String(statusCode));
   if (statusCode >= 500) {
     span.setAttribute("error.type", String(statusCode));
-    span.setStatus({ code: 2, message: "" });
+    span.setStatus({ code: 2 });
   }
 }
 
@@ -1680,7 +1680,7 @@ function onSessionHeaders(
         span.setAttribute("http.response.status_code", String(status));
         if (status >= 400) {
           span.setAttribute("error.type", String(status));
-          span.setStatus({ code: 2, message: "" });
+          span.setStatus({ code: 2 });
         }
       }
     }
@@ -4646,7 +4646,7 @@ class ClientHttp2Session extends Http2Session {
             },
           });
         }
-      } else if (typeof headersParam === "object") {
+      } else if (!!headersParam && typeof headersParam === "object") {
         for (const propagator of otelState.PROPAGATORS) {
           propagator.inject(spanContext, headersParam, {
             set(carrier, key, value) {
@@ -4657,146 +4657,169 @@ class ClientHttp2Session extends Http2Session {
       }
     }
 
-    let headersList;
-    let headersObject;
-    let rawHeaders;
-    let scheme;
-    let authority;
-    let method;
+    // From here on, several steps (header validation/preparation, option
+    // validation, stream construction) can throw synchronously. The span was
+    // started above but is only handed off to Http2Stream._destroy once it is
+    // attached to the stream. Wrap the body so a throw before/after that
+    // hand-off ends the span instead of leaking it.
+    let stream;
+    try {
+      let headersList;
+      let headersObject;
+      let rawHeaders;
+      let scheme;
+      let authority;
+      let method;
 
-    if (ArrayIsArray(headersParam)) {
-      ({
-        rawHeaders,
-        headersList,
-        scheme,
-        authority,
-        method,
-      } = prepareRequestHeadersArray(headersParam, this));
-    } else if (!!headersParam && typeof headersParam === "object") {
-      ({
-        headersObject,
-        headersList,
-        scheme,
-        authority,
-        method,
-      } = prepareRequestHeadersObject(headersParam, this));
-    } else if (headersParam === undefined) {
-      ({
-        headersObject,
-        headersList,
-        scheme,
-        authority,
-        method,
-      } = prepareRequestHeadersObject({}, this));
-    } else {
-      throw new ERR_INVALID_ARG_TYPE(
-        "headers",
-        ["Object", "Array"],
-        headersParam,
-      );
-    }
+      if (ArrayIsArray(headersParam)) {
+        ({
+          rawHeaders,
+          headersList,
+          scheme,
+          authority,
+          method,
+        } = prepareRequestHeadersArray(headersParam, this));
+      } else if (!!headersParam && typeof headersParam === "object") {
+        ({
+          headersObject,
+          headersList,
+          scheme,
+          authority,
+          method,
+        } = prepareRequestHeadersObject(headersParam, this));
+      } else if (headersParam === undefined) {
+        ({
+          headersObject,
+          headersList,
+          scheme,
+          authority,
+          method,
+        } = prepareRequestHeadersObject({}, this));
+      } else {
+        throw new ERR_INVALID_ARG_TYPE(
+          "headers",
+          ["Object", "Array"],
+          headersParam,
+        );
+      }
 
-    assertIsObject(options, "options");
-    options = { ...options };
+      assertIsObject(options, "options");
+      options = { ...options };
 
-    setAndValidatePriorityOptions(options);
+      setAndValidatePriorityOptions(options);
 
-    if (options.endStream === undefined) {
-      // For some methods, we know that a payload is meaningless, so end the
-      // stream by default if the user has not specifically indicated a
-      // preference.
-      options.endStream = isPayloadMeaningless(method);
-    } else {
-      validateBoolean(options.endStream, "options.endStream");
-    }
+      if (options.endStream === undefined) {
+        // For some methods, we know that a payload is meaningless, so end the
+        // stream by default if the user has not specifically indicated a
+        // preference.
+        options.endStream = isPayloadMeaningless(method);
+      } else {
+        validateBoolean(options.endStream, "options.endStream");
+      }
 
-    // eslint-disable-next-line no-use-before-define
-    const stream = new ClientHttp2Stream(this, undefined, undefined, {});
-    stream[kSentHeaders] = headersObject; // N.b. Only set for object headers, not raw headers
-    stream[kRawHeaders] = rawHeaders; // N.b. Only set for raw headers, not object headers
-    stream[kOrigin] = `${scheme}://${authority}`;
-    stream[kRequestAsyncResource] = new AsyncResource("PendingRequest");
+      // eslint-disable-next-line no-use-before-define
+      stream = new ClientHttp2Stream(this, undefined, undefined, {});
+      stream[kSentHeaders] = headersObject; // N.b. Only set for object headers, not raw headers
+      stream[kRawHeaders] = rawHeaders; // N.b. Only set for raw headers, not object headers
+      stream[kOrigin] = `${scheme}://${authority}`;
+      stream[kRequestAsyncResource] = new AsyncResource("PendingRequest");
 
-    if (span) {
-      stream[kOtelSpan] = span;
-      span.setAttribute("http.request.method", method);
-      if (scheme) span.setAttribute("url.scheme", scheme);
-      if (authority) span.setAttribute("server.address", authority);
-      let path;
-      if (headersObject) {
-        path = headersObject[HTTP2_HEADER_PATH];
-      } else if (rawHeaders) {
-        for (let i = 0; i < rawHeaders.length; i += 2) {
-          if (
-            StringPrototypeToLowerCase(rawHeaders[i]) === HTTP2_HEADER_PATH
-          ) {
-            path = rawHeaders[i + 1];
-            break;
+      if (span) {
+        stream[kOtelSpan] = span;
+        span.setAttribute("http.request.method", method);
+        if (scheme) span.setAttribute("url.scheme", scheme);
+        if (authority) span.setAttribute("server.address", authority);
+        let path;
+        if (headersObject) {
+          path = headersObject[HTTP2_HEADER_PATH];
+        } else if (rawHeaders) {
+          for (let i = 0; i < rawHeaders.length; i += 2) {
+            if (
+              StringPrototypeToLowerCase(rawHeaders[i]) === HTTP2_HEADER_PATH
+            ) {
+              path = rawHeaders[i + 1];
+              break;
+            }
+          }
+        }
+        if (path !== undefined) {
+          const qIdx = StringPrototypeIndexOf(path, "?");
+          if (qIdx < 0) {
+            span.setAttribute("url.path", path);
+          } else {
+            span.setAttribute("url.path", StringPrototypeSlice(path, 0, qIdx));
+            span.setAttribute(
+              "url.query",
+              StringPrototypeSlice(path, qIdx + 1),
+            );
           }
         }
       }
-      if (path !== undefined) {
-        const qIdx = StringPrototypeIndexOf(path, "?");
-        if (qIdx < 0) {
-          span.setAttribute("url.path", path);
+
+      // Close the writable side of the stream if options.endStream is set.
+      if (options.endStream) {
+        stream.end();
+      }
+
+      if (options.waitForTrailers) {
+        stream[kState].flags |= STREAM_FLAGS_HAS_TRAILERS;
+      }
+
+      const { signal } = options;
+      if (signal) {
+        validateAbortSignal(signal, "options.signal");
+        const aborter = () => {
+          stream.destroy(new AbortError(undefined, { cause: signal.reason }));
+        };
+        if (signal.aborted) {
+          aborter();
         } else {
-          span.setAttribute("url.path", StringPrototypeSlice(path, 0, qIdx));
-          span.setAttribute("url.query", StringPrototypeSlice(path, qIdx + 1));
+          const disposable = addAbortListener(signal, aborter);
+          stream.once("close", disposable[SymbolDispose]);
         }
       }
-    }
 
-    // Close the writable side of the stream if options.endStream is set.
-    if (options.endStream) {
-      stream.end();
-    }
-
-    if (options.waitForTrailers) {
-      stream[kState].flags |= STREAM_FLAGS_HAS_TRAILERS;
-    }
-
-    const { signal } = options;
-    if (signal) {
-      validateAbortSignal(signal, "options.signal");
-      const aborter = () => {
-        stream.destroy(new AbortError(undefined, { cause: signal.reason }));
-      };
-      if (signal.aborted) {
-        aborter();
+      const onConnect = FunctionPrototypeBind(
+        requestOnConnect,
+        stream,
+        headersList,
+        options,
+      );
+      if (this.connecting) {
+        if (this[kPendingRequestCalls] !== null) {
+          ArrayPrototypePush(this[kPendingRequestCalls], onConnect);
+        } else {
+          this[kPendingRequestCalls] = [onConnect];
+          this.once("connect", () => {
+            ArrayPrototypeForEach(this[kPendingRequestCalls], (f) => f());
+            this[kPendingRequestCalls] = null;
+          });
+        }
       } else {
-        const disposable = addAbortListener(signal, aborter);
-        stream.once("close", disposable[SymbolDispose]);
+        onConnect();
       }
-    }
 
-    const onConnect = FunctionPrototypeBind(
-      requestOnConnect,
-      stream,
-      headersList,
-      options,
-    );
-    if (this.connecting) {
-      if (this[kPendingRequestCalls] !== null) {
-        ArrayPrototypePush(this[kPendingRequestCalls], onConnect);
-      } else {
-        this[kPendingRequestCalls] = [onConnect];
-        this.once("connect", () => {
-          ArrayPrototypeForEach(this[kPendingRequestCalls], (f) => f());
-          this[kPendingRequestCalls] = null;
+      if (onClientStreamCreatedChannel.hasSubscribers) {
+        onClientStreamCreatedChannel.publish({
+          stream,
+          headers: stream.sentHeaders,
         });
       }
-    } else {
-      onConnect();
-    }
 
-    if (onClientStreamCreatedChannel.hasSubscribers) {
-      onClientStreamCreatedChannel.publish({
-        stream,
-        headers: stream.sentHeaders,
-      });
+      return stream;
+    } catch (err) {
+      // End the span unless Http2Stream._destroy already did (it clears
+      // kOtelSpan after ending). Covers throws both before the stream exists
+      // and after it was attached but never destroyed.
+      if (
+        span !== undefined &&
+        (stream === undefined || stream[kOtelSpan] === span)
+      ) {
+        updateSpanFromError(span, err);
+        span.end();
+      }
+      throw err;
     }
-
-    return stream;
   }
 }
 

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -4642,6 +4642,15 @@ class ClientHttp2Session extends Http2Session {
         for (const propagator of otelState.PROPAGATORS) {
           propagator.inject(spanContext, headersParam, {
             set(carrier, key, value) {
+              // Match the object path's overwrite semantics: replace an
+              // existing entry rather than appending a duplicate (a caller
+              // could have already set `traceparent`/`tracestate`).
+              for (let i = 0; i < carrier.length; i += 2) {
+                if (StringPrototypeToLowerCase(carrier[i]) === key) {
+                  carrier[i + 1] = value;
+                  return;
+                }
+              }
               ArrayPrototypePush(carrier, key, value);
             },
           });

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -38,6 +38,7 @@ const {
   SafeRegExp,
   SafeSet,
   StringPrototypeCharCodeAt,
+  StringPrototypeIndexOf,
   StringPrototypeSlice,
   StringPrototypeToLowerCase,
   Symbol,
@@ -230,6 +231,15 @@ const {
   Http2ServerResponse,
   onServerStream,
 } = core.loadExtScript("ext:deno_node/internal/http2/compat.js");
+const { updateSpanFromError } = core.loadExtScript(
+  "ext:deno_telemetry/util.ts",
+);
+const {
+  otelState,
+  builtinTracer,
+  ContextManager,
+  SPAN_KEY,
+} = core.loadExtScript("ext:deno_telemetry/telemetry.ts");
 const onClientStreamCreatedChannel = dc.channel("http2.client.stream.created");
 const onClientStreamStartChannel = dc.channel("http2.client.stream.start");
 const onClientStreamErrorChannel = dc.channel("http2.client.stream.error");
@@ -514,6 +524,20 @@ const kState = Symbol("state");
 const kType = Symbol("type");
 const kWriteGeneric = Symbol("write-generic");
 const kSessions = Symbol("sessions");
+const kOtelSpan = Symbol("kOtelSpan");
+
+// Server-side helper: record HTTP response status on the OTel span attached
+// to a stream by onSessionHeaders. Per OTel HTTP semconv, server spans are
+// only marked ERROR for 5xx (client errors stay OK).
+function setOtelServerStatus(stream, statusCode) {
+  const span = stream[kOtelSpan];
+  if (span === undefined || statusCode === undefined) return;
+  span.setAttribute("http.response.status_code", String(statusCode));
+  if (statusCode >= 500) {
+    span.setAttribute("error.type", String(statusCode));
+    span.setStatus({ code: 2, message: "" });
+  }
+}
 
 // Symbols for tracking perf_hooks `http2` performance entry stats. The
 // `pingRTT`, `streamCount`, etc. fields surfaced via `entry.detail` are
@@ -1506,6 +1530,47 @@ function onSessionHeaders(
     if (type === NGHTTP2_SESSION_SERVER) {
       // eslint-disable-next-line no-use-before-define
       stream = new ServerHttp2Stream(session, handle, id, {}, obj);
+      if (otelState.TRACING_ENABLED) {
+        let ctx = ContextManager.active();
+        for (const propagator of otelState.PROPAGATORS) {
+          ctx = propagator.extract(ctx, obj, {
+            get(carrier, key) {
+              return carrier[key];
+            },
+            keys(carrier) {
+              return ObjectKeys(carrier);
+            },
+          });
+        }
+        const reqMethod = obj[HTTP2_HEADER_METHOD] ?? "GET";
+        const span = builtinTracer().startSpan(
+          reqMethod,
+          { kind: 1 }, // SpanKind.SERVER
+          ctx,
+        );
+        span.setAttribute("http.request.method", reqMethod);
+        const reqScheme = obj[HTTP2_HEADER_SCHEME];
+        if (reqScheme) span.setAttribute("url.scheme", reqScheme);
+        const reqAuthority = obj[HTTP2_HEADER_AUTHORITY];
+        if (reqAuthority) span.setAttribute("server.address", reqAuthority);
+        const reqPath = obj[HTTP2_HEADER_PATH];
+        if (reqPath !== undefined) {
+          const qIdx = StringPrototypeIndexOf(reqPath, "?");
+          if (qIdx < 0) {
+            span.setAttribute("url.path", reqPath);
+          } else {
+            span.setAttribute(
+              "url.path",
+              StringPrototypeSlice(reqPath, 0, qIdx),
+            );
+            span.setAttribute(
+              "url.query",
+              StringPrototypeSlice(reqPath, qIdx + 1),
+            );
+          }
+        }
+        stream[kOtelSpan] = span;
+      }
       if (onServerStreamCreatedChannel.hasSubscribers) {
         onServerStreamCreatedChannel.publish({
           stream,
@@ -1608,6 +1673,16 @@ function onSessionHeaders(
         headers: obj,
         flags: flags,
       });
+    }
+    if (event === "response" && status !== undefined) {
+      const span = stream[kOtelSpan];
+      if (span) {
+        span.setAttribute("http.response.status_code", String(status));
+        if (status >= 400) {
+          span.setAttribute("error.type", String(status));
+          span.setStatus({ code: 2, message: "" });
+        }
+      }
     }
   }
   if (endOfStream) {
@@ -2500,6 +2575,20 @@ class Http2Stream extends Duplex {
 
     emitStreamPerfEntry(this);
 
+    const otelSpan = this[kOtelSpan];
+    if (otelSpan !== undefined) {
+      if (err != null) {
+        updateSpanFromError(otelSpan, err);
+      } else if (code !== NGHTTP2_NO_ERROR) {
+        updateSpanFromError(
+          otelSpan,
+          new ERR_HTTP2_STREAM_ERROR(nameForErrorCode[code] || code),
+        );
+      }
+      otelSpan.end();
+      this[kOtelSpan] = undefined;
+    }
+
     this[kSession] = undefined;
     this[kHandle] = undefined;
 
@@ -3075,6 +3164,8 @@ class ServerHttp2Stream extends Http2Stream {
       statusCode,
     } = prepareResponseHeaders(this, headersParam, options);
 
+    setOtelServerStatus(this, statusCode);
+
     state.flags |= STREAM_FLAGS_HEADERS_SENT;
 
     // Close the writable side if the endStream option is set or status
@@ -3166,6 +3257,8 @@ class ServerHttp2Stream extends Http2Stream {
       statusCode,
     } = prepareResponseHeadersObject(headersParam, options);
 
+    setOtelServerStatus(this, statusCode);
+
     // Payload/DATA frames are not permitted in these cases
     if (
       statusCode === HTTP_STATUS_NO_CONTENT ||
@@ -3250,6 +3343,8 @@ class ServerHttp2Stream extends Http2Stream {
       headers,
       statusCode,
     } = prepareResponseHeadersObject(headersParam, options);
+
+    setOtelServerStatus(this, statusCode);
 
     // Payload/DATA frames are not permitted in these cases
     if (
@@ -4517,6 +4612,51 @@ class ClientHttp2Session extends Http2Session {
 
     this[kUpdateTimer]();
 
+    let span;
+    if (otelState.TRACING_ENABLED) {
+      // Determine the method name for the span; mirrors the default applied
+      // by prepareRequestHeaders{Object,Array} below.
+      let spanMethod;
+      if (ArrayIsArray(headersParam)) {
+        for (let i = 0; i < headersParam.length; i += 2) {
+          if (
+            StringPrototypeToLowerCase(headersParam[i]) === HTTP2_HEADER_METHOD
+          ) {
+            spanMethod = headersParam[i + 1];
+            break;
+          }
+        }
+      } else if (!!headersParam && typeof headersParam === "object") {
+        spanMethod = headersParam[HTTP2_HEADER_METHOD];
+      }
+      span = builtinTracer().startSpan(spanMethod ?? "GET", { kind: 2 });
+
+      // Inject propagation headers directly into the user-supplied headers
+      // before prepareRequestHeaders* reads them. Object form: assign keys.
+      // Array form: push [name, value] pairs.
+      const spanContext = ContextManager.active().setValue(SPAN_KEY, span);
+      if (headersParam === undefined) {
+        headersParam = { __proto__: null };
+      }
+      if (ArrayIsArray(headersParam)) {
+        for (const propagator of otelState.PROPAGATORS) {
+          propagator.inject(spanContext, headersParam, {
+            set(carrier, key, value) {
+              ArrayPrototypePush(carrier, key, value);
+            },
+          });
+        }
+      } else if (typeof headersParam === "object") {
+        for (const propagator of otelState.PROPAGATORS) {
+          propagator.inject(spanContext, headersParam, {
+            set(carrier, key, value) {
+              carrier[key] = value;
+            },
+          });
+        }
+      }
+    }
+
     let headersList;
     let headersObject;
     let rawHeaders;
@@ -4576,6 +4716,35 @@ class ClientHttp2Session extends Http2Session {
     stream[kRawHeaders] = rawHeaders; // N.b. Only set for raw headers, not object headers
     stream[kOrigin] = `${scheme}://${authority}`;
     stream[kRequestAsyncResource] = new AsyncResource("PendingRequest");
+
+    if (span) {
+      stream[kOtelSpan] = span;
+      span.setAttribute("http.request.method", method);
+      if (scheme) span.setAttribute("url.scheme", scheme);
+      if (authority) span.setAttribute("server.address", authority);
+      let path;
+      if (headersObject) {
+        path = headersObject[HTTP2_HEADER_PATH];
+      } else if (rawHeaders) {
+        for (let i = 0; i < rawHeaders.length; i += 2) {
+          if (
+            StringPrototypeToLowerCase(rawHeaders[i]) === HTTP2_HEADER_PATH
+          ) {
+            path = rawHeaders[i + 1];
+            break;
+          }
+        }
+      }
+      if (path !== undefined) {
+        const qIdx = StringPrototypeIndexOf(path, "?");
+        if (qIdx < 0) {
+          span.setAttribute("url.path", path);
+        } else {
+          span.setAttribute("url.path", StringPrototypeSlice(path, 0, qIdx));
+          span.setAttribute("url.query", StringPrototypeSlice(path, qIdx + 1));
+        }
+      }
+    }
 
     // Close the writable side of the stream if options.endStream is set.
     if (options.endStream) {

--- a/tests/specs/cli/otel_basic/__test__.jsonc
+++ b/tests/specs/cli/otel_basic/__test__.jsonc
@@ -66,6 +66,10 @@
       "args": "run -A main.ts node_http_request.ts",
       "output": "node_http_request.out"
     },
+    "http2": {
+      "args": "run -A main.ts http2.ts",
+      "output": "http2.out"
+    },
     "events": {
       "args": "run -A main.ts events.ts",
       "output": "events.out"

--- a/tests/specs/cli/otel_basic/http2.out
+++ b/tests/specs/cli/otel_basic/http2.out
@@ -329,6 +329,146 @@
         "message": "",
         "code": 2
       }
+    },
+    {
+      "traceId": "00000000000000000000000000000004",
+      "spanId": "0000000000000007",
+      "traceState": "",
+      "parentSpanId": "",
+      "flags": 1,
+      "name": "GET",
+      "kind": 3,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "http.request.method",
+          "value": {
+            "stringValue": "GET"
+          }
+        },
+        {
+          "key": "url.scheme",
+          "value": {
+            "stringValue": "http"
+          }
+        },
+        {
+          "key": "server.address",
+          "value": {
+            "stringValue": "[WILDLINE]"
+          }
+        },
+        {
+          "key": "url.path",
+          "value": {
+            "stringValue": "/reset"
+          }
+        },
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "Error"
+          }
+        },
+        {
+          "key": "exception.type",
+          "value": {
+            "stringValue": "Error"
+          }
+        },
+        {
+          "key": "exception.message",
+          "value": {
+            "stringValue": "Stream closed with error code NGHTTP2_INTERNAL_ERROR"
+          }
+        },
+        {
+          "key": "exception.stacktrace",
+          "value": {
+            "stringValue": "[WILDCARD]"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "Stream closed with error code NGHTTP2_INTERNAL_ERROR",
+        "code": 2
+      }
+    },
+    {
+      "traceId": "00000000000000000000000000000004",
+      "spanId": "0000000000000008",
+      "traceState": "",
+      "parentSpanId": "0000000000000007",
+      "flags": 1,
+      "name": "GET",
+      "kind": 2,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "http.request.method",
+          "value": {
+            "stringValue": "GET"
+          }
+        },
+        {
+          "key": "url.scheme",
+          "value": {
+            "stringValue": "http"
+          }
+        },
+        {
+          "key": "server.address",
+          "value": {
+            "stringValue": "[WILDLINE]"
+          }
+        },
+        {
+          "key": "url.path",
+          "value": {
+            "stringValue": "/reset"
+          }
+        },
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "Error"
+          }
+        },
+        {
+          "key": "exception.type",
+          "value": {
+            "stringValue": "Error"
+          }
+        },
+        {
+          "key": "exception.message",
+          "value": {
+            "stringValue": "Stream closed with error code NGHTTP2_INTERNAL_ERROR"
+          }
+        },
+        {
+          "key": "exception.stacktrace",
+          "value": {
+            "stringValue": "[WILDCARD]"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "Stream closed with error code NGHTTP2_INTERNAL_ERROR",
+        "code": 2
+      }
     }
   ],
   "logs": [],

--- a/tests/specs/cli/otel_basic/http2.out
+++ b/tests/specs/cli/otel_basic/http2.out
@@ -213,6 +213,122 @@
         "message": "",
         "code": 0
       }
+    },
+    {
+      "traceId": "00000000000000000000000000000003",
+      "spanId": "0000000000000005",
+      "traceState": "",
+      "parentSpanId": "",
+      "flags": 1,
+      "name": "GET",
+      "kind": 3,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "http.request.method",
+          "value": {
+            "stringValue": "GET"
+          }
+        },
+        {
+          "key": "url.scheme",
+          "value": {
+            "stringValue": "http"
+          }
+        },
+        {
+          "key": "server.address",
+          "value": {
+            "stringValue": "[WILDLINE]"
+          }
+        },
+        {
+          "key": "url.path",
+          "value": {
+            "stringValue": "/error"
+          }
+        },
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "500"
+          }
+        },
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "500"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "",
+        "code": 2
+      }
+    },
+    {
+      "traceId": "00000000000000000000000000000003",
+      "spanId": "0000000000000006",
+      "traceState": "",
+      "parentSpanId": "0000000000000005",
+      "flags": 1,
+      "name": "GET",
+      "kind": 2,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "http.request.method",
+          "value": {
+            "stringValue": "GET"
+          }
+        },
+        {
+          "key": "url.scheme",
+          "value": {
+            "stringValue": "http"
+          }
+        },
+        {
+          "key": "server.address",
+          "value": {
+            "stringValue": "[WILDLINE]"
+          }
+        },
+        {
+          "key": "url.path",
+          "value": {
+            "stringValue": "/error"
+          }
+        },
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "500"
+          }
+        },
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "500"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "",
+        "code": 2
+      }
     }
   ],
   "logs": [],

--- a/tests/specs/cli/otel_basic/http2.out
+++ b/tests/specs/cli/otel_basic/http2.out
@@ -1,0 +1,220 @@
+{
+  "spans": [
+    {
+      "traceId": "00000000000000000000000000000001",
+      "spanId": "0000000000000001",
+      "traceState": "",
+      "parentSpanId": "",
+      "flags": 1,
+      "name": "GET",
+      "kind": 3,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "http.request.method",
+          "value": {
+            "stringValue": "GET"
+          }
+        },
+        {
+          "key": "url.scheme",
+          "value": {
+            "stringValue": "http"
+          }
+        },
+        {
+          "key": "server.address",
+          "value": {
+            "stringValue": "[WILDLINE]"
+          }
+        },
+        {
+          "key": "url.path",
+          "value": {
+            "stringValue": "/found"
+          }
+        },
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "200"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "",
+        "code": 0
+      }
+    },
+    {
+      "traceId": "00000000000000000000000000000001",
+      "spanId": "0000000000000002",
+      "traceState": "",
+      "parentSpanId": "0000000000000001",
+      "flags": 1,
+      "name": "GET",
+      "kind": 2,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "http.request.method",
+          "value": {
+            "stringValue": "GET"
+          }
+        },
+        {
+          "key": "url.scheme",
+          "value": {
+            "stringValue": "http"
+          }
+        },
+        {
+          "key": "server.address",
+          "value": {
+            "stringValue": "[WILDLINE]"
+          }
+        },
+        {
+          "key": "url.path",
+          "value": {
+            "stringValue": "/found"
+          }
+        },
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "200"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "",
+        "code": 0
+      }
+    },
+    {
+      "traceId": "00000000000000000000000000000002",
+      "spanId": "0000000000000003",
+      "traceState": "",
+      "parentSpanId": "",
+      "flags": 1,
+      "name": "GET",
+      "kind": 3,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "http.request.method",
+          "value": {
+            "stringValue": "GET"
+          }
+        },
+        {
+          "key": "url.scheme",
+          "value": {
+            "stringValue": "http"
+          }
+        },
+        {
+          "key": "server.address",
+          "value": {
+            "stringValue": "[WILDLINE]"
+          }
+        },
+        {
+          "key": "url.path",
+          "value": {
+            "stringValue": "/not-found"
+          }
+        },
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "404"
+          }
+        },
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "404"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "",
+        "code": 2
+      }
+    },
+    {
+      "traceId": "00000000000000000000000000000002",
+      "spanId": "0000000000000004",
+      "traceState": "",
+      "parentSpanId": "0000000000000003",
+      "flags": 1,
+      "name": "GET",
+      "kind": 2,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "http.request.method",
+          "value": {
+            "stringValue": "GET"
+          }
+        },
+        {
+          "key": "url.scheme",
+          "value": {
+            "stringValue": "http"
+          }
+        },
+        {
+          "key": "server.address",
+          "value": {
+            "stringValue": "[WILDLINE]"
+          }
+        },
+        {
+          "key": "url.path",
+          "value": {
+            "stringValue": "/not-found"
+          }
+        },
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "404"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "",
+        "code": 0
+      }
+    }
+  ],
+  "logs": [],
+  "metrics": []
+}

--- a/tests/specs/cli/otel_basic/http2.ts
+++ b/tests/specs/cli/otel_basic/http2.ts
@@ -6,6 +6,11 @@ const server = http2.createServer((req, res) => {
     status = 200;
   } else if (req.url === "/error") {
     status = 500;
+  } else if (req.url === "/reset") {
+    // Reset the stream so both the server and client spans exercise the
+    // error fan-in in Http2Stream._destroy (updateSpanFromError).
+    res.stream.close(http2.constants.NGHTTP2_INTERNAL_ERROR);
+    return;
   }
   res.writeHead(status);
   res.end();
@@ -27,9 +32,19 @@ async function request(path: string) {
   });
 }
 
+async function requestExpectError(path: string) {
+  const req = client.request({ ":path": path });
+  return new Promise<void>((resolve) => {
+    req.on("error", () => {});
+    req.on("close", () => resolve());
+    req.end();
+  });
+}
+
 await request("/found");
 await request("/not-found");
 await request("/error");
+await requestExpectError("/reset");
 
 client.close();
 server.close();

--- a/tests/specs/cli/otel_basic/http2.ts
+++ b/tests/specs/cli/otel_basic/http2.ts
@@ -1,7 +1,12 @@
 import http2 from "node:http2";
 
 const server = http2.createServer((req, res) => {
-  const status = req.url === "/found" ? 200 : 404;
+  let status = 404;
+  if (req.url === "/found") {
+    status = 200;
+  } else if (req.url === "/error") {
+    status = 500;
+  }
   res.writeHead(status);
   res.end();
 });
@@ -24,6 +29,7 @@ async function request(path: string) {
 
 await request("/found");
 await request("/not-found");
+await request("/error");
 
 client.close();
 server.close();

--- a/tests/specs/cli/otel_basic/http2.ts
+++ b/tests/specs/cli/otel_basic/http2.ts
@@ -1,0 +1,29 @@
+import http2 from "node:http2";
+
+const server = http2.createServer((req, res) => {
+  const status = req.url === "/found" ? 200 : 404;
+  res.writeHead(status);
+  res.end();
+});
+
+await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+const port = (server.address() as { port: number }).port;
+const url = `http://localhost:${port}`;
+
+const client = http2.connect(url);
+
+async function request(path: string) {
+  const req = client.request({ ":path": path });
+  return new Promise<void>((resolve) => {
+    req.on("response", () => {});
+    req.on("data", () => {});
+    req.on("end", () => resolve());
+    req.end();
+  });
+}
+
+await request("/found");
+await request("/not-found");
+
+client.close();
+server.close();


### PR DESCRIPTION
node:http and Deno.serve / fetch are already auto-instrumented when
OpenTelemetry is enabled, but node:http2 was a gap: applications using
HTTP/2 (clients or servers) saw no spans for their requests. This wires
up the same instrumentation pattern in the http2 polyfill so HTTP/2
traffic shows up in traces alongside the rest of the stack and trace
context propagates across services that speak h2.

Every hot path entry is gated on a single otelState.TRACING_ENABLED
boolean load, so when OTel is disabled the only added cost is one
branch and the existing code runs untouched. Client spans (CLIENT
kind) are created in ClientHttp2Session.request and inject propagator
headers into the user-supplied headers before they are frozen into
the nghttp2 representation. Server spans (SERVER kind) are created in
onSessionHeaders for incoming requests with the parent context
extracted from the incoming headers via the registered propagators.
Spans are ended exactly once in Http2Stream._destroy, which is the
single fan-in point for every close path (normal, error, abort,
session destroy).