### PR TITLE
fix(cli/task): run recursive workspace tasks in parallel

### DIFF
--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -219,6 +219,7 @@ pub async fn execute_script(
         .run_deno_task(
           &Url::from_directory_path(cli_options.initial_cwd()).unwrap(),
           None,
+          None,
           "",
           &TaskDefinition {
             command: Some(task_flags.task.as_ref().unwrap().to_string()),
@@ -232,16 +233,14 @@ pub async fn execute_script(
         .await;
     }
 
-    for task_config in &packages_task_configs {
-      let exit_code = task_runner
-        .run_tasks(task_config, name, &kill_signal, cli_options.argv())
-        .await?;
-      if exit_code > 0 {
-        return Ok(exit_code);
-      }
-    }
-
-    Ok(0)
+    task_runner
+      .run_all_tasks(
+        &packages_task_configs,
+        name,
+        &kill_signal,
+        cli_options.argv(),
+      )
+      .await
   })
   .await
 }
@@ -249,7 +248,10 @@ pub async fn execute_script(
 #[derive(Clone, Copy)]
 struct ParallelInfo {
   color_index: usize,
-  name_pad_width: usize,
+  label_pad_width: usize,
+  /// When true, the prefix label includes the package name (`[pkg#task]`) so
+  /// identically-named tasks from sibling workspace members stay distinct.
+  include_package: bool,
 }
 
 /// For each task that could run concurrently with at least one other task,
@@ -301,6 +303,40 @@ fn compute_concurrent_task_color_indices(
   color_indices
 }
 
+/// Returns the workspace member's display name for a task's prefix label —
+/// its `name` from deno.json/package.json if set, otherwise the folder's
+/// directory name as a fallback so unnamed sibling packages stay
+/// distinguishable. Tasks from the workspace root get no fallback (their
+/// root folder name is typically not a meaningful package name).
+fn task_label_name<'a>(
+  task: &ResolvedTask<'a>,
+  workspace_root_url: &Url,
+) -> Option<&'a str> {
+  if let Some(name) = task.task_or_script.package_name() {
+    return Some(name);
+  }
+  if task.task_or_script.folder_url() == workspace_root_url {
+    return None;
+  }
+  workspace_folder_dir_name(task.task_or_script.folder_url())
+}
+
+/// Length of the inner part of the prefix label (without the surrounding
+/// brackets) — used to right-align brackets across concurrent tasks.
+fn label_inner_len(
+  task: &ResolvedTask<'_>,
+  include_package: bool,
+  workspace_root_url: &Url,
+) -> usize {
+  if include_package
+    && let Some(pkg) = task_label_name(task, workspace_root_url)
+  {
+    pkg.len() + 1 + task.name.len()
+  } else {
+    task.name.len()
+  }
+}
+
 fn colorize_task_prefix(label: &str, color_index: usize) -> String {
   match color_index % 6 {
     0 => colors::cyan(label).to_string(),
@@ -315,6 +351,10 @@ fn colorize_task_prefix(label: &str, color_index: usize) -> String {
 struct RunSingleOptions<'a> {
   task_name: &'a str,
   package_name: Option<&'a str>,
+  /// Display name used in the parallel-mode prefix label only. Falls back to
+  /// the folder's directory name when the package itself is unnamed (and the
+  /// folder isn't the workspace root). May be `None`.
+  label_name: Option<&'a str>,
   script: &'a str,
   cwd: PathBuf,
   custom_commands: HashMap<String, Rc<dyn ShellCommand>>,
@@ -337,33 +377,52 @@ struct TaskRunner<'a> {
 }
 
 impl<'a> TaskRunner<'a> {
-  pub async fn run_tasks(
+  /// Topologically sort all matched tasks across the given packages into a
+  /// single flat list, then run them through `run_tasks_in_parallel` so tasks
+  /// from sibling packages execute concurrently.
+  pub async fn run_all_tasks(
     &self,
-    pkg_tasks_config: &PackageTaskInfo,
+    packages: &'a [PackageTaskInfo],
     task_name: &str,
     kill_signal: &KillSignal,
-    argv: &[String],
+    argv: &'a [String],
   ) -> Result<i32, deno_core::anyhow::Error> {
-    match sort_tasks_topo(pkg_tasks_config, task_name) {
-      Ok(sorted) => self.run_tasks_in_parallel(sorted, kill_signal, argv).await,
-      Err(err) => match err {
-        TaskError::NotFound(name) => {
-          if self.task_flags.is_run {
-            return Err(anyhow!("Task not found: {}", name));
+    let mut sorted: Vec<ResolvedTask<'a>> = Vec::new();
+    for pkg in packages {
+      if let Err(err) = sort_tasks_topo(pkg, &mut sorted) {
+        return match err {
+          TaskError::NotFound(name) => {
+            if self.task_flags.is_run {
+              return Err(anyhow!("Task not found: {}", name));
+            }
+            log::error!("Task not found: {}", name);
+            if log::log_enabled!(log::Level::Error) {
+              self.print_available_tasks(&pkg.tasks_config)?;
+            }
+            Ok(1)
           }
-
-          log::error!("Task not found: {}", name);
-          if log::log_enabled!(log::Level::Error) {
-            self.print_available_tasks(&pkg_tasks_config.tasks_config)?;
+          TaskError::TaskDepCycle { path } => {
+            log::error!("Task cycle detected: {}", path.join(" -> "));
+            Ok(1)
           }
-          Ok(1)
-        }
-        TaskError::TaskDepCycle { path } => {
-          log::error!("Task cycle detected: {}", path.join(" -> "));
-          Ok(1)
-        }
-      },
+        };
+      }
     }
+
+    if sorted.is_empty() {
+      if self.task_flags.is_run {
+        return Err(anyhow!("Task not found: {}", task_name));
+      }
+      log::error!("Task not found: {}", task_name);
+      if log::log_enabled!(log::Level::Error)
+        && let Some(pkg) = packages.first()
+      {
+        self.print_available_tasks(&pkg.tasks_config)?;
+      }
+      return Ok(1);
+    }
+
+    self.run_tasks_in_parallel(sorted, kill_signal, argv).await
   }
 
   pub fn print_available_tasks(
@@ -384,15 +443,33 @@ impl<'a> TaskRunner<'a> {
     kill_signal: &KillSignal,
     args: &[String],
   ) -> Result<i32, deno_core::anyhow::Error> {
+    let workspace_root_url: &Url =
+      self.cli_options.workspace().root_dir_url().as_ref();
     let concurrent_task_color_indices = if self.task_flags.no_prefix {
       HashMap::new()
     } else {
       compute_concurrent_task_color_indices(&tasks)
     };
-    let max_task_name_len = tasks
+    // Include the package name in prefix labels when concurrent tasks span
+    // more than one workspace member.
+    let include_package = {
+      let mut seen: HashSet<&Url> = HashSet::new();
+      let mut multi = false;
+      for t in &tasks {
+        if !concurrent_task_color_indices.contains_key(&t.id) {
+          continue;
+        }
+        if seen.insert(t.task_or_script.folder_url()) && seen.len() > 1 {
+          multi = true;
+          break;
+        }
+      }
+      multi
+    };
+    let max_label_len = tasks
       .iter()
       .filter(|t| concurrent_task_color_indices.contains_key(&t.id))
-      .map(|t| t.name.len())
+      .map(|t| label_inner_len(t, include_package, workspace_root_url))
       .max()
       .unwrap_or(0);
 
@@ -401,7 +478,9 @@ impl<'a> TaskRunner<'a> {
       running: HashSet<usize>,
       tasks: &'a [ResolvedTask<'a>],
       concurrent_task_color_indices: HashMap<usize, usize>,
-      max_task_name_len: usize,
+      max_label_len: usize,
+      include_package: bool,
+      workspace_root_url: &'a Url,
     }
 
     impl<'a> PendingTasksContext<'a> {
@@ -454,8 +533,10 @@ impl<'a> TaskRunner<'a> {
             .get(&task.id)
             .map(|&color_index| ParallelInfo {
               color_index,
-              name_pad_width: self.max_task_name_len,
+              label_pad_width: self.max_label_len,
+              include_package: self.include_package,
             });
+          let label_name = task_label_name(task, self.workspace_root_url);
           return Some(
             async move {
               match task.task_or_script {
@@ -464,6 +545,7 @@ impl<'a> TaskRunner<'a> {
                     .run_deno_task(
                       task.task_or_script.folder_url(),
                       task.task_or_script.package_name(),
+                      label_name,
                       task.name,
                       def,
                       kill_signal,
@@ -477,6 +559,7 @@ impl<'a> TaskRunner<'a> {
                     .run_npm_script(
                       task.task_or_script.folder_url(),
                       task.task_or_script.package_name(),
+                      label_name,
                       task.name,
                       &details.tasks,
                       kill_signal,
@@ -500,7 +583,9 @@ impl<'a> TaskRunner<'a> {
       running: HashSet::with_capacity(self.concurrency),
       tasks: &tasks,
       concurrent_task_color_indices,
-      max_task_name_len,
+      max_label_len,
+      include_package,
+      workspace_root_url,
     };
 
     let mut queue = futures_unordered::FuturesUnordered::new();
@@ -542,6 +627,7 @@ impl<'a> TaskRunner<'a> {
     &self,
     dir_url: &Url,
     package_name: Option<&str>,
+    label_name: Option<&str>,
     task_name: &str,
     definition: &TaskDefinition,
     kill_signal: KillSignal,
@@ -579,6 +665,7 @@ impl<'a> TaskRunner<'a> {
       .run_single(RunSingleOptions {
         task_name,
         package_name,
+        label_name,
         script: command,
         cwd,
         custom_commands,
@@ -598,6 +685,7 @@ impl<'a> TaskRunner<'a> {
     &self,
     dir_url: &Url,
     package_name: Option<&str>,
+    label_name: Option<&str>,
     task_name: &str,
     scripts: &IndexMap<String, String>,
     kill_signal: KillSignal,
@@ -634,6 +722,7 @@ impl<'a> TaskRunner<'a> {
           .run_single(RunSingleOptions {
             task_name,
             package_name,
+            label_name,
             script,
             cwd: cwd.to_path_buf(),
             custom_commands: custom_commands.clone(),
@@ -659,6 +748,7 @@ impl<'a> TaskRunner<'a> {
     let RunSingleOptions {
       task_name,
       package_name,
+      label_name,
       script,
       cwd,
       custom_commands,
@@ -677,9 +767,16 @@ impl<'a> TaskRunner<'a> {
     let (stdio, prefix_handles) = if let Some(info) = parallel_info {
       // Right-align the entire `[name]` block so brackets line up across rows,
       // putting the leading padding spaces *outside* the brackets.
-      let label = format!("[{}]", task_name);
+      let inner: Cow<str> = if info.include_package
+        && let Some(pkg) = label_name
+      {
+        Cow::Owned(format!("{}#{}", pkg, task_name))
+      } else {
+        Cow::Borrowed(task_name)
+      };
+      let label = format!("[{}]", inner);
       let padded_label =
-        format!("{:>width$}", label, width = info.name_pad_width + 2);
+        format!("{:>width$}", label, width = info.label_pad_width + 2);
       let prefix =
         format!("{} ", colorize_task_prefix(&padded_label, info.color_index));
       let (io, handles) = task_runner::make_prefixed_task_io(prefix);
@@ -760,8 +857,8 @@ struct ResolvedTask<'a> {
 
 fn sort_tasks_topo<'a>(
   pkg_task_config: &'a PackageTaskInfo,
-  task_name: &str,
-) -> Result<Vec<ResolvedTask<'a>>, TaskError> {
+  sorted: &mut Vec<ResolvedTask<'a>>,
+) -> Result<(), TaskError> {
   trait TasksConfig {
     fn task(&self, name: &str) -> Option<(TaskOrScript<'_>, &dyn TasksConfig)>;
   }
@@ -833,17 +930,11 @@ fn sort_tasks_topo<'a>(
     Ok(id)
   }
 
-  let mut sorted: Vec<ResolvedTask<'a>> = vec![];
-
   for name in &pkg_task_config.matched_tasks {
-    sort_visit(name, &mut sorted, Vec::new(), &pkg_task_config.tasks_config)?;
+    sort_visit(name, sorted, Vec::new(), &pkg_task_config.tasks_config)?;
   }
 
-  if sorted.is_empty() {
-    return Err(TaskError::NotFound(task_name.to_string()));
-  }
-
-  Ok(sorted)
+  Ok(())
 }
 
 fn matches_package(

--- a/tests/specs/task/dependencies_shadowed_root_name/member_depending_root_and_member.out
+++ b/tests/specs/task/dependencies_shadowed_root_name/member_depending_root_and_member.out
@@ -1,6 +1,6 @@
 [UNORDERED_START]
 Task build echo member
-              [build] member
+       [member#build] member
 Task build echo root
               [build] root
 [UNORDERED_END]

--- a/tests/specs/task/filter/deno_all.out
+++ b/tests/specs/task/filter/deno_all.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev (@deno/bar) echo '@deno/bar'
-@deno/bar
 Task dev (@deno/foo) echo '@deno/foo'
-@deno/foo
+[@deno/bar#dev] @deno/bar
+[@deno/foo#dev] @deno/foo
+[UNORDERED_END]

--- a/tests/specs/task/filter/deno_recursive.out
+++ b/tests/specs/task/filter/deno_recursive.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev (@deno/bar) echo '@deno/bar'
-@deno/bar
 Task dev (@deno/foo) echo '@deno/foo'
-@deno/foo
+[@deno/bar#dev] @deno/bar
+[@deno/foo#dev] @deno/foo
+[UNORDERED_END]

--- a/tests/specs/task/filter/deno_recursive_no_pkg.out
+++ b/tests/specs/task/filter/deno_recursive_no_pkg.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev echo 'bar'
-bar
 Task dev echo 'foo'
-foo
+[bar#dev] bar
+[foo#dev] foo
+[UNORDERED_END]

--- a/tests/specs/task/filter/deno_scoped_multi.out
+++ b/tests/specs/task/filter/deno_scoped_multi.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev (@foo/bar) echo '@foo/bar'
-@foo/bar
 Task dev (@foo/baz) echo '@foo/baz'
-@foo/baz
+[@foo/bar#dev] @foo/bar
+[@foo/baz#dev] @foo/baz
+[UNORDERED_END]

--- a/tests/specs/task/filter/deno_workspace_order.out
+++ b/tests/specs/task/filter/deno_workspace_order.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev (@foo/bar) echo '@foo/bar'
-@foo/bar
 Task dev (@foo/baz) echo '@foo/baz'
-@foo/baz
+[@foo/bar#dev] @foo/bar
+[@foo/baz#dev] @foo/baz
+[UNORDERED_END]

--- a/tests/specs/task/filter/npm_all.out
+++ b/tests/specs/task/filter/npm_all.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev (bar) echo 'bar'
-bar
 Task dev (foo) echo 'foo'
-foo
+[bar#dev] bar
+[foo#dev] foo
+[UNORDERED_END]

--- a/tests/specs/task/filter/npm_multi.out
+++ b/tests/specs/task/filter/npm_multi.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev (multi-a) echo 'multi-a'
-multi-a
 Task dev (multi-b) echo 'multi-b'
-multi-b
+[multi-a#dev] multi-a
+[multi-b#dev] multi-b
+[UNORDERED_END]

--- a/tests/specs/task/filter/npm_recursive.out
+++ b/tests/specs/task/filter/npm_recursive.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev (bar) echo 'bar'
-bar
 Task dev (foo) echo 'foo'
-foo
+[bar#dev] bar
+[foo#dev] foo
+[UNORDERED_END]

--- a/tests/specs/task/filter/npm_recursive_no_pkg.out
+++ b/tests/specs/task/filter/npm_recursive_no_pkg.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev echo 'bar'
-bar
 Task dev echo 'foo'
-foo
+[bar#dev] bar
+[foo#dev] foo
+[UNORDERED_END]

--- a/tests/specs/task/filter/npm_scoped_multi.out
+++ b/tests/specs/task/filter/npm_scoped_multi.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev (@foo/bar) echo '@foo/bar'
-@foo/bar
 Task dev (@foo/baz) echo '@foo/baz'
-@foo/baz
+[@foo/bar#dev] @foo/bar
+[@foo/baz#dev] @foo/baz
+[UNORDERED_END]

--- a/tests/specs/task/filter/npm_workspace_order.out
+++ b/tests/specs/task/filter/npm_workspace_order.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task dev (@foo/bar) echo '@foo/bar'
-@foo/bar
 Task dev (@foo/baz) echo '@foo/baz'
-@foo/baz
+[@foo/bar#dev] @foo/bar
+[@foo/baz#dev] @foo/baz
+[UNORDERED_END]

--- a/tests/specs/task/recursive_order/task.out
+++ b/tests/specs/task/recursive_order/task.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 Task build (b) echo b
-b
 Task build (a) echo a
-a
+[b#build] b
+[a#build] a
+[UNORDERED_END]

--- a/tests/specs/task/recursive_parallel/__test__.jsonc
+++ b/tests/specs/task/recursive_parallel/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  // Regression test for https://github.com/denoland/deno/issues/27586.
+  //
+  // Three workspace members each have a `dev` task that depends on a local
+  // `build` task. The dev tasks rendezvous on a filesystem barrier — each
+  // member writes a marker file, then waits until all three markers exist
+  // before exiting. Sequential execution would deadlock on the very first
+  // member, so the test only passes when `deno task -r dev` runs the dev
+  // tasks concurrently across packages.
+  "tempDir": true,
+  "args": "task -r dev",
+  "output": "task.out"
+}

--- a/tests/specs/task/recursive_parallel/__test__.jsonc
+++ b/tests/specs/task/recursive_parallel/__test__.jsonc
@@ -9,5 +9,8 @@
   // tasks concurrently across packages.
   "tempDir": true,
   "args": "task -r dev",
+  "envs": {
+    "DENO_JOBS": "3"
+  },
   "output": "task.out"
 }

--- a/tests/specs/task/recursive_parallel/apps/server/deno.json
+++ b/tests/specs/task/recursive_parallel/apps/server/deno.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/server",
+  "version": "0.0.1",
+  "exports": "./main.ts",
+  "tasks": {
+    "build": "echo 'server build'",
+    "dev": {
+      "command": "deno run -A main.ts",
+      "dependencies": ["build"]
+    }
+  }
+}

--- a/tests/specs/task/recursive_parallel/apps/server/main.ts
+++ b/tests/specs/task/recursive_parallel/apps/server/main.ts
@@ -1,0 +1,20 @@
+const NAME = "server";
+const root = Deno.env.get("INIT_CWD")!;
+console.log(`${NAME} ready`);
+await Deno.writeTextFile(`${root}/marker.${NAME}`, "");
+const deadline = Date.now() + 15_000;
+while (true) {
+  try {
+    await Deno.stat(`${root}/marker.server`);
+    await Deno.stat(`${root}/marker.web`);
+    await Deno.stat(`${root}/marker.shared`);
+    break;
+  } catch {
+    if (Date.now() > deadline) {
+      console.error(`${NAME}: timed out waiting for siblings`);
+      Deno.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, 30));
+  }
+}
+console.log(`${NAME} done`);

--- a/tests/specs/task/recursive_parallel/apps/web/deno.json
+++ b/tests/specs/task/recursive_parallel/apps/web/deno.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/web",
+  "version": "0.0.1",
+  "exports": "./main.ts",
+  "tasks": {
+    "build": "echo 'web build'",
+    "dev": {
+      "command": "deno run -A main.ts",
+      "dependencies": ["build"]
+    }
+  }
+}

--- a/tests/specs/task/recursive_parallel/apps/web/main.ts
+++ b/tests/specs/task/recursive_parallel/apps/web/main.ts
@@ -1,0 +1,20 @@
+const NAME = "web";
+const root = Deno.env.get("INIT_CWD")!;
+console.log(`${NAME} ready`);
+await Deno.writeTextFile(`${root}/marker.${NAME}`, "");
+const deadline = Date.now() + 15_000;
+while (true) {
+  try {
+    await Deno.stat(`${root}/marker.server`);
+    await Deno.stat(`${root}/marker.web`);
+    await Deno.stat(`${root}/marker.shared`);
+    break;
+  } catch {
+    if (Date.now() > deadline) {
+      console.error(`${NAME}: timed out waiting for siblings`);
+      Deno.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, 30));
+  }
+}
+console.log(`${NAME} done`);

--- a/tests/specs/task/recursive_parallel/deno.json
+++ b/tests/specs/task/recursive_parallel/deno.json
@@ -1,0 +1,3 @@
+{
+  "workspace": ["./apps/server", "./apps/web", "./packages/shared"]
+}

--- a/tests/specs/task/recursive_parallel/packages/shared/deno.json
+++ b/tests/specs/task/recursive_parallel/packages/shared/deno.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/shared",
+  "version": "0.0.1",
+  "exports": "./main.ts",
+  "tasks": {
+    "build": "echo 'shared build'",
+    "dev": {
+      "command": "deno run -A main.ts",
+      "dependencies": ["build"]
+    }
+  }
+}

--- a/tests/specs/task/recursive_parallel/packages/shared/main.ts
+++ b/tests/specs/task/recursive_parallel/packages/shared/main.ts
@@ -1,0 +1,24 @@
+// Sibling-barrier handshake. Each member writes its own marker, then polls
+// until all three markers exist. This only completes when the three `dev`
+// tasks run concurrently — under sequential execution it would deadlock and
+// the test would time out.
+const NAME = "shared";
+const root = Deno.env.get("INIT_CWD")!;
+console.log(`${NAME} ready`);
+await Deno.writeTextFile(`${root}/marker.${NAME}`, "");
+const deadline = Date.now() + 15_000;
+while (true) {
+  try {
+    await Deno.stat(`${root}/marker.server`);
+    await Deno.stat(`${root}/marker.web`);
+    await Deno.stat(`${root}/marker.shared`);
+    break;
+  } catch {
+    if (Date.now() > deadline) {
+      console.error(`${NAME}: timed out waiting for siblings`);
+      Deno.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, 30));
+  }
+}
+console.log(`${NAME} done`);

--- a/tests/specs/task/recursive_parallel/task.out
+++ b/tests/specs/task/recursive_parallel/task.out
@@ -1,0 +1,21 @@
+[UNORDERED_START]
+Task build (@app/server) echo 'server build'
+Task build (@app/web) echo 'web build'
+Task build (@app/shared) echo 'shared build'
+[@app/server#build] server build
+   [@app/web#build] web build
+[@app/shared#build] shared build
+[UNORDERED_END]
+[UNORDERED_START]
+Task dev (@app/server) deno run -A main.ts
+Task dev (@app/web) deno run -A main.ts
+Task dev (@app/shared) deno run -A main.ts
+  [@app/server#dev] server ready
+     [@app/web#dev] web ready
+  [@app/shared#dev] shared ready
+[UNORDERED_END]
+[UNORDERED_START]
+  [@app/server#dev] server done
+     [@app/web#dev] web done
+  [@app/shared#dev] shared done
+[UNORDERED_END]


### PR DESCRIPTION
`deno task -r <name>` (and `deno task --filter <pattern> <name>`)
walked workspace members one at a time, so a long-running task in the
first matched member blocked every other member from starting. This was
especially painful for the common dev-server case described in #27586,
where running `dev` recursively across an `apps/server` + `apps/web`
workspace would only ever boot one of them.

The fix flattens all matched packages' resolved tasks into a single
topology and runs them through the existing parallel task runner, so
cross-package siblings execute concurrently while intra-package task
dependencies still order correctly. When concurrent tasks span more
than one workspace member, the colored output prefix becomes
`[pkg#task]` so identically-named siblings stay distinguishable; if a
member has no `name` field the folder's directory name is used, except
for the workspace root which falls back to the bare task name.

Fixes #27586