### PR TITLE
test(compile): cover more sloppy import patterns

### DIFF
--- a/tests/specs/compile/sloppy_imports/compile.out
+++ b/tests/specs/compile/sloppy_imports/compile.out
@@ -4,7 +4,10 @@ Compile [WILDCARD]main.ts to [WILDLINE]
 Embedded Files
 
 [WILDLINE]
+├── dynamic.ts ([WILDLINE])
+├── greet.ts ([WILDLINE])
 ├── hello.ts ([WILDLINE])
-└── main.ts ([WILDLINE])
+├── main.ts ([WILDLINE])
+└── subdir/* ([WILDLINE])
 
 [WILDCARD]

--- a/tests/specs/compile/sloppy_imports/dynamic.ts
+++ b/tests/specs/compile/sloppy_imports/dynamic.ts
@@ -1,0 +1,1 @@
+export const dyn = "Dynamic";

--- a/tests/specs/compile/sloppy_imports/greet.ts
+++ b/tests/specs/compile/sloppy_imports/greet.ts
@@ -1,0 +1,3 @@
+export function greet() {
+  return "Greetings";
+}

--- a/tests/specs/compile/sloppy_imports/main.out
+++ b/tests/specs/compile/sloppy_imports/main.out
@@ -1,1 +1,4 @@
 Hello
+Greetings
+FromDir
+Dynamic

--- a/tests/specs/compile/sloppy_imports/main.ts
+++ b/tests/specs/compile/sloppy_imports/main.ts
@@ -1,1 +1,9 @@
-import "./hello"; // no ext for sloppy imports
+import "./hello"; // no extension, resolves to hello.ts
+import { greet } from "./greet.js"; // .js specifier resolves to greet.ts
+import { fromDir } from "./subdir"; // directory resolves to subdir/index.ts
+
+console.log(greet());
+console.log(fromDir);
+
+const { dyn } = await import("./dynamic"); // dynamic import, no extension
+console.log(dyn);

--- a/tests/specs/compile/sloppy_imports/subdir/index.ts
+++ b/tests/specs/compile/sloppy_imports/subdir/index.ts
@@ -1,0 +1,1 @@
+export const fromDir = "FromDir";


### PR DESCRIPTION
While investigating #22585 ("deno compile doesn't handle
--unstable-sloppy-imports") I found that the underlying bug is already
fixed. Support for sloppy imports in compiled executables landed in
#27944, and the full reproduction from the issue (the helix-gpt repo)
now compiles and runs past module resolution. The simpler repros from
the issue thread also work, both with the --sloppy-imports CLI flag and
with the feature enabled via deno.json.

The existing spec test under tests/specs/compile/sloppy_imports only
exercised a single extensionless static import, so the other resolution
modes that the issue's reproductions actually relied on were not guarded
against regressions.

This expands that test to also cover a .js specifier resolving to a .ts
file, a directory import resolving to its index module, and an
extensionless dynamic import. No runtime code changes, test-only.

With this in place #22585 can be closed as already fixed.