### PR TITLE
fix(ext/fs): report broken symlink read as NotFound, not FilesystemLoop

### DIFF
--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -1311,6 +1311,20 @@ fn open_path_with_options(
       let fallback = open_options_for_checked_path_no_backup(opts, path);
       fallback.open(path).map_err(|_| err)
     }
+    // A canonicalized path is opened with `O_NOFOLLOW` (see
+    // `open_options_for_checked_path`). If the final component is still a
+    // symlink at this point it must be a broken/dangling link: its target was
+    // removed after canonicalization resolved the parent directory, so the link
+    // survived as the path tail. `O_NOFOLLOW` reports it as `ELOOP` ("Too many
+    // levels of symbolic links"), which is misleading. Translate it to
+    // `ENOENT` so the error matches reading a nonexistent file.
+    // See https://github.com/denoland/deno/issues/29139.
+    #[cfg(unix)]
+    Err(err)
+      if path.canonicalized() && err.raw_os_error() == Some(libc::ELOOP) =>
+    {
+      Err(io::Error::from_raw_os_error(libc::ENOENT))
+    }
     Err(err) => Err(err),
   }
 }

--- a/tests/unit/read_text_file_test.ts
+++ b/tests/unit/read_text_file_test.ts
@@ -37,6 +37,30 @@ Deno.test({ permissions: { read: true } }, function readTextFileSyncNotFound() {
   }, Deno.errors.NotFound);
 });
 
+// Reading a broken (dangling) symlink should report NotFound, not
+// FilesystemLoop ("Too many levels of symbolic links"). The canonicalized
+// path is opened with O_NOFOLLOW, which reports a surviving symlink tail as
+// ELOOP; that is translated to ENOENT. Regression test for
+// https://github.com/denoland/deno/issues/29139
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function readTextFileSyncBrokenSymlink() {
+    const testDir = Deno.makeTempDirSync();
+    const target = testDir + "/target.txt";
+    const link = testDir + "/link.txt";
+    Deno.writeTextFileSync(target, "hello");
+    Deno.symlinkSync(target, link);
+    // The link resolves while the target exists.
+    assertEquals(Deno.readTextFileSync(link), "hello");
+    // Once the target is gone the link is broken.
+    Deno.removeSync(target);
+    assertThrows(() => Deno.readTextFileSync(link), Deno.errors.NotFound);
+  },
+);
+
 Deno.test(
   { permissions: { read: true } },
   async function readTextFileSuccess() {


### PR DESCRIPTION
Reading a broken (dangling) symlink reported a misleading
"Too many levels of symbolic links" error instead of "No such file or
directory". A canonicalized path is opened with O_NOFOLLOW so a symlink
swapped in after the permission check is never followed. A broken
symlink survives canonicalization as the path tail, because
canonicalize_path_maybe_not_exists resolves the parent directory and
re-appends the missing final component. Opening that surviving symlink
with O_NOFOLLOW fails with ELOOP, which surfaced to users as
FilesystemLoop.

This translates the ELOOP returned for a canonicalized path into ENOENT,
so a broken symlink now reads as NotFound, matching the behavior of
reading a file that does not exist. The O_NOFOLLOW guarantee is
unchanged.

Fixes #29139