### PR TITLE
fix(runtime): show import location for unsupported import attributes

### DIFF
--- a/libs/core/lib.rs
+++ b/libs/core/lib.rs
@@ -137,6 +137,7 @@ pub use crate::module_specifier::resolve_url;
 pub use crate::modules::CustomModuleEvaluationKind;
 pub use crate::modules::ExtCodeCache;
 pub use crate::modules::FsModuleLoader;
+pub use crate::modules::ImportAttributesContext;
 pub use crate::modules::ModuleCodeBytes;
 pub use crate::modules::ModuleCodeString;
 pub use crate::modules::ModuleId;

--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -28,6 +28,7 @@ use v8::PromiseState;
 use wasm_dep_analyzer::WasmDeps;
 
 use super::CustomModuleEvaluationKind;
+use super::ImportAttributesContext;
 use super::IntoModuleCodeString;
 use super::IntoModuleName;
 use super::LazyEsmModuleLoader;
@@ -1032,7 +1033,16 @@ impl ModuleMap {
         if let Some(validate_import_attributes_cb) =
           &state.validate_import_attributes_cb
         {
-          (validate_import_attributes_cb)(tc_scope, &attributes);
+          let location = module
+            .source_offset_to_location(module_request.get_source_offset());
+          let context = ImportAttributesContext {
+            referrer: name.as_str().to_string(),
+            specifier: import_specifier.to_string(),
+            // V8 reports 0-based line/column; report them 1-based.
+            line_number: Some(location.get_line_number() as u32 + 1),
+            column_number: Some(location.get_column_number() as u32 + 1),
+          };
+          (validate_import_attributes_cb)(tc_scope, &attributes, &context);
         }
       }
 

--- a/libs/core/modules/mod.rs
+++ b/libs/core/modules/mod.rs
@@ -221,10 +221,49 @@ impl From<&'static [u8]> for ModuleCodeBytes {
   }
 }
 
+/// Location of the import statement whose attributes are being validated.
+/// Used to produce error messages that point at the offending import.
+#[derive(Debug, Default, Clone)]
+pub struct ImportAttributesContext {
+  /// URL of the module that contains the import statement.
+  pub referrer: String,
+  /// The imported specifier (the string after `from`/`import`).
+  pub specifier: String,
+  /// 1-based line number of the import statement, if known. Only available
+  /// for static imports.
+  pub line_number: Option<u32>,
+  /// 1-based column number of the import statement, if known. Only available
+  /// for static imports.
+  pub column_number: Option<u32>,
+}
+
+impl ImportAttributesContext {
+  /// Formats a human-readable suffix describing where the import occurs, e.g.
+  /// `\n    at file:///main.js:1:1`.
+  ///
+  /// Only emitted for static imports (where a line/column is known). Dynamic
+  /// imports already surface the call site through the rejected promise's
+  /// stack trace, so appending a location there would just duplicate it.
+  pub fn format_location(&self) -> String {
+    let Some(line) = self.line_number else {
+      return String::new();
+    };
+    if self.referrer.is_empty() {
+      return String::new();
+    }
+    let mut s = format!("\n    at {}:{line}", self.referrer);
+    if let Some(column) = self.column_number {
+      s.push_str(&format!(":{column}"));
+    }
+    s
+  }
+}
+
 /// Callback to validate import attributes. If the validation fails and exception
 /// should be thrown using `scope.throw_exception()`.
-pub type ValidateImportAttributesCb =
-  Box<dyn Fn(&mut v8::PinScope, &HashMap<String, String>)>;
+pub type ValidateImportAttributesCb = Box<
+  dyn Fn(&mut v8::PinScope, &HashMap<String, String>, &ImportAttributesContext),
+>;
 
 /// Callback to validate import attributes. If the validation fails and exception
 /// should be thrown using `scope.throw_exception()`.

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -25,6 +25,7 @@ use tokio::task::LocalSet;
 use url::Url;
 
 use crate::FastString;
+use crate::ImportAttributesContext;
 use crate::ModuleCodeString;
 use crate::ModuleSource;
 use crate::ModuleSpecifier;
@@ -948,6 +949,7 @@ fn test_validate_import_attributes_callback() {
   fn validate_import_attributes(
     scope: &mut v8::PinScope,
     assertions: &HashMap<String, String>,
+    _context: &ImportAttributesContext,
   ) {
     for (key, value) in assertions {
       let msg = if key != "type" {
@@ -1036,6 +1038,7 @@ fn test_validate_import_attributes_callback2() {
   fn validate_import_attrs(
     scope: &mut v8::PinScope,
     _attrs: &HashMap<String, String>,
+    _context: &ImportAttributesContext,
   ) {
     let msg = v8::String::new(scope, "boom!").unwrap();
     let ex = v8::Exception::type_error(scope, msg);

--- a/libs/core/runtime/bindings.rs
+++ b/libs/core/runtime/bindings.rs
@@ -941,7 +941,15 @@ pub fn host_import_module_with_phase_dynamically_callback<'s, 'i>(
       if let Some(validate_import_attributes_cb) =
         &state.validate_import_attributes_cb
       {
-        (validate_import_attributes_cb)(tc_scope, &assertions);
+        // Dynamic imports don't expose a source offset, so line/column are
+        // unavailable here.
+        let context = crate::modules::ImportAttributesContext {
+          referrer: referrer_name_str.clone(),
+          specifier: specifier_str.clone(),
+          line_number: None,
+          column_number: None,
+        };
+        (validate_import_attributes_cb)(tc_scope, &assertions, &context);
       }
     }
 

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -98,7 +98,8 @@ pub fn create_validate_import_attributes_callback(
 ) -> deno_core::ValidateImportAttributesCb {
   Box::new(
     move |scope: &mut v8::PinScope<'_, '_>,
-          attributes: &HashMap<String, String>| {
+          attributes: &HashMap<String, String>,
+          context: &deno_core::ImportAttributesContext| {
       let valid_attribute = |kind: &str| {
         matches!(kind, "json" | "text")
           || (enable_raw_imports.load(Ordering::Relaxed) && kind == "bytes")
@@ -116,6 +117,7 @@ pub fn create_validate_import_attributes_callback(
           continue;
         };
 
+        let msg = format!("{msg}{}", context.format_location());
         let message = v8::String::new(scope, &msg).unwrap();
         let exception = v8::Exception::type_error(scope, message);
         scope.throw_exception(exception);

--- a/tests/specs/run/import_attributes_unsupported_attribute/__test__.jsonc
+++ b/tests/specs/run/import_attributes_unsupported_attribute/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tests": {
+    "static": {
+      "args": "run static.ts",
+      "output": "static.out",
+      "exitCode": 1
+    },
+    "dynamic": {
+      "args": "run dynamic.ts",
+      "output": "dynamic.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/run/import_attributes_unsupported_attribute/dynamic.out
+++ b/tests/specs/run/import_attributes_unsupported_attribute/dynamic.out
@@ -1,0 +1,4 @@
+error: Uncaught (in promise) TypeError: "BABEL_8_BREAKING" attribute is not supported.
+await import("./mod.ts", { with: { BABEL_8_BREAKING: "false" } });
+^
+    at [WILDCARD]dynamic.ts:1:1

--- a/tests/specs/run/import_attributes_unsupported_attribute/dynamic.ts
+++ b/tests/specs/run/import_attributes_unsupported_attribute/dynamic.ts
@@ -1,0 +1,1 @@
+await import("./mod.ts", { with: { BABEL_8_BREAKING: "false" } });

--- a/tests/specs/run/import_attributes_unsupported_attribute/mod.ts
+++ b/tests/specs/run/import_attributes_unsupported_attribute/mod.ts
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/tests/specs/run/import_attributes_unsupported_attribute/static.out
+++ b/tests/specs/run/import_attributes_unsupported_attribute/static.out
@@ -1,0 +1,2 @@
+error: Uncaught TypeError: "BABEL_8_BREAKING" attribute is not supported.
+    at [WILDCARD]static.ts:1:8

--- a/tests/specs/run/import_attributes_unsupported_attribute/static.ts
+++ b/tests/specs/run/import_attributes_unsupported_attribute/static.ts
@@ -1,0 +1,1 @@
+import "./mod.ts" with { BABEL_8_BREAKING: "false" };


### PR DESCRIPTION
When a module used an unsupported import attribute, Deno reported only
`error: Uncaught TypeError: "X" attribute is not supported.` with no
indication of which file or line the offending import was on. For a
static import the error didn't even carry a stack frame, so there was
nothing to go on.

The import-attribute validation callback now receives the referrer URL
and, for static imports, the 1-based line and column of the import
(derived from the module request's source offset). The error message
gains an `at <url>:<line>:<col>` suffix pointing straight at the import.
Dynamic imports are left as-is: V8 already attaches a real stack frame to
the rejected promise, so adding our own location there would only
duplicate it.

Closes #27983