### PR TITLE
fix(watch): detect newly created files in fmt/lint/test/bench --watch

### DIFF
--- a/cli/tools/bench/mod.rs
+++ b/cli/tools/bench/mod.rs
@@ -564,14 +564,9 @@ pub async fn run_benchmarks_with_watch(
           cli_options.resolve_bench_options_for_members(&bench_flags)?;
         let watch_paths = members_with_bench_options
           .iter()
-          .filter_map(|(_, bench_options)| {
-            bench_options
-              .files
-              .include
-              .as_ref()
-              .map(|set| set.base_paths())
+          .flat_map(|(_, bench_options)| {
+            file_watcher::watch_paths_for_file_patterns(&bench_options.files)
           })
-          .flatten()
           .collect::<Vec<_>>();
         let _ = watcher_communicator.watch_paths(watch_paths);
         let collected_bench_modules = members_with_bench_options

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -96,8 +96,11 @@ pub async fn format(
             resolve_paths_with_options_batches(cli_options, &fmt_flags)?;
 
           for paths_with_options in &mut paths_with_options_batches {
-            let _ = watcher_communicator
-              .watch_paths(paths_with_options.paths.clone());
+            let _ = watcher_communicator.watch_paths(
+              file_watcher::watch_paths_for_file_patterns(
+                &paths_with_options.options.files,
+              ),
+            );
             let files = std::mem::take(&mut paths_with_options.paths);
             paths_with_options.paths = if let Some(paths) = &changed_paths {
               if fmt_flags.check {

--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -145,7 +145,11 @@ async fn lint_with_watch_inner(
   let mut paths_with_options_batches =
     resolve_paths_with_options_batches(cli_options, &lint_flags)?;
   for paths_with_options in &mut paths_with_options_batches {
-    _ = watcher_communicator.watch_paths(paths_with_options.paths.clone());
+    _ = watcher_communicator.watch_paths(
+      file_watcher::watch_paths_for_file_patterns(
+        &paths_with_options.options.files,
+      ),
+    );
 
     let files = std::mem::take(&mut paths_with_options.paths);
     paths_with_options.paths = if let Some(paths) = &changed_paths {

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -2067,14 +2067,9 @@ pub async fn run_tests_with_watch(
           cli_options.resolve_test_options_for_members(&test_flags)?;
         let watch_paths = members_with_test_options
           .iter()
-          .filter_map(|(_, test_options)| {
-            test_options
-              .files
-              .include
-              .as_ref()
-              .map(|set| set.base_paths())
+          .flat_map(|(_, test_options)| {
+            file_watcher::watch_paths_for_file_patterns(&test_options.files)
           })
-          .flatten()
           .collect::<Vec<_>>();
         let _ = watcher_communicator.watch_paths(watch_paths);
         let test_modules = members_with_test_options

--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
+use deno_config::glob::FilePatterns;
 use deno_config::glob::PathOrPatternSet;
 use deno_core::error::AnyError;
 use deno_core::futures::FutureExt;
@@ -535,6 +536,25 @@ fn new_watcher(
     },
     Default::default(),
   )?)
+}
+
+/// Computes the set of paths a watcher should observe for a given set of file
+/// patterns.
+///
+/// When `include` patterns are present, their base paths are watched: a
+/// directory for directory/glob patterns, or the file itself for explicit file
+/// paths. When no `include` is set, the base directory is watched so that newly
+/// created files within it are detected.
+///
+/// This is important for subcommands like `fmt`, `lint`, `test` and `bench`
+/// running in `--watch` mode: watching the already-resolved list of files would
+/// miss files created after the watcher started, because the watcher would only
+/// observe the individual file inodes rather than their containing directories.
+pub fn watch_paths_for_file_patterns(patterns: &FilePatterns) -> Vec<PathBuf> {
+  match &patterns.include {
+    Some(set) => set.base_paths(),
+    None => vec![patterns.base.clone()],
+  }
 }
 
 fn add_paths_to_watcher(

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -302,6 +302,47 @@ async fn lint_watch_without_args_test() {
   drop(t);
 }
 
+// Regression test for https://github.com/denoland/deno/issues/28437
+#[test(flaky)]
+async fn lint_watch_picks_up_new_file_test() {
+  let t = TempDir::new();
+  let badly_linted_fixed1 =
+    util::testdata_path().join("lint/watch/badly_linted_fixed1.js");
+
+  // Start with a single file present. No path args are passed, so the watcher
+  // must fall back to watching the base directory rather than the resolved
+  // file list.
+  let existing = t.path().join("existing.js");
+  badly_linted_fixed1.copy(&existing);
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("lint")
+    .arg("--watch")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (_stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "Lint started");
+  assert_contains!(
+    wait_contains("Checked", &mut stderr_lines).await,
+    "Checked 1 file"
+  );
+
+  // Create a new file *after* the watcher started. The watcher should notice it
+  // and include it in the next run even though it wasn't initially resolved.
+  let new_file = t.path().join("new_file.js");
+  badly_linted_fixed1.copy(&new_file);
+
+  assert_contains!(
+    wait_contains("Checked", &mut stderr_lines).await,
+    "Checked 2 files"
+  );
+
+  check_alive_then_kill(child);
+}
+
 #[test(flaky)]
 async fn lint_all_files_on_each_change_test() {
   let t = TempDir::new();
@@ -450,6 +491,50 @@ async fn fmt_watch_without_args_test() {
   let expected = fixed.read_to_string();
   let actual = badly_formatted.read_to_string();
   assert_eq!(actual, expected);
+  check_alive_then_kill(child);
+}
+
+// Regression test for https://github.com/denoland/deno/issues/28437
+#[test(flaky)]
+async fn fmt_watch_picks_up_new_file_test() {
+  let fmt_testdata_path = util::testdata_path().join("fmt");
+  let t = TempDir::new();
+  let fixed = fmt_testdata_path.join("badly_formatted_fixed.js");
+  let badly_formatted_original = fmt_testdata_path.join("badly_formatted.mjs");
+
+  // Start with a single, already-formatted file so the initial run is clean.
+  let existing = t.path().join("existing.js");
+  fixed.copy(&existing);
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("fmt")
+    .arg("--watch")
+    .arg(".")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (_stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "Fmt started");
+  wait_contains("Fmt finished.", &mut stderr_lines).await;
+
+  // Create a new badly-formatted file *after* the watcher started. The watcher
+  // should notice it even though it wasn't part of the initially resolved set.
+  let new_file = t.path().join("new_file.js");
+  badly_formatted_original.copy(&new_file);
+
+  assert_contains!(
+    wait_contains("new_file.js", &mut stderr_lines).await,
+    "new_file.js"
+  );
+  wait_contains("Fmt finished.", &mut stderr_lines).await;
+
+  // The newly created file should have been formatted by the watcher.
+  let expected = fixed.read_to_string();
+  let actual = new_file.read_to_string();
+  assert_eq!(actual, expected);
+
   check_alive_then_kill(child);
 }
 


### PR DESCRIPTION
`deno fmt --watch`, `deno lint --watch`, `deno test --watch` and
`deno bench --watch` did not notice files created after the watcher
started. With `foo.ts` present, starting `deno fmt --watch` and then
adding `bar.ts` would leave `bar.ts` untouched until the watcher was
restarted.

The cause was what each subcommand registered with the watcher. `fmt`
and `lint` passed the already-resolved list of files, so the watcher
only observed those individual file inodes and never saw siblings
created later. `test` and `bench` already watched the include patterns'
base paths, but they dropped the case where no include patterns were
set, which is exactly the bare `--watch` with no path arguments, so they
also missed new files in the common default case.

This watches the file patterns' include base paths instead, falling back
to the base directory when no include is set, through a shared
`watch_paths_for_file_patterns` helper in `file_watcher`. `base_paths()`
already returns explicit file paths as-is and directory or glob patterns
as their base directory, which matches the desired behavior of watching
explicit paths directly and watching directory roots otherwise. The
watcher already watches recursively, filters incoming events through the
exclude set, and re-resolves the file list on every change, so once the
right roots are registered the new files are picked up without any
further plumbing.

Added regression tests covering a file created after startup for `fmt`
(with an explicit path argument, exercising the include base paths) and
for `lint` (with no arguments, exercising the base directory fallback).

Closes #28437
