### PR TITLE
fix(npm): resolve workspace members with prerelease versions

### DIFF
--- a/cli/tools/pm/cache_deps.rs
+++ b/cli/tools/pm/cache_deps.rs
@@ -13,6 +13,7 @@ use deno_graph::JsrPackageReqNotFoundError;
 use deno_graph::packages::JsrPackageVersionInfo;
 use deno_npm_installer::PackageCaching;
 use deno_npm_installer::graph::NpmCachingStrategy;
+use deno_resolver::npm::version_req_matches_including_pre;
 use deno_semver::Version;
 use deno_semver::jsr::JsrPackageReqReference;
 use deno_semver::npm::NpmPackageReqReference;
@@ -166,7 +167,10 @@ pub async fn cache_top_level_deps(
               continue;
             };
             let version_req = &req_ref.req().version_req;
-            if version_req.tag().is_none() && version_req.matches(&version) {
+            // match prereleases too: a workspace member is provided explicitly
+            // by the user, so e.g. `0.40.0-pre` should still resolve to it
+            // instead of being fetched from the registry.
+            if version_req_matches_including_pre(version_req, &version) {
               // if version req matches the workspace package's version, use that
               // (so it doesn't need to be installed)
               continue;

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -136,6 +136,10 @@ impl NpmPackageConfig {
       RangeSetOrTag::Tag(tag) => tag == "workspace",
     }
   }
+
+  pub fn matches_name(&self, name: &str) -> bool {
+    name == self.nv.name
+  }
 }
 
 #[derive(Clone, Debug, Default, Hash, PartialEq)]

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -137,8 +137,60 @@ impl NpmPackageConfig {
     }
   }
 
+  /// Like [`Self::matches_req`], but also matches prerelease versions that fall
+  /// within the requirement's range bounds (see
+  /// [`version_req_matches_including_pre`]). Used when resolving a local
+  /// workspace member, which is provided explicitly by the user.
+  pub fn matches_req_including_pre(&self, req: &PackageReq) -> bool {
+    self.matches_name_and_version_req_including_pre(&req.name, &req.version_req)
+  }
+
+  /// Like [`Self::matches_name_and_version_req`], but prerelease-inclusive.
+  pub fn matches_name_and_version_req_including_pre(
+    &self,
+    name: &str,
+    version_req: &VersionReq,
+  ) -> bool {
+    if name != self.nv.name {
+      return false;
+    }
+    version_req_matches_including_pre(version_req, &self.nv.version)
+      || matches!(version_req.inner(), RangeSetOrTag::Tag(tag) if tag == "workspace")
+  }
+
   pub fn matches_name(&self, name: &str) -> bool {
     name == self.nv.name
+  }
+}
+
+/// Like [`VersionReq::matches`], but also matches prerelease versions that fall
+/// within the requirement's range bounds.
+///
+/// npm's default semver rules exclude prereleases from ranges like `*` or
+/// `^1.0.0` to avoid silently selecting an unstable version from the registry,
+/// but a locally provided package (a pnpm/npm workspace member, or a package
+/// already installed in `node_modules`) is there because the user put it there,
+/// so a member with a prerelease version (e.g. `0.40.0-pre`) should still
+/// satisfy a bare `npm:<pkg>` (`*`) requirement instead of being rejected.
+///
+/// This is intentionally a touch more permissive than npm's `includePrerelease`
+/// (e.g. `^1.0.0` matches `2.0.0-pre` here, whereas npm excludes it because
+/// `2.0.0-pre >= 2.0.0-0`); that is acceptable because it only applies to
+/// explicitly provided local packages.
+///
+/// Unlike [`VersionReq::matches`], a tag requirement never matches here (rather
+/// than panicking), since a local package has no dist-tags to compare against.
+pub fn version_req_matches_including_pre(
+  version_req: &VersionReq,
+  version: &Version,
+) -> bool {
+  match version_req.inner() {
+    RangeSetOrTag::RangeSet(set) => {
+      set.satisfies(version)
+        || (!version.pre.is_empty()
+          && set.0.iter().any(|range| range.intersects_version(version)))
+    }
+    RangeSetOrTag::Tag(_) => false,
   }
 }
 
@@ -3043,6 +3095,32 @@ pub mod test {
     } else {
       PathBuf::from("/home/user")
     }
+  }
+
+  #[test]
+  fn version_req_matches_including_pre_cases() {
+    fn matches(req: &str, version: &str) -> bool {
+      version_req_matches_including_pre(
+        &VersionReq::parse_from_npm(req).unwrap(),
+        &Version::parse_from_npm(version).unwrap(),
+      )
+    }
+
+    // a prerelease version satisfies a wildcard, unlike plain npm semver
+    assert!(matches("*", "0.40.0-pre"));
+    // ... and an explicit prerelease range that contains it
+    assert!(matches("^0.40.0-pre", "0.40.0-pre"));
+    // but not a range whose lower bound is above the prerelease
+    assert!(!matches("^0.40.0", "0.40.0-pre"));
+    // an exact version does not match a lower prerelease of itself
+    assert!(!matches("1.3.6", "1.3.6-beta"));
+    // a prerelease below the exclusive upper bound is included
+    assert!(matches("^1.0.0", "2.0.0-pre"));
+    // non-prerelease behaviour is unchanged
+    assert!(matches("^1.0.0", "1.5.0"));
+    assert!(!matches("^1.0.0", "2.0.0"));
+    // a tag never matches a local package (and does not panic)
+    assert!(!matches("latest", "1.0.0"));
   }
 
   #[test]

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -180,6 +180,10 @@ impl NpmPackageConfig {
 ///
 /// Unlike [`VersionReq::matches`], a tag requirement never matches here (rather
 /// than panicking), since a local package has no dist-tags to compare against.
+///
+/// `deno_npm`'s `link_version_req_satisfies` keeps an identical copy of this
+/// fallback for the npm graph resolver (it can't depend on this crate). Keep
+/// the two in sync.
 pub fn version_req_matches_including_pre(
   version_req: &VersionReq,
   version: &Version,

--- a/libs/npm/resolution/common.rs
+++ b/libs/npm/resolution/common.rs
@@ -192,6 +192,11 @@ impl<'a> NpmPackageVersionResolver<'a> {
   /// with a prerelease version (e.g. `0.40.0-pre`) should still be selectable
   /// for a bare `npm:<pkg>` (`*`) requirement instead of falling back to the
   /// registry.
+  ///
+  /// This is the canonical prerelease fallback used by the npm graph resolver.
+  /// `deno_config`'s `version_req_matches_including_pre` keeps an identical
+  /// copy for the workspace/byonm paths (it can't depend on this crate, since
+  /// the dependency goes the other way). Keep the two in sync.
   fn link_version_req_satisfies(
     &self,
     version_req: &VersionReq,

--- a/libs/npm/resolution/common.rs
+++ b/libs/npm/resolution/common.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use deno_semver::RangeSetOrTag;
 use deno_semver::StackString;
 use deno_semver::Version;
 use deno_semver::VersionReq;
@@ -181,6 +182,33 @@ impl<'a> NpmPackageVersionResolver<'a> {
     }
   }
 
+  /// Like `version_req_satisfies`, but also matches prerelease versions that
+  /// fall within the requirement's range bounds.
+  ///
+  /// This is used only for linked (workspace) packages. npm's default semver
+  /// rules exclude prereleases from ranges like `*` or `^1.0.0` to avoid
+  /// silently selecting an unstable version from the registry. Linked packages
+  /// are provided explicitly by the user though, so a local workspace member
+  /// with a prerelease version (e.g. `0.40.0-pre`) should still be selectable
+  /// for a bare `npm:<pkg>` (`*`) requirement instead of falling back to the
+  /// registry.
+  fn link_version_req_satisfies(
+    &self,
+    version_req: &VersionReq,
+    version: &Version,
+  ) -> Result<bool, NpmPackageVersionResolutionError> {
+    if self.version_req_satisfies(version_req, version)? {
+      return Ok(true);
+    }
+    Ok(match version_req.inner() {
+      RangeSetOrTag::RangeSet(set) => {
+        !version.pre.is_empty()
+          && set.0.iter().any(|range| range.intersects_version(version))
+      }
+      RangeSetOrTag::Tag(_) => false,
+    })
+  }
+
   /// Gets if the provided version should be ignored or not
   /// based on the `newest_dependency_date`.
   pub fn matches_newest_dependency_date(&self, version: &Version) -> bool {
@@ -203,7 +231,7 @@ impl<'a> NpmPackageVersionResolver<'a> {
       let mut best_version: Option<&'a NpmPackageVersionInfo> = None;
       for version_info in version_infos {
         let version = &version_info.version;
-        if self.version_req_satisfies(version_req, version)? {
+        if self.link_version_req_satisfies(version_req, version)? {
           let is_greater =
             best_version.map(|c| *version > c.version).unwrap_or(true);
           if is_greater {

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -6789,6 +6789,50 @@ mod test {
   }
 
   #[tokio::test]
+  async fn link_package_prerelease_as_root() {
+    // A link package with a prerelease version should be selected for a bare
+    // `*` requirement, even though the registry also publishes a stable
+    // version that a `*` range would normally prefer (npm semver excludes
+    // prereleases). The explicitly linked local package wins.
+    let api = TestNpmRegistryApi::default();
+    api.ensure_package_version("my-local-pkg", "0.1.4");
+
+    let link_packages = HashMap::from([(
+      PackageName::from_static("my-local-pkg"),
+      vec![NpmPackageVersionInfo {
+        version: Version::parse_from_npm("0.40.0-pre").unwrap(),
+        ..Default::default()
+      }],
+    )]);
+
+    let (packages, package_reqs) = run_resolver_with_options_and_get_output(
+      api,
+      RunResolverOptions {
+        reqs: vec!["my-local-pkg@*"],
+        link_packages: Some(&link_packages),
+        ..Default::default()
+      },
+    )
+    .await;
+
+    assert_eq!(
+      packages,
+      vec![TestNpmResolutionPackage {
+        pkg_id: "my-local-pkg@0.40.0-pre".to_string(),
+        copy_index: 0,
+        dependencies: Default::default(),
+      }]
+    );
+    assert_eq!(
+      package_reqs,
+      vec![(
+        "my-local-pkg".to_string(),
+        "my-local-pkg@0.40.0-pre".to_string()
+      )]
+    );
+  }
+
+  #[tokio::test]
   async fn link_package_tag() {
     let api = TestNpmRegistryApi::default();
     api.ensure_package_version("package-a", "1.0.0");

--- a/libs/npm_installer/lib.rs
+++ b/libs/npm_installer/lib.rs
@@ -58,8 +58,8 @@ use self::local::LocalNpmPackageInstallerOptions;
 pub use self::local::LocalSetupCache;
 pub use self::local::node_modules_package_actual_dir_to_name;
 pub use self::local::remove_unused_node_modules_symlinks;
+use self::package_json::EnsurePackageJsonDepsError;
 use self::package_json::NpmInstallDepsProvider;
-use self::package_json::PackageJsonDepValueParseWithLocationError;
 use self::resolution::AddPkgReqsResult;
 use self::resolution::NpmResolutionInstaller;
 use self::resolution::NpmResolutionInstallerSys;
@@ -408,12 +408,12 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmInstallerSys>
 
   pub fn ensure_no_pkg_json_dep_errors(
     &self,
-  ) -> Result<(), Box<PackageJsonDepValueParseWithLocationError>> {
+  ) -> Result<(), EnsurePackageJsonDepsError> {
     for err in self.npm_install_deps_provider.pkg_json_dep_errors() {
       match err.source.as_kind() {
         deno_package_json::PackageJsonDepValueParseErrorKind::JsrRequiresScope { .. } |
         deno_package_json::PackageJsonDepValueParseErrorKind::VersionReq { .. } => {
-          return Err(Box::new(err.clone()));
+          return Err(Box::new(err.clone()).into());
         }
         deno_package_json::PackageJsonDepValueParseErrorKind::Unsupported {
           ..
@@ -428,6 +428,16 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmInstallerSys>
           )
         }
       }
+    }
+    // A `workspace:<range>` whose member version doesn't satisfy the range is
+    // always a hard error, the same way `deno run` rejects it during
+    // resolution.
+    if let Some(err) = self
+      .npm_install_deps_provider
+      .workspace_member_version_errors()
+      .first()
+    {
+      return Err(Box::new(err.clone()).into());
     }
     Ok(())
   }

--- a/libs/npm_installer/package_json.rs
+++ b/libs/npm_installer/package_json.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use deno_config::workspace::Workspace;
 use deno_package_json::PackageJsonDepValue;
 use deno_package_json::PackageJsonDepValueParseError;
-use deno_package_json::PackageJsonDepWorkspaceReq;
 use deno_semver::SmallStackString;
 use deno_semver::StackString;
 use deno_semver::Version;
@@ -222,19 +221,18 @@ impl NpmInstallDepsProvider {
                 });
               }
             }
-            PackageJsonDepValue::Workspace(workspace_version_req) => {
-              let version_req = match workspace_version_req {
-                PackageJsonDepWorkspaceReq::VersionReq(version_req) => {
-                  version_req.clone()
-                }
-                PackageJsonDepWorkspaceReq::Tilde
-                | PackageJsonDepWorkspaceReq::Caret => {
-                  VersionReq::parse_from_npm("*").unwrap()
-                }
-              };
-              if let Some(pkg) = workspace_npm_pkgs.iter().find(|pkg| {
-                pkg.matches_name_and_version_req(alias, &version_req)
-              }) {
+            PackageJsonDepValue::Workspace(_workspace_version_req) => {
+              // A `workspace:` dependency always resolves to the local
+              // workspace member with a matching name. The version range
+              // (`*`, `~`, `^` or an explicit version) only affects what gets
+              // written when publishing, so it must not gate resolution here.
+              // Matching on the version range would incorrectly skip members
+              // whose version is a prerelease (e.g. `0.40.0-pre`), since semver
+              // ranges don't match prereleases, and fall back to the registry.
+              if let Some(pkg) = workspace_npm_pkgs
+                .iter()
+                .find(|pkg| pkg.matches_name(alias))
+              {
                 workspace_pkg_deps.push(InstallWorkspacePkgDep::Workspace {
                   alias: alias.clone(),
                   nv: pkg.nv.clone(),

--- a/libs/npm_installer/package_json.rs
+++ b/libs/npm_installer/package_json.rs
@@ -134,7 +134,7 @@ impl NpmInstallDepsProvider {
 
             let workspace_pkg = workspace_npm_pkgs
               .iter()
-              .find(|pkg| pkg.matches_req(&pkg_req));
+              .find(|pkg| pkg.matches_req_including_pre(&pkg_req));
 
             if let Some(pkg) = workspace_pkg {
               local_pkgs.push(InstallLocalPkg {
@@ -195,7 +195,7 @@ impl NpmInstallDepsProvider {
                 continue;
               }
               let workspace_pkg = workspace_npm_pkgs.iter().find(|pkg| {
-                pkg.matches_req(pkg_req)
+                pkg.matches_req_including_pre(pkg_req)
                         // do not resolve to the current package
                         && pkg.pkg_json.path != pkg_json.path
               });
@@ -255,7 +255,7 @@ impl NpmInstallDepsProvider {
                   version_req,
                 };
                 let workspace_pkg = workspace_npm_pkgs.iter().find(|pkg| {
-                  pkg.matches_req(&pkg_req)
+                  pkg.matches_req_including_pre(&pkg_req)
                     && pkg.pkg_json.path != pkg_json.path
                 });
 

--- a/libs/npm_installer/package_json.rs
+++ b/libs/npm_installer/package_json.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use deno_config::workspace::Workspace;
 use deno_package_json::PackageJsonDepValue;
 use deno_package_json::PackageJsonDepValueParseError;
+use deno_package_json::PackageJsonDepWorkspaceReq;
 use deno_semver::SmallStackString;
 use deno_semver::StackString;
 use deno_semver::Version;
@@ -60,6 +61,34 @@ pub struct PackageJsonDepValueParseWithLocationError {
   pub source: PackageJsonDepValueParseError,
 }
 
+/// A `workspace:<version>` dependency referenced a local workspace member by
+/// name, but the member's version did not satisfy the requested constraint.
+/// Like pnpm, this is a hard error rather than silently linking the member or
+/// falling back to the registry. The message mirrors the equivalent
+/// `deno run` resolver error (`VersionNotSatisfied`).
+#[derive(Debug, Error, Clone)]
+#[error(
+  "Failed to install '{alias}': found package.json in workspace, but version '{version}' didn't satisfy constraint '{version_req}'\n    at {location}"
+)]
+pub struct WorkspaceMemberVersionNotSatisfiedError {
+  pub location: Url,
+  pub alias: StackString,
+  pub version_req: VersionReq,
+  pub version: Version,
+}
+
+/// An error surfaced while reconciling a package.json's dependencies against
+/// the workspace before installing.
+#[derive(Debug, Error, Clone)]
+pub enum EnsurePackageJsonDepsError {
+  #[error(transparent)]
+  DepValueParse(#[from] Box<PackageJsonDepValueParseWithLocationError>),
+  #[error(transparent)]
+  WorkspaceMemberVersionNotSatisfied(
+    #[from] Box<WorkspaceMemberVersionNotSatisfiedError>,
+  ),
+}
+
 #[derive(Debug, Default)]
 pub struct NpmInstallDepsProvider {
   remote_pkgs: Vec<InstallNpmRemotePkg>,
@@ -67,6 +96,7 @@ pub struct NpmInstallDepsProvider {
   patch_pkgs: Vec<InstallPatchPkg>,
   workspace_pkgs: Vec<InstallWorkspacePkg>,
   pkg_json_dep_errors: Vec<PackageJsonDepValueParseWithLocationError>,
+  workspace_member_version_errors: Vec<WorkspaceMemberVersionNotSatisfiedError>,
 }
 
 fn package_json_to_lifecycle_nv(
@@ -109,6 +139,7 @@ impl NpmInstallDepsProvider {
     let mut patch_pkgs = Vec::new();
     let mut workspace_pkgs = Vec::new();
     let mut pkg_json_dep_errors = Vec::new();
+    let mut workspace_member_version_errors = Vec::new();
     let workspace_npm_pkgs = workspace.npm_packages();
 
     for (_, folder) in workspace.config_folders() {
@@ -221,26 +252,51 @@ impl NpmInstallDepsProvider {
                 });
               }
             }
-            PackageJsonDepValue::Workspace(_workspace_version_req) => {
-              // A `workspace:` dependency always resolves to the local
-              // workspace member with a matching name. The version range
-              // (`*`, `~`, `^` or an explicit version) only affects what gets
-              // written when publishing, so it must not gate resolution here.
-              // Matching on the version range would incorrectly skip members
-              // whose version is a prerelease (e.g. `0.40.0-pre`), since semver
-              // ranges don't match prereleases, and fall back to the registry.
+            PackageJsonDepValue::Workspace(workspace_version_req) => {
+              // A `workspace:` dependency resolves to the local workspace
+              // member with a matching name. `workspace:*`, `workspace:~` and
+              // `workspace:^` are placeholders that match the member regardless
+              // of its version (the range only affects what gets written when
+              // publishing). An explicit `workspace:<range>` must be satisfied
+              // by the member's version though; like pnpm, a mismatch is a hard
+              // error rather than silently linking the member or falling back
+              // to the registry. Prerelease versions within the range bounds
+              // match too, since the member is provided explicitly (#30155).
               if let Some(pkg) = workspace_npm_pkgs
                 .iter()
                 .find(|pkg| pkg.matches_name(alias))
               {
-                workspace_pkg_deps.push(InstallWorkspacePkgDep::Workspace {
-                  alias: alias.clone(),
-                  nv: pkg.nv.clone(),
-                });
-                local_pkgs.push(InstallLocalPkg {
-                  alias: Some(alias.clone()),
-                  target_dir: pkg.pkg_json.dir_path().to_path_buf(),
-                });
+                let satisfied = match workspace_version_req {
+                  PackageJsonDepWorkspaceReq::Tilde
+                  | PackageJsonDepWorkspaceReq::Caret => true,
+                  PackageJsonDepWorkspaceReq::VersionReq(version_req) => pkg
+                    .matches_name_and_version_req_including_pre(
+                      alias,
+                      version_req,
+                    ),
+                };
+                if satisfied {
+                  workspace_pkg_deps.push(InstallWorkspacePkgDep::Workspace {
+                    alias: alias.clone(),
+                    nv: pkg.nv.clone(),
+                  });
+                  local_pkgs.push(InstallLocalPkg {
+                    alias: Some(alias.clone()),
+                    target_dir: pkg.pkg_json.dir_path().to_path_buf(),
+                  });
+                } else if let PackageJsonDepWorkspaceReq::VersionReq(
+                  version_req,
+                ) = workspace_version_req
+                {
+                  workspace_member_version_errors.push(
+                    WorkspaceMemberVersionNotSatisfiedError {
+                      location: pkg_json.specifier(),
+                      alias: alias.clone(),
+                      version_req: version_req.clone(),
+                      version: pkg.nv.version.clone(),
+                    },
+                  );
+                }
               }
             }
             PackageJsonDepValue::Catalog(catalog_name) => {
@@ -337,6 +393,7 @@ impl NpmInstallDepsProvider {
       patch_pkgs,
       workspace_pkgs,
       pkg_json_dep_errors,
+      workspace_member_version_errors,
     }
   }
 
@@ -360,5 +417,11 @@ impl NpmInstallDepsProvider {
     &self,
   ) -> &[PackageJsonDepValueParseWithLocationError] {
     &self.pkg_json_dep_errors
+  }
+
+  pub fn workspace_member_version_errors(
+    &self,
+  ) -> &[WorkspaceMemberVersionNotSatisfiedError] {
+    &self.workspace_member_version_errors
   }
 }

--- a/libs/resolver/npm/byonm.rs
+++ b/libs/resolver/npm/byonm.rs
@@ -30,6 +30,7 @@ use url::Url;
 
 use super::local::normalize_pkg_name_for_node_modules_deno_folder;
 use crate::npm::join_package_name_to_path;
+use crate::npm::version_req_matches_including_pre;
 
 #[derive(Debug, Error, deno_error::JsError)]
 pub enum ByonmResolvePkgFolderFromDenoReqError {
@@ -182,7 +183,10 @@ impl<TSys: ByonmNpmResolverSys> ByonmNpmResolver<TSys> {
             .and_then(|pkg| {
               let version =
                 Version::parse_from_npm(pkg.version.as_ref()?).ok()?;
-              Some(req.version_req.matches(&version))
+              Some(version_req_matches_including_pre(
+                &req.version_req,
+                &version,
+              ))
             })
             .unwrap_or(true);
         if version_matches {
@@ -300,7 +304,9 @@ impl<TSys: ByonmNpmResolverSys> ByonmNpmResolver<TSys> {
           .version
           .as_ref()
           .and_then(|v| Version::parse_from_npm(v).ok())
-          .map(|version| req.version_req.matches(&version))
+          .map(|version| {
+            version_req_matches_including_pre(&req.version_req, &version)
+          })
           .unwrap_or(true);
         if matches_req {
           return Some((dep_pkg_json, req.name.clone()));

--- a/libs/resolver/npm/mod.rs
+++ b/libs/resolver/npm/mod.rs
@@ -700,18 +700,52 @@ pub(crate) fn join_package_name_to_path(
 /// in `node_modules` was put there explicitly by the user, so a member with a
 /// prerelease version (e.g. `0.40.0-pre`) should still satisfy a bare
 /// `npm:<pkg>` (`*`) requirement instead of being rejected.
-pub(crate) fn version_req_matches_including_pre(
+///
+/// Unlike `VersionReq::matches`, a tag requirement never matches here (rather
+/// than panicking), since a local package has no dist-tags to compare against.
+pub fn version_req_matches_including_pre(
   version_req: &deno_semver::VersionReq,
   version: &Version,
 ) -> bool {
-  if version_req.matches(version) {
-    return true;
-  }
   match version_req.inner() {
     RangeSetOrTag::RangeSet(set) => {
-      !version.pre.is_empty()
-        && set.0.iter().any(|range| range.intersects_version(version))
+      set.satisfies(version)
+        || (!version.pre.is_empty()
+          && set.0.iter().any(|range| range.intersects_version(version)))
     }
     RangeSetOrTag::Tag(_) => false,
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use deno_semver::VersionReq;
+
+  use super::*;
+
+  #[test]
+  fn version_req_matches_including_pre_cases() {
+    fn matches(req: &str, version: &str) -> bool {
+      version_req_matches_including_pre(
+        &VersionReq::parse_from_npm(req).unwrap(),
+        &Version::parse_from_npm(version).unwrap(),
+      )
+    }
+
+    // a prerelease version satisfies a wildcard, unlike plain npm semver
+    assert!(matches("*", "0.40.0-pre"));
+    // ... and an explicit prerelease range that contains it
+    assert!(matches("^0.40.0-pre", "0.40.0-pre"));
+    // but not a range whose lower bound is above the prerelease
+    assert!(!matches("^0.40.0", "0.40.0-pre"));
+    // an exact version does not match a lower prerelease of itself
+    assert!(!matches("1.3.6", "1.3.6-beta"));
+    // a prerelease below the exclusive upper bound is included
+    assert!(matches("^1.0.0", "2.0.0-pre"));
+    // non-prerelease behaviour is unchanged
+    assert!(matches("^1.0.0", "1.5.0"));
+    assert!(!matches("^1.0.0", "2.0.0"));
+    // a tag never matches a local package (and does not panic)
+    assert!(!matches("latest", "1.0.0"));
   }
 }

--- a/libs/resolver/npm/mod.rs
+++ b/libs/resolver/npm/mod.rs
@@ -10,6 +10,7 @@ use deno_error::JsError;
 use deno_maybe_sync::MaybeSend;
 use deno_maybe_sync::MaybeSync;
 use deno_maybe_sync::new_rc;
+use deno_semver::RangeSetOrTag;
 use deno_semver::Version;
 use deno_semver::npm::NpmPackageReqReference;
 use deno_semver::package::PackageReq;
@@ -687,4 +688,30 @@ pub(crate) fn join_package_name_to_path(
     }
   }
   path.into_owned()
+}
+
+/// Like `VersionReq::matches`, but also matches prerelease versions that fall
+/// within the requirement's range bounds.
+///
+/// This is used when matching a locally installed (e.g. pnpm/npm workspace)
+/// package against a requirement. npm's default semver rules exclude
+/// prereleases from ranges like `*` or `^1.0.0` to avoid silently selecting an
+/// unstable version from the registry, but a package that is already installed
+/// in `node_modules` was put there explicitly by the user, so a member with a
+/// prerelease version (e.g. `0.40.0-pre`) should still satisfy a bare
+/// `npm:<pkg>` (`*`) requirement instead of being rejected.
+pub(crate) fn version_req_matches_including_pre(
+  version_req: &deno_semver::VersionReq,
+  version: &Version,
+) -> bool {
+  if version_req.matches(version) {
+    return true;
+  }
+  match version_req.inner() {
+    RangeSetOrTag::RangeSet(set) => {
+      !version.pre.is_empty()
+        && set.0.iter().any(|range| range.intersects_version(version))
+    }
+    RangeSetOrTag::Tag(_) => false,
+  }
 }

--- a/libs/resolver/npm/mod.rs
+++ b/libs/resolver/npm/mod.rs
@@ -10,7 +10,6 @@ use deno_error::JsError;
 use deno_maybe_sync::MaybeSend;
 use deno_maybe_sync::MaybeSync;
 use deno_maybe_sync::new_rc;
-use deno_semver::RangeSetOrTag;
 use deno_semver::Version;
 use deno_semver::npm::NpmPackageReqReference;
 use deno_semver::package::PackageReq;
@@ -690,62 +689,8 @@ pub(crate) fn join_package_name_to_path(
   path.into_owned()
 }
 
-/// Like `VersionReq::matches`, but also matches prerelease versions that fall
-/// within the requirement's range bounds.
-///
-/// This is used when matching a locally installed (e.g. pnpm/npm workspace)
-/// package against a requirement. npm's default semver rules exclude
-/// prereleases from ranges like `*` or `^1.0.0` to avoid silently selecting an
-/// unstable version from the registry, but a package that is already installed
-/// in `node_modules` was put there explicitly by the user, so a member with a
-/// prerelease version (e.g. `0.40.0-pre`) should still satisfy a bare
-/// `npm:<pkg>` (`*`) requirement instead of being rejected.
-///
-/// Unlike `VersionReq::matches`, a tag requirement never matches here (rather
-/// than panicking), since a local package has no dist-tags to compare against.
-pub fn version_req_matches_including_pre(
-  version_req: &deno_semver::VersionReq,
-  version: &Version,
-) -> bool {
-  match version_req.inner() {
-    RangeSetOrTag::RangeSet(set) => {
-      set.satisfies(version)
-        || (!version.pre.is_empty()
-          && set.0.iter().any(|range| range.intersects_version(version)))
-    }
-    RangeSetOrTag::Tag(_) => false,
-  }
-}
-
-#[cfg(test)]
-mod test {
-  use deno_semver::VersionReq;
-
-  use super::*;
-
-  #[test]
-  fn version_req_matches_including_pre_cases() {
-    fn matches(req: &str, version: &str) -> bool {
-      version_req_matches_including_pre(
-        &VersionReq::parse_from_npm(req).unwrap(),
-        &Version::parse_from_npm(version).unwrap(),
-      )
-    }
-
-    // a prerelease version satisfies a wildcard, unlike plain npm semver
-    assert!(matches("*", "0.40.0-pre"));
-    // ... and an explicit prerelease range that contains it
-    assert!(matches("^0.40.0-pre", "0.40.0-pre"));
-    // but not a range whose lower bound is above the prerelease
-    assert!(!matches("^0.40.0", "0.40.0-pre"));
-    // an exact version does not match a lower prerelease of itself
-    assert!(!matches("1.3.6", "1.3.6-beta"));
-    // a prerelease below the exclusive upper bound is included
-    assert!(matches("^1.0.0", "2.0.0-pre"));
-    // non-prerelease behaviour is unchanged
-    assert!(matches("^1.0.0", "1.5.0"));
-    assert!(!matches("^1.0.0", "2.0.0"));
-    // a tag never matches a local package (and does not panic)
-    assert!(!matches("latest", "1.0.0"));
-  }
-}
+// Matching a locally installed (e.g. pnpm/npm workspace) package against a
+// requirement is prerelease-inclusive. The canonical implementation lives in
+// `deno_config` so it can be shared with `NpmPackageConfig` matching; re-export
+// it here for the byonm and cache_deps callers.
+pub use deno_config::workspace::version_req_matches_including_pre;

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -1528,7 +1528,15 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
               .and_then(|v| Version::parse_from_npm(v).ok())
             {
               Some(version) => {
-                if set.satisfies(&version) {
+                // Match prerelease versions that fall within the range bounds
+                // too (npm's `includePrerelease`). A workspace member with a
+                // prerelease version (e.g. `0.40.0-pre`) should still resolve
+                // to the local package instead of being rejected, since it is
+                // provided explicitly rather than picked from the registry.
+                let matches = set.satisfies(&version)
+                  || (!version.pre.is_empty()
+                    && set.0.iter().any(|r| r.intersects_version(&version)));
+                if matches {
                   Ok(pkg_json.dir_path())
                 } else {
                   Err(
@@ -2044,7 +2052,8 @@ mod test {
         "workspaces": [
           "a",
           "b",
-          "no-version"
+          "no-version",
+          "pre"
         ]
       }),
     );
@@ -2066,6 +2075,13 @@ mod test {
       root_dir().join("no-version/package.json"),
       json!({
         "name": "@scope/no-version",
+      }),
+    );
+    sys.fs_insert_json(
+      root_dir().join("pre/package.json"),
+      json!({
+        "name": "@scope/pre",
+        "version": "0.40.0-pre",
       }),
     );
     let workspace = workspace_at_start_dir(&sys, &root_dir());
@@ -2103,6 +2119,14 @@ mod test {
       // just match any tags with the workspace
       assert_eq!(resolve("@scope/a", "latest").unwrap(), root_dir().join("a"));
 
+      // a workspace member with a prerelease version still resolves, even
+      // though npm semver ranges normally exclude prereleases
+      assert_eq!(resolve("@scope/pre", "*").unwrap(), root_dir().join("pre"));
+      assert_eq!(
+        resolve("@scope/pre", "^0.40.0-pre").unwrap(),
+        root_dir().join("pre")
+      );
+
       // match any version for a pkg with no version
       assert_eq!(
         resolve("@scope/no-version", "1").unwrap(),
@@ -2125,6 +2149,8 @@ mod test {
         resolve("@scope/no-version@1").unwrap(),
         root_dir().join("no-version")
       );
+      // a bare `npm:` specifier (`*`) resolves a prerelease workspace member
+      assert_eq!(resolve("@scope/pre@*").unwrap(), root_dir().join("pre"));
 
       // won't match for tags
       assert_eq!(resolve("@scope/a@workspace"), None);

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -1521,7 +1521,7 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
     match workspace_version_req {
       PackageJsonDepWorkspaceReq::VersionReq(version_req) => {
         match version_req.inner() {
-          RangeSetOrTag::RangeSet(set) => {
+          RangeSetOrTag::RangeSet(_) => {
             match pkg_json
               .version
               .as_ref()
@@ -1529,14 +1529,14 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
             {
               Some(version) => {
                 // Match prerelease versions that fall within the range bounds
-                // too (npm's `includePrerelease`). A workspace member with a
-                // prerelease version (e.g. `0.40.0-pre`) should still resolve
-                // to the local package instead of being rejected, since it is
-                // provided explicitly rather than picked from the registry.
-                let matches = set.satisfies(&version)
-                  || (!version.pre.is_empty()
-                    && set.0.iter().any(|r| r.intersects_version(&version)));
-                if matches {
+                // too. A workspace member with a prerelease version (e.g.
+                // `0.40.0-pre`) should still resolve to the local package
+                // instead of being rejected, since it is provided explicitly
+                // rather than picked from the registry.
+                if crate::npm::version_req_matches_including_pre(
+                  version_req,
+                  &version,
+                ) {
                   Ok(pkg_json.dir_path())
                 } else {
                   Err(

--- a/tests/specs/npm/workspace_explicit_version_mismatch/__test__.jsonc
+++ b/tests/specs/npm/workspace_explicit_version_mismatch/__test__.jsonc
@@ -1,0 +1,15 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      // An explicit `workspace:<range>` whose local member version doesn't
+      // satisfy the range is a hard error during `deno install`, the same way
+      // pnpm rejects it (and the same way `deno run` rejects it at resolution
+      // time) instead of silently linking the member or falling back to the
+      // registry.
+      "args": "install",
+      "output": "mismatch.out",
+      "exitCode": 1
+    }
+  ]
+}

--- a/tests/specs/npm/workspace_explicit_version_mismatch/app/package.json
+++ b/tests/specs/npm/workspace_explicit_version_mismatch/app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@denotest/app",
+  "dependencies": {
+    "@denotest/member": "workspace:1.0.0"
+  }
+}

--- a/tests/specs/npm/workspace_explicit_version_mismatch/deno.json
+++ b/tests/specs/npm/workspace_explicit_version_mismatch/deno.json
@@ -1,0 +1,4 @@
+{
+  "workspace": ["./member", "./app"],
+  "nodeModulesDir": "auto"
+}

--- a/tests/specs/npm/workspace_explicit_version_mismatch/member/mod.js
+++ b/tests/specs/npm/workspace_explicit_version_mismatch/member/mod.js
@@ -1,0 +1,1 @@
+export function hello() {}

--- a/tests/specs/npm/workspace_explicit_version_mismatch/member/package.json
+++ b/tests/specs/npm/workspace_explicit_version_mismatch/member/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/member",
+  "version": "2.0.0",
+  "exports": "./mod.js"
+}

--- a/tests/specs/npm/workspace_explicit_version_mismatch/mismatch.out
+++ b/tests/specs/npm/workspace_explicit_version_mismatch/mismatch.out
@@ -1,0 +1,2 @@
+[WILDCARD]error: Failed to install '@denotest/member': found package.json in workspace, but version '2.0.0' didn't satisfy constraint '1.0.0'
+[WILDCARD]

--- a/tests/specs/npm/workspace_prerelease_member/__test__.jsonc
+++ b/tests/specs/npm/workspace_prerelease_member/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "run -A npm:@denotest/prerelease-member",
+      "cwd": "app",
+      "output": "run.out"
+    }
+  ]
+}

--- a/tests/specs/npm/workspace_prerelease_member/app/package.json
+++ b/tests/specs/npm/workspace_prerelease_member/app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@denotest/app",
+  "dependencies": {
+    "@denotest/prerelease-member": "workspace:*"
+  }
+}

--- a/tests/specs/npm/workspace_prerelease_member/member/bin.js
+++ b/tests/specs/npm/workspace_prerelease_member/member/bin.js
@@ -1,0 +1,1 @@
+console.log("hello from local prerelease member");

--- a/tests/specs/npm/workspace_prerelease_member/member/package.json
+++ b/tests/specs/npm/workspace_prerelease_member/member/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/prerelease-member",
+  "version": "0.40.0-pre",
+  "bin": "bin.js"
+}

--- a/tests/specs/npm/workspace_prerelease_member/package.json
+++ b/tests/specs/npm/workspace_prerelease_member/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@denotest/workspace-prerelease",
+  "workspaces": [
+    "member",
+    "app"
+  ]
+}

--- a/tests/specs/npm/workspace_prerelease_member/run.out
+++ b/tests/specs/npm/workspace_prerelease_member/run.out
@@ -1,0 +1,1 @@
+hello from local prerelease member

--- a/tests/specs/npm/workspace_prerelease_member_local/__test__.jsonc
+++ b/tests/specs/npm/workspace_prerelease_member_local/__test__.jsonc
@@ -1,0 +1,16 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      // a plain `*` dependency on a prerelease workspace member (not
+      // `workspace:*`) must resolve to the local member with deno-managed
+      // node_modules, instead of being fetched from the registry.
+      "args": "install",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "run app/main.ts",
+      "output": "main.out"
+    }
+  ]
+}

--- a/tests/specs/npm/workspace_prerelease_member_local/app/main.ts
+++ b/tests/specs/npm/workspace_prerelease_member_local/app/main.ts
@@ -1,0 +1,3 @@
+import { hello } from "@denotest/prerelease-member";
+
+hello();

--- a/tests/specs/npm/workspace_prerelease_member_local/app/package.json
+++ b/tests/specs/npm/workspace_prerelease_member_local/app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@denotest/app",
+  "dependencies": {
+    "@denotest/prerelease-member": "*"
+  }
+}

--- a/tests/specs/npm/workspace_prerelease_member_local/deno.json
+++ b/tests/specs/npm/workspace_prerelease_member_local/deno.json
@@ -1,0 +1,4 @@
+{
+  "workspace": ["./member", "./app"],
+  "nodeModulesDir": "auto"
+}

--- a/tests/specs/npm/workspace_prerelease_member_local/main.out
+++ b/tests/specs/npm/workspace_prerelease_member_local/main.out
@@ -1,0 +1,1 @@
+[WILDCARD]hello from local prerelease member

--- a/tests/specs/npm/workspace_prerelease_member_local/member/mod.js
+++ b/tests/specs/npm/workspace_prerelease_member_local/member/mod.js
@@ -1,0 +1,3 @@
+export function hello() {
+  console.log("hello from local prerelease member");
+}

--- a/tests/specs/npm/workspace_prerelease_member_local/member/package.json
+++ b/tests/specs/npm/workspace_prerelease_member_local/member/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/prerelease-member",
+  "version": "0.40.0-pre",
+  "exports": "./mod.js"
+}


### PR DESCRIPTION
When a pnpm/npm workspace member has a prerelease version such as
`0.40.0-pre`, running `deno run npm:<member>` (and resolving any
`workspace:` dependency on it) ignored the local package and fetched the
published version from the npm registry instead. With a normal version
the same setup resolves the local member correctly.

The cause is that resolution matched the member's version against the
dependency requirement using semver `satisfies`/`matches`, and npm
semver ranges (`*`, `^`, `~`) exclude prerelease versions by default.
That exclusion exists so the registry doesn't silently select an
unstable version, but a workspace member is provided explicitly by the
user and should resolve regardless of its prerelease tag. The reported
case goes through the byonm resolver, which re-verifies the version of a
package reached via a node_modules symlink; the workspace resolver, the
npm graph's linked-package matching, and the installer all had the same
gap. This makes those local-resolution paths prerelease-inclusive, and
lets a `workspace:` dependency resolve to the member by name since the
version range only matters at publish time.

Closes #30155