### PR TITLE
feat(workspace): auto-discover external deno.json import maps

### DIFF
--- a/libs/config/workspace/discovery.rs
+++ b/libs/config/workspace/discovery.rs
@@ -359,9 +359,10 @@ fn discover_workspace_config_files_for_single_dir<
             config_folder.deno_json().map(|d| d.as_ref()),
             opts.maybe_vendor_override.as_ref(),
           );
-          let links = resolve_link_config_folders(
+          let links = resolve_link_config_folders_with_auto(
             sys,
             &config_folder,
+            &Default::default(),
             load_config_folder,
           )?;
           return Ok(ConfigFileDiscovery::Workspace {
@@ -500,8 +501,12 @@ fn discover_workspace_config_files_for_single_dir<
       config_folder.deno_json().map(|d| d.as_ref()),
       opts.maybe_vendor_override.as_ref(),
     );
-    let link =
-      resolve_link_config_folders(sys, &config_folder, load_config_folder)?;
+    let link = resolve_link_config_folders_with_auto(
+      sys,
+      &config_folder,
+      &Default::default(),
+      load_config_folder,
+    )?;
     let workspace = new_rc(Workspace::new(
       config_folder,
       Default::default(),
@@ -545,9 +550,10 @@ fn handle_workspace_folder_with_members<
     &mut found_config_folders,
     load_config_folder,
   )?;
-  let links = resolve_link_config_folders(
+  let links = resolve_link_config_folders_with_auto(
     sys,
     &raw_root_workspace.root,
+    &raw_root_workspace.members,
     load_config_folder,
   )?;
   let root_workspace = new_rc(Workspace::new(
@@ -606,8 +612,12 @@ fn handle_workspace_with_members<TSys: FsRead + FsMetadata + FsReadDir>(
       config_folder.deno_json().map(|d| d.as_ref()),
       opts.maybe_vendor_override.as_ref(),
     );
-    let links =
-      resolve_link_config_folders(sys, &config_folder, load_config_folder)?;
+    let links = resolve_link_config_folders_with_auto(
+      sys,
+      &config_folder,
+      &Default::default(),
+      load_config_folder,
+    )?;
     let workspace = new_rc(Workspace::new(
       config_folder,
       Default::default(),
@@ -1101,6 +1111,178 @@ fn resolve_link_member_config_folders<TSys: FsRead + FsMetadata + FsReadDir>(
       config_folder,
     )]))
   }
+}
+
+/// Resolves links from a config folder and then additionally auto-discovers
+/// external packages that are referenced by relative/absolute path in import
+/// maps, registering them so that bare specifier imports made *from* those
+/// external modules resolve against their own import map (issue #26764).
+fn resolve_link_config_folders_with_auto<
+  TSys: FsRead + FsMetadata + FsReadDir,
+>(
+  sys: &TSys,
+  root_config_folder: &ConfigFolder,
+  members: &BTreeMap<UrlRc, ConfigFolder>,
+  load_config_folder: impl Fn(
+    &Path,
+  ) -> Result<Option<ConfigFolder>, ConfigReadError>,
+) -> Result<BTreeMap<UrlRc, ConfigFolder>, WorkspaceDiscoverError> {
+  let mut links =
+    resolve_link_config_folders(sys, root_config_folder, &load_config_folder)?;
+  resolve_auto_link_config_folders(
+    sys,
+    root_config_folder,
+    members,
+    &mut links,
+    &load_config_folder,
+  );
+  Ok(links)
+}
+
+/// Walks path-style import map entries to a fixpoint and registers the
+/// governing `deno.json` of each external file as an (implicit) link, so its
+/// `imports`/`scopes` become a referrer-scoped entry in the synthetic import
+/// map. This is equivalent to the user manually listing those directories in
+/// the `links` field, but discovered automatically.
+fn resolve_auto_link_config_folders<TSys: FsRead + FsMetadata + FsReadDir>(
+  sys: &TSys,
+  root_config_folder: &ConfigFolder,
+  members: &BTreeMap<UrlRc, ConfigFolder>,
+  links: &mut BTreeMap<UrlRc, ConfigFolder>,
+  load_config_folder: &impl Fn(
+    &Path,
+  ) -> Result<Option<ConfigFolder>, ConfigReadError>,
+) {
+  // dirs that are already known and must not be (re)discovered as links: the
+  // workspace root, its members, and explicit links.
+  let mut visited: HashSet<Url> = HashSet::new();
+  visited.insert(root_config_folder.folder_url());
+  for key in members.keys().chain(links.keys()) {
+    visited.insert((**key).clone());
+  }
+
+  // worklist of (config dir, path-style import map values) still to scan
+  let mut worklist: Vec<(Url, Vec<String>)> = Vec::new();
+  enqueue_import_path_values(root_config_folder, &mut worklist);
+  for folder in members.values().chain(links.values()) {
+    enqueue_import_path_values(folder, &mut worklist);
+  }
+
+  while let Some((base_dir, values)) = worklist.pop() {
+    for value in values {
+      let Some(target_url) = import_value_target_url(&base_dir, &value) else {
+        continue;
+      };
+      let Some(governing_dir) =
+        find_governing_config_dir(&target_url, load_config_folder)
+      else {
+        continue;
+      };
+      if visited.contains(&governing_dir) {
+        continue;
+      }
+      // expand via the same logic explicit links use, so a referenced
+      // workspace member pulls in its sibling packages too
+      let expanded = match resolve_link_member_config_folders(
+        sys,
+        &governing_dir,
+        load_config_folder,
+      ) {
+        Ok(folders) => folders,
+        Err(_) => {
+          // not resolvable as a linkable package; skip and don't retry
+          visited.insert(governing_dir);
+          continue;
+        }
+      };
+      for (dir_url, folder) in expanded {
+        if visited.insert((*dir_url).clone()) {
+          enqueue_import_path_values(&folder, &mut worklist);
+          links.insert(dir_url, folder);
+        }
+      }
+    }
+  }
+}
+
+fn enqueue_import_path_values(
+  folder: &ConfigFolder,
+  worklist: &mut Vec<(Url, Vec<String>)>,
+) {
+  if let Some(deno_json) = folder.deno_json() {
+    let values = collect_import_path_values(deno_json);
+    if !values.is_empty() {
+      worklist.push((url_parent(&deno_json.specifier), values));
+    }
+  }
+}
+
+/// Collects the string values of a config file's `imports` and `scopes` maps.
+/// Only inline import maps are considered (not an external `importMap` file).
+fn collect_import_path_values(config: &ConfigFile) -> Vec<String> {
+  fn collect_from_map(
+    map: &serde_json::Map<String, serde_json::Value>,
+    out: &mut Vec<String>,
+  ) {
+    for value in map.values() {
+      if let Some(s) = value.as_str() {
+        out.push(s.to_string());
+      }
+    }
+  }
+
+  let mut out = Vec::new();
+  if let Some(serde_json::Value::Object(imports)) = &config.json.imports {
+    collect_from_map(imports, &mut out);
+  }
+  if let Some(serde_json::Value::Object(scopes)) = &config.json.scopes {
+    for scope_value in scopes.values() {
+      if let serde_json::Value::Object(scope_imports) = scope_value {
+        collect_from_map(scope_imports, &mut out);
+      }
+    }
+  }
+  out
+}
+
+/// Resolves an import map value to a target URL when it points at a path on
+/// disk. Returns `None` for bare specifiers and non-file schemes (npm:, jsr:,
+/// http(s):, node:, data:, ...).
+fn import_value_target_url(base_dir: &Url, value: &str) -> Option<Url> {
+  if value.starts_with("./")
+    || value.starts_with("../")
+    || value.starts_with('/')
+  {
+    base_dir.join(value).ok()
+  } else if value.starts_with("file:") {
+    Url::parse(value).ok()
+  } else {
+    None
+  }
+}
+
+/// Finds the directory of the nearest `deno.json` that governs `target_url`,
+/// walking up from the target's directory.
+fn find_governing_config_dir(
+  target_url: &Url,
+  load_config_folder: &impl Fn(
+    &Path,
+  ) -> Result<Option<ConfigFolder>, ConfigReadError>,
+) -> Option<Url> {
+  let target_path = url_to_file_path(target_url).ok()?;
+  let start_dir = if target_url.path().ends_with('/') {
+    target_path
+  } else {
+    target_path.parent()?.to_path_buf()
+  };
+  for ancestor in start_dir.ancestors() {
+    if let Ok(Some(folder)) = load_config_folder(ancestor)
+      && folder.deno_json().is_some()
+    {
+      return Some(folder.folder_url());
+    }
+  }
+  None
 }
 
 fn resolve_vendor_dir(

--- a/libs/config/workspace/discovery.rs
+++ b/libs/config/workspace/discovery.rs
@@ -1161,11 +1161,11 @@ fn resolve_auto_link_config_folders<TSys: FsRead + FsMetadata + FsReadDir>(
     visited.insert((**key).clone());
   }
 
-  // worklist of (config dir, path-style import map values) still to scan
+  // worklist of (import map dir, path-style import map values) still to scan
   let mut worklist: Vec<(Url, Vec<String>)> = Vec::new();
-  enqueue_import_path_values(root_config_folder, &mut worklist);
+  enqueue_import_path_values(sys, root_config_folder, &mut worklist);
   for folder in members.values().chain(links.values()) {
-    enqueue_import_path_values(folder, &mut worklist);
+    enqueue_import_path_values(sys, folder, &mut worklist);
   }
 
   while let Some((base_dir, values)) = worklist.pop() {
@@ -1189,15 +1189,20 @@ fn resolve_auto_link_config_folders<TSys: FsRead + FsMetadata + FsReadDir>(
         load_config_folder,
       ) {
         Ok(folders) => folders,
-        Err(_) => {
+        Err(err) => {
           // not resolvable as a linkable package; skip and don't retry
+          log::debug!(
+            "Skipping auto-linked import map dir {}: {:#}",
+            governing_dir,
+            err
+          );
           visited.insert(governing_dir);
           continue;
         }
       };
       for (dir_url, folder) in expanded {
         if visited.insert((*dir_url).clone()) {
-          enqueue_import_path_values(&folder, &mut worklist);
+          enqueue_import_path_values(sys, &folder, &mut worklist);
           links.insert(dir_url, folder);
         }
       }
@@ -1205,21 +1210,39 @@ fn resolve_auto_link_config_folders<TSys: FsRead + FsMetadata + FsReadDir>(
   }
 }
 
-fn enqueue_import_path_values(
+fn enqueue_import_path_values<TSys: FsRead>(
+  sys: &TSys,
   folder: &ConfigFolder,
   worklist: &mut Vec<(Url, Vec<String>)>,
 ) {
-  if let Some(deno_json) = folder.deno_json() {
-    let values = collect_import_path_values(deno_json);
-    if !values.is_empty() {
-      worklist.push((url_parent(&deno_json.specifier), values));
+  let Some(deno_json) = folder.deno_json() else {
+    return;
+  };
+  // Resolve the import map, following an external `importMap` file if present.
+  // Path entries resolve against the import map's own location: the deno.json
+  // for inline maps, or the external file's directory otherwise.
+  let map_value = match deno_json.to_import_map_value(sys) {
+    Ok(Some((specifier, value))) => (url_parent(&specifier), value),
+    Ok(None) => return,
+    Err(err) => {
+      log::debug!(
+        "Skipping auto-link discovery for {}: {:#}",
+        deno_json.specifier,
+        err
+      );
+      return;
     }
+  };
+  let (base_dir, value) = map_value;
+  let values = collect_import_path_values(&value);
+  if !values.is_empty() {
+    worklist.push((base_dir, values));
   }
 }
 
-/// Collects the string values of a config file's `imports` and `scopes` maps.
-/// Only inline import maps are considered (not an external `importMap` file).
-fn collect_import_path_values(config: &ConfigFile) -> Vec<String> {
+/// Collects the path-style string values from an import map value's `imports`
+/// and `scopes` maps.
+fn collect_import_path_values(value: &serde_json::Value) -> Vec<String> {
   fn collect_from_map(
     map: &serde_json::Map<String, serde_json::Value>,
     out: &mut Vec<String>,
@@ -1232,10 +1255,13 @@ fn collect_import_path_values(config: &ConfigFile) -> Vec<String> {
   }
 
   let mut out = Vec::new();
-  if let Some(serde_json::Value::Object(imports)) = &config.json.imports {
+  let serde_json::Value::Object(obj) = value else {
+    return out;
+  };
+  if let Some(serde_json::Value::Object(imports)) = obj.get("imports") {
     collect_from_map(imports, &mut out);
   }
-  if let Some(serde_json::Value::Object(scopes)) = &config.json.scopes {
+  if let Some(serde_json::Value::Object(scopes)) = obj.get("scopes") {
     for scope_value in scopes.values() {
       if let serde_json::Value::Object(scope_imports) = scope_value {
         collect_from_map(scope_imports, &mut out);
@@ -1256,6 +1282,10 @@ fn import_value_target_url(base_dir: &Url, value: &str) -> Option<Url> {
     base_dir.join(value).ok()
   } else if value.starts_with("file:") {
     Url::parse(value).ok()
+  } else if cfg!(windows) && value.contains('\\') {
+    // a Windows absolute path like `C:\pkg\mod.ts`; mirror the backslash
+    // handling that `resolve_link_dir_url` applies to explicit links
+    url_from_file_path(Path::new(value)).ok()
   } else {
     None
   }

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use deno_config::deno_json::ConfigFileError;
+use deno_config::deno_json::ConfigFileRc;
 use deno_config::workspace::ResolverWorkspaceJsrPackage;
 use deno_config::workspace::Workspace;
 use deno_error::JsError;
@@ -860,14 +861,60 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
       specified_import_map: Option<SpecifiedImportMap>,
     ) -> Result<Option<ImportMapWithDiagnostics>, WorkspaceResolverCreateError>
     {
+      // Builds the import map scope contributed by a workspace member or linked
+      // package. The member's `imports` (not its `scopes`) are layered into the
+      // synthetic map; this follows an external `importMap` file when the
+      // member uses one. `to_import_map_value` already applies Deno's bare
+      // specifier expansion for inline maps and leaves external maps untouched,
+      // matching the import map standard, so no extra expansion is done here.
+      fn child_import_map_config(
+        sys: &impl FsRead,
+        config: &ConfigFileRc,
+      ) -> import_map::ext::ImportMapConfig {
+        let (base_url, value) = match config.to_import_map_value(sys) {
+          Ok(Some((specifier, value))) => (specifier.into_owned(), value),
+          Ok(None) => (
+            config.specifier.clone(),
+            serde_json::Value::Object(Default::default()),
+          ),
+          Err(err) => {
+            log::debug!(
+              "Ignoring import map for {}: {:#}",
+              config.specifier,
+              err
+            );
+            (
+              config.specifier.clone(),
+              serde_json::Value::Object(Default::default()),
+            )
+          }
+        };
+        let mut imports_only = serde_json::Map::with_capacity(1);
+        if let serde_json::Value::Object(mut obj) = value
+          && let Some(imports) = obj.remove("imports")
+        {
+          imports_only.insert("imports".to_string(), imports);
+        }
+        import_map::ext::ImportMapConfig {
+          base_url,
+          import_map_value: imports_only.into(),
+        }
+      }
+
       let root_deno_json = workspace.root_deno_json();
       let deno_jsons = workspace.resolver_deno_jsons().collect::<Vec<_>>();
 
-      let (import_map_url, import_map) = match specified_import_map {
-        Some(SpecifiedImportMap {
-          base_url,
-          value: import_map,
-        }) => (base_url, import_map),
+      // The base of the synthetic import map: either an explicitly specified map
+      // (the `--import-map` flag or the root's external `importMap` file) or the
+      // root deno.json's own import map. Either way, workspace member and linked
+      // package scopes are layered on top so their bare specifiers resolve.
+      let base_import_map_config = match specified_import_map {
+        Some(SpecifiedImportMap { base_url, value }) => {
+          import_map::ext::ImportMapConfig {
+            base_url,
+            import_map_value: value,
+          }
+        }
         None => {
           if !deno_jsons.iter().any(|p| p.is_package())
             && !deno_jsons.iter().any(|c| {
@@ -886,59 +933,48 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
             return Ok(None);
           }
 
-          let config_specified_import_map = match root_deno_json.as_ref() {
+          let (base_url, value) = match root_deno_json.as_ref() {
             Some(deno_json) => deno_json
               .to_import_map_value(sys)
               .map_err(|source| WorkspaceResolverCreateError::ImportMapFetch {
                 referrer: deno_json.specifier.clone(),
                 source: Box::new(source),
               })?
+              .map(|(specifier, value)| (specifier.into_owned(), value))
               .unwrap_or_else(|| {
                 (
-                  Cow::Borrowed(&deno_json.specifier),
+                  deno_json.specifier.clone(),
                   serde_json::Value::Object(Default::default()),
                 )
               }),
             None => (
-              Cow::Owned(workspace.root_dir_url().join("deno.json").unwrap()),
+              workspace.root_dir_url().join("deno.json").unwrap(),
               serde_json::Value::Object(Default::default()),
             ),
           };
-          let base_import_map_config = import_map::ext::ImportMapConfig {
-            base_url: config_specified_import_map.0.into_owned(),
-            import_map_value: config_specified_import_map.1,
-          };
-          let child_import_map_configs = deno_jsons
-            .iter()
-            .filter(|f| {
-              Some(&f.specifier)
-                != root_deno_json.as_ref().map(|c| &c.specifier)
-            })
-            .map(|config| import_map::ext::ImportMapConfig {
-              base_url: config.specifier.clone(),
-              import_map_value: {
-                // don't include scopes here
-                let mut value = serde_json::Map::with_capacity(1);
-                if let Some(imports) = &config.json.imports {
-                  value.insert("imports".to_string(), imports.clone());
-                }
-                value.into()
-              },
-            })
-            .collect::<Vec<_>>();
-          let (import_map_url, import_map) =
-            ::import_map::ext::create_synthetic_import_map(
-              base_import_map_config,
-              child_import_map_configs,
-            );
-          let import_map = import_map::ext::expand_import_map_value(import_map);
-          log::debug!(
-            "Workspace config generated this import map {}",
-            serde_json::to_string_pretty(&import_map).unwrap()
-          );
-          (import_map_url, import_map)
+          import_map::ext::ImportMapConfig {
+            base_url,
+            import_map_value: value,
+          }
         }
       };
+
+      let child_import_map_configs = deno_jsons
+        .iter()
+        .filter(|f| {
+          Some(&f.specifier) != root_deno_json.as_ref().map(|c| &c.specifier)
+        })
+        .map(|config| child_import_map_config(sys, config))
+        .collect::<Vec<_>>();
+      let (import_map_url, import_map) =
+        ::import_map::ext::create_synthetic_import_map(
+          base_import_map_config,
+          child_import_map_configs,
+        );
+      log::debug!(
+        "Workspace config generated this import map {}",
+        serde_json::to_string_pretty(&import_map).unwrap()
+      );
       Ok(Some(import_map::parse_from_value(
         import_map_url,
         import_map,
@@ -2245,6 +2281,55 @@ mod test {
   }
 
   #[test]
+  fn auto_link_external_import_map_file() {
+    // Same as the basic case, but the root project points at an external
+    // `importMap` file instead of an inline `imports` map. The path entry
+    // there resolves relative to the import map file, and discovery must still
+    // find repo1's deno.json (issue #26764).
+    let sys = InMemorySys::default();
+    let repo2 = root_dir().join("repo2");
+    let repo1 = root_dir().join("repo1");
+    sys.fs_insert_json(
+      repo2.join("deno.json"),
+      json!({
+        "importMap": "./import_map.json",
+      }),
+    );
+    sys.fs_insert_json(
+      repo2.join("import_map.json"),
+      json!({
+        "imports": {
+          "@jpravetz/bmod": "../repo1/bmod/mod.ts",
+        },
+      }),
+    );
+    sys.fs_insert_json(
+      repo1.join("bmod/deno.json"),
+      json!({
+        "imports": {
+          "@scope/amod": "../amod/mod.ts",
+        },
+      }),
+    );
+
+    let workspace = workspace_at_start_dir(&sys, &repo2);
+    let resolver = create_resolver_with_sys(sys.clone(), &workspace);
+    let referrer = url_from_file_path(&repo1.join("bmod/mod.ts")).unwrap();
+    let resolution = resolver
+      .resolve("@scope/amod", &referrer, ResolutionKind::Execution)
+      .unwrap();
+    let MappedResolution::Normal { specifier, .. } = &resolution else {
+      unreachable!("{:#?}", &resolution);
+    };
+    assert_eq!(
+      specifier.as_str(),
+      url_from_file_path(&repo1.join("amod/mod.ts"))
+        .unwrap()
+        .as_str()
+    );
+  }
+
+  #[test]
   fn auto_link_external_import_map_transitive() {
     // Auto-discovery follows path import entries transitively across several
     // external packages.
@@ -2975,6 +3060,72 @@ mod test {
   }
 
   #[test]
+  fn specified_import_map_layers_link_scopes() {
+    // A specified import map (e.g. the root's external `importMap` file passed
+    // by the CLI) must still layer in the scopes of linked packages, so a bare
+    // specifier imported from a linked package resolves against that package's
+    // own import map (issue #26764).
+    let sys = InMemorySys::default();
+    let repo2 = root_dir().join("repo2");
+    let repo1 = root_dir().join("repo1");
+    sys.fs_insert_json(
+      repo2.join("deno.json"),
+      json!({
+        "importMap": "./import_map.json",
+      }),
+    );
+    sys.fs_insert_json(
+      repo2.join("import_map.json"),
+      json!({
+        "imports": {
+          "@jpravetz/bmod": "../repo1/bmod/mod.ts",
+        },
+      }),
+    );
+    sys.fs_insert_json(
+      repo1.join("bmod/deno.json"),
+      json!({
+        "imports": {
+          "@scope/amod": "../amod/mod.ts",
+        },
+      }),
+    );
+    let workspace_dir = workspace_at_start_dir(&sys, &repo2);
+    let resolver = WorkspaceResolver::from_workspace(
+      &workspace_dir.workspace,
+      sys,
+      super::CreateResolverOptions {
+        pkg_json_dep_resolution: PackageJsonDepResolution::Enabled,
+        // mimic the CLI loading the root's external `importMap` file
+        specified_import_map: Some(SpecifiedImportMap {
+          base_url: url_from_file_path(&repo2.join("import_map.json")).unwrap(),
+          value: json!({
+            "imports": {
+              "@jpravetz/bmod": "../repo1/bmod/mod.ts",
+            },
+          }),
+        }),
+        sloppy_imports_options: SloppyImportsOptions::Unspecified,
+        fs_cache_options: FsCacheOptions::Enabled,
+      },
+    )
+    .unwrap();
+    let referrer = url_from_file_path(&repo1.join("bmod/mod.ts")).unwrap();
+    let MappedResolution::Normal { specifier, .. } = resolver
+      .resolve("@scope/amod", &referrer, ResolutionKind::Execution)
+      .unwrap()
+    else {
+      unreachable!();
+    };
+    assert_eq!(
+      specifier.as_str(),
+      url_from_file_path(&repo1.join("amod/mod.ts"))
+        .unwrap()
+        .as_str()
+    );
+  }
+
+  #[test]
   fn workspace_specified_import_map() {
     let sys = InMemorySys::default();
     sys.fs_insert_json(
@@ -3323,6 +3474,25 @@ mod test {
     WorkspaceResolver::from_workspace(
       &workspace_dir.workspace,
       UnreachableSys,
+      super::CreateResolverOptions {
+        pkg_json_dep_resolution: PackageJsonDepResolution::Enabled,
+        specified_import_map: None,
+        sloppy_imports_options: SloppyImportsOptions::Unspecified,
+        fs_cache_options: FsCacheOptions::Enabled,
+      },
+    )
+    .unwrap()
+  }
+
+  // Like `create_resolver`, but uses a real (in-memory) sys so the resolver can
+  // read external `importMap` files referenced by config files.
+  fn create_resolver_with_sys(
+    sys: InMemorySys,
+    workspace_dir: &WorkspaceDirectory,
+  ) -> WorkspaceResolver<InMemorySys> {
+    WorkspaceResolver::from_workspace(
+      &workspace_dir.workspace,
+      sys,
       super::CreateResolverOptions {
         pkg_json_dep_resolution: PackageJsonDepResolution::Enabled,
         specified_import_map: None,

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -2203,6 +2203,144 @@ mod test {
   }
 
   #[test]
+  fn auto_link_external_import_map() {
+    // A project that references an external package by relative path should
+    // resolve that package's own bare specifier imports against its own
+    // import map, without needing a `links` entry (issue #26764).
+    let sys = InMemorySys::default();
+    let repo2 = root_dir().join("repo2");
+    let repo1 = root_dir().join("repo1");
+    sys.fs_insert_json(
+      repo2.join("deno.json"),
+      json!({
+        "imports": {
+          "@jpravetz/bmod": "../repo1/bmod/mod.ts",
+        },
+      }),
+    );
+    sys.fs_insert_json(
+      repo1.join("bmod/deno.json"),
+      json!({
+        "imports": {
+          "@scope/amod": "../amod/mod.ts",
+        },
+      }),
+    );
+
+    let workspace = workspace_at_start_dir(&sys, &repo2);
+    let resolver = create_resolver(&workspace);
+    let referrer = url_from_file_path(&repo1.join("bmod/mod.ts")).unwrap();
+    let resolution = resolver
+      .resolve("@scope/amod", &referrer, ResolutionKind::Execution)
+      .unwrap();
+    let MappedResolution::Normal { specifier, .. } = &resolution else {
+      unreachable!("{:#?}", &resolution);
+    };
+    assert_eq!(
+      specifier.as_str(),
+      url_from_file_path(&repo1.join("amod/mod.ts"))
+        .unwrap()
+        .as_str()
+    );
+  }
+
+  #[test]
+  fn auto_link_external_import_map_transitive() {
+    // Auto-discovery follows path import entries transitively across several
+    // external packages.
+    let sys = InMemorySys::default();
+    let repo2 = root_dir().join("repo2");
+    let repo1 = root_dir().join("repo1");
+    let repo3 = root_dir().join("repo3");
+    sys.fs_insert_json(
+      repo2.join("deno.json"),
+      json!({
+        "imports": { "@a/bmod": "../repo1/bmod/mod.ts" },
+      }),
+    );
+    sys.fs_insert_json(
+      repo1.join("bmod/deno.json"),
+      json!({
+        "imports": { "@a/cmod": "../../repo3/cmod/mod.ts" },
+      }),
+    );
+    sys.fs_insert_json(
+      repo3.join("cmod/deno.json"),
+      json!({
+        "imports": { "@a/dmod": "./sub/mod.ts" },
+      }),
+    );
+
+    let workspace = workspace_at_start_dir(&sys, &repo2);
+    let resolver = create_resolver(&workspace);
+    let referrer = url_from_file_path(&repo3.join("cmod/mod.ts")).unwrap();
+    let resolution = resolver
+      .resolve("@a/dmod", &referrer, ResolutionKind::Execution)
+      .unwrap();
+    let MappedResolution::Normal { specifier, .. } = &resolution else {
+      unreachable!("{:#?}", &resolution);
+    };
+    assert_eq!(
+      specifier.as_str(),
+      url_from_file_path(&repo3.join("cmod/sub/mod.ts"))
+        .unwrap()
+        .as_str()
+    );
+  }
+
+  #[test]
+  fn auto_link_external_import_map_cycle() {
+    // Mutually-referencing external packages must terminate discovery and
+    // still resolve both directions.
+    let sys = InMemorySys::default();
+    let repo2 = root_dir().join("repo2");
+    let repo1 = root_dir().join("repo1");
+    sys.fs_insert_json(
+      repo2.join("deno.json"),
+      json!({
+        "imports": { "@x/bmod": "../repo1/bmod/mod.ts" },
+      }),
+    );
+    sys.fs_insert_json(
+      repo1.join("bmod/deno.json"),
+      json!({
+        "imports": { "@x/emod": "../emod/mod.ts" },
+      }),
+    );
+    sys.fs_insert_json(
+      repo1.join("emod/deno.json"),
+      json!({
+        "imports": { "@x/bmod": "../bmod/mod.ts" },
+      }),
+    );
+
+    let workspace = workspace_at_start_dir(&sys, &repo2);
+    let resolver = create_resolver(&workspace);
+    let resolve = |specifier: &str, referrer: &Path| {
+      let referrer = url_from_file_path(referrer).unwrap();
+      let resolution = resolver
+        .resolve(specifier, &referrer, ResolutionKind::Execution)
+        .unwrap();
+      match resolution {
+        MappedResolution::Normal { specifier, .. } => specifier,
+        other => unreachable!("{:#?}", other),
+      }
+    };
+    assert_eq!(
+      resolve("@x/emod", &repo1.join("bmod/mod.ts")).as_str(),
+      url_from_file_path(&repo1.join("emod/mod.ts"))
+        .unwrap()
+        .as_str()
+    );
+    assert_eq!(
+      resolve("@x/bmod", &repo1.join("emod/mod.ts")).as_str(),
+      url_from_file_path(&repo1.join("bmod/mod.ts"))
+        .unwrap()
+        .as_str()
+    );
+  }
+
+  #[test]
   fn root_member_imports_and_scopes() {
     let sys = InMemorySys::default();
     sys.fs_insert_json(

--- a/tests/specs/workspaces/auto_link_external_import_map/__test__.jsonc
+++ b/tests/specs/workspaces/auto_link_external_import_map/__test__.jsonc
@@ -15,6 +15,9 @@
       "args": "check main.ts",
       "output": "check.out"
     },
+    // Auto-linking pulls repo1's deno.json into resolution, but it must not
+    // widen lint scope: running `lint` from repo2 still only checks repo2's own
+    // file (repo2/main.ts), not the auto-linked repo1 packages.
     "lint": {
       "args": "lint",
       "output": "Checked 1 file\n"

--- a/tests/specs/workspaces/auto_link_external_import_map/__test__.jsonc
+++ b/tests/specs/workspaces/auto_link_external_import_map/__test__.jsonc
@@ -1,0 +1,23 @@
+{
+  // Regression test for https://github.com/denoland/deno/issues/26764
+  // repo2 references a package in repo1 by relative path. That package has its
+  // own import map referencing a sibling package by bare specifier. Without any
+  // "links" field, Deno should auto-discover repo1's deno.json so the bare
+  // specifier resolves.
+  "tempDir": true,
+  "cwd": "./repo2",
+  "tests": {
+    "run": {
+      "args": "run main.ts",
+      "output": "42\n"
+    },
+    "check": {
+      "args": "check main.ts",
+      "output": "check.out"
+    },
+    "lint": {
+      "args": "lint",
+      "output": "Checked 1 file\n"
+    }
+  }
+}

--- a/tests/specs/workspaces/auto_link_external_import_map/check.out
+++ b/tests/specs/workspaces/auto_link_external_import_map/check.out
@@ -1,0 +1,1 @@
+Check [WILDLINE]

--- a/tests/specs/workspaces/auto_link_external_import_map/repo1/amod/deno.json
+++ b/tests/specs/workspaces/auto_link_external_import_map/repo1/amod/deno.json
@@ -1,0 +1,4 @@
+{
+  "name": "@scope/amod",
+  "exports": "./mod.ts"
+}

--- a/tests/specs/workspaces/auto_link_external_import_map/repo1/amod/mod.ts
+++ b/tests/specs/workspaces/auto_link_external_import_map/repo1/amod/mod.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/tests/specs/workspaces/auto_link_external_import_map/repo1/bmod/deno.json
+++ b/tests/specs/workspaces/auto_link_external_import_map/repo1/bmod/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@scope/amod": "../amod/mod.ts"
+  }
+}

--- a/tests/specs/workspaces/auto_link_external_import_map/repo1/bmod/mod.ts
+++ b/tests/specs/workspaces/auto_link_external_import_map/repo1/bmod/mod.ts
@@ -1,0 +1,5 @@
+import { add } from "@scope/amod";
+
+export function bmod(x: number): number {
+  return add(x, 1);
+}

--- a/tests/specs/workspaces/auto_link_external_import_map/repo2/deno.json
+++ b/tests/specs/workspaces/auto_link_external_import_map/repo2/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@jpravetz/bmod": "../repo1/bmod/mod.ts"
+  }
+}

--- a/tests/specs/workspaces/auto_link_external_import_map/repo2/main.ts
+++ b/tests/specs/workspaces/auto_link_external_import_map/repo2/main.ts
@@ -1,0 +1,3 @@
+import { bmod } from "@jpravetz/bmod";
+
+console.log(bmod(41));

--- a/tests/specs/workspaces/auto_link_external_import_map_file/__test__.jsonc
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  // Regression test for https://github.com/denoland/deno/issues/26764, variant
+  // where the root project points at an external "importMap" file rather than
+  // an inline `imports` map. The path entry there (`../repo1/bmod/mod.ts`)
+  // resolves relative to the import map file, and auto-discovery must still pick
+  // up repo1's deno.json so bmod's bare `@scope/amod` specifier resolves.
+  "tempDir": true,
+  "cwd": "./repo2",
+  "tests": {
+    "run": {
+      "args": "run main.ts",
+      "output": "42\n"
+    },
+    "check": {
+      "args": "check main.ts",
+      "output": "check.out"
+    }
+  }
+}

--- a/tests/specs/workspaces/auto_link_external_import_map_file/check.out
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/check.out
@@ -1,0 +1,1 @@
+Check [WILDLINE]

--- a/tests/specs/workspaces/auto_link_external_import_map_file/repo1/amod/deno.json
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/repo1/amod/deno.json
@@ -1,0 +1,4 @@
+{
+  "name": "@scope/amod",
+  "exports": "./mod.ts"
+}

--- a/tests/specs/workspaces/auto_link_external_import_map_file/repo1/amod/mod.ts
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/repo1/amod/mod.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/tests/specs/workspaces/auto_link_external_import_map_file/repo1/bmod/deno.json
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/repo1/bmod/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@scope/amod": "../amod/mod.ts"
+  }
+}

--- a/tests/specs/workspaces/auto_link_external_import_map_file/repo1/bmod/mod.ts
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/repo1/bmod/mod.ts
@@ -1,0 +1,5 @@
+import { add } from "@scope/amod";
+
+export function bmod(x: number): number {
+  return add(x, 1);
+}

--- a/tests/specs/workspaces/auto_link_external_import_map_file/repo2/deno.json
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/repo2/deno.json
@@ -1,0 +1,3 @@
+{
+  "importMap": "./import_map.json"
+}

--- a/tests/specs/workspaces/auto_link_external_import_map_file/repo2/import_map.json
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/repo2/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@jpravetz/bmod": "../repo1/bmod/mod.ts"
+  }
+}

--- a/tests/specs/workspaces/auto_link_external_import_map_file/repo2/main.ts
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/repo2/main.ts
@@ -1,0 +1,3 @@
+import { bmod } from "@jpravetz/bmod";
+
+console.log(bmod(41));


### PR DESCRIPTION
When a project's import map maps a specifier to a relative or absolute file
path that lands inside a directory governed by its own deno.json, imports made
from that external module previously failed to resolve. For example, a project
mapping `"@scope/pkg": "../other/pkg/mod.ts"` could load `pkg/mod.ts`, but any
bare specifier that module imported (resolved through `other/pkg`'s own import
map) errored with "Relative import path ... not in import map". The only
workaround was to manually list the directory in the `links` field.

This makes Deno discover those external deno.json files automatically. It walks
path-style import map entries to a fixpoint, finds the governing deno.json of
each referenced file, and registers it the same way an explicit `links` entry
would, so the external module's bare specifiers resolve against its own import
map. Discovery follows external `importMap` files in addition to inline
`imports`/`scopes`, so a project (or a discovered package) that points at a
separate import map file is handled too. Bare specifiers and non-file schemes
(npm:, jsr:, http:, ...) are skipped, and a visited-set guards against cycles
and the workspace's own members.

The resolver builds the per-package referrer scopes from each linked package's
import map. This previously only read inline `imports` and, when the root used
an external `importMap` file (or `--import-map`), skipped the linked-package
scopes entirely. It now reads external `importMap` files for linked packages
and layers their scopes on top of a specified import map, so external import
maps produce working resolution. As a side effect this also fixes explicit
`links` combined with an external root `importMap`, which was broken before.

This changes default resolution behavior rather than gating it behind a config
flag, on the basis that it only turns previously-erroring resolutions into
working ones. @dsherret, flagging you since you were assigned to decide the
course of action here, in case you'd prefer this behind an opt-in instead.

Closes #26764
