### PR TITLE
feat(x): add deno x --ignore-scripts

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -59,6 +59,7 @@ pub use deno_runtime::deno_inspector_server::InspectPublishUid;
 use deno_runtime::deno_permissions::SysDescriptor;
 use deno_semver::jsr::JsrDepPackageReq;
 use deno_semver::package::PackageKind;
+use deno_semver::package::PackageReq;
 use deno_telemetry::OtelConfig;
 use deno_telemetry::OtelConsoleConfig;
 use deno_telemetry::OtelPropagators;
@@ -542,6 +543,7 @@ pub enum XFlagsKind {
 pub struct XCommandFlags {
   pub yes: bool,
   pub command: String,
+  pub ignore_scripts: PackagesAllowedScripts,
   /// When set via `--package`/`-p`, specifies the package to install
   /// while `command` is the binary name to execute from that package.
   pub package: Option<String>,
@@ -955,15 +957,30 @@ fn minutes_duration_or_date_parser(
     .map_err(|e| clap::Error::raw(clap::error::ErrorKind::InvalidValue, e))
 }
 
-fn parse_packages_allowed_scripts(s: &str) -> Result<String, AnyError> {
+fn parse_packages_scripts_arg(
+  s: &str,
+  flag_name: &str,
+) -> Result<String, AnyError> {
   if !s.starts_with("npm:") {
     bail!(
-      "Invalid package for --allow-scripts: '{}'. An 'npm:' specifier is required",
-      s
+      "Invalid package for {}: '{}'. An 'npm:' specifier is required",
+      flag_name,
+      s,
     );
   } else {
     Ok(s.into())
   }
+}
+
+fn parse_packages_allowed_scripts(s: &str) -> Result<String, AnyError> {
+  parse_packages_scripts_arg(s, "--allow-scripts")
+}
+
+fn parse_packages_ignored_scripts(s: &str) -> Result<String, AnyError> {
+  if s.is_empty() {
+    bail!("Invalid package for --ignore-scripts: package cannot be empty");
+  }
+  Ok(s.into())
 }
 
 /// Parse --inspect-publish-uid from a comma-separated string like "stderr,http".
@@ -1061,6 +1078,7 @@ pub struct Flags {
   pub code_cache_enabled: bool,
   pub permissions: PermissionFlags,
   pub allow_scripts: PackagesAllowedScripts,
+  pub deny_scripts: Vec<PackageReq>,
   pub permission_set: Option<String>,
   pub eszip: bool,
   pub node_conditions: Vec<String>,
@@ -4191,6 +4209,9 @@ fn x_subcommand() -> Command {
           .conflicts_with("install-alias"),
       )
       .arg(
+        ignore_scripts_arg().conflicts_with("install-alias"),
+      )
+      .arg(
         Arg::new("package")
           .long("package")
           .short('p')
@@ -6548,6 +6569,17 @@ fn allow_scripts_arg() -> Arg {
   <p(245)>Note: Scripts will only be executed when using a node_modules directory (`--node-modules-dir`)</>"))
 }
 
+fn ignore_scripts_arg() -> Arg {
+  Arg::new("ignore-scripts")
+    .long("ignore-scripts")
+    .num_args(0..)
+    .action(ArgAction::Append)
+    .require_equals(true)
+    .value_name("PACKAGE")
+    .value_parser(parse_packages_ignored_scripts)
+    .help("Do not run npm lifecycle scripts for the given packages")
+}
+
 enum UnstableArgsConfig {
   // for backwards-compatability
   None,
@@ -6654,6 +6686,48 @@ fn allow_scripts_arg_parse(
     );
   }
   Ok(())
+}
+
+fn ignore_scripts_arg_parse(
+  matches: &mut ArgMatches,
+) -> clap::error::Result<PackagesAllowedScripts> {
+  let Some(parts) = matches.remove_many::<String>("ignore-scripts") else {
+    return Ok(PackagesAllowedScripts::None);
+  };
+  if parts.len() == 0 {
+    Ok(PackagesAllowedScripts::All)
+  } else {
+    Ok(PackagesAllowedScripts::Some(
+      parts
+        .flat_map(flat_escape_split_commas)
+        .map(|result| {
+          let value = result?;
+          let value = if value.starts_with("npm:") || value.starts_with("jsr:")
+          {
+            value
+          } else {
+            format!("npm:{}", value)
+          };
+          let dep = JsrDepPackageReq::from_str_loose(&value).map_err(|e| {
+            clap::Error::raw(clap::error::ErrorKind::InvalidValue, e)
+          })?;
+          if dep.kind != PackageKind::Npm {
+            return Err(clap::Error::raw(
+              clap::error::ErrorKind::InvalidValue,
+              format!("Only npm package constraints are supported: {}", value),
+            ));
+          }
+          if dep.req.version_req.tag().is_some() {
+            return Err(clap::Error::raw(
+              clap::error::ErrorKind::InvalidValue,
+              format!("Tags are not supported in --ignore-scripts: {}", value),
+            ));
+          }
+          Ok(dep.req)
+        })
+        .collect::<Result<_, _>>()?,
+    ))
+  }
 }
 
 fn audit_parse(
@@ -8378,12 +8452,22 @@ fn x_parse(
   {
     if let Some(command) = script_arg.next() {
       let yes = matches.get_flag("yes");
+      let ignore_scripts = ignore_scripts_arg_parse(matches)?;
       let package = matches.remove_one::<String>("package");
       flags.argv.extend(script_arg);
       runtime_args_parse(flags, matches, true, true, true)?;
+      if matches!(ignore_scripts, PackagesAllowedScripts::All)
+        && !matches!(flags.allow_scripts, PackagesAllowedScripts::None)
+      {
+        return Err(clap::Error::raw(
+          clap::error::ErrorKind::ArgumentConflict,
+          "--ignore-scripts cannot be used with --allow-scripts",
+        ));
+      }
       XFlagsKind::Command(XCommandFlags {
         yes,
         command,
+        ignore_scripts,
         package,
       })
     } else {
@@ -15389,6 +15473,77 @@ mod tests {
         }
       }
     }
+  }
+
+  #[test]
+  fn x_ignore_scripts() {
+    let flags = flags_from_vec(svec![
+      "deno",
+      "x",
+      "--ignore-scripts",
+      "-y",
+      "npm:foo",
+      "--bar"
+    ])
+    .unwrap();
+    assert_eq!(
+      flags,
+      Flags {
+        subcommand: DenoSubcommand::X(XFlags {
+          kind: XFlagsKind::Command(XCommandFlags {
+            yes: true,
+            command: "npm:foo".to_string(),
+            ignore_scripts: PackagesAllowedScripts::All,
+            package: None,
+          }),
+        }),
+        argv: svec!["--bar"],
+        permissions: PermissionFlags {
+          allow_all: true,
+          ..Default::default()
+        },
+        ..Flags::default()
+      }
+    );
+
+    let err = flags_from_vec(svec![
+      "deno",
+      "x",
+      "--ignore-scripts",
+      "--allow-scripts",
+      "npm:foo"
+    ])
+    .unwrap_err();
+    assert!(err.to_string().contains("cannot be used with"));
+
+    let flags = flags_from_vec(svec![
+      "deno",
+      "x",
+      "--ignore-scripts=foo,npm:bar@2",
+      "npm:foo"
+    ])
+    .unwrap();
+    assert_eq!(
+      flags,
+      Flags {
+        subcommand: DenoSubcommand::X(XFlags {
+          kind: XFlagsKind::Command(XCommandFlags {
+            yes: false,
+            command: "npm:foo".to_string(),
+            ignore_scripts: PackagesAllowedScripts::Some(vec![
+              PackageReq::from_str("foo").unwrap(),
+              PackageReq::from_str("bar@2").unwrap(),
+            ]),
+            package: None,
+          }),
+        }),
+        permissions: PermissionFlags {
+          allow_all: true,
+          ..Default::default()
+        },
+        ..Flags::default()
+      }
+    );
   }
 
   #[test]

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1544,7 +1544,7 @@ impl CliOptions {
   pub fn lifecycle_scripts_config(&self) -> LifecycleScriptsConfig {
     LifecycleScriptsConfig {
       allowed: self.flags.allow_scripts.clone(),
-      denied: Default::default(),
+      denied: self.flags.deny_scripts.clone(),
       initial_cwd: self.initial_cwd.clone(),
       root_dir: self.workspace().root_dir_path(),
       explicit_install: matches!(

--- a/cli/tools/x.rs
+++ b/cli/tools/x.rs
@@ -477,6 +477,7 @@ pub async fn run(flags: Arc<Flags>, x_flags: XFlags) -> Result<i32, AnyError> {
         &flags,
         reload,
         command_flags.yes,
+        &command_flags.ignore_scripts,
         &factory.deno_dir()?.root,
       )
       .await?;
@@ -551,6 +552,7 @@ pub async fn run(flags: Arc<Flags>, x_flags: XFlags) -> Result<i32, AnyError> {
         &flags,
         reload,
         command_flags.yes,
+        &command_flags.ignore_scripts,
         &factory.deno_dir()?.root,
       )
       .await?;
@@ -591,9 +593,14 @@ async fn autoinstall_package(
   old_flags: &Flags,
   reload: bool,
   yes: bool,
+  ignore_scripts: &PackagesAllowedScripts,
   deno_dir: &Path,
 ) -> Result<(Arc<Flags>, CliFactory), AnyError> {
-  fn make_new_flags(old_flags: &Flags, temp_dir: &Path) -> Arc<Flags> {
+  fn make_new_flags(
+    old_flags: &Flags,
+    temp_dir: &Path,
+    ignore_scripts: &PackagesAllowedScripts,
+  ) -> Arc<Flags> {
     let mut new_flags = (*old_flags).clone();
     new_flags.node_modules_dir =
       Some(deno_config::deno_json::NodeModulesDirMode::Auto);
@@ -602,7 +609,23 @@ async fn autoinstall_package(
     new_flags.config_flag = crate::args::ConfigFlag::Path(
       temp_dir.join("deno.json").to_string_lossy().into_owned(),
     );
-    new_flags.allow_scripts = PackagesAllowedScripts::All;
+    match ignore_scripts {
+      PackagesAllowedScripts::All => {
+        new_flags.allow_scripts = PackagesAllowedScripts::None;
+        new_flags.deny_scripts.clear();
+      }
+      PackagesAllowedScripts::Some(package_reqs) => {
+        if matches!(old_flags.allow_scripts, PackagesAllowedScripts::None) {
+          new_flags.allow_scripts = PackagesAllowedScripts::All;
+        }
+        new_flags.deny_scripts = package_reqs.clone();
+      }
+      PackagesAllowedScripts::None => {
+        if matches!(old_flags.allow_scripts, PackagesAllowedScripts::None) {
+          new_flags.allow_scripts = PackagesAllowedScripts::All;
+        }
+      }
+    };
 
     log::debug!("new_flags: {:?}", new_flags);
 
@@ -615,7 +638,7 @@ async fn autoinstall_package(
     deno_dir,
   )?;
 
-  let new_flags = make_new_flags(old_flags, temp_dir.path());
+  let new_flags = make_new_flags(old_flags, temp_dir.path(), ignore_scripts);
   let new_factory = CliFactory::from_flags(new_flags.clone());
 
   match temp_dir {

--- a/libs/npm_installer/factory.rs
+++ b/libs/npm_installer/factory.rs
@@ -216,9 +216,13 @@ impl<
         },
         denied: match &args.allowed {
           PackagesAllowedScripts::All | PackagesAllowedScripts::Some(_) => {
-            vec![]
+            args.denied.clone()
           }
-          PackagesAllowedScripts::None => jsr_deps_to_reqs(allow_scripts.deny),
+          PackagesAllowedScripts::None => {
+            let mut denied = jsr_deps_to_reqs(allow_scripts.deny);
+            denied.extend(args.denied.clone());
+            denied
+          }
         },
         initial_cwd: args.initial_cwd.clone(),
         root_dir: args.root_dir.clone(),

--- a/tests/specs/x/ignore_scripts/__test__.jsonc
+++ b/tests/specs/x/ignore_scripts/__test__.jsonc
@@ -1,0 +1,6 @@
+{
+  "tempDir": true,
+  "args": "x -y --ignore-scripts=@denotest/lifecycle-scripts-simple npm:@denotest/lifecycle-scripts-simple",
+  "output": "ignore_scripts.out",
+  "exitCode": 1
+}

--- a/tests/specs/x/ignore_scripts/ignore_scripts.out
+++ b/tests/specs/x/ignore_scripts/ignore_scripts.out
@@ -1,0 +1,1 @@
+[WILDCARD]message.js[WILDCARD]


### PR DESCRIPTION
## Summary

Adds `--ignore-scripts` to `deno x` / `dx` so users can opt out of npm lifecycle scripts during the temporary package install used by `deno x`.

The autoinstall path now preserves explicit lifecycle-script policy:

- default `deno x` behavior still permits scripts for autoinstalled packages
- bare `--ignore-scripts` forces scripts off
- `--ignore-scripts=<package>` keeps scripts enabled except for the ignored package, and accepts prefixless npm package names like `--ignore-scripts=@scope/pkg`
- explicit `--allow-scripts=<package>` is preserved instead of being widened to all packages

Fixes denoland/deno#31903.

## Validation

- `cargo test -p deno --lib args::flags::tests::x_ignore_scripts`
- `./x test-spec x/ignore_scripts`
- `./x fmt cli/args/flags.rs cli/args/mod.rs cli/tools/x.rs libs/npm_installer/factory.rs tests/specs/x/ignore_scripts/__test__.jsonc tests/specs/x/ignore_scripts/ignore_scripts.out`
