### PR TITLE
feat(jupyter): support Variables view via debug protocol

### DIFF
--- a/cli/js/jupyter_kernel.js
+++ b/cli/js/jupyter_kernel.js
@@ -476,6 +476,9 @@ async function startJupyterKernel() {
   let currentParentHeader = {};
   let currentAllowStdin = false;
   let shuttingDown = false;
+  // Monotonic sequence number for Debug Adapter Protocol responses sent over
+  // the control channel (debug_reply). See handleDebugRequest.
+  let dapSeq = 1;
 
   async function publishStatus(status, parentHeader) {
     const frames = await encodeMsg(
@@ -541,7 +544,11 @@ async function startJupyterKernel() {
       },
       banner: "Welcome to Deno kernel",
       help_links: [{ text: "Visit Deno manual", url: "https://docs.deno.com" }],
-      debugger: false,
+      // Advertise debugger support so frontends (e.g. VSCode) engage the
+      // Jupyter debug protocol. We implement just enough of it to populate the
+      // notebook Variables view via `inspectVariables`. See handleDebugRequest
+      // and denoland/deno#26068.
+      debugger: true,
     };
   }
 
@@ -978,7 +985,137 @@ async function startJupyterKernel() {
       );
       await socket.send(peerId, [peerId, ...replyFrames]);
     } else if (msgType === "debug_request") {
-      // Not supported
+      const dapRequest = msg.content || {};
+      const body = await handleDebugRequest(dapRequest);
+      const replyFrames = await encodeMsg(
+        session,
+        key,
+        [],
+        "debug_reply",
+        {
+          type: "response",
+          seq: dapSeq++,
+          request_seq: dapRequest.seq,
+          success: true,
+          command: dapRequest.command,
+          body,
+        },
+        parentHeader,
+      );
+      await socket.send(peerId, [peerId, ...replyFrames]);
+    }
+  }
+
+  // --- Jupyter debug protocol (Variables view) -------------------------------
+  //
+  // VSCode and other frontends populate the notebook Variables table by driving
+  // the kernel over the Debug Adapter Protocol, wrapped in Jupyter
+  // debug_request/debug_reply messages on the control channel. We implement the
+  // minimal subset needed to enumerate top-level variables; full stepping
+  // debugging is not supported. See denoland/deno#26068.
+
+  // Turn a CDP RemoteObject into a DAP-friendly { value, type } pair.
+  function formatRemoteObject(remoteObject) {
+    if (!remoteObject) return { value: "undefined", type: "undefined" };
+    const type = remoteObject.type || "undefined";
+    let value;
+    if (type === "string") {
+      value = JSON.stringify(
+        remoteObject.value ?? remoteObject.description ?? "",
+      );
+    } else if (remoteObject.description != null) {
+      // Objects, arrays, functions, etc. carry a human-readable description.
+      value = remoteObject.description;
+    } else if (remoteObject.unserializableValue != null) {
+      // NaN, Infinity, -0, BigInt literals.
+      value = remoteObject.unserializableValue;
+    } else {
+      value = String(remoteObject.value);
+    }
+    return { value, type };
+  }
+
+  // Evaluate a top-level binding name without side effects on the REPL output,
+  // returning its CDP RemoteObject (or null if evaluation failed).
+  async function evaluateName(name) {
+    try {
+      // op_jupyter_repl_evaluate returns a CDP EvaluateResponse:
+      // { result: RemoteObject, exceptionDetails?: ExceptionDetails }.
+      const resp = await op_jupyter_repl_evaluate(`(${name})`);
+      if (resp?.exceptionDetails) return null;
+      return resp?.result ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  // Collect the kernel's top-level variables as DAP Variable entries. Uses the
+  // global lexical scope (top-level let/const/class declarations), which is
+  // where notebook variables live. var-declared and bare-assigned globals are
+  // not yet included.
+  async function collectVariables() {
+    let names = [];
+    try {
+      const resp = await op_jupyter_repl_global_lexical_scope_names();
+      names = resp?.names || [];
+    } catch {
+      names = [];
+    }
+    const variables = [];
+    for (const name of names) {
+      const { value, type } = formatRemoteObject(await evaluateName(name));
+      variables.push({
+        name,
+        value,
+        type,
+        variablesReference: 0,
+        evaluateName: name,
+      });
+    }
+    return variables;
+  }
+
+  async function handleDebugRequest(dapRequest) {
+    const command = dapRequest?.command;
+    switch (command) {
+      case "initialize":
+        // DAP InitializeResponse body is a Capabilities object. We support no
+        // optional capabilities; an empty object means everything defaults off.
+        return {};
+      case "debugInfo":
+        // Jupyter-specific request describing debugger state. Reporting
+        // isStarted lets the frontend proceed straight to inspectVariables.
+        return {
+          isStarted: true,
+          hashMethod: "Murmur2",
+          hashSeed: 0,
+          tmpFilePrefix: "",
+          tmpFileSuffix: "",
+          breakpoints: [],
+          stoppedThreads: [],
+          richRendering: true,
+          exceptionPaths: [],
+        };
+      case "inspectVariables":
+        // Powers the Variables table.
+        return { variables: await collectVariables() };
+      case "richInspectVariables": {
+        // Used by "show variable in data viewer"/hover. Return a plain-text
+        // mimebundle of the variable's value.
+        const name = dapRequest?.arguments?.variableName;
+        const { value } = formatRemoteObject(
+          name ? await evaluateName(name) : null,
+        );
+        return { data: { "text/plain": value }, metadata: {} };
+      }
+      case "attach":
+      case "configurationDone":
+      case "disconnect":
+        return {};
+      default:
+        // Unknown/unsupported DAP command: ack with an empty body so the
+        // frontend's debug session stays alive instead of erroring out.
+        return {};
     }
   }
 

--- a/tests/integration/jupyter_tests.rs
+++ b/tests/integration/jupyter_tests.rs
@@ -567,6 +567,85 @@ async fn jupyter_execute_request() -> Result<()> {
 }
 
 #[test]
+async fn jupyter_kernel_info_advertises_debugger() -> Result<()> {
+  let (_ctx, client, _process) = setup().await;
+  client
+    .send(Control, "kernel_info_request", json!({}))
+    .await?;
+  let msg = client.recv(Control).await?;
+  assert_eq!(msg.header.msg_type, "kernel_info_reply");
+  // The Variables view is only engaged by frontends when the kernel advertises
+  // debugger support. See denoland/deno#26068.
+  assert_json_subset(msg.content, json!({ "debugger": true }));
+
+  Ok(())
+}
+
+#[test]
+async fn jupyter_debug_inspect_variables() -> Result<()> {
+  let (_ctx, client, _process) = setup().await;
+
+  // Define top-level variables in the kernel.
+  client
+    .send(
+      Shell,
+      "execute_request",
+      json!({
+        "silent": false,
+        "store_history": true,
+        "user_expressions": {},
+        "allow_stdin": true,
+        "stop_on_error": false,
+        "code": "let x = 42; let y = \"hi\"; const arr = [1, 2, 3];"
+      }),
+    )
+    .await?;
+  let reply = client.recv(Shell).await?;
+  assert_eq!(reply.header.msg_type, "execute_reply");
+  assert_json_subset(reply.content, json!({ "status": "ok" }));
+
+  // Ask the kernel for its variables over the Jupyter debug protocol.
+  client
+    .send(
+      Control,
+      "debug_request",
+      json!({
+        "type": "request",
+        "seq": 1,
+        "command": "inspectVariables",
+        "arguments": {}
+      }),
+    )
+    .await?;
+  let msg = client.recv(Control).await?;
+  assert_eq!(msg.header.msg_type, "debug_reply");
+  assert_json_subset(
+    msg.content.clone(),
+    json!({ "success": true, "command": "inspectVariables" }),
+  );
+
+  let variables = msg
+    .content
+    .get("body")
+    .and_then(|b| b.get("variables"))
+    .and_then(|v| v.as_array())
+    .expect("debug_reply body.variables array");
+  let find = |name: &str| {
+    variables
+      .iter()
+      .find(|v| v.get("name").and_then(|n| n.as_str()) == Some(name))
+      .unwrap_or_else(|| panic!("variable {name} not found in {variables:#?}"))
+      .clone()
+  };
+
+  assert_json_subset(find("x"), json!({ "value": "42", "type": "number" }));
+  assert_json_subset(find("y"), json!({ "value": "\"hi\"", "type": "string" }));
+  assert_json_subset(find("arr"), json!({ "type": "object" }));
+
+  Ok(())
+}
+
+#[test]
 async fn jupyter_store_history_false() -> Result<()> {
   let (_ctx, client, _process) = setup().await;
   client


### PR DESCRIPTION
VSCode and other notebook frontends populate the Variables table by
driving the kernel over the Jupyter debug protocol (Debug Adapter
Protocol requests wrapped in debug_request/debug_reply on the control
channel), and they only engage it when the kernel advertises debugger
support in its kernel_info reply. The JS kernel reported
debugger: false and its debug_request handler was a no-op, so the
Variables view was always empty.

This advertises debugger: true and implements the minimal subset of the
debug protocol needed to enumerate top-level variables: initialize,
attach, configurationDone, debugInfo, inspectVariables and
richInspectVariables. inspectVariables walks the global lexical scope
(top-level let/const/class declarations, which is where notebook
variables live), evaluates each binding through the existing REPL
session, and maps the resulting CDP RemoteObject to a DAP variable
({ name, value, type, variablesReference, evaluateName }).
richInspectVariables returns a plain-text mimebundle for the data
viewer. Unknown commands are acknowledged with an empty body so the
frontend's debug session stays alive.

Two integration tests drive the real kernel over ZMQ: one asserts the
debugger advertisement, the other defines variables and checks the
inspectVariables round-trip returns them with the right values and
types.

This is intentionally a first cut and is left as a draft. Known gaps to
resolve before it lands: only top-level let/const/class are listed
(var-declared and bare-assigned globals are not yet included);
variablesReference is always 0, so objects and arrays do not expand in
the UI yet; and full stepping debugging remains unsupported.

Towards #26068.