### PR TITLE
fix(ext/kv): validate batchSize and expireIn inputs

### DIFF
--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -236,8 +236,13 @@ class Kv {
       consistency?: Deno.KvConsistencyLevel;
     } = { __proto__: null },
   ): KvListIterator {
-    if (options.limit !== undefined && options.limit <= 0) {
-      throw new Error(`Limit must be positive: received ${options.limit}`);
+    if (
+      options.limit !== undefined &&
+      (!NumberIsInteger(options.limit) || options.limit <= 0)
+    ) {
+      throw new Error(
+        `Limit must be a positive integer: received ${options.limit}`,
+      );
     }
 
     let batchSize = options.batchSize ?? (options.limit ?? 100);

--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -77,6 +77,18 @@ function validateQueueDelay(delay: number) {
   }
 }
 
+function validateExpireIn(expireIn: number | undefined) {
+  if (expireIn === undefined) return;
+  // Reject NaN, Infinity, fractional and negative values. A non-finite
+  // expireIn otherwise reaches the native layer and overflows when computing
+  // the absolute expiry, panicking the process.
+  if (!NumberIsInteger(expireIn) || expireIn < 0) {
+    throw new TypeError(
+      `expireIn must be a non-negative integer: received ${expireIn}`,
+    );
+  }
+}
+
 const maxQueueBackoffIntervals = 5;
 const maxQueueBackoffInterval = 60 * 60 * 1000;
 
@@ -193,6 +205,7 @@ class Kv {
   }
 
   async set(key: Deno.KvKey, value: unknown, options?: { expireIn?: number }) {
+    validateExpireIn(options?.expireIn);
     const versionstamp = await doAtomicWriteInPlace(
       this.#rid,
       [],
@@ -471,6 +484,7 @@ class AtomicOperation {
           if (typeof mutation.expireIn === "number") {
             expireIn = mutation.expireIn;
           }
+          validateExpireIn(expireIn);
           /* falls through */
         case "sum":
         case "min":
@@ -524,6 +538,7 @@ class AtomicOperation {
     value: unknown,
     options?: { expireIn?: number },
   ): this {
+    validateExpireIn(options?.expireIn);
     ArrayPrototypePush(this.#mutations, [
       key,
       "set",

--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -1,967 +1,982 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 (function () {
-const { core, internals, primordials } = __bootstrap;
-const {
-  isPromise,
-} = core;
-const {
-  op_kv_atomic_write,
-  op_kv_database_open,
-  op_kv_dequeue_next_message,
-  op_kv_encode_cursor,
-  op_kv_finish_dequeued_message,
-  op_kv_snapshot_read,
-  op_kv_watch,
-  op_kv_watch_next,
-} = core.ops;
-const {
-  ArrayFrom,
-  ArrayPrototypeJoin,
-  ArrayPrototypeMap,
-  ArrayPrototypePush,
-  ArrayPrototypeReverse,
-  ArrayPrototypeSlice,
-  AsyncGeneratorPrototype,
-  BigInt,
-  BigIntPrototypeToString,
-  Error,
-  NumberIsNaN,
-  Object,
-  ObjectFreeze,
-  ObjectGetPrototypeOf,
-  ObjectHasOwn,
-  ObjectPrototypeIsPrototypeOf,
-  RangeError,
-  SafeMap,
-  SafeMapIterator,
-  StringPrototypeReplace,
-  Symbol,
-  SymbolAsyncIterator,
-  SymbolDispose,
-  SymbolFor,
-  SymbolToStringTag,
-  TypeError,
-  TypedArrayPrototypeGetSymbolToStringTag,
-} = primordials;
+  const { core, internals, primordials } = __bootstrap;
+  const {
+    isPromise,
+  } = core;
+  const {
+    op_kv_atomic_write,
+    op_kv_database_open,
+    op_kv_dequeue_next_message,
+    op_kv_encode_cursor,
+    op_kv_finish_dequeued_message,
+    op_kv_snapshot_read,
+    op_kv_watch,
+    op_kv_watch_next,
+  } = core.ops;
+  const {
+    ArrayFrom,
+    ArrayPrototypeJoin,
+    ArrayPrototypeMap,
+    ArrayPrototypePush,
+    ArrayPrototypeReverse,
+    ArrayPrototypeSlice,
+    AsyncGeneratorPrototype,
+    BigInt,
+    BigIntPrototypeToString,
+    Error,
+    NumberIsInteger,
+    NumberIsNaN,
+    Object,
+    ObjectFreeze,
+    ObjectGetPrototypeOf,
+    ObjectHasOwn,
+    ObjectPrototypeIsPrototypeOf,
+    RangeError,
+    SafeMap,
+    SafeMapIterator,
+    StringPrototypeReplace,
+    Symbol,
+    SymbolAsyncIterator,
+    SymbolDispose,
+    SymbolFor,
+    SymbolToStringTag,
+    TypeError,
+    TypedArrayPrototypeGetSymbolToStringTag,
+  } = primordials;
 
-const { ReadableStream } = core.loadExtScript("ext:deno_web/06_streams.js");
+  const { ReadableStream } = core.loadExtScript("ext:deno_web/06_streams.js");
 
-const cloneableDeserializers = core.getCloneableDeserializers();
+  const cloneableDeserializers = core.getCloneableDeserializers();
 
-const encodeCursor: (
-  selector: [Deno.KvKey | null, Deno.KvKey | null, Deno.KvKey | null],
-  boundaryKey: Deno.KvKey,
-) => string = (selector, boundaryKey) =>
-  op_kv_encode_cursor(selector, boundaryKey);
+  const encodeCursor: (
+    selector: [Deno.KvKey | null, Deno.KvKey | null, Deno.KvKey | null],
+    boundaryKey: Deno.KvKey,
+  ) => string = (selector, boundaryKey) =>
+    op_kv_encode_cursor(selector, boundaryKey);
 
-async function openKv(path: string) {
-  const rid = await op_kv_database_open(path);
-  return new Kv(rid, kvSymbol);
-}
-
-const maxQueueDelay = 30 * 24 * 60 * 60 * 1000;
-
-function validateQueueDelay(delay: number) {
-  if (delay < 0) {
-    throw new TypeError(`Delay must be >= 0: received ${delay}`);
+  async function openKv(path: string) {
+    const rid = await op_kv_database_open(path);
+    return new Kv(rid, kvSymbol);
   }
-  if (delay > maxQueueDelay) {
-    throw new TypeError(
-      `Delay cannot be greater than 30 days: received ${delay}`,
-    );
-  }
-  if (NumberIsNaN(delay)) {
-    throw new TypeError("Delay cannot be NaN");
-  }
-}
 
-const maxQueueBackoffIntervals = 5;
-const maxQueueBackoffInterval = 60 * 60 * 1000;
+  const maxQueueDelay = 30 * 24 * 60 * 60 * 1000;
 
-function validateBackoffSchedule(backoffSchedule: number[]) {
-  if (backoffSchedule.length > maxQueueBackoffIntervals) {
-    throw new TypeError(
-      `Invalid backoffSchedule, max ${maxQueueBackoffIntervals} intervals allowed`,
-    );
+  function validateQueueDelay(delay: number) {
+    if (delay < 0) {
+      throw new TypeError(`Delay must be >= 0: received ${delay}`);
+    }
+    if (delay > maxQueueDelay) {
+      throw new TypeError(
+        `Delay cannot be greater than 30 days: received ${delay}`,
+      );
+    }
+    if (NumberIsNaN(delay)) {
+      throw new TypeError("Delay cannot be NaN");
+    }
   }
-  for (let i = 0; i < backoffSchedule.length; ++i) {
-    const interval = backoffSchedule[i];
-    if (
-      interval < 0 || interval > maxQueueBackoffInterval ||
-      NumberIsNaN(interval)
+
+  const maxQueueBackoffIntervals = 5;
+  const maxQueueBackoffInterval = 60 * 60 * 1000;
+
+  function validateBackoffSchedule(backoffSchedule: number[]) {
+    if (backoffSchedule.length > maxQueueBackoffIntervals) {
+      throw new TypeError(
+        `Invalid backoffSchedule, max ${maxQueueBackoffIntervals} intervals allowed`,
+      );
+    }
+    for (let i = 0; i < backoffSchedule.length; ++i) {
+      const interval = backoffSchedule[i];
+      if (
+        interval < 0 || interval > maxQueueBackoffInterval ||
+        NumberIsNaN(interval)
+      ) {
+        throw new TypeError(
+          `Invalid backoffSchedule, interval at index ${i} is invalid`,
+        );
+      }
+    }
+  }
+
+  interface RawKvEntry {
+    key: Deno.KvKey;
+    value: RawValue;
+    versionstamp: string;
+  }
+
+  type RawValue = {
+    kind: "v8";
+    value: Uint8Array;
+  } | {
+    kind: "bytes";
+    value: Uint8Array;
+  } | {
+    kind: "u64";
+    value: bigint;
+  };
+
+  const kvSymbol = Symbol("KvRid");
+  const commitVersionstampSymbol = Symbol("KvCommitVersionstamp");
+
+  class Kv {
+    #rid: number;
+    #isClosed: boolean;
+
+    constructor(rid: number = undefined, symbol: symbol = undefined) {
+      if (kvSymbol !== symbol) {
+        throw new TypeError(
+          "Deno.Kv can not be constructed: use Deno.openKv instead",
+        );
+      }
+      this.#rid = rid;
+      this.#isClosed = false;
+    }
+
+    atomic() {
+      return new AtomicOperation(this.#rid);
+    }
+
+    commitVersionstamp(): symbol {
+      return commitVersionstampSymbol;
+    }
+
+    async get(
+      key: Deno.KvKey,
+      opts?: { consistency?: Deno.KvConsistencyLevel },
     ) {
-      throw new TypeError(
-        `Invalid backoffSchedule, interval at index ${i} is invalid`,
+      const { 0: entries }: [RawKvEntry[]] = await op_kv_snapshot_read(
+        this.#rid,
+        [[
+          null,
+          key,
+          null,
+          1,
+          false,
+          null,
+        ]],
+        opts?.consistency ?? "strong",
       );
-    }
-  }
-}
-
-interface RawKvEntry {
-  key: Deno.KvKey;
-  value: RawValue;
-  versionstamp: string;
-}
-
-type RawValue = {
-  kind: "v8";
-  value: Uint8Array;
-} | {
-  kind: "bytes";
-  value: Uint8Array;
-} | {
-  kind: "u64";
-  value: bigint;
-};
-
-const kvSymbol = Symbol("KvRid");
-const commitVersionstampSymbol = Symbol("KvCommitVersionstamp");
-
-class Kv {
-  #rid: number;
-  #isClosed: boolean;
-
-  constructor(rid: number = undefined, symbol: symbol = undefined) {
-    if (kvSymbol !== symbol) {
-      throw new TypeError(
-        "Deno.Kv can not be constructed: use Deno.openKv instead",
-      );
-    }
-    this.#rid = rid;
-    this.#isClosed = false;
-  }
-
-  atomic() {
-    return new AtomicOperation(this.#rid);
-  }
-
-  commitVersionstamp(): symbol {
-    return commitVersionstampSymbol;
-  }
-
-  async get(key: Deno.KvKey, opts?: { consistency?: Deno.KvConsistencyLevel }) {
-    const { 0: entries }: [RawKvEntry[]] = await op_kv_snapshot_read(
-      this.#rid,
-      [[
-        null,
-        key,
-        null,
-        1,
-        false,
-        null,
-      ]],
-      opts?.consistency ?? "strong",
-    );
-    if (!entries.length) {
-      return {
-        key,
-        value: null,
-        versionstamp: null,
-      };
-    }
-    return deserializeValue(entries[0]);
-  }
-
-  async getMany(
-    keys: Deno.KvKey[],
-    opts?: { consistency?: Deno.KvConsistencyLevel },
-  ): Promise<Deno.KvEntry<unknown>[]> {
-    const ranges: RawKvEntry[][] = await op_kv_snapshot_read(
-      this.#rid,
-      ArrayPrototypeMap(keys, (key: Deno.KvKey) => [
-        null,
-        key,
-        null,
-        1,
-        false,
-        null,
-      ]),
-      opts?.consistency ?? "strong",
-    );
-    return ArrayPrototypeMap(ranges, (entries: RawKvEntry[], i: number) => {
       if (!entries.length) {
         return {
-          key: keys[i],
+          key,
           value: null,
           versionstamp: null,
         };
       }
       return deserializeValue(entries[0]);
-    });
-  }
-
-  async set(key: Deno.KvKey, value: unknown, options?: { expireIn?: number }) {
-    const versionstamp = await doAtomicWriteInPlace(
-      this.#rid,
-      [],
-      [[key, "set", serializeValue(value), options?.expireIn]],
-      [],
-    );
-    if (versionstamp === null) throw new TypeError("Failed to set value");
-    return { ok: true, versionstamp };
-  }
-
-  async delete(key: Deno.KvKey) {
-    const result = await doAtomicWriteInPlace(
-      this.#rid,
-      [],
-      [[key, "delete", null, undefined]],
-      [],
-    );
-    if (!result) throw new TypeError("Failed to set value");
-  }
-
-  list(
-    selector: Deno.KvListSelector,
-    options: {
-      limit?: number;
-      batchSize?: number;
-      cursor?: string;
-      reverse?: boolean;
-      consistency?: Deno.KvConsistencyLevel;
-    } = { __proto__: null },
-  ): KvListIterator {
-    if (options.limit !== undefined && options.limit <= 0) {
-      throw new Error(`Limit must be positive: received ${options.limit}`);
     }
 
-    let batchSize = options.batchSize ?? (options.limit ?? 100);
-    if (batchSize <= 0) throw new Error("batchSize must be positive");
-    if (options.batchSize === undefined && batchSize > 500) batchSize = 500;
-
-    return new KvListIterator({
-      limit: options.limit,
-      selector,
-      cursor: options.cursor,
-      reverse: options.reverse ?? false,
-      consistency: options.consistency ?? "strong",
-      batchSize,
-      pullBatch: this.#pullBatch(batchSize),
-    });
-  }
-
-  #pullBatch(batchSize: number): (
-    selector: Deno.KvListSelector,
-    cursor: string | undefined,
-    reverse: boolean,
-    consistency: Deno.KvConsistencyLevel,
-  ) => Promise<Deno.KvEntry<unknown>[]> {
-    return async (selector, cursor, reverse, consistency) => {
-      const { 0: entries }: [RawKvEntry[]] = await op_kv_snapshot_read(
+    async getMany(
+      keys: Deno.KvKey[],
+      opts?: { consistency?: Deno.KvConsistencyLevel },
+    ): Promise<Deno.KvEntry<unknown>[]> {
+      const ranges: RawKvEntry[][] = await op_kv_snapshot_read(
         this.#rid,
-        [[
-          ObjectHasOwn(selector, "prefix") ? selector.prefix : null,
-          ObjectHasOwn(selector, "start") ? selector.start : null,
-          ObjectHasOwn(selector, "end") ? selector.end : null,
-          batchSize,
-          reverse,
-          cursor,
-        ]],
-        consistency,
+        ArrayPrototypeMap(keys, (key: Deno.KvKey) => [
+          null,
+          key,
+          null,
+          1,
+          false,
+          null,
+        ]),
+        opts?.consistency ?? "strong",
       );
-
-      return ArrayPrototypeMap(entries, deserializeValue);
-    };
-  }
-
-  async enqueue(
-    message: unknown,
-    opts?: {
-      delay?: number;
-      keysIfUndelivered?: Deno.KvKey[];
-      backoffSchedule?: number[];
-    },
-  ) {
-    if (opts?.delay !== undefined) {
-      validateQueueDelay(opts?.delay);
-    }
-    if (opts?.backoffSchedule !== undefined) {
-      validateBackoffSchedule(opts?.backoffSchedule);
-    }
-
-    const versionstamp = await doAtomicWriteInPlace(
-      this.#rid,
-      [],
-      [],
-      [
-        [
-          core.serialize(message, { forStorage: true }),
-          opts?.delay ?? 0,
-          opts?.keysIfUndelivered ?? [],
-          opts?.backoffSchedule ?? null,
-        ],
-      ],
-    );
-    if (versionstamp === null) throw new TypeError("Failed to enqueue value");
-    return { ok: true, versionstamp };
-  }
-
-  async listenQueue(
-    handler: (message: unknown) => Promise<void> | void,
-  ): Promise<void> {
-    if (this.#isClosed) {
-      throw new Error("Queue already closed");
-    }
-    const finishMessageOps = new SafeMap<number, Promise<void>>();
-    while (true) {
-      // Wait for the next message.
-      const next: { 0: Uint8Array; 1: number } =
-        await op_kv_dequeue_next_message(
-          this.#rid,
-        );
-      if (next === null) {
-        break;
-      }
-
-      // Deserialize the payload.
-      const { 0: payload, 1: handleId } = next;
-      const deserializedPayload = core.deserialize(payload, {
-        forStorage: true,
-        deserializers: cloneableDeserializers,
+      return ArrayPrototypeMap(ranges, (entries: RawKvEntry[], i: number) => {
+        if (!entries.length) {
+          return {
+            key: keys[i],
+            value: null,
+            versionstamp: null,
+          };
+        }
+        return deserializeValue(entries[0]);
       });
-
-      // Dispatch the payload.
-      (async () => {
-        let success = false;
-        try {
-          const result = handler(deserializedPayload);
-          const _res = isPromise(result) ? (await result) : result;
-          success = true;
-        } catch (error) {
-          internals.log("error", "Exception in queue handler", error);
-        } finally {
-          const promise: Promise<void> = op_kv_finish_dequeued_message(
-            handleId,
-            success,
-          );
-          finishMessageOps.set(handleId, promise);
-          try {
-            await promise;
-          } finally {
-            finishMessageOps.delete(handleId);
-          }
-        }
-      })();
     }
 
-    for (const { 1: promise } of new SafeMapIterator(finishMessageOps)) {
-      await promise;
-    }
-    finishMessageOps.clear();
-  }
-
-  watch(keys: Deno.KvKey[], options = { __proto__: null }) {
-    const raw = options.raw ?? false;
-    const rid = op_kv_watch(this.#rid, keys);
-    const lastEntries: (Deno.KvEntryMaybe<unknown> | undefined)[] = ArrayFrom(
-      { length: keys.length },
-    );
-    return new ReadableStream({
-      async pull(controller) {
-        while (true) {
-          let updates;
-          try {
-            updates = await op_kv_watch_next(rid);
-          } catch (err) {
-            core.tryClose(rid);
-            controller.error(err);
-            return;
-          }
-          if (updates === null) {
-            core.tryClose(rid);
-            controller.close();
-            return;
-          }
-          let changed = false;
-          for (let i = 0; i < keys.length; i++) {
-            if (updates[i] === "unchanged") {
-              if (lastEntries[i] === undefined) {
-                throw new Error(
-                  "'watch': invalid unchanged update (internal error)",
-                );
-              }
-              continue;
-            }
-            if (
-              lastEntries[i] !== undefined &&
-              (updates[i]?.versionstamp ?? null) ===
-                lastEntries[i]?.versionstamp
-            ) {
-              continue;
-            }
-            changed = true;
-            if (updates[i] === null) {
-              lastEntries[i] = {
-                key: ArrayPrototypeSlice(keys[i]),
-                value: null,
-                versionstamp: null,
-              };
-            } else {
-              lastEntries[i] = updates[i];
-            }
-          }
-          if (!changed && !raw) continue; // no change
-          const entries = ArrayPrototypeMap(
-            lastEntries,
-            (entry) =>
-              entry.versionstamp === null
-                ? { ...entry }
-                : deserializeValue(entry),
-          );
-          controller.enqueue(entries);
-          return;
-        }
-      },
-      cancel() {
-        core.tryClose(rid);
-      },
-    });
-  }
-
-  close() {
-    core.close(this.#rid);
-    this.#isClosed = true;
-  }
-
-  [SymbolDispose]() {
-    core.tryClose(this.#rid);
-  }
-}
-
-class AtomicOperation {
-  #rid: number;
-
-  #checks: [Deno.KvKey, string | null][] = [];
-  #mutations: [Deno.KvKey, string, RawValue | null, number | undefined][] = [];
-  #enqueues: [Uint8Array, number, Deno.KvKey[], number[] | null][] = [];
-
-  constructor(rid: number) {
-    this.#rid = rid;
-  }
-
-  check(...checks: Deno.AtomicCheck[]): this {
-    for (let i = 0; i < checks.length; ++i) {
-      const check = checks[i];
-      ArrayPrototypePush(this.#checks, [check.key, check.versionstamp]);
-    }
-    return this;
-  }
-
-  mutate(...mutations: Deno.KvMutation[]): this {
-    for (let i = 0; i < mutations.length; ++i) {
-      const mutation = mutations[i];
-      const key = mutation.key;
-      let type: string;
-      let value: RawValue | null;
-      let expireIn: number | undefined = undefined;
-      switch (mutation.type) {
-        case "delete":
-          type = "delete";
-          if (mutation.value) {
-            throw new TypeError("Invalid mutation 'delete' with value");
-          }
-          break;
-        case "set":
-          if (typeof mutation.expireIn === "number") {
-            expireIn = mutation.expireIn;
-          }
-          /* falls through */
-        case "sum":
-        case "min":
-        case "max":
-          type = mutation.type;
-          if (!ObjectHasOwn(mutation, "value")) {
-            throw new TypeError(`Invalid mutation '${type}' without value`);
-          }
-          value = serializeValue(mutation.value);
-          break;
-        default:
-          throw new TypeError("Invalid mutation type");
-      }
-      ArrayPrototypePush(this.#mutations, [key, type, value, expireIn]);
-    }
-    return this;
-  }
-
-  sum(key: Deno.KvKey, n: bigint): this {
-    ArrayPrototypePush(this.#mutations, [
-      key,
-      "sum",
-      serializeValue(new KvU64(n)),
-      undefined,
-    ]);
-    return this;
-  }
-
-  min(key: Deno.KvKey, n: bigint): this {
-    ArrayPrototypePush(this.#mutations, [
-      key,
-      "min",
-      serializeValue(new KvU64(n)),
-      undefined,
-    ]);
-    return this;
-  }
-
-  max(key: Deno.KvKey, n: bigint): this {
-    ArrayPrototypePush(this.#mutations, [
-      key,
-      "max",
-      serializeValue(new KvU64(n)),
-      undefined,
-    ]);
-    return this;
-  }
-
-  set(
-    key: Deno.KvKey,
-    value: unknown,
-    options?: { expireIn?: number },
-  ): this {
-    ArrayPrototypePush(this.#mutations, [
-      key,
-      "set",
-      serializeValue(value),
-      options?.expireIn,
-    ]);
-    return this;
-  }
-
-  delete(key: Deno.KvKey): this {
-    ArrayPrototypePush(this.#mutations, [key, "delete", null, undefined]);
-    return this;
-  }
-
-  enqueue(
-    message: unknown,
-    opts?: {
-      delay?: number;
-      keysIfUndelivered?: Deno.KvKey[];
-      backoffSchedule?: number[];
-    },
-  ): this {
-    if (opts?.delay !== undefined) {
-      validateQueueDelay(opts?.delay);
-    }
-    if (opts?.backoffSchedule !== undefined) {
-      validateBackoffSchedule(opts?.backoffSchedule);
-    }
-    ArrayPrototypePush(this.#enqueues, [
-      core.serialize(message, { forStorage: true }),
-      opts?.delay ?? 0,
-      opts?.keysIfUndelivered ?? [],
-      opts?.backoffSchedule ?? null,
-    ]);
-    return this;
-  }
-
-  async commit(): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
-    const versionstamp = await doAtomicWriteInPlace(
-      this.#rid,
-      this.#checks,
-      this.#mutations,
-      this.#enqueues,
-    );
-    if (versionstamp === null) return { ok: false };
-    return { ok: true, versionstamp };
-  }
-
-  then() {
-    throw new TypeError(
-      "'Deno.AtomicOperation' is not a promise: did you forget to call 'commit()'",
-    );
-  }
-
-  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
-    const operations = [];
-
-    // Format checks
-    for (let i = 0; i < this.#checks.length; ++i) {
-      const check = this.#checks[i];
-      const key = check[0];
-      const versionstamp = check[1];
-      const keyStr = inspect(key, inspectOptions);
-      const versionstampStr = versionstamp === null
-        ? "null"
-        : `"${versionstamp}"`;
-      ArrayPrototypePush(
-        operations,
-        `  check({ key: ${keyStr}, versionstamp: ${versionstampStr} })`,
+    async set(
+      key: Deno.KvKey,
+      value: unknown,
+      options?: { expireIn?: number },
+    ) {
+      const versionstamp = await doAtomicWriteInPlace(
+        this.#rid,
+        [],
+        [[key, "set", serializeValue(value), options?.expireIn]],
+        [],
       );
+      if (versionstamp === null) throw new TypeError("Failed to set value");
+      return { ok: true, versionstamp };
     }
 
-    // Format mutations
-    for (let i = 0; i < this.#mutations.length; ++i) {
-      const mutation = this.#mutations[i];
-      const key = mutation[0];
-      const type = mutation[1];
-      const rawValue = mutation[2];
-      const expireIn = mutation[3];
-      const keyStr = inspect(key, inspectOptions);
+    async delete(key: Deno.KvKey) {
+      const result = await doAtomicWriteInPlace(
+        this.#rid,
+        [],
+        [[key, "delete", null, undefined]],
+        [],
+      );
+      if (!result) throw new TypeError("Failed to set value");
+    }
 
-      if (type === "delete") {
-        ArrayPrototypePush(operations, `  delete(${keyStr})`);
-      } else {
-        // Deserialize value for display
-        let value;
-        try {
-          if (rawValue === null) {
-            value = null;
-          } else {
-            switch (rawValue.kind) {
-              case "v8":
-                value = core.deserialize(rawValue.value, {
-                  forStorage: true,
-                  deserializers: cloneableDeserializers,
-                });
-                break;
-              case "bytes":
-                value = rawValue.value;
-                break;
-              case "u64":
-                value = new KvU64(rawValue.value);
-                break;
-              default:
-                value = rawValue;
-            }
-          }
-        } catch {
-          // If deserialization fails, show the raw value structure
-          value = `[${rawValue?.kind || "unknown"} value]`;
-        }
-
-        const valueStr = inspect(value, inspectOptions);
-
-        if (type === "set" && expireIn !== undefined) {
-          ArrayPrototypePush(
-            operations,
-            `  set(${keyStr}, ${valueStr}, { expireIn: ${expireIn} })`,
-          );
-        } else {
-          ArrayPrototypePush(operations, `  ${type}(${keyStr}, ${valueStr})`);
-        }
+    list(
+      selector: Deno.KvListSelector,
+      options: {
+        limit?: number;
+        batchSize?: number;
+        cursor?: string;
+        reverse?: boolean;
+        consistency?: Deno.KvConsistencyLevel;
+      } = { __proto__: null },
+    ): KvListIterator {
+      if (options.limit !== undefined && options.limit <= 0) {
+        throw new Error(`Limit must be positive: received ${options.limit}`);
       }
+
+      let batchSize = options.batchSize ?? (options.limit ?? 100);
+      if (!NumberIsInteger(batchSize) || batchSize <= 0) {
+        throw new Error(
+          `batchSize must be a positive integer: received ${batchSize}`,
+        );
+      }
+      if (options.batchSize === undefined && batchSize > 500) batchSize = 500;
+
+      return new KvListIterator({
+        limit: options.limit,
+        selector,
+        cursor: options.cursor,
+        reverse: options.reverse ?? false,
+        consistency: options.consistency ?? "strong",
+        batchSize,
+        pullBatch: this.#pullBatch(batchSize),
+      });
     }
 
-    // Format enqueues
-    for (let i = 0; i < this.#enqueues.length; ++i) {
-      const enqueue = this.#enqueues[i];
-      const serializedMessage = enqueue[0];
-      const delay = enqueue[1];
-      const keysIfUndelivered = enqueue[2];
-      const backoffSchedule = enqueue[3];
+    #pullBatch(batchSize: number): (
+      selector: Deno.KvListSelector,
+      cursor: string | undefined,
+      reverse: boolean,
+      consistency: Deno.KvConsistencyLevel,
+    ) => Promise<Deno.KvEntry<unknown>[]> {
+      return async (selector, cursor, reverse, consistency) => {
+        const { 0: entries }: [RawKvEntry[]] = await op_kv_snapshot_read(
+          this.#rid,
+          [[
+            ObjectHasOwn(selector, "prefix") ? selector.prefix : null,
+            ObjectHasOwn(selector, "start") ? selector.start : null,
+            ObjectHasOwn(selector, "end") ? selector.end : null,
+            batchSize,
+            reverse,
+            cursor,
+          ]],
+          consistency,
+        );
 
-      // Deserialize message for display
-      let message;
-      try {
-        message = core.deserialize(serializedMessage, {
+        return ArrayPrototypeMap(entries, deserializeValue);
+      };
+    }
+
+    async enqueue(
+      message: unknown,
+      opts?: {
+        delay?: number;
+        keysIfUndelivered?: Deno.KvKey[];
+        backoffSchedule?: number[];
+      },
+    ) {
+      if (opts?.delay !== undefined) {
+        validateQueueDelay(opts?.delay);
+      }
+      if (opts?.backoffSchedule !== undefined) {
+        validateBackoffSchedule(opts?.backoffSchedule);
+      }
+
+      const versionstamp = await doAtomicWriteInPlace(
+        this.#rid,
+        [],
+        [],
+        [
+          [
+            core.serialize(message, { forStorage: true }),
+            opts?.delay ?? 0,
+            opts?.keysIfUndelivered ?? [],
+            opts?.backoffSchedule ?? null,
+          ],
+        ],
+      );
+      if (versionstamp === null) throw new TypeError("Failed to enqueue value");
+      return { ok: true, versionstamp };
+    }
+
+    async listenQueue(
+      handler: (message: unknown) => Promise<void> | void,
+    ): Promise<void> {
+      if (this.#isClosed) {
+        throw new Error("Queue already closed");
+      }
+      const finishMessageOps = new SafeMap<number, Promise<void>>();
+      while (true) {
+        // Wait for the next message.
+        const next: { 0: Uint8Array; 1: number } =
+          await op_kv_dequeue_next_message(
+            this.#rid,
+          );
+        if (next === null) {
+          break;
+        }
+
+        // Deserialize the payload.
+        const { 0: payload, 1: handleId } = next;
+        const deserializedPayload = core.deserialize(payload, {
           forStorage: true,
           deserializers: cloneableDeserializers,
         });
-      } catch {
-        message = "[serialized message]";
+
+        // Dispatch the payload.
+        (async () => {
+          let success = false;
+          try {
+            const result = handler(deserializedPayload);
+            const _res = isPromise(result) ? (await result) : result;
+            success = true;
+          } catch (error) {
+            internals.log("error", "Exception in queue handler", error);
+          } finally {
+            const promise: Promise<void> = op_kv_finish_dequeued_message(
+              handleId,
+              success,
+            );
+            finishMessageOps.set(handleId, promise);
+            try {
+              await promise;
+            } finally {
+              finishMessageOps.delete(handleId);
+            }
+          }
+        })();
       }
 
-      const messageStr = inspect(message, inspectOptions);
+      for (const { 1: promise } of new SafeMapIterator(finishMessageOps)) {
+        await promise;
+      }
+      finishMessageOps.clear();
+    }
 
-      if (
-        delay === 0 && keysIfUndelivered.length === 0 &&
-        backoffSchedule === null
-      ) {
-        ArrayPrototypePush(operations, `  enqueue(${messageStr})`);
-      } else {
-        const options = [];
-        if (delay !== 0) ArrayPrototypePush(options, `delay: ${delay}`);
-        if (keysIfUndelivered.length > 0) {
-          const keysStr = inspect(keysIfUndelivered, inspectOptions);
-          ArrayPrototypePush(options, `keysIfUndelivered: ${keysStr}`);
+    watch(keys: Deno.KvKey[], options = { __proto__: null }) {
+      const raw = options.raw ?? false;
+      const rid = op_kv_watch(this.#rid, keys);
+      const lastEntries: (Deno.KvEntryMaybe<unknown> | undefined)[] = ArrayFrom(
+        { length: keys.length },
+      );
+      return new ReadableStream({
+        async pull(controller) {
+          while (true) {
+            let updates;
+            try {
+              updates = await op_kv_watch_next(rid);
+            } catch (err) {
+              core.tryClose(rid);
+              controller.error(err);
+              return;
+            }
+            if (updates === null) {
+              core.tryClose(rid);
+              controller.close();
+              return;
+            }
+            let changed = false;
+            for (let i = 0; i < keys.length; i++) {
+              if (updates[i] === "unchanged") {
+                if (lastEntries[i] === undefined) {
+                  throw new Error(
+                    "'watch': invalid unchanged update (internal error)",
+                  );
+                }
+                continue;
+              }
+              if (
+                lastEntries[i] !== undefined &&
+                (updates[i]?.versionstamp ?? null) ===
+                  lastEntries[i]?.versionstamp
+              ) {
+                continue;
+              }
+              changed = true;
+              if (updates[i] === null) {
+                lastEntries[i] = {
+                  key: ArrayPrototypeSlice(keys[i]),
+                  value: null,
+                  versionstamp: null,
+                };
+              } else {
+                lastEntries[i] = updates[i];
+              }
+            }
+            if (!changed && !raw) continue; // no change
+            const entries = ArrayPrototypeMap(
+              lastEntries,
+              (entry) =>
+                entry.versionstamp === null
+                  ? { ...entry }
+                  : deserializeValue(entry),
+            );
+            controller.enqueue(entries);
+            return;
+          }
+        },
+        cancel() {
+          core.tryClose(rid);
+        },
+      });
+    }
+
+    close() {
+      core.close(this.#rid);
+      this.#isClosed = true;
+    }
+
+    [SymbolDispose]() {
+      core.tryClose(this.#rid);
+    }
+  }
+
+  class AtomicOperation {
+    #rid: number;
+
+    #checks: [Deno.KvKey, string | null][] = [];
+    #mutations: [Deno.KvKey, string, RawValue | null, number | undefined][] =
+      [];
+    #enqueues: [Uint8Array, number, Deno.KvKey[], number[] | null][] = [];
+
+    constructor(rid: number) {
+      this.#rid = rid;
+    }
+
+    check(...checks: Deno.AtomicCheck[]): this {
+      for (let i = 0; i < checks.length; ++i) {
+        const check = checks[i];
+        ArrayPrototypePush(this.#checks, [check.key, check.versionstamp]);
+      }
+      return this;
+    }
+
+    mutate(...mutations: Deno.KvMutation[]): this {
+      for (let i = 0; i < mutations.length; ++i) {
+        const mutation = mutations[i];
+        const key = mutation.key;
+        let type: string;
+        let value: RawValue | null;
+        let expireIn: number | undefined = undefined;
+        switch (mutation.type) {
+          case "delete":
+            type = "delete";
+            if (mutation.value) {
+              throw new TypeError("Invalid mutation 'delete' with value");
+            }
+            break;
+          case "set":
+            if (typeof mutation.expireIn === "number") {
+              expireIn = mutation.expireIn;
+            }
+            /* falls through */
+          case "sum":
+          case "min":
+          case "max":
+            type = mutation.type;
+            if (!ObjectHasOwn(mutation, "value")) {
+              throw new TypeError(`Invalid mutation '${type}' without value`);
+            }
+            value = serializeValue(mutation.value);
+            break;
+          default:
+            throw new TypeError("Invalid mutation type");
         }
-        if (backoffSchedule !== null) {
-          const scheduleStr = inspect(backoffSchedule, inspectOptions);
-          ArrayPrototypePush(options, `backoffSchedule: ${scheduleStr}`);
-        }
+        ArrayPrototypePush(this.#mutations, [key, type, value, expireIn]);
+      }
+      return this;
+    }
+
+    sum(key: Deno.KvKey, n: bigint): this {
+      ArrayPrototypePush(this.#mutations, [
+        key,
+        "sum",
+        serializeValue(new KvU64(n)),
+        undefined,
+      ]);
+      return this;
+    }
+
+    min(key: Deno.KvKey, n: bigint): this {
+      ArrayPrototypePush(this.#mutations, [
+        key,
+        "min",
+        serializeValue(new KvU64(n)),
+        undefined,
+      ]);
+      return this;
+    }
+
+    max(key: Deno.KvKey, n: bigint): this {
+      ArrayPrototypePush(this.#mutations, [
+        key,
+        "max",
+        serializeValue(new KvU64(n)),
+        undefined,
+      ]);
+      return this;
+    }
+
+    set(
+      key: Deno.KvKey,
+      value: unknown,
+      options?: { expireIn?: number },
+    ): this {
+      ArrayPrototypePush(this.#mutations, [
+        key,
+        "set",
+        serializeValue(value),
+        options?.expireIn,
+      ]);
+      return this;
+    }
+
+    delete(key: Deno.KvKey): this {
+      ArrayPrototypePush(this.#mutations, [key, "delete", null, undefined]);
+      return this;
+    }
+
+    enqueue(
+      message: unknown,
+      opts?: {
+        delay?: number;
+        keysIfUndelivered?: Deno.KvKey[];
+        backoffSchedule?: number[];
+      },
+    ): this {
+      if (opts?.delay !== undefined) {
+        validateQueueDelay(opts?.delay);
+      }
+      if (opts?.backoffSchedule !== undefined) {
+        validateBackoffSchedule(opts?.backoffSchedule);
+      }
+      ArrayPrototypePush(this.#enqueues, [
+        core.serialize(message, { forStorage: true }),
+        opts?.delay ?? 0,
+        opts?.keysIfUndelivered ?? [],
+        opts?.backoffSchedule ?? null,
+      ]);
+      return this;
+    }
+
+    async commit(): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
+      const versionstamp = await doAtomicWriteInPlace(
+        this.#rid,
+        this.#checks,
+        this.#mutations,
+        this.#enqueues,
+      );
+      if (versionstamp === null) return { ok: false };
+      return { ok: true, versionstamp };
+    }
+
+    then() {
+      throw new TypeError(
+        "'Deno.AtomicOperation' is not a promise: did you forget to call 'commit()'",
+      );
+    }
+
+    [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
+      const operations = [];
+
+      // Format checks
+      for (let i = 0; i < this.#checks.length; ++i) {
+        const check = this.#checks[i];
+        const key = check[0];
+        const versionstamp = check[1];
+        const keyStr = inspect(key, inspectOptions);
+        const versionstampStr = versionstamp === null
+          ? "null"
+          : `"${versionstamp}"`;
         ArrayPrototypePush(
           operations,
-          `  enqueue(${messageStr}, { ${ArrayPrototypeJoin(options, ", ")} })`,
+          `  check({ key: ${keyStr}, versionstamp: ${versionstampStr} })`,
         );
       }
-    }
 
-    if (operations.length === 0) {
-      return "AtomicOperation (empty)";
-    }
+      // Format mutations
+      for (let i = 0; i < this.#mutations.length; ++i) {
+        const mutation = this.#mutations[i];
+        const key = mutation[0];
+        const type = mutation[1];
+        const rawValue = mutation[2];
+        const expireIn = mutation[3];
+        const keyStr = inspect(key, inspectOptions);
 
-    return `AtomicOperation\n${ArrayPrototypeJoin(operations, "\n")}`;
+        if (type === "delete") {
+          ArrayPrototypePush(operations, `  delete(${keyStr})`);
+        } else {
+          // Deserialize value for display
+          let value;
+          try {
+            if (rawValue === null) {
+              value = null;
+            } else {
+              switch (rawValue.kind) {
+                case "v8":
+                  value = core.deserialize(rawValue.value, {
+                    forStorage: true,
+                    deserializers: cloneableDeserializers,
+                  });
+                  break;
+                case "bytes":
+                  value = rawValue.value;
+                  break;
+                case "u64":
+                  value = new KvU64(rawValue.value);
+                  break;
+                default:
+                  value = rawValue;
+              }
+            }
+          } catch {
+            // If deserialization fails, show the raw value structure
+            value = `[${rawValue?.kind || "unknown"} value]`;
+          }
+
+          const valueStr = inspect(value, inspectOptions);
+
+          if (type === "set" && expireIn !== undefined) {
+            ArrayPrototypePush(
+              operations,
+              `  set(${keyStr}, ${valueStr}, { expireIn: ${expireIn} })`,
+            );
+          } else {
+            ArrayPrototypePush(operations, `  ${type}(${keyStr}, ${valueStr})`);
+          }
+        }
+      }
+
+      // Format enqueues
+      for (let i = 0; i < this.#enqueues.length; ++i) {
+        const enqueue = this.#enqueues[i];
+        const serializedMessage = enqueue[0];
+        const delay = enqueue[1];
+        const keysIfUndelivered = enqueue[2];
+        const backoffSchedule = enqueue[3];
+
+        // Deserialize message for display
+        let message;
+        try {
+          message = core.deserialize(serializedMessage, {
+            forStorage: true,
+            deserializers: cloneableDeserializers,
+          });
+        } catch {
+          message = "[serialized message]";
+        }
+
+        const messageStr = inspect(message, inspectOptions);
+
+        if (
+          delay === 0 && keysIfUndelivered.length === 0 &&
+          backoffSchedule === null
+        ) {
+          ArrayPrototypePush(operations, `  enqueue(${messageStr})`);
+        } else {
+          const options = [];
+          if (delay !== 0) ArrayPrototypePush(options, `delay: ${delay}`);
+          if (keysIfUndelivered.length > 0) {
+            const keysStr = inspect(keysIfUndelivered, inspectOptions);
+            ArrayPrototypePush(options, `keysIfUndelivered: ${keysStr}`);
+          }
+          if (backoffSchedule !== null) {
+            const scheduleStr = inspect(backoffSchedule, inspectOptions);
+            ArrayPrototypePush(options, `backoffSchedule: ${scheduleStr}`);
+          }
+          ArrayPrototypePush(
+            operations,
+            `  enqueue(${messageStr}, { ${
+              ArrayPrototypeJoin(options, ", ")
+            } })`,
+          );
+        }
+      }
+
+      if (operations.length === 0) {
+        return "AtomicOperation (empty)";
+      }
+
+      return `AtomicOperation\n${ArrayPrototypeJoin(operations, "\n")}`;
+    }
   }
-}
 
-const MIN_U64 = BigInt("0");
-const MAX_U64 = BigInt("0xffffffffffffffff");
+  const MIN_U64 = BigInt("0");
+  const MAX_U64 = BigInt("0xffffffffffffffff");
 
-class KvU64 {
-  value: bigint;
+  class KvU64 {
+    value: bigint;
 
-  constructor(value: bigint) {
-    if (typeof value !== "bigint") {
-      throw new TypeError(`Value must be a bigint: received ${typeof value}`);
+    constructor(value: bigint) {
+      if (typeof value !== "bigint") {
+        throw new TypeError(`Value must be a bigint: received ${typeof value}`);
+      }
+      if (value < MIN_U64) {
+        throw new RangeError(
+          `Value must be a positive bigint: received ${value}`,
+        );
+      }
+      if (value > MAX_U64) {
+        throw new RangeError("Value must fit in a 64-bit unsigned integer");
+      }
+      this.value = value;
+      ObjectFreeze(this);
     }
-    if (value < MIN_U64) {
-      throw new RangeError(
-        `Value must be a positive bigint: received ${value}`,
+
+    valueOf() {
+      return this.value;
+    }
+
+    toString() {
+      return BigIntPrototypeToString(this.value);
+    }
+
+    get [SymbolToStringTag]() {
+      return "Deno.KvU64";
+    }
+
+    [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
+      return StringPrototypeReplace(
+        inspect(Object(this.value), inspectOptions),
+        "BigInt",
+        "Deno.KvU64",
       );
     }
-    if (value > MAX_U64) {
-      throw new RangeError("Value must fit in a 64-bit unsigned integer");
+  }
+
+  function deserializeValue(entry: RawKvEntry): Deno.KvEntry<unknown> {
+    const { kind, value } = entry.value;
+    switch (kind) {
+      case "v8":
+        return {
+          ...entry,
+          value: core.deserialize(value, {
+            forStorage: true,
+            deserializers: cloneableDeserializers,
+          }),
+        };
+      case "bytes":
+        return {
+          ...entry,
+          value,
+        };
+      case "u64":
+        return {
+          ...entry,
+          value: new KvU64(value),
+        };
+      default:
+        throw new TypeError("Invalid value type");
     }
-    this.value = value;
-    ObjectFreeze(this);
   }
 
-  valueOf() {
-    return this.value;
-  }
-
-  toString() {
-    return BigIntPrototypeToString(this.value);
-  }
-
-  get [SymbolToStringTag]() {
-    return "Deno.KvU64";
-  }
-
-  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
-    return StringPrototypeReplace(
-      inspect(Object(this.value), inspectOptions),
-      "BigInt",
-      "Deno.KvU64",
-    );
-  }
-}
-
-function deserializeValue(entry: RawKvEntry): Deno.KvEntry<unknown> {
-  const { kind, value } = entry.value;
-  switch (kind) {
-    case "v8":
+  function serializeValue(value: unknown): RawValue {
+    if (TypedArrayPrototypeGetSymbolToStringTag(value) === "Uint8Array") {
       return {
-        ...entry,
-        value: core.deserialize(value, {
-          forStorage: true,
-          deserializers: cloneableDeserializers,
-        }),
-      };
-    case "bytes":
-      return {
-        ...entry,
+        kind: "bytes",
         value,
       };
-    case "u64":
+    } else if (ObjectPrototypeIsPrototypeOf(KvU64.prototype, value)) {
       return {
-        ...entry,
-        value: new KvU64(value),
+        kind: "u64",
+        // deno-lint-ignore prefer-primordials
+        value: value.valueOf(),
       };
-    default:
-      throw new TypeError("Invalid value type");
-  }
-}
-
-function serializeValue(value: unknown): RawValue {
-  if (TypedArrayPrototypeGetSymbolToStringTag(value) === "Uint8Array") {
-    return {
-      kind: "bytes",
-      value,
-    };
-  } else if (ObjectPrototypeIsPrototypeOf(KvU64.prototype, value)) {
-    return {
-      kind: "u64",
-      // deno-lint-ignore prefer-primordials
-      value: value.valueOf(),
-    };
-  } else {
-    return {
-      kind: "v8",
-      value: core.serialize(value, { forStorage: true }),
-    };
-  }
-}
-
-// This gets the %AsyncIteratorPrototype% object (which exists but is not a
-// global). We extend the KvListIterator iterator from, so that we immediately
-// support async iterator helpers once they land. The %AsyncIterator% does not
-// yet actually exist however, so right now the AsyncIterator binding refers to
-// %Object%. I know.
-// Once AsyncIterator is a global, we can just use it (from primordials), rather
-// than doing this here.
-const AsyncIteratorPrototype = ObjectGetPrototypeOf(AsyncGeneratorPrototype);
-const AsyncIterator = AsyncIteratorPrototype.constructor;
-
-class KvListIterator extends AsyncIterator
-  implements AsyncIterator<Deno.KvEntry<unknown>> {
-  #selector: Deno.KvListSelector;
-  #entries: Deno.KvEntry<unknown>[] | null = null;
-  #cursorGen: (() => string) | null = null;
-  #done = false;
-  #lastBatch = false;
-  #pullBatch: (
-    selector: Deno.KvListSelector,
-    cursor: string | undefined,
-    reverse: boolean,
-    consistency: Deno.KvConsistencyLevel,
-  ) => Promise<Deno.KvEntry<unknown>[]>;
-  #limit: number | undefined;
-  #count = 0;
-  #reverse: boolean;
-  #batchSize: number;
-  #consistency: Deno.KvConsistencyLevel;
-
-  constructor(
-    { limit, selector, cursor, reverse, consistency, batchSize, pullBatch }: {
-      limit?: number;
-      selector: Deno.KvListSelector;
-      cursor?: string;
-      reverse: boolean;
-      batchSize: number;
-      consistency: Deno.KvConsistencyLevel;
-      pullBatch: (
-        selector: Deno.KvListSelector,
-        cursor: string | undefined,
-        reverse: boolean,
-        consistency: Deno.KvConsistencyLevel,
-      ) => Promise<Deno.KvEntry<unknown>[]>;
-    },
-  ) {
-    super();
-    let prefix: Deno.KvKey | undefined;
-    let start: Deno.KvKey | undefined;
-    let end: Deno.KvKey | undefined;
-    if (ObjectHasOwn(selector, "prefix") && selector.prefix !== undefined) {
-      prefix = ObjectFreeze(ArrayPrototypeSlice(selector.prefix));
-    }
-    if (ObjectHasOwn(selector, "start") && selector.start !== undefined) {
-      start = ObjectFreeze(ArrayPrototypeSlice(selector.start));
-    }
-    if (ObjectHasOwn(selector, "end") && selector.end !== undefined) {
-      end = ObjectFreeze(ArrayPrototypeSlice(selector.end));
-    }
-    if (prefix) {
-      if (start && end) {
-        throw new TypeError(
-          "Selector can not specify both 'start' and 'end' key when specifying 'prefix'",
-        );
-      }
-      if (start) {
-        this.#selector = { prefix, start };
-      } else if (end) {
-        this.#selector = { prefix, end };
-      } else {
-        this.#selector = { prefix };
-      }
     } else {
-      if (start && end) {
-        this.#selector = { start, end };
+      return {
+        kind: "v8",
+        value: core.serialize(value, { forStorage: true }),
+      };
+    }
+  }
+
+  // This gets the %AsyncIteratorPrototype% object (which exists but is not a
+  // global). We extend the KvListIterator iterator from, so that we immediately
+  // support async iterator helpers once they land. The %AsyncIterator% does not
+  // yet actually exist however, so right now the AsyncIterator binding refers to
+  // %Object%. I know.
+  // Once AsyncIterator is a global, we can just use it (from primordials), rather
+  // than doing this here.
+  const AsyncIteratorPrototype = ObjectGetPrototypeOf(AsyncGeneratorPrototype);
+  const AsyncIterator = AsyncIteratorPrototype.constructor;
+
+  class KvListIterator extends AsyncIterator
+    implements AsyncIterator<Deno.KvEntry<unknown>> {
+    #selector: Deno.KvListSelector;
+    #entries: Deno.KvEntry<unknown>[] | null = null;
+    #cursorGen: (() => string) | null = null;
+    #done = false;
+    #lastBatch = false;
+    #pullBatch: (
+      selector: Deno.KvListSelector,
+      cursor: string | undefined,
+      reverse: boolean,
+      consistency: Deno.KvConsistencyLevel,
+    ) => Promise<Deno.KvEntry<unknown>[]>;
+    #limit: number | undefined;
+    #count = 0;
+    #reverse: boolean;
+    #batchSize: number;
+    #consistency: Deno.KvConsistencyLevel;
+
+    constructor(
+      { limit, selector, cursor, reverse, consistency, batchSize, pullBatch }: {
+        limit?: number;
+        selector: Deno.KvListSelector;
+        cursor?: string;
+        reverse: boolean;
+        batchSize: number;
+        consistency: Deno.KvConsistencyLevel;
+        pullBatch: (
+          selector: Deno.KvListSelector,
+          cursor: string | undefined,
+          reverse: boolean,
+          consistency: Deno.KvConsistencyLevel,
+        ) => Promise<Deno.KvEntry<unknown>[]>;
+      },
+    ) {
+      super();
+      let prefix: Deno.KvKey | undefined;
+      let start: Deno.KvKey | undefined;
+      let end: Deno.KvKey | undefined;
+      if (ObjectHasOwn(selector, "prefix") && selector.prefix !== undefined) {
+        prefix = ObjectFreeze(ArrayPrototypeSlice(selector.prefix));
+      }
+      if (ObjectHasOwn(selector, "start") && selector.start !== undefined) {
+        start = ObjectFreeze(ArrayPrototypeSlice(selector.start));
+      }
+      if (ObjectHasOwn(selector, "end") && selector.end !== undefined) {
+        end = ObjectFreeze(ArrayPrototypeSlice(selector.end));
+      }
+      if (prefix) {
+        if (start && end) {
+          throw new TypeError(
+            "Selector can not specify both 'start' and 'end' key when specifying 'prefix'",
+          );
+        }
+        if (start) {
+          this.#selector = { prefix, start };
+        } else if (end) {
+          this.#selector = { prefix, end };
+        } else {
+          this.#selector = { prefix };
+        }
       } else {
-        throw new TypeError(
-          "Selector must specify either 'prefix' or both 'start' and 'end' key",
+        if (start && end) {
+          this.#selector = { start, end };
+        } else {
+          throw new TypeError(
+            "Selector must specify either 'prefix' or both 'start' and 'end' key",
+          );
+        }
+      }
+      ObjectFreeze(this.#selector);
+      this.#pullBatch = pullBatch;
+      this.#limit = limit;
+      this.#reverse = reverse;
+      this.#consistency = consistency;
+      this.#batchSize = batchSize;
+      this.#cursorGen = cursor ? () => cursor : null;
+    }
+
+    get cursor(): string {
+      if (this.#cursorGen === null) {
+        throw new Error("Cannot get cursor before first iteration");
+      }
+
+      return this.#cursorGen();
+    }
+
+    async next(): Promise<IteratorResult<Deno.KvEntry<unknown>>> {
+      // Fused or limit exceeded
+      if (
+        this.#done ||
+        (this.#limit !== undefined && this.#count >= this.#limit)
+      ) {
+        return { done: true, value: undefined };
+      }
+
+      // Attempt to fill the buffer
+      if (!this.#entries?.length && !this.#lastBatch) {
+        const batch = await this.#pullBatch(
+          this.#selector,
+          this.#cursorGen ? this.#cursorGen() : undefined,
+          this.#reverse,
+          this.#consistency,
         );
+
+        // Reverse the batch so we can pop from the end
+        ArrayPrototypeReverse(batch);
+        this.#entries = batch;
+
+        // Last batch, do not attempt to pull more
+        if (batch.length < this.#batchSize) {
+          this.#lastBatch = true;
+        }
+      }
+
+      const entry = this.#entries?.pop();
+      if (!entry) {
+        this.#done = true;
+        this.#cursorGen = () => "";
+        return { done: true, value: undefined };
+      }
+
+      this.#cursorGen = () => {
+        const selector = this.#selector;
+        return encodeCursor([
+          ObjectHasOwn(selector, "prefix") ? selector.prefix : null,
+          ObjectHasOwn(selector, "start") ? selector.start : null,
+          ObjectHasOwn(selector, "end") ? selector.end : null,
+        ], entry.key);
+      };
+      this.#count++;
+      return {
+        done: false,
+        value: entry,
+      };
+    }
+
+    [SymbolAsyncIterator](): AsyncIterator<Deno.KvEntry<unknown>> {
+      return this;
+    }
+  }
+
+  async function doAtomicWriteInPlace(
+    rid: number,
+    checks: [Deno.KvKey, string | null][],
+    mutations: [Deno.KvKey, string, RawValue | null, number | undefined][],
+    enqueues: [Uint8Array, number, Deno.KvKey[], number[] | null][],
+  ): Promise<string | null> {
+    for (let i = 0; i < mutations.length; ++i) {
+      const mutation = mutations[i];
+      const key = mutation[0];
+      if (
+        key.length && mutation[1] === "set" &&
+        key[key.length - 1] === commitVersionstampSymbol
+      ) {
+        mutation[0] = ArrayPrototypeSlice(key, 0, key.length - 1);
+        mutation[1] = "setSuffixVersionstampedKey";
       }
     }
-    ObjectFreeze(this.#selector);
-    this.#pullBatch = pullBatch;
-    this.#limit = limit;
-    this.#reverse = reverse;
-    this.#consistency = consistency;
-    this.#batchSize = batchSize;
-    this.#cursorGen = cursor ? () => cursor : null;
+
+    return await op_kv_atomic_write(
+      rid,
+      checks,
+      mutations,
+      enqueues,
+    );
   }
 
-  get cursor(): string {
-    if (this.#cursorGen === null) {
-      throw new Error("Cannot get cursor before first iteration");
-    }
-
-    return this.#cursorGen();
-  }
-
-  async next(): Promise<IteratorResult<Deno.KvEntry<unknown>>> {
-    // Fused or limit exceeded
-    if (
-      this.#done ||
-      (this.#limit !== undefined && this.#count >= this.#limit)
-    ) {
-      return { done: true, value: undefined };
-    }
-
-    // Attempt to fill the buffer
-    if (!this.#entries?.length && !this.#lastBatch) {
-      const batch = await this.#pullBatch(
-        this.#selector,
-        this.#cursorGen ? this.#cursorGen() : undefined,
-        this.#reverse,
-        this.#consistency,
-      );
-
-      // Reverse the batch so we can pop from the end
-      ArrayPrototypeReverse(batch);
-      this.#entries = batch;
-
-      // Last batch, do not attempt to pull more
-      if (batch.length < this.#batchSize) {
-        this.#lastBatch = true;
-      }
-    }
-
-    const entry = this.#entries?.pop();
-    if (!entry) {
-      this.#done = true;
-      this.#cursorGen = () => "";
-      return { done: true, value: undefined };
-    }
-
-    this.#cursorGen = () => {
-      const selector = this.#selector;
-      return encodeCursor([
-        ObjectHasOwn(selector, "prefix") ? selector.prefix : null,
-        ObjectHasOwn(selector, "start") ? selector.start : null,
-        ObjectHasOwn(selector, "end") ? selector.end : null,
-      ], entry.key);
-    };
-    this.#count++;
-    return {
-      done: false,
-      value: entry,
-    };
-  }
-
-  [SymbolAsyncIterator](): AsyncIterator<Deno.KvEntry<unknown>> {
-    return this;
-  }
-}
-
-async function doAtomicWriteInPlace(
-  rid: number,
-  checks: [Deno.KvKey, string | null][],
-  mutations: [Deno.KvKey, string, RawValue | null, number | undefined][],
-  enqueues: [Uint8Array, number, Deno.KvKey[], number[] | null][],
-): Promise<string | null> {
-  for (let i = 0; i < mutations.length; ++i) {
-    const mutation = mutations[i];
-    const key = mutation[0];
-    if (
-      key.length && mutation[1] === "set" &&
-      key[key.length - 1] === commitVersionstampSymbol
-    ) {
-      mutation[0] = ArrayPrototypeSlice(key, 0, key.length - 1);
-      mutation[1] = "setSuffixVersionstampedKey";
-    }
-  }
-
-  return await op_kv_atomic_write(
-    rid,
-    checks,
-    mutations,
-    enqueues,
-  );
-}
-
-return { AtomicOperation, Kv, KvListIterator, KvU64, openKv };
+  return { AtomicOperation, Kv, KvListIterator, KvU64, openKv };
 })();

--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -1,982 +1,972 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 (function () {
-  const { core, internals, primordials } = __bootstrap;
-  const {
-    isPromise,
-  } = core;
-  const {
-    op_kv_atomic_write,
-    op_kv_database_open,
-    op_kv_dequeue_next_message,
-    op_kv_encode_cursor,
-    op_kv_finish_dequeued_message,
-    op_kv_snapshot_read,
-    op_kv_watch,
-    op_kv_watch_next,
-  } = core.ops;
-  const {
-    ArrayFrom,
-    ArrayPrototypeJoin,
-    ArrayPrototypeMap,
-    ArrayPrototypePush,
-    ArrayPrototypeReverse,
-    ArrayPrototypeSlice,
-    AsyncGeneratorPrototype,
-    BigInt,
-    BigIntPrototypeToString,
-    Error,
-    NumberIsInteger,
-    NumberIsNaN,
-    Object,
-    ObjectFreeze,
-    ObjectGetPrototypeOf,
-    ObjectHasOwn,
-    ObjectPrototypeIsPrototypeOf,
-    RangeError,
-    SafeMap,
-    SafeMapIterator,
-    StringPrototypeReplace,
-    Symbol,
-    SymbolAsyncIterator,
-    SymbolDispose,
-    SymbolFor,
-    SymbolToStringTag,
-    TypeError,
-    TypedArrayPrototypeGetSymbolToStringTag,
-  } = primordials;
+const { core, internals, primordials } = __bootstrap;
+const {
+  isPromise,
+} = core;
+const {
+  op_kv_atomic_write,
+  op_kv_database_open,
+  op_kv_dequeue_next_message,
+  op_kv_encode_cursor,
+  op_kv_finish_dequeued_message,
+  op_kv_snapshot_read,
+  op_kv_watch,
+  op_kv_watch_next,
+} = core.ops;
+const {
+  ArrayFrom,
+  ArrayPrototypeJoin,
+  ArrayPrototypeMap,
+  ArrayPrototypePush,
+  ArrayPrototypeReverse,
+  ArrayPrototypeSlice,
+  AsyncGeneratorPrototype,
+  BigInt,
+  BigIntPrototypeToString,
+  Error,
+  NumberIsInteger,
+  NumberIsNaN,
+  Object,
+  ObjectFreeze,
+  ObjectGetPrototypeOf,
+  ObjectHasOwn,
+  ObjectPrototypeIsPrototypeOf,
+  RangeError,
+  SafeMap,
+  SafeMapIterator,
+  StringPrototypeReplace,
+  Symbol,
+  SymbolAsyncIterator,
+  SymbolDispose,
+  SymbolFor,
+  SymbolToStringTag,
+  TypeError,
+  TypedArrayPrototypeGetSymbolToStringTag,
+} = primordials;
 
-  const { ReadableStream } = core.loadExtScript("ext:deno_web/06_streams.js");
+const { ReadableStream } = core.loadExtScript("ext:deno_web/06_streams.js");
 
-  const cloneableDeserializers = core.getCloneableDeserializers();
+const cloneableDeserializers = core.getCloneableDeserializers();
 
-  const encodeCursor: (
-    selector: [Deno.KvKey | null, Deno.KvKey | null, Deno.KvKey | null],
-    boundaryKey: Deno.KvKey,
-  ) => string = (selector, boundaryKey) =>
-    op_kv_encode_cursor(selector, boundaryKey);
+const encodeCursor: (
+  selector: [Deno.KvKey | null, Deno.KvKey | null, Deno.KvKey | null],
+  boundaryKey: Deno.KvKey,
+) => string = (selector, boundaryKey) =>
+  op_kv_encode_cursor(selector, boundaryKey);
 
-  async function openKv(path: string) {
-    const rid = await op_kv_database_open(path);
-    return new Kv(rid, kvSymbol);
+async function openKv(path: string) {
+  const rid = await op_kv_database_open(path);
+  return new Kv(rid, kvSymbol);
+}
+
+const maxQueueDelay = 30 * 24 * 60 * 60 * 1000;
+
+function validateQueueDelay(delay: number) {
+  if (delay < 0) {
+    throw new TypeError(`Delay must be >= 0: received ${delay}`);
   }
-
-  const maxQueueDelay = 30 * 24 * 60 * 60 * 1000;
-
-  function validateQueueDelay(delay: number) {
-    if (delay < 0) {
-      throw new TypeError(`Delay must be >= 0: received ${delay}`);
-    }
-    if (delay > maxQueueDelay) {
-      throw new TypeError(
-        `Delay cannot be greater than 30 days: received ${delay}`,
-      );
-    }
-    if (NumberIsNaN(delay)) {
-      throw new TypeError("Delay cannot be NaN");
-    }
+  if (delay > maxQueueDelay) {
+    throw new TypeError(
+      `Delay cannot be greater than 30 days: received ${delay}`,
+    );
   }
-
-  const maxQueueBackoffIntervals = 5;
-  const maxQueueBackoffInterval = 60 * 60 * 1000;
-
-  function validateBackoffSchedule(backoffSchedule: number[]) {
-    if (backoffSchedule.length > maxQueueBackoffIntervals) {
-      throw new TypeError(
-        `Invalid backoffSchedule, max ${maxQueueBackoffIntervals} intervals allowed`,
-      );
-    }
-    for (let i = 0; i < backoffSchedule.length; ++i) {
-      const interval = backoffSchedule[i];
-      if (
-        interval < 0 || interval > maxQueueBackoffInterval ||
-        NumberIsNaN(interval)
-      ) {
-        throw new TypeError(
-          `Invalid backoffSchedule, interval at index ${i} is invalid`,
-        );
-      }
-    }
+  if (NumberIsNaN(delay)) {
+    throw new TypeError("Delay cannot be NaN");
   }
+}
 
-  interface RawKvEntry {
-    key: Deno.KvKey;
-    value: RawValue;
-    versionstamp: string;
+const maxQueueBackoffIntervals = 5;
+const maxQueueBackoffInterval = 60 * 60 * 1000;
+
+function validateBackoffSchedule(backoffSchedule: number[]) {
+  if (backoffSchedule.length > maxQueueBackoffIntervals) {
+    throw new TypeError(
+      `Invalid backoffSchedule, max ${maxQueueBackoffIntervals} intervals allowed`,
+    );
   }
-
-  type RawValue = {
-    kind: "v8";
-    value: Uint8Array;
-  } | {
-    kind: "bytes";
-    value: Uint8Array;
-  } | {
-    kind: "u64";
-    value: bigint;
-  };
-
-  const kvSymbol = Symbol("KvRid");
-  const commitVersionstampSymbol = Symbol("KvCommitVersionstamp");
-
-  class Kv {
-    #rid: number;
-    #isClosed: boolean;
-
-    constructor(rid: number = undefined, symbol: symbol = undefined) {
-      if (kvSymbol !== symbol) {
-        throw new TypeError(
-          "Deno.Kv can not be constructed: use Deno.openKv instead",
-        );
-      }
-      this.#rid = rid;
-      this.#isClosed = false;
-    }
-
-    atomic() {
-      return new AtomicOperation(this.#rid);
-    }
-
-    commitVersionstamp(): symbol {
-      return commitVersionstampSymbol;
-    }
-
-    async get(
-      key: Deno.KvKey,
-      opts?: { consistency?: Deno.KvConsistencyLevel },
+  for (let i = 0; i < backoffSchedule.length; ++i) {
+    const interval = backoffSchedule[i];
+    if (
+      interval < 0 || interval > maxQueueBackoffInterval ||
+      NumberIsNaN(interval)
     ) {
-      const { 0: entries }: [RawKvEntry[]] = await op_kv_snapshot_read(
-        this.#rid,
-        [[
-          null,
-          key,
-          null,
-          1,
-          false,
-          null,
-        ]],
-        opts?.consistency ?? "strong",
+      throw new TypeError(
+        `Invalid backoffSchedule, interval at index ${i} is invalid`,
       );
+    }
+  }
+}
+
+interface RawKvEntry {
+  key: Deno.KvKey;
+  value: RawValue;
+  versionstamp: string;
+}
+
+type RawValue = {
+  kind: "v8";
+  value: Uint8Array;
+} | {
+  kind: "bytes";
+  value: Uint8Array;
+} | {
+  kind: "u64";
+  value: bigint;
+};
+
+const kvSymbol = Symbol("KvRid");
+const commitVersionstampSymbol = Symbol("KvCommitVersionstamp");
+
+class Kv {
+  #rid: number;
+  #isClosed: boolean;
+
+  constructor(rid: number = undefined, symbol: symbol = undefined) {
+    if (kvSymbol !== symbol) {
+      throw new TypeError(
+        "Deno.Kv can not be constructed: use Deno.openKv instead",
+      );
+    }
+    this.#rid = rid;
+    this.#isClosed = false;
+  }
+
+  atomic() {
+    return new AtomicOperation(this.#rid);
+  }
+
+  commitVersionstamp(): symbol {
+    return commitVersionstampSymbol;
+  }
+
+  async get(key: Deno.KvKey, opts?: { consistency?: Deno.KvConsistencyLevel }) {
+    const { 0: entries }: [RawKvEntry[]] = await op_kv_snapshot_read(
+      this.#rid,
+      [[
+        null,
+        key,
+        null,
+        1,
+        false,
+        null,
+      ]],
+      opts?.consistency ?? "strong",
+    );
+    if (!entries.length) {
+      return {
+        key,
+        value: null,
+        versionstamp: null,
+      };
+    }
+    return deserializeValue(entries[0]);
+  }
+
+  async getMany(
+    keys: Deno.KvKey[],
+    opts?: { consistency?: Deno.KvConsistencyLevel },
+  ): Promise<Deno.KvEntry<unknown>[]> {
+    const ranges: RawKvEntry[][] = await op_kv_snapshot_read(
+      this.#rid,
+      ArrayPrototypeMap(keys, (key: Deno.KvKey) => [
+        null,
+        key,
+        null,
+        1,
+        false,
+        null,
+      ]),
+      opts?.consistency ?? "strong",
+    );
+    return ArrayPrototypeMap(ranges, (entries: RawKvEntry[], i: number) => {
       if (!entries.length) {
         return {
-          key,
+          key: keys[i],
           value: null,
           versionstamp: null,
         };
       }
       return deserializeValue(entries[0]);
-    }
-
-    async getMany(
-      keys: Deno.KvKey[],
-      opts?: { consistency?: Deno.KvConsistencyLevel },
-    ): Promise<Deno.KvEntry<unknown>[]> {
-      const ranges: RawKvEntry[][] = await op_kv_snapshot_read(
-        this.#rid,
-        ArrayPrototypeMap(keys, (key: Deno.KvKey) => [
-          null,
-          key,
-          null,
-          1,
-          false,
-          null,
-        ]),
-        opts?.consistency ?? "strong",
-      );
-      return ArrayPrototypeMap(ranges, (entries: RawKvEntry[], i: number) => {
-        if (!entries.length) {
-          return {
-            key: keys[i],
-            value: null,
-            versionstamp: null,
-          };
-        }
-        return deserializeValue(entries[0]);
-      });
-    }
-
-    async set(
-      key: Deno.KvKey,
-      value: unknown,
-      options?: { expireIn?: number },
-    ) {
-      const versionstamp = await doAtomicWriteInPlace(
-        this.#rid,
-        [],
-        [[key, "set", serializeValue(value), options?.expireIn]],
-        [],
-      );
-      if (versionstamp === null) throw new TypeError("Failed to set value");
-      return { ok: true, versionstamp };
-    }
-
-    async delete(key: Deno.KvKey) {
-      const result = await doAtomicWriteInPlace(
-        this.#rid,
-        [],
-        [[key, "delete", null, undefined]],
-        [],
-      );
-      if (!result) throw new TypeError("Failed to set value");
-    }
-
-    list(
-      selector: Deno.KvListSelector,
-      options: {
-        limit?: number;
-        batchSize?: number;
-        cursor?: string;
-        reverse?: boolean;
-        consistency?: Deno.KvConsistencyLevel;
-      } = { __proto__: null },
-    ): KvListIterator {
-      if (options.limit !== undefined && options.limit <= 0) {
-        throw new Error(`Limit must be positive: received ${options.limit}`);
-      }
-
-      let batchSize = options.batchSize ?? (options.limit ?? 100);
-      if (!NumberIsInteger(batchSize) || batchSize <= 0) {
-        throw new Error(
-          `batchSize must be a positive integer: received ${batchSize}`,
-        );
-      }
-      if (options.batchSize === undefined && batchSize > 500) batchSize = 500;
-
-      return new KvListIterator({
-        limit: options.limit,
-        selector,
-        cursor: options.cursor,
-        reverse: options.reverse ?? false,
-        consistency: options.consistency ?? "strong",
-        batchSize,
-        pullBatch: this.#pullBatch(batchSize),
-      });
-    }
-
-    #pullBatch(batchSize: number): (
-      selector: Deno.KvListSelector,
-      cursor: string | undefined,
-      reverse: boolean,
-      consistency: Deno.KvConsistencyLevel,
-    ) => Promise<Deno.KvEntry<unknown>[]> {
-      return async (selector, cursor, reverse, consistency) => {
-        const { 0: entries }: [RawKvEntry[]] = await op_kv_snapshot_read(
-          this.#rid,
-          [[
-            ObjectHasOwn(selector, "prefix") ? selector.prefix : null,
-            ObjectHasOwn(selector, "start") ? selector.start : null,
-            ObjectHasOwn(selector, "end") ? selector.end : null,
-            batchSize,
-            reverse,
-            cursor,
-          ]],
-          consistency,
-        );
-
-        return ArrayPrototypeMap(entries, deserializeValue);
-      };
-    }
-
-    async enqueue(
-      message: unknown,
-      opts?: {
-        delay?: number;
-        keysIfUndelivered?: Deno.KvKey[];
-        backoffSchedule?: number[];
-      },
-    ) {
-      if (opts?.delay !== undefined) {
-        validateQueueDelay(opts?.delay);
-      }
-      if (opts?.backoffSchedule !== undefined) {
-        validateBackoffSchedule(opts?.backoffSchedule);
-      }
-
-      const versionstamp = await doAtomicWriteInPlace(
-        this.#rid,
-        [],
-        [],
-        [
-          [
-            core.serialize(message, { forStorage: true }),
-            opts?.delay ?? 0,
-            opts?.keysIfUndelivered ?? [],
-            opts?.backoffSchedule ?? null,
-          ],
-        ],
-      );
-      if (versionstamp === null) throw new TypeError("Failed to enqueue value");
-      return { ok: true, versionstamp };
-    }
-
-    async listenQueue(
-      handler: (message: unknown) => Promise<void> | void,
-    ): Promise<void> {
-      if (this.#isClosed) {
-        throw new Error("Queue already closed");
-      }
-      const finishMessageOps = new SafeMap<number, Promise<void>>();
-      while (true) {
-        // Wait for the next message.
-        const next: { 0: Uint8Array; 1: number } =
-          await op_kv_dequeue_next_message(
-            this.#rid,
-          );
-        if (next === null) {
-          break;
-        }
-
-        // Deserialize the payload.
-        const { 0: payload, 1: handleId } = next;
-        const deserializedPayload = core.deserialize(payload, {
-          forStorage: true,
-          deserializers: cloneableDeserializers,
-        });
-
-        // Dispatch the payload.
-        (async () => {
-          let success = false;
-          try {
-            const result = handler(deserializedPayload);
-            const _res = isPromise(result) ? (await result) : result;
-            success = true;
-          } catch (error) {
-            internals.log("error", "Exception in queue handler", error);
-          } finally {
-            const promise: Promise<void> = op_kv_finish_dequeued_message(
-              handleId,
-              success,
-            );
-            finishMessageOps.set(handleId, promise);
-            try {
-              await promise;
-            } finally {
-              finishMessageOps.delete(handleId);
-            }
-          }
-        })();
-      }
-
-      for (const { 1: promise } of new SafeMapIterator(finishMessageOps)) {
-        await promise;
-      }
-      finishMessageOps.clear();
-    }
-
-    watch(keys: Deno.KvKey[], options = { __proto__: null }) {
-      const raw = options.raw ?? false;
-      const rid = op_kv_watch(this.#rid, keys);
-      const lastEntries: (Deno.KvEntryMaybe<unknown> | undefined)[] = ArrayFrom(
-        { length: keys.length },
-      );
-      return new ReadableStream({
-        async pull(controller) {
-          while (true) {
-            let updates;
-            try {
-              updates = await op_kv_watch_next(rid);
-            } catch (err) {
-              core.tryClose(rid);
-              controller.error(err);
-              return;
-            }
-            if (updates === null) {
-              core.tryClose(rid);
-              controller.close();
-              return;
-            }
-            let changed = false;
-            for (let i = 0; i < keys.length; i++) {
-              if (updates[i] === "unchanged") {
-                if (lastEntries[i] === undefined) {
-                  throw new Error(
-                    "'watch': invalid unchanged update (internal error)",
-                  );
-                }
-                continue;
-              }
-              if (
-                lastEntries[i] !== undefined &&
-                (updates[i]?.versionstamp ?? null) ===
-                  lastEntries[i]?.versionstamp
-              ) {
-                continue;
-              }
-              changed = true;
-              if (updates[i] === null) {
-                lastEntries[i] = {
-                  key: ArrayPrototypeSlice(keys[i]),
-                  value: null,
-                  versionstamp: null,
-                };
-              } else {
-                lastEntries[i] = updates[i];
-              }
-            }
-            if (!changed && !raw) continue; // no change
-            const entries = ArrayPrototypeMap(
-              lastEntries,
-              (entry) =>
-                entry.versionstamp === null
-                  ? { ...entry }
-                  : deserializeValue(entry),
-            );
-            controller.enqueue(entries);
-            return;
-          }
-        },
-        cancel() {
-          core.tryClose(rid);
-        },
-      });
-    }
-
-    close() {
-      core.close(this.#rid);
-      this.#isClosed = true;
-    }
-
-    [SymbolDispose]() {
-      core.tryClose(this.#rid);
-    }
+    });
   }
 
-  class AtomicOperation {
-    #rid: number;
+  async set(key: Deno.KvKey, value: unknown, options?: { expireIn?: number }) {
+    const versionstamp = await doAtomicWriteInPlace(
+      this.#rid,
+      [],
+      [[key, "set", serializeValue(value), options?.expireIn]],
+      [],
+    );
+    if (versionstamp === null) throw new TypeError("Failed to set value");
+    return { ok: true, versionstamp };
+  }
 
-    #checks: [Deno.KvKey, string | null][] = [];
-    #mutations: [Deno.KvKey, string, RawValue | null, number | undefined][] =
-      [];
-    #enqueues: [Uint8Array, number, Deno.KvKey[], number[] | null][] = [];
+  async delete(key: Deno.KvKey) {
+    const result = await doAtomicWriteInPlace(
+      this.#rid,
+      [],
+      [[key, "delete", null, undefined]],
+      [],
+    );
+    if (!result) throw new TypeError("Failed to set value");
+  }
 
-    constructor(rid: number) {
-      this.#rid = rid;
+  list(
+    selector: Deno.KvListSelector,
+    options: {
+      limit?: number;
+      batchSize?: number;
+      cursor?: string;
+      reverse?: boolean;
+      consistency?: Deno.KvConsistencyLevel;
+    } = { __proto__: null },
+  ): KvListIterator {
+    if (options.limit !== undefined && options.limit <= 0) {
+      throw new Error(`Limit must be positive: received ${options.limit}`);
     }
 
-    check(...checks: Deno.AtomicCheck[]): this {
-      for (let i = 0; i < checks.length; ++i) {
-        const check = checks[i];
-        ArrayPrototypePush(this.#checks, [check.key, check.versionstamp]);
-      }
-      return this;
+    let batchSize = options.batchSize ?? (options.limit ?? 100);
+    if (!NumberIsInteger(batchSize) || batchSize <= 0) {
+      throw new Error(
+        `batchSize must be a positive integer: received ${batchSize}`,
+      );
     }
+    if (options.batchSize === undefined && batchSize > 500) batchSize = 500;
 
-    mutate(...mutations: Deno.KvMutation[]): this {
-      for (let i = 0; i < mutations.length; ++i) {
-        const mutation = mutations[i];
-        const key = mutation.key;
-        let type: string;
-        let value: RawValue | null;
-        let expireIn: number | undefined = undefined;
-        switch (mutation.type) {
-          case "delete":
-            type = "delete";
-            if (mutation.value) {
-              throw new TypeError("Invalid mutation 'delete' with value");
-            }
-            break;
-          case "set":
-            if (typeof mutation.expireIn === "number") {
-              expireIn = mutation.expireIn;
-            }
-            /* falls through */
-          case "sum":
-          case "min":
-          case "max":
-            type = mutation.type;
-            if (!ObjectHasOwn(mutation, "value")) {
-              throw new TypeError(`Invalid mutation '${type}' without value`);
-            }
-            value = serializeValue(mutation.value);
-            break;
-          default:
-            throw new TypeError("Invalid mutation type");
-        }
-        ArrayPrototypePush(this.#mutations, [key, type, value, expireIn]);
-      }
-      return this;
-    }
+    return new KvListIterator({
+      limit: options.limit,
+      selector,
+      cursor: options.cursor,
+      reverse: options.reverse ?? false,
+      consistency: options.consistency ?? "strong",
+      batchSize,
+      pullBatch: this.#pullBatch(batchSize),
+    });
+  }
 
-    sum(key: Deno.KvKey, n: bigint): this {
-      ArrayPrototypePush(this.#mutations, [
-        key,
-        "sum",
-        serializeValue(new KvU64(n)),
-        undefined,
-      ]);
-      return this;
-    }
-
-    min(key: Deno.KvKey, n: bigint): this {
-      ArrayPrototypePush(this.#mutations, [
-        key,
-        "min",
-        serializeValue(new KvU64(n)),
-        undefined,
-      ]);
-      return this;
-    }
-
-    max(key: Deno.KvKey, n: bigint): this {
-      ArrayPrototypePush(this.#mutations, [
-        key,
-        "max",
-        serializeValue(new KvU64(n)),
-        undefined,
-      ]);
-      return this;
-    }
-
-    set(
-      key: Deno.KvKey,
-      value: unknown,
-      options?: { expireIn?: number },
-    ): this {
-      ArrayPrototypePush(this.#mutations, [
-        key,
-        "set",
-        serializeValue(value),
-        options?.expireIn,
-      ]);
-      return this;
-    }
-
-    delete(key: Deno.KvKey): this {
-      ArrayPrototypePush(this.#mutations, [key, "delete", null, undefined]);
-      return this;
-    }
-
-    enqueue(
-      message: unknown,
-      opts?: {
-        delay?: number;
-        keysIfUndelivered?: Deno.KvKey[];
-        backoffSchedule?: number[];
-      },
-    ): this {
-      if (opts?.delay !== undefined) {
-        validateQueueDelay(opts?.delay);
-      }
-      if (opts?.backoffSchedule !== undefined) {
-        validateBackoffSchedule(opts?.backoffSchedule);
-      }
-      ArrayPrototypePush(this.#enqueues, [
-        core.serialize(message, { forStorage: true }),
-        opts?.delay ?? 0,
-        opts?.keysIfUndelivered ?? [],
-        opts?.backoffSchedule ?? null,
-      ]);
-      return this;
-    }
-
-    async commit(): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
-      const versionstamp = await doAtomicWriteInPlace(
+  #pullBatch(batchSize: number): (
+    selector: Deno.KvListSelector,
+    cursor: string | undefined,
+    reverse: boolean,
+    consistency: Deno.KvConsistencyLevel,
+  ) => Promise<Deno.KvEntry<unknown>[]> {
+    return async (selector, cursor, reverse, consistency) => {
+      const { 0: entries }: [RawKvEntry[]] = await op_kv_snapshot_read(
         this.#rid,
-        this.#checks,
-        this.#mutations,
-        this.#enqueues,
-      );
-      if (versionstamp === null) return { ok: false };
-      return { ok: true, versionstamp };
-    }
-
-    then() {
-      throw new TypeError(
-        "'Deno.AtomicOperation' is not a promise: did you forget to call 'commit()'",
-      );
-    }
-
-    [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
-      const operations = [];
-
-      // Format checks
-      for (let i = 0; i < this.#checks.length; ++i) {
-        const check = this.#checks[i];
-        const key = check[0];
-        const versionstamp = check[1];
-        const keyStr = inspect(key, inspectOptions);
-        const versionstampStr = versionstamp === null
-          ? "null"
-          : `"${versionstamp}"`;
-        ArrayPrototypePush(
-          operations,
-          `  check({ key: ${keyStr}, versionstamp: ${versionstampStr} })`,
-        );
-      }
-
-      // Format mutations
-      for (let i = 0; i < this.#mutations.length; ++i) {
-        const mutation = this.#mutations[i];
-        const key = mutation[0];
-        const type = mutation[1];
-        const rawValue = mutation[2];
-        const expireIn = mutation[3];
-        const keyStr = inspect(key, inspectOptions);
-
-        if (type === "delete") {
-          ArrayPrototypePush(operations, `  delete(${keyStr})`);
-        } else {
-          // Deserialize value for display
-          let value;
-          try {
-            if (rawValue === null) {
-              value = null;
-            } else {
-              switch (rawValue.kind) {
-                case "v8":
-                  value = core.deserialize(rawValue.value, {
-                    forStorage: true,
-                    deserializers: cloneableDeserializers,
-                  });
-                  break;
-                case "bytes":
-                  value = rawValue.value;
-                  break;
-                case "u64":
-                  value = new KvU64(rawValue.value);
-                  break;
-                default:
-                  value = rawValue;
-              }
-            }
-          } catch {
-            // If deserialization fails, show the raw value structure
-            value = `[${rawValue?.kind || "unknown"} value]`;
-          }
-
-          const valueStr = inspect(value, inspectOptions);
-
-          if (type === "set" && expireIn !== undefined) {
-            ArrayPrototypePush(
-              operations,
-              `  set(${keyStr}, ${valueStr}, { expireIn: ${expireIn} })`,
-            );
-          } else {
-            ArrayPrototypePush(operations, `  ${type}(${keyStr}, ${valueStr})`);
-          }
-        }
-      }
-
-      // Format enqueues
-      for (let i = 0; i < this.#enqueues.length; ++i) {
-        const enqueue = this.#enqueues[i];
-        const serializedMessage = enqueue[0];
-        const delay = enqueue[1];
-        const keysIfUndelivered = enqueue[2];
-        const backoffSchedule = enqueue[3];
-
-        // Deserialize message for display
-        let message;
-        try {
-          message = core.deserialize(serializedMessage, {
-            forStorage: true,
-            deserializers: cloneableDeserializers,
-          });
-        } catch {
-          message = "[serialized message]";
-        }
-
-        const messageStr = inspect(message, inspectOptions);
-
-        if (
-          delay === 0 && keysIfUndelivered.length === 0 &&
-          backoffSchedule === null
-        ) {
-          ArrayPrototypePush(operations, `  enqueue(${messageStr})`);
-        } else {
-          const options = [];
-          if (delay !== 0) ArrayPrototypePush(options, `delay: ${delay}`);
-          if (keysIfUndelivered.length > 0) {
-            const keysStr = inspect(keysIfUndelivered, inspectOptions);
-            ArrayPrototypePush(options, `keysIfUndelivered: ${keysStr}`);
-          }
-          if (backoffSchedule !== null) {
-            const scheduleStr = inspect(backoffSchedule, inspectOptions);
-            ArrayPrototypePush(options, `backoffSchedule: ${scheduleStr}`);
-          }
-          ArrayPrototypePush(
-            operations,
-            `  enqueue(${messageStr}, { ${
-              ArrayPrototypeJoin(options, ", ")
-            } })`,
-          );
-        }
-      }
-
-      if (operations.length === 0) {
-        return "AtomicOperation (empty)";
-      }
-
-      return `AtomicOperation\n${ArrayPrototypeJoin(operations, "\n")}`;
-    }
-  }
-
-  const MIN_U64 = BigInt("0");
-  const MAX_U64 = BigInt("0xffffffffffffffff");
-
-  class KvU64 {
-    value: bigint;
-
-    constructor(value: bigint) {
-      if (typeof value !== "bigint") {
-        throw new TypeError(`Value must be a bigint: received ${typeof value}`);
-      }
-      if (value < MIN_U64) {
-        throw new RangeError(
-          `Value must be a positive bigint: received ${value}`,
-        );
-      }
-      if (value > MAX_U64) {
-        throw new RangeError("Value must fit in a 64-bit unsigned integer");
-      }
-      this.value = value;
-      ObjectFreeze(this);
-    }
-
-    valueOf() {
-      return this.value;
-    }
-
-    toString() {
-      return BigIntPrototypeToString(this.value);
-    }
-
-    get [SymbolToStringTag]() {
-      return "Deno.KvU64";
-    }
-
-    [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
-      return StringPrototypeReplace(
-        inspect(Object(this.value), inspectOptions),
-        "BigInt",
-        "Deno.KvU64",
-      );
-    }
-  }
-
-  function deserializeValue(entry: RawKvEntry): Deno.KvEntry<unknown> {
-    const { kind, value } = entry.value;
-    switch (kind) {
-      case "v8":
-        return {
-          ...entry,
-          value: core.deserialize(value, {
-            forStorage: true,
-            deserializers: cloneableDeserializers,
-          }),
-        };
-      case "bytes":
-        return {
-          ...entry,
-          value,
-        };
-      case "u64":
-        return {
-          ...entry,
-          value: new KvU64(value),
-        };
-      default:
-        throw new TypeError("Invalid value type");
-    }
-  }
-
-  function serializeValue(value: unknown): RawValue {
-    if (TypedArrayPrototypeGetSymbolToStringTag(value) === "Uint8Array") {
-      return {
-        kind: "bytes",
-        value,
-      };
-    } else if (ObjectPrototypeIsPrototypeOf(KvU64.prototype, value)) {
-      return {
-        kind: "u64",
-        // deno-lint-ignore prefer-primordials
-        value: value.valueOf(),
-      };
-    } else {
-      return {
-        kind: "v8",
-        value: core.serialize(value, { forStorage: true }),
-      };
-    }
-  }
-
-  // This gets the %AsyncIteratorPrototype% object (which exists but is not a
-  // global). We extend the KvListIterator iterator from, so that we immediately
-  // support async iterator helpers once they land. The %AsyncIterator% does not
-  // yet actually exist however, so right now the AsyncIterator binding refers to
-  // %Object%. I know.
-  // Once AsyncIterator is a global, we can just use it (from primordials), rather
-  // than doing this here.
-  const AsyncIteratorPrototype = ObjectGetPrototypeOf(AsyncGeneratorPrototype);
-  const AsyncIterator = AsyncIteratorPrototype.constructor;
-
-  class KvListIterator extends AsyncIterator
-    implements AsyncIterator<Deno.KvEntry<unknown>> {
-    #selector: Deno.KvListSelector;
-    #entries: Deno.KvEntry<unknown>[] | null = null;
-    #cursorGen: (() => string) | null = null;
-    #done = false;
-    #lastBatch = false;
-    #pullBatch: (
-      selector: Deno.KvListSelector,
-      cursor: string | undefined,
-      reverse: boolean,
-      consistency: Deno.KvConsistencyLevel,
-    ) => Promise<Deno.KvEntry<unknown>[]>;
-    #limit: number | undefined;
-    #count = 0;
-    #reverse: boolean;
-    #batchSize: number;
-    #consistency: Deno.KvConsistencyLevel;
-
-    constructor(
-      { limit, selector, cursor, reverse, consistency, batchSize, pullBatch }: {
-        limit?: number;
-        selector: Deno.KvListSelector;
-        cursor?: string;
-        reverse: boolean;
-        batchSize: number;
-        consistency: Deno.KvConsistencyLevel;
-        pullBatch: (
-          selector: Deno.KvListSelector,
-          cursor: string | undefined,
-          reverse: boolean,
-          consistency: Deno.KvConsistencyLevel,
-        ) => Promise<Deno.KvEntry<unknown>[]>;
-      },
-    ) {
-      super();
-      let prefix: Deno.KvKey | undefined;
-      let start: Deno.KvKey | undefined;
-      let end: Deno.KvKey | undefined;
-      if (ObjectHasOwn(selector, "prefix") && selector.prefix !== undefined) {
-        prefix = ObjectFreeze(ArrayPrototypeSlice(selector.prefix));
-      }
-      if (ObjectHasOwn(selector, "start") && selector.start !== undefined) {
-        start = ObjectFreeze(ArrayPrototypeSlice(selector.start));
-      }
-      if (ObjectHasOwn(selector, "end") && selector.end !== undefined) {
-        end = ObjectFreeze(ArrayPrototypeSlice(selector.end));
-      }
-      if (prefix) {
-        if (start && end) {
-          throw new TypeError(
-            "Selector can not specify both 'start' and 'end' key when specifying 'prefix'",
-          );
-        }
-        if (start) {
-          this.#selector = { prefix, start };
-        } else if (end) {
-          this.#selector = { prefix, end };
-        } else {
-          this.#selector = { prefix };
-        }
-      } else {
-        if (start && end) {
-          this.#selector = { start, end };
-        } else {
-          throw new TypeError(
-            "Selector must specify either 'prefix' or both 'start' and 'end' key",
-          );
-        }
-      }
-      ObjectFreeze(this.#selector);
-      this.#pullBatch = pullBatch;
-      this.#limit = limit;
-      this.#reverse = reverse;
-      this.#consistency = consistency;
-      this.#batchSize = batchSize;
-      this.#cursorGen = cursor ? () => cursor : null;
-    }
-
-    get cursor(): string {
-      if (this.#cursorGen === null) {
-        throw new Error("Cannot get cursor before first iteration");
-      }
-
-      return this.#cursorGen();
-    }
-
-    async next(): Promise<IteratorResult<Deno.KvEntry<unknown>>> {
-      // Fused or limit exceeded
-      if (
-        this.#done ||
-        (this.#limit !== undefined && this.#count >= this.#limit)
-      ) {
-        return { done: true, value: undefined };
-      }
-
-      // Attempt to fill the buffer
-      if (!this.#entries?.length && !this.#lastBatch) {
-        const batch = await this.#pullBatch(
-          this.#selector,
-          this.#cursorGen ? this.#cursorGen() : undefined,
-          this.#reverse,
-          this.#consistency,
-        );
-
-        // Reverse the batch so we can pop from the end
-        ArrayPrototypeReverse(batch);
-        this.#entries = batch;
-
-        // Last batch, do not attempt to pull more
-        if (batch.length < this.#batchSize) {
-          this.#lastBatch = true;
-        }
-      }
-
-      const entry = this.#entries?.pop();
-      if (!entry) {
-        this.#done = true;
-        this.#cursorGen = () => "";
-        return { done: true, value: undefined };
-      }
-
-      this.#cursorGen = () => {
-        const selector = this.#selector;
-        return encodeCursor([
+        [[
           ObjectHasOwn(selector, "prefix") ? selector.prefix : null,
           ObjectHasOwn(selector, "start") ? selector.start : null,
           ObjectHasOwn(selector, "end") ? selector.end : null,
-        ], entry.key);
-      };
-      this.#count++;
-      return {
-        done: false,
-        value: entry,
-      };
-    }
+          batchSize,
+          reverse,
+          cursor,
+        ]],
+        consistency,
+      );
 
-    [SymbolAsyncIterator](): AsyncIterator<Deno.KvEntry<unknown>> {
-      return this;
-    }
+      return ArrayPrototypeMap(entries, deserializeValue);
+    };
   }
 
-  async function doAtomicWriteInPlace(
-    rid: number,
-    checks: [Deno.KvKey, string | null][],
-    mutations: [Deno.KvKey, string, RawValue | null, number | undefined][],
-    enqueues: [Uint8Array, number, Deno.KvKey[], number[] | null][],
-  ): Promise<string | null> {
-    for (let i = 0; i < mutations.length; ++i) {
-      const mutation = mutations[i];
-      const key = mutation[0];
-      if (
-        key.length && mutation[1] === "set" &&
-        key[key.length - 1] === commitVersionstampSymbol
-      ) {
-        mutation[0] = ArrayPrototypeSlice(key, 0, key.length - 1);
-        mutation[1] = "setSuffixVersionstampedKey";
-      }
+  async enqueue(
+    message: unknown,
+    opts?: {
+      delay?: number;
+      keysIfUndelivered?: Deno.KvKey[];
+      backoffSchedule?: number[];
+    },
+  ) {
+    if (opts?.delay !== undefined) {
+      validateQueueDelay(opts?.delay);
+    }
+    if (opts?.backoffSchedule !== undefined) {
+      validateBackoffSchedule(opts?.backoffSchedule);
     }
 
-    return await op_kv_atomic_write(
-      rid,
-      checks,
-      mutations,
-      enqueues,
+    const versionstamp = await doAtomicWriteInPlace(
+      this.#rid,
+      [],
+      [],
+      [
+        [
+          core.serialize(message, { forStorage: true }),
+          opts?.delay ?? 0,
+          opts?.keysIfUndelivered ?? [],
+          opts?.backoffSchedule ?? null,
+        ],
+      ],
+    );
+    if (versionstamp === null) throw new TypeError("Failed to enqueue value");
+    return { ok: true, versionstamp };
+  }
+
+  async listenQueue(
+    handler: (message: unknown) => Promise<void> | void,
+  ): Promise<void> {
+    if (this.#isClosed) {
+      throw new Error("Queue already closed");
+    }
+    const finishMessageOps = new SafeMap<number, Promise<void>>();
+    while (true) {
+      // Wait for the next message.
+      const next: { 0: Uint8Array; 1: number } =
+        await op_kv_dequeue_next_message(
+          this.#rid,
+        );
+      if (next === null) {
+        break;
+      }
+
+      // Deserialize the payload.
+      const { 0: payload, 1: handleId } = next;
+      const deserializedPayload = core.deserialize(payload, {
+        forStorage: true,
+        deserializers: cloneableDeserializers,
+      });
+
+      // Dispatch the payload.
+      (async () => {
+        let success = false;
+        try {
+          const result = handler(deserializedPayload);
+          const _res = isPromise(result) ? (await result) : result;
+          success = true;
+        } catch (error) {
+          internals.log("error", "Exception in queue handler", error);
+        } finally {
+          const promise: Promise<void> = op_kv_finish_dequeued_message(
+            handleId,
+            success,
+          );
+          finishMessageOps.set(handleId, promise);
+          try {
+            await promise;
+          } finally {
+            finishMessageOps.delete(handleId);
+          }
+        }
+      })();
+    }
+
+    for (const { 1: promise } of new SafeMapIterator(finishMessageOps)) {
+      await promise;
+    }
+    finishMessageOps.clear();
+  }
+
+  watch(keys: Deno.KvKey[], options = { __proto__: null }) {
+    const raw = options.raw ?? false;
+    const rid = op_kv_watch(this.#rid, keys);
+    const lastEntries: (Deno.KvEntryMaybe<unknown> | undefined)[] = ArrayFrom(
+      { length: keys.length },
+    );
+    return new ReadableStream({
+      async pull(controller) {
+        while (true) {
+          let updates;
+          try {
+            updates = await op_kv_watch_next(rid);
+          } catch (err) {
+            core.tryClose(rid);
+            controller.error(err);
+            return;
+          }
+          if (updates === null) {
+            core.tryClose(rid);
+            controller.close();
+            return;
+          }
+          let changed = false;
+          for (let i = 0; i < keys.length; i++) {
+            if (updates[i] === "unchanged") {
+              if (lastEntries[i] === undefined) {
+                throw new Error(
+                  "'watch': invalid unchanged update (internal error)",
+                );
+              }
+              continue;
+            }
+            if (
+              lastEntries[i] !== undefined &&
+              (updates[i]?.versionstamp ?? null) ===
+                lastEntries[i]?.versionstamp
+            ) {
+              continue;
+            }
+            changed = true;
+            if (updates[i] === null) {
+              lastEntries[i] = {
+                key: ArrayPrototypeSlice(keys[i]),
+                value: null,
+                versionstamp: null,
+              };
+            } else {
+              lastEntries[i] = updates[i];
+            }
+          }
+          if (!changed && !raw) continue; // no change
+          const entries = ArrayPrototypeMap(
+            lastEntries,
+            (entry) =>
+              entry.versionstamp === null
+                ? { ...entry }
+                : deserializeValue(entry),
+          );
+          controller.enqueue(entries);
+          return;
+        }
+      },
+      cancel() {
+        core.tryClose(rid);
+      },
+    });
+  }
+
+  close() {
+    core.close(this.#rid);
+    this.#isClosed = true;
+  }
+
+  [SymbolDispose]() {
+    core.tryClose(this.#rid);
+  }
+}
+
+class AtomicOperation {
+  #rid: number;
+
+  #checks: [Deno.KvKey, string | null][] = [];
+  #mutations: [Deno.KvKey, string, RawValue | null, number | undefined][] = [];
+  #enqueues: [Uint8Array, number, Deno.KvKey[], number[] | null][] = [];
+
+  constructor(rid: number) {
+    this.#rid = rid;
+  }
+
+  check(...checks: Deno.AtomicCheck[]): this {
+    for (let i = 0; i < checks.length; ++i) {
+      const check = checks[i];
+      ArrayPrototypePush(this.#checks, [check.key, check.versionstamp]);
+    }
+    return this;
+  }
+
+  mutate(...mutations: Deno.KvMutation[]): this {
+    for (let i = 0; i < mutations.length; ++i) {
+      const mutation = mutations[i];
+      const key = mutation.key;
+      let type: string;
+      let value: RawValue | null;
+      let expireIn: number | undefined = undefined;
+      switch (mutation.type) {
+        case "delete":
+          type = "delete";
+          if (mutation.value) {
+            throw new TypeError("Invalid mutation 'delete' with value");
+          }
+          break;
+        case "set":
+          if (typeof mutation.expireIn === "number") {
+            expireIn = mutation.expireIn;
+          }
+          /* falls through */
+        case "sum":
+        case "min":
+        case "max":
+          type = mutation.type;
+          if (!ObjectHasOwn(mutation, "value")) {
+            throw new TypeError(`Invalid mutation '${type}' without value`);
+          }
+          value = serializeValue(mutation.value);
+          break;
+        default:
+          throw new TypeError("Invalid mutation type");
+      }
+      ArrayPrototypePush(this.#mutations, [key, type, value, expireIn]);
+    }
+    return this;
+  }
+
+  sum(key: Deno.KvKey, n: bigint): this {
+    ArrayPrototypePush(this.#mutations, [
+      key,
+      "sum",
+      serializeValue(new KvU64(n)),
+      undefined,
+    ]);
+    return this;
+  }
+
+  min(key: Deno.KvKey, n: bigint): this {
+    ArrayPrototypePush(this.#mutations, [
+      key,
+      "min",
+      serializeValue(new KvU64(n)),
+      undefined,
+    ]);
+    return this;
+  }
+
+  max(key: Deno.KvKey, n: bigint): this {
+    ArrayPrototypePush(this.#mutations, [
+      key,
+      "max",
+      serializeValue(new KvU64(n)),
+      undefined,
+    ]);
+    return this;
+  }
+
+  set(
+    key: Deno.KvKey,
+    value: unknown,
+    options?: { expireIn?: number },
+  ): this {
+    ArrayPrototypePush(this.#mutations, [
+      key,
+      "set",
+      serializeValue(value),
+      options?.expireIn,
+    ]);
+    return this;
+  }
+
+  delete(key: Deno.KvKey): this {
+    ArrayPrototypePush(this.#mutations, [key, "delete", null, undefined]);
+    return this;
+  }
+
+  enqueue(
+    message: unknown,
+    opts?: {
+      delay?: number;
+      keysIfUndelivered?: Deno.KvKey[];
+      backoffSchedule?: number[];
+    },
+  ): this {
+    if (opts?.delay !== undefined) {
+      validateQueueDelay(opts?.delay);
+    }
+    if (opts?.backoffSchedule !== undefined) {
+      validateBackoffSchedule(opts?.backoffSchedule);
+    }
+    ArrayPrototypePush(this.#enqueues, [
+      core.serialize(message, { forStorage: true }),
+      opts?.delay ?? 0,
+      opts?.keysIfUndelivered ?? [],
+      opts?.backoffSchedule ?? null,
+    ]);
+    return this;
+  }
+
+  async commit(): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
+    const versionstamp = await doAtomicWriteInPlace(
+      this.#rid,
+      this.#checks,
+      this.#mutations,
+      this.#enqueues,
+    );
+    if (versionstamp === null) return { ok: false };
+    return { ok: true, versionstamp };
+  }
+
+  then() {
+    throw new TypeError(
+      "'Deno.AtomicOperation' is not a promise: did you forget to call 'commit()'",
     );
   }
 
-  return { AtomicOperation, Kv, KvListIterator, KvU64, openKv };
+  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
+    const operations = [];
+
+    // Format checks
+    for (let i = 0; i < this.#checks.length; ++i) {
+      const check = this.#checks[i];
+      const key = check[0];
+      const versionstamp = check[1];
+      const keyStr = inspect(key, inspectOptions);
+      const versionstampStr = versionstamp === null
+        ? "null"
+        : `"${versionstamp}"`;
+      ArrayPrototypePush(
+        operations,
+        `  check({ key: ${keyStr}, versionstamp: ${versionstampStr} })`,
+      );
+    }
+
+    // Format mutations
+    for (let i = 0; i < this.#mutations.length; ++i) {
+      const mutation = this.#mutations[i];
+      const key = mutation[0];
+      const type = mutation[1];
+      const rawValue = mutation[2];
+      const expireIn = mutation[3];
+      const keyStr = inspect(key, inspectOptions);
+
+      if (type === "delete") {
+        ArrayPrototypePush(operations, `  delete(${keyStr})`);
+      } else {
+        // Deserialize value for display
+        let value;
+        try {
+          if (rawValue === null) {
+            value = null;
+          } else {
+            switch (rawValue.kind) {
+              case "v8":
+                value = core.deserialize(rawValue.value, {
+                  forStorage: true,
+                  deserializers: cloneableDeserializers,
+                });
+                break;
+              case "bytes":
+                value = rawValue.value;
+                break;
+              case "u64":
+                value = new KvU64(rawValue.value);
+                break;
+              default:
+                value = rawValue;
+            }
+          }
+        } catch {
+          // If deserialization fails, show the raw value structure
+          value = `[${rawValue?.kind || "unknown"} value]`;
+        }
+
+        const valueStr = inspect(value, inspectOptions);
+
+        if (type === "set" && expireIn !== undefined) {
+          ArrayPrototypePush(
+            operations,
+            `  set(${keyStr}, ${valueStr}, { expireIn: ${expireIn} })`,
+          );
+        } else {
+          ArrayPrototypePush(operations, `  ${type}(${keyStr}, ${valueStr})`);
+        }
+      }
+    }
+
+    // Format enqueues
+    for (let i = 0; i < this.#enqueues.length; ++i) {
+      const enqueue = this.#enqueues[i];
+      const serializedMessage = enqueue[0];
+      const delay = enqueue[1];
+      const keysIfUndelivered = enqueue[2];
+      const backoffSchedule = enqueue[3];
+
+      // Deserialize message for display
+      let message;
+      try {
+        message = core.deserialize(serializedMessage, {
+          forStorage: true,
+          deserializers: cloneableDeserializers,
+        });
+      } catch {
+        message = "[serialized message]";
+      }
+
+      const messageStr = inspect(message, inspectOptions);
+
+      if (
+        delay === 0 && keysIfUndelivered.length === 0 &&
+        backoffSchedule === null
+      ) {
+        ArrayPrototypePush(operations, `  enqueue(${messageStr})`);
+      } else {
+        const options = [];
+        if (delay !== 0) ArrayPrototypePush(options, `delay: ${delay}`);
+        if (keysIfUndelivered.length > 0) {
+          const keysStr = inspect(keysIfUndelivered, inspectOptions);
+          ArrayPrototypePush(options, `keysIfUndelivered: ${keysStr}`);
+        }
+        if (backoffSchedule !== null) {
+          const scheduleStr = inspect(backoffSchedule, inspectOptions);
+          ArrayPrototypePush(options, `backoffSchedule: ${scheduleStr}`);
+        }
+        ArrayPrototypePush(
+          operations,
+          `  enqueue(${messageStr}, { ${ArrayPrototypeJoin(options, ", ")} })`,
+        );
+      }
+    }
+
+    if (operations.length === 0) {
+      return "AtomicOperation (empty)";
+    }
+
+    return `AtomicOperation\n${ArrayPrototypeJoin(operations, "\n")}`;
+  }
+}
+
+const MIN_U64 = BigInt("0");
+const MAX_U64 = BigInt("0xffffffffffffffff");
+
+class KvU64 {
+  value: bigint;
+
+  constructor(value: bigint) {
+    if (typeof value !== "bigint") {
+      throw new TypeError(`Value must be a bigint: received ${typeof value}`);
+    }
+    if (value < MIN_U64) {
+      throw new RangeError(
+        `Value must be a positive bigint: received ${value}`,
+      );
+    }
+    if (value > MAX_U64) {
+      throw new RangeError("Value must fit in a 64-bit unsigned integer");
+    }
+    this.value = value;
+    ObjectFreeze(this);
+  }
+
+  valueOf() {
+    return this.value;
+  }
+
+  toString() {
+    return BigIntPrototypeToString(this.value);
+  }
+
+  get [SymbolToStringTag]() {
+    return "Deno.KvU64";
+  }
+
+  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
+    return StringPrototypeReplace(
+      inspect(Object(this.value), inspectOptions),
+      "BigInt",
+      "Deno.KvU64",
+    );
+  }
+}
+
+function deserializeValue(entry: RawKvEntry): Deno.KvEntry<unknown> {
+  const { kind, value } = entry.value;
+  switch (kind) {
+    case "v8":
+      return {
+        ...entry,
+        value: core.deserialize(value, {
+          forStorage: true,
+          deserializers: cloneableDeserializers,
+        }),
+      };
+    case "bytes":
+      return {
+        ...entry,
+        value,
+      };
+    case "u64":
+      return {
+        ...entry,
+        value: new KvU64(value),
+      };
+    default:
+      throw new TypeError("Invalid value type");
+  }
+}
+
+function serializeValue(value: unknown): RawValue {
+  if (TypedArrayPrototypeGetSymbolToStringTag(value) === "Uint8Array") {
+    return {
+      kind: "bytes",
+      value,
+    };
+  } else if (ObjectPrototypeIsPrototypeOf(KvU64.prototype, value)) {
+    return {
+      kind: "u64",
+      // deno-lint-ignore prefer-primordials
+      value: value.valueOf(),
+    };
+  } else {
+    return {
+      kind: "v8",
+      value: core.serialize(value, { forStorage: true }),
+    };
+  }
+}
+
+// This gets the %AsyncIteratorPrototype% object (which exists but is not a
+// global). We extend the KvListIterator iterator from, so that we immediately
+// support async iterator helpers once they land. The %AsyncIterator% does not
+// yet actually exist however, so right now the AsyncIterator binding refers to
+// %Object%. I know.
+// Once AsyncIterator is a global, we can just use it (from primordials), rather
+// than doing this here.
+const AsyncIteratorPrototype = ObjectGetPrototypeOf(AsyncGeneratorPrototype);
+const AsyncIterator = AsyncIteratorPrototype.constructor;
+
+class KvListIterator extends AsyncIterator
+  implements AsyncIterator<Deno.KvEntry<unknown>> {
+  #selector: Deno.KvListSelector;
+  #entries: Deno.KvEntry<unknown>[] | null = null;
+  #cursorGen: (() => string) | null = null;
+  #done = false;
+  #lastBatch = false;
+  #pullBatch: (
+    selector: Deno.KvListSelector,
+    cursor: string | undefined,
+    reverse: boolean,
+    consistency: Deno.KvConsistencyLevel,
+  ) => Promise<Deno.KvEntry<unknown>[]>;
+  #limit: number | undefined;
+  #count = 0;
+  #reverse: boolean;
+  #batchSize: number;
+  #consistency: Deno.KvConsistencyLevel;
+
+  constructor(
+    { limit, selector, cursor, reverse, consistency, batchSize, pullBatch }: {
+      limit?: number;
+      selector: Deno.KvListSelector;
+      cursor?: string;
+      reverse: boolean;
+      batchSize: number;
+      consistency: Deno.KvConsistencyLevel;
+      pullBatch: (
+        selector: Deno.KvListSelector,
+        cursor: string | undefined,
+        reverse: boolean,
+        consistency: Deno.KvConsistencyLevel,
+      ) => Promise<Deno.KvEntry<unknown>[]>;
+    },
+  ) {
+    super();
+    let prefix: Deno.KvKey | undefined;
+    let start: Deno.KvKey | undefined;
+    let end: Deno.KvKey | undefined;
+    if (ObjectHasOwn(selector, "prefix") && selector.prefix !== undefined) {
+      prefix = ObjectFreeze(ArrayPrototypeSlice(selector.prefix));
+    }
+    if (ObjectHasOwn(selector, "start") && selector.start !== undefined) {
+      start = ObjectFreeze(ArrayPrototypeSlice(selector.start));
+    }
+    if (ObjectHasOwn(selector, "end") && selector.end !== undefined) {
+      end = ObjectFreeze(ArrayPrototypeSlice(selector.end));
+    }
+    if (prefix) {
+      if (start && end) {
+        throw new TypeError(
+          "Selector can not specify both 'start' and 'end' key when specifying 'prefix'",
+        );
+      }
+      if (start) {
+        this.#selector = { prefix, start };
+      } else if (end) {
+        this.#selector = { prefix, end };
+      } else {
+        this.#selector = { prefix };
+      }
+    } else {
+      if (start && end) {
+        this.#selector = { start, end };
+      } else {
+        throw new TypeError(
+          "Selector must specify either 'prefix' or both 'start' and 'end' key",
+        );
+      }
+    }
+    ObjectFreeze(this.#selector);
+    this.#pullBatch = pullBatch;
+    this.#limit = limit;
+    this.#reverse = reverse;
+    this.#consistency = consistency;
+    this.#batchSize = batchSize;
+    this.#cursorGen = cursor ? () => cursor : null;
+  }
+
+  get cursor(): string {
+    if (this.#cursorGen === null) {
+      throw new Error("Cannot get cursor before first iteration");
+    }
+
+    return this.#cursorGen();
+  }
+
+  async next(): Promise<IteratorResult<Deno.KvEntry<unknown>>> {
+    // Fused or limit exceeded
+    if (
+      this.#done ||
+      (this.#limit !== undefined && this.#count >= this.#limit)
+    ) {
+      return { done: true, value: undefined };
+    }
+
+    // Attempt to fill the buffer
+    if (!this.#entries?.length && !this.#lastBatch) {
+      const batch = await this.#pullBatch(
+        this.#selector,
+        this.#cursorGen ? this.#cursorGen() : undefined,
+        this.#reverse,
+        this.#consistency,
+      );
+
+      // Reverse the batch so we can pop from the end
+      ArrayPrototypeReverse(batch);
+      this.#entries = batch;
+
+      // Last batch, do not attempt to pull more
+      if (batch.length < this.#batchSize) {
+        this.#lastBatch = true;
+      }
+    }
+
+    const entry = this.#entries?.pop();
+    if (!entry) {
+      this.#done = true;
+      this.#cursorGen = () => "";
+      return { done: true, value: undefined };
+    }
+
+    this.#cursorGen = () => {
+      const selector = this.#selector;
+      return encodeCursor([
+        ObjectHasOwn(selector, "prefix") ? selector.prefix : null,
+        ObjectHasOwn(selector, "start") ? selector.start : null,
+        ObjectHasOwn(selector, "end") ? selector.end : null,
+      ], entry.key);
+    };
+    this.#count++;
+    return {
+      done: false,
+      value: entry,
+    };
+  }
+
+  [SymbolAsyncIterator](): AsyncIterator<Deno.KvEntry<unknown>> {
+    return this;
+  }
+}
+
+async function doAtomicWriteInPlace(
+  rid: number,
+  checks: [Deno.KvKey, string | null][],
+  mutations: [Deno.KvKey, string, RawValue | null, number | undefined][],
+  enqueues: [Uint8Array, number, Deno.KvKey[], number[] | null][],
+): Promise<string | null> {
+  for (let i = 0; i < mutations.length; ++i) {
+    const mutation = mutations[i];
+    const key = mutation[0];
+    if (
+      key.length && mutation[1] === "set" &&
+      key[key.length - 1] === commitVersionstampSymbol
+    ) {
+      mutation[0] = ArrayPrototypeSlice(key, 0, key.length - 1);
+      mutation[1] = "setSuffixVersionstampedKey";
+    }
+  }
+
+  return await op_kv_atomic_write(
+    rid,
+    checks,
+    mutations,
+    enqueues,
+  );
+}
+
+return { AtomicOperation, Kv, KvListIterator, KvU64, openKv };
 })();

--- a/ext/kv/lib.rs
+++ b/ext/kv/lib.rs
@@ -11,7 +11,6 @@ use std::cell::RefCell;
 use std::num::NonZeroU32;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::Duration;
 
 use base64::Engine;
 use base64::prelude::BASE64_URL_SAFE;
@@ -186,7 +185,7 @@ pub enum KvErrorKind {
   #[error("Invalid check")]
   InvalidCheck(#[source] KvCheckError),
   #[class(inherit)]
-  #[error("Invalid mutation")]
+  #[error("Invalid mutation: {0}")]
   InvalidMutation(#[source] KvMutationError),
   #[class(inherit)]
   #[error("Invalid enqueue")]
@@ -633,6 +632,9 @@ pub enum KvMutationError {
   #[class(type)]
   #[error("Invalid mutation '{0}' without value")]
   InvalidMutationWithoutValue(String),
+  #[class(type)]
+  #[error("expireIn is too large: {0}")]
+  InvalidExpireAt(u64),
 }
 
 type V8KvMutation = (KvKey, String, Option<FromV8Value>, Option<u64>);
@@ -662,12 +664,26 @@ fn mutation_from_v8(
       return Err(KvMutationError::InvalidMutationWithoutValue(op.to_string()));
     }
   };
+  let expire_at = match value.3 {
+    None => None,
+    Some(expire_in) => {
+      // Compute the absolute expiry with checked arithmetic so an
+      // out-of-range expireIn surfaces as an error instead of panicking the
+      // process on overflow.
+      let expire_at = i64::try_from(expire_in)
+        .ok()
+        .and_then(chrono::TimeDelta::try_milliseconds)
+        .and_then(|delta| current_timstamp.checked_add_signed(delta));
+      match expire_at {
+        Some(expire_at) => Some(expire_at),
+        None => return Err(KvMutationError::InvalidExpireAt(expire_in)),
+      }
+    }
+  };
   Ok(Mutation {
     key,
     kind,
-    expire_at: value
-      .3
-      .map(|expire_in| current_timstamp + Duration::from_millis(expire_in)),
+    expire_at,
   })
 }
 

--- a/tests/unit/kv_test.ts
+++ b/tests/unit/kv_test.ts
@@ -905,6 +905,15 @@ dbTest("list prefix with small batch size reverse", async (db) => {
   ]);
 });
 
+dbTest("list prefix with non-integer batch size throws", async (db) => {
+  await setupData(db);
+  await assertRejects(
+    async () => await collect(db.list({ prefix: ["a"] }, { batchSize: 2.3 })),
+    Error,
+    "batchSize must be a positive integer",
+  );
+});
+
 dbTest("list prefix with small batch size and limit", async (db) => {
   const versionstamp = await setupData(db);
   const entries = await collect(

--- a/tests/unit/kv_test.ts
+++ b/tests/unit/kv_test.ts
@@ -914,6 +914,15 @@ dbTest("list prefix with non-integer batch size throws", async (db) => {
   );
 });
 
+dbTest("list prefix with non-integer limit throws", async (db) => {
+  await setupData(db);
+  await assertRejects(
+    async () => await collect(db.list({ prefix: ["a"] }, { limit: 2.3 })),
+    Error,
+    "Limit must be a positive integer",
+  );
+});
+
 dbTest("set with invalid expireIn throws", async (db) => {
   // A non-finite expireIn (notably Infinity) used to panic the process when
   // the native layer computed the absolute expiry; these must be rejected.
@@ -938,6 +947,27 @@ dbTest("set with invalid expireIn throws", async (db) => {
   const res = await db.set(["a"], 1, { expireIn: 1000 });
   assert(res.ok);
 });
+
+dbTest(
+  "set with too-large expireIn throws instead of panicking",
+  async (db) => {
+    // A large but valid integer passes the JS integer check, but computing the
+    // absolute expiry overflows in the native layer. It must surface as an
+    // error rather than panic the process.
+    await assertRejects(
+      () => db.set(["a"], 1, { expireIn: Number.MAX_SAFE_INTEGER }),
+      TypeError,
+      "expireIn is too large",
+    );
+    await assertRejects(
+      () =>
+        db.atomic().set(["a"], 1, { expireIn: Number.MAX_SAFE_INTEGER })
+          .commit(),
+      TypeError,
+      "expireIn is too large",
+    );
+  },
+);
 
 dbTest("list prefix with small batch size and limit", async (db) => {
   const versionstamp = await setupData(db);

--- a/tests/unit/kv_test.ts
+++ b/tests/unit/kv_test.ts
@@ -914,6 +914,31 @@ dbTest("list prefix with non-integer batch size throws", async (db) => {
   );
 });
 
+dbTest("set with invalid expireIn throws", async (db) => {
+  // A non-finite expireIn (notably Infinity) used to panic the process when
+  // the native layer computed the absolute expiry; these must be rejected.
+  for (const expireIn of [-1, 1.5, NaN, Infinity]) {
+    await assertRejects(
+      () => db.set(["a"], 1, { expireIn }),
+      TypeError,
+      "expireIn must be a non-negative integer",
+    );
+    assertThrows(
+      () => db.atomic().set(["a"], 1, { expireIn }),
+      TypeError,
+      "expireIn must be a non-negative integer",
+    );
+    assertThrows(
+      () => db.atomic().mutate({ type: "set", key: ["a"], value: 1, expireIn }),
+      TypeError,
+      "expireIn must be a non-negative integer",
+    );
+  }
+  // A valid expireIn still works.
+  const res = await db.set(["a"], 1, { expireIn: 1000 });
+  assert(res.ok);
+});
+
 dbTest("list prefix with small batch size and limit", async (db) => {
   const versionstamp = await setupData(db);
   const entries = await collect(


### PR DESCRIPTION
This validates two KV inputs that were either silently mishandled or could
crash the process.

batchSize: a non-integer batchSize passed to Kv.list, such as 2.3, silently
truncated the iteration instead of being rejected. The native query layer
floors the value when reading a batch, but the iterator's termination check
compared the returned batch length against the un-floored value, so a full
batch looked short and iteration stopped early (with three entries and
batchSize: 2.3, only two were returned). batchSize is now validated as a
positive integer, matching how negative and zero values were already rejected.

expireIn: a non-finite expireIn, notably Infinity, passed to set or an atomic
set reached the native layer, where computing the absolute expiry overflowed
chronos Duration to TimeDelta conversion and panicked the whole process. NaN
and fractional values were also silently accepted (NaN behaved like 0, floats
were truncated). expireIn is now validated as a non-negative integer in the KV
layer, so invalid values throw a TypeError instead of panicking or being
silently coerced.

Both checks live in the JS layer (ext/kv/01_db.ts) and cover the set, atomic
set, and atomic mutate paths. Unit tests are added for both.

Fixes #21013.
Fixes #21009.