### PR TITLE
fix(run): error instead of panicking when watch flags are used with stdin

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -7773,9 +7773,16 @@ fn run_parse(
     Some(mut script_arg) => {
       let script = script_arg.next().unwrap();
       flags.argv.extend(script_arg);
+      let watch = watch_arg_parse_with_paths(matches)?;
+      if script == "-" && watch.is_some() {
+        return Err(clap::Error::raw(
+          clap::error::ErrorKind::ArgumentConflict,
+          "--watch and --watch-hmr cannot be used while reading from stdin.\n",
+        ));
+      }
       flags.subcommand = DenoSubcommand::Run(RunFlags {
         script,
-        watch: watch_arg_parse_with_paths(matches)?,
+        watch,
         bare,
         coverage_dir,
         print_task_list: false,
@@ -9318,6 +9325,24 @@ mod tests {
         ..Flags::default()
       }
     );
+  }
+
+  #[test]
+  fn run_watch_with_stdin_is_error() {
+    // `--watch` and `--watch-hmr` cannot be combined with reading from stdin,
+    // previously `--watch-hmr -` panicked and `--watch -` was silently ignored.
+    for watch_flag in ["--watch", "--watch-hmr", "--unstable-hmr"] {
+      let r = flags_from_vec(svec!["deno", "run", watch_flag, "-"]);
+      assert_eq!(
+        r.unwrap_err().kind(),
+        clap::error::ErrorKind::ArgumentConflict,
+        "expected conflict for {watch_flag}"
+      );
+    }
+
+    // a regular script with the same flags must still parse fine
+    let r = flags_from_vec(svec!["deno", "run", "--watch-hmr", "script.ts"]);
+    assert!(r.is_ok());
   }
 
   #[test]


### PR DESCRIPTION
Running `deno run --watch-hmr -` panicked. The stdin run path builds a
`CliFactory` that has no watcher communicator, but `has_hmr()` is true,
so the factory unwrapped that `None` and crashed. The plain `--watch -`
case was silently ignored instead, which is also surprising since the
user explicitly asked to watch.

Watching makes little sense when the program is read from stdin, so this
rejects the combination at flag-parse time with a clear
`ArgumentConflict` error covering `--watch`, `--watch-hmr`, and the
`--unstable-hmr` alias, rather than panicking or quietly doing nothing.

Closes #21069