### PR TITLE
fix(compile): embed workspace package.json files in the VFS

### DIFF
--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -394,6 +394,13 @@ impl<'a> DenoCompileBinaryWriter<'a> {
     for path in exclude_paths {
       vfs.add_exclude_path(path);
     }
+    // Embed the workspace package.json files so the standalone binary's node
+    // resolver can read their "exports" (and other) fields at runtime. Without
+    // this, resolving a workspace member by its package name falls back to
+    // legacy `index.js` resolution instead of honoring the package's exports.
+    for pkg_json in self.cli_options.workspace().package_jsons() {
+      vfs.add_path(&pkg_json.path)?;
+    }
     let progress_bar = ProgressBar::new(ProgressBarStyle::ProgressBars);
     let npm_snapshot = match &self.npm_resolver {
       CliNpmResolver::Managed(managed) => {
@@ -983,9 +990,6 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       }
       CliNpmResolver::Byonm(_) => {
         maybe_warn_different_system(&self.npm_system_info);
-        for pkg_json in self.cli_options.workspace().package_jsons() {
-          builder.add_path(&pkg_json.path)?;
-        }
         let _progress =
           progress_bar.update_with_prompt(ProgressMessagePrompt::Compile, "");
         // traverse and add all the node_modules directories in the workspace

--- a/tests/specs/compile/workspace_package_json_exports/__test__.jsonc
+++ b/tests/specs/compile/workspace_package_json_exports/__test__.jsonc
@@ -1,0 +1,22 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "if": "unix",
+    "args": "compile --no-check --output main main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "if": "unix",
+    "commandName": "./main",
+    "args": [],
+    "output": "main.out"
+  }, {
+    "if": "windows",
+    "args": "compile --no-check --output main.exe main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "if": "windows",
+    "commandName": "./main.exe",
+    "args": [],
+    "output": "main.out"
+  }]
+}

--- a/tests/specs/compile/workspace_package_json_exports/deno.json
+++ b/tests/specs/compile/workspace_package_json_exports/deno.json
@@ -1,0 +1,3 @@
+{
+  "workspace": ["./libs/lib"]
+}

--- a/tests/specs/compile/workspace_package_json_exports/libs/lib/dist/index.js
+++ b/tests/specs/compile/workspace_package_json_exports/libs/lib/dist/index.js
@@ -1,0 +1,1 @@
+export const greet = () => "hello from @repo/lib";

--- a/tests/specs/compile/workspace_package_json_exports/libs/lib/dist/util.js
+++ b/tests/specs/compile/workspace_package_json_exports/libs/lib/dist/util.js
@@ -1,0 +1,1 @@
+export const sum = (a, b) => a + b;

--- a/tests/specs/compile/workspace_package_json_exports/libs/lib/package.json
+++ b/tests/specs/compile/workspace_package_json_exports/libs/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repo/lib",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./dist/index.js",
+    "./util": "./dist/util.js"
+  }
+}

--- a/tests/specs/compile/workspace_package_json_exports/main.out
+++ b/tests/specs/compile/workspace_package_json_exports/main.out
@@ -1,0 +1,2 @@
+hello from @repo/lib
+3

--- a/tests/specs/compile/workspace_package_json_exports/main.ts
+++ b/tests/specs/compile/workspace_package_json_exports/main.ts
@@ -1,0 +1,8 @@
+// Importing a non-Deno workspace member (package.json with an "exports" map) by
+// its package name must honor the exports map in the compiled binary, both for
+// the root export and a subpath export. Regression test for #28926.
+import { greet } from "@repo/lib";
+import { sum } from "@repo/lib/util";
+
+console.log(greet());
+console.log(sum(1, 2));

--- a/tests/specs/compile/workspace_package_json_exports_ts/__test__.jsonc
+++ b/tests/specs/compile/workspace_package_json_exports_ts/__test__.jsonc
@@ -1,0 +1,22 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "if": "unix",
+    "args": "compile --no-check --output main lib-b/main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "if": "unix",
+    "commandName": "./main",
+    "args": [],
+    "output": "main.out"
+  }, {
+    "if": "windows",
+    "args": "compile --no-check --output main.exe lib-b/main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "if": "windows",
+    "commandName": "./main.exe",
+    "args": [],
+    "output": "main.out"
+  }]
+}

--- a/tests/specs/compile/workspace_package_json_exports_ts/deno.json
+++ b/tests/specs/compile/workspace_package_json_exports_ts/deno.json
@@ -1,0 +1,3 @@
+{
+  "workspace": ["./lib-a", "./lib-b"]
+}

--- a/tests/specs/compile/workspace_package_json_exports_ts/lib-a/main.ts
+++ b/tests/specs/compile/workspace_package_json_exports_ts/lib-a/main.ts
@@ -1,0 +1,1 @@
+export const a: string = "Hello from lib-a";

--- a/tests/specs/compile/workspace_package_json_exports_ts/lib-a/package.json
+++ b/tests/specs/compile/workspace_package_json_exports_ts/lib-a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@my-scope/lib-a",
+  "type": "module",
+  "version": "1.0.0",
+  "main": "main.ts",
+  "exports": "./main.ts"
+}

--- a/tests/specs/compile/workspace_package_json_exports_ts/lib-b/main.ts
+++ b/tests/specs/compile/workspace_package_json_exports_ts/lib-b/main.ts
@@ -1,0 +1,7 @@
+// A workspace member (package.json) importing another workspace member by its
+// package name, where the "exports" map points at a TypeScript file. The
+// compiled binary must honor the exports map and transpile the target.
+// Regression test for #27315.
+import { a } from "@my-scope/lib-a";
+
+console.log(a);

--- a/tests/specs/compile/workspace_package_json_exports_ts/lib-b/package.json
+++ b/tests/specs/compile/workspace_package_json_exports_ts/lib-b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@my-scope/lib-b",
+  "type": "module",
+  "version": "1.0.0",
+  "main": "main.ts",
+  "exports": "./main.ts"
+}

--- a/tests/specs/compile/workspace_package_json_exports_ts/main.out
+++ b/tests/specs/compile/workspace_package_json_exports_ts/main.out
@@ -1,0 +1,1 @@
+Hello from lib-a


### PR DESCRIPTION
Compiling a project that imports a non-Deno workspace member by its package
name, where the member is described by a package.json with an "exports" map,
produced a binary that failed at runtime with ERR_MODULE_NOT_FOUND. Instead of
honoring the exports target it resolved the bare "<dir>/index.js", because the
workspace package.json files were only embedded into the virtual filesystem for
the byonm npm resolver. With a managed resolver (for example "nodeModulesDir":
"auto"), or with no npm packages at all, the file was missing from the VFS, so
the runtime node resolver could not read the exports field and fell back to
legacy index.js resolution.

This embeds the workspace package.json files unconditionally, before the npm
resolver branch runs, so the exports map is available at runtime regardless of
npm mode. This covers exports maps that point at either a built .js file or a
.ts source file, and members that are themselves package.json packages. The
runtime type-checking gap for these members (TS2307) is a separate resolver
issue and is left for a follow-up; the spec tests use --no-check to isolate the
runtime resolution behavior.

Fixes #28926
Fixes #27315