### PR TITLE
fix(runtime): don't panic on missing SnapshotOptions when no snapshot

### DIFF
--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -68,14 +68,11 @@ impl Default for SnapshotOptions {
 #[op2]
 #[serde]
 pub fn op_snapshot_options(state: &mut OpState) -> SnapshotOptions {
-  #[cfg(feature = "hmr")]
-  {
-    state.try_take::<SnapshotOptions>().unwrap_or_default()
-  }
-  #[cfg(not(feature = "hmr"))]
-  {
-    state.take::<SnapshotOptions>()
-  }
+  // `SnapshotOptions` is only placed into the op state when the runtime is
+  // bootstrapped with a startup snapshot. Embedders that bootstrap without one
+  // (`startup_snapshot: None`) never insert it, so fall back to the default
+  // instead of panicking when the value is absent.
+  state.try_take::<SnapshotOptions>().unwrap_or_default()
 }
 
 #[op2]


### PR DESCRIPTION
`op_snapshot_options` is called unconditionally at the top level of
`runtime/js/99_main.js` during bootstrap, but `SnapshotOptions` is only
inserted into the op state when the worker is bootstrapped with a startup
snapshot — in `runtime/worker.rs` the value passed to `deno_bootstrap::init`
is `has_snapshot.then(Default::default)`, where `has_snapshot =
options.startup_snapshot.is_some()`.

In non-`hmr` builds the op did a hard `state.take::<SnapshotOptions>()`, so an
embedder that bootstraps a worker without a snapshot (`startup_snapshot:
None`) panics with:

    required type deno_runtime::ops::bootstrap::SnapshotOptions is not present
    in GothamState container

The `hmr` build already avoided this by using
`try_take().unwrap_or_default()`. This change uses that graceful fallback
unconditionally, so a missing `SnapshotOptions` resolves to the default rather
than panicking. There is no behavioral change for the normal CLI, which always
bootstraps with a snapshot present.

Closes #34926