### PR TITLE
feat(types): prototype `deno types <specifier>`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -719,6 +719,13 @@ pub struct BundleFlags {
   pub watch: bool,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct TypesFlags {
+  /// Modules to print type declarations for (e.g. `jsr:@std/testing/bdd`).
+  /// When empty, `deno types` prints Deno's built-in runtime declarations.
+  pub specifiers: Vec<String>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DenoSubcommand {
   Add(AddFlags),
@@ -753,7 +760,7 @@ pub enum DenoSubcommand {
   Test(TestFlags),
   Transpile(TranspileFlags),
   Outdated(OutdatedFlags),
-  Types,
+  Types(TypesFlags),
   Upgrade(UpgradeFlags),
   Vendor,
   Why(WhyFlags),
@@ -4932,9 +4939,22 @@ fn types_subcommand() -> Command {
 
   <p(245)>deno types > lib.deno.d.ts</>
 
-The declaration file could be saved and used for typing information."
+The declaration file could be saved and used for typing information.
+
+When one or more module specifiers are given, the type declarations for
+those modules are emitted instead of the built-in runtime declarations:
+
+  <p(245)>deno types jsr:@std/testing/bdd > bdd.d.ts</>"
     ),
     UnstableArgsConfig::None,
+  )
+  .arg(
+    Arg::new("specifiers")
+      .help(
+        "Modules to print type declarations for (e.g. jsr:@std/testing/bdd)",
+      )
+      .num_args(0..)
+      .action(ArgAction::Append),
   )
 }
 
@@ -8219,8 +8239,12 @@ fn transpile_parse(
   Ok(())
 }
 
-fn types_parse(flags: &mut Flags, _matches: &mut ArgMatches) {
-  flags.subcommand = DenoSubcommand::Types;
+fn types_parse(flags: &mut Flags, matches: &mut ArgMatches) {
+  let specifiers = matches
+    .remove_many::<String>("specifiers")
+    .map(|s| s.collect())
+    .unwrap_or_default();
+  flags.subcommand = DenoSubcommand::Types(TypesFlags { specifiers });
 }
 
 fn upgrade_parse(
@@ -10374,7 +10398,22 @@ mod tests {
     assert_eq!(
       r.unwrap(),
       Flags {
-        subcommand: DenoSubcommand::Types,
+        subcommand: DenoSubcommand::Types(TypesFlags::default()),
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn types_with_specifiers() {
+    let r =
+      flags_from_vec(svec!["deno", "types", "jsr:@std/testing/bdd", "npm:foo"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Types(TypesFlags {
+          specifiers: svec!["jsr:@std/testing/bdd", "npm:foo"],
+        }),
         ..Flags::default()
       }
     );

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -643,7 +643,7 @@ impl CliFactory {
             | DenoSubcommand::Test { .. }
             | DenoSubcommand::Transpile { .. }
             | DenoSubcommand::Outdated { .. }
-            | DenoSubcommand::Types
+            | DenoSubcommand::Types { .. }
             | DenoSubcommand::Upgrade { .. }
             | DenoSubcommand::Vendor
             | DenoSubcommand::Why { .. }

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -468,9 +468,8 @@ async fn run_subcommand(
         }
       })
     }
-    DenoSubcommand::Types => spawn_subcommand(async move {
-      let types = tsc::get_types_declaration_file_text();
-      display::write_to_stdout_ignore_sigpipe(types.as_bytes())
+    DenoSubcommand::Types(types_flags) => spawn_subcommand(async move {
+      tools::types::types(Arc::new(flags), types_flags).await
     }),
     #[cfg(feature = "upgrade")]
     DenoSubcommand::Upgrade(upgrade_flags) => spawn_subcommand(async {

--- a/cli/tools/mod.rs
+++ b/cli/tools/mod.rs
@@ -25,6 +25,7 @@ pub mod serve;
 pub mod task;
 pub mod test;
 pub mod transpile;
+pub mod types;
 pub mod unfurl_utils;
 pub mod upgrade;
 pub mod x;

--- a/cli/tools/types.rs
+++ b/cli/tools/types.rs
@@ -1,0 +1,104 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+use std::sync::Arc;
+
+use deno_ast::MediaType;
+use deno_core::ModuleSpecifier;
+use deno_core::anyhow;
+use deno_core::error::AnyError;
+use deno_graph::GraphKind;
+use deno_graph::Module;
+use deno_graph::ModuleGraph;
+use deno_path_util::resolve_url_or_path;
+
+use crate::args::Flags;
+use crate::args::TypesFlags;
+use crate::factory::CliFactory;
+use crate::graph_util::BuildGraphWithNpmOptions;
+use crate::tsc;
+use crate::util::display;
+
+pub async fn types(
+  flags: Arc<Flags>,
+  types_flags: TypesFlags,
+) -> Result<(), AnyError> {
+  // No specifiers: keep the historical behavior of printing Deno's built-in
+  // runtime declarations.
+  if types_flags.specifiers.is_empty() {
+    let types = tsc::get_types_declaration_file_text();
+    return display::write_to_stdout_ignore_sigpipe(types.as_bytes())
+      .map_err(Into::into);
+  }
+
+  let factory = CliFactory::from_flags(flags);
+  let cli_options = factory.cli_options()?;
+
+  // Resolve each specifier argument. `resolve_url_or_path` handles jsr:, npm:,
+  // http(s): and bare file paths.
+  let roots = types_flags
+    .specifiers
+    .iter()
+    .map(|s| resolve_url_or_path(s, cli_options.initial_cwd()))
+    .collect::<Result<Vec<_>, _>>()?;
+
+  // Build a graph for the roots so jsr:/npm: specifiers get resolved to their
+  // underlying modules and all dependencies are available to TSC.
+  let mut graph = ModuleGraph::new(GraphKind::All);
+  let module_graph_builder = factory.module_graph_builder().await?;
+  module_graph_builder
+    .build_graph_roots_with_npm_resolution(
+      &mut graph,
+      roots,
+      BuildGraphWithNpmOptions {
+        is_dynamic: false,
+        loader: None,
+        npm_caching: cli_options.default_npm_caching_strategy(),
+      },
+    )
+    .await?;
+  graph.valid()?;
+
+  // Building the graph may have rewritten the roots (e.g. jsr:/npm: to the
+  // underlying file:/https: module), so read them back from the graph and pair
+  // each with its media type for TSC.
+  let mut root_names: Vec<(ModuleSpecifier, MediaType)> = Vec::new();
+  for root in &graph.roots {
+    let resolved = graph.resolve(root);
+    match graph.get(resolved) {
+      Some(Module::Js(module)) => {
+        root_names.push((module.specifier.clone(), module.media_type));
+      }
+      _ => {
+        root_names
+          .push((resolved.clone(), MediaType::from_specifier(resolved)));
+      }
+    }
+  }
+
+  let type_checker = factory.type_checker().await?;
+  let result = type_checker.emit_declarations(
+    Arc::new(graph),
+    root_names,
+    cli_options.ts_type_lib_window(),
+  )?;
+
+  if result.diagnostics.has_diagnostic() {
+    anyhow::bail!("Type checking failed:\n{}", result.diagnostics);
+  }
+
+  // Concatenate the emitted `.d.ts` files and print to stdout. Each file is
+  // prefixed with a comment noting its source specifier.
+  let mut output = String::new();
+  for (file_name, content) in &result.emitted_files {
+    output.push_str("// ");
+    output.push_str(file_name);
+    output.push('\n');
+    output.push_str(content);
+    if !content.ends_with('\n') {
+      output.push('\n');
+    }
+  }
+
+  display::write_to_stdout_ignore_sigpipe(output.as_bytes())?;
+  Ok(())
+}


### PR DESCRIPTION
Prototype for #33290.

Extends `deno types` to accept one or more module specifiers and emit
their TypeScript declarations to stdout, instead of only printing Deno's
built-in runtime declarations. Bare `deno types` is unchanged.

```
$ deno types jsr:@std/testing/bdd > bdd.d.ts
```

For each specifier (`jsr:`, `https:`, or a local file path) a module
graph is built, and the existing declaration-emit path
(`TypeChecker::emit_declarations`, the same machinery behind
`deno transpile --declaration`) produces the `.d.ts` output. The root
modules and all their transitive dependencies are emitted, each prefixed
with a comment noting its source specifier.

Opening as a draft to agree on direction before investing further. Open
questions:

- Output shape. Today it concatenates raw tsc declaration emit for the
  root plus every transitive dependency. The use case in the issue is
  feeding the result to `tsc`, which cannot resolve `jsr:` specifiers, so
  the more useful form is probably ambient `declare module "..."` blocks
  rather than raw declarations with `/// <amd-module ...>` headers.
- Flags. The issue suggests `--write`, `--depth`, and
  `--ignore-subdependencies`. None are implemented yet (stdout only,
  always full depth).
- `npm:` specifiers are not supported yet. They hit the "resolving npm
  specifier entrypoints not supported with nodeModules: manual" path and
  the subcommand does not register the `--node-modules-dir` arg group.
- No spec test yet.
