### PR TITLE
fix(compile): enable ANSI colors on Windows in compiled binaries

### DIFF
--- a/cli/rt/lib.rs
+++ b/cli/rt/lib.rs
@@ -66,6 +66,13 @@ fn load_env_vars(env_vars: &IndexMap<String, String>) {
 pub fn main() {
   init_logging(None, None);
 
+  // Enable ANSI virtual terminal processing on Windows consoles that don't
+  // do so by default (e.g. Windows Server / classic conhost), so that
+  // compiled binaries render colored output instead of raw escape codes.
+  // This mirrors the setup done in the main `deno` binary entrypoint.
+  #[cfg(windows)]
+  colors::enable_ansi(); // For Windows 10
+
   deno_runtime::deno_permissions::mark_standalone();
 
   rustls::crypto::aws_lc_rs::default_provider()


### PR DESCRIPTION
Fixes #29875.

Since Deno 2.2.6, `deno compile`'d executables print raw ANSI escape codes
instead of colored output on Windows consoles that do not enable virtual
terminal processing by default, such as Windows Server 2022 and the classic
conhost. `deno run` is unaffected.

The cause is that a compiled binary does not run the normal `deno`
entrypoint. It embeds the denort runtime in `cli/rt`, which has its own
`main()`. The main `deno` binary enables ANSI on Windows via
`colors::enable_ansi()` (in `cli/lib.rs`), but denort's `main()` never did,
so the console was never switched into virtual terminal mode and treated the
escape sequences literally. The new Windows Terminal enables VT processing
itself, which is why the regression only shows on older or server consoles.

This mirrors the `colors::enable_ansi()` call into denort's `main()` behind
`#[cfg(windows)]`, matching what the main binary already does.

Note: this is Windows console behavior and cannot be reproduced on macOS or
Linux, so it should be validated on a Windows Server / non Windows Terminal
console before merge.
