### PR TITLE
fix(bundle): apply node-style CJS interop on all platforms

### DIFF
--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -775,7 +775,7 @@ var __require = __deno_internal_createRequire(import.meta.url);
 }
 
 // Force esbuild's CommonJS-to-ESM interop helper (`__toESM`) into "node mode"
-// for the Deno platform.
+// for every platform.
 //
 // esbuild emits a node-mode interop call (`__toESM(require_x(), 1)`) only when
 // it can tell the importing module is *explicitly* ESM (a `.mjs`/`.mts` file or
@@ -787,10 +787,12 @@ var __require = __deno_internal_createRequire(import.meta.url);
 //
 // For packages whose ESM wrapper default-imports a CJS entry that sets
 // `module.exports.__esModule = true` (e.g. tslib's `modules/index.js`), that
-// means `import_x.default` ends up undefined and module init throws. Deno's own
-// runtime always uses node-style interop here, so the bundle should too. We
-// rewrite the helper's `<isNodeMode> || !mod || !mod.__esModule` condition to
-// always pick the node-mode branch. See denoland/deno#34524.
+// means `import_x.default` ends up undefined and module init throws. This is a
+// property of how the source module resolves its default import (Node interop
+// semantics, which is what such packages are authored against), not of the
+// runtime target, so it applies regardless of `--platform`. We rewrite the
+// helper's `<isNodeMode> || !mod || !mod.__esModule` condition to always pick
+// the node-mode branch. See denoland/deno#34524 and denoland/deno#34837.
 //
 // The variable names differ between minified and non-minified output, but the
 // `.__esModule` access and surrounding shape are stable, so a single regex
@@ -2160,11 +2162,15 @@ pub fn maybe_process_contents(
   let is_js = is_js(path) || path.ends_with("<stdout>");
   if is_js {
     let string = str::from_utf8(&file.contents)?;
+    // The `createRequire` shim is Deno-specific (it injects an import from
+    // `node:module`), so it is only applied for the Deno platform. The CJS
+    // interop fix-up below is platform-independent and always runs.
     let string = if should_replace_require_shim {
-      force_node_cjs_interop(&replace_require_shim(string, minified))
+      replace_require_shim(string, minified)
     } else {
       string.to_string()
     };
+    let string = force_node_cjs_interop(&string);
     Ok(ProcessedContents {
       contents: Some(string.into_bytes()),
       is_js,

--- a/tests/specs/bundle/cjs_esm_default_interop/__test__.jsonc
+++ b/tests/specs/bundle/cjs_esm_default_interop/__test__.jsonc
@@ -1,10 +1,13 @@
 {
-  // Regression test for https://github.com/denoland/deno/issues/34524
+  // Regression test for https://github.com/denoland/deno/issues/34524 and
+  // https://github.com/denoland/deno/issues/34837
   //
   // A dual CJS/ESM package whose ESM entry default-imports a CJS entry that
   // sets `module.exports.__esModule = true` (the shape tslib ships). The
   // bundle must use node-style CJS interop so the default import is the whole
-  // `module.exports`, matching how `deno run` executes the same files.
+  // `module.exports`, matching how `deno run` executes the same files. This
+  // must hold regardless of `--platform` (#34837), since it reflects how the
+  // source resolves its default import, not the runtime target.
   "tempDir": true,
   "tests": {
     "bundle": {
@@ -27,6 +30,30 @@
         },
         {
           "args": "run -A out.min.js",
+          "output": "out.out"
+        }
+      ]
+    },
+    "bundle_browser": {
+      "steps": [
+        {
+          "args": "bundle --quiet --platform browser -o out.browser.js entry.mjs",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run -A out.browser.js",
+          "output": "out.out"
+        }
+      ]
+    },
+    "bundle_browser_minified": {
+      "steps": [
+        {
+          "args": "bundle --quiet --minify --platform browser -o out.browser.min.js entry.mjs",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run -A out.browser.min.js",
           "output": "out.out"
         }
       ]


### PR DESCRIPTION
`deno bundle --platform=browser` miscompiled imports of dual CJS/ESM
packages whose ESM entry default-imports a CJS entry that sets
`module.exports.__esModule = true`. `tslib`'s `modules/index.js` is the
canonical example. The generated bundle threw at module-init time with
`TypeError: Cannot destructure property '__extends' of 'Opt.default' as
it is undefined`, even though the same code runs fine under `deno run`
and under `--platform=deno`.

This is the same root cause as #34524, which was fixed in #34533 by
rewriting esbuild's `__toESM` interop helper into "node mode" (so the
default import resolves to the whole `module.exports` rather than to a
synthesized `.default` that the `__esModule` marker suppresses). That
fix, however, was gated behind `should_replace_require_shim`, which only
returns true for `--platform=deno`, so the browser platform never
received it.

The `createRequire` shim genuinely is Deno-specific, since it injects an
import from `node:module` that a browser bundle must not contain. The
node-style CJS interop fix-up is not: it reflects how the source module
resolves its default import of a CJS entry (Node interop semantics, which
is what these packages are authored against), and that is a property of
the importing module, not of the runtime target. This decouples the two
so `force_node_cjs_interop` runs for every platform while
`replace_require_shim` stays Deno-only.

The existing `cjs_esm_default_interop` spec test gains `bundle_browser`
and `bundle_browser_minified` variants covering the `--platform=browser`
path.

Fixes #34837.
