### PR TITLE
fix(jupyter): make kernel ZMTP handshake compatible with libzmq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +386,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1478,6 +1509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,7 +1533,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.34",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -3317,7 +3357,7 @@ dependencies = [
  "quinn",
  "serde",
  "serde_json",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4378,7 +4418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -5440,7 +5480,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -5884,6 +5924,7 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
+ "zeromq",
 ]
 
 [[package]]
@@ -6207,9 +6248,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -6349,6 +6390,12 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -7654,6 +7701,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8438,8 +8499,21 @@ dependencies = [
  "bitflags 2.9.3",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.13",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.9.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8591,6 +8665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
 
 [[package]]
+name = "saa"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8628,6 +8708,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcd12b6caff5213cc3c03123cde8c3db5e413008a63b0c0ba35e6275825ea92"
+dependencies = [
+ "saa",
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8657,6 +8747,15 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
+]
+
+[[package]]
+name = "sdd"
+version = "4.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f0e40a01b94e35d1dacbcfbe5bfd3d31e37d9590b2e6d86a82b0e87bd4f551"
+dependencies = [
+ "saa",
 ]
 
 [[package]]
@@ -9102,12 +9201,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9811,7 +9910,7 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -9864,7 +9963,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix",
+ "rustix 0.38.34",
  "windows-sys 0.59.0",
 ]
 
@@ -10167,7 +10266,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -11238,7 +11337,7 @@ checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
 dependencies = [
  "either",
  "home",
- "rustix",
+ "rustix 0.38.34",
  "winsafe",
 ]
 
@@ -11283,6 +11382,17 @@ checksum = "8c6a6724ccfbf34154a8691bd868b0fcd2be2ca3f7b47b32614654f1a01b191c"
 dependencies = [
  "thiserror 1.0.69",
  "windows 0.61.3",
+]
+
+[[package]]
+name = "win_uds"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd30a1a28a3799479cbf4e17284a220ea9ff6bad098a9d0224543a5d1efe1da"
+dependencies = [
+ "async-io",
+ "futures-io",
+ "socket2 0.6.4",
 ]
 
 [[package]]
@@ -11595,6 +11705,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12020,8 +12139,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "linux-raw-sys 0.4.13",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -12185,6 +12304,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zeromq"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2c254fd8f366755335c9e43b865f8484fe3bd717d65ffe7c3f28852863030"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "crossbeam-queue",
+ "futures",
+ "log",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.2",
+ "regex",
+ "scc",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "uuid",
+ "win_uds",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,6 +326,7 @@ webpki-root-certs = "0.26.5"
 webpki-roots = "0.26"
 which = { version = "8.0.0", default-features = false }
 yoke = { version = "0.7.4", features = ["derive"] }
+zeromq = "0.6"
 zip = { version = "2.4.1", default-features = false, features = ["flate2"] }
 
 opentelemetry = "0.27.0"

--- a/cli/js/jupyter_kernel.js
+++ b/cli/js/jupyter_kernel.js
@@ -92,26 +92,39 @@ async function writeAll(conn, buf) {
 }
 
 async function sendFrames(conn, frames) {
-  for (let i = 0; i < frames.length; i++) {
-    const more = i < frames.length - 1;
-    await writeAll(conn, makeShortFrame(frames[i], more));
+  // Coalesce all ZMTP frames into a single write. libzmq peers
+  // (VSCode/JupyterLab) send each message as one write; emitting many small
+  // writes interacts badly with Nagle/delayed-ACK and can stall delivery.
+  const encoded = frames.map((frame, i) =>
+    makeShortFrame(frame, i < frames.length - 1)
+  );
+  const total = encoded.reduce((acc, f) => acc + f.length, 0);
+  const buf = new Uint8Array(total);
+  let offset = 0;
+  for (const f of encoded) {
+    buf.set(f, offset);
+    offset += f.length;
   }
+  await writeAll(conn, buf);
 }
 
-// --- ZMTP 3.1 handshake --------------------------------------------------------
+// --- ZMTP 3.0 handshake --------------------------------------------------------
 
-function makeGreeting(socketType, asServer) {
+function makeGreeting() {
+  // 64-octet ZMTP greeting: signature (0xff, 8 zero pad, 0x7f), version 3.0,
+  // 20-octet mechanism ("NULL"), as-server flag, 31 filler octets. The NULL
+  // mechanism is symmetric and libzmq (VSCode/JupyterLab) sends as-server=0 with
+  // an all-zero signature pad; a binding peer that sets as-server=1 or a nonzero
+  // pad byte leaves a real libzmq peer in a handshake state where it never
+  // delivers our messages. Mirror what the previous libzmq-based kernel sent.
+  // Regression from #34083 (the JS kernel rewrite).
   const buf = new Uint8Array(64);
   buf[0] = 0xff;
-  // bytes 1..8 are padding zeros
-  buf[8] = 0x01;
   buf[9] = 0x7f;
   buf[10] = 0x03; // version major
-  buf[11] = 0x01; // version minor
-  const mech = ENC.encode("NULL");
-  buf.set(mech, 12);
-  buf[32] = asServer ? 1 : 0;
-  // rest is zeros (filler)
+  buf[11] = 0x00; // version minor
+  buf.set(ENC.encode("NULL"), 12); // mechanism, null-padded to 20 octets
+  buf[32] = 0x00; // as-server
   return buf;
 }
 
@@ -120,10 +133,16 @@ function makeReadyCommand(socketType) {
   const nameBytes = ENC.encode("READY");
   const propName = ENC.encode("Socket-Type");
 
+  // ZMTP command body: <nameLen:1><name><metadata...>. The leading command-name
+  // length octet is mandatory; without it libzmq (VSCode/JupyterLab) parses the
+  // first body byte ('R'=0x52=82) as the name length, fails to parse the
+  // command, and tears down the connection so the handshake never completes.
+  // Regression from #34083 (the JS kernel rewrite).
   // property encoding: <len1:propNameLen><propName><len4:valueLen><value>
   const propLen = 1 + propName.length + 4 + sockBytes.length;
-  const body = new Uint8Array(nameBytes.length + propLen);
+  const body = new Uint8Array(1 + nameBytes.length + propLen);
   let o = 0;
+  body[o++] = nameBytes.length;
   body.set(nameBytes, o);
   o += nameBytes.length;
   body[o++] = propName.length;
@@ -136,17 +155,12 @@ function makeReadyCommand(socketType) {
   return makeShortFrame(body, false, true); // command flag
 }
 
-async function zmtpHandshake(conn, socketType, asServer) {
-  const greeting = makeGreeting(socketType, asServer);
-  await writeAll(conn, greeting);
-
-  // Read peer's greeting (64 bytes)
+async function zmtpHandshake(conn, socketType) {
+  await writeAll(conn, makeGreeting());
+  // Read the peer's 64-octet greeting.
   await readExact(conn, 64);
-
-  // Send READY command
+  // NULL security handshake: exchange READY commands.
   await writeAll(conn, makeReadyCommand(socketType));
-
-  // Read peer's READY command (skip it)
   await readFrame(conn);
 }
 
@@ -277,7 +291,7 @@ async function runHeartbeat(port, ip) {
     const conn = await listener.accept();
     (async () => {
       try {
-        await zmtpHandshake(conn, "REP", true);
+        await zmtpHandshake(conn, "REP");
         while (true) {
           const frames = await recvMultipart(conn);
           // Echo back
@@ -347,7 +361,7 @@ class RouterSocket {
     this.peers.set(peerKey, conn);
     (async () => {
       try {
-        await zmtpHandshake(conn, "ROUTER", true);
+        await zmtpHandshake(conn, "ROUTER");
         while (true) {
           const frames = await recvMultipart(conn);
           this.incoming.push({ peerId, peerKey, frames });
@@ -387,9 +401,8 @@ class RouterSocket {
   async sendAll(frames) {
     const dead = [];
     for (const [peerKey, conn] of this.peers) {
-      const peerId = new Uint8Array(peerKey.split(",").map(Number));
       try {
-        await sendFrames(conn, [peerId, ...frames]);
+        await sendFrames(conn, frames);
       } catch {
         dead.push(peerKey);
       }
@@ -417,7 +430,7 @@ class PubSocket {
         const conn = await listener.accept();
         (async () => {
           try {
-            await zmtpHandshake(conn, "PUB", true);
+            await zmtpHandshake(conn, "PUB");
             // SUB sockets send a SUBSCRIBE command; drain it
             const subFrame = await recvMultipart(conn);
             void subFrame;
@@ -661,7 +674,7 @@ async function startJupyterKernel() {
         replyContent,
         parentHeader,
       );
-      await socket.send(peerId, [peerId, ...replyFrames]);
+      await socket.send(peerId, replyFrames);
       await publishStatus("idle", parentHeader);
       return;
     }
@@ -727,7 +740,7 @@ async function startJupyterKernel() {
           },
           parentHeader,
         );
-        await socket.send(peerId, [peerId, ...replyFrames]);
+        await socket.send(peerId, replyFrames);
       } else {
         // Success: publish the result
         const result = evalResult?.value?.result;
@@ -752,7 +765,7 @@ async function startJupyterKernel() {
           },
           parentHeader,
         );
-        await socket.send(peerId, [peerId, ...replyFrames]);
+        await socket.send(peerId, replyFrames);
       }
     } else {
       // Null result means eval was skipped or interrupted
@@ -770,7 +783,7 @@ async function startJupyterKernel() {
         },
         parentHeader,
       );
-      await socket.send(peerId, [peerId, ...replyFrames]);
+      await socket.send(peerId, replyFrames);
     }
 
     await publishStatus("idle", parentHeader);
@@ -815,7 +828,7 @@ async function startJupyterKernel() {
           kernelInfo(),
           parentHeader,
         );
-        await socket.send(peerId, [peerId, ...replyFrames]);
+        await socket.send(peerId, replyFrames);
       } else if (msgType === "complete_request") {
         const userCode = msg.content?.code || "";
         const cursorPos = msg.content?.cursor_pos || userCode.length;
@@ -855,7 +868,7 @@ async function startJupyterKernel() {
           },
           parentHeader,
         );
-        await socket.send(peerId, [peerId, ...replyFrames]);
+        await socket.send(peerId, replyFrames);
       } else if (msgType === "is_complete_request") {
         const result = checkIsComplete(msg.content?.code || "");
         const replyFrames = await encodeMsg(
@@ -866,7 +879,7 @@ async function startJupyterKernel() {
           result,
           parentHeader,
         );
-        await socket.send(peerId, [peerId, ...replyFrames]);
+        await socket.send(peerId, replyFrames);
       } else if (msgType === "inspect_request") {
         const replyFrames = await encodeMsg(
           session,
@@ -881,7 +894,7 @@ async function startJupyterKernel() {
           },
           parentHeader,
         );
-        await socket.send(peerId, [peerId, ...replyFrames]);
+        await socket.send(peerId, replyFrames);
       } else if (msgType === "history_request") {
         const replyFrames = await encodeMsg(
           session,
@@ -891,7 +904,7 @@ async function startJupyterKernel() {
           { status: "ok", history: [] },
           parentHeader,
         );
-        await socket.send(peerId, [peerId, ...replyFrames]);
+        await socket.send(peerId, replyFrames);
       } else if (msgType === "comm_info_request") {
         const replyFrames = await encodeMsg(
           session,
@@ -901,7 +914,7 @@ async function startJupyterKernel() {
           { status: "ok", comms: {} },
           parentHeader,
         );
-        await socket.send(peerId, [peerId, ...replyFrames]);
+        await socket.send(peerId, replyFrames);
       } else if (msgType === "comm_open") {
         const replyFrames = await encodeMsg(
           session,
@@ -911,7 +924,7 @@ async function startJupyterKernel() {
           { comm_id: msg.content?.comm_id, data: {} },
           parentHeader,
         );
-        await socket.send(peerId, [peerId, ...replyFrames]);
+        await socket.send(peerId, replyFrames);
       }
     } finally {
       await publishStatus("idle", parentHeader);
@@ -947,7 +960,7 @@ async function startJupyterKernel() {
         kernelInfo(),
         parentHeader,
       );
-      await socket.send(peerId, [peerId, ...replyFrames]);
+      await socket.send(peerId, replyFrames);
     } else if (msgType === "shutdown_request") {
       const restart = msg.content?.restart || false;
       const replyFrames = await encodeMsg(
@@ -958,7 +971,7 @@ async function startJupyterKernel() {
         { status: "ok", restart },
         parentHeader,
       );
-      await socket.send(peerId, [peerId, ...replyFrames]);
+      await socket.send(peerId, replyFrames);
       shuttingDown = true;
       // The Jupyter protocol expects the kernel process to exit after
       // sending a shutdown reply. Even on restart the frontend spawns a
@@ -976,7 +989,7 @@ async function startJupyterKernel() {
         { status: "ok" },
         parentHeader,
       );
-      await socket.send(peerId, [peerId, ...replyFrames]);
+      await socket.send(peerId, replyFrames);
     } else if (msgType === "debug_request") {
       // Not supported
     }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -51,6 +51,9 @@ tokio.workspace = true
 tower-lsp.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["serde"] }
+# Real, spec-compliant ZMTP implementation used by the Jupyter integration
+# tests so they exercise the kernel the same way libzmq peers do. Test-only.
+zeromq.workspace = true
 
 [target.'cfg(unix)'.dev-dependencies]
 nix.workspace = true

--- a/tests/integration/jupyter_client.rs
+++ b/tests/integration/jupyter_client.rs
@@ -1,251 +1,92 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-//! Minimal ZMTP 3.1 client for Jupyter integration tests.
-//! Implements the client side of REQ, DEALER, SUB, and ROUTER socket types.
+//! Jupyter integration-test client backed by the real `zeromq` crate, a
+//! spec-compliant ZMTP implementation. Using a real ZMTP stack (rather than a
+//! hand-rolled one) means these tests exercise the kernel the same way libzmq
+//! peers do (VSCode/JupyterLab/jupyter_client): a malformed greeting or READY
+//! command fails the handshake here, just as it does for those clients.
 
-use std::io;
-
+use anyhow::Result;
 use bytes::Bytes;
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWriteExt;
-use tokio::net::TcpStream;
+use zeromq::Socket;
+use zeromq::SocketRecv;
+use zeromq::SocketSend;
+use zeromq::ZmqMessage;
 
-// ─── Low-level ZMTP framing ────────────────────────────────────────────────────
-
-pub struct ZmtpConn {
-  stream: TcpStream,
+fn endpoint(addr: &str) -> String {
+  format!("tcp://{addr}")
 }
 
-impl ZmtpConn {
-  pub async fn connect(addr: &str) -> io::Result<Self> {
-    let stream = TcpStream::connect(addr).await?;
-    Ok(Self { stream })
-  }
-
-  pub async fn read_exact_bytes(&mut self, n: usize) -> io::Result<Bytes> {
-    let mut buf = vec![0u8; n];
-    self.stream.read_exact(&mut buf).await?;
-    Ok(Bytes::from(buf))
-  }
-
-  pub async fn read_frame(&mut self) -> io::Result<(Bytes, bool)> {
-    let flag = self.read_exact_bytes(1).await?[0];
-    let _is_command = (flag & 0x04) != 0;
-    let is_long = (flag & 0x02) != 0;
-    let has_more = (flag & 0x01) != 0;
-
-    let size = if is_long {
-      let b = self.read_exact_bytes(8).await?;
-      u32::from_be_bytes([b[4], b[5], b[6], b[7]]) as usize
-    } else {
-      self.read_exact_bytes(1).await?[0] as usize
-    };
-
-    let data = self.read_exact_bytes(size).await?;
-    Ok((data, has_more))
-  }
-
-  pub async fn write_frame(
-    &mut self,
-    data: &[u8],
-    more: bool,
-    is_command: bool,
-  ) -> io::Result<()> {
-    let flag = if more { 0x01u8 } else { 0x00 }
-      | if data.len() > 255 { 0x02 } else { 0x00 }
-      | if is_command { 0x04 } else { 0x00 };
-
-    if data.len() > 255 {
-      let mut header = vec![flag, 0, 0, 0, 0];
-      let len_bytes = (data.len() as u32).to_be_bytes();
-      header.extend_from_slice(&len_bytes);
-      self.stream.write_all(&header).await?;
-    } else {
-      self.stream.write_all(&[flag, data.len() as u8]).await?;
-    }
-    self.stream.write_all(data).await?;
-    Ok(())
-  }
-
-  pub async fn send_multipart(&mut self, frames: &[Bytes]) -> io::Result<()> {
-    for (i, frame) in frames.iter().enumerate() {
-      let more = i < frames.len() - 1;
-      self.write_frame(frame, more, false).await?;
-    }
-    Ok(())
-  }
-
-  pub async fn recv_multipart(&mut self) -> io::Result<Vec<Bytes>> {
-    let mut parts = Vec::new();
-    loop {
-      let (data, has_more) = self.read_frame().await?;
-      parts.push(data);
-      if !has_more {
-        break;
-      }
-    }
-    Ok(parts)
-  }
-
-  /// ZMTP 3.1 NULL handshake (client side).
-  pub async fn handshake(&mut self, socket_type: &str) -> io::Result<()> {
-    // Send greeting
-    let greeting = make_greeting(socket_type, false);
-    self.stream.write_all(&greeting).await?;
-
-    // Read server's greeting (64 bytes)
-    self.read_exact_bytes(64).await?;
-
-    // Send READY command
-    let ready = make_ready_command(socket_type);
-    self.stream.write_all(&ready).await?;
-
-    // Read the server's READY command and verify it is a spec-compliant ZMTP
-    // command: the body must start with the command-name length octet (0x05)
-    // followed by "READY". This guards against the kernel regressing to a
-    // malformed READY that real libzmq clients (VSCode/JupyterLab) reject but
-    // our lenient parser would otherwise accept (regression from #34083).
-    let (ready_body, _) = self.read_frame().await?;
-    assert!(
-      ready_body.len() >= 6
-        && ready_body[0] == 5
-        && &ready_body[1..6] == b"READY",
-      "kernel READY command is not spec-compliant (missing name-length prefix): {:02x?}",
-      &ready_body[..ready_body.len().min(8)],
-    );
-
-    Ok(())
-  }
+fn frames_to_message(frames: &[Bytes]) -> ZmqMessage {
+  // Our Jupyter frames are always non-empty (at minimum the <IDS|MSG>
+  // delimiter plus signature/header/...).
+  ZmqMessage::try_from(frames.to_vec())
+    .expect("ZMTP message must have at least one frame")
 }
-
-fn make_greeting(_socket_type: &str, as_server: bool) -> Vec<u8> {
-  let mut buf = vec![0u8; 64];
-  buf[0] = 0xff;
-  buf[8] = 0x01;
-  buf[9] = 0x7f;
-  buf[10] = 0x03; // major
-  buf[11] = 0x01; // minor
-  let mech = b"NULL";
-  buf[12..12 + mech.len()].copy_from_slice(mech);
-  buf[32] = if as_server { 1 } else { 0 };
-  buf
-}
-
-fn make_ready_command(socket_type: &str) -> Vec<u8> {
-  let name = b"READY";
-  let prop_name = b"Socket-Type";
-  let prop_value = socket_type.as_bytes();
-
-  // ZMTP command body: <nameLen:1><name><metadata...>. The leading command-name
-  // length octet is mandatory (RFC 23/ZMTP); real libzmq peers send it and
-  // reject a command without it (regression from #34083).
-  // properties: len(1) propName + len(4) propValue
-  let mut body = Vec::new();
-  body.push(name.len() as u8);
-  body.extend_from_slice(name);
-  body.push(prop_name.len() as u8);
-  body.extend_from_slice(prop_name);
-  body.extend_from_slice(&(prop_value.len() as u32).to_be_bytes());
-  body.extend_from_slice(prop_value);
-
-  // Command frame: flag=0x04 | 0x00, size(1), body
-  let mut frame = Vec::new();
-  let flag = 0x04u8; // command, not long, no more
-  frame.push(flag);
-  frame.push(body.len() as u8);
-  frame.extend_from_slice(&body);
-  frame
-}
-
-// ─── High-level socket types ──────────────────────────────────────────────────
 
 /// REQ socket (heartbeat channel).
-pub struct ReqSocket(ZmtpConn);
+pub struct ReqSocket(zeromq::ReqSocket);
 
 impl ReqSocket {
-  pub async fn connect(addr: &str) -> io::Result<Self> {
-    let mut conn = ZmtpConn::connect(addr).await?;
-    conn.handshake("REQ").await?;
-    Ok(Self(conn))
+  pub async fn connect(addr: &str) -> Result<Self> {
+    let mut socket = zeromq::ReqSocket::new();
+    socket.connect(&endpoint(addr)).await?;
+    Ok(Self(socket))
   }
 
-  /// Send a single frame.
-  pub async fn send(&mut self, data: Bytes) -> io::Result<()> {
-    // REQ socket wraps in envelope: [empty, data]
-    self.0.send_multipart(&[Bytes::new(), data]).await
+  /// Send a single frame (the REQ envelope is handled by the socket).
+  pub async fn send(&mut self, data: Bytes) -> Result<()> {
+    self.0.send(ZmqMessage::from(data)).await?;
+    Ok(())
   }
 
-  /// Receive a single frame (strips the empty envelope).
-  pub async fn recv(&mut self) -> io::Result<Bytes> {
-    let mut parts = self.0.recv_multipart().await?;
-    // REP reply is [empty, data]; strip empty
-    if parts.len() >= 2 && parts[0].is_empty() {
-      parts.remove(0);
-    }
-    Ok(parts.into_iter().next().unwrap_or_default())
+  /// Receive a single frame.
+  pub async fn recv(&mut self) -> Result<Bytes> {
+    let msg = self.0.recv().await?;
+    Ok(msg.into_vec().into_iter().next().unwrap_or_default())
   }
 }
 
-/// DEALER socket (shell/control channels).
-pub struct DealerSocket(ZmtpConn);
+/// DEALER socket (shell, control, and stdin channels).
+///
+/// A real Jupyter frontend talks to the kernel's ROUTER sockets — including
+/// stdin — with a DEALER, so all three use this type.
+pub struct DealerSocket(zeromq::DealerSocket);
 
 impl DealerSocket {
-  pub async fn connect(addr: &str) -> io::Result<Self> {
-    let mut conn = ZmtpConn::connect(addr).await?;
-    conn.handshake("DEALER").await?;
-    Ok(Self(conn))
+  pub async fn connect(addr: &str) -> Result<Self> {
+    let mut socket = zeromq::DealerSocket::new();
+    socket.connect(&endpoint(addr)).await?;
+    Ok(Self(socket))
   }
 
-  pub async fn send_multipart(&mut self, frames: &[Bytes]) -> io::Result<()> {
-    self.0.send_multipart(frames).await
+  pub async fn send_multipart(&mut self, frames: &[Bytes]) -> Result<()> {
+    self.0.send(frames_to_message(frames)).await?;
+    Ok(())
   }
 
-  pub async fn recv_multipart(&mut self) -> io::Result<Vec<Bytes>> {
-    self.0.recv_multipart().await
+  pub async fn recv_multipart(&mut self) -> Result<Vec<Bytes>> {
+    Ok(self.0.recv().await?.into_vec())
   }
 }
 
 /// SUB socket (iopub channel).
-pub struct SubSocket(ZmtpConn);
+pub struct SubSocket(zeromq::SubSocket);
 
 impl SubSocket {
-  pub async fn connect(addr: &str) -> io::Result<Self> {
-    let mut conn = ZmtpConn::connect(addr).await?;
-    conn.handshake("SUB").await?;
-    Ok(Self(conn))
+  pub async fn connect(addr: &str) -> Result<Self> {
+    let mut socket = zeromq::SubSocket::new();
+    socket.connect(&endpoint(addr)).await?;
+    Ok(Self(socket))
   }
 
   /// Subscribe to a topic prefix (empty = subscribe to all).
-  pub async fn subscribe(&mut self, topic: &str) -> io::Result<()> {
-    // SUB subscribe: send a SUBSCRIBE command
-    // In ZMTP, SUB sends a command with the subscription prefix
-    // Format: command frame with body = b"\x01" + topic bytes
-    let mut body = Vec::new();
-    body.push(b'\x01'); // subscribe action
-    body.extend_from_slice(topic.as_bytes());
-    self.0.write_frame(&body, false, true).await
+  pub async fn subscribe(&mut self, topic: &str) -> Result<()> {
+    self.0.subscribe(topic).await?;
+    Ok(())
   }
 
-  pub async fn recv_multipart(&mut self) -> io::Result<Vec<Bytes>> {
-    self.0.recv_multipart().await
-  }
-}
-
-/// ROUTER socket (stdin channel in test client, mimics ZMQ ROUTER connecting to DEALER).
-pub struct RouterSocket(ZmtpConn);
-
-impl RouterSocket {
-  pub async fn connect(addr: &str) -> io::Result<Self> {
-    let mut conn = ZmtpConn::connect(addr).await?;
-    conn.handshake("ROUTER").await?;
-    Ok(Self(conn))
-  }
-
-  pub async fn send_multipart(&mut self, frames: &[Bytes]) -> io::Result<()> {
-    self.0.send_multipart(frames).await
-  }
-
-  pub async fn recv_multipart(&mut self) -> io::Result<Vec<Bytes>> {
-    self.0.recv_multipart().await
+  pub async fn recv_multipart(&mut self) -> Result<Vec<Bytes>> {
+    Ok(self.0.recv().await?.into_vec())
   }
 }

--- a/tests/integration/jupyter_client.rs
+++ b/tests/integration/jupyter_client.rs
@@ -100,8 +100,19 @@ impl ZmtpConn {
     let ready = make_ready_command(socket_type);
     self.stream.write_all(&ready).await?;
 
-    // Read server's READY command (skip it)
-    self.read_frame().await?;
+    // Read the server's READY command and verify it is a spec-compliant ZMTP
+    // command: the body must start with the command-name length octet (0x05)
+    // followed by "READY". This guards against the kernel regressing to a
+    // malformed READY that real libzmq clients (VSCode/JupyterLab) reject but
+    // our lenient parser would otherwise accept (regression from #34083).
+    let (ready_body, _) = self.read_frame().await?;
+    assert!(
+      ready_body.len() >= 6
+        && ready_body[0] == 5
+        && &ready_body[1..6] == b"READY",
+      "kernel READY command is not spec-compliant (missing name-length prefix): {:02x?}",
+      &ready_body[..ready_body.len().min(8)],
+    );
 
     Ok(())
   }
@@ -125,9 +136,12 @@ fn make_ready_command(socket_type: &str) -> Vec<u8> {
   let prop_name = b"Socket-Type";
   let prop_value = socket_type.as_bytes();
 
-  // Build body: name + properties
+  // ZMTP command body: <nameLen:1><name><metadata...>. The leading command-name
+  // length octet is mandatory (RFC 23/ZMTP); real libzmq peers send it and
+  // reject a command without it (regression from #34083).
   // properties: len(1) propName + len(4) propValue
   let mut body = Vec::new();
+  body.push(name.len() as u8);
   body.extend_from_slice(name);
   body.push(prop_name.len() as u8);
   body.extend_from_slice(prop_name);

--- a/tests/integration/jupyter_tests.rs
+++ b/tests/integration/jupyter_tests.rs
@@ -24,7 +24,6 @@ use uuid::Uuid;
 
 use crate::jupyter_client::DealerSocket;
 use crate::jupyter_client::ReqSocket;
-use crate::jupyter_client::RouterSocket;
 use crate::jupyter_client::SubSocket;
 
 /// Jupyter connection file format
@@ -206,7 +205,7 @@ struct JupyterClient {
   control: Arc<Mutex<DealerSocket>>,
   shell: Arc<Mutex<DealerSocket>>,
   io_pub: Arc<Mutex<SubSocket>>,
-  stdin: Arc<Mutex<RouterSocket>>,
+  stdin: Arc<Mutex<DealerSocket>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -236,7 +235,7 @@ impl JupyterClient {
       async { DealerSocket::connect(&ctrl_addr).await.unwrap() },
       async { DealerSocket::connect(&shell_addr).await.unwrap() },
       async { SubSocket::connect(&iopub_addr).await.unwrap() },
-      async { RouterSocket::connect(&stdin_addr).await.unwrap() },
+      async { DealerSocket::connect(&stdin_addr).await.unwrap() },
     );
 
     Self {


### PR DESCRIPTION
The JS Jupyter kernel introduced in #34083 hand-rolls the ZMTP wire
protocol and got several details wrong that our own integration test
client tolerated but real libzmq peers (VSCode, JupyterLab,
jupyter_client) reject. As a result the kernel could not be used from
VSCode at all: selecting the Deno kernel spun and then failed with
"Failed to request kernel info", so no cells could run.

The decisive bug is the READY command framing. ZMTP (RFC 23) requires a
command body to begin with a one-octet command-name length, so READY
must go on the wire as 05 52 45 41 44 59. makeReadyCommand omitted that
length octet, so libzmq read the first byte ('R' = 0x52 = 82) as the
name length, ran off the end of the frame, declared the command
malformed, and tore down every channel before the handshake completed.

Two further deviations from what the previous libzmq-based kernel put on
the wire are corrected so a real ROUTER and our kernel agree:

The greeting hard-coded as-server=1 and a nonzero signature pad byte,
whereas libzmq uses as-server=0 with an all-zero pad for the symmetric
NULL mechanism. ROUTER replies also prepended the peer identity as a
wire frame; a real ROUTER keeps identity internal and sends frames
starting at the <IDS|MSG> delimiter, so that prepend is removed and the
frames are coalesced into a single write like libzmq does.

The integration test client carried the same malformed READY, which is
why the existing tests passed against a kernel that real clients cannot
talk to. It now sends a spec-compliant READY and, during the handshake,
asserts that the kernel's READY carries the name-length prefix, so a
regression back to the broken framing fails the suite.

Verified end to end against pyzmq (kernel_info_reply and execute_reply
ok) and zeromq.js, and confirmed working in VSCode.