### PR TITLE
fix(add): replace panic with error when deno.json discovery fails

### DIFF
--- a/cli/tools/pm/mod.rs
+++ b/cli/tools/pm/mod.rs
@@ -408,10 +408,12 @@ fn load_configs(
     _ => {
       let factory = create_deno_json(flags, options)?;
       let options = factory.cli_options()?.clone();
-      let deno_json = options
-        .start_dir
-        .member_or_root_deno_json()
-        .expect("Just created deno.json");
+      let Some(deno_json) = options.start_dir.member_or_root_deno_json() else {
+        bail!(
+          "Failed to discover the newly created deno.json at \"{}\". This can happen when the current directory is inside a node_modules directory.",
+          options.initial_cwd().join("deno.json").display(),
+        );
+      };
       (
         factory,
         Some(ConfigUpdater::new(


### PR DESCRIPTION
Running `deno add` inside a directory under `node_modules/` panics
because workspace discovery does not surface the newly created
`deno.json`, so the `expect("Just created deno.json")` blows up.

This swaps the `expect` for a `bail!` with a message that names the
expected path and hints at the likely cause (running under
`node_modules`). The underlying scenario of bootstrapping a project
inside `node_modules` is still not really supported, but at least we
fail cleanly instead of asking the user to file a panic report.

Closes #28488