### PR TITLE
fix(core): don't set ERR_MODULE_NOT_FOUND code on module linking errors

### DIFF
--- a/libs/core/runtime/bindings.rs
+++ b/libs/core/runtime/bindings.rs
@@ -1298,10 +1298,15 @@ fn catch_dynamic_import_promise_error<'s, 'i>(
         }
         _ => v8::Exception::error(scope, message),
       };
-      let code_key = CODE.v8_string(scope).unwrap();
-      let code_value = ERR_MODULE_NOT_FOUND.v8_string(scope).unwrap();
-      let exception_obj = exception.to_object(scope).unwrap();
-      exception_obj.set(scope, code_key.into(), code_value.into());
+      // V8 module linking errors (e.g. a missing named export) are
+      // spec-defined `SyntaxError`s and must not carry a host-defined `code`.
+      // Only genuine resolution/loading failures get `ERR_MODULE_NOT_FOUND`.
+      if name.as_str() != deno_error::builtin_classes::SYNTAX_ERROR {
+        let code_key = CODE.v8_string(scope).unwrap();
+        let code_value = ERR_MODULE_NOT_FOUND.v8_string(scope).unwrap();
+        let exception_obj = exception.to_object(scope).unwrap();
+        exception_obj.set(scope, code_key.into(), code_value.into());
+      }
       scope.throw_exception(exception);
       return;
     }

--- a/tests/specs/run/dynamic_import_linking_error_code/__test__.jsonc
+++ b/tests/specs/run/dynamic_import_linking_error_code/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run --quiet main.js",
+  "output": "main.out"
+}

--- a/tests/specs/run/dynamic_import_linking_error_code/bad_export.js
+++ b/tests/specs/run/dynamic_import_linking_error_code/bad_export.js
@@ -1,0 +1,2 @@
+import { x } from "./exports_nothing.js";
+console.log(x);

--- a/tests/specs/run/dynamic_import_linking_error_code/exports_nothing.js
+++ b/tests/specs/run/dynamic_import_linking_error_code/exports_nothing.js
@@ -1,0 +1,1 @@
+export const y = 1;

--- a/tests/specs/run/dynamic_import_linking_error_code/main.js
+++ b/tests/specs/run/dynamic_import_linking_error_code/main.js
@@ -1,0 +1,12 @@
+// A missing named export is a spec-defined `SyntaxError` (ES InitializeEnvironment,
+// step 7.c.ii) and must NOT carry a host-defined `code` property.
+await import("./bad_export.js").catch((e) => {
+  console.log("linking error name:", e.name);
+  console.log("linking error has code:", "code" in e);
+});
+
+// A genuinely missing module is a host resolution error and should still
+// report `ERR_MODULE_NOT_FOUND`.
+await import("./does_not_exist.js").catch((e) => {
+  console.log("missing module code:", e.code);
+});

--- a/tests/specs/run/dynamic_import_linking_error_code/main.out
+++ b/tests/specs/run/dynamic_import_linking_error_code/main.out
@@ -1,0 +1,3 @@
+linking error name: SyntaxError
+linking error has code: false
+missing module code: ERR_MODULE_NOT_FOUND


### PR DESCRIPTION
A missing named export is a spec-defined `SyntaxError` (ECMAScript
InitializeEnvironment, step 7.c.ii) and, per the spec, carries no
host-defined properties. When such an error surfaced through a dynamic
`import()`, Deno was decorating it with `code: "ERR_MODULE_NOT_FOUND"`:

```js
// entrypoint.js
import("./mod.js").catch(console.log);
// mod.js
import { x } from "./mod.js";
```

```
[SyntaxError: ... does not provide an export named 'x' ...] {
  code: "ERR_MODULE_NOT_FOUND"
}
```

Node reports the same `SyntaxError` with no `code` property.

The cause is in `catch_dynamic_import_promise_error`, which handles rejected
dynamic-import promises. It assumes any error without stack frames is a module
resolution error and unconditionally sets `ERR_MODULE_NOT_FOUND`. That
assumption is wrong for V8 module linking errors (missing exports and the
like), which also have no stack frames yet are spec-defined `SyntaxError`s.

The fix only sets the code when the error is not a `SyntaxError`. Genuine
resolution/loading failures surface as `TypeError` (or a generic `Error`) and
keep `ERR_MODULE_NOT_FOUND`; spec-defined linking errors now match Node and
carry no `code`. A spec test covers both: a missing-export `import()` yields a
`SyntaxError` with no `code`, while a missing-module `import()` still reports
`ERR_MODULE_NOT_FOUND`.

Closes #26817
