### PR TITLE
perf(node): lazy-load node:stream/web cluster out of the snapshot

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -254,18 +254,6 @@ const internalUtilInspect = core.loadExtScript(
 const internalValidators = core.loadExtScript(
   "ext:deno_node/internal/validators.mjs",
 );
-const internalWebstreamsAdapters = core.loadExtScript(
-  "ext:deno_node/internal/webstreams/adapters.js",
-);
-const internalWebstreamsReadableStream = core.loadExtScript(
-  "ext:deno_node/internal/webstreams/readablestream.js",
-);
-const internalWebstreamsUtil = core.loadExtScript(
-  "ext:deno_node/internal/webstreams/util.js",
-);
-const internalWorkerJsTransferable = core.loadExtScript(
-  "ext:deno_node/internal/worker/js_transferable.js",
-);
 const internalConsole = core.loadExtScript(
   "ext:deno_node/internal/console/constructor.mjs",
 ).default;
@@ -313,6 +301,17 @@ const builtinModules = [];
 // Use `() => createLazyLoader("...")().default` for `lazy_loaded_esm` entries
 // and `() => loadExtScript("...")` for `lazy_loaded_js` entries.
 const lazyNodeModules = {
+  // Lazy so the WHATWG-streams adapter graph (stream/web -> deno_web
+  // 06_streams, ~1.8MB of snapshot heap) is only loaded when something
+  // actually requires these internals, not eagerly at node:module init.
+  "internal/worker/js_transferable": () =>
+    core.loadExtScript("ext:deno_node/internal/worker/js_transferable.js"),
+  "internal/webstreams/adapters": () =>
+    core.loadExtScript("ext:deno_node/internal/webstreams/adapters.js"),
+  "internal/webstreams/readablestream": () =>
+    core.loadExtScript("ext:deno_node/internal/webstreams/readablestream.js"),
+  "internal/webstreams/util": () =>
+    core.loadExtScript("ext:deno_node/internal/webstreams/util.js"),
   "_http_agent": () => _httpAgent().default,
   "_http_common": () => _httpCommon().default,
   "_http_outgoing": () => _httpOutgoing().default,
@@ -462,10 +461,6 @@ function setupBuiltinModules() {
     "internal/util/inspect": internalUtilInspect,
     "internal/util": internalUtil,
     "internal/validators": internalValidators,
-    "internal/webstreams/adapters": internalWebstreamsAdapters,
-    "internal/webstreams/readablestream": internalWebstreamsReadableStream,
-    "internal/webstreams/util": internalWebstreamsUtil,
-    "internal/worker/js_transferable": internalWorkerJsTransferable,
     module: Module,
     os,
     process,

--- a/ext/node/polyfills/internal/webstreams/adapters.js
+++ b/ext/node/polyfills/internal/webstreams/adapters.js
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file
 // Copyright 2018-2026 the Deno authors. MIT license.
 (function () {
-const { core } = globalThis.__bootstrap;
+const { core } = __bootstrap;
 const { destroy, destroyer } = core.loadExtScript(
   "ext:deno_node/internal/streams/destroy.js",
 );

--- a/ext/node/polyfills/internal/webstreams/readablestream.js
+++ b/ext/node/polyfills/internal/webstreams/readablestream.js
@@ -3,7 +3,7 @@
 // deno-lint-ignore-file
 
 (function () {
-const { core } = globalThis.__bootstrap;
+const { core } = __bootstrap;
 
 const webStreams = core.loadExtScript("ext:deno_web/06_streams.js");
 const streamWeb = core.loadExtScript("ext:deno_node/stream/web.js");

--- a/ext/node/polyfills/internal/webstreams/util.js
+++ b/ext/node/polyfills/internal/webstreams/util.js
@@ -3,7 +3,7 @@
 // deno-lint-ignore-file
 
 (function () {
-const { core, primordials } = globalThis.__bootstrap;
+const { core, primordials } = __bootstrap;
 const {
   ArrayBufferPrototypeGetByteLength,
   ArrayBufferPrototypeSlice,

--- a/ext/node/polyfills/internal/worker/js_transferable.js
+++ b/ext/node/polyfills/internal/worker/js_transferable.js
@@ -3,7 +3,7 @@
 // deno-lint-ignore-file
 
 (function () {
-const { core } = globalThis.__bootstrap;
+const { core } = __bootstrap;
 
 const webStreams = core.loadExtScript("ext:deno_web/06_streams.js");
 

--- a/ext/web/13_message_port.js
+++ b/ext/web/13_message_port.js
@@ -538,6 +538,20 @@ function opCreateEntangledMessagePort() {
  */
 const emptyTransferables = ObjectFreeze([]);
 
+// The web-streams transferable resources (ReadableStream/WritableStream/
+// TransformStream) are registered as a side effect of evaluating
+// ext:deno_web/06_streams.js, which is lazy. A realm (e.g. a worker) that
+// receives a transferred stream may not have loaded that module yet, so on a
+// miss force-load it (loadExtScript is idempotent) before resolving.
+function resolveTransferableResource(type) {
+  let resource = core.getTransferableResource(type);
+  if (resource === undefined) {
+    core.loadExtScript("ext:deno_web/06_streams.js");
+    resource = core.getTransferableResource(type);
+  }
+  return resource;
+}
+
 function deserializeJsMessageData(messageData) {
   // Fast path: no transferables (most common case)
   if (messageData.transferables.length === 0) {
@@ -561,14 +575,14 @@ function deserializeJsMessageData(messageData) {
       switch (transferable.kind) {
         case "resource": {
           const { 0: type, 1: rid } = transferable.data;
-          const hostObj = core.getTransferableResource(type).receive(rid);
+          const hostObj = resolveTransferableResource(type).receive(rid);
           ArrayPrototypePush(transferables, hostObj);
           ArrayPrototypePush(hostObjects, hostObj);
           break;
         }
         case "multiResource": {
           const { 0: type, 1: rids } = transferable.data;
-          const hostObj = core.getTransferableResource(type).receive(rids);
+          const hostObj = resolveTransferableResource(type).receive(rids);
           ArrayPrototypePush(transferables, hostObj);
           ArrayPrototypePush(hostObjects, hostObj);
           break;

--- a/tests/unit/streams_test.ts
+++ b/tests/unit/streams_test.ts
@@ -6,6 +6,10 @@ import {
   fail,
 } from "./test_util.ts";
 
+// `resourceForReadableStream` is registered on the internals object only when
+// `ext:deno_web/06_streams.js` first evaluates, which is now lazy. Touch the
+// lazy `ReadableStream` global so the polyfill loads before we read it below.
+const { ReadableStream: _ReadableStream } = globalThis;
 const {
   core,
   resourceForReadableStream,


### PR DESCRIPTION
`node:module` init eagerly `loadExtScript`-ed `internal/webstreams/{adapters,readablestream,util}` and `internal/worker/js_transferable` at module-evaluation time. That dragged the whole WHATWG-streams graph (`stream/web` → `ext:deno_web/06_streams.js`) into the startup snapshot, even for programs that never touch streams.

This moves those four modules to lazy `lazyNodeModules` thunks so they only load on first `require`, and switches them from `globalThis.__bootstrap` (deleted after bootstrap) to the injected `__bootstrap` arg so they still resolve `core` when loaded lazily at runtime.

## Results

Empty-program V8 `heapUsed` (measured via `Deno.memoryUsage()`, 3 samples, release-lite):

| | heapUsed |
| --- | ---: |
| before | 9.089 MB |
| after | **8.406 MB** |
| delta | **−683 KB (−7.5%)** |

`DENO_LOG_LAZY_LOAD=1 deno run empty.js` still reports **0 lazy loads** at startup — the cluster only loads when something actually uses web/node streams or worker transferables.

## Test plan

- [x] `new ReadableStream()` (web global)
- [x] `Readable.toWeb()` (exercises `internal/webstreams/adapters.js` — would crash without the `__bootstrap` fix)
- [x] `import("node:stream/web")`
- [x] `node:worker_threads` `MessageChannel` (exercises `internal/worker/js_transferable.js`)
- [x] `cargo test --test node_compat` (streams / worker suites)