### PR TITLE
fix(ext/fetch): only match multipart delimiter lines

### DIFF
--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -385,6 +385,7 @@ function decodeLatin1StringAsUtf8(latin1String) {
 const CRLF = "\r\n";
 const LF = StringPrototypeCodePointAt(CRLF, 1);
 const CR = StringPrototypeCodePointAt(CRLF, 0);
+const DASH = StringPrototypeCodePointAt("-", 0);
 
 class MultipartParser {
   /**
@@ -429,6 +430,31 @@ class MultipartParser {
   }
 
   /**
+   * @param {number} index
+   * @returns {0 | 1 | 2}
+   */
+  #delimiterType(index) {
+    for (let i = 0; i < this.boundaryChars.length; i++) {
+      if (this.body[index + i] !== this.boundaryChars[i]) {
+        return 0;
+      }
+    }
+
+    const suffixIndex = index + this.boundaryChars.length;
+    if (this.body[suffixIndex] === CR && this.body[suffixIndex + 1] === LF) {
+      return 1;
+    }
+    if (
+      this.body[suffixIndex] === DASH &&
+      this.body[suffixIndex + 1] === DASH
+    ) {
+      return 2;
+    }
+
+    return 0;
+  }
+
+  /**
    * @returns {FormData}
    */
   parse() {
@@ -449,7 +475,6 @@ class MultipartParser {
 
     const formData = new FormData();
     let headerText = "";
-    let boundaryIndex = 0;
     let state = 0;
     let fileStart = 0;
 
@@ -476,18 +501,17 @@ class MultipartParser {
           fileStart = i + 3; // After \r\n
         }
       } else if (state === 2) {
-        if (this.boundaryChars[boundaryIndex] !== byte) {
-          boundaryIndex = 0;
-        } else {
-          boundaryIndex++;
-        }
+        if (isNewLine) {
+          const delimiterType = this.#delimiterType(i + 1);
+          if (delimiterType === 0) {
+            continue;
+          }
 
-        if (boundaryIndex >= this.boundary.length) {
           const { headers, disposition } = this.#parseHeaders(headerText);
           const content = TypedArrayPrototypeSubarray(
             this.body,
             fileStart,
-            i - boundaryIndex - 1,
+            i - 1,
           );
           // https://fetch.spec.whatwg.org/#ref-for-dom-body-formdata
           // These are UTF-8 decoded as if it was Latin-1.
@@ -496,9 +520,6 @@ class MultipartParser {
           const latin1Filename = MapPrototypeGet(disposition, "filename");
           const latin1Name = MapPrototypeGet(disposition, "name");
 
-          state = 3;
-          // Reset
-          boundaryIndex = 0;
           headerText = "";
 
           if (!latin1Name) {
@@ -518,9 +539,14 @@ class MultipartParser {
           } else {
             formData.append(name, core.decode(content));
           }
+
+          if (delimiterType === 2) {
+            break;
+          }
+
+          state = 1;
+          i += this.boundaryChars.length + 2; // Skip boundary + trailing \r\n
         }
-      } else if (state === 3 && isNewLine) {
-        state = 1;
       }
     }
 

--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -522,22 +522,21 @@ class MultipartParser {
 
           headerText = "";
 
-          if (!latin1Name) {
-            continue; // Skip, unknown name
-          }
-
-          const name = decodeLatin1StringAsUtf8(latin1Name);
-          if (latin1Filename) {
-            const blob = new Blob([content], {
-              type: headers.get("Content-Type") || "application/octet-stream",
-            });
-            formData.append(
-              name,
-              blob,
-              decodeLatin1StringAsUtf8(latin1Filename),
-            );
-          } else {
-            formData.append(name, core.decode(content));
+          // Skip nameless parts, but still advance past the matched delimiter.
+          if (latin1Name) {
+            const name = decodeLatin1StringAsUtf8(latin1Name);
+            if (latin1Filename) {
+              const blob = new Blob([content], {
+                type: headers.get("Content-Type") || "application/octet-stream",
+              });
+              formData.append(
+                name,
+                blob,
+                decodeLatin1StringAsUtf8(latin1Filename),
+              );
+            } else {
+              formData.append(name, core.decode(content));
+            }
           }
 
           if (delimiterType === 2) {

--- a/tests/unit/body_test.ts
+++ b/tests/unit/body_test.ts
@@ -265,6 +265,34 @@ Deno.test(
   },
 );
 
+Deno.test(
+  async function bodyMultipartFormDataSkipsNamelessPartAndParsesNextPart() {
+    const boundary = "AaB03x";
+    const payload = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; filename="skip.txt"',
+      "Content-Type: text/plain",
+      "",
+      "skip me",
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="field"',
+      "",
+      "value",
+      `--${boundary}--`,
+    ].join("\r\n");
+
+    const body = buildBody(
+      new TextEncoder().encode(payload),
+      new Headers({
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+      }),
+    );
+
+    const formData = await body.formData();
+    assertEquals(formData.get("field"), "value");
+  },
+);
+
 Deno.test(async function bodyBadResourceError() {
   const file = await Deno.open("README.md");
   file.close();

--- a/tests/unit/body_test.ts
+++ b/tests/unit/body_test.ts
@@ -211,6 +211,60 @@ Deno.test(
   },
 );
 
+Deno.test(
+  async function bodyMultipartFormDataEmbeddedBoundaryTextInFileContent() {
+    const boundary = "AaB03x";
+    const payload = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="x.txt"',
+      "Content-Type: text/plain",
+      "",
+      `before--${boundary}after`,
+      `--${boundary}--`,
+    ].join("\r\n");
+
+    const body = buildBody(
+      new TextEncoder().encode(payload),
+      new Headers({
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+      }),
+    );
+
+    const formData = await body.formData();
+    const file = formData.get("file");
+    assert(file instanceof File);
+    assertEquals(await file.text(), `before--${boundary}after`);
+  },
+);
+
+Deno.test(
+  async function bodyMultipartFormDataBoundaryPrefixLineInFileContent() {
+    const boundary = "AaB03x";
+    const payload = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="x.txt"',
+      "Content-Type: text/plain",
+      "",
+      "before",
+      `--${boundary}x`,
+      "after",
+      `--${boundary}--`,
+    ].join("\r\n");
+
+    const body = buildBody(
+      new TextEncoder().encode(payload),
+      new Headers({
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+      }),
+    );
+
+    const formData = await body.formData();
+    const file = formData.get("file");
+    assert(file instanceof File);
+    assertEquals(await file.text(), `before\r\n--${boundary}x\r\nafter`);
+  },
+);
+
 Deno.test(async function bodyBadResourceError() {
   const file = await Deno.open("README.md");
   file.close();


### PR DESCRIPTION
## Summary

Fixes #34586.

The multipart parser was treating raw `--boundary` bytes inside part content as a delimiter candidate, even when they were not part of a real delimiter line. That can truncate valid uploaded content.

This changes the parser to only recognize actual delimiter lines after `\r\n`, and to require a valid delimiter suffix (`\r\n` for the next part or `--` for the final boundary).

It also adds regression coverage for:
- embedded boundary text inside file content
- a boundary-like line prefix that should stay part of the file body

## Testing

- `git diff --check -- ext/fetch/21_formdata.js tests/unit/body_test.ts`
- `/opt/homebrew/bin/node --check ext/fetch/21_formdata.js`
- attempted `cargo test unit::body_test --no-run`
- attempted `cargo test unit::body_test -- --nocapture`

The cargo test attempts are currently blocked in this environment by the local linker setup:
`clang: error: invalid linker name in argument '-fuse-ld=lld'`

## AI disclosure

AI-assisted contribution, disclosed per the contributing guide.
