### PR TITLE
perf(ext/fs): use file identity instead of canonicalize in copyFile same-path guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,6 +2352,7 @@ dependencies = [
  "nix 0.30.1",
  "rand 0.8.5",
  "rayon",
+ "same-file",
  "serde",
  "thiserror 2.0.12",
  "windows-sys 0.59.0",

--- a/ext/fs/Cargo.toml
+++ b/ext/fs/Cargo.toml
@@ -29,6 +29,7 @@ filetime.workspace = true
 libc.workspace = true
 rand.workspace = true
 rayon.workspace = true
+same-file.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 

--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -640,15 +640,16 @@ fn remove(path: &Path, recursive: bool) -> FsResult<()> {
 fn copy_file(from: &Path, to: &Path) -> FsResult<()> {
   // Guard against copying a file onto itself. Otherwise the destination is
   // opened with truncation (or unlinked) before the source is read, which
-  // silently empties the file. Match `cp` behavior and error instead. The
-  // `to` path is canonicalized first so the common case where it does not yet
-  // exist fails fast and skips canonicalizing `from` entirely; the full check
-  // only runs when overwriting an existing file, and it also catches
-  // equivalent paths such as `./`, `..` and symlinks.
-  if let Ok(to_real) = to.canonicalize()
-    && let Ok(from_real) = from.canonicalize()
-    && from_real == to_real
-  {
+  // silently empties the file. Match `cp` behavior and error instead.
+  //
+  // `same_file::is_same_file` compares the file identity (device + inode on
+  // Unix, file index + volume serial via the open handle on Windows) using a
+  // single stat per path, rather than fully canonicalizing both paths which
+  // would `lstat`/`readlink` every component twice. It still catches
+  // equivalent paths such as `./`, `..`, symlinks and hard links, and returns
+  // `Err` (treated as "not the same file") in the common case where the
+  // destination does not yet exist.
+  if same_file::is_same_file(from, to).unwrap_or(false) {
     return Err(
       io::Error::new(
         io::ErrorKind::InvalidInput,


### PR DESCRIPTION
The same-path guard added in #34718 calls `Path::canonicalize` on both the
source and destination before every `copyFile`. On Unix that resolves to
`realpath`, which `lstat`/`readlink`s every component of each path, so the
cost is proportional to path depth and is paid twice on each call. A quick
microbenchmark on macOS put the two `canonicalize` calls at ~13us for a
shallow path and ~28us for an eight-level path, versus ~2.5us flat for a
device+inode comparison; on a 4KB copy that is roughly +7% overhead from the
guard, growing with depth.

This swaps the guard to `same_file::is_same_file`, which compares the file's
identity (device + inode on Unix, file index + volume serial via the open
handle on Windows) with a single stat per path. It is constant time
regardless of path depth, still rejects equivalent paths such as `./`, `..`,
symlinks and hard links, and treats a missing destination as "not the same
file" so the common create-new-file case stays cheap. `same-file` is already
in the dependency tree, so this adds no new third-party code.