### PR TITLE
fix: support --inspect family in NODE_OPTIONS

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -4351,10 +4351,26 @@ thread_local! {
   static TEST_NODE_OPTIONS: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
 }
 
+/// Whether `word` is a `--inspect`, `--inspect-brk`, or `--inspect-wait` flag
+/// (with or without a `=value` suffix), as it might appear in `NODE_OPTIONS`.
+/// Note `--inspect-publish-uid` is intentionally excluded here; it's handled
+/// separately.
+fn is_inspect_node_option(word: &str) -> bool {
+  ["--inspect", "--inspect-brk", "--inspect-wait"]
+    .iter()
+    .any(|name| {
+      word == *name
+        || word
+          .strip_prefix(name)
+          .is_some_and(|rest| rest.starts_with('='))
+    })
+}
+
 /// Reads some flags from NODE_OPTIONS:
 /// https://nodejs.org/api/cli.html#node_optionsoptions
 /// Currently supports:
 /// - `--require` / `-r`
+/// - `--inspect` / `--inspect-brk` / `--inspect-wait`
 /// - `--inspect-publish-uid`
 fn apply_node_options(flags: &mut Flags) {
   let node_options = match std::env::var("NODE_OPTIONS") {
@@ -4383,19 +4399,18 @@ fn apply_node_options(flags: &mut Flags) {
         *prev_was_require = true;
         return Some((word, true));
       }
-      if word.starts_with("--inspect-publish-uid=") || *prev_was_require {
-        *prev_was_require = false;
-        return Some((word, true));
-      }
+      let keep = *prev_was_require
+        || word.starts_with("--inspect-publish-uid=")
+        || is_inspect_node_option(word);
       *prev_was_require = false;
-      Some((word, false))
+      Some((word, keep))
     })
     .filter_map(|(word, should_keep)| should_keep.then_some(word));
 
-  let cmd = Command::new("node-options-parser")
-    .arg(require_arg().short('r'))
-    .arg(inspect_publish_uid_arg())
-    .ignore_errors(true);
+  let cmd = inspect_args(
+    Command::new("node-options-parser").arg(require_arg().short('r')),
+  )
+  .ignore_errors(true);
   let mut matches =
     cmd.get_matches_from(std::iter::once("node-options-parser").chain(args));
 
@@ -4405,6 +4420,18 @@ fn apply_node_options(flags: &mut Flags) {
     flags.require = merged_require;
   }
 
+  // `--inspect`, `--inspect-brk`, and `--inspect-wait` are mutually exclusive,
+  // so only apply them from NODE_OPTIONS if the user didn't pass any inspector
+  // flag on the command line. An explicit CLI flag takes precedence over the
+  // whole NODE_OPTIONS inspector family.
+  if flags.inspect.is_none()
+    && flags.inspect_brk.is_none()
+    && flags.inspect_wait.is_none()
+  {
+    flags.inspect = matches.remove_one::<SocketAddr>("inspect");
+    flags.inspect_brk = matches.remove_one::<SocketAddr>("inspect-brk");
+    flags.inspect_wait = matches.remove_one::<SocketAddr>("inspect-wait");
+  }
   if flags.inspect_publish_uid.is_none() {
     flags.inspect_publish_uid =
       matches.remove_one::<InspectPublishUid>("inspect-publish-uid");
@@ -16461,6 +16488,52 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
         http: false,
       })
     );
+  }
+
+  #[test]
+  fn node_options_inspect() {
+    set_test_node_options(Some("--inspect=127.0.0.1:9333"));
+    let flags = flags_from_vec(svec!["deno", "run", "script.ts",]).unwrap();
+    set_test_node_options(None);
+    assert_eq!(flags.inspect, Some("127.0.0.1:9333".parse().unwrap()));
+  }
+
+  #[test]
+  fn node_options_inspect_default_address() {
+    set_test_node_options(Some("--inspect"));
+    let flags = flags_from_vec(svec!["deno", "run", "script.ts",]).unwrap();
+    set_test_node_options(None);
+    assert_eq!(flags.inspect, Some("127.0.0.1:9229".parse().unwrap()));
+  }
+
+  #[test]
+  fn node_options_inspect_brk_and_wait() {
+    set_test_node_options(Some("--inspect-brk=127.0.0.1:9334"));
+    let flags = flags_from_vec(svec!["deno", "run", "script.ts",]).unwrap();
+    set_test_node_options(None);
+    assert_eq!(flags.inspect_brk, Some("127.0.0.1:9334".parse().unwrap()));
+
+    set_test_node_options(Some("--inspect-wait=127.0.0.1:9335"));
+    let flags = flags_from_vec(svec!["deno", "run", "script.ts",]).unwrap();
+    set_test_node_options(None);
+    assert_eq!(flags.inspect_wait, Some("127.0.0.1:9335".parse().unwrap()));
+  }
+
+  #[test]
+  fn node_options_inspect_cli_precedence() {
+    // An explicit CLI inspector flag suppresses the entire NODE_OPTIONS
+    // inspector family, since --inspect/-brk/-wait are mutually exclusive.
+    set_test_node_options(Some("--inspect=127.0.0.1:9333"));
+    let flags = flags_from_vec(svec![
+      "deno",
+      "run",
+      "--inspect-brk=127.0.0.1:9444",
+      "script.ts",
+    ])
+    .unwrap();
+    set_test_node_options(None);
+    assert_eq!(flags.inspect, None);
+    assert_eq!(flags.inspect_brk, Some("127.0.0.1:9444".parse().unwrap()));
   }
 
   #[test]

--- a/ext/node/polyfills/internal/cluster/primary.ts
+++ b/ext/node/polyfills/internal/cluster/primary.ts
@@ -40,6 +40,17 @@ const {
 const SCHED_NONE = 1;
 const SCHED_RR = 2;
 
+// Inspector port range and per-worker offset, mirroring
+// lib/internal/cluster/primary.js. When the inspector is activated, each
+// worker needs a distinct port so they don't collide on the default (9229).
+const minPort = 1024;
+const maxPort = 65535;
+// Matches the inspector activation/port flags Node looks for. Mirrors the
+// `debugArgRegex` in lib/internal/cluster/primary.js, which also matches
+// `--inspect-wait` via its `--inspect` prefix.
+const debugArgRegex = /--inspect(?:-brk|-port|-wait)?|--debug-port/;
+let debugPortOffset = 1;
+
 let initialized = false;
 
 // Initialize primary-side state and methods on the shared cluster object.
@@ -123,6 +134,42 @@ function init(cluster: any) {
     }
 
     const execArgv = [...(cluster.settings.execArgv || [])];
+
+    // If the inspector is activated (via execArgv or the inherited
+    // NODE_OPTIONS), give each worker its own port so they don't all try to
+    // bind the default 9229. Node appends `--inspect-port=<port>` to execArgv
+    // and lets it combine with the NODE_OPTIONS activation flag. Deno doesn't
+    // carry `--inspect-port` as a runtime flag, so we instead append an
+    // activating `--inspect[-brk|-wait]=host:port`; an explicit CLI inspector
+    // flag takes precedence over the inherited NODE_OPTIONS one, so the worker
+    // ends up bound to the unique port.
+    const nodeOptions = (process as any).env.NODE_OPTIONS ?? "";
+    const inspectSource =
+      execArgv.find((arg: string) => debugArgRegex.test(arg)) ??
+        (debugArgRegex.test(nodeOptions) ? nodeOptions : undefined);
+    if (inspectSource !== undefined) {
+      let inspectPort;
+      if ("inspectPort" in cluster.settings) {
+        inspectPort = typeof cluster.settings.inspectPort === "function"
+          ? cluster.settings.inspectPort()
+          : cluster.settings.inspectPort;
+      } else {
+        inspectPort = (process as any).debugPort + debugPortOffset;
+        if (inspectPort > maxPort) {
+          inspectPort = inspectPort - maxPort + minPort - 1;
+        }
+        debugPortOffset++;
+      }
+      // A falsy port (e.g. 0) means "pick a free port"; leave it to the worker.
+      if (inspectPort) {
+        const flag = /--inspect-brk\b/.test(inspectSource)
+          ? "--inspect-brk"
+          : /--inspect-wait\b/.test(inspectSource)
+          ? "--inspect-wait"
+          : "--inspect";
+        execArgv.push(`${flag}=127.0.0.1:${inspectPort}`);
+      }
+    }
 
     return lazyChildProcess().fork(
       cluster.settings.exec,


### PR DESCRIPTION
Deno already reads a couple of flags from `NODE_OPTIONS` (`--require`/`-r`
and `--inspect-publish-uid`), but it filtered out the inspector activation
flags. Node honors `--inspect`, `--inspect-brk`, and `--inspect-wait` via
`NODE_OPTIONS`, and tooling that activates the inspector through the
environment rather than an explicit flag relies on this. The most common
case is VS Code's "JavaScript Debug Terminal", which auto-attaches by
injecting environment variables into the terminal so any launched process
starts its inspector; without honoring these flags, `deno run` in that
terminal never starts the inspector.

This extends `apply_node_options` to also parse `--inspect`,
`--inspect-brk`, and `--inspect-wait` from `NODE_OPTIONS`. Since the three
are mutually exclusive, an explicit inspector flag passed on the command
line suppresses the entire `NODE_OPTIONS` inspector family, so a CLI flag
always takes precedence.

You can verify it with:

```
echo 'console.log("hello")' > dbg.ts
NODE_OPTIONS='--inspect' deno run dbg.ts   # now prints "Debugger listening on ws://127.0.0.1:9229/..."
```

Tests are added for the new behavior, the default address, and CLI
precedence.

This is a step towards #19328 (full VS Code JavaScript Debug Terminal
support may still need changes in the vscode_deno extension to inject the
appropriate environment, but the runtime side now supports env-based
inspector activation).



Closes #28474.
