### PR TITLE
fix(compile): transpile TypeScript imported at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,6 +3543,7 @@ version = "2.8.1"
 dependencies = [
  "async-trait",
  "bincode",
+ "deno_ast",
  "deno_cache_dir",
  "deno_config",
  "deno_core",

--- a/cli/rt/Cargo.toml
+++ b/cli/rt/Cargo.toml
@@ -29,6 +29,7 @@ deno_runtime.workspace = true
 deno_core.workspace = true
 
 [dependencies]
+deno_ast.workspace = true
 deno_cache_dir = { workspace = true, features = ["sync"] }
 deno_config = { workspace = true, features = ["sync", "workspace"] }
 deno_core.workspace = true

--- a/cli/rt/binary.rs
+++ b/cli/rt/binary.rs
@@ -661,7 +661,7 @@ impl StandaloneModules {
           ) {
             let text = String::from_utf8_lossy(&bytes).into_owned();
             let transpiled_text =
-              maybe_transpile_source(specifier, media_type, text)?;
+              transpile_runtime_module(specifier, media_type, text)?;
             transpiled = Some(Cow::Owned(transpiled_text.into_bytes()));
           }
           bytes
@@ -690,7 +690,7 @@ impl StandaloneModules {
 /// TypeScript that it builds or discovers while running. `deno_ast` is already
 /// linked into the binary via `ext/node`, so transpiling here adds no extra
 /// binary size.
-pub(crate) fn maybe_transpile_source(
+pub(crate) fn transpile_runtime_module(
   specifier: &Url,
   media_type: MediaType,
   source: String,

--- a/cli/rt/binary.rs
+++ b/cli/rt/binary.rs
@@ -635,19 +635,36 @@ impl StandaloneModules {
             .and_then(|t| self.vfs.read_file_offset_with_len(t).ok());
           bytes
         }
-        Err(err) if err.kind() == ErrorKind::NotFound =>
-        {
+        Err(err) if err.kind() == ErrorKind::NotFound => {
           #[allow(
             clippy::disallowed_types,
             reason = "use real file system because not in vfs"
           )]
-          match sys_traits::impls::RealSys.fs_read(&path) {
+          let bytes = match sys_traits::impls::RealSys.fs_read(&path) {
             Ok(bytes) => bytes,
             Err(err) if err.kind() == ErrorKind::NotFound => {
               return Ok(None);
             }
             Err(err) => return Err(JsErrorBox::from_err(err)),
+          };
+          // A file read from disk at runtime (e.g. a plugin discovered by a
+          // compiled program) hasn't been transpiled at compile time, so
+          // transpile TypeScript/JSX here, mirroring `deno run`.
+          let media_type = MediaType::from_specifier(specifier);
+          if matches!(
+            media_type,
+            MediaType::TypeScript
+              | MediaType::Mts
+              | MediaType::Cts
+              | MediaType::Jsx
+              | MediaType::Tsx
+          ) {
+            let text = String::from_utf8_lossy(&bytes).into_owned();
+            let transpiled_text =
+              maybe_transpile_source(specifier, media_type, text)?;
+            transpiled = Some(Cow::Owned(transpiled_text.into_bytes()));
           }
+          bytes
         }
         Err(err) => return Err(JsErrorBox::from_err(err)),
       };
@@ -664,6 +681,53 @@ impl StandaloneModules {
       self.modules.read(specifier).map_err(JsErrorBox::from_err)
     }
   }
+}
+
+/// Transpile TypeScript/JSX source to JavaScript for modules that are not
+/// embedded in the binary, namely `data:`/`blob:` URLs and local files read
+/// from disk at runtime. Embedded modules are already transpiled at
+/// `deno compile` time, but a compiled program can still dynamically `import()`
+/// TypeScript that it builds or discovers while running. `deno_ast` is already
+/// linked into the binary via `ext/node`, so transpiling here adds no extra
+/// binary size.
+pub(crate) fn maybe_transpile_source(
+  specifier: &Url,
+  media_type: MediaType,
+  source: String,
+) -> Result<String, JsErrorBox> {
+  match media_type {
+    MediaType::TypeScript
+    | MediaType::Mts
+    | MediaType::Cts
+    | MediaType::Jsx
+    | MediaType::Tsx => {}
+    // JavaScript, JSON, Wasm, etc. are served verbatim.
+    _ => return Ok(source),
+  }
+
+  let parsed = deno_ast::parse_module(deno_ast::ParseParams {
+    specifier: specifier.clone(),
+    text: source.into(),
+    media_type,
+    capture_tokens: false,
+    scope_analysis: false,
+    maybe_syntax: None,
+  })
+  .map_err(JsErrorBox::from_err)?;
+  let transpiled = parsed
+    .transpile(
+      &deno_ast::TranspileOptions {
+        imports_not_used_as_values: deno_ast::ImportsNotUsedAsValues::Remove,
+        ..Default::default()
+      },
+      &deno_ast::TranspileModuleOptions { module_kind: None },
+      &deno_ast::EmitOptions {
+        source_map: deno_ast::SourceMapOption::Inline,
+        ..Default::default()
+      },
+    )
+    .map_err(JsErrorBox::from_err)?;
+  Ok(transpiled.into_source().text)
 }
 
 pub struct DenoCompileModuleData<'a> {

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -97,6 +97,7 @@ use sys_traits::EnvCurrentDir;
 use crate::binary::DenoCompileModuleSource;
 use crate::binary::StandaloneData;
 use crate::binary::StandaloneModules;
+use crate::binary::maybe_transpile_source;
 use crate::code_cache::DenoCompileCodeCache;
 use crate::file_system::DenoRtSys;
 use crate::file_system::FileBackedVfs;
@@ -628,21 +629,41 @@ impl ModuleLoader for EmbeddedModuleLoader {
     options: ModuleLoadOptions,
   ) -> deno_core::ModuleLoadResponse {
     if original_specifier.scheme() == "data" {
-      let data_url_text =
-        match deno_media_type::data_url::RawDataUrl::parse(original_specifier)
-          .and_then(|url| url.decode())
-        {
-          Ok(response) => response,
-          Err(err) => {
-            return deno_core::ModuleLoadResponse::Sync(Err(
-              JsErrorBox::type_error(format!("{:#}", err)),
-            ));
-          }
-        };
+      let raw_data_url = match deno_media_type::data_url::RawDataUrl::parse(
+        original_specifier,
+      ) {
+        Ok(raw) => raw,
+        Err(err) => {
+          return deno_core::ModuleLoadResponse::Sync(Err(
+            JsErrorBox::type_error(format!("{:#}", err)),
+          ));
+        }
+      };
+      let media_type = raw_data_url.media_type();
+      let data_url_text = match raw_data_url.decode() {
+        Ok(text) => text,
+        Err(err) => {
+          return deno_core::ModuleLoadResponse::Sync(Err(
+            JsErrorBox::type_error(format!("{:#}", err)),
+          ));
+        }
+      };
+      // Transpile when the data URL carries TypeScript/JSX, so compiled
+      // programs can dynamically import TypeScript built at runtime.
+      let code = match maybe_transpile_source(
+        original_specifier,
+        media_type,
+        data_url_text,
+      ) {
+        Ok(code) => code,
+        Err(err) => {
+          return deno_core::ModuleLoadResponse::Sync(Err(err));
+        }
+      };
       return deno_core::ModuleLoadResponse::Sync(Ok(
         deno_core::ModuleSource::new(
           deno_core::ModuleType::JavaScript,
-          ModuleSourceCode::String(data_url_text.into()),
+          ModuleSourceCode::String(code.into()),
           original_specifier,
           None,
         ),
@@ -689,6 +710,9 @@ impl ModuleLoader for EmbeddedModuleLoader {
                       "Failed decoding \"{specifier}\": {err}"
                     ))
                   })?;
+              // Transpile when the blob carries TypeScript/JSX, so compiled
+              // programs can dynamically import TypeScript built at runtime.
+              let text = maybe_transpile_source(&specifier, media_type, text)?;
               ModuleSourceCode::String(text.into())
             }
           };

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -97,7 +97,7 @@ use sys_traits::EnvCurrentDir;
 use crate::binary::DenoCompileModuleSource;
 use crate::binary::StandaloneData;
 use crate::binary::StandaloneModules;
-use crate::binary::maybe_transpile_source;
+use crate::binary::transpile_runtime_module;
 use crate::code_cache::DenoCompileCodeCache;
 use crate::file_system::DenoRtSys;
 use crate::file_system::FileBackedVfs;
@@ -650,7 +650,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
       };
       // Transpile when the data URL carries TypeScript/JSX, so compiled
       // programs can dynamically import TypeScript built at runtime.
-      let code = match maybe_transpile_source(
+      let code = match transpile_runtime_module(
         original_specifier,
         media_type,
         data_url_text,
@@ -712,7 +712,8 @@ impl ModuleLoader for EmbeddedModuleLoader {
                   })?;
               // Transpile when the blob carries TypeScript/JSX, so compiled
               // programs can dynamically import TypeScript built at runtime.
-              let text = maybe_transpile_source(&specifier, media_type, text)?;
+              let text =
+                transpile_runtime_module(&specifier, media_type, text)?;
               ModuleSourceCode::String(text.into())
             }
           };

--- a/tests/specs/compile/dynamic_import_typescript/__test__.jsonc
+++ b/tests/specs/compile/dynamic_import_typescript/__test__.jsonc
@@ -1,0 +1,22 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "if": "unix",
+    "args": "compile --output main main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "if": "unix",
+    "commandName": "./main",
+    "args": [],
+    "output": "main.out"
+  }, {
+    "if": "windows",
+    "args": "compile --output main.exe main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "if": "windows",
+    "commandName": "./main.exe",
+    "args": [],
+    "output": "main.out"
+  }]
+}

--- a/tests/specs/compile/dynamic_import_typescript/main.out
+++ b/tests/specs/compile/dynamic_import_typescript/main.out
@@ -1,0 +1,3 @@
+hello data
+hello blob
+hello file

--- a/tests/specs/compile/dynamic_import_typescript/main.ts
+++ b/tests/specs/compile/dynamic_import_typescript/main.ts
@@ -1,0 +1,27 @@
+// A compiled binary can dynamically import TypeScript that it builds at
+// runtime, via `data:` and `blob:` URLs, as well as a local TypeScript file
+// that was not embedded at compile time. The embedded module loader transpiles
+// the TypeScript source on the fly (see #27945).
+
+const tsSource =
+  `export const greet = (name: string): string => "hello " + name;`;
+
+const dataUrl = "data:text/typescript;charset=utf-8," +
+  encodeURIComponent(tsSource);
+const fromData = await import(dataUrl);
+console.log(fromData.greet("data"));
+
+const blob = new Blob([tsSource], { type: "text/typescript" });
+const blobUrl = URL.createObjectURL(blob);
+const fromBlob = await import(blobUrl);
+console.log(fromBlob.greet("blob"));
+URL.revokeObjectURL(blobUrl);
+
+// A TypeScript file discovered on disk at runtime. Its specifier is built from
+// the real cwd (compiled binaries remap embedded paths into a virtual root, so
+// the file must be addressed by its real on-disk path), and it is not part of
+// the compile-time module graph.
+const cwd = Deno.cwd().replaceAll("\\", "/");
+const pluginUrl = `file://${cwd.startsWith("/") ? "" : "/"}${cwd}/plugin.ts`;
+const fromFile = await import(pluginUrl);
+console.log(fromFile.greet("file"));

--- a/tests/specs/compile/dynamic_import_typescript/plugin.ts
+++ b/tests/specs/compile/dynamic_import_typescript/plugin.ts
@@ -1,0 +1,1 @@
+export const greet = (name: string): string => "hello " + name;


### PR DESCRIPTION
A compiled binary could not dynamically import TypeScript that the
program builds or discovers while running. The embedded module loader
decoded data: and blob: URLs, and local files read from disk, straight
to V8 as JavaScript, so any TypeScript syntax threw
"SyntaxError: Unexpected token ':'". This blocked plugin-style use cases
where a program imports TypeScript it assembles at runtime.

The TypeScript transpiler (deno_ast) is already linked into every
compiled binary through ext/node, so this transpiles those modules on
the fly: data:/blob: URLs and local files that were not embedded at
compile time. Modules embedded at compile time are unaffected, since
they are still served pre-transpiled from the virtual file system. Note
that compiled binaries remap embedded paths into a virtual root, so a
runtime file: import must use a real on-disk absolute path (for example
one derived from Deno.cwd()), not a specifier relative to
import.meta.url.

Closes #27945