### PR TITLE
fix(coverage): exclude linked/patched packages from coverage report

### DIFF
--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -545,6 +545,7 @@ fn filter_coverages(
   include: Vec<String>,
   exclude: Vec<String>,
   in_npm_pkg_checker: &DenoInNpmPackageChecker,
+  link_dir_urls: &[String],
 ) -> Vec<cdp::ScriptCoverage> {
   let include: Vec<Regex> =
     include.iter().map(|e| Regex::new(e).unwrap()).collect();
@@ -569,6 +570,11 @@ fn filter_coverages(
         || e.url.ends_with(".snap")
         || is_supported_test_path(Path::new(e.url.as_str()))
         || doc_test_re.is_match(e.url.as_str())
+        // Exclude packages brought in via the "links" (formerly "patch")
+        // feature. These are third-party dependencies replacing a registry
+        // version, so they shouldn't show up in the user's coverage report,
+        // matching how npm packages are excluded above.
+        || link_dir_urls.iter().any(|dir| e.url.starts_with(dir))
         || Url::parse(&e.url)
           .ok()
           .map(|url| in_npm_pkg_checker.in_npm_package(&url))
@@ -615,8 +621,19 @@ pub fn cover_files(
   if script_coverages.is_empty() {
     return Err(anyhow!("No coverage files found"));
   }
-  let script_coverages =
-    filter_coverages(script_coverages, include, exclude, in_npm_pkg_checker);
+  let link_dir_urls = cli_options
+    .workspace()
+    .link_folders()
+    .keys()
+    .map(|url| url.as_str().to_string())
+    .collect::<Vec<_>>();
+  let script_coverages = filter_coverages(
+    script_coverages,
+    include,
+    exclude,
+    in_npm_pkg_checker,
+    &link_dir_urls,
+  );
   if script_coverages.is_empty() {
     return Err(anyhow!("No covered files included in the report"));
   }

--- a/tests/specs/coverage/patched_package_excluded/__test__.jsonc
+++ b/tests/specs/coverage/patched_package_excluded/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  // Regression test for https://github.com/denoland/deno/issues/29391
+  // Packages brought in via the "links" (formerly "patch") feature are
+  // third-party dependencies replacing a registry version, so they must not
+  // appear in the user's coverage report (matching how npm packages are
+  // excluded). Before the fix, "flag/mod.ts" from the linked "@denotest/flag"
+  // package showed up in the report; after, only the user's "main.ts" does.
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "test --coverage=coverage main_test.ts",
+      "output": "[WILDCARD]1 passed[WILDCARD]"
+    },
+    {
+      "args": "coverage coverage --lcov",
+      "output": "expected_lcov.out"
+    }
+  ]
+}

--- a/tests/specs/coverage/patched_package_excluded/deno.json
+++ b/tests/specs/coverage/patched_package_excluded/deno.json
@@ -1,0 +1,6 @@
+{
+  "links": ["./flag"],
+  "imports": {
+    "@denotest/flag": "jsr:@denotest/flag@^1.0.0"
+  }
+}

--- a/tests/specs/coverage/patched_package_excluded/expected_lcov.out
+++ b/tests/specs/coverage/patched_package_excluded/expected_lcov.out
@@ -1,0 +1,14 @@
+SF:[WILDCARD]main.ts
+FN:3,greet
+FNDA:1,greet
+FNF:1
+FNH:1
+BRF:0
+BRH:0
+DA:1,1
+DA:3,1
+DA:4,1
+DA:5,1
+LH:4
+LF:4
+end_of_record

--- a/tests/specs/coverage/patched_package_excluded/flag/deno.json
+++ b/tests/specs/coverage/patched_package_excluded/flag/deno.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/flag",
+  "version": "1.0.0",
+  "exports": "./mod.ts"
+}

--- a/tests/specs/coverage/patched_package_excluded/flag/mod.ts
+++ b/tests/specs/coverage/patched_package_excluded/flag/mod.ts
@@ -1,0 +1,6 @@
+export function flag(value: number): string {
+  if (value > 0) {
+    return "positive";
+  }
+  return "non-positive";
+}

--- a/tests/specs/coverage/patched_package_excluded/main.ts
+++ b/tests/specs/coverage/patched_package_excluded/main.ts
@@ -1,0 +1,5 @@
+import "@denotest/flag";
+
+export function greet(name: string): string {
+  return `hello ${name}`;
+}

--- a/tests/specs/coverage/patched_package_excluded/main_test.ts
+++ b/tests/specs/coverage/patched_package_excluded/main_test.ts
@@ -1,0 +1,5 @@
+import { greet } from "./main.ts";
+
+Deno.test("greet", () => {
+  greet("world");
+});


### PR DESCRIPTION
Running `deno test --coverage` in a project that uses the `links` (formerly
`patch`) feature included the linked package's files in the coverage report.
For example, a project linking `@luca/flag` saw an entry like
`patch/jsr.io/@luca/flag/1.0.1/main.ts` with low coverage, which also skewed
the "All files" totals.

Linked/patched packages are third-party dependencies that replace a registry
version, so they should be excluded from the user's coverage report the same way
npm packages already are. `filter_coverages` now drops any coverage entry whose
URL falls under one of the workspace's link folders, which it gets from
`Workspace::link_folders()`.

Added a spec test under `tests/specs/coverage/patched_package_excluded` that
links a local `@denotest/flag` package, runs `deno test --coverage`, and asserts
the lcov report contains only the user's `main.ts`. The test was confirmed to
fail before the change (the linked `flag/mod.ts` appeared) and pass after.

Fixes #29391
