### PR TITLE
fix(ext/websocket): send URL userinfo as Basic auth header

### DIFF
--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -31,6 +31,7 @@ const {
   ArrayPrototypeShift,
   ArrayPrototypeSome,
   DateNow,
+  decodeURIComponent,
   Error,
   ErrorPrototypeToString,
   ObjectDefineProperties,
@@ -55,9 +56,10 @@ const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
 const { createFilteredInspectProxy } = core.loadExtScript(
   "ext:deno_web/01_console.js",
 );
-const { HTTP_TOKEN_CODE_POINT_RE, byteLowerCase } = core.loadExtScript(
-  "ext:deno_web/00_infra.js",
-);
+const { HTTP_TOKEN_CODE_POINT_RE, byteLowerCase, forgivingBase64Encode } = core
+  .loadExtScript(
+    "ext:deno_web/00_infra.js",
+  );
 const { DOMException } = core.loadExtScript("ext:deno_web/01_dom_exception.js");
 const {
   CloseEvent,
@@ -301,6 +303,22 @@ class WebSocket extends EventTarget {
       );
     }
 
+    // WHATWG WebSocket: credentials in the URL userinfo are sent as an
+    // `Authorization: Basic` header during the handshake and then stripped
+    // from the URL exposed via `url`. This matches browser behavior.
+    let urlCredentials = null;
+    if (wsURL.username !== "" || wsURL.password !== "") {
+      urlCredentials = forgivingBase64Encode(
+        core.encode(
+          `${decodeURIComponent(wsURL.username)}:${
+            decodeURIComponent(wsURL.password)
+          }`,
+        ),
+      );
+      wsURL.username = "";
+      wsURL.password = "";
+    }
+
     this[_url] = wsURL.href;
     this[_role] = CLIENT;
 
@@ -357,6 +375,17 @@ class WebSocket extends EventTarget {
           unsafelyIgnoreCertificateErrors =
             dispatcherOptions.unsafelyIgnoreCertificateErrors === true;
         }
+      }
+    }
+
+    // Apply URL-derived Basic credentials. An explicit `Authorization` header
+    // in `init.headers` takes precedence over the URL userinfo.
+    if (urlCredentials !== null) {
+      if (headers === null) {
+        headers = headersFromHeaderList([], "request");
+      }
+      if (headers.get("Authorization") === null) {
+        headers.set("Authorization", `Basic ${urlCredentials}`);
       }
     }
 

--- a/tests/unit/websocket_test.ts
+++ b/tests/unit/websocket_test.ts
@@ -306,6 +306,46 @@ Deno.test({
   assert(seenBye);
 });
 
+// https://github.com/denoland/deno/issues/19283
+Deno.test({
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async function websocketUrlCredentialsAsBasicAuth() {
+  const deferred = Promise.withResolvers<void>();
+  const ac = new AbortController();
+  const listeningDeferred = Promise.withResolvers<void>();
+
+  let seenAuth: string | null = null;
+  const server = Deno.serve({
+    handler: (req) => {
+      seenAuth = req.headers.get("authorization");
+      if (seenAuth !== "Basic " + btoa("user:p@ss")) {
+        return new Response("unauthorized", { status: 401 });
+      }
+      const { response, socket } = Deno.upgradeWebSocket(req);
+      socket.onopen = () => socket.close();
+      socket.onclose = () => ac.abort();
+      return response;
+    },
+    signal: ac.signal,
+    onListen: () => listeningDeferred.resolve(),
+    hostname: "localhost",
+    port: servePort,
+  });
+
+  await listeningDeferred.promise;
+
+  // Percent-encoded userinfo (p%40ss decodes to p@ss).
+  const ws = new WebSocket(`ws://user:p%40ss@localhost:${servePort}/`);
+  // Credentials are stripped from the URL exposed via `url`.
+  assertEquals(ws.url, serveUrl);
+  ws.onerror = () => fail();
+  ws.onclose = () => deferred.resolve();
+
+  await Promise.all([deferred.promise, server.finished]);
+  assertEquals(seenAuth, "Basic " + btoa("user:p@ss"));
+});
+
 Deno.test(
   { sanitizeOps: false },
   function websocketConstructorWithPrototypePollution() {


### PR DESCRIPTION
When a `WebSocket` URL carried credentials in its userinfo, like
`ws://user:pass@host/`, Deno parsed the URL but never did anything with
the username and password. Servers that require HTTP Basic authentication
therefore rejected the handshake with a 401, even though browsers accept
the same code by sending the credentials as an `Authorization: Basic`
header. This is the behavior reported in #19283.

This change derives an `Authorization: Basic <base64>` header from the URL
userinfo during the handshake. The username and password are percent
decoded and UTF-8 encoded before base64 encoding, matching how `fetch`
treats credentials in a URL. The credentials are then stripped from the
URL exposed via the `url` attribute, which is what browsers do as well.

An explicit `Authorization` header supplied through `init.headers` takes
precedence over the URL userinfo, so existing code that sets the header
itself is unaffected.

A unit test in `tests/unit/websocket_test.ts` connects to a server that
demands Basic auth, verifies the handshake succeeds, checks that the
credentials are removed from `ws.url`, and exercises percent decoding of
the userinfo.

Closes #19283