### PR TITLE
fix(install): suppress peer dependency warnings for overridden packages

### DIFF
--- a/libs/npm_installer/resolution.rs
+++ b/libs/npm_installer/resolution.rs
@@ -216,11 +216,32 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmResolutionInstallerSys>
 
     self.registry_info_provider.clear_memory_cache();
 
-    if !result.unmet_peer_diagnostics.is_empty()
-      && log::log_enabled!(log::Level::Warn)
-    {
-      let root_node =
-        peer_dep_diagnostics_to_display_tree(&result.unmet_peer_diagnostics);
+    // Suppress peer dependency warnings for packages that the user has
+    // explicitly overridden in the root package.json "overrides" field. An
+    // override is an authoritative resolution directive, so a peer mismatch
+    // against an overridden version is intentional and shouldn't be reported.
+    // See https://github.com/denoland/deno/issues/32801.
+    let overrides = &self.npm_version_resolver.overrides;
+    let diagnostics: Vec<UnmetPeerDepDiagnostic> = if overrides.is_empty() {
+      result.unmet_peer_diagnostics.clone()
+    } else {
+      result
+        .unmet_peer_diagnostics
+        .iter()
+        .filter(|d| {
+          overrides
+            .get_override_for(
+              &StackString::from_str(&d.dependency.name),
+              Some(&d.resolved),
+            )
+            .is_none()
+        })
+        .cloned()
+        .collect()
+    };
+
+    if !diagnostics.is_empty() && log::log_enabled!(log::Level::Warn) {
+      let root_node = peer_dep_diagnostics_to_display_tree(&diagnostics);
       let mut text = String::new();
       _ = root_node.print(&mut text);
       log::warn!("{}", text);

--- a/libs/npm_installer/resolution.rs
+++ b/libs/npm_installer/resolution.rs
@@ -222,26 +222,27 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmResolutionInstallerSys>
     // against an overridden version is intentional and shouldn't be reported.
     // See https://github.com/denoland/deno/issues/32801.
     let overrides = &self.npm_version_resolver.overrides;
-    let diagnostics: Vec<UnmetPeerDepDiagnostic> = if overrides.is_empty() {
-      result.unmet_peer_diagnostics.clone()
+    // Only allocate when there are overrides to filter against; otherwise
+    // display the diagnostics directly without copying them.
+    let filtered: Vec<UnmetPeerDepDiagnostic>;
+    let diagnostics: &[UnmetPeerDepDiagnostic] = if overrides.is_empty() {
+      &result.unmet_peer_diagnostics
     } else {
-      result
+      filtered = result
         .unmet_peer_diagnostics
         .iter()
         .filter(|d| {
           overrides
-            .get_override_for(
-              &StackString::from_str(&d.dependency.name),
-              Some(&d.resolved),
-            )
+            .get_override_for(&d.dependency.name, Some(&d.resolved))
             .is_none()
         })
         .cloned()
-        .collect()
+        .collect();
+      &filtered
     };
 
     if !diagnostics.is_empty() && log::log_enabled!(log::Level::Warn) {
-      let root_node = peer_dep_diagnostics_to_display_tree(&diagnostics);
+      let root_node = peer_dep_diagnostics_to_display_tree(diagnostics);
       let mut text = String::new();
       _ = root_node.print(&mut text);
       log::warn!("{}", text);

--- a/tests/specs/install/peer_dep_override_suppresses_warning/__test__.jsonc
+++ b/tests/specs/install/peer_dep_override_suppresses_warning/__test__.jsonc
@@ -1,0 +1,7 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": "install",
+    "output": "install.out"
+  }]
+}

--- a/tests/specs/install/peer_dep_override_suppresses_warning/install.out
+++ b/tests/specs/install/peer_dep_override_suppresses_warning/install.out
@@ -1,0 +1,20 @@
+Download http://localhost:4260/@denotest%2fadd
+Download http://localhost:4260/@denotest%2fpeer-dep-specific-constraint
+[UNORDERED_START]
+Download http://localhost:4260/@denotest/peer-dep-specific-constraint/1.0.0.tgz
+Download http://localhost:4260/@denotest/add/1.0.0.tgz
+Initialize @denotest/peer-dep-specific-constraint@1.0.0
+Initialize @denotest/add@1.0.0
+[UNORDERED_END]
+Installed [WILDLINE] packages in [WILDCARD]
+Reused [WILDLINE] packages from cache
+Downloaded [WILDLINE] packages from JSR
+Downloaded [WILDLINE] packages from npm
+[WILDLINE]
+
+Dependencies:
+[UNORDERED_START]
++ npm:@denotest/add 1.0.0
++ npm:@denotest/peer-dep-specific-constraint 1.0.0
+[UNORDERED_END]
+

--- a/tests/specs/install/peer_dep_override_suppresses_warning/package.json
+++ b/tests/specs/install/peer_dep_override_suppresses_warning/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "@denotest/peer-dep-specific-constraint": "*",
+    "@denotest/add": "1"
+  },
+  "overrides": {
+    "@denotest/add": "1"
+  }
+}


### PR DESCRIPTION
When a package is pinned through the root package.json "overrides" field,
Deno still emitted a peer dependency mismatch warning for it, even though
the override is the user explicitly choosing that version. The warning was
computed purely from the declared peer range versus the resolved version,
with no awareness of overrides, so there was no way to silence it short of
removing the override.

This treats an override as an authoritative resolution directive: when a
package has a matching entry in "overrides", its peer dependency mismatch
is intentional and is no longer reported. Mismatches for packages that are
not overridden continue to warn as before. The filtering happens at the
single point where the diagnostics are displayed, which already has access
to the parsed overrides via the version resolver.

Closes #32801