### PR TITLE
fix(publish): improve error reporting for JSR manifest verification

### DIFF
--- a/cli/tools/publish/mod.rs
+++ b/cli/tools/publish/mod.rs
@@ -1041,14 +1041,14 @@ async fn publish_package(
     let status = resp.status();
     let meta_bytes = resp.collect().await?.to_bytes();
 
-    if !status.is_success() {
-      bail!(
-        "Failed to fetch package manifest from {meta_url}: status {status}\n\n{}",
-        response_body_snippet(&meta_bytes),
-      );
-    }
-
     if std::env::var("DISABLE_JSR_MANIFEST_VERIFICATION_FOR_TESTING").is_err() {
+      if !status.is_success() {
+        bail!(
+          "Failed to fetch package manifest from {meta_url}: status {status}\n\n{}",
+          response_body_snippet(&meta_bytes),
+        );
+      }
+
       verify_version_manifest(&meta_bytes, &package).with_context(|| {
         format!("Failed to verify package manifest from {meta_url}")
       })?;

--- a/cli/tools/publish/mod.rs
+++ b/cli/tools/publish/mod.rs
@@ -1031,11 +1031,27 @@ async fn publish_package(
       package.scope, package.package, package.version
     ))?;
 
-    let resp = http_client.get(meta_url)?.send().await?;
+    let resp = http_client
+      .get(meta_url.clone())?
+      .send()
+      .await
+      .with_context(|| {
+        format!("Failed to fetch package manifest from {meta_url}")
+      })?;
+    let status = resp.status();
     let meta_bytes = resp.collect().await?.to_bytes();
 
+    if !status.is_success() {
+      bail!(
+        "Failed to fetch package manifest from {meta_url}: status {status}\n\n{}",
+        response_body_snippet(&meta_bytes),
+      );
+    }
+
     if std::env::var("DISABLE_JSR_MANIFEST_VERIFICATION_FOR_TESTING").is_err() {
-      verify_version_manifest(&meta_bytes, &package)?;
+      verify_version_manifest(&meta_bytes, &package).with_context(|| {
+        format!("Failed to verify package manifest from {meta_url}")
+      })?;
     }
 
     let subject = provenance::Subject {
@@ -1187,11 +1203,35 @@ struct VersionManifest {
   exports: HashMap<String, String>,
 }
 
+/// Returns a truncated, lossy UTF-8 rendering of a response body for use in
+/// error messages, so that a non-JSON response (e.g. an HTML error page) is
+/// diagnosable instead of surfacing as an opaque deserialization error.
+fn response_body_snippet(bytes: &[u8]) -> String {
+  const MAX_LEN: usize = 512;
+  let text = String::from_utf8_lossy(bytes);
+  let text = text.trim();
+  if text.len() > MAX_LEN {
+    let mut end = MAX_LEN;
+    while !text.is_char_boundary(end) {
+      end -= 1;
+    }
+    format!("{}... (truncated)", &text[..end])
+  } else {
+    text.to_string()
+  }
+}
+
 fn verify_version_manifest(
   meta_bytes: &[u8],
   package: &PreparedPublishPackage,
 ) -> Result<(), AnyError> {
-  let manifest = serde_json::from_slice::<VersionManifest>(meta_bytes)?;
+  let manifest = serde_json::from_slice::<VersionManifest>(meta_bytes)
+    .with_context(|| {
+      format!(
+        "Failed to parse package manifest as JSON. Response body:\n\n{}",
+        response_body_snippet(meta_bytes),
+      )
+    })?;
   // Check that nothing was removed from the manifest.
   if manifest.manifest.len() != package.tarball.files.len() {
     bail!(


### PR DESCRIPTION
Fixes #29671.

When publishing a package with provenance enabled, Deno fetches the
package `_meta.json` from the JSR registry and verifies it against the
local tarball before generating the provenance attestation. The fetched
body was deserialized with a bare `?`, so any non-JSON response (an HTML
error page, a truncated body, a 5xx from the registry) surfaced as an
opaque serde error such as `expected value at line 1 column 1`, with no
indication of the URL fetched, the HTTP status, or the response contents.
As the reporter noted, that left no useful signal for diagnosing a CI
publish failure.

This adds context at the point of failure:

- The fetch itself is wrapped with the request URL so a network-level
  failure names the endpoint.
- The response status is checked before parsing. A non-2xx response now
  bails with the URL, the status, and a truncated snippet of the body
  instead of being fed into the JSON parser.
- The manifest deserialization is wrapped with context that includes a
  truncated, lossy-UTF8 snippet of the response body, so a malformed but
  200 response is diagnosable.

A small `response_body_snippet` helper renders bodies for these messages,
trimming and truncating to 512 bytes on a char boundary.

No behavior changes on the success path; this only affects the wording
and detail of the error surfaced when manifest verification fails.
