### PR TITLE
fix(ext/fs): error when copyFile source and destination are the same file

### DIFF
--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -640,11 +640,13 @@ fn remove(path: &Path, recursive: bool) -> FsResult<()> {
 fn copy_file(from: &Path, to: &Path) -> FsResult<()> {
   // Guard against copying a file onto itself. Otherwise the destination is
   // opened with truncation (or unlinked) before the source is read, which
-  // silently empties the file. Match `cp` behavior and error instead. This
-  // only triggers when both paths resolve to the same existing file; the
-  // common case where `to` does not yet exist fails to canonicalize and is
-  // skipped.
-  if let (Ok(from_real), Ok(to_real)) = (from.canonicalize(), to.canonicalize())
+  // silently empties the file. Match `cp` behavior and error instead. The
+  // `to` path is canonicalized first so the common case where it does not yet
+  // exist fails fast and skips canonicalizing `from` entirely; the full check
+  // only runs when overwriting an existing file, and it also catches
+  // equivalent paths such as `./`, `..` and symlinks.
+  if let Ok(to_real) = to.canonicalize()
+    && let Ok(from_real) = from.canonicalize()
     && from_real == to_real
   {
     return Err(

--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -638,6 +638,24 @@ fn remove(path: &Path, recursive: bool) -> FsResult<()> {
 }
 
 fn copy_file(from: &Path, to: &Path) -> FsResult<()> {
+  // Guard against copying a file onto itself. Otherwise the destination is
+  // opened with truncation (or unlinked) before the source is read, which
+  // silently empties the file. Match `cp` behavior and error instead. This
+  // only triggers when both paths resolve to the same existing file; the
+  // common case where `to` does not yet exist fails to canonicalize and is
+  // skipped.
+  if let (Ok(from_real), Ok(to_real)) = (from.canonicalize(), to.canonicalize())
+    && from_real == to_real
+  {
+    return Err(
+      io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "Source and destination paths refer to the same file",
+      )
+      .into(),
+    );
+  }
+
   #[cfg(target_os = "macos")]
   {
     use std::ffi::CString;

--- a/tests/unit/copy_file_test.ts
+++ b/tests/unit/copy_file_test.ts
@@ -266,3 +266,34 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  { permissions: { read: true, write: true } },
+  function copyFileSyncSamePathThrows() {
+    const tempDir = Deno.makeTempDirSync();
+    const filename = tempDir + "/file.txt";
+    writeFileString(filename, "Hello world!");
+    // Copying a file onto itself must not truncate it.
+    assertThrows(() => Deno.copyFileSync(filename, filename), TypeError);
+    // An equivalent-but-different path resolving to the same file too.
+    Deno.mkdirSync(tempDir + "/sub");
+    assertThrows(
+      () => Deno.copyFileSync(filename, tempDir + "/sub/../file.txt"),
+      TypeError,
+    );
+    assertEquals(readFileString(filename), "Hello world!");
+    Deno.removeSync(tempDir, { recursive: true });
+  },
+);
+
+Deno.test(
+  { permissions: { read: true, write: true } },
+  async function copyFileSamePathThrows() {
+    const tempDir = Deno.makeTempDirSync();
+    const filename = tempDir + "/file.txt";
+    writeFileString(filename, "Hello world!");
+    await assertRejects(() => Deno.copyFile(filename, filename), TypeError);
+    assertEquals(readFileString(filename), "Hello world!");
+    Deno.removeSync(tempDir, { recursive: true });
+  },
+);


### PR DESCRIPTION
Copying a file onto itself with `Deno.copyFile()` silently destroyed its
contents. The implementation opens the destination with truncation (or
unlinks it) before reading the source, so when both paths point at the same
file the read loop runs against an already-emptied file, leaving it zero
bytes. This is easy to hit when source and destination are derived
separately and happen to resolve to the same path.

This adds a guard in the shared `copy_file` used by both the sync and async
ops that errors when the two paths canonicalize to the same existing file,
matching `cp` behavior. The check is skipped in the common case where the
destination does not yet exist (canonicalization fails), so it only adds
cost when overwriting an existing file, and it also catches equivalent paths
such as `./`, `..` and symlinks.

Closes #21449