### PR TITLE
fix(config): warn instead of erroring when workspace member dir is missing

### DIFF
--- a/libs/config/workspace/discovery.rs
+++ b/libs/config/workspace/discovery.rs
@@ -844,7 +844,21 @@ fn resolve_workspace_for_config_folder<
         );
       }
       validate_member_url_is_descendant(&member_dir_url)?;
-      let member_config_folder = find_member_config_folder(&member_dir_url)?;
+      let member_config_folder =
+        match find_member_config_folder(&member_dir_url) {
+          Ok(folder) => folder,
+          Err(err) => match err.into_kind() {
+            ResolveWorkspaceMemberErrorKind::NotFound { dir_url } => {
+              log::warn!(
+                "Workspace member \"{}\" not found at {}. Skipping.",
+                raw_member,
+                dir_url,
+              );
+              continue;
+            }
+            other => return Err(other.into_box().into()),
+          },
+        };
       let previous_member = final_members
         .insert(new_rc(member_dir_url.clone()), member_config_folder);
       if previous_member.is_some() {
@@ -894,21 +908,16 @@ fn resolve_workspace_for_config_folder<
       let member_config_folder =
         match find_member_config_folder(&member_dir_url) {
           Ok(config_folder) => config_folder,
-          Err(err) => {
-            return Err(
-              match err.into_kind() {
-                ResolveWorkspaceMemberErrorKind::NotFound { dir_url } => {
-                  // enhance the error to say we didn't find a package.json
-                  ResolveWorkspaceMemberErrorKind::NotFoundPackageJson {
-                    dir_url,
-                  }
-                  .into_box()
-                }
-                err => err.into_box(),
-              }
-              .into(),
-            );
-          }
+          Err(err) => match err.into_kind() {
+            ResolveWorkspaceMemberErrorKind::NotFound { dir_url } => {
+              log::warn!(
+                "Workspace member directory \"{}\" not found. Skipping.",
+                dir_url,
+              );
+              continue;
+            }
+            other => return Err(other.into_box().into()),
+          },
         };
       if member_config_folder.pkg_json().is_none() {
         return Err(

--- a/libs/config/workspace/discovery.rs
+++ b/libs/config/workspace/discovery.rs
@@ -848,7 +848,9 @@ fn resolve_workspace_for_config_folder<
         match find_member_config_folder(&member_dir_url) {
           Ok(folder) => folder,
           Err(err) => match err.into_kind() {
-            ResolveWorkspaceMemberErrorKind::NotFound { dir_url } => {
+            ResolveWorkspaceMemberErrorKind::NotFound { dir_url }
+              if !member_dir_exists(sys, &dir_url) =>
+            {
               log::warn!(
                 "Workspace member \"{}\" not found at {}. Skipping.",
                 raw_member,
@@ -892,15 +894,16 @@ fn resolve_workspace_for_config_folder<
       IndexSet::with_capacity(path_members.len() + pkg_json_paths.len());
     for path_member in path_members {
       let member_dir_url = resolve_member_url(path_member)?;
-      member_dir_urls.insert(member_dir_url);
+      member_dir_urls.insert((path_member.clone(), member_dir_url));
     }
     for pkg_json_path in pkg_json_paths {
-      let member_dir_url =
-        url_from_directory_path(pkg_json_path.parent().unwrap())?;
-      member_dir_urls.insert(member_dir_url);
+      let member_dir = pkg_json_path.parent().unwrap();
+      let member_dir_url = url_from_directory_path(member_dir)?;
+      member_dir_urls
+        .insert((member_dir.to_string_lossy().into_owned(), member_dir_url));
     }
 
-    for member_dir_url in member_dir_urls {
+    for (raw_member, member_dir_url) in member_dir_urls {
       if member_dir_url == root_config_file_directory_url {
         continue; // ignore self references
       }
@@ -909,12 +912,27 @@ fn resolve_workspace_for_config_folder<
         match find_member_config_folder(&member_dir_url) {
           Ok(config_folder) => config_folder,
           Err(err) => match err.into_kind() {
-            ResolveWorkspaceMemberErrorKind::NotFound { dir_url } => {
+            ResolveWorkspaceMemberErrorKind::NotFound { dir_url }
+              if !member_dir_exists(sys, &dir_url) =>
+            {
               log::warn!(
-                "Workspace member directory \"{}\" not found. Skipping.",
+                "Workspace member \"{}\" not found at {}. Skipping.",
+                raw_member,
                 dir_url,
               );
               continue;
+            }
+            ResolveWorkspaceMemberErrorKind::NotFound { dir_url } => {
+              // dir exists but neither deno.json nor package.json — for
+              // an npm workspace member, surface this as the more specific
+              // "package.json not found" error.
+              return Err(
+                ResolveWorkspaceMemberErrorKind::NotFoundPackageJson {
+                  dir_url,
+                }
+                .into_box()
+                .into(),
+              );
             }
             other => return Err(other.into_box().into()),
           },
@@ -939,6 +957,13 @@ fn resolve_workspace_for_config_folder<
     members: final_members,
     vendor_dir: maybe_vendor_dir,
   })
+}
+
+fn member_dir_exists<TSys: FsMetadata>(sys: &TSys, dir_url: &Url) -> bool {
+  let Ok(path) = url_to_file_path(dir_url) else {
+    return false;
+  };
+  sys.fs_is_dir_no_err(&path)
 }
 
 fn resolve_link_config_folders<TSys: FsRead + FsMetadata + FsReadDir>(

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -4936,6 +4936,28 @@ pub mod test {
   }
 
   #[test]
+  fn test_deno_workspace_member_dir_without_config_errors() {
+    let sys = InMemorySys::default();
+    sys.fs_insert_json(
+      root_dir().join("deno.json"),
+      json!({
+        "workspace": ["./member"]
+      }),
+    );
+    // The member directory exists but has no deno.json(c). This is a
+    // genuine misconfiguration (typo'd path or missing config file) and
+    // should still error rather than being silently skipped.
+    sys.fs_insert(root_dir().join("member/other.ts"), "");
+    let err = workspace_at_start_dir_err(&sys, &root_dir());
+    assert_eq!(
+      err.to_string(),
+      normalize_err_text(
+        "Could not find config file for workspace member in '[ROOT_DIR_URL]/member/'."
+      )
+    );
+  }
+
+  #[test]
   fn test_deno_workspace_member_deno_json_member_name() {
     let sys = InMemorySys::default();
     sys.fs_insert_json(
@@ -5215,6 +5237,28 @@ pub mod test {
     // Member exists with a deno.json but no package.json — that's a
     // genuine npm-workspace misconfiguration and should still error.
     sys.fs_insert_json(root_dir().join("member/deno.json"), json!({}));
+    let err = workspace_at_start_dir_err(&sys, &root_dir());
+    assert_eq!(
+      err.to_string(),
+      normalize_err_text(
+        "Could not find package.json for workspace member in '[ROOT_DIR_URL]/member/'."
+      )
+    );
+  }
+
+  #[test]
+  fn test_npm_workspace_member_dir_without_config_errors() {
+    let sys = InMemorySys::default();
+    sys.fs_insert_json(
+      root_dir().join("package.json"),
+      json!({
+        "workspaces": ["./member"]
+      }),
+    );
+    // Member directory exists but has no package.json (or deno.json) at
+    // all. Treat this like a typo'd path and surface the package.json
+    // error rather than silently skipping it.
+    sys.fs_insert(root_dir().join("member/other.ts"), "");
     let err = workspace_at_start_dir_err(&sys, &root_dir());
     assert_eq!(
       err.to_string(),

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -4918,7 +4918,7 @@ pub mod test {
   }
 
   #[test]
-  fn test_deno_workspace_member_no_config_file_error() {
+  fn test_deno_workspace_member_missing_dir_skipped() {
     let sys = InMemorySys::default();
     sys.fs_insert_json(
       root_dir().join("deno.json"),
@@ -4926,14 +4926,13 @@ pub mod test {
         "workspace": ["./member"]
       }),
     );
-    // no deno.json in this folder, so should error
-    let err = workspace_at_start_dir_err(&sys, &root_dir().join("package"));
-    assert_eq!(
-      err.to_string(),
-      normalize_err_text(
-        "Could not find config file for workspace member in '[ROOT_DIR_URL]/member/'."
-      )
-    );
+    // The listed member directory does not exist on disk; we should warn
+    // and skip it instead of erroring, so other workspace operations can
+    // still proceed (e.g. partial Docker images that only copy a subset
+    // of workspace members).
+    let workspace_dir = workspace_at_start_dir(&sys, &root_dir());
+    assert_eq!(workspace_dir.workspace.deno_jsons().count(), 1);
+    assert_eq!(workspace_dir.workspace.config_folders().len(), 1);
   }
 
   #[test]
@@ -5188,7 +5187,7 @@ pub mod test {
   }
 
   #[test]
-  fn test_npm_workspace_member_no_config_file_error() {
+  fn test_npm_workspace_member_missing_dir_skipped() {
     let sys = InMemorySys::default();
     sys.fs_insert_json(
       root_dir().join("package.json"),
@@ -5196,8 +5195,27 @@ pub mod test {
         "workspaces": ["./member"]
       }),
     );
-    // no package.json in this folder, so should error
-    let err = workspace_at_start_dir_err(&sys, &root_dir().join("package"));
+    // The listed npm workspace member directory does not exist; warn and
+    // skip instead of erroring, matching npm's behavior and supporting
+    // partial Docker image scenarios.
+    let workspace_dir = workspace_at_start_dir(&sys, &root_dir());
+    assert_eq!(workspace_dir.workspace.package_jsons().count(), 1);
+    assert_eq!(workspace_dir.workspace.config_folders().len(), 1);
+  }
+
+  #[test]
+  fn test_npm_workspace_member_only_deno_json_errors() {
+    let sys = InMemorySys::default();
+    sys.fs_insert_json(
+      root_dir().join("package.json"),
+      json!({
+        "workspaces": ["./member"]
+      }),
+    );
+    // Member exists with a deno.json but no package.json — that's a
+    // genuine npm-workspace misconfiguration and should still error.
+    sys.fs_insert_json(root_dir().join("member/deno.json"), json!({}));
+    let err = workspace_at_start_dir_err(&sys, &root_dir());
     assert_eq!(
       err.to_string(),
       normalize_err_text(


### PR DESCRIPTION
Listing a workspace member by literal path required the directory to be
present on disk, otherwise workspace discovery failed with "Could not
find config file for workspace member". This broke the documented Docker
workflow that only copies the relevant member subset into the image, and
it diverged from npm, which silently tolerates missing workspace
members. Now we emit a warning and skip the missing member, so any
remaining members install and run normally.

Genuine misconfigurations are unchanged: pointing at a config file
instead of a directory still errors, and an npm workspace member whose
directory exists but contains no `package.json` still errors.

Fixes #28365