### PR TITLE
fix(compile): allow process.chdir() into the VFS

### DIFF
--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -145,7 +145,8 @@ impl FileSystem for DenoRtSys {
       // inside the embedded virtual file system, but applications (e.g.
       // Next.js standalone builds) commonly chdir into their own directory.
       // Verify the target exists and is a directory in the VFS and treat the
-      // change as a no-op rather than failing with NotSupported.
+      // change as a no-op rather than failing with NotSupported. Note that
+      // Deno.cwd() still reports the previous (real) working directory.
       if self.vfs.stat(path)?.as_fs_stat().is_directory {
         Ok(())
       } else {

--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -140,8 +140,23 @@ impl FileSystem for DenoRtSys {
   }
 
   fn chdir(&self, path: &CheckedPath) -> FsResult<()> {
-    self.error_if_in_vfs(path)?;
-    RealFs.chdir(path)
+    if self.is_vfs_path(path) {
+      // The process working directory can't actually be changed to a path
+      // inside the embedded virtual file system, but applications (e.g.
+      // Next.js standalone builds) commonly chdir into their own directory.
+      // Verify the target exists and is a directory in the VFS and treat the
+      // change as a no-op rather than failing with NotSupported.
+      if self.vfs.stat(path)?.as_fs_stat().is_directory {
+        Ok(())
+      } else {
+        Err(FsError::Io(std::io::Error::new(
+          ErrorKind::NotADirectory,
+          "Not a directory",
+        )))
+      }
+    } else {
+      RealFs.chdir(path)
+    }
   }
 
   fn umask(&self, mask: Option<u32>) -> FsResult<u32> {

--- a/tests/specs/compile/npm_fs/main.ts
+++ b/tests/specs/compile/npm_fs/main.ts
@@ -82,6 +82,11 @@ assert.throws(
   () => Deno.chdir(vfsPackageJsonPath),
   Deno.errors.NotADirectory,
 );
+// chdir into a non-existent VFS path still fails
+assert.throws(
+  () => Deno.chdir(path.join(dirPath, "nonexistent")),
+  Deno.errors.NotFound,
+);
 
 // mkdir
 assert.throws(

--- a/tests/specs/compile/npm_fs/main.ts
+++ b/tests/specs/compile/npm_fs/main.ts
@@ -73,7 +73,15 @@ Deno.removeSync("package.json");
 }
 
 // chdir
-assert.throws(() => Deno.chdir(dirPath), Deno.errors.NotSupported);
+// Changing into a directory inside the VFS is a no-op rather than an error,
+// so that programs that chdir into their own directory (e.g. Next.js
+// standalone builds) keep working when compiled.
+Deno.chdir(dirPath);
+// chdir into a file in the VFS still fails
+assert.throws(
+  () => Deno.chdir(vfsPackageJsonPath),
+  Deno.errors.NotADirectory,
+);
 
 // mkdir
 assert.throws(


### PR DESCRIPTION
Compiled executables embed their source files in a virtual file system
rooted at a temp directory, so `import.meta.url` and `__dirname` point
inside the VFS. `chdir()` unconditionally returned `NotSupported` for
any path within the VFS, which crashed programs that change into their
own directory on startup. Next.js standalone builds are the common case:
their bootstrap script calls `process.chdir(__dirname)` before doing
anything else, so they could never run when compiled.

The process working directory genuinely can't be moved onto a virtual
path, but the call doesn't need to fail. This treats a `chdir` into a
VFS directory as a no-op, returns `NotADirectory` when the target is a
file and `NotFound` when it doesn't exist, so the startup sequence
proceeds instead of throwing. `Deno.cwd()` still reports the previous
(real) working directory.

Fixes #26175
