### PR TITLE
feat: bump deno_task_shell to 0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,11 +3235,10 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5724630e5d004297ca84920ef90cbf8a5459b06f8cd553e1a75d9f3ad5cd6fd"
+checksum = "bd069c87eb3cdc25e9898fe633a07ec7f20218e92ad3e7eccab3db324764d4fb"
 dependencies = [
- "anyhow",
  "bitflags 2.9.3",
  "deno_path_util",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_path_util = "=0.6.4"
 deno_semver = "=0.10.0"
-deno_task_shell = "=0.32.0"
+deno_task_shell = "=0.33.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"


### PR DESCRIPTION
Bumps `deno_task_shell` from 0.32.0 to 0.33.0, which brings several
parser and builtin improvements that resolve long-standing `deno task`
limitations.

The new release adds bash-style brace expansion (`{a,b,c}`, `{1..5}`,
single-char ranges and nesting), so common idioms like
`mocha test/{*,**/**}.js` now parse instead of failing with
"Unexpected character." It also allows redirects on commands inside a
pipe sequence (`cmd 2>&1 | tee log`), which previously errored out, and
makes malformed glob patterns fall back to literal pass-through (matching
bash with `failglob` off) so things like `--allow-write=**/*.txt` no
longer abort with a glob syntax error. Finally it adds a POSIX `test`
builtin for a useful subset of operators.

The release also drops the `anyhow` dependency from the crate, changing
the `parser::parse` return type; the CLI usage compiles unchanged since
the new error type still satisfies the `Context` bound.

Fixes #20893
Fixes #24500
Fixes #28808
Fixes #27238