### PR TITLE
fix(watch): respect --watch-exclude in deno serve

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -764,6 +764,9 @@ impl DenoSubcommand {
       Self::Run(RunFlags {
         watch: Some(flags), ..
       })
+      | Self::Serve(ServeFlags {
+        watch: Some(flags), ..
+      })
       | Self::Test(TestFlags {
         watch: Some(flags), ..
       }) => Some(WatchFlagsRef::WithPaths(flags)),

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -673,6 +673,64 @@ async fn serve_watch_all() {
   check_alive_then_kill(child);
 }
 
+// Regression test for https://github.com/denoland/deno/issues/30046
+// `deno serve` used to ignore `--watch-exclude` entirely, so writing to an
+// excluded file that's part of the module graph would trigger a restart.
+#[test(flaky)]
+async fn serve_watch_with_excluded_paths() {
+  let t = TempDir::new();
+
+  let excluded_file = t.path().join("excluded.js");
+  excluded_file.write("export const foo = 0;");
+
+  let main_file = t.path().join("main_file_to_watch.js");
+  main_file.write(
+    "import { foo } from './excluded.js';
+    console.log('ran', foo);
+    export default { fetch: () => new Response('ok') };",
+  );
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("serve")
+    .arg("--watch")
+    .arg("--watch-exclude=excluded.js")
+    .arg("-L")
+    .arg("debug")
+    .arg("--allow-net")
+    .arg(&main_file)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_contains("ran", &mut stdout_lines).await;
+  wait_for_watcher("main_file_to_watch.js", &mut stderr_lines).await;
+
+  // Writing the excluded file must not trigger a restart. Writing the watched
+  // main file must, and the first restart we observe must be for the main file
+  // rather than the excluded one.
+  excluded_file.write("export const foo = 42;");
+  main_file.write(
+    "import { foo } from './excluded.js';
+    console.log('ran2', foo);
+    export default { fetch: () => new Response('ok') };",
+  );
+
+  let restart = wait_contains("File change detected", &mut stderr_lines).await;
+  assert!(
+    restart.contains("main_file_to_watch.js"),
+    "unexpected file triggered restart: {restart}"
+  );
+  assert!(
+    !restart.contains("excluded.js"),
+    "excluded file triggered a restart: {restart}"
+  );
+  wait_contains("ran2", &mut stdout_lines).await;
+  check_alive_then_kill(child);
+}
+
 #[test(flaky)]
 async fn run_watch_npm_specifier() {
   let _g = util::http_server();


### PR DESCRIPTION
`deno serve --watch` and `deno serve --watch-hmr` ignored `--watch-exclude`. A
file that matched the exclude pattern but was part of the module graph was still
watched, so writing to it triggered a restart. With a server that writes to such
a file on startup (the case in the issue, a snapshot written on boot), this
produced an endless restart loop.

The cause is in `Flags::watch_flags()`, which maps each subcommand to its watch
flags. It had arms for `run`, `test`, `bench`, `check`, `lint`, and `fmt`, but
not `serve`, so for `serve` it fell through to `None`. Downstream,
`resolve_watch_exclude_set()` then returned an empty set and the watcher never
excluded anything.

The fix adds a `Serve` arm next to `Run`/`Test` (serve already stores its watch
config as `WatchFlagsWithPaths`, same as run), so the exclude set is resolved for
serve as well. This is not specific to HMR: plain `deno serve --watch` was
affected too, while `deno run` (with or without `--watch-hmr`) already worked.

Added a regression test that starts `deno serve --watch --watch-exclude` with a
module that imports an excluded file, writes the excluded file, and verifies the
next restart is triggered by the watched entrypoint rather than the excluded
file.

Closes #30046
