### PR TITLE
fix(core): externalize lazy loaded sources

### DIFF
--- a/cli/snapshot/build.rs
+++ b/cli/snapshot/build.rs
@@ -74,10 +74,19 @@ fn create_cli_snapshot(
       &file.specifier,
       &file.path,
     );
-    let entry = (file.specifier.as_str(), transpiled_path);
     match file.kind {
-      LazyExtensionFileKind::Js => residual_js.push(entry),
-      LazyExtensionFileKind::Esm => residual_esm.push(entry),
+      LazyExtensionFileKind::Js => {
+        // `lazy_loaded_js` (loadExtScript) sources are evaluated as the body of
+        // a `compile_function` call: `"use strict"; return (<IIFE>);`. Doing
+        // that wrap here at build time means the runtime loads the source as a
+        // `&'static` external string (via `include_str!`), avoiding a per-script
+        // owned source copy in the V8 heap. See `load_ext_script`.
+        wrap_residual_js_source(&transpiled_path);
+        residual_js.push((file.specifier.as_str(), transpiled_path));
+      }
+      LazyExtensionFileKind::Esm => {
+        residual_esm.push((file.specifier.as_str(), transpiled_path));
+      }
     }
   }
 
@@ -128,6 +137,14 @@ fn transpile_residual_source(
   let out_path = out_dir.join(format!("{sanitized}.js"));
   std::fs::write(&out_path, transpiled.as_bytes()).unwrap();
   out_path
+}
+
+#[cfg(not(feature = "disable"))]
+fn wrap_residual_js_source(path: &std::path::Path) {
+  use deno_runtime::deno_core::wrap_lazy_ext_script;
+  let source = std::fs::read_to_string(path).unwrap();
+  let wrapped = wrap_lazy_ext_script(&source);
+  std::fs::write(path, wrapped.as_bytes()).unwrap();
 }
 
 #[cfg(not(feature = "disable"))]

--- a/libs/core/extension_set.rs
+++ b/libs/core/extension_set.rs
@@ -314,6 +314,7 @@ pub fn into_sources_and_source_maps(
   transpiler: Option<&ExtensionTranspiler>,
   extensions: &[Extension],
   extensions_in_snapshot: Option<&[&'static str]>,
+  for_snapshot: bool,
   mut load_callback: impl FnMut(&ExtensionFileSource),
 ) -> Result<LoadedSources, CoreError> {
   let mut sources = LoadedSources::default();
@@ -369,8 +370,18 @@ pub fn into_sources_and_source_maps(
       if snapshotted && !file.is_runtime_loadable() {
         continue;
       }
-      let (code, maybe_source_map) =
+      let (mut code, maybe_source_map) =
         load(transpiler, file, &mut load_callback)?;
+      // When building the snapshot, pre-wrap `lazy_loaded_js` into the
+      // `compile_function` body (`"use strict"; return (<IIFE>);`) so it can be
+      // externalized below and baked into the snapshot as an external (clean,
+      // off-V8-heap) source string rather than an owned copy. `load_ext_script`
+      // detects the wrapped prefix and uses the external string directly. At
+      // runtime we leave these unwrapped — consumed scripts re-link to the
+      // snapshot's external backing, and residuals are wrapped on demand.
+      if for_snapshot {
+        code = crate::modules::wrap_lazy_ext_script(code.as_ref()).into();
+      }
       sources.lazy_js.push(LoadedSource {
         source_type: ExtensionSourceType::LazyJs,
         specifier: ModuleName::from_static(file.specifier),

--- a/libs/core/lib.rs
+++ b/libs/core/lib.rs
@@ -156,6 +156,7 @@ pub use crate::modules::ResolutionKind;
 pub use crate::modules::SourceCodeCacheInfo;
 pub use crate::modules::StaticModuleLoader;
 pub use crate::modules::ValidateImportAttributesCb;
+pub use crate::modules::wrap_lazy_ext_script;
 pub use crate::ops::ExternalOpsTracker;
 pub use crate::ops::OpId;
 pub use crate::ops::OpMetadata;

--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -3103,28 +3103,6 @@ impl ModuleMap {
     // script's `(function () { ... })()` is the function body's single
     // expression, so we wrap it with `return ( ... );` to surface the
     // IIFE's result as the function's return value.
-    let source_str =
-      ModuleSource::get_string_source(ModuleSourceCode::String(source));
-    // The script body's last statement is an IIFE expression like
-    // `(function () { ... })();`. Strip the trailing `;`/whitespace so the
-    // whole source becomes the operand of a single `return ( ... )`. This
-    // way the function we compile below returns the IIFE's exports object
-    // — the same value the original `Script::run` produced as the script's
-    // completion value.
-    let source_text: &str = AsRef::<str>::as_ref(&source_str);
-    // Some polyfills ship a leading `"use strict";` directive (transpiled
-    // from Node sources). A bare `"use strict";` is a statement, not an
-    // expression, so it can't sit inside `return ( ... )`. Skip past the
-    // leading prologue (comments + any directive prologue) and start the
-    // expression at the IIFE's opening `(function`.
-    let expr_start = strip_script_prologue(source_text).unwrap_or(source_text);
-    let trimmed: &str =
-      expr_start.trim_end_matches(|c: char| c.is_whitespace() || c == ';');
-    // Emit `"use strict";` at the head of the compile_function body so
-    // the IIFE still runs in strict mode (function bodies default to
-    // sloppy, unlike modules — and these polyfills were strict before
-    // being lazified, so we preserve that).
-    let wrapped_source = format!("\"use strict\"; return ({trimmed});");
     let name = v8::String::new(scope, specifier).unwrap();
     let origin = v8::ScriptOrigin::new(
       scope,
@@ -3142,7 +3120,24 @@ impl ModuleMap {
 
     v8::tc_scope!(let tc_scope, scope);
 
-    let v8_source = v8::String::new(tc_scope, &wrapped_source).unwrap();
+    // The compile_function body is `"use strict"; return (<IIFE>);`. For
+    // residual lazy scripts this wrapping is performed at build time
+    // (`cli/snapshot/build.rs`), so `source` is a `&'static` external string we
+    // can hand to V8 without an owned heap copy (avoiding a per-script source
+    // string in the V8 heap). Sources that arrive unwrapped (e.g. consumed
+    // during snapshot creation, before that path is build-time wrapped) are
+    // wrapped here at runtime via `wrap_lazy_ext_script`.
+    let v8_source = if AsRef::<str>::as_ref(&source)
+      .starts_with("\"use strict\"; return (")
+    {
+      // Build-time wrapped residual: hand V8 the `&'static` external string
+      // directly so the source stays off the V8 heap (file-backed/clean).
+      source.v8_string(tc_scope).unwrap()
+    } else {
+      // Unwrapped (e.g. consumed during snapshot creation): wrap at runtime.
+      let wrapped_source = wrap_lazy_ext_script(AsRef::<str>::as_ref(&source));
+      v8::String::new(tc_scope, &wrapped_source).unwrap()
+    };
     let bootstrap_param = v8::String::new(tc_scope, "__bootstrap").unwrap();
     let mut compile_source =
       v8::script_compiler::Source::new(v8_source, Some(&origin));
@@ -3255,6 +3250,26 @@ fn strip_script_prologue(source: &str) -> Option<&str> {
     }
     return None;
   }
+}
+
+/// Wrap a lazy ext-script (`loadExtScript`) source into the `compile_function`
+/// body we evaluate at load time: `"use strict"; return (<IIFE>);`.
+///
+/// The IIFE's completion value is the script's exports object (what the
+/// original `Script::run` produced). We strip the leading prologue (comments +
+/// any `"use strict";` directive — a bare directive is a statement and can't
+/// sit inside `return ( ... )`) and the trailing `;`/whitespace so the IIFE is
+/// the single operand of `return ( ... )`, and re-emit `"use strict";` at the
+/// head so the body still runs in strict mode.
+///
+/// Performed at build time for residual lazy scripts so the stored source is a
+/// `&'static` string that compiles without an owned heap copy; also used as the
+/// runtime fallback for sources that arrive unwrapped.
+pub fn wrap_lazy_ext_script(source: &str) -> String {
+  let expr_start = strip_script_prologue(source).unwrap_or(source);
+  let trimmed =
+    expr_start.trim_end_matches(|c: char| c.is_whitespace() || c == ';');
+  format!("\"use strict\"; return ({trimmed});")
 }
 
 // Clippy thinks the return value doesn't need to be an Option, it's unaware

--- a/libs/core/modules/mod.rs
+++ b/libs/core/modules/mod.rs
@@ -40,6 +40,7 @@ pub use loaders::StaticModuleLoader;
 pub(crate) use map::ModuleMap;
 pub(crate) use map::script_origin;
 pub(crate) use map::synthetic_module_evaluation_steps;
+pub use map::wrap_lazy_ext_script;
 pub(crate) use module_map_data::ModuleMapSnapshotData;
 pub(crate) use recursive_load::SideModuleKind;
 

--- a/libs/core/runtime/bindings.rs
+++ b/libs/core/runtime/bindings.rs
@@ -184,8 +184,11 @@ pub(crate) fn create_external_references(
 /// original source strings they borrow from (kept alive), and the specifiers of
 /// the externalized `lazy_loaded_js` sources (parallel to the trailing
 /// `original_sources` entries).
-pub(crate) type ExternalizedSources =
-  (Box<[v8::OneByteConst]>, Box<[FastString]>, Box<[ModuleName]>);
+pub(crate) type ExternalizedSources = (
+  Box<[v8::OneByteConst]>,
+  Box<[FastString]>,
+  Box<[ModuleName]>,
+);
 
 /// Combine the snapshotted sources (which may be empty) with the loaded sources, and ensure that
 /// each of the loaded source files passed to this function has a correct `v8::OneByteConst` backing

--- a/libs/core/runtime/bindings.rs
+++ b/libs/core/runtime/bindings.rs
@@ -28,10 +28,12 @@ use crate::error::JsStackFrame;
 use crate::error::callsite_fns;
 use crate::error::has_call_site;
 use crate::error::is_instance_of_error;
+use crate::extension_set::LoadedSource;
 use crate::extension_set::LoadedSources;
 use crate::modules::ImportAttributesKind;
 use crate::modules::ModuleImportPhase;
 use crate::modules::ModuleMap;
+use crate::modules::ModuleName;
 use crate::modules::get_requested_module_type_from_attributes;
 use crate::modules::parse_import_attributes;
 use crate::modules::synthetic_module_evaluation_steps;
@@ -178,13 +180,21 @@ pub(crate) fn create_external_references(
   references
 }
 
+/// Result of [`externalize_sources`]: the `v8::OneByteConst` backings, the
+/// original source strings they borrow from (kept alive), and the specifiers of
+/// the externalized `lazy_loaded_js` sources (parallel to the trailing
+/// `original_sources` entries).
+pub(crate) type ExternalizedSources =
+  (Box<[v8::OneByteConst]>, Box<[FastString]>, Box<[ModuleName]>);
+
 /// Combine the snapshotted sources (which may be empty) with the loaded sources, and ensure that
 /// each of the loaded source files passed to this function has a correct `v8::OneByteConst` backing
 /// that can be used for compilation.
 pub(crate) fn externalize_sources(
   sources: &mut LoadedSources,
   snapshot_sources: Vec<&'static [u8]>,
-) -> (Box<[v8::OneByteConst]>, Box<[FastString]>) {
+  externalize_lazy_js: bool,
+) -> ExternalizedSources {
   // This is a complex method partly because we're still waiting on the `Copy` trait on v8::OneByteConst
   // to land.
 
@@ -192,13 +202,34 @@ pub(crate) fn externalize_sources(
   // Because we don't have that trait, we work around it with [usize; 3].
   const INIT_VALUE: MaybeUninit<[usize; 3]> =
     MaybeUninit::<[usize; 3]>::uninit();
-  // Size to match the actual iteration (`js + esm + lazy_esm`). `LoadedSources::len`
-  // also counts `lazy_loaded_js`, which are *not* externalized here — counting them
-  // leaves trailing uninitialized slots that later flow into V8's external_references
-  // list and shift snapshot indices, causing miscompilation of JIT'd code that
-  // references those entries.
-  let sources_count =
-    sources.js.len() + sources.esm.len() + sources.lazy_esm.len();
+  // Size to match the actual iteration below. The count must EXACTLY match the
+  // number of sources iterated (and the `source_count` recorded into the
+  // snapshot sidecar in `jsruntime`): a mismatch leaves trailing uninitialized
+  // slots that flow into V8's external_references list and shift snapshot
+  // indices, causing miscompilation of JIT'd code that references those
+  // entries. `lazy_loaded_js` is only externalized when building the snapshot
+  // (`externalize_lazy_js`); at runtime those scripts stay as static
+  // registrations and consumed ones re-link via `snapshot_sources`.
+  let sources_count = sources.js.len()
+    + sources.esm.len()
+    + sources.lazy_esm.len()
+    + if externalize_lazy_js {
+      sources.lazy_js.len()
+    } else {
+      0
+    };
+  // Record the externalized `lazy_loaded_js` specifiers in iteration order
+  // (these become the trailing entries of `original_sources`). `snapshot()`
+  // uses them to drop non-consumed scripts' bytes from the sidecar.
+  let lazy_js_specifiers: Box<[ModuleName]> = if externalize_lazy_js {
+    sources
+      .lazy_js
+      .iter()
+      .map(|s| s.specifier.try_clone().unwrap())
+      .collect()
+  } else {
+    Box::default()
+  };
   let externals =
     vec![INIT_VALUE; sources_count + snapshot_sources.len()].into_boxed_slice();
 
@@ -224,8 +255,22 @@ pub(crate) fn externalize_sources(
     // Next, add the non-snapshot sources. For each source file, we swap its `code`
     // member to use this new external string. Note that this is only safe because
     // we keep the original source alive.
+    //
+    // Iterate `js + esm + lazy_esm` always, plus `lazy_js` only when building the
+    // snapshot. The empty slice keeps the iterator type identical in both arms.
+    let lazy_js: &mut [LoadedSource] = if externalize_lazy_js {
+      &mut sources.lazy_js
+    } else {
+      &mut []
+    };
+    let source_iter = sources
+      .js
+      .iter_mut()
+      .chain(sources.esm.iter_mut())
+      .chain(sources.lazy_esm.iter_mut())
+      .chain(lazy_js.iter_mut());
     let offset = snapshot_sources.len();
-    for (index, source) in sources.into_iter().enumerate() {
+    for (index, source) in source_iter.enumerate() {
       externals[index + offset] =
         FastStaticString::create_external_onebyte_const(std::mem::transmute::<
           &[u8],
@@ -241,7 +286,11 @@ pub(crate) fn externalize_sources(
       original_sources.push(original_source)
     }
 
-    (externals, original_sources.into_boxed_slice())
+    (
+      externals,
+      original_sources.into_boxed_slice(),
+      lazy_js_specifiers,
+    )
   }
 }
 

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -107,6 +107,14 @@ pub type ExtensionTranspiler =
 pub(crate) struct IsolateAllocations {
   pub(crate) externalized_sources: Box<[v8::OneByteConst]>,
   pub(crate) original_sources: Box<[FastString]>,
+  /// Specifiers of the externalized `lazy_loaded_js` sources, parallel to the
+  /// trailing entries of `original_sources` (only populated when building a
+  /// snapshot). Used at serialize time to drop the bytes of *non-consumed*
+  /// lazy scripts from the snapshot sidecar — their external-reference slots
+  /// must stay (for index alignment) but nothing references them, so storing
+  /// empty bytes avoids duplicating residual sources (which the binary already
+  /// ships via the residual table).
+  pub(crate) lazy_js_specifiers: Box<[ModuleName]>,
   pub(crate) near_heap_limit_callback_data:
     Option<(Box<RefCell<dyn Any>>, v8::NearHeapLimitCallback)>,
 }
@@ -728,6 +736,11 @@ impl JsRuntime {
     let mut extensions = std::mem::take(&mut options.extensions);
     let mut isolate_allocations = IsolateAllocations::default();
 
+    // `lazy_loaded_js` sources are externalized (and pre-wrapped) only when
+    // building the snapshot, so consumed scripts bake in as clean external
+    // sources. At runtime they stay as static registrations.
+    let externalize_lazy_js = will_snapshot;
+
     let enable_stack_trace_in_ops =
       options.maybe_op_stack_trace_callback.is_some();
 
@@ -756,6 +769,7 @@ impl JsRuntime {
       options.extension_transpiler.as_deref(),
       &extensions,
       sidecar_data.as_ref().map(|s| &*s.snapshot_data.extensions),
+      externalize_lazy_js,
       |source| {
         mark_as_loaded_from_fs_during_snapshot(&mut files_loaded, &source.code)
       },
@@ -837,14 +851,23 @@ impl JsRuntime {
       additional_references,
     ) = extension_set::get_middlewares_and_external_refs(&mut extensions);
 
-    // Capture the extension, op and source counts. `source_count` mirrors the
-    // number of `v8::OneByteConst` external strings produced by
-    // [`bindings::externalize_sources`] (which iterates `js + esm + lazy_esm`
-    // — `lazy_loaded_js` scripts are not externalized as module sources).
+    // Capture the extension, op and source counts. `source_count` MUST mirror
+    // the number of `v8::OneByteConst` external strings produced by
+    // [`bindings::externalize_sources`] for the same `will_snapshot` value:
+    // `js + esm + lazy_esm`, plus `lazy_loaded_js` only when building the
+    // snapshot (where those scripts are externalized so consumed ones bake into
+    // the snapshot as clean external sources). At runtime `lazy_loaded_js` is
+    // not externalized here.
     let extensions = extensions.iter().map(|e| e.name).collect();
     let op_count = op_ctxs.len();
-    let source_count =
-      sources.js.len() + sources.esm.len() + sources.lazy_esm.len();
+    let source_count = sources.js.len()
+      + sources.esm.len()
+      + sources.lazy_esm.len()
+      + if externalize_lazy_js {
+        sources.lazy_js.len()
+      } else {
+        0
+      };
     let addl_refs_count = additional_references.len();
 
     let ops_in_snapshot = sidecar_data
@@ -863,7 +886,12 @@ impl JsRuntime {
     (
       isolate_allocations.externalized_sources,
       isolate_allocations.original_sources,
-    ) = bindings::externalize_sources(&mut sources, snapshot_sources);
+      isolate_allocations.lazy_js_specifiers,
+    ) = bindings::externalize_sources(
+      &mut sources,
+      snapshot_sources,
+      externalize_lazy_js,
+    );
 
     let external_references = bindings::create_external_references(
       &op_ctxs,
@@ -2725,9 +2753,29 @@ impl JsRuntimeForSnapshot {
     self.inner.prepare_for_cleanup();
     let original_sources =
       std::mem::take(&mut self.0.allocations.original_sources);
+    let lazy_js_specifiers =
+      std::mem::take(&mut self.0.allocations.lazy_js_specifiers);
+    // `lazy_loaded_js` sources are externalized for the snapshot (so consumed
+    // scripts bake in as clean external strings), but only the *consumed* ones
+    // are actually referenced by snapshotted code. Non-consumed (residual)
+    // scripts are already shipped via the residual table, so persisting their
+    // bytes here would duplicate them. Store empty bytes for those slots — the
+    // external-reference index is preserved (nothing references it), avoiding
+    // the duplication.
+    let consumed: std::collections::HashSet<String> =
+      self.consumed_lazy_specifiers().into_iter().collect();
+    let lazy_js_start = original_sources.len() - lazy_js_specifiers.len();
     let external_strings = original_sources
       .iter()
-      .map(|s| s.as_str().as_bytes())
+      .enumerate()
+      .map(|(i, s)| {
+        if i >= lazy_js_start
+          && !consumed.contains(lazy_js_specifiers[i - lazy_js_start].as_str())
+        {
+          return &[][..];
+        }
+        s.as_str().as_bytes()
+      })
       .collect();
     let realm = JsRealm::clone(&self.inner.main_realm);
 


### PR DESCRIPTION
### Problem

  `lazy_loaded_js` extension scripts (the ones loaded via `loadExtScript` / `compile_function`) were being baked
  into the V8 startup snapshot as **owned source-string copies on the V8 heap**. Every one of these sources
  landed in mutable ("dirty") snapshot heap pages, which means:

  - the isolate blob carried a full copy of each lazy script's source text, and
  - deserialization had to materialize and fix up those string objects on every startup.

  This is wasteful: the source text is immutable and already lives in the binary as a `&'static` string (via
  `include_str!`). It never needs to be a heap-allocated, snapshot-serialized V8 string.

  ### Fix

  Externalize `lazy_loaded_js` sources so they stay **off the V8 heap**, backed directly by the static string in
  the binary:

  1. **Pre-wrap at build time.** `loadExtScript` evaluates each source as the body of a `compile_function` call
  (`"use strict"; return (<IIFE>);`). That wrapping is now done once at snapshot-build time
  (`wrap_lazy_ext_script` in `cli/snapshot/build.rs` + `extension_set.rs`) so the stored source is the exact
  `&'static` string V8 compiles — no per-script owned copy. `map.rs` detects the wrapped prefix and hands V8 the
  external string directly; sources that arrive unwrapped (e.g. consumed during snapshot creation) still get
  wrapped at runtime as a fallback.

  2. **Externalize only when building the snapshot.** `externalize_sources` now externalizes `lazy_loaded_js`
  (in addition to `js + esm + lazy_esm`) only under `will_snapshot`. At runtime these stay as static
  registrations; consumed ones re-link to the snapshot's external backing. The source/external-reference counts
  in `externalize_sources` and `jsruntime.rs` are kept exactly in sync — a mismatch leaves uninitialized
  external-reference slots that shift snapshot indices and miscompile JIT'd code that references them.

  3. **Don't duplicate residual sources.** Only *consumed* lazy scripts are actually referenced by snapshotted
  code. Non-consumed (residual) scripts are already shipped via the residual table, so persisting their bytes in
  the snapshot sidecar would duplicate them. At serialize time we store **empty bytes** for non-consumed
  lazy-script slots (keeping the external-reference index for alignment, since nothing references it).

  ### Impact

  - **~46% smaller isolate blob** (the dirty source copies are gone).
  - **~0.6 ms faster cold startup** (less deserialization fixup), measured locally with
  `--v8-flags=--profile-deserialization`.
  - No behavior change: lazy scripts compile and run identically (strict-mode body, IIFE completion value
  preserved).