### PR TITLE
fix(ext/os): don't expose invalid env var keys from Deno.env.toObject()

### DIFF
--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -223,10 +223,16 @@ fn op_env(
   state: &mut OpState,
 ) -> Result<HashMap<String, String>, PermissionCheckError> {
   fn map_kv(kv: (OsString, OsString)) -> Option<(String, String)> {
-    kv.0
-      .into_string()
-      .ok()
-      .and_then(|key| kv.1.into_string().ok().map(|value| (key, value)))
+    let key = kv.0.into_string().ok()?;
+    // Skip keys that `Deno.env.get`/`set`/`delete` would reject, so that
+    // enumeration stays consistent with the rest of the API. On Windows,
+    // cmd.exe exposes hidden per-drive cwd variables such as `=C:` which
+    // contain `=` and are not meant to be surfaced to users.
+    if key.is_empty() || key.contains(&['=', '\0'] as &[char]) {
+      return None;
+    }
+    let value = kv.1.into_string().ok()?;
+    Some((key, value))
   }
 
   let permissions_container = state.borrow::<PermissionsContainer>();

--- a/tests/unit/os_test.ts
+++ b/tests/unit/os_test.ts
@@ -48,6 +48,20 @@ Deno.test({ permissions: { env: true } }, function avoidEmptyNamedEnv() {
   assertThrows(() => Deno.env.delete("a\0a"), TypeError);
 });
 
+// Regression test for https://github.com/denoland/deno/issues/23443
+// Every key returned by `toObject()` must be one that `get()` accepts.
+// On Windows, cmd.exe injects hidden per-drive cwd variables such as `=C:`
+// that contain `=`, which used to be enumerated but were not gettable.
+Deno.test({ permissions: { env: true } }, function envToObjectKeysAreValid() {
+  for (const key of Object.keys(Deno.env.toObject())) {
+    assert(key.length > 0, "toObject() returned an empty key");
+    assert(!key.includes("="), `toObject() returned an invalid key: ${key}`);
+    assert(!key.includes("\0"), `toObject() returned an invalid key: ${key}`);
+    // Must not throw.
+    Deno.env.get(key);
+  }
+});
+
 Deno.test({ permissions: { env: false } }, function envPerm1() {
   assertThrows(() => {
     Deno.env.toObject();


### PR DESCRIPTION
On Windows, `cmd.exe` injects hidden per-drive current-directory
variables whose names start with `=` (for example `=C:` or `=D:`). These
are documented behavior cmd uses to track a separate working directory per
drive, and they are not meant to be surfaced to programs as ordinary
environment variables.

`Deno.env.toObject()` enumerated every entry returned by the OS, including
those `=`-prefixed names, but `Deno.env.get()`, `set()`, and `delete()` all
reject keys containing `=` or a NUL byte with "Key contains invalid
characters". The result was an inconsistency where you could iterate a key
that you could not then read, as reported in #23443:

```ts
for (const key of Object.keys(Deno.env.toObject())) {
  console.log(Deno.env.get(key)); // throws on "=C:"
}
```

This filters empty, NUL-containing, and `=`-containing keys out of the
`op_env` enumeration so that the set of keys returned by `toObject()` is
always a set the rest of the env API accepts. The same keys also back
`process.env` enumeration via the Node polyfill, so that is brought in line
too.

Added a regression test asserting that every key from `toObject()` is
non-empty, free of `=`/`\0`, and gettable without throwing.

Fixes #23443
