### PR TITLE
fix(console): %c colors with same red component as previous color

### DIFF
--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -3425,10 +3425,22 @@ function colorEquals(color1, color2) {
     color1?.[2] == color2?.[2];
 }
 
+// `background-color` and `color` can be stored either as an already parsed
+// `[r, g, b]` array or as a raw string (a named color like "white" or a
+// hex/rgb/hsl string). Normalize both sides to `[r, g, b]` arrays before
+// comparing, otherwise raw strings get compared by character index and two
+// different colors sharing a prefix (e.g. "#FFFFFF" and "#FFAFC8", which share
+// the same red component) are wrongly treated as equal. See #21605.
+function cssColorEquals(color1, color2) {
+  const c1 = typeof color1 === "string" ? parseCssColor(color1) : color1;
+  const c2 = typeof color2 === "string" ? parseCssColor(color2) : color2;
+  return colorEquals(c1, c2);
+}
+
 function cssToAnsi(css, prevCss = null) {
   prevCss = prevCss ?? getDefaultCss();
   let ansi = "";
-  if (!colorEquals(css.backgroundColor, prevCss.backgroundColor)) {
+  if (!cssColorEquals(css.backgroundColor, prevCss.backgroundColor)) {
     if (css.backgroundColor == null) {
       ansi += "\x1b[49m";
     } else if (css.backgroundColor == "black") {
@@ -3462,7 +3474,7 @@ function cssToAnsi(css, prevCss = null) {
       }
     }
   }
-  if (!colorEquals(css.color, prevCss.color)) {
+  if (!cssColorEquals(css.color, prevCss.color)) {
     if (css.color == null) {
       ansi += "\x1b[39m";
     } else if (css.color == "black") {

--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -3427,14 +3427,19 @@ function colorEquals(color1, color2) {
 
 // `background-color` and `color` can be stored either as an already parsed
 // `[r, g, b]` array or as a raw string (a named color like "white" or a
-// hex/rgb/hsl string). Normalize both sides to `[r, g, b]` arrays before
-// comparing, otherwise raw strings get compared by character index and two
-// different colors sharing a prefix (e.g. "#FFFFFF" and "#FFAFC8", which share
-// the same red component) are wrongly treated as equal. See #21605.
+// hex/rgb/hsl string). When both sides are strings, `colorEquals` would index
+// them by character, so two different colors sharing a prefix (e.g. "#FFFFFF"
+// and "#FFAFC8", which share the same red component) are wrongly treated as
+// equal. Parse both strings to `[r, g, b]` arrays so they are compared by
+// value. Mixed cases (a string against `null` or an array) keep the original
+// comparison: an unparseable string like "inherit" parses to `null`, and
+// conflating that with an absent color would suppress the reset escape.
+// See #21605.
 function cssColorEquals(color1, color2) {
-  const c1 = typeof color1 === "string" ? parseCssColor(color1) : color1;
-  const c2 = typeof color2 === "string" ? parseCssColor(color2) : color2;
-  return colorEquals(c1, c2);
+  if (typeof color1 === "string" && typeof color2 === "string") {
+    return colorEquals(parseCssColor(color1), parseCssColor(color2));
+  }
+  return colorEquals(color1, color2);
 }
 
 function cssToAnsi(css, prevCss = null) {

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -1379,6 +1379,23 @@ Deno.test(function consoleCssToAnsi() {
     cssToAnsiEsc({ ...DEFAULT_CSS, color: [203, 204, 205] }),
     "_[38;2;203;204;205m",
   );
+  // Regression test for https://github.com/denoland/deno/issues/21605: two hex
+  // colors sharing the same red component must not be treated as equal, so the
+  // new background color is still emitted.
+  assertEquals(
+    cssToAnsiEsc(
+      { ...DEFAULT_CSS, backgroundColor: "#FFAFC8" },
+      { ...DEFAULT_CSS, backgroundColor: "#FFFFFF" },
+    ),
+    "_[48;2;255;175;200m",
+  );
+  assertEquals(
+    cssToAnsiEsc(
+      { ...DEFAULT_CSS, color: "#FFAFC8" },
+      { ...DEFAULT_CSS, color: "#FFFFFF" },
+    ),
+    "_[38;2;255;175;200m",
+  );
   assertEquals(cssToAnsiEsc({ ...DEFAULT_CSS, fontWeight: "bold" }), "_[1m");
   assertEquals(cssToAnsiEsc({ ...DEFAULT_CSS, fontStyle: "italic" }), "_[3m");
   assertEquals(


### PR DESCRIPTION
When formatting `console.log` `%c` directives, the background-color and
color of a span are compared against the previous span's to decide whether
a new ANSI escape needs to be emitted. That comparison used `colorEquals`,
which indexes its arguments as `[r, g, b]` arrays, but `background-color`
and `color` are stored as raw strings (a named color, or a hex/rgb/hsl
string). Comparing two hex strings by index instead compares their leading
characters, so any two colors sharing the same red component (e.g.
`#FFFFFF` and `#FFAFC8`, both starting `#FF`) were treated as equal and the
new color was never emitted, leaving the previous background to bleed into
the next span.

This normalizes both operands to `[r, g, b]` arrays before comparing, so
colors are compared by value regardless of how they were written.

Fixes #21605