### PR TITLE
fix(core): re-enable include_icu_data (external ICU data file)

### DIFF
--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -14,7 +14,7 @@ description = "A modern JavaScript/TypeScript runtime built with V8, Rust, and T
 path = "lib.rs"
 
 [features]
-default = ["v8_use_custom_libcxx", "reactor-tokio"]
+default = ["include_icu_data", "v8_use_custom_libcxx", "reactor-tokio"]
 reactor-tokio = []
 include_icu_data = ["deno_core_icudata"]
 v8_use_custom_libcxx = ["v8/use_custom_libcxx"]


### PR DESCRIPTION
This re-enables the include_icu_data feature by default, reverting
#34279, so deno_core again calls v8::icu::set_common_data with
deno_core_icudata at startup.

It depends on denoland/rusty_v8#1999, which stops V8 from embedding the
ICU data blob into the static library and restores the external ICU data
file build. Once V8 uses an external data file, the embedder must supply
the data at runtime; without this feature V8 boots with no ICU data and
Intl (and Temporal) fail. The build-time snapshot generator also runs V8
and aborts without the data, so the feature has to be on for the build to
succeed at all.

The motivation is to keep ICU data a separate, swappable artifact rather
than something baked into libv8. That is what makes it possible to ship a
smaller small-icu data set, or no data, without rebuilding V8, and it
removes the roughly 11MB binary size regression that embedding
reintroduced.

Draft until rusty_v8#1999 lands and a new v8 crate is published with the
external-data-file build; this was verified end-to-end locally by linking
against a from-source rusty_v8 build (RUSTY_V8_ARCHIVE) and confirming
Intl works while the no-feature build fails at snapshot generation, which
confirms the data is genuinely external.