### PR TITLE
fix(node): full re-export fallback for unresolvable member re-exports

### DIFF
--- a/libs/node_resolver/analyze.rs
+++ b/libs/node_resolver/analyze.rs
@@ -221,7 +221,7 @@ impl<
 
     if !analysis.member_reexports.is_empty() {
       let mut errors = Vec::new();
-      self
+      let fallback_reexports = self
         .resolve_member_reexports(
           entry_specifier,
           &analysis.member_reexports,
@@ -229,6 +229,18 @@ impl<
           &mut errors,
         )
         .await;
+      // Members whose attached names couldn't be determined statically
+      // fall back to a wholesale re-export of the inner module.
+      if !fallback_reexports.is_empty() {
+        self
+          .analyze_reexports(
+            entry_specifier,
+            fallback_reexports,
+            &mut all_exports,
+            &mut errors,
+          )
+          .await;
+      }
       if !errors.is_empty() {
         errors.sort_by_cached_key(|e| e.to_string());
         return Err(TranslateCjsToEsmError::ExportAnalysis(errors.remove(0)));
@@ -245,6 +257,13 @@ impl<
   /// strictly narrower than treating `X` as a wildcard re-export: only
   /// names the inner module statically attaches to the specific member
   /// are advertised, so unrelated names from `X` don't leak through.
+  ///
+  /// When the attached names can't be determined statically (e.g.
+  /// graphql-tag@2's UMD wraps its `exports.gql = …` / `gql.* = …`
+  /// assignments inside the factory IIFE and builds the value through a
+  /// namespace alias), the inner specifier is returned so the caller can
+  /// fall back to a wholesale re-export, matching Node's behavior for
+  /// `module.exports = require(X).Y`.
   #[allow(
     clippy::needless_lifetimes,
     reason = "explicit lifetimes improve clarity"
@@ -255,7 +274,8 @@ impl<
     member_reexports: &[CjsMemberReExport],
     all_exports: &mut BTreeSet<String>,
     errors: &mut Vec<JsErrorBox>,
-  ) {
+  ) -> Vec<String> {
+    let mut fallback_reexports = Vec::new();
     for entry in member_reexports {
       let result = self
         .resolve(
@@ -290,7 +310,12 @@ impl<
         .await
       {
         Ok(Some(props)) => props,
-        Ok(None) => continue,
+        // Couldn't statically narrow to the member's attached names;
+        // fall back to re-exporting the inner module wholesale.
+        Ok(None) => {
+          fallback_reexports.push(entry.specifier.clone());
+          continue;
+        }
         Err(err) => {
           errors.push(err);
           continue;
@@ -303,6 +328,7 @@ impl<
         all_exports.insert(prop);
       }
     }
+    fallback_reexports
   }
 
   #[allow(
@@ -430,7 +456,7 @@ impl<
           }
 
           if !analysis.member_reexports.is_empty() {
-            self
+            let fallback_reexports = self
               .resolve_member_reexports(
                 &reexport_specifier,
                 &analysis.member_reexports,
@@ -438,6 +464,16 @@ impl<
                 errors,
               )
               .await;
+            // Members that couldn't be narrowed statically fall back to a
+            // wholesale re-export, fed back through the same loop.
+            if !fallback_reexports.is_empty() {
+              handle_reexports(
+                reexport_specifier.clone(),
+                fallback_reexports,
+                &mut analyze_futures,
+                errors,
+              );
+            }
           }
 
           all_exports.extend(

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-umd/1.0.0/lib/inner.umd.js
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-umd/1.0.0/lib/inner.umd.js
@@ -1,0 +1,26 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.gqlmod = {}));
+}(this, (function (exports) {
+  'use strict';
+  function gql() { return "gql-result"; }
+  function resetCaches() { return "reset"; }
+  function disableFragmentWarnings() { return "disabled"; }
+  var extras = {
+    gql: gql,
+    resetCaches: resetCaches,
+    disableFragmentWarnings: disableFragmentWarnings,
+  };
+  (function (gql_1) {
+    gql_1.gql = extras.gql;
+    gql_1.resetCaches = extras.resetCaches;
+    gql_1.disableFragmentWarnings = extras.disableFragmentWarnings;
+  })(gql || (gql = {}));
+  gql["default"] = gql;
+  exports.default = gql;
+  exports.gql = gql;
+  exports.resetCaches = resetCaches;
+  exports.disableFragmentWarnings = disableFragmentWarnings;
+  Object.defineProperty(exports, '__esModule', { value: true });
+})));

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-umd/1.0.0/main.js
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-umd/1.0.0/main.js
@@ -1,0 +1,3 @@
+// Mirrors graphql-tag@2's main entry exactly: re-export a single named
+// property of an inner UMD module as the whole `module.exports`.
+module.exports = require('./lib/inner.umd.js').gql;

--- a/tests/registry/npm/@denotest/cjs-module-exports-require-member-umd/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/cjs-module-exports-require-member-umd/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/cjs-module-exports-require-member-umd",
+  "version": "1.0.0",
+  "main": "main.js"
+}

--- a/tests/specs/npm/cjs_module_exports_require_member_umd/__test__.jsonc
+++ b/tests/specs/npm/cjs_module_exports_require_member_umd/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run -A --quiet main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/npm/cjs_module_exports_require_member_umd/main.out
+++ b/tests/specs/npm/cjs_module_exports_require_member_umd/main.out
@@ -1,0 +1,3 @@
+gql-result
+reset
+disabled

--- a/tests/specs/npm/cjs_module_exports_require_member_umd/main.ts
+++ b/tests/specs/npm/cjs_module_exports_require_member_umd/main.ts
@@ -1,0 +1,16 @@
+// Regression test for #16708: graphql-tag@2's main entry is
+//   module.exports = require("./lib/graphql-tag.umd.js").gql;
+// where the inner module is a UMD bundle that attaches its named
+// exports inside the factory IIFE through a namespace alias. The
+// member's attached names can't be narrowed statically, so the
+// analyzer falls back to re-exporting the inner module wholesale and
+// `import { gql }` resolves (matching Node).
+import {
+  disableFragmentWarnings,
+  gql,
+  resetCaches,
+} from "npm:@denotest/cjs-module-exports-require-member-umd";
+
+console.log(gql());
+console.log(resetCaches());
+console.log(disableFragmentWarnings());


### PR DESCRIPTION
Importing a named export from graphql-tag still failed with "does not
provide an export named 'gql'", even though #34363 added handling for the
`module.exports = require("X").MEMBER` entry shape that graphql-tag@2
uses. That fix narrows the wrapper's named exports to the names
statically attached to MEMBER inside X, which works when the attachments
are top-level but not for graphql-tag's actual inner file: a UMD bundle
that performs its `exports.gql = ...` and `gql.* = ...` assignments inside
the factory IIFE and builds the value through a namespace alias. Static
narrowing finds nothing there, so the wrapper advertised no names at all.

When the member's attached names cannot be determined statically, fall
back to re-exporting the inner module wholesale rather than advertising
nothing. This matches Node, which over-approximates `require(X).Y` to the
inner module's full set of named exports. The narrow path is unchanged
for the cases where the attachments are statically known, so unrelated
names still do not leak through there.

Closes #16708
Closes #25311
