### PR TITLE
fix(compile): resolve bare npm imports in --bundle worker sources

### DIFF
--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -1386,6 +1386,17 @@ fn browser_map_disabled_specifier(error: &BundleError) -> Option<String> {
   Some(disabled.specifier.clone())
 }
 
+/// Whether a specifier looks like a bare (npm/node-style) specifier, i.e. not
+/// a relative path, absolute path, package-internal `#` import, or a URL with a
+/// scheme (`file:`, `data:`, `node:`, `npm:`, `jsr:`, `http(s):`, ...).
+fn looks_like_bare_specifier(specifier: &str) -> bool {
+  !specifier.is_empty()
+    && !specifier.starts_with('.')
+    && !specifier.starts_with('/')
+    && !specifier.starts_with('#')
+    && Url::parse(specifier).is_err()
+}
+
 fn maybe_ignorable_resolution_error(
   error: &ResolveWithGraphError,
 ) -> Option<String> {
@@ -1515,6 +1526,26 @@ impl DenoPluginHandler {
       Ok(specifier) => Ok(Some(file_path_or_url(specifier)?)),
       Err(e) => {
         log::debug!("{}: {:?}", deno_terminal::colors::red("error"), e);
+        // The graph may record an unmapped-bare-specifier error for a referrer
+        // pulled in from outside the entrypoint's package scope (e.g. a source
+        // file reached via a `new Worker(new URL(...))` reference next to a
+        // `dist/`-rooted entrypoint). The package is still in the build's npm
+        // snapshot, so resolve it by name the way Node/Bun do before giving up.
+        if looks_like_bare_specifier(path)
+          && let Some(url) = resolver.resolve_bare_specifier_in_npm_snapshot(
+            path,
+            Some(&referrer),
+            import_kind_to_resolution_mode(kind),
+            NodeResolutionKind::Execution,
+          )
+        {
+          log::debug!(
+            "{}: resolved {} via npm snapshot fallback",
+            deno_terminal::colors::cyan("op_bundle_resolve"),
+            path
+          );
+          return Ok(Some(file_path_or_url(url)?));
+        }
         if let Some(specifier) = maybe_ignorable_resolution_error(&e) {
           log::debug!(
             "{}: resolution failed, but maybe ignorable",

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -1394,6 +1394,9 @@ fn looks_like_bare_specifier(specifier: &str) -> bool {
     && !specifier.starts_with('.')
     && !specifier.starts_with('/')
     && !specifier.starts_with('#')
+    // Load-bearing on Windows: `Url::parse("C:/foo")` succeeds (scheme `c`), so
+    // a drive-letter absolute path is correctly treated as not bare here. Don't
+    // "simplify" this away or Windows absolute paths regress into the fallback.
     && Url::parse(specifier).is_err()
 }
 

--- a/libs/resolver/graph.rs
+++ b/libs/resolver/graph.rs
@@ -414,6 +414,13 @@ impl<
   /// back to the snapshot by package name, matching Node/Bun's "find it in a
   /// reachable node_modules" behavior.
   ///
+  /// Known limitation: the specifier carries no version constraint, so this
+  /// resolves `name@*`. If the build's snapshot holds more than one version
+  /// of the package, the snapshot picks one by name alone, which may not be
+  /// the version the referrer's own `node_modules` tree would select. Node
+  /// and Bun resolve to the nearest reachable version; this does not. For the
+  /// common single-version case the result is identical.
+  ///
   /// Returns `None` when npm resolution isn't managed or the package isn't
   /// present in the snapshot.
   pub fn resolve_bare_specifier_in_npm_snapshot(
@@ -423,24 +430,19 @@ impl<
     resolution_mode: node_resolver::ResolutionMode,
     resolution_kind: node_resolver::NodeResolutionKind,
   ) -> Option<Url> {
-    let node_and_npm_resolver = self.resolver.node_and_npm_resolver.as_ref()?;
-    let managed_resolver = node_and_npm_resolver.npm_resolver.as_managed()?;
     let req_ref =
       NpmPackageReqReference::from_str(&format!("npm:{raw_specifier}")).ok()?;
-    let package_folder = managed_resolver
-      .resolve_pkg_folder_from_deno_module_req(req_ref.req())
-      .ok()?;
-    node_and_npm_resolver
-      .node_resolver
-      .resolve_package_subpath_from_deno_module(
-        &package_folder,
-        req_ref.sub_path(),
+    // Bail unless npm resolution is managed; `resolve_managed_npm_req_ref`
+    // unwraps these and would otherwise panic.
+    let node_and_npm_resolver = self.resolver.node_and_npm_resolver.as_ref()?;
+    node_and_npm_resolver.npm_resolver.as_managed()?;
+    self
+      .resolve_managed_npm_req_ref(
+        &req_ref,
         maybe_referrer,
         resolution_mode,
         resolution_kind,
       )
-      .ok()?
-      .into_url()
       .ok()
   }
 

--- a/libs/resolver/graph.rs
+++ b/libs/resolver/graph.rs
@@ -401,6 +401,49 @@ impl<
     )
   }
 
+  /// Best-effort resolution of a bare specifier against the managed npm
+  /// snapshot, regardless of whether the referrer's `package.json` declares
+  /// it.
+  ///
+  /// `deno compile --bundle` follows `new Worker(new URL(...))` and similar
+  /// references into modules that can live outside the entrypoint's package
+  /// scope (e.g. a worker authored in a sibling source tree, pulled in
+  /// alongside a `dist/`-rooted entrypoint). A bare npm import from such a
+  /// referrer can fail to map even though the package is installed and
+  /// resolves fine elsewhere in the same build. This lets the bundler fall
+  /// back to the snapshot by package name, matching Node/Bun's "find it in a
+  /// reachable node_modules" behavior.
+  ///
+  /// Returns `None` when npm resolution isn't managed or the package isn't
+  /// present in the snapshot.
+  pub fn resolve_bare_specifier_in_npm_snapshot(
+    &self,
+    raw_specifier: &str,
+    maybe_referrer: Option<&Url>,
+    resolution_mode: node_resolver::ResolutionMode,
+    resolution_kind: node_resolver::NodeResolutionKind,
+  ) -> Option<Url> {
+    let node_and_npm_resolver = self.resolver.node_and_npm_resolver.as_ref()?;
+    let managed_resolver = node_and_npm_resolver.npm_resolver.as_managed()?;
+    let req_ref =
+      NpmPackageReqReference::from_str(&format!("npm:{raw_specifier}")).ok()?;
+    let package_folder = managed_resolver
+      .resolve_pkg_folder_from_deno_module_req(req_ref.req())
+      .ok()?;
+    node_and_npm_resolver
+      .node_resolver
+      .resolve_package_subpath_from_deno_module(
+        &package_folder,
+        req_ref.sub_path(),
+        maybe_referrer,
+        resolution_mode,
+        resolution_kind,
+      )
+      .ok()?
+      .into_url()
+      .ok()
+  }
+
   pub fn resolve(
     &self,
     raw_specifier: &str,

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/__test__.jsonc
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/__test__.jsonc
@@ -1,0 +1,32 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "cwd": "entry",
+    "args": "install",
+    "output": "[WILDCARD]"
+  }, {
+    "if": "unix",
+    "cwd": "entry",
+    "args": "compile --bundle --no-check --allow-all --output app main.ts",
+    "output": "compile.out"
+  }, {
+    "if": "unix",
+    "cwd": "entry",
+    "commandName": "./app",
+    "args": [],
+    "output": "run.out",
+    "exitCode": 0
+  }, {
+    "if": "windows",
+    "cwd": "entry",
+    "args": "compile --bundle --no-check --allow-all --output app.exe main.ts",
+    "output": "compile.out"
+  }, {
+    "if": "windows",
+    "cwd": "entry",
+    "commandName": "./app.exe",
+    "args": [],
+    "output": "run.out",
+    "exitCode": 0
+  }]
+}

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/__test__.jsonc
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/__test__.jsonc
@@ -28,5 +28,17 @@
     "args": [],
     "output": "run.out",
     "exitCode": 0
+  }, {
+    "if": "unix",
+    "cwd": "entry",
+    "args": "compile --bundle --no-check --allow-all --output app_unknown main_unknown.ts",
+    "output": "compile_unknown.out",
+    "exitCode": 1
+  }, {
+    "if": "windows",
+    "cwd": "entry",
+    "args": "compile --bundle --no-check --allow-all --output app_unknown.exe main_unknown.ts",
+    "output": "compile_unknown.out",
+    "exitCode": 1
   }]
 }

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/compile.out
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/compile.out
@@ -1,0 +1,1 @@
+[WILDCARD]Embedded Files[WILDCARD]

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/compile_unknown.out
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/compile_unknown.out
@@ -1,0 +1,3 @@
+[WILDCARD]error: Import "@denotest/this-package-does-not-exist" not a dependency
+    at [WILDLINE]/outside/worker_unknown.ts:5:7
+error: bundling failed

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/entry/deno.json
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/entry/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "auto"
+}

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/entry/main.ts
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/entry/main.ts
@@ -1,9 +1,10 @@
 // The entrypoint lives in `entry/` (its package scope), where the npm
-// dependency resolves normally. It spawns a worker authored in a sibling
-// `outside/` directory, which is outside this package scope. `deno compile`
-// follows the `new Worker(new URL(...))` reference and pulls that source file
-// into the graph; its bare npm import must still resolve against the build's
-// npm snapshot. See https://github.com/denoland/deno/issues/34937.
+// dependency is declared and resolves normally. It spawns a worker authored in
+// a sibling `outside/` directory, which has no package scope of its own and
+// does not declare the dependency. `deno compile` follows the
+// `new Worker(new URL(...))` reference and pulls that source file into the
+// graph; its bare npm import must still resolve against the build's npm
+// snapshot. See https://github.com/denoland/deno/issues/34937.
 import { getValue, setValue } from "@denotest/esm-basic";
 
 setValue(5);

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/entry/main.ts
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/entry/main.ts
@@ -1,0 +1,20 @@
+// The entrypoint lives in `entry/` (its package scope), where the npm
+// dependency resolves normally. It spawns a worker authored in a sibling
+// `outside/` directory, which is outside this package scope. `deno compile`
+// follows the `new Worker(new URL(...))` reference and pulls that source file
+// into the graph; its bare npm import must still resolve against the build's
+// npm snapshot. See https://github.com/denoland/deno/issues/34937.
+import { getValue, setValue } from "@denotest/esm-basic";
+
+setValue(5);
+console.log("main", getValue());
+
+const worker = new Worker(
+  new URL("../outside/worker.ts", import.meta.url),
+  { type: "module" },
+);
+worker.onmessage = (e) => {
+  console.log("main got:", e.data);
+  worker.terminate();
+};
+worker.postMessage("ping");

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/entry/main_unknown.ts
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/entry/main_unknown.ts
@@ -1,0 +1,7 @@
+// Entrypoint for the negative case. Spawns a worker whose bare npm import is
+// not present in the build's snapshot; compiling this must error.
+const worker = new Worker(
+  new URL("../outside/worker_unknown.ts", import.meta.url),
+  { type: "module" },
+);
+worker.postMessage("ping");

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/entry/package.json
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/entry/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "entry-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@denotest/esm-basic": "1.0.0"
+  }
+}

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/outside/package.json
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/outside/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "outside-worker",
-  "version": "1.0.0",
-  "dependencies": {
-    "@denotest/esm-basic": "1.0.0"
-  }
-}

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/outside/package.json
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/outside/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "outside-worker",
+  "version": "1.0.0",
+  "dependencies": {
+    "@denotest/esm-basic": "1.0.0"
+  }
+}

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/outside/worker.ts
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/outside/worker.ts
@@ -1,0 +1,8 @@
+import { getValue, setValue } from "@denotest/esm-basic";
+
+self.onmessage = (e) => {
+  setValue(7);
+  (self as unknown as Worker).postMessage(
+    "pong-" + e.data + "-" + getValue(),
+  );
+};

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/outside/worker_unknown.ts
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/outside/worker_unknown.ts
@@ -1,0 +1,9 @@
+// Negative case: this worker imports a package that is not in the build's npm
+// snapshot at all. The snapshot fallback must not silently swallow it; the
+// build is expected to fail rather than produce a binary with an unresolved
+// import.
+import "@denotest/this-package-does-not-exist";
+
+self.onmessage = () => {
+  (self as unknown as Worker).postMessage("unreachable");
+};

--- a/tests/specs/compile/bundle/worker_npm_outside_scope/run.out
+++ b/tests/specs/compile/bundle/worker_npm_outside_scope/run.out
@@ -1,0 +1,2 @@
+main 5
+main got: pong-ping-7


### PR DESCRIPTION
deno compile --bundle follows new Worker(new URL(...)) references and
pulls the referenced modules into the bundle graph. When the entrypoint
lives in a subdirectory with its own package scope (for example a dist/
build output with its own package.json) and a worker is authored in a
sibling source tree, a bare npm import from that worker source failed
to resolve with "Import X not a dependency", even though the package is
declared, installed, and resolves fine from the entrypoint's own tree
in the same build. Plain deno bundle was unaffected because it does not
follow those worker references into the source tree.

The package is already present in the build's resolved npm snapshot, so
this falls back to resolving such bare specifiers against that snapshot
by package name, the way Node and Bun locate a package in a reachable
node_modules. The fallback only runs after normal resolution has already
failed, so successful resolutions and plain deno bundle behavior are
unchanged.

Closes #34937