### PR TITLE
fix(rt): support host-FS CJS files in the standalone runtime

### DIFF
--- a/cli/rt/Cargo.toml
+++ b/cli/rt/Cargo.toml
@@ -29,7 +29,7 @@ deno_runtime.workspace = true
 deno_core.workspace = true
 
 [dependencies]
-deno_ast.workspace = true
+deno_ast = { workspace = true, features = ["cjs"] }
 deno_cache_dir = { workspace = true, features = ["sync"] }
 deno_config = { workspace = true, features = ["sync", "workspace"] }
 deno_core.workspace = true

--- a/cli/rt/node.rs
+++ b/cli/rt/node.rs
@@ -115,21 +115,28 @@ impl CjsCodeAnalyzer {
           }
         }
         None => {
-          if log::log_enabled!(log::Level::Debug) {
-            if self.sys.is_specifier_in_vfs(specifier) {
+          if self.sys.is_specifier_in_vfs(specifier) {
+            // VFS-embedded modules always have a pre-computed analysis
+            // written by the compile step. A missing entry here means
+            // the compile step skipped analysis for this file — bug.
+            if log::log_enabled!(log::Level::Debug) {
               log::debug!(
                 "No CJS export analysis was stored for '{}'. Assuming ESM. This might indicate a bug in Deno.",
                 specifier
               );
-            } else {
-              log::debug!(
-                "Analyzing potentially CommonJS files is not supported at runtime in a compiled executable ({}). Assuming ESM.",
-                specifier
-              );
             }
+            CjsAnalysis::Esm(source, None)
+          } else {
+            // Host-FS fallback: the file was read from the user's real
+            // filesystem (HMR / dev mode), so it has no embedded
+            // analysis. Run the analyzer live with deno_ast — without
+            // this the loader would treat every host-FS CJS module as
+            // ESM and any `import { name }` from it would fail with
+            // "does not provide an export named 'name'", even for
+            // common npm packages whose CJS index re-exports names
+            // via `Object.defineProperty(exports, ...)`.
+            analyze_cjs_live(cjs_tracker, specifier, media_type, source)?
           }
-          // assume ESM as we don't have access to swc here
-          CjsAnalysis::Esm(source, None)
         }
       }
     } else {
@@ -137,6 +144,52 @@ impl CjsCodeAnalyzer {
     };
 
     Ok(analysis)
+  }
+}
+
+/// Parse `source` with deno_ast and classify it as CJS (with its named
+/// exports) or ESM. Used at runtime in the standalone executable for
+/// files read from the host filesystem (HMR / dev mode) which have no
+/// pre-computed analysis embedded in the VFS.
+///
+/// Mirrors what `DenoCjsCodeAnalyzer` does at compile time, minus the
+/// re-export resolution (the loader walks reexports separately). The
+/// `compute_is_script` + `is_cjs_with_known_is_script` two-step is the
+/// same one the compile-time analyzer uses; without it, ESM files that
+/// happen to look CJS-ish would be mis-classified.
+fn analyze_cjs_live<'a>(
+  cjs_tracker: &DenoRtCjsTracker,
+  specifier: &Url,
+  media_type: MediaType,
+  source: Cow<'a, str>,
+) -> Result<CjsAnalysis<'a>, JsErrorBox> {
+  let parsed = deno_ast::parse_program(deno_ast::ParseParams {
+    specifier: specifier.clone(),
+    text: source.to_string().into(),
+    media_type,
+    capture_tokens: true,
+    scope_analysis: false,
+    maybe_syntax: None,
+  })
+  .map_err(JsErrorBox::from_err)?;
+  let is_script = parsed.compute_is_script();
+  let is_cjs = cjs_tracker
+    .is_cjs_with_known_is_script(specifier, media_type, is_script)
+    .map_err(JsErrorBox::from_err)?;
+  if is_cjs {
+    let analysis = parsed.analyze_cjs();
+    cjs_tracker.set_is_known_script(specifier, true);
+    Ok(CjsAnalysis::Cjs(CjsAnalysisExports {
+      exports: analysis.exports,
+      reexports: analysis.reexports,
+      // `deno_ast::analyze_cjs` doesn't surface member-level
+      // reexports; the loader walks them via its own reexport
+      // resolution.
+      member_reexports: Vec::new(),
+    }))
+  } else {
+    cjs_tracker.set_is_known_script(specifier, false);
+    Ok(CjsAnalysis::Esm(source, None))
   }
 }
 

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -919,22 +919,48 @@ impl NodeRequireLoader for EmbeddedModuleLoader {
     &self,
     path: &std::path::Path,
   ) -> Result<FastString, JsErrorBox> {
-    let file_entry = self
-      .shared
-      .vfs
-      .file_entry(path)
-      .map_err(JsErrorBox::from_err)?;
-    let file_bytes = self
-      .shared
-      .vfs
-      .read_file_offset_with_len(
-        file_entry.transpiled_offset.unwrap_or(file_entry.offset),
-      )
-      .map_err(JsErrorBox::from_err)?;
-    Ok(match from_utf8_lossy_cow(file_bytes) {
-      Cow::Borrowed(s) => FastString::from_static(s),
-      Cow::Owned(s) => s.into(),
-    })
+    match self.shared.vfs.file_entry(path) {
+      Ok(file_entry) => {
+        let file_bytes = self
+          .shared
+          .vfs
+          .read_file_offset_with_len(
+            file_entry.transpiled_offset.unwrap_or(file_entry.offset),
+          )
+          .map_err(JsErrorBox::from_err)?;
+        Ok(match from_utf8_lossy_cow(file_bytes) {
+          Cow::Borrowed(s) => FastString::from_static(s),
+          Cow::Owned(s) => s.into(),
+        })
+      }
+      Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+        // Fall back to the host filesystem. Mirrors the fallback
+        // `StandaloneModules::read` does for the ESM loader path.
+        // Without it, a CJS `require()` that resolves to a file
+        // outside the embedded VFS (HMR / dev mode, or a dynamic
+        // import that landed on a host-FS path) would fail with
+        // "path not found" even though the file exists on disk and
+        // the permission layer already allowed reading it.
+        use sys_traits::FsRead;
+        #[allow(
+          clippy::disallowed_types,
+          reason = "use real file system because not in vfs"
+        )]
+        let bytes = sys_traits::impls::RealSys
+          .fs_read(path)
+          .map_err(JsErrorBox::from_err)?;
+        let text = String::from_utf8_lossy(&bytes).into_owned();
+        // Mirror the ESM loader path: TypeScript/JSX read from disk at
+        // runtime hasn't been transpiled at compile time, so transpile
+        // here. Non-TS media types are returned verbatim.
+        let specifier = deno_path_util::url_from_file_path(path)
+          .map_err(JsErrorBox::from_err)?;
+        let media_type = MediaType::from_specifier(&specifier);
+        let text = transpile_runtime_module(&specifier, media_type, text)?;
+        Ok(text.into())
+      }
+      Err(err) => Err(JsErrorBox::from_err(err)),
+    }
   }
 
   fn is_maybe_cjs(

--- a/tests/specs/compile/fallback_cjs_define_property/__test__.jsonc
+++ b/tests/specs/compile/fallback_cjs_define_property/__test__.jsonc
@@ -1,0 +1,27 @@
+{
+  // Regression test for the standalone runtime's host-FS fallback path.
+  //
+  // When `require()` or a dynamic `import()` resolves to a file that
+  // isn't in the embedded VFS (HMR / dev mode, or a runtime-resolved
+  // path the compile-time graph walker couldn't follow), the runtime
+  // now (a) reads the file from the host filesystem in the CJS loader
+  // path and (b) runs CJS export analysis live with deno_ast.
+  //
+  // Before the fix, named imports from CJS modules using the
+  // TypeScript-emitted `Object.defineProperty(exports, "name", { get })`
+  // pattern — used by packages like `@opentelemetry/api` — would fail
+  // with "does not provide an export named 'name'" because the runtime
+  // assumed ESM when no embedded analysis existed for the file.
+  "tempDir": true,
+  "steps": [{
+    "args": "run --allow-write setup.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "args": "compile -A --no-check --output bin main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "commandName": "./bin",
+    "args": [],
+    "output": "ok 42\n"
+  }]
+}

--- a/tests/specs/compile/fallback_cjs_define_property/setup.ts
+++ b/tests/specs/compile/fallback_cjs_define_property/setup.ts
@@ -1,0 +1,40 @@
+// Two CJS modules using the `Object.defineProperty(exports, "name", { get })`
+// pattern that TypeScript emits when targeting CommonJS, and that npm
+// packages like `@opentelemetry/api` ship in their CJS build. `.cjs`
+// extension so the runtime classifies them as CJS without needing a
+// `package.json` with `"type": "commonjs"`.
+Deno.writeTextFileSync(
+  "inner.cjs",
+  `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.value = 42;
+`,
+);
+Deno.writeTextFileSync(
+  "cjs_pkg.cjs",
+  `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.value = void 0;
+const inner_1 = require("./inner.cjs");
+Object.defineProperty(exports, "value", {
+  enumerable: true,
+  get: function () { return inner_1.value; },
+});
+`,
+);
+// The entry uses a dynamic import the compile-time graph walker can't
+// statically follow — `Function("p", "return import(p)")` evades AST
+// analysis cleanly. That keeps `cjs_pkg.cjs` and `inner.cjs` out of
+// the embedded VFS, forcing the host-FS fallback paths exercised by
+// this regression test.
+Deno.writeTextFileSync(
+  "main.ts",
+  `const dynImport = new Function(
+  "p",
+  "return import(p);",
+) as (p: string) => Promise<{ value: number }>;
+const url = new URL("./cjs_pkg.cjs", "file://" + Deno.cwd() + "/").href;
+const mod = await dynImport(url);
+console.log("ok", mod.value);
+`,
+);

--- a/tests/specs/compile/fallback_cjs_define_property/setup.ts
+++ b/tests/specs/compile/fallback_cjs_define_property/setup.ts
@@ -1,13 +1,17 @@
 // Two CJS modules using the `Object.defineProperty(exports, "name", { get })`
 // pattern that TypeScript emits when targeting CommonJS, and that npm
-// packages like `@opentelemetry/api` ship in their CJS build. `.cjs`
-// extension so the runtime classifies them as CJS without needing a
-// `package.json` with `"type": "commonjs"`.
+// packages like `@opentelemetry/api` ship in their CJS build. `.cjs` for
+// `cjs_pkg` and `.cts` for `inner` so the runtime classifies them as CJS
+// without needing a `package.json` with `"type": "commonjs"`, while still
+// exercising the TypeScript transpile branch of the host-FS require path.
 Deno.writeTextFileSync(
-  "inner.cjs",
+  "inner.cts",
   `"use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.value = 42;
+// TypeScript-only syntax — if the host-FS require path doesn't transpile
+// this, V8 throws "Unexpected token" before the module can run.
+const value: number = 42;
+exports.value = value satisfies number;
 `,
 );
 Deno.writeTextFileSync(
@@ -15,7 +19,7 @@ Deno.writeTextFileSync(
   `"use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.value = void 0;
-const inner_1 = require("./inner.cjs");
+const inner_1 = require("./inner.cts");
 Object.defineProperty(exports, "value", {
   enumerable: true,
   get: function () { return inner_1.value; },
@@ -24,7 +28,7 @@ Object.defineProperty(exports, "value", {
 );
 // The entry uses a dynamic import the compile-time graph walker can't
 // statically follow — `Function("p", "return import(p)")` evades AST
-// analysis cleanly. That keeps `cjs_pkg.cjs` and `inner.cjs` out of
+// analysis cleanly. That keeps `cjs_pkg.cjs` and `inner.cts` out of
 // the embedded VFS, forcing the host-FS fallback paths exercised by
 // this regression test.
 Deno.writeTextFileSync(


### PR DESCRIPTION
## What

In a `deno compile`d binary, importing a named export from a CJS module that lives **outside the embedded VFS** silently failed.

The user-visible symptom is a `SyntaxError: The requested module '…' does not provide an export named 'X'` even though the module clearly does export `X` — `@opentelemetry/api` is a real-world example, and several Fresh apps hit it because `@fresh/core/.../otel.ts` does `import { SpanStatusCode } from "@opentelemetry/api"`. The same chain works under `deno run` / `deno serve`; only the standalone runtime broke.

## Why it broke

The standalone runtime (`denort`) is built around the assumption that everything live in the embedded VFS:

1. **CJS export analysis** is pre-computed at compile time and serialized into the VFS entry. At runtime, the analyzer in `cli/rt/node.rs::inner_cjs_analysis` reads that pre-computed list. When the analysis is missing (file not in VFS), it dropped to *"assume ESM"* — so any real CJS file read from the host filesystem looked exports-less to the loader, and `import { X }` failed the static export check.
2. **The CJS require-loader** (`NodeRequireLoader::load_text_file_lossy` in `cli/rt/run.rs`) only looked in the VFS. If a `require()` resolved to a path outside the VFS, it returned `path not found` even when the file existed on disk and permissions had already passed.

The non-VFS path matters because:
- `deno compile` can land here whenever a runtime-resolved import or `require` reaches a path the compile-time graph walker couldn't statically follow (dynamic `Function(…)` imports, eval, certain `__dirname`-relative requires).
- The upcoming `deno desktop` subcommand (#33441) runs the user's project from the host FS by design — every project file goes through this fallback.

## What this PR does

Two small, surgical changes in `cli/rt/`:

- `node.rs::inner_cjs_analysis`: when the embedded analysis is absent **and** the file isn't in the VFS, run `deno_ast`'s CJS analyzer (`analyze_cjs`) live instead of guessing ESM. Mirrors what `DenoCjsCodeAnalyzer` does at compile time. Enabled by adding the `cjs` feature on `deno_ast` in `cli/rt/Cargo.toml`.
- `run.rs::NodeRequireLoader::load_text_file_lossy`: on `NotFound` from the VFS, fall through to `RealSys.fs_read`. Mirrors the fallback `StandaloneModules::read` already does for the ESM loader path.

Together these let `denort` load and correctly interop with CJS modules sitting on the real filesystem.

## Test plan

- New spec test: `tests/specs/compile/fallback_cjs_define_property/` — compiles a binary whose entry uses `new Function("p", "return import(p)")(…)` so the compile-time graph walker can't reach the CJS modules, then the runtime imports a name from a CJS file using the TypeScript-emitted `Object.defineProperty(exports, "name", { get })` pattern (this is the exact pattern `@opentelemetry/api` uses) with an inner `require()` to a second CJS file. Expects `ok 42`. Without either of the two fixes above it errors.
- Manual verification against the Fresh app that originally surfaced this — `SpanStatusCode` now resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)