### PR TITLE
feat(ext/node): notify control socket when node:http server starts serving

### DIFF
--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -111,6 +111,7 @@ const { enqueueNodePerformanceEntry, hasNodeObserverForType } = core
   );
 import {
   applyAddressOverride,
+  notifyAddressOverrideServing,
   startOverrideListener,
 } from "ext:deno_node/internal/http/address_override.js";
 const {
@@ -1446,6 +1447,7 @@ Server.prototype.listen = function listen(...args) {
       }
       const rewritten = [{ host: applied.host, port: applied.port }];
       if (cb) ArrayPrototypePush(rewritten, cb);
+      this.once("listening", notifyAddressOverrideServing);
       return FunctionPrototypeApply(
         net.Server.prototype.listen,
         this,

--- a/ext/node/polyfills/https.ts
+++ b/ext/node/polyfills/https.ts
@@ -60,7 +60,11 @@ const { Buffer } = core.loadExtScript("ext:deno_node/internal/buffer.mjs");
 const tls = lazyTls().default;
 const net = lazyNet();
 const http = lazyHttp();
-const { applyAddressOverride, startOverrideListener } = lazyAddressOverride();
+const {
+  applyAddressOverride,
+  notifyAddressOverrideServing,
+  startOverrideListener,
+} = lazyAddressOverride();
 const { _connectionListener, ClientRequest, ServerImpl: HttpServer } = http;
 
 function getExtraCACertificates() {
@@ -151,6 +155,7 @@ Server.prototype.listen = function listen(this: any, ...args: any[]) {
       }
       const rewritten: any[] = [{ host: applied.host, port: applied.port }];
       if (cb) ArrayPrototypePush(rewritten, cb);
+      this.once("listening", notifyAddressOverrideServing);
       return FunctionPrototypeApply(
         net.Server.prototype.listen,
         this,

--- a/ext/node/polyfills/internal/http/address_override.js
+++ b/ext/node/polyfills/internal/http/address_override.js
@@ -17,7 +17,10 @@
 // Duplex wrapper around the Deno.Conn.
 
 import { core, primordials } from "ext:core/mod.js";
-import { op_http_serve_address_override } from "ext:core/ops";
+import {
+  op_http_notify_serving,
+  op_http_serve_address_override,
+} from "ext:core/ops";
 
 import { Buffer } from "node:buffer";
 import { Duplex } from "node:stream";
@@ -59,6 +62,10 @@ function peekOverride() {
 // Mark the override as consumed. Subsequent servers see no override.
 function consumeOverride() {
   addressOverrideConsumed = true;
+}
+
+function notifyAddressOverrideServing() {
+  op_http_notify_serving();
 }
 
 // Translate an override record into the argument for denoListen().
@@ -271,6 +278,7 @@ function startOverrideListener(server, override, connectionListener) {
   }
 
   server[kOverrideListener] = denoListener;
+  notifyAddressOverrideServing();
 
   (async () => {
     try {
@@ -337,4 +345,8 @@ function applyAddressOverride() {
   return { mode: "override-only", override };
 }
 
-export { applyAddressOverride, startOverrideListener };
+export {
+  applyAddressOverride,
+  notifyAddressOverrideServing,
+  startOverrideListener,
+};

--- a/tests/specs/run/unconfigured/main.out
+++ b/tests/specs/run/unconfigured/main.out
@@ -3,3 +3,7 @@ hello world
 EVENT: "Serving"
 
 [Object: null prototype] { success: true, code: 0, signal: null }
+node listening
+NODE EVENT: "Serving"
+
+[Object: null prototype] { success: true, code: 0, signal: null }

--- a/tests/specs/run/unconfigured/main.ts
+++ b/tests/specs/run/unconfigured/main.ts
@@ -54,3 +54,68 @@ const n = await sock.read(buf);
 console.log("EVENT:", new TextDecoder().decode(buf.subarray(0, n)));
 
 console.log(await child.status);
+
+const nodeSockPath = `${tempDirPath}/node-control.sock`;
+const nodeOverrideSockPath = `${tempDirPath}/node-override.sock`;
+const nodeTestPath = `${tempDirPath}/node_test.ts`;
+
+const nodeCommand = new Deno.Command(Deno.execPath(), {
+  env: {
+    DENO_UNSTABLE_CONTROL_SOCK: `unix:${nodeSockPath}`,
+  },
+});
+
+const nodeChild = nodeCommand.spawn();
+
+i = 0;
+while (true) {
+  try {
+    await Deno.lstat(nodeSockPath);
+    break;
+  } catch {}
+
+  i += 1;
+  if (i > 100) {
+    throw new Error(`${nodeSockPath} did not exist`);
+  }
+
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+const nodeSock = await Deno.connect({
+  transport: "unix",
+  path: nodeSockPath,
+});
+
+Deno.writeTextFileSync(
+  nodeTestPath,
+  `
+import http from "node:http";
+const server = http.createServer((_req, res) => res.end("ok"));
+server.listen(0, () => {
+  console.log("node listening");
+  server.close();
+});
+`,
+);
+
+const nodeData = JSON.stringify({
+  cwd: tempDirPath,
+  args: ["run", "-A", "node_test.ts"],
+  env: [
+    ["DENO_AUTO_SERVE", "1"],
+    ["DENO_SERVE_ADDRESS", `duplicate,unix:${nodeOverrideSockPath}`],
+  ],
+});
+
+await nodeSock.write(new TextEncoder().encode(nodeData + "\n"));
+
+const nodeBuf = new Uint8Array(128);
+const nodeN = await nodeSock.read(nodeBuf);
+
+console.log(
+  "NODE EVENT:",
+  new TextDecoder().decode(nodeBuf.subarray(0, nodeN)),
+);
+
+console.log(await nodeChild.status);


### PR DESCRIPTION
Upstream PR #34662 landed the `DENO_SERVE_ADDRESS` override for
`node:http`/`node:https`, and PR #34676 wired `Deno.serve()` to call
`op_http_notify_serving()` so that `DENO_AUTO_SERVE` setups can wait for a
"Serving" event over `DENO_UNSTABLE_CONTROL_SOCK`. Node servers were left out:
they observed the override address but never fired the notification, so a
control plane waiting on the socket would hang.

This hooks `notifyAddressOverrideServing()` into the `listen()` path of both
`http.Server` and `https.Server` (and into `startOverrideListener` for non-TCP
override transports) so `node:http` servers fire the same notification that
`Deno.serve()` does. The unconfigured spec gains a `node:http` variant
exercising the full `DENO_AUTO_SERVE` +
`DENO_SERVE_ADDRESS=duplicate,unix:...` + `DENO_UNSTABLE_CONTROL_SOCK` flow.