### PR TITLE
fix(resolver): collapse redundant slashes in file specifiers

### DIFF
--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -1201,6 +1201,12 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
     };
     let resolve_error = match resolve_result {
       Ok(mut resolved_specifier) => {
+        // Collapse redundant path segments (e.g. `//`) introduced by
+        // non-normalized specifiers like `.//a.js`. Without this, a cyclic
+        // import graph keeps producing distinct specifiers that accumulate
+        // slashes on every cycle and never dedupe, eventually exceeding the
+        // OS file name length limit.
+        collapse_redundant_file_specifier_segments(&mut resolved_specifier);
         let mut used_compiler_options_root_dirs = false;
         let mut sloppy_reason = None;
         if let Some((probed_specifier, probed_sloppy_reason)) = self
@@ -1591,6 +1597,37 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
   pub fn has_compiler_options_root_dirs(&self) -> bool {
     self.compiler_options_resolver.read().has_root_dirs()
   }
+}
+
+/// Collapses redundant path segments (such as the empty segment produced by a
+/// `//` in the specifier) in a `file:` URL. Other schemes are left untouched.
+///
+/// `deno_path_util::normalize_path` intentionally leaves a lone `//` alone, so
+/// we rely on `Path::components()` here, which discards repeated separators and
+/// `.` segments while preserving the rest of the path verbatim.
+fn collapse_redundant_file_specifier_segments(specifier: &mut Url) {
+  if specifier.scheme() != "file" {
+    return;
+  }
+  // Quick check to avoid the path round-trip for the common case.
+  if !specifier.path().contains("//") {
+    return;
+  }
+  let Ok(path) = url_to_file_path(specifier) else {
+    return;
+  };
+  let collapsed = path.components().collect::<PathBuf>();
+  // Note: `PathBuf` compares by component, so the raw `OsStr` must be compared
+  // here to detect a difference in the separators that were collapsed.
+  if collapsed.as_os_str() == path.as_os_str() {
+    return;
+  }
+  let Ok(mut collapsed_specifier) = url_from_file_path(&collapsed) else {
+    return;
+  };
+  collapsed_specifier.set_query(specifier.query());
+  collapsed_specifier.set_fragment(specifier.fragment());
+  *specifier = collapsed_specifier;
 }
 
 #[derive(Deserialize, Serialize)]

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -1933,6 +1933,74 @@ mod test {
   }
 
   #[test]
+  fn collapse_redundant_segments_ignores_non_file_schemes() {
+    // The scheme guard must win even when the path itself contains a `//`, so
+    // non-file specifiers are returned completely untouched.
+    for url in [
+      "https://example.com//a//b.js",
+      "http://deno.land/x//mod.ts",
+      "data:text/plain,//hello",
+    ] {
+      let mut specifier = Url::parse(url).unwrap();
+      let original = specifier.clone();
+      collapse_redundant_file_specifier_segments(&mut specifier);
+      assert_eq!(specifier, original, "{url} should be left unchanged");
+    }
+  }
+
+  #[cfg(not(windows))]
+  #[test]
+  fn collapse_redundant_segments_file() {
+    fn collapse(url: &str) -> String {
+      let mut specifier = Url::parse(url).unwrap();
+      collapse_redundant_file_specifier_segments(&mut specifier);
+      specifier.to_string()
+    }
+
+    // The empty segment produced by `.//a.js` (the regression in #23821) is
+    // collapsed so cyclic imports dedupe instead of growing a slash per cycle.
+    assert_eq!(collapse("file:///dir//a.js"), "file:///dir/a.js");
+    // Multiple runs of redundant separators are all collapsed.
+    assert_eq!(collapse("file:///a////b//c.js"), "file:///a/b/c.js");
+    // A `.` segment next to the redundant slash is collapsed too.
+    assert_eq!(collapse("file:///a/.//b.js"), "file:///a/b.js");
+    // An already-normalized specifier is returned byte-for-byte unchanged.
+    assert_eq!(collapse("file:///a/b.js"), "file:///a/b.js");
+    // Note: there is intentionally no `..` case here. The `Url` type always
+    // resolves `.`/`..` dot segments when a specifier is constructed, so the
+    // only redundancy that can reach this helper is empty (`//`) segments;
+    // `Path::components()` never resolves `..`, so the collapse stays
+    // symlink-safe regardless.
+    // Query and fragment survive the path round-trip.
+    assert_eq!(
+      collapse("file:///a//b.js?foo=1#bar"),
+      "file:///a/b.js?foo=1#bar"
+    );
+    // Percent-encoded characters survive the decode/re-encode round-trip.
+    assert_eq!(collapse("file:///a//b%20c.js"), "file:///a/b%20c.js");
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn collapse_redundant_segments_file_windows() {
+    fn collapse(url: &str) -> String {
+      let mut specifier = Url::parse(url).unwrap();
+      collapse_redundant_file_specifier_segments(&mut specifier);
+      specifier.to_string()
+    }
+
+    // The drive-letter prefix is preserved while redundant separators after it
+    // are collapsed.
+    assert_eq!(collapse("file:///C:/dir//a.js"), "file:///C:/dir/a.js");
+    assert_eq!(collapse("file:///C:/a////b//c.js"), "file:///C:/a/b/c.js");
+    assert_eq!(collapse("file:///C:/a/b.js"), "file:///C:/a/b.js");
+    assert_eq!(
+      collapse("file:///C:/a//b.js?foo=1#bar"),
+      "file:///C:/a/b.js?foo=1#bar"
+    );
+  }
+
+  #[test]
   fn pkg_json_resolution() {
     let sys = InMemorySys::default();
     sys.fs_insert_json(

--- a/tests/specs/run/non_normalized_specifier_cycle/__test__.jsonc
+++ b/tests/specs/run/non_normalized_specifier_cycle/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tests": {
+    "run": {
+      "args": "run b.js",
+      "output": "4\n"
+    },
+    "check": {
+      "args": "check --quiet b.js",
+      "output": "",
+      "exitCode": 0
+    }
+  }
+}

--- a/tests/specs/run/non_normalized_specifier_cycle/a.js
+++ b/tests/specs/run/non_normalized_specifier_cycle/a.js
@@ -1,0 +1,2 @@
+export * from "./b.js";
+export const deps = 4;

--- a/tests/specs/run/non_normalized_specifier_cycle/b.js
+++ b/tests/specs/run/non_normalized_specifier_cycle/b.js
@@ -1,0 +1,2 @@
+import { deps } from ".//a.js";
+console.log(deps);


### PR DESCRIPTION
A non-normalized relative import such as `import { x } from ".//a.js"`
resolves to a file URL with an empty path segment (`file:///dir//a.js`).
In a cyclic import graph this empty segment accumulates one more slash on
every cycle, so each pass produces a distinct specifier that never dedupes
against the already-loaded module. The graph builder keeps recursing until
the path exceeds the OS file name length limit and fails with
"File name too long". Node resolves the same program without issue.

The resolved specifier wasn't being normalized because
`deno_path_util::normalize_path` intentionally leaves a lone `//` in place.
This collapses redundant path segments in resolved `file:` specifiers via
`Path::components()`, so the referrer in the next cycle is already
normalized and the import cycle terminates, matching Node.

Fixes #23821