### PR TITLE
fix(clean): keep cleaning when cache files are locked and report holders

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -185,7 +185,7 @@ zip = { workspace = true, features = ["deflate-flate2"] }
 zstd.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Threading"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_RestartManager", "Win32_System_Threading"] }
 deno_subprocess_windows.workspace = true
 
 [target.'cfg(unix)'.dependencies]

--- a/cli/tools/clean.rs
+++ b/cli/tools/clean.rs
@@ -78,10 +78,75 @@ pub async fn clean(
 
     if clean_flags.dry_run {
       log::info!("{}", colors::yellow("Aborting due to --dry-run flag"));
+    } else {
+      report_locked_files(&cleaner.failed);
     }
   }
 
   Ok(())
+}
+
+/// Warns about cache files that could not be removed because another process is
+/// holding them open. On Windows this resolves the offending process(es) via
+/// the Restart Manager and points the user at a running Deno language server,
+/// which is the most common cause (see issue #33903).
+fn report_locked_files(failed: &[(PathBuf, std::io::Error)]) {
+  if failed.is_empty() {
+    return;
+  }
+  let paths = failed
+    .iter()
+    .map(|(path, _)| path.clone())
+    .collect::<Vec<_>>();
+  let processes = crate::util::windows::processes_locking_files(&paths);
+  log::warn!("{}", format_locked_files_message(&paths, &processes));
+}
+
+fn format_locked_files_message(
+  paths: &[PathBuf],
+  processes: &[crate::util::windows::LockingProcess],
+) -> String {
+  const MAX_LISTED: usize = 10;
+  let mut message = format!(
+    "{} could not be removed because they are in use by another process:",
+    if paths.len() == 1 {
+      "1 file".to_string()
+    } else {
+      format!("{} files", paths.len())
+    }
+  );
+  for path in paths.iter().take(MAX_LISTED) {
+    message.push_str(&format!("\n  {}", path.display()));
+  }
+  if paths.len() > MAX_LISTED {
+    message.push_str(&format!("\n  ... and {} more", paths.len() - MAX_LISTED));
+  }
+
+  if processes.is_empty() {
+    message.push_str(
+      "\n\nThis is usually an editor running the Deno language server holding \
+       the cache open. Close it (or any running `deno` process) and run `deno \
+       clean` again.",
+    );
+  } else {
+    message.push_str("\n\nHeld open by:");
+    for process in processes {
+      let label = match &process.exe {
+        Some(exe) => exe.display().to_string(),
+        None => process.name.clone(),
+      };
+      let hint = if process.is_deno {
+        " (a running Deno process, likely the language server in your editor)"
+      } else {
+        ""
+      };
+      message.push_str(&format!("\n  {} (PID {}){}", label, process.pid, hint));
+    }
+    message
+      .push_str("\n\nClose the process(es) above and run `deno clean` again.");
+  }
+
+  message
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -401,6 +466,11 @@ async fn clean_except(
     if let Some(dir) = options.vendor_dir_path() {
       log_stats(&vendor_cleaned, dir);
     }
+
+    let mut failed = state.failed;
+    failed.extend(node_modules_cleaned.failed);
+    failed.extend(vendor_cleaned.failed);
+    report_locked_files(&failed);
   }
 
   Ok(())
@@ -613,8 +683,61 @@ fn clean_node_modules(
 #[cfg(test)]
 mod tests {
   use std::path::Path;
+  use std::path::PathBuf;
 
   use super::Found::*;
+  use super::format_locked_files_message;
+  use crate::util::windows::LockingProcess;
+
+  #[test]
+  fn locked_files_message_without_processes() {
+    let paths = vec![PathBuf::from("/deno/dep_analysis_cache_v2")];
+    let message = format_locked_files_message(&paths, &[]);
+    assert!(message.starts_with(
+      "1 file could not be removed because they are in use by another process:"
+    ));
+    assert!(message.contains("dep_analysis_cache_v2"));
+    assert!(message.contains("Deno language server"));
+  }
+
+  #[test]
+  fn locked_files_message_lists_holding_processes() {
+    let paths = vec![
+      PathBuf::from("/deno/dep_analysis_cache_v2"),
+      PathBuf::from("/deno/node_analysis_cache_v2"),
+    ];
+    let processes = vec![
+      LockingProcess {
+        pid: 1234,
+        name: "deno".to_string(),
+        exe: Some(PathBuf::from("C:/Program Files/deno/deno.exe")),
+        is_deno: true,
+      },
+      LockingProcess {
+        pid: 5678,
+        name: "Some Editor".to_string(),
+        exe: None,
+        is_deno: false,
+      },
+    ];
+    let message = format_locked_files_message(&paths, &processes);
+    assert!(message.starts_with("2 files could not be removed"));
+    assert!(message.contains("Held open by:"));
+    assert!(message.contains("deno.exe (PID 1234)"));
+    assert!(message.contains("likely the language server"));
+    assert!(message.contains("Some Editor (PID 5678)"));
+    assert!(message.contains("Close the process(es) above"));
+  }
+
+  #[test]
+  fn locked_files_message_truncates_long_lists() {
+    let paths = (0..15)
+      .map(|i| PathBuf::from(format!("/deno/file_{i}")))
+      .collect::<Vec<_>>();
+    let message = format_locked_files_message(&paths, &[]);
+    assert!(message.starts_with("15 files could not be removed"));
+    assert!(message.contains("... and 5 more"));
+  }
 
   #[test]
   fn path_trie() {

--- a/cli/util/fs.rs
+++ b/cli/util/fs.rs
@@ -184,6 +184,11 @@ pub struct FsCleaner {
   pub files_removed: u64,
   pub dirs_removed: u64,
   pub bytes_removed: u64,
+  /// Paths that could not be removed, along with the error encountered. The
+  /// cleaner is best-effort: a single locked or read-only file (for example a
+  /// cache database held open by a running Deno process) should not abort the
+  /// entire clean, so failures are collected here and reported afterwards.
+  pub failed: Vec<(PathBuf, std::io::Error)>,
   pub progress_guard: Option<UpdateGuard>,
 }
 
@@ -193,6 +198,7 @@ impl FsCleaner {
       files_removed: 0,
       dirs_removed: 0,
       bytes_removed: 0,
+      failed: Vec::new(),
       progress_guard,
     }
   }
@@ -201,12 +207,29 @@ impl FsCleaner {
     let sys = CliSys::default();
     let sys = sys.with_paths_in_errors();
     for entry in walkdir::WalkDir::new(path).contents_first(true) {
-      let entry = entry.map_err(std::io::Error::other)?;
+      let entry = match entry {
+        Ok(entry) => entry,
+        Err(err) => {
+          // Record the path we failed to walk (e.g. permission denied) and
+          // keep going so the rest of the tree is still cleaned.
+          if let Some(path) = err.path().map(Path::to_path_buf) {
+            let err = err
+              .into_io_error()
+              .unwrap_or_else(|| std::io::Error::other("failed to walk path"));
+            self.failed.push((path, err));
+          }
+          continue;
+        }
+      };
 
       if entry.file_type().is_dir() {
-        self.dirs_removed += 1;
+        // A directory only fails to be removed when one of its children could
+        // not be removed, which we already record below, so swallow the error
+        // here rather than reporting the same cause twice.
+        if sys.fs_remove_dir_all(entry.path()).is_ok() {
+          self.dirs_removed += 1;
+        }
         self.update_progress();
-        sys.fs_remove_dir_all(entry.path())?;
       } else {
         self.remove_file(entry.path(), entry.metadata().ok())?;
       }
@@ -239,12 +262,22 @@ impl FsCleaner {
     path: &Path,
     meta: Option<std::fs::Metadata>,
   ) -> Result<(), std::io::Error> {
-    if let Some(meta) = meta {
-      self.bytes_removed += meta.len();
+    match remove_file_or_symlink(&CliSys::default(), path) {
+      Ok(()) => {
+        if let Some(meta) = meta {
+          self.bytes_removed += meta.len();
+        }
+        self.files_removed += 1;
+        self.update_progress();
+        Ok(())
+      }
+      Err(err) => {
+        // Best-effort: keep cleaning the rest of the cache and surface the
+        // locked path to the user afterwards.
+        self.failed.push((path.to_path_buf(), err));
+        Ok(())
+      }
     }
-    self.files_removed += 1;
-    self.update_progress();
-    remove_file_or_symlink(&CliSys::default(), path)
   }
 
   fn update_progress(&self) {

--- a/cli/util/windows.rs
+++ b/cli/util/windows.rs
@@ -1,5 +1,184 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+use std::path::PathBuf;
+
+/// A process that currently holds an open handle to one of the files we tried
+/// to remove. Used to give the user an actionable message (for example, that a
+/// running Deno language server is keeping cache files locked) when `deno
+/// clean` cannot delete part of the cache on Windows.
+pub struct LockingProcess {
+  pub pid: u32,
+  /// Friendly application name as reported by the Restart Manager.
+  pub name: String,
+  /// Full path to the process image, when it could be resolved.
+  pub exe: Option<PathBuf>,
+  /// Whether the process image looks like a `deno` executable.
+  pub is_deno: bool,
+}
+
+/// Returns the processes that currently hold open handles to any of `paths`.
+///
+/// This is only meaningful on Windows, where an open file cannot be deleted; on
+/// other platforms open files can be unlinked, so this always returns an empty
+/// list.
+#[cfg(not(windows))]
+pub fn processes_locking_files(_paths: &[PathBuf]) -> Vec<LockingProcess> {
+  Vec::new()
+}
+
+/// Returns the processes that currently hold open handles to any of `paths`,
+/// using the Windows Restart Manager. Returns an empty list on any failure so
+/// callers can degrade gracefully.
+#[cfg(windows)]
+pub fn processes_locking_files(paths: &[PathBuf]) -> Vec<LockingProcess> {
+  use std::os::windows::ffi::OsStrExt;
+
+  use windows_sys::Win32::Foundation::ERROR_MORE_DATA;
+  use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+  use windows_sys::Win32::System::RestartManager::CCH_RM_SESSION_KEY;
+  use windows_sys::Win32::System::RestartManager::RM_PROCESS_INFO;
+  use windows_sys::Win32::System::RestartManager::RmEndSession;
+  use windows_sys::Win32::System::RestartManager::RmGetList;
+  use windows_sys::Win32::System::RestartManager::RmRegisterResources;
+  use windows_sys::Win32::System::RestartManager::RmStartSession;
+
+  if paths.is_empty() {
+    return Vec::new();
+  }
+
+  // SAFETY: Win32 Restart Manager calls. The session is always closed with
+  // RmEndSession before returning, and all buffers passed to the API outlive
+  // the calls that use them.
+  unsafe {
+    let mut session: u32 = 0;
+    let mut session_key = [0u16; CCH_RM_SESSION_KEY as usize + 1];
+    if RmStartSession(&mut session, 0, session_key.as_mut_ptr())
+      != ERROR_SUCCESS
+    {
+      return Vec::new();
+    }
+
+    // Wide, null-terminated copies of the file names. These must stay alive for
+    // the RmRegisterResources call below, which borrows pointers into them.
+    let wide_paths: Vec<Vec<u16>> = paths
+      .iter()
+      .map(|path| {
+        path
+          .as_os_str()
+          .encode_wide()
+          .chain(std::iter::once(0))
+          .collect()
+      })
+      .collect();
+    let file_ptrs: Vec<*const u16> =
+      wide_paths.iter().map(|w| w.as_ptr()).collect();
+
+    let registered = RmRegisterResources(
+      session,
+      file_ptrs.len() as u32,
+      file_ptrs.as_ptr(),
+      0,
+      std::ptr::null(),
+      0,
+      std::ptr::null(),
+    );
+    if registered != ERROR_SUCCESS {
+      RmEndSession(session);
+      return Vec::new();
+    }
+
+    // First call discovers how many processes hold the resources.
+    let mut needed: u32 = 0;
+    let mut have: u32 = 0;
+    let mut reboot_reasons: u32 = 0;
+    let status = RmGetList(
+      session,
+      &mut needed,
+      &mut have,
+      std::ptr::null_mut(),
+      &mut reboot_reasons,
+    );
+    if (status != ERROR_SUCCESS && status != ERROR_MORE_DATA) || needed == 0 {
+      RmEndSession(session);
+      return Vec::new();
+    }
+
+    // Second call fills a buffer sized for the reported number of processes.
+    let mut infos: Vec<RM_PROCESS_INFO> = Vec::with_capacity(needed as usize);
+    have = needed;
+    let status = RmGetList(
+      session,
+      &mut needed,
+      &mut have,
+      infos.as_mut_ptr(),
+      &mut reboot_reasons,
+    );
+
+    let mut result = Vec::new();
+    if status == ERROR_SUCCESS {
+      infos.set_len(have as usize);
+      for info in &infos {
+        let pid = info.Process.dwProcessId;
+        let name = wide_to_string(&info.strAppName);
+        let exe = process_image_path(pid);
+        let is_deno = exe.as_deref().is_some_and(is_deno_exe);
+        result.push(LockingProcess {
+          pid,
+          name,
+          exe,
+          is_deno,
+        });
+      }
+    }
+
+    RmEndSession(session);
+    result
+  }
+}
+
+#[cfg(windows)]
+fn wide_to_string(buf: &[u16]) -> String {
+  let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+  String::from_utf16_lossy(&buf[..len])
+}
+
+#[cfg(windows)]
+fn is_deno_exe(path: &std::path::Path) -> bool {
+  path
+    .file_stem()
+    .and_then(|stem| stem.to_str())
+    .is_some_and(|stem| stem.eq_ignore_ascii_case("deno"))
+}
+
+/// Resolves the full image path for a process id, or `None` if it cannot be
+/// queried (for example, the process exited or access was denied).
+#[cfg(windows)]
+fn process_image_path(pid: u32) -> Option<PathBuf> {
+  use std::ffi::OsString;
+  use std::os::windows::ffi::OsStringExt;
+
+  use windows_sys::Win32::Foundation::CloseHandle;
+  use windows_sys::Win32::System::Threading::OpenProcess;
+  use windows_sys::Win32::System::Threading::PROCESS_QUERY_LIMITED_INFORMATION;
+  use windows_sys::Win32::System::Threading::QueryFullProcessImageNameW;
+
+  // SAFETY: Win32 calls. The opened handle is always closed before returning.
+  unsafe {
+    let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+    if handle.is_null() {
+      return None;
+    }
+    let mut buf = [0u16; 1024];
+    let mut size = buf.len() as u32;
+    let ok = QueryFullProcessImageNameW(handle, 0, buf.as_mut_ptr(), &mut size);
+    CloseHandle(handle);
+    if ok == 0 {
+      return None;
+    }
+    Some(PathBuf::from(OsString::from_wide(&buf[..size as usize])))
+  }
+}
+
 /// Ensures that stdin, stdout, and stderr are open and have valid HANDLEs
 /// associated with them. There are many places where a `std::fs::File` is
 /// constructed from a stdio handle; if the handle is null this causes a panic.

--- a/ext/webgpu/lib.rs
+++ b/ext/webgpu/lib.rs
@@ -61,6 +61,8 @@ pub fn print_linker_flags(name: &str) {
       // debugging/diagnostics (only needed on panic/crash)
       "dbghelp",
       "psapi",
+      // restart manager (only needed on the `deno clean` locked-file path)
+      "rstrtmgr",
     ];
     for dll in dlls {
       println!("cargo:rustc-link-arg-bin={name}=/delayload:{dll}.dll");

--- a/tests/specs/build/windows_delay_loaded_dlls/output.out
+++ b/tests/specs/build/windows_delay_loaded_dlls/output.out
@@ -13,6 +13,7 @@ ntdll.dll: eager
 oleaut32.dll: delay
 opengl32.dll: delay
 psapi.dll: delay
+rstrtmgr.dll: delay
 setupapi.dll: delay
 shell32.dll: eager
 user32.dll: eager


### PR DESCRIPTION
On Windows an open file cannot be deleted, which means `deno clean` would
abort partway through with a file-locking error whenever another Deno process
held one of the cache databases open. The most common trigger is the Deno
language server spawned by the VS Code extension: it eagerly opens the SQLite
caches under `DENO_DIR` (`dep_analysis_cache_v2`, `node_analysis_cache_v2`,
and others) and keeps the handles open for its whole lifetime, so running
`deno clean` from the integrated terminal fails until the editor is closed.
The failure is intermittent because the language server only opens some of
those caches lazily, after it has analyzed dependencies. This does not occur
on Unix, where an open file can still be unlinked.

This makes the cleaner best-effort instead of fail-fast. Per-file and
per-directory removal errors are collected rather than propagated, so the rest
of the cache is still removed even when a few files are locked. After the walk
completes, a warning lists the files that could not be removed.

On Windows the warning is enriched using the Restart Manager API
(`RmStartSession` / `RmRegisterResources` / `RmGetList`) to resolve which
process(es) currently hold the locked files open. Each holder's image path is
resolved via `QueryFullProcessImageNameW`, and holders that are a `deno`
executable are called out as the likely cause (the language server running in
an editor), so the message tells the user exactly what to close. The lookup
runs only on the failure path and is gated to Windows; on other platforms the
helper returns an empty list and the generic message is shown.

Closes #33903