### PR TITLE
fix(cli): include config file in invalid workspace version error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,9 +3196,9 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147261611819fb4dfe339b53e3b45d6704c7e32c86ce33a88511d5bcebebaaa3"
+checksum = "ff487e9bf55c39bfbc47418a009a0de0988c4fea5e48e8ca787fa7dbff8056cc"
 dependencies = [
  "capacity_builder",
  "deno_error",
@@ -5887,7 +5887,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8356,7 +8356,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9027,7 +9027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ deno_lint = "=0.84.1"
 deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_path_util = "=0.6.4"
-deno_semver = "=0.10.0"
+deno_semver = "=0.10.1"
 deno_task_shell = "=0.33.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -33,6 +33,7 @@ use deno_config::workspace::WorkspaceDirLintConfig;
 use deno_config::workspace::WorkspaceDirectory;
 use deno_config::workspace::WorkspaceDirectoryRc;
 use deno_config::workspace::WorkspaceLintConfig;
+use deno_core::anyhow::Context;
 use deno_core::anyhow::bail;
 use deno_core::error::AnyError;
 use deno_core::url::Url;
@@ -1658,7 +1659,14 @@ pub fn config_to_deno_graph_workspace_member(
     None => bail!("Missing 'name' field in config file."),
   };
   let version = match &config.json.version {
-    Some(name) => Some(deno_semver::Version::parse_standard(name)?),
+    Some(version) => Some(
+      deno_semver::Version::parse_standard(version).with_context(|| {
+        format!(
+          "Failed to parse version '{}' in config file '{}'",
+          version, config.specifier
+        )
+      })?,
+    ),
     None => None,
   };
   Ok(deno_graph::WorkspaceMember {
@@ -1996,6 +2004,31 @@ mod test {
     assert!(reg_url.as_str().ends_with('/'));
     let reg_api_url = jsr_api_url();
     assert!(reg_api_url.as_str().ends_with('/'));
+  }
+
+  #[test]
+  fn config_to_deno_graph_workspace_member_invalid_version_error() {
+    let config_text = r#"{
+      "name": "@test/foo",
+      "version": "1.0",
+      "exports": "./mod.ts"
+    }"#;
+    let config_specifier =
+      Url::parse("file:///workspace/foo/deno.jsonc").unwrap();
+    let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
+
+    let error =
+      config_to_deno_graph_workspace_member(&config_file).unwrap_err();
+    let error_text = format!("{:#}", error);
+    assert!(
+      error_text.contains(
+        "Failed to parse version '1.0' in config file \
+         'file:///workspace/foo/deno.jsonc'"
+      ),
+      "{error_text}"
+    );
+    assert!(error_text.contains("Invalid version"), "{error_text}");
+    assert!(error_text.contains("Unexpected character"), "{error_text}");
   }
 
   #[test]

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -2028,7 +2028,13 @@ mod test {
       "{error_text}"
     );
     assert!(error_text.contains("Invalid version"), "{error_text}");
-    assert!(error_text.contains("Unexpected character"), "{error_text}");
+    assert!(
+      error_text.contains(
+        "Missing patch version. Versions must be in the form \
+         MAJOR.MINOR.PATCH (ex. 1.0.0)."
+      ),
+      "{error_text}"
+    );
   }
 
   #[test]


### PR DESCRIPTION
Closes #27226.

This adds config-file context when a workspace member version fails semver parsing. For the reported `version: "1.0"` case, `deno lint` now reports which member `deno.jsonc` contains the invalid version instead of only showing the semver parser error.

A focused unit test covers the workspace-member conversion error text and preserves the underlying semver diagnostic.

Testing:
- `PATH="$PWD/target/debug:$PATH" ./x fmt`
- `git diff --check`
- `PATH="$PWD/target/debug:$PATH" ./x lint-js`
- `cargo fmt -p deno --check`
- `cargo test --manifest-path /Users/deepakkudi23/ai-contrib-new-105/work/deno/Cargo.toml -p deno args::test::config_to_deno_graph_workspace_member_invalid_version_error` (run from `/tmp` to avoid repo-local macOS linker flags)
- Manual repro with `target/debug/deno lint` on a workspace member using `version: "1.0"`; it now includes the member config file URL in the error.

Notes:
- `./x lint` did not complete locally. One run exhausted local disk while growing `target/`; after freeing incremental build artifacts, the repo-root clippy path failed before reaching this patch because this local Apple clang rejects the repo-local `-fuse-ld=lld` macOS rustflag.
- A package-scoped clippy workaround from `/tmp` avoided that linker flag, but failed on the existing `runtime/tokio_util.rs` `metrics_enabled` unused-variable warning under `-D warnings`, outside this patch.

AI/LLM assistance disclosure:
- LLM assistance was used to inspect the code path and draft the patch/test. I reviewed the final change and verified it locally with the commands above.
