### PR TITLE
fix(ext/node): don't expose Module.register stub

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -3242,7 +3242,6 @@ export function registerHooks(hooks) {
 }
 
 Module.registerHooks = registerHooks;
-Module.register = register;
 
 let initialized = false;
 

--- a/tests/unit_node/module_test.ts
+++ b/tests/unit_node/module_test.ts
@@ -243,18 +243,20 @@ Deno.test("[node/module stripTypeScriptTypes] rejects unsupported strip-only syn
   );
 });
 
-// Regression test: tsx and other tools probe `Module.register` (the default
-// export of `node:module`) to decide whether the host supports module loader
-// hooks. Make sure both `Module.register` and `Module.registerHooks` are
-// attached as static methods so `import M from "node:module"; M.register`
-// resolves to the stub instead of `undefined`.
-Deno.test("[node/module] Module.register and Module.registerHooks are exposed", () => {
+// Regression test for https://github.com/denoland/deno/issues/34868.
+// We don't implement the out-of-thread `module.register()` loader (it's a
+// no-op stub), so `Module.register` must NOT be exposed as a static. Tools
+// like Playwright and tsx feature-probe `import M from "node:module";
+// M.register`; when it's present they set up an ESM loader and wait on a
+// `MessagePort` handshake that our stub never answers, hanging silently.
+// With it absent they fall back to a path that works: Playwright skips the
+// loader and tsx uses `Module.registerHooks` (which we do implement) now
+// that the emulated Node version (>= 24.11.1) clears tsx's feature gate.
+Deno.test("[node/module] Module.register is not exposed, registerHooks is", () => {
   // @ts-ignore Not in our bundled @types/node yet.
-  assertEquals(typeof Module.register, "function");
+  assertEquals(Module.register, undefined);
   // @ts-ignore Not in our bundled @types/node yet.
   assertEquals(typeof Module.registerHooks, "function");
-  // @ts-ignore Stub returns undefined.
-  assertEquals(Module.register("foo"), undefined);
 });
 
 Deno.test("[node/module syncBuiltinESMExports] is exposed", () => {


### PR DESCRIPTION
Playwright (and other tools) silently exit on Deno 2.8.x instead of
running, because they feature-probe `import M from "node:module";
M.register` to decide whether to install an out-of-thread ESM loader.
PR #34305 attached our `register` stub as a static on `Module` to
unblock tsx, but the stub is a no-op: it never imports the loader and
never runs its `initialize({ port })`. Tools that take the
`module.register()` path then `await` a `MessagePort` round-trip that
nothing ever answers, so the event loop drains with the promise pending
and the process exits 0 with no output.

The original reason #34305 was needed no longer holds. tsx only fell
back to `register` because its `registerHooks` feature gate requires
Node >= 24.11.1 while Deno reported 24.2.0. The emulated Node version
bump to v24.15.0 in #34804 clears that gate, so tsx now uses
`module.registerHooks` (which we do implement) and no longer touches the
stub. This reverts #34305 so `Module.register` is absent again:
Playwright skips the loader and works, and tsx takes the working
`registerHooks` path.

Closes #34868