### PR TITLE
fix(compile): persist default Deno.openKv() path in compiled binaries

### DIFF
--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -51,6 +51,8 @@ use deno_npm::resolution::NpmResolutionSnapshot;
 use deno_npmrc::ResolvedNpmRc;
 use deno_package_json::PackageJsonDepValue;
 use deno_resolver::DenoResolveErrorKind;
+use deno_resolver::cache::DenoDirOptions;
+use deno_resolver::cache::DenoDirProvider;
 use deno_resolver::cjs::CjsTracker;
 use deno_resolver::cjs::IsCjsResolutionMode;
 use deno_resolver::loader::NpmModuleLoader;
@@ -1224,6 +1226,34 @@ pub async fn run(
     }
     checker
   });
+  // Resolve a persistent storage directory so that origin-bound storage such
+  // as `Deno.openKv()` (without an explicit path) and `localStorage` persists
+  // to disk instead of silently falling back to an in-memory database. We reuse
+  // the `DENO_DIR`'s `location_data` folder, matching `deno run`. If the deno
+  // dir can't be resolved we leave this unset and keep the in-memory fallback.
+  let origin_data_folder_path = DenoDirProvider::new(
+    sys_traits::impls::RealSys,
+    DenoDirOptions {
+      maybe_initial_cwd: None,
+      maybe_custom_root: None,
+    },
+  )
+  .get_or_create()
+  .ok()
+  .map(|deno_dir| deno_dir.origin_data_folder_path());
+  // Derive the storage key the same way `deno run` does: prefer an explicit
+  // `--location`, otherwise fall back to the main module (which is stable for a
+  // given compiled binary). Only do this when we have somewhere to persist the
+  // data, otherwise stay empty so the runtime keeps the in-memory fallback
+  // (and avoids unwrapping a missing `origin_data_folder_path`).
+  let storage_key_resolver = if origin_data_folder_path.is_some() {
+    match &metadata.location {
+      Some(location) => StorageKeyResolver::from_flag(location),
+      None => StorageKeyResolver::new_use_main_module(),
+    }
+  } else {
+    StorageKeyResolver::empty()
+  };
   let lib_main_worker_options = LibMainWorkerOptions {
     argv: metadata.argv,
     log_level: WorkerLogLevel::Info,
@@ -1244,7 +1274,7 @@ pub async fn run(
     node_debug: std::env::var("NODE_DEBUG").ok(),
     node_cluster_unique_id: std::env::var("NODE_UNIQUE_ID").ok(),
     node_cluster_sched_policy: std::env::var("NODE_CLUSTER_SCHED_POLICY").ok(),
-    origin_data_folder_path: None,
+    origin_data_folder_path,
     seed: metadata.seed,
     unsafely_ignore_certificate_errors: metadata
       .unsafely_ignore_certificate_errors,
@@ -1272,7 +1302,7 @@ pub async fn run(
     create_npm_process_state_provider(&npm_resolver),
     pkg_json_resolver,
     root_cert_store_provider,
-    StorageKeyResolver::empty(),
+    storage_key_resolver,
     sys.clone(),
     lib_main_worker_options,
     Default::default(),

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -1246,6 +1246,13 @@ pub async fn run(
   // given compiled binary). Only do this when we have somewhere to persist the
   // data, otherwise stay empty so the runtime keeps the in-memory fallback
   // (and avoids unwrapping a missing `origin_data_folder_path`).
+  //
+  // NOTE: for a non-self-extracting binary the main module URL is derived from
+  // just the executable's file name (see `root_path` in `cli/rt/binary.rs`), so
+  // two unrelated compiled binaries that happen to share a name (e.g. both
+  // `out`) resolve to the same storage key and therefore share the same default
+  // KV database. This predates persistence actually working; a future fix could
+  // mix the entrypoint content hash into the key. See #24318.
   let storage_key_resolver = if origin_data_folder_path.is_some() {
     match &metadata.location {
       Some(location) => StorageKeyResolver::from_flag(location),

--- a/tests/specs/compile/kv_default_path/__test__.jsonc
+++ b/tests/specs/compile/kv_default_path/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "compile -A --unstable-kv --output out main.ts",
+      "output": "[WILDCARD]"
+    },
+    {
+      "commandName": "./out",
+      "args": ["set"],
+      "output": "set\n"
+    },
+    {
+      "commandName": "./out",
+      "args": ["get"],
+      "output": "value: hi deno team.\n"
+    }
+  ]
+}

--- a/tests/specs/compile/kv_default_path/main.ts
+++ b/tests/specs/compile/kv_default_path/main.ts
@@ -1,0 +1,15 @@
+// Regression test for https://github.com/denoland/deno/issues/24318
+// `Deno.openKv()` without an explicit path should persist to disk in a
+// compiled binary, not silently fall back to an in-memory database.
+const kv = await Deno.openKv();
+const key = ["device", "key"];
+
+if (Deno.args[0] === "set") {
+  await kv.set(key, "hi deno team.");
+  console.log("set");
+} else {
+  const { value } = await kv.get(key);
+  console.log("value:", value);
+}
+
+kv.close();

--- a/tests/specs/compile/kv_location_storage_key/__test__.jsonc
+++ b/tests/specs/compile/kv_location_storage_key/__test__.jsonc
@@ -1,0 +1,23 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "compile -A --unstable-kv --location https://example.com --output out_a main.ts",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "compile -A --unstable-kv --location https://example.com --output out_b main.ts",
+      "output": "[WILDCARD]"
+    },
+    {
+      "commandName": "./out_a",
+      "args": ["set"],
+      "output": "set\n"
+    },
+    {
+      "commandName": "./out_b",
+      "args": ["get"],
+      "output": "value: hi deno team.\n"
+    }
+  ]
+}

--- a/tests/specs/compile/kv_location_storage_key/main.ts
+++ b/tests/specs/compile/kv_location_storage_key/main.ts
@@ -1,0 +1,18 @@
+// Regression test for https://github.com/denoland/deno/issues/24318
+// When compiled with `--location`, the origin-bound storage key is derived
+// from that location rather than from the main module. Two binaries with
+// different names (hence different main-module URLs) compiled with the same
+// `--location` therefore share the same default `Deno.openKv()` database,
+// proving `--location` takes precedence over the main module.
+const kv = await Deno.openKv();
+const key = ["device", "key"];
+
+if (Deno.args[0] === "set") {
+  await kv.set(key, "hi deno team.");
+  console.log("set");
+} else {
+  const { value } = await kv.get(key);
+  console.log("value:", value);
+}
+
+kv.close();


### PR DESCRIPTION
Fixes #24318.

In a `deno compile`-d binary, `Deno.openKv()` called without an explicit
path silently fell back to an in-memory database, so data never persisted
across runs. The same mechanism also prevented `localStorage` from
persisting, and passing `--location` at compile time did not help.

The root cause was in the standalone runtime (`cli/rt/run.rs`), which
constructed the worker factory with `StorageKeyResolver::empty()` and
`origin_data_folder_path: None`. With no storage key, the worker resolves
`origin_storage_dir` to `None`, which is handed to the KV SQLite handler as
its default storage dir. In `ext/kv/sqlite.rs` the "no path, no default
dir" case opens an in-memory connection, so writes never reach disk. This
is unlike `deno run`, which builds a real storage key (location, then
deno.json URL, then the main module) and points the data folder at the
`DENO_DIR`'s `location_data` directory.

This change makes the standalone runtime resolve both pieces. It derives the
storage key the same way `deno run` does (prefer an explicit `--location`,
otherwise fall back to the main module, which is stable for a given compiled
binary) and reuses the `DENO_DIR`'s `location_data` folder so default KV and
`localStorage` persist to disk. The two are tied together: the storage key
is only set when a data folder can be resolved, so if the deno dir is
unavailable both stay empty and the previous in-memory behavior is kept
(this also avoids unwrapping a missing data folder path in the worker).

A spec test under `tests/specs/compile/kv_default_path` compiles a script
that uses `Deno.openKv()` without a path, runs the binary once to write a
value and again to read it back, asserting the value survives across
processes.
