### PR TITLE
fix: reject empty package name in package.json dependencies

### DIFF
--- a/cli/tools/publish/unfurl.rs
+++ b/cli/tools/publish/unfurl.rs
@@ -584,7 +584,8 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
               PackageJsonDepValueParseErrorKind::VersionReq { .. }
               | PackageJsonDepValueParseErrorKind::JsrRequiresScope {
                 ..
-              } => {
+              }
+              | PackageJsonDepValueParseErrorKind::EmptyName => {
                 log::warn!(
                   "Ignoring failed to resolve package.json dependency. {:#}",
                   err

--- a/libs/npm_installer/lib.rs
+++ b/libs/npm_installer/lib.rs
@@ -409,8 +409,9 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmInstallerSys>
         }
         deno_package_json::PackageJsonDepValueParseErrorKind::Unsupported {
           ..
-        } => {
-          // only warn for this one
+        }
+        | deno_package_json::PackageJsonDepValueParseErrorKind::EmptyName => {
+          // only warn for these
           log::warn!(
             "{} {}\n    at {}",
             colors::yellow("Warning"),

--- a/libs/package_json/lib.rs
+++ b/libs/package_json/lib.rs
@@ -96,6 +96,9 @@ pub enum PackageJsonDepValueParseErrorKind {
   #[class(inherit)]
   #[error(transparent)]
   JsrRequiresScope(#[from] JsrDepPackageParseError),
+  #[class(type)]
+  #[error("Package name must not be empty")]
+  EmptyName,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -185,6 +188,9 @@ impl PackageJsonDepValue {
       name: StackString,
       version_req: &str,
     ) -> Result<PackageJsonDepValue, PackageJsonDepValueParseError> {
+      if name.is_empty() {
+        return Err(PackageJsonDepValueParseErrorKind::EmptyName.into_box());
+      }
       match VersionReq::parse_from_npm(version_req) {
         Ok(version_req) => {
           Ok(PackageJsonDepValue::Req(PackageReq { name, version_req }))
@@ -193,6 +199,10 @@ impl PackageJsonDepValue {
           Err(PackageJsonDepValueParseErrorKind::VersionReq(err).into_box())
         }
       }
+    }
+
+    if key.is_empty() {
+      return Err(PackageJsonDepValueParseErrorKind::EmptyName.into_box());
     }
 
     if let Some((scheme, value)) = value.split_once(':') {
@@ -876,6 +886,28 @@ mod test {
         ),
       ])
     );
+  }
+
+  #[test]
+  fn test_get_local_package_json_version_reqs_empty_name() {
+    let mut package_json =
+      PackageJson::load_from_string(PathBuf::from("/package.json"), "{}")
+        .unwrap();
+    package_json.dependencies = Some(IndexMap::from([
+      ("".to_string(), ".".to_string()),
+      ("npm-empty".to_string(), "npm:".to_string()),
+      ("ok".to_string(), "^1".to_string()),
+    ]));
+    let map = get_local_package_json_version_reqs_for_tests(&package_json);
+    assert_eq!(
+      map.get("").unwrap().as_ref().unwrap_err(),
+      &PackageJsonDepValueParseErrorKind::EmptyName,
+    );
+    assert_eq!(
+      map.get("npm-empty").unwrap().as_ref().unwrap_err(),
+      &PackageJsonDepValueParseErrorKind::EmptyName,
+    );
+    assert!(map.get("ok").unwrap().is_ok());
   }
 
   #[test]

--- a/tests/specs/lockfile/empty_pkg_json_dep_name/__test__.jsonc
+++ b/tests/specs/lockfile/empty_pkg_json_dep_name/__test__.jsonc
@@ -1,0 +1,24 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "run a.js",
+      "output": "ok\n"
+    },
+    {
+      "args": "run a.js",
+      "output": "ok\n"
+    },
+    {
+      "args": [
+        "eval",
+        "console.log(Deno.readTextFileSync('./deno.lock').trim())"
+      ],
+      "output": "deno.lock.out"
+    }
+  ]
+}

--- a/tests/specs/lockfile/empty_pkg_json_dep_name/a.js
+++ b/tests/specs/lockfile/empty_pkg_json_dep_name/a.js
@@ -1,0 +1,3 @@
+import { setValue } from "@denotest/esm-basic";
+setValue(2);
+console.log("ok");

--- a/tests/specs/lockfile/empty_pkg_json_dep_name/deno.lock.out
+++ b/tests/specs/lockfile/empty_pkg_json_dep_name/deno.lock.out
@@ -1,0 +1,16 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@denotest/esm-basic@*": "1.0.0"
+  },
+  "npm": {
+    "@denotest/esm-basic@1.0.0": [WILDCARD]
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@denotest/esm-basic@*"
+      ]
+    }
+  }
+}

--- a/tests/specs/lockfile/empty_pkg_json_dep_name/package.json
+++ b/tests/specs/lockfile/empty_pkg_json_dep_name/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lockfile_empty_pkg_json_dep_name",
+  "dependencies": {
+    "": ".",
+    "@denotest/esm-basic": "*"
+  },
+  "type": "module"
+}


### PR DESCRIPTION
A `package.json` with an empty-string dependency key, e.g. `"": "."`,
produced a corrupt lockfile entry like `npm:@.`, which then failed to
parse on the next run with "Invalid workspace section: Invalid package
requirement '@.'".

Treat an empty package name as a parse error so the entry is filtered
out before reaching the lockfile and a warning is surfaced during
install, matching how the existing unsupported-scheme case is handled.

Fixes #32113