### PR TITLE
fix: throw ERR_DIR_CLOSED on use-after-close in Dir

### DIFF
--- a/ext/node/polyfills/_fs/_fs_dir.ts
+++ b/ext/node/polyfills/_fs/_fs_dir.ts
@@ -6,7 +6,7 @@ import {
   direntFromDeno,
 } from "ext:deno_node/internal/fs/utils.mjs";
 const { default: assert } = core.loadExtScript("ext:deno_node/assert.ts");
-const { ERR_MISSING_ARGS } = core.loadExtScript(
+const { ERR_MISSING_ARGS, ERR_DIR_CLOSED } = core.loadExtScript(
   "ext:deno_node/internal/errors.ts",
 );
 const { TextDecoder } = core.loadExtScript("ext:deno_web/08_text_encoding.js");
@@ -28,6 +28,7 @@ export default class Dir {
   #dirPath: string | Uint8Array;
   #syncIterator!: Iterator<Deno.DirEntry, undefined> | null;
   #asyncIterator!: AsyncIterator<Deno.DirEntry, undefined> | null;
+  #closed = false;
 
   constructor(path: string | Uint8Array) {
     if (!path) {
@@ -46,6 +47,16 @@ export default class Dir {
   // deno-lint-ignore no-explicit-any
   read(callback?: (...args: any[]) => void): Promise<Dirent | null> {
     return new Promise((resolve, reject) => {
+      if (this.#closed) {
+        const err = new ERR_DIR_CLOSED();
+        if (callback) {
+          callback(err);
+          resolve(null);
+        } else {
+          reject(err);
+        }
+        return;
+      }
       if (!this.#asyncIterator) {
         this.#asyncIterator = Deno.readDir(this.path)[SymbolAsyncIterator]();
       }
@@ -78,6 +89,9 @@ export default class Dir {
   }
 
   readSync(): Dirent | null {
+    if (this.#closed) {
+      throw new ERR_DIR_CLOSED();
+    }
     if (!this.#syncIterator) {
       this.#syncIterator = Deno.readDirSync(this.path)![SymbolIterator]();
     }
@@ -98,6 +112,7 @@ export default class Dir {
   // deno-lint-ignore no-explicit-any
   close(callback?: (...args: any[]) => void): Promise<void> {
     return new Promise((resolve) => {
+      this.#closed = true;
       if (callback) {
         callback(null);
       }
@@ -111,7 +126,7 @@ export default class Dir {
    * finished reading
    */
   closeSync() {
-    //No op
+    this.#closed = true;
   }
 
   [SymbolDispose]() {

--- a/tests/unit_node/_fs/_fs_dir_test.ts
+++ b/tests/unit_node/_fs/_fs_dir_test.ts
@@ -203,3 +203,87 @@ Deno.test(
     });
   },
 );
+
+Deno.test({
+  name: "Dir.readSync throws ERR_DIR_CLOSED after closeSync",
+  fn() {
+    const testDir: string = Deno.makeTempDirSync();
+    try {
+      const dir = new Dir(testDir);
+      dir.closeSync();
+      try {
+        dir.readSync();
+        fail("Expected ERR_DIR_CLOSED to be thrown");
+      } catch (e) {
+        // deno-lint-ignore no-explicit-any
+        assertEquals((e as any).code, "ERR_DIR_CLOSED");
+      }
+    } finally {
+      Deno.removeSync(testDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "Dir.read rejects with ERR_DIR_CLOSED after close",
+  async fn() {
+    const testDir: string = Deno.makeTempDirSync();
+    try {
+      const dir = new Dir(testDir);
+      await dir.close();
+      try {
+        await dir.read();
+        fail("Expected ERR_DIR_CLOSED to be thrown");
+      } catch (e) {
+        // deno-lint-ignore no-explicit-any
+        assertEquals((e as any).code, "ERR_DIR_CLOSED");
+      }
+    } finally {
+      Deno.removeSync(testDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "Dir.readSync throws ERR_DIR_CLOSED after async close",
+  async fn() {
+    const testDir: string = Deno.makeTempDirSync();
+    try {
+      const dir = new Dir(testDir);
+      await dir.close();
+      try {
+        dir.readSync();
+        fail("Expected ERR_DIR_CLOSED to be thrown");
+      } catch (e) {
+        // deno-lint-ignore no-explicit-any
+        assertEquals((e as any).code, "ERR_DIR_CLOSED");
+      }
+    } finally {
+      Deno.removeSync(testDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "Dir.read callback receives ERR_DIR_CLOSED after close",
+  async fn() {
+    const testDir: string = Deno.makeTempDirSync();
+    try {
+      const dir = new Dir(testDir);
+      await dir.close();
+      await new Promise<void>((resolve, reject) => {
+        // deno-lint-ignore no-explicit-any
+        dir.read((err: any) => {
+          try {
+            assertEquals(err.code, "ERR_DIR_CLOSED");
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+    } finally {
+      Deno.removeSync(testDir, { recursive: true });
+    }
+  },
+});


### PR DESCRIPTION
Fixes #34900

  I traced the issue to ext/node/polyfills/_fs/_fs_dir.ts, specifically the Dir class. The
  problem is that close() and closeSync() don't track the closed state, so after closing a
  directory handle, calling read() or readSync() continues to work instead of throwing
  ERR_DIR_CLOSED.

  What happens is: when you call dir.close() and then try to continue iteration with
  iter.next(), the iterator silently continues instead of throwing an error like Node.js does.
  This can lead to subtle bugs where code continues to use a closed directory handle without
  realizing it.

  The fix adds a #closed private field to track the directory state, and checks it at the
  beginning of read() and readSync(). If the directory is closed, it throws ERR_DIR_CLOSED
  immediately, matching Node.js behavior.

  I used AI tools to help trace the code and write the fix.