### PR TITLE
fix(runtime): throw a descriptive error for disabled __proto__ accessor

### DIFF
--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -718,6 +718,33 @@ const executionModes = {
   jupyter: 8,
 };
 
+// By default Deno disables the `Object.prototype.__proto__` accessor for
+// security reasons (it can be used for prototype pollution), see
+// https://tc39.es/ecma262/#sec-get-object.prototype.__proto__
+//
+// Instead of `delete`-ing the property (which silently turns `obj.__proto__`
+// reads into `undefined` and writes into a useless own property, making bugs
+// hard to track down) we replace it with an accessor that throws a descriptive
+// error, similar to Node's `--disable-proto=throw`. The `__proto__` key in
+// object literals (e.g. `{ __proto__: null }`) is separate syntax and keeps
+// working. The `--unstable-unsafe-proto` flag restores the native accessor.
+function disableProtoAccessor() {
+  function throwDisabledProto() {
+    throw new TypeError(
+      'The "Object.prototype.__proto__" accessor is disabled. Use ' +
+        "Object.getPrototypeOf()/Object.setPrototypeOf() instead, or run with " +
+        "--unstable-unsafe-proto to restore it.",
+    );
+  }
+  ObjectDefineProperty(Object.prototype, "__proto__", {
+    __proto__: null,
+    configurable: true,
+    enumerable: false,
+    get: throwDisabledProto,
+    set: throwDisabledProto,
+  });
+}
+
 function bootstrapMainRuntime(runtimeOptions, warmup = false) {
   if (!warmup) {
     if (hasBootstrapped) {
@@ -910,9 +937,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
     }
 
     if (!ArrayPrototypeIncludes(unstableFeatures, unstableIds.unsafeProto)) {
-      // Removes the `__proto__` for security reasons.
-      // https://tc39.es/ecma262/#sec-get-object.prototype.__proto__
-      delete Object.prototype.__proto__;
+      disableProtoAccessor();
     }
 
     // Setup `Deno` global - we're actually overriding already existing global
@@ -1042,9 +1067,7 @@ function bootstrapWorkerRuntime(
     delete finalDenoNs.mainModule;
 
     if (!ArrayPrototypeIncludes(unstableFeatures, unstableIds.unsafeProto)) {
-      // Removes the `__proto__` for security reasons.
-      // https://tc39.es/ecma262/#sec-get-object.prototype.__proto__
-      delete Object.prototype.__proto__;
+      disableProtoAccessor();
     }
 
     // Setup `Deno` global - we're actually overriding already existing global

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -40,6 +40,7 @@ const {
   ObjectGetOwnPropertyDescriptors,
   ObjectHasOwn,
   ObjectKeys,
+  ObjectPrototype,
   ObjectPrototypeIsPrototypeOf,
   ObjectSetPrototypeOf,
   PromisePrototypeThen,
@@ -736,7 +737,7 @@ function disableProtoAccessor() {
         "--unstable-unsafe-proto to restore it.",
     );
   }
-  ObjectDefineProperty(Object.prototype, "__proto__", {
+  ObjectDefineProperty(ObjectPrototype, "__proto__", {
     __proto__: null,
     configurable: true,
     enumerable: false,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -737,12 +737,20 @@ function disableProtoAccessor() {
         "--unstable-unsafe-proto to restore it.",
     );
   }
+  // The getter and setter must be distinct function objects: the native
+  // `__proto__` accessor has separate get/set functions, and WPT
+  // (webidl/ecmascript-binding/attributes-accessors-unique-function-objects)
+  // asserts every accessor's getter and setter are unique built-in functions.
   ObjectDefineProperty(ObjectPrototype, "__proto__", {
     __proto__: null,
     configurable: true,
     enumerable: false,
-    get: throwDisabledProto,
-    set: throwDisabledProto,
+    get: function __proto__() {
+      throwDisabledProto();
+    },
+    set: function __proto__(_value) {
+      throwDisabledProto();
+    },
   });
 }
 

--- a/tests/registry/npm/@denotest/unsafe-proto-bin/1.0.0/cli.mjs
+++ b/tests/registry/npm/@denotest/unsafe-proto-bin/1.0.0/cli.mjs
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 
-const hasUnsafeProto = Object.hasOwn(Object.prototype, "__proto__");
+let hasUnsafeProto;
+try {
+  // When the `__proto__` accessor is disabled this throws; with
+  // --unstable-unsafe-proto the native accessor returns the prototype.
+  ({}).__proto__;
+  hasUnsafeProto = true;
+} catch {
+  hasUnsafeProto = false;
+}
 if (hasUnsafeProto) {
   console.log("unsafe proto enabled");
 } else {

--- a/tests/specs/run/proto_exploit/proto_exploit.js
+++ b/tests/specs/run/proto_exploit/proto_exploit.js
@@ -1,5 +1,15 @@
 const payload = `{ "__proto__": null }`;
 const obj = {};
 console.log("Before: " + obj);
-Object.assign(obj, JSON.parse(payload));
-console.log("After: " + obj);
+// Assigning a `__proto__` key now goes through the disabled accessor and
+// throws, instead of silently creating an own property. Prototype pollution
+// is still prevented.
+try {
+  Object.assign(obj, JSON.parse(payload));
+  console.log("After: " + obj);
+} catch (e) {
+  console.log("Throws: " + (e instanceof TypeError));
+}
+console.log(
+  "Prototype intact: " + (Object.getPrototypeOf(obj) === Object.prototype),
+);

--- a/tests/specs/run/proto_exploit/proto_exploit.js.out
+++ b/tests/specs/run/proto_exploit/proto_exploit.js.out
@@ -1,2 +1,3 @@
 Before: [object Object]
-After: [object Object]
+Throws: true
+Prototype intact: true

--- a/tests/specs/run/unsafe_proto/main.js
+++ b/tests/specs/run/unsafe_proto/main.js
@@ -1,4 +1,12 @@
-console.log(Object.hasOwn(Object.prototype, "__proto__"));
+// The `__proto__` accessor is disabled by default. Reading it throws a
+// descriptive TypeError instead of silently returning `undefined`.
+try {
+  ({}).__proto__;
+  console.log("did not throw");
+} catch (e) {
+  console.log(e instanceof TypeError);
+  console.log(e.message);
+}
 
 new Worker(import.meta.resolve("./worker.js"), {
   type: "module",

--- a/tests/specs/run/unsafe_proto/main.out
+++ b/tests/specs/run/unsafe_proto/main.out
@@ -1,2 +1,3 @@
-false
-false
+true
+The "Object.prototype.__proto__" accessor is disabled. Use Object.getPrototypeOf()/Object.setPrototypeOf() instead, or run with --unstable-unsafe-proto to restore it.
+true

--- a/tests/specs/run/unsafe_proto/worker.js
+++ b/tests/specs/run/unsafe_proto/worker.js
@@ -1,2 +1,8 @@
-console.log(Object.hasOwn(Object.prototype, "__proto__"));
+// Writing through the `__proto__` accessor throws as well.
+try {
+  ({}).__proto__ = {};
+  console.log("did not throw");
+} catch (e) {
+  console.log(e instanceof TypeError);
+}
 close();


### PR DESCRIPTION
Deno disables the `Object.prototype.__proto__` accessor by default to
guard against prototype pollution. It did this by deleting the property,
which means `obj.__proto__` reads silently return `undefined` and writes
silently create a useless own property without changing the prototype.
These quiet failures are hard to track down when code accidentally
relies on `__proto__`.

This replaces the deletion with an accessor that throws a descriptive
`TypeError` on read or write, matching the behavior of Node's
`--disable-proto=throw`. The security property is unchanged (prototype
pollution is still prevented) and the `__proto__` object-literal syntax
(`{ __proto__: null }`) keeps working since it bypasses the accessor.
The `--unstable-unsafe-proto` flag still restores the native accessor.