### PR TITLE
fix(cache): allow no-remote to read vendored modules

### DIFF
--- a/libs/cache_dir/file_fetcher/mod.rs
+++ b/libs/cache_dir/file_fetcher/mod.rs
@@ -648,7 +648,15 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
     } else if scheme == "blob" {
       strategy.handle_blob_url(url).await
     } else if scheme == "https" || scheme == "http" {
+      let cache_setting =
+        options.maybe_cache_setting.unwrap_or(&self.cache_setting);
       if !self.allow_remote {
+        if self.should_use_cache(url, cache_setting)
+          && let Some(value) = strategy
+            .handle_fetch_cached_no_follow(url, options.maybe_checksum)?
+        {
+          return Ok(value);
+        }
         Err(FetchNoFollowErrorKind::NoRemote(url.clone()).into_box())
       } else {
         self
@@ -656,7 +664,7 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
             strategy,
             url,
             options.maybe_accept,
-            options.maybe_cache_setting.unwrap_or(&self.cache_setting),
+            cache_setting,
             options.maybe_checksum,
             options.maybe_auth,
           )

--- a/tests/specs/jsr/vendor_no_remote/__test__.jsonc
+++ b/tests/specs/jsr/vendor_no_remote/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_DIR": "./denodir"
+  },
+  "steps": [{
+    "args": "install -e main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "args": [
+      "eval",
+      "Deno.removeSync('denodir', { recursive: true, force: true })"
+    ],
+    "output": ""
+  }, {
+    "args": "run --no-remote main.ts",
+    "output": "ok\n"
+  }]
+}

--- a/tests/specs/jsr/vendor_no_remote/deno.json
+++ b/tests/specs/jsr/vendor_no_remote/deno.json
@@ -1,0 +1,3 @@
+{
+  "vendor": true
+}

--- a/tests/specs/jsr/vendor_no_remote/main.ts
+++ b/tests/specs/jsr/vendor_no_remote/main.ts
@@ -1,0 +1,3 @@
+import "jsr:@denotest/add@1.0.0";
+
+console.log("ok");


### PR DESCRIPTION
Fixes #34793.

Summary:
- allow the file fetcher to satisfy http/https requests from cache or vendor data before returning `NoRemote`
- add a JSR vendor regression that clears `DENO_DIR` and runs the vendored module with `--no-remote`

AI assistance disclosure: I used AI tooling while developing this patch and reviewed the final code and tests.

Tests:
- `cargo test -p specs_tests --test specs vendor_no_remote`
- `target/debug/deps/specs-4c25e2a61e04fe22 vendor_no_remote`
- `PATH="$PWD/target/debug:$PATH" deno run -A --no-config npm:dprint@0.47.2 check --config=.dprint.json libs/cache_dir/file_fetcher/mod.rs tests/specs/jsr/vendor_no_remote/__test__.jsonc tests/specs/jsr/vendor_no_remote/deno.json tests/specs/jsr/vendor_no_remote/main.ts`
- `PATH="$PWD/target/debug:$PATH" deno run -A --config=tests/config/deno.json tools/format.js --check`