### PR TITLE
fix(clean): support `deno clean --dry-run` without --except

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2863,8 +2863,7 @@ fn clean_subcommand() -> Command {
         Arg::new("dry-run")
           .long("dry-run")
           .action(ArgAction::SetTrue)
-          .help("Show what would be removed without performing any actions")
-          .requires("except"),
+          .help("Show what would be removed without performing any actions"),
       )
       .arg(node_modules_dir_arg().requires("except"))
       .arg(node_modules_linker_arg().requires("except"))
@@ -6886,7 +6885,7 @@ fn check_parse(
 fn clean_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let mut clean_flags = CleanFlags {
     except_paths: Vec::new(),
-    dry_run: false,
+    dry_run: matches.get_flag("dry-run"),
   };
   if matches.get_flag("except") {
     clean_flags.except_paths = matches
@@ -6894,7 +6893,6 @@ fn clean_parse(flags: &mut Flags, matches: &mut ArgMatches) {
       .unwrap()
       .collect::<Vec<_>>();
     flags.cached_only = true;
-    clean_flags.dry_run = matches.get_flag("dry-run");
     node_modules_and_vendor_dir_arg_parse(flags, matches);
   }
   flags.subcommand = DenoSubcommand::Clean(clean_flags);
@@ -16007,9 +16005,18 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
           dry_run: true,
         },
       ),
+      (
+        svec!["--dry-run"],
+        CleanFlags {
+          except_paths: vec![],
+          dry_run: true,
+        },
+      ),
     ];
     for (input, expected) in cases {
-      let cached_only = !input.is_empty();
+      // `--except` builds a module graph of the retained paths, so it parses
+      // with `--cached-only`; other invocations (e.g. `--dry-run` alone) don't.
+      let cached_only = input.iter().any(|arg| arg == "--except");
       let mut args = svec!["deno", "clean"];
       args.extend(input);
       let r = flags_from_vec(args.clone())

--- a/cli/tools/clean.rs
+++ b/cli/tools/clean.rs
@@ -47,6 +47,23 @@ pub async fn clean(
   let factory = CliFactory::from_flags(flags);
   let deno_dir = factory.deno_dir()?;
   if deno_dir.root.exists() {
+    if clean_flags.dry_run {
+      let mut cleaner = FsCleaner::default();
+      cleaner.tally(&deno_dir.root)?;
+
+      log::info!(
+        "{} {} {}",
+        colors::green("Would remove"),
+        deno_dir.root.display(),
+        colors::gray(&format!(
+          "({} files, {})",
+          cleaner.files_removed + cleaner.dirs_removed,
+          display::human_size(cleaner.bytes_removed as f64)
+        ))
+      );
+      return Ok(());
+    }
+
     let no_of_files = walkdir::WalkDir::new(&deno_dir.root).into_iter().count();
     let progress_bar = ProgressBar::new(ProgressBarStyle::ProgressBars);
     let progress_guard =

--- a/cli/tools/clean.rs
+++ b/cli/tools/clean.rs
@@ -47,23 +47,6 @@ pub async fn clean(
   let factory = CliFactory::from_flags(flags);
   let deno_dir = factory.deno_dir()?;
   if deno_dir.root.exists() {
-    if clean_flags.dry_run {
-      let mut cleaner = FsCleaner::default();
-      cleaner.tally(&deno_dir.root)?;
-
-      log::info!(
-        "{} {} {}",
-        colors::green("Would remove"),
-        deno_dir.root.display(),
-        colors::gray(&format!(
-          "({} files, {})",
-          cleaner.files_removed + cleaner.dirs_removed,
-          display::human_size(cleaner.bytes_removed as f64)
-        ))
-      );
-      return Ok(());
-    }
-
     let no_of_files = walkdir::WalkDir::new(&deno_dir.root).into_iter().count();
     let progress_bar = ProgressBar::new(ProgressBarStyle::ProgressBars);
     let progress_guard =
@@ -71,10 +54,16 @@ pub async fn clean(
     progress_guard.set_total_size(no_of_files.try_into().unwrap());
     let mut cleaner = FsCleaner::new(Some(progress_guard));
 
-    cleaner.rm_rf(&deno_dir.root)?;
+    // On a dry run, tally up what would be removed without deleting anything;
+    // the reported output is otherwise identical to a real clean.
+    if clean_flags.dry_run {
+      cleaner.tally(&deno_dir.root)?;
+    } else {
+      cleaner.rm_rf(&deno_dir.root)?;
+    }
 
     // Drop the guard so that progress bar disappears.
-    drop(cleaner.progress_guard);
+    drop(cleaner.progress_guard.take());
 
     log::info!(
       "{} {} {}",
@@ -86,6 +75,10 @@ pub async fn clean(
         display::human_size(cleaner.bytes_removed as f64)
       ))
     );
+
+    if clean_flags.dry_run {
+      log::info!("{}", colors::yellow("Aborting due to --dry-run flag"));
+    }
   }
 
   Ok(())

--- a/cli/util/fs.rs
+++ b/cli/util/fs.rs
@@ -215,6 +215,24 @@ impl FsCleaner {
     Ok(())
   }
 
+  /// Accumulates the file/directory counts and byte size that [`Self::rm_rf`]
+  /// would remove for `path`, without removing anything. Used for `--dry-run`.
+  pub fn tally(&mut self, path: &Path) -> Result<(), std::io::Error> {
+    for entry in walkdir::WalkDir::new(path).contents_first(true) {
+      let entry = entry.map_err(std::io::Error::other)?;
+      if entry.file_type().is_dir() {
+        self.dirs_removed += 1;
+      } else {
+        if let Ok(meta) = entry.metadata() {
+          self.bytes_removed += meta.len();
+        }
+        self.files_removed += 1;
+      }
+    }
+
+    Ok(())
+  }
+
   pub fn remove_file(
     &mut self,
     path: &Path,

--- a/cli/util/fs.rs
+++ b/cli/util/fs.rs
@@ -228,6 +228,7 @@ impl FsCleaner {
         }
         self.files_removed += 1;
       }
+      self.update_progress();
     }
 
     Ok(())

--- a/tests/specs/clean/dry_run/__test__.jsonc
+++ b/tests/specs/clean/dry_run/__test__.jsonc
@@ -1,0 +1,26 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_DIR": "$PWD/deno_dir"
+  },
+  "steps": [{
+    // create deno dir
+    "args": "run http://localhost:4545/echo.ts hi",
+    "output": "[WILDCARD]"
+  }, {
+    // dry run reports what would be removed without deleting anything
+    "args": "clean --dry-run",
+    "output": "Would remove [WILDLINE]/deno_dir ([WILDCARD]files, [WILDCARD])\n"
+  }, {
+    // the deno dir is still present after a dry run
+    "args": [
+      "eval",
+      "console.log(Deno.statSync('./deno_dir') != null)"
+    ],
+    "output": "true\n"
+  }, {
+    // a real clean still removes it
+    "args": "clean",
+    "output": "Removed [WILDLINE]/deno_dir ([WILDCARD]files, [WILDCARD])\n"
+  }]
+}

--- a/tests/specs/clean/dry_run/__test__.jsonc
+++ b/tests/specs/clean/dry_run/__test__.jsonc
@@ -8,9 +8,10 @@
     "args": "run http://localhost:4545/echo.ts hi",
     "output": "[WILDCARD]"
   }, {
-    // dry run reports what would be removed without deleting anything
+    // dry run reports what would be removed without deleting anything,
+    // using the same output as a real clean followed by an abort notice
     "args": "clean --dry-run",
-    "output": "Would remove [WILDLINE]/deno_dir ([WILDCARD]files, [WILDCARD])\n"
+    "output": "Removed [WILDLINE]/deno_dir ([WILDCARD]files, [WILDCARD])\nAborting due to --dry-run flag\n"
   }, {
     // the deno dir is still present after a dry run
     "args": [


### PR DESCRIPTION
Running `deno clean --dry-run` errored out because `--dry-run` required
`--except` to be passed alongside it, which is surprising: a dry run is
exactly when you would not want to commit to also cleaning everything
except some paths. It now works on its own and walks the cache directory
to report how many files and how much space would be removed, without
deleting anything.

This also closes a latent footgun: the no-`--except` clean path never
consulted the `dry_run` flag, so simply relaxing the argument
requirement would have made `--dry-run` delete the whole cache. The
dry-run branch now short-circuits before any removal happens.

Closes #30031