### PR TITLE
fix(core): preserve WebAssembly streaming callback across new contexts

### DIFF
--- a/libs/core/ops_builtin_v8.rs
+++ b/libs/core/ops_builtin_v8.rs
@@ -1262,11 +1262,10 @@ pub fn wasm_streaming_callback<'a>(
   let context_state_rc = JsRealm::state_from_scope(scope);
   let maybe_cb_handle = context_state_rc.js_wasm_streaming_cb.borrow().clone();
   let Some(cb_handle) = maybe_cb_handle else {
-    // The JS handler has not been registered yet (only possible before the
-    // runtime finishes bootstrapping). Abort the streaming compilation rather
-    // than panicking.
-    wasm_streaming.abort(None);
-    return;
+    // The JS handler is registered while the runtime bootstraps, before any
+    // user code can trigger wasm streaming. Reaching this without a handler
+    // means deno_core was misconfigured.
+    panic!("wasm streaming callback invoked before the JS handler was set");
   };
 
   let streaming_rid = {

--- a/libs/core/ops_builtin_v8.rs
+++ b/libs/core/ops_builtin_v8.rs
@@ -1233,9 +1233,12 @@ pub fn op_set_wasm_streaming_callback(
 ) -> Result<(), JsErrorBox> {
   let cb = v8::Global::new(scope, cb);
   let context_state_rc = JsRealm::state_from_scope(scope);
-  // The callback to pass to the v8 API has to be a unit type, so it can't
-  // borrow or move any local variables. Therefore, we're storing the JS
-  // callback in a JsRuntimeState slot.
+  // We only store the JS callback here. The v8-level streaming callback is
+  // installed natively at isolate creation (see `wasm_streaming_callback`),
+  // because v8 re-creates the `WebAssembly` object - and resets the
+  // isolate-wide streaming callback - every time a new context is created
+  // (e.g. through `node:vm`). Setting it from this op would mean any later
+  // context creation silently clobbers it. See denoland/deno#34677.
   if context_state_rc.js_wasm_streaming_cb.borrow().is_some() {
     return Err(JsErrorBox::type_error(
       "op_set_wasm_streaming_callback already called",
@@ -1243,31 +1246,43 @@ pub fn op_set_wasm_streaming_callback(
   }
   *context_state_rc.js_wasm_streaming_cb.borrow_mut() = Some(cb);
 
-  scope.set_wasm_streaming_callback(|scope, arg, wasm_streaming| {
-    let (cb_handle, streaming_rid) = {
-      let context_state_rc = JsRealm::state_from_scope(scope);
-      let cb_handle = context_state_rc
-        .js_wasm_streaming_cb
-        .borrow()
-        .as_ref()
-        .unwrap()
-        .clone();
-      let state = JsRuntime::state_from(scope);
-      let streaming_rid = state
-        .op_state
-        .borrow_mut()
-        .resource_table
-        .add(WasmStreamingResource(RefCell::new(wasm_streaming)));
-      (cb_handle, streaming_rid)
-    };
-
-    let undefined = v8::undefined(scope);
-    let rid = serde_v8::to_v8(scope, streaming_rid).unwrap();
-    cb_handle
-      .open(scope)
-      .call(scope, undefined.into(), &[arg, rid]);
-  });
   Ok(())
+}
+
+/// The isolate-wide [`v8::Isolate::set_wasm_streaming_callback`] handler. It
+/// dispatches to the JS handler registered through
+/// `op_set_wasm_streaming_callback`. This is installed once at isolate creation
+/// so that it survives v8 re-installing the `WebAssembly` object (and resetting
+/// the isolate-wide streaming callback) on every newly created context.
+pub fn wasm_streaming_callback<'a>(
+  scope: &mut v8::PinScope<'a, '_>,
+  arg: v8::Local<'a, v8::Value>,
+  wasm_streaming: v8::WasmStreaming<false>,
+) {
+  let context_state_rc = JsRealm::state_from_scope(scope);
+  let maybe_cb_handle = context_state_rc.js_wasm_streaming_cb.borrow().clone();
+  let Some(cb_handle) = maybe_cb_handle else {
+    // The JS handler has not been registered yet (only possible before the
+    // runtime finishes bootstrapping). Abort the streaming compilation rather
+    // than panicking.
+    wasm_streaming.abort(None);
+    return;
+  };
+
+  let streaming_rid = {
+    let state = JsRuntime::state_from(scope);
+    state
+      .op_state
+      .borrow_mut()
+      .resource_table
+      .add(WasmStreamingResource(RefCell::new(wasm_streaming)))
+  };
+
+  let undefined = v8::undefined(scope);
+  let rid = serde_v8::to_v8(scope, streaming_rid).unwrap();
+  cb_handle
+    .open(scope)
+    .call(scope, undefined.into(), &[arg, rid]);
 }
 
 // This op is re-entrant as it makes a v8 call. It also cannot be fast because

--- a/libs/core/runtime/setup.rs
+++ b/libs/core/runtime/setup.rs
@@ -148,7 +148,6 @@ fn v8_init(
   }
 
   let base_flags = concat!(
-    " --wasm-test-streaming",
     " --no-validate-asm",
     " --turbo_fast_api_calls",
     " --harmony-temporal",
@@ -279,6 +278,9 @@ pub fn create_isolate(
   );
   isolate.set_wasm_async_resolve_promise_callback(
     bindings::wasm_async_resolve_promise_callback,
+  );
+  isolate.set_wasm_streaming_callback(
+    crate::ops_builtin_v8::wasm_streaming_callback,
   );
 
   isolate

--- a/libs/core/runtime/tests/misc.rs
+++ b/libs/core/runtime/tests/misc.rs
@@ -300,8 +300,13 @@ async fn test_resolve_value_generic(
   }
 }
 
-#[test]
-fn terminate_execution_webassembly() {
+// Uses `tokio::test` because, without `--wasm-test-streaming`, async
+// `WebAssembly.compile` finishes on a V8 background thread and posts a
+// foreground task to resolve the promise. The custom V8 platform only delivers
+// those foreground tasks when the isolate was created inside a tokio runtime
+// (see `register_isolate`), so `block_on` without tokio would hang.
+#[tokio::test]
+async fn terminate_execution_webassembly() {
   let (mut runtime, _dispatch_count) = setup(Mode::Async);
   let v8_isolate_handle = runtime.v8_isolate().thread_safe_handle();
 
@@ -321,7 +326,7 @@ fn terminate_execution_webassembly() {
                                 })()
                                     "#).unwrap();
   #[allow(deprecated, reason = "test code")]
-  futures::executor::block_on(runtime.resolve_value(promise)).unwrap();
+  runtime.resolve_value(promise).await.unwrap();
   let terminator_thread = std::thread::spawn(move || {
     std::thread::sleep(std::time::Duration::from_millis(1000));
 

--- a/tests/specs/node/vm_wasm_streaming/__test__.jsonc
+++ b/tests/specs/node/vm_wasm_streaming/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "vm_wasm_streaming": {
+      "args": "run -A main.mjs",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/node/vm_wasm_streaming/main.mjs
+++ b/tests/specs/node/vm_wasm_streaming/main.mjs
@@ -1,0 +1,25 @@
+// Regression test for https://github.com/denoland/deno/issues/34677
+//
+// `node:vm` creating a new context caused v8 to reset the isolate-wide
+// WebAssembly streaming callback, which broke `WebAssembly.compileStreaming`
+// and `WebAssembly.instantiateStreaming` (they started rejecting `Response`
+// arguments with "Argument 0 must be a buffer source").
+import { createContext } from "node:vm";
+
+// A valid empty WebAssembly module (`\0asm` + version 1).
+const wasmUrl = "data:application/wasm;base64,AGFzbQEAAAA=";
+
+async function streamingWorks() {
+  const mod = await WebAssembly.compileStreaming(await fetch(wasmUrl));
+  const { instance } = await WebAssembly.instantiateStreaming(
+    await fetch(wasmUrl),
+  );
+  return mod instanceof WebAssembly.Module &&
+    instance instanceof WebAssembly.Instance;
+}
+
+console.log("before createContext:", await streamingWorks());
+
+createContext();
+
+console.log("after createContext:", await streamingWorks());

--- a/tests/specs/node/vm_wasm_streaming/main.out
+++ b/tests/specs/node/vm_wasm_streaming/main.out
@@ -1,0 +1,2 @@
+before createContext: true
+after createContext: true

--- a/tests/specs/run/worker_close_in_wasm_reactions/worker_close_in_wasm_reactions.js.out
+++ b/tests/specs/run/worker_close_in_wasm_reactions/worker_close_in_wasm_reactions.js.out
@@ -1,2 +1,1 @@
-Error: CompileError: WebAssembly.compile(): reached end while decoding length @+10
-    at file:///[WILDCARD]/close_in_wasm_reactions.js:18:13
+Error: [CompileError: WebAssembly.compile(): reached end while decoding length @+10]


### PR DESCRIPTION
WebAssembly.compileStreaming and WebAssembly.instantiateStreaming broke
after creating a new context with node:vm (e.g. via happy-dom's
new Window()) or after attaching the inspector. Subsequent calls rejected
Response arguments with "WebAssembly.compile(): Argument 0 must be a buffer
source", even though the same code worked moments earlier and works in
Node.

The cause is in deno_core. The streaming callback is installed lazily from
JS, so deno_core set the --wasm-test-streaming V8 flag to force V8 to
install compileStreaming/instantiateStreaming at all. That flag also makes
V8 reset the isolate-wide streaming callback to its own testing callback
every time it re-creates the WebAssembly object, which happens on every new
context (node:vm) and when the inspector attaches. The testing callback only
accepts BufferSource arguments, hence the error.

This installs the streaming callback natively at isolate creation, the same
way Node does, and drops the --wasm-test-streaming flag so V8 no longer
overwrites it. op_set_wasm_streaming_callback now only stores the JS handler;
the v8-level callback is set once and survives later context creation.

Fixes #34677
Fixes #21508