### PR TITLE
Revert "fix(runtime): throw a descriptive error for disabled __proto__ accessor (#34730)"

### DIFF
--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -40,7 +40,6 @@ const {
   ObjectGetOwnPropertyDescriptors,
   ObjectHasOwn,
   ObjectKeys,
-  ObjectPrototype,
   ObjectPrototypeIsPrototypeOf,
   ObjectSetPrototypeOf,
   PromisePrototypeThen,
@@ -719,41 +718,6 @@ const executionModes = {
   jupyter: 8,
 };
 
-// By default Deno disables the `Object.prototype.__proto__` accessor for
-// security reasons (it can be used for prototype pollution), see
-// https://tc39.es/ecma262/#sec-get-object.prototype.__proto__
-//
-// Instead of `delete`-ing the property (which silently turns `obj.__proto__`
-// reads into `undefined` and writes into a useless own property, making bugs
-// hard to track down) we replace it with an accessor that throws a descriptive
-// error, similar to Node's `--disable-proto=throw`. The `__proto__` key in
-// object literals (e.g. `{ __proto__: null }`) is separate syntax and keeps
-// working. The `--unstable-unsafe-proto` flag restores the native accessor.
-function disableProtoAccessor() {
-  function throwDisabledProto() {
-    throw new TypeError(
-      'The "Object.prototype.__proto__" accessor is disabled. Use ' +
-        "Object.getPrototypeOf()/Object.setPrototypeOf() instead, or run with " +
-        "--unstable-unsafe-proto to restore it.",
-    );
-  }
-  // The getter and setter must be distinct function objects: the native
-  // `__proto__` accessor has separate get/set functions, and WPT
-  // (webidl/ecmascript-binding/attributes-accessors-unique-function-objects)
-  // asserts every accessor's getter and setter are unique built-in functions.
-  ObjectDefineProperty(ObjectPrototype, "__proto__", {
-    __proto__: null,
-    configurable: true,
-    enumerable: false,
-    get: function __proto__() {
-      throwDisabledProto();
-    },
-    set: function __proto__(_value) {
-      throwDisabledProto();
-    },
-  });
-}
-
 function bootstrapMainRuntime(runtimeOptions, warmup = false) {
   if (!warmup) {
     if (hasBootstrapped) {
@@ -946,7 +910,9 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
     }
 
     if (!ArrayPrototypeIncludes(unstableFeatures, unstableIds.unsafeProto)) {
-      disableProtoAccessor();
+      // Removes the `__proto__` for security reasons.
+      // https://tc39.es/ecma262/#sec-get-object.prototype.__proto__
+      delete Object.prototype.__proto__;
     }
 
     // Setup `Deno` global - we're actually overriding already existing global
@@ -1076,7 +1042,9 @@ function bootstrapWorkerRuntime(
     delete finalDenoNs.mainModule;
 
     if (!ArrayPrototypeIncludes(unstableFeatures, unstableIds.unsafeProto)) {
-      disableProtoAccessor();
+      // Removes the `__proto__` for security reasons.
+      // https://tc39.es/ecma262/#sec-get-object.prototype.__proto__
+      delete Object.prototype.__proto__;
     }
 
     // Setup `Deno` global - we're actually overriding already existing global

--- a/tests/registry/npm/@denotest/unsafe-proto-bin/1.0.0/cli.mjs
+++ b/tests/registry/npm/@denotest/unsafe-proto-bin/1.0.0/cli.mjs
@@ -1,14 +1,6 @@
 #!/usr/bin/env node
 
-let hasUnsafeProto;
-try {
-  // When the `__proto__` accessor is disabled this throws; with
-  // --unstable-unsafe-proto the native accessor returns the prototype.
-  ({}).__proto__;
-  hasUnsafeProto = true;
-} catch {
-  hasUnsafeProto = false;
-}
+const hasUnsafeProto = Object.hasOwn(Object.prototype, "__proto__");
 if (hasUnsafeProto) {
   console.log("unsafe proto enabled");
 } else {

--- a/tests/specs/run/proto_exploit/proto_exploit.js
+++ b/tests/specs/run/proto_exploit/proto_exploit.js
@@ -1,15 +1,5 @@
 const payload = `{ "__proto__": null }`;
 const obj = {};
 console.log("Before: " + obj);
-// Assigning a `__proto__` key now goes through the disabled accessor and
-// throws, instead of silently creating an own property. Prototype pollution
-// is still prevented.
-try {
-  Object.assign(obj, JSON.parse(payload));
-  console.log("After: " + obj);
-} catch (e) {
-  console.log("Throws: " + (e instanceof TypeError));
-}
-console.log(
-  "Prototype intact: " + (Object.getPrototypeOf(obj) === Object.prototype),
-);
+Object.assign(obj, JSON.parse(payload));
+console.log("After: " + obj);

--- a/tests/specs/run/proto_exploit/proto_exploit.js.out
+++ b/tests/specs/run/proto_exploit/proto_exploit.js.out
@@ -1,3 +1,2 @@
 Before: [object Object]
-Throws: true
-Prototype intact: true
+After: [object Object]

--- a/tests/specs/run/unsafe_proto/main.js
+++ b/tests/specs/run/unsafe_proto/main.js
@@ -1,12 +1,4 @@
-// The `__proto__` accessor is disabled by default. Reading it throws a
-// descriptive TypeError instead of silently returning `undefined`.
-try {
-  ({}).__proto__;
-  console.log("did not throw");
-} catch (e) {
-  console.log(e instanceof TypeError);
-  console.log(e.message);
-}
+console.log(Object.hasOwn(Object.prototype, "__proto__"));
 
 new Worker(import.meta.resolve("./worker.js"), {
   type: "module",

--- a/tests/specs/run/unsafe_proto/main.out
+++ b/tests/specs/run/unsafe_proto/main.out
@@ -1,3 +1,2 @@
-true
-The "Object.prototype.__proto__" accessor is disabled. Use Object.getPrototypeOf()/Object.setPrototypeOf() instead, or run with --unstable-unsafe-proto to restore it.
-true
+false
+false

--- a/tests/specs/run/unsafe_proto/worker.js
+++ b/tests/specs/run/unsafe_proto/worker.js
@@ -1,8 +1,2 @@
-// Writing through the `__proto__` accessor throws as well.
-try {
-  ({}).__proto__ = {};
-  console.log("did not throw");
-} catch (e) {
-  console.log(e instanceof TypeError);
-}
+console.log(Object.hasOwn(Object.prototype, "__proto__"));
 close();


### PR DESCRIPTION
This reverts commit 2f912ccc66c4ca60b3a340f158977045ef89d150.

Sadly this causes Playwright to throw so we can't do that 😢 