### PR TITLE
chore: upgrade tokio-socks 0.5.1 -> 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10496,9 +10496,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-socks"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
 dependencies = [
  "either",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,7 +310,7 @@ tokio = { version = "1.47.1", features = ["full"] }
 tokio-eld = "0.3"
 tokio-metrics = { version = "0.3.0", features = ["rt"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["aws_lc_rs", "tls12"] }
-tokio-socks = "0.5.1"
+tokio-socks = "0.5.3"
 tokio-util = "0.7.16"
 tower = { version = "0.5.2", default-features = false, features = ["retry", "util"] }
 tower-http = { version = "0.6.1", features = ["decompression-br", "decompression-gzip"] }


### PR DESCRIPTION
The upgraded version of tokio-socks fixes the DNS resolution issue reported in #34435

fixes #34435
