### PR TITLE
fix(cli): strip ANSI color from output when stderr is not a TTY

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -697,6 +697,14 @@ pub fn main() {
     deno_subprocess_windows::disable_stdio_inheritance();
     colors::enable_ansi(); // For Windows 10
   }
+  // Strip ANSI color from Deno's own status/log messages when stderr is not a
+  // terminal (e.g. redirected to a file or pipe), unless color is explicitly
+  // forced via `FORCE_COLOR`. These messages are emitted with the global color
+  // state, which otherwise only honors `NO_COLOR`/`FORCE_COLOR` and ignores
+  // whether the stream is a TTY.
+  if !colors::force_color() && !deno_terminal::is_stderr_tty() {
+    colors::set_use_color(false);
+  }
   deno_runtime::deno_permissions::prompter::set_prompt_callbacks(
     Box::new(util::draw_thread::DrawThread::hide),
     Box::new(util::draw_thread::DrawThread::show),

--- a/tests/specs/run/no_color_when_not_tty/__test__.jsonc
+++ b/tests/specs/run/no_color_when_not_tty/__test__.jsonc
@@ -1,0 +1,18 @@
+{
+  // Regression test for https://github.com/denoland/deno/issues/26689
+  //
+  // Deno's own colored status/error messages must not contain ANSI escape
+  // codes when the output stream is not a TTY (here the spec harness captures
+  // stderr through a pipe). This must hold even when `NO_COLOR` is unset, so we
+  // override the harness default of `NO_COLOR=1` with an empty value to take the
+  // default color code path. The `error:` prefix is emitted with the global
+  // color state, so a plain (escape-free) match proves color was stripped.
+  "tests": {
+    "error_has_no_ansi_when_piped": {
+      "envs": { "NO_COLOR": "" },
+      "args": "run nonexistent.ts",
+      "exitCode": 1,
+      "output": "error.out"
+    }
+  }
+}

--- a/tests/specs/run/no_color_when_not_tty/error.out
+++ b/tests/specs/run/no_color_when_not_tty/error.out
@@ -1,0 +1,1 @@
+error: Module not found "file:///[WILDCARD]/nonexistent.ts".


### PR DESCRIPTION
Deno's own colored status and error messages, such as the install
summary, the "Download" progress lines, and the "error:" prefix, leaked
raw ANSI escape codes into the output when it was redirected to a file
or a pipe. Other tools like npm strip color in that case, but Deno did
not.

The cause is that the global color state in deno_terminal only honors
NO_COLOR and FORCE_COLOR and never consults whether the stream is a
terminal, and the CLI never narrowed it. As a result any message built
with the color helpers embedded escape codes regardless of where it was
written. This gates the global color state on whether stderr is a TTY at
startup, disabling color for non-terminal output unless FORCE_COLOR is
set. JS-side console coloring is unaffected because it already consults
the per-stream bootstrap ops.

Closes #26689