### PR TITLE
docs(contributing): fix Windows build prerequisites

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -204,29 +204,12 @@ brew install llvm lld
      (Notice: it will download the files, you should install
      `X64 Debuggers And Tools-x64_en-us.msi` file manually.)
 
-#### Protobuf Compiler
-
-Building Deno requires the
-[Protocol Buffers compiler](https://grpc.io/docs/protoc-installation/).
-
-##### Linux(Debian)/WSL
-
-```sh
-apt install -y protobuf-compiler
-protoc --version  # Ensure compiler version is 3+
-```
-
-##### Mac
-
-```sh
-brew install protobuf
-protoc --version  # Ensure compiler version is 3+
-```
-
-##### Windows
-
-Windows users can download the latest binary release from
-[GitHub](https://github.com/protocolbuffers/protobuf/releases/latest).
+3. Make sure [CMake](https://cmake.org/download/) is installed and on your
+   `PATH`. Some native dependencies (such as `aws-lc-sys`, pulled in via rustls)
+   compile C code with CMake. The CMake that ships with Visual Studio is only
+   available from within a "Developer Command Prompt" and is invisible to
+   `cargo` or rust-analyzer run elsewhere, so a standalone CMake on `PATH` is
+   recommended.
 
 ### Python 3
 


### PR DESCRIPTION
Updates the "building from source" prerequisites in the contributing guide.

Removes the Protobuf Compiler section. Deno no longer compiles any `.proto`
files at build time. There are no `.proto` sources in the tree, no `build.rs`
runs `protoc`, and `prost-build`/`tonic-build`/`protobuf-src` are not in the
dependency graph (only the `prost` runtime crate is used, with hand-written
messages), so `protoc` is not needed to build Deno. The section was leftover
from when it was required.

Adds a CMake note to the Windows prerequisites. CMake is still required, since
`aws-lc-sys` (pulled in via rustls) builds C code with it, but the CMake that
ships with Visual Studio is only available from within a "Developer Command
Prompt" and is invisible to `cargo` or rust-analyzer run elsewhere. The note
recommends installing a standalone CMake on `PATH`.

NASM is intentionally not mentioned: the workspace enables the `prebuilt-nasm`
feature on `aws-lc-sys`, so the assembler is not required.

Closes #29820
