### PR TITLE
fix(ext/http): include buffered request bytes in size hint

### DIFF
--- a/ext/http/request_body.rs
+++ b/ext/http/request_body.rs
@@ -114,7 +114,21 @@ impl Body for BufferedIncoming {
   }
 
   fn size_hint(&self) -> SizeHint {
-    self.inner.size_hint()
+    let pending_len = self.pending.len() as u64;
+    if pending_len == 0 {
+      return self.inner.size_hint();
+    }
+
+    // Hyper's inner body only reports bytes it has not yielded yet. Include
+    // frames buffered by `try_take_full` so downstream fetch() sees the full
+    // request length when falling back to the streaming path.
+    let inner_hint = self.inner.size_hint();
+    let mut hint = SizeHint::new();
+    hint.set_lower(inner_hint.lower().saturating_add(pending_len));
+    if let Some(upper) = inner_hint.upper() {
+      hint.set_upper(upper.saturating_add(pending_len));
+    }
+    hint
   }
 
   fn is_end_stream(&self) -> bool {

--- a/tests/specs/run/fetch_forward_static_request_body_length/main.out
+++ b/tests/specs/run/fetch_forward_static_request_body_length/main.out
@@ -5,3 +5,7 @@ content-length preserved: true
 stream body forwarded: true
 stream content-length: null
 stream content-length unknown: true
+split body forwarded: true
+split content-length: 54
+split expected length: 54
+split content-length preserved: true

--- a/tests/specs/run/fetch_forward_static_request_body_length/main.ts
+++ b/tests/specs/run/fetch_forward_static_request_body_length/main.ts
@@ -1,11 +1,17 @@
+import { setTimeout } from "node:timers/promises";
+
 const echoServer = Deno.serve(
   { hostname: "127.0.0.1", port: 0, onListen() {} },
   async (req: Request) => {
+    const path = new URL(req.url).pathname;
+    if (path === "/split") {
+      resolveSplitStarted();
+    }
     const forwarded = {
       contentLength: req.headers.get("content-length"),
       body: await req.text(),
     };
-    if (new URL(req.url).pathname === "/split") {
+    if (path === "/split") {
       resolveSplitForwarded(forwarded);
     }
     return Response.json(forwarded);
@@ -13,6 +19,10 @@ const echoServer = Deno.serve(
 );
 
 const echoUrl = `http://127.0.0.1:${echoServer.addr.port}/`;
+let resolveSplitStarted: () => void;
+const splitStartedPromise = new Promise<void>((resolve) => {
+  resolveSplitStarted = resolve;
+});
 let resolveSplitForwarded: (
   forwarded: { contentLength: string | null; body: string },
 ) => void;
@@ -90,7 +100,19 @@ await conn.write(encoder.encode(
   `POST /split HTTP/1.1\r\nhost: x\r\ncontent-length: ${splitExpectedLength}\r\n\r\n` +
     splitBody.slice(0, splitAt),
 ));
-await new Promise((resolve) => setTimeout(resolve, 200));
+const splitStartedTimeout = new AbortController();
+try {
+  await Promise.race([
+    splitStartedPromise,
+    setTimeout(5_000, undefined, {
+      signal: splitStartedTimeout.signal,
+    }).then(() => {
+      throw new Error("Timed out waiting for split request to start");
+    }),
+  ]);
+} finally {
+  splitStartedTimeout.abort();
+}
 await conn.write(encoder.encode(splitBody.slice(splitAt)));
 const splitForwarded = await splitForwardedPromise;
 

--- a/tests/specs/run/fetch_forward_static_request_body_length/main.ts
+++ b/tests/specs/run/fetch_forward_static_request_body_length/main.ts
@@ -19,18 +19,10 @@ const echoServer = Deno.serve(
 );
 
 const echoUrl = `http://127.0.0.1:${echoServer.addr.port}/`;
-let resolveSplitStarted: () => void;
-const splitStartedPromise = new Promise<void>((resolve) => {
-  resolveSplitStarted = resolve;
-});
-let resolveSplitForwarded: (
-  forwarded: { contentLength: string | null; body: string },
-) => void;
-const splitForwardedPromise = new Promise<
-  { contentLength: string | null; body: string }
->((resolve) => {
-  resolveSplitForwarded = resolve;
-});
+const { promise: splitStartedPromise, resolve: resolveSplitStarted } = Promise
+  .withResolvers<void>();
+const { promise: splitForwardedPromise, resolve: resolveSplitForwarded } =
+  Promise.withResolvers<{ contentLength: string | null; body: string }>();
 const proxyServer = Deno.serve(
   { hostname: "127.0.0.1", port: 0, onListen() {} },
   (req: Request) => {

--- a/tests/specs/run/fetch_forward_static_request_body_length/main.ts
+++ b/tests/specs/run/fetch_forward_static_request_body_length/main.ts
@@ -1,18 +1,31 @@
 const echoServer = Deno.serve(
   { hostname: "127.0.0.1", port: 0, onListen() {} },
   async (req: Request) => {
-    return Response.json({
+    const forwarded = {
       contentLength: req.headers.get("content-length"),
       body: await req.text(),
-    });
+    };
+    if (new URL(req.url).pathname === "/split") {
+      resolveSplitForwarded(forwarded);
+    }
+    return Response.json(forwarded);
   },
 );
 
 const echoUrl = `http://127.0.0.1:${echoServer.addr.port}/`;
+let resolveSplitForwarded: (
+  forwarded: { contentLength: string | null; body: string },
+) => void;
+const splitForwardedPromise = new Promise<
+  { contentLength: string | null; body: string }
+>((resolve) => {
+  resolveSplitForwarded = resolve;
+});
 const proxyServer = Deno.serve(
   { hostname: "127.0.0.1", port: 0, onListen() {} },
   (req: Request) => {
-    return fetch(echoUrl, {
+    const path = new URL(req.url).pathname;
+    return fetch(path === "/split" ? `${echoUrl}split` : echoUrl, {
       method: "POST",
       body: req.body,
     });
@@ -61,5 +74,38 @@ console.log(
   streamForwarded.contentLength === null,
 );
 
+// Scenario 3: if the request body has only partially arrived when the proxy
+// reads req.body, the forwarded request should still use the full length and
+// stream all bytes.
+const splitBody = JSON.stringify({
+  tags: ["http-12345678-1234-1234-1234-123456789abc"],
+});
+const splitExpectedLength = String(encoder.encode(splitBody).byteLength);
+const splitAt = splitBody.length - 3;
+const conn = await Deno.connect({
+  hostname: "127.0.0.1",
+  port: proxyServer.addr.port,
+});
+await conn.write(encoder.encode(
+  `POST /split HTTP/1.1\r\nhost: x\r\ncontent-length: ${splitExpectedLength}\r\n\r\n` +
+    splitBody.slice(0, splitAt),
+));
+await new Promise((resolve) => setTimeout(resolve, 200));
+await conn.write(encoder.encode(splitBody.slice(splitAt)));
+const splitForwarded = await splitForwardedPromise;
+
+console.log("split body forwarded:", splitForwarded.body === splitBody);
+console.log("split content-length:", splitForwarded.contentLength);
+console.log("split expected length:", splitExpectedLength);
+console.log(
+  "split content-length preserved:",
+  splitForwarded.contentLength === splitExpectedLength,
+);
+
+try {
+  conn.close();
+} catch {
+  // The server may already have closed the connection.
+}
 await proxyServer.shutdown();
 await echoServer.shutdown();


### PR DESCRIPTION
Fixes #34830

## Summary

Fixes a Deno 2.8.0+ regression where forwarding a `Deno.serve` request body with `fetch(upstream, { body: req.body })` could silently truncate the outgoing request when the incoming body had only partially arrived.

`BufferedIncoming::try_take_full()` may buffer currently available frames before falling back to streaming. `BufferedIncoming::size_hint()` was only reporting hyper's remaining bytes, so `fetch()` could synthesize a too-small `Content-Length` and frame only that prefix of the body.

This updates the size hint to include bytes already buffered in `pending`.

## Tests

Added a regression case that sends a request body in two TCP writes and verifies the proxy forwards all bytes with the original content length.

- `cargo build --bin deno`
- `cargo test -p specs_tests --test specs fetch_forward_static_request_body_length -- --nocapture`
- `cargo test -p deno_http`
- `rustfmt --check ext/http/request_body.rs`
- `./target/debug/deno fmt --check tests/specs/run/fetch_forward_static_request_body_length/main.ts tests/specs/run/fetch_forward_static_request_body_length/main.out`
- `git diff --check -- ext/http/request_body.rs tests/specs/run/fetch_forward_static_request_body_length/main.ts tests/specs/run/fetch_forward_static_request_body_length/main.out`
