### PR TITLE
fix(cli): check worker's own permissions for dynamic asset imports

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -775,11 +775,16 @@ impl<TGraphContainer: ModuleGraphContainer>
       .file_fetcher
       .fetch_with_options(
         specifier,
+        // Always check against this worker's own permissions, never the
+        // broader `parent_permissions`. Dynamic `import()` of a text/bytes
+        // asset (`with { type: "text" | "bytes" }`) returns the file's raw
+        // contents to the caller and therefore requires read access; routing
+        // it through `parent_permissions` would let a worker created with
+        // restricted permissions read files its parent can but it cannot.
+        // For statically analyzable imports `check_specifier` skips the read
+        // check entirely, so the chosen container does not matter there.
         FetchPermissionsOptionRef::Restricted(
-          match check_specifier_kind {
-            CheckSpecifierKind::Static => &self.permissions,
-            CheckSpecifierKind::Dynamic => &self.parent_permissions,
-          },
+          &self.permissions,
           check_specifier_kind,
         ),
         FetchOptions {

--- a/tests/specs/worker/worker_permissions_dynamic_text_local/__test__.jsonc
+++ b/tests/specs/worker/worker_permissions_dynamic_text_local/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run --quiet --reload --allow-read --unstable-worker-options parent.ts",
+  "output": "parent.ts.out"
+}

--- a/tests/specs/worker/worker_permissions_dynamic_text_local/parent.ts
+++ b/tests/specs/worker/worker_permissions_dynamic_text_local/parent.ts
@@ -1,0 +1,12 @@
+// The parent holds `--allow-read`, but spawns a worker that is explicitly
+// restricted with `read: false`. The worker then tries to read a local file
+// through a dynamic text import. That import must be checked against the
+// worker's own (restricted) permissions, not the parent's, so it is denied.
+const worker = new Worker(import.meta.resolve("./worker.ts"), {
+  type: "module",
+  deno: {
+    permissions: {
+      read: false,
+    },
+  },
+});

--- a/tests/specs/worker/worker_permissions_dynamic_text_local/parent.ts.out
+++ b/tests/specs/worker/worker_permissions_dynamic_text_local/parent.ts.out
@@ -1,0 +1,1 @@
+worker import denied: Requires read access to "[WILDCARD]secret.txt", run again with the --allow-read flag

--- a/tests/specs/worker/worker_permissions_dynamic_text_local/secret.txt
+++ b/tests/specs/worker/worker_permissions_dynamic_text_local/secret.txt
@@ -1,0 +1,1 @@
+this file must not be readable by a worker created with read: false

--- a/tests/specs/worker/worker_permissions_dynamic_text_local/worker.ts
+++ b/tests/specs/worker/worker_permissions_dynamic_text_local/worker.ts
@@ -1,0 +1,15 @@
+// A text/bytes import returns the file's raw contents as data, so it requires
+// read access. This worker was created with `read: false`, so the import must
+// be denied even though the parent thread has `--allow-read`.
+//
+// The specifier is assembled at runtime so it is not statically analyzable;
+// statically analyzable imports intentionally skip the read check and are a
+// separate, by-design code path.
+const specifier = ["./sec", "ret.txt"].join("");
+try {
+  await import(specifier, { with: { type: "text" } });
+  console.log("FAIL: read:false worker was able to import the file as text");
+} catch (err) {
+  console.log("worker import denied:", (err as Error).message);
+}
+self.close();


### PR DESCRIPTION
A dynamic text or bytes import (`import(specifier, { with: { type: "text" |
"bytes" } })`) returns the imported file's raw contents to the caller as data,
so it requires read access, just like the `Deno.readFile` family. The main
thread blocks such an import when run without `--allow-read`.

In `load_asset` the permission container was selected based on whether the
specifier was statically analyzable: statically analyzable imports were checked
against the loader's own `permissions`, while non-statically-analyzable ones
were checked against `parent_permissions`. For a Web Worker, `parent_permissions`
is the parent thread's broader set, so a worker created with restricted
permissions (for example `deno: { permissions: { read: false } }`) could read a
file its parent was allowed to read but it was not, by importing it as text or
bytes through a specifier assembled at runtime.

This changes `load_asset` to always check against the loader's own
`permissions`. For statically analyzable imports `check_specifier` skips the
read check entirely, so the choice of container never mattered there; for
non-statically-analyzable dynamic text and bytes imports it now correctly
enforces the worker's own restrictions. On the main thread the two containers
are identical, so behavior there is unchanged.

Adds a spec test in which a `read: false` worker, spawned by a parent holding
`--allow-read`, performs a non-statically-analyzable dynamic text import and is
denied.