### PR TITLE
feat(cli): provide a `node` on PATH when Node.js is not installed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "rustls",
  "rustyline",
  "rustyline-derive",
+ "same-file",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1929,6 +1930,7 @@ dependencies = [
  "walkdir",
  "wasm-encoder",
  "wasmparser",
+ "which 8.0.0",
  "windows-sys 0.59.0",
  "winres",
  "zip",
@@ -4216,6 +4218,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -11161,6 +11169,11 @@ name = "which"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.1.4",
+ "winsafe",
+]
 
 [[package]]
 name = "whoami"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -154,6 +154,7 @@ rustc-hash.workspace = true
 rustls.workspace = true
 rustyline.workspace = true
 rustyline-derive.workspace = true
+same-file.workspace = true
 serde.workspace = true
 serde_repr.workspace = true
 sha2.workspace = true
@@ -180,6 +181,7 @@ uuid = { workspace = true, features = ["serde"] }
 walkdir.workspace = true
 wasm-encoder = { version = "0.244.0", features = ["wasmparser"] }
 wasmparser = "0.244.0"
+which = { workspace = true, features = ["real-sys"] }
 zip = { workspace = true, features = ["deflate-flate2"] }
 zstd.workspace = true
 

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -826,6 +826,33 @@ async fn resolve_flags_and_init(
   }
 
   let sys = crate::sys::CliSys::default();
+
+  // Best-effort: make a `node` available on PATH (pointing back at this binary)
+  // when no real Node.js is installed, so child processes that spawn `node`
+  // natively (e.g. Next.js Turbopack) can find one. Must run before any threads
+  // spawn since it mutates PATH (the tunnel below can spawn threads), and only
+  // for subcommands that execute user code, so unrelated commands (`fmt`,
+  // `lint`, `check`, `lsp`, ...) don't pay for the `node` PATH scan on startup.
+  if node_compat_shim::subcommand_may_spawn_node(&flags.subcommand) {
+    match deno_cache_dir::resolve_deno_dir(
+      &sys,
+      deno_cache_dir::ResolveDenoDirOptions {
+        maybe_initial_cwd: initial_cwd.as_deref(),
+        maybe_custom_root: None,
+      },
+    ) {
+      Ok(deno_dir_root) => {
+        if let Err(err) = node_compat_shim::ensure_node_on_path(&deno_dir_root)
+        {
+          log::debug!("node compat shim setup failed (best-effort): {err}");
+        }
+      }
+      Err(err) => {
+        log::debug!("could not resolve DENO_DIR for node compat shim: {err}");
+      }
+    }
+  }
+
   if deno_lib::args::has_flag_env_var(&sys, "DENO_CONNECTED") {
     flags.tunnel = true;
   }
@@ -841,27 +868,6 @@ async fn resolve_flags_and_init(
     // SAFETY: We're doing this before any threads are created.
     unsafe {
       std::env::set_var("DENO_CONNECTED", "1");
-    }
-  }
-
-  // Best-effort: make a `node` available on PATH (pointing back at this binary)
-  // when no real Node.js is installed, so child processes that spawn `node`
-  // natively (e.g. Next.js Turbopack) can find one. Must run before threads
-  // spawn since it mutates PATH.
-  match deno_cache_dir::resolve_deno_dir(
-    &sys,
-    deno_cache_dir::ResolveDenoDirOptions {
-      maybe_initial_cwd: initial_cwd.as_deref(),
-      maybe_custom_root: None,
-    },
-  ) {
-    Ok(deno_dir_root) => {
-      if let Err(err) = node_compat_shim::ensure_node_on_path(&deno_dir_root) {
-        log::debug!("node compat shim setup failed (best-effort): {err}");
-      }
-    }
-    Err(err) => {
-      log::debug!("could not resolve DENO_DIR for node compat shim: {err}");
     }
   }
 

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -12,6 +12,7 @@ mod jsr;
 mod lsp;
 mod module_loader;
 mod node;
+mod node_compat_shim;
 mod npm;
 mod ops;
 mod registry;
@@ -709,6 +710,10 @@ pub fn main() {
     .unwrap();
 
   let args: Vec<_> = env::args_os().collect();
+  // If we were invoked through a `node` shim (a symlink/hardlink named `node`
+  // pointing at this binary), translate the Node.js CLI args to Deno args.
+  // Done here, before any threads are spawned, because it may set env vars.
+  let args = node_compat_shim::maybe_rewrite_node_arg0(args);
   let future = async move {
     let roots = LibWorkerFactoryRoots::default();
 
@@ -836,6 +841,27 @@ async fn resolve_flags_and_init(
     // SAFETY: We're doing this before any threads are created.
     unsafe {
       std::env::set_var("DENO_CONNECTED", "1");
+    }
+  }
+
+  // Best-effort: make a `node` available on PATH (pointing back at this binary)
+  // when no real Node.js is installed, so child processes that spawn `node`
+  // natively (e.g. Next.js Turbopack) can find one. Must run before threads
+  // spawn since it mutates PATH.
+  match deno_cache_dir::resolve_deno_dir(
+    &sys,
+    deno_cache_dir::ResolveDenoDirOptions {
+      maybe_initial_cwd: initial_cwd.as_deref(),
+      maybe_custom_root: None,
+    },
+  ) {
+    Ok(deno_dir_root) => {
+      if let Err(err) = node_compat_shim::ensure_node_on_path(&deno_dir_root) {
+        log::debug!("node compat shim setup failed (best-effort): {err}");
+      }
+    }
+    Err(err) => {
+      log::debug!("could not resolve DENO_DIR for node compat shim: {err}");
     }
   }
 

--- a/cli/node_compat_shim.rs
+++ b/cli/node_compat_shim.rs
@@ -353,4 +353,41 @@ mod tests {
     assert!(!is_truthy("false"));
     assert!(!is_truthy(""));
   }
+
+  #[test]
+  fn create_shim_round_trip() {
+    // Exercises create_shim + shim_is_valid on every platform. On Windows this
+    // is the only coverage of the hardlink/copy path, which the unix-only spec
+    // tests can't reach.
+    let base = std::env::temp_dir()
+      .join(format!("deno_node_shim_test_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).unwrap();
+
+    // Stand-in for the deno binary the shim points back at. Keep it in the same
+    // directory tree as the shim so a Windows hardlink stays on one volume.
+    let fake_exe = base.join(if cfg!(windows) { "deno.exe" } else { "deno" });
+    std::fs::write(&fake_exe, b"binary").unwrap();
+
+    let shim_dir = base.join(SHIM_DIR_NAME);
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    let shim_name = if cfg!(windows) { "node.exe" } else { "node" };
+    let shim_path = shim_dir.join(shim_name);
+
+    // Fresh creation, then idempotent recreation over an existing shim: both
+    // must yield a shim that validates against the target.
+    for _ in 0..2 {
+      create_shim(&shim_path, &fake_exe).unwrap();
+      assert!(shim_path.exists());
+      assert!(shim_is_valid(&shim_path, &fake_exe));
+    }
+
+    // A shim pointing at a different binary must be reported invalid (this is
+    // what triggers recreation after a deno upgrade).
+    let other_exe = base.join("other");
+    std::fs::write(&other_exe, b"binary").unwrap();
+    assert!(!shim_is_valid(&shim_path, &other_exe));
+
+    let _ = std::fs::remove_dir_all(&base);
+  }
 }

--- a/cli/node_compat_shim.rs
+++ b/cli/node_compat_shim.rs
@@ -1,0 +1,332 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Lets Deno stand in for `node` when no real Node.js binary is available.
+//!
+//! Two complementary mechanisms:
+//!
+//! 1. Arg0 dispatch ([`maybe_rewrite_node_arg0`]): when the deno binary is
+//!    invoked through a file named `node` (a symlink/hardlink created below),
+//!    translate the Node.js CLI arguments to Deno arguments and run as if
+//!    `deno node ...` had been invoked.
+//!
+//! 2. PATH injection ([`ensure_node_on_path`]): create a `node` executable
+//!    pointing back at the current deno binary in a cache directory and prepend
+//!    that directory to the process's own `PATH`, so that child processes
+//!    (including native ones such as Next.js Turbopack, which spawn `node` via
+//!    a raw OS PATH lookup that bypasses Deno's JS-level interception) can find
+//!    a `node` to run.
+//!
+//! Both are best-effort and only kick in when a real `node` is not already
+//! available on `PATH`, so existing Node.js setups are never shadowed. The
+//! behavior can be disabled entirely with `DENO_DISABLE_NODE_SHIM=1`.
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::path::PathBuf;
+
+/// Env var that disables the whole feature when set to a truthy value.
+const DISABLE_ENV_VAR: &str = "DENO_DISABLE_NODE_SHIM";
+/// Internal marker set once the shim has been put on PATH, used to avoid the
+/// shim recursively validating against itself when a spawned `node` (which is
+/// really deno) re-enters this code.
+const ACTIVE_ENV_VAR: &str = "DENO_NODE_SHIM_ACTIVE";
+/// Name of the directory under DENO_DIR that holds the `node` shim.
+const SHIM_DIR_NAME: &str = "node_compat_bin";
+
+fn is_truthy(value: &str) -> bool {
+  matches!(value, "1" | "true" | "TRUE" | "True")
+}
+
+fn env_disabled() -> bool {
+  std::env::var(DISABLE_ENV_VAR)
+    .map(|v| is_truthy(&v))
+    .unwrap_or(false)
+}
+
+/// Returns whether `arg0`'s file name is exactly `node` (or `node.exe` on
+/// Windows). Deliberately an exact match, not a suffix match, so names like
+/// `anode` or `mynode` do not trigger dispatch.
+fn is_node_arg0(arg0: &OsString) -> bool {
+  let Some(file_name) = Path::new(arg0).file_name() else {
+    return false;
+  };
+  // Never misfire on the deno binary itself.
+  if file_name.eq_ignore_ascii_case("deno")
+    || file_name.eq_ignore_ascii_case("deno.exe")
+  {
+    return false;
+  }
+  if file_name == "node" {
+    return true;
+  }
+  cfg!(windows) && file_name.eq_ignore_ascii_case("node.exe")
+}
+
+/// If the process was invoked as `node`, translate the Node.js CLI args into
+/// Deno args and return the rewritten argv. Otherwise returns `args` unchanged.
+///
+/// Must be called before any threads are spawned, as it may mutate process
+/// environment variables (`NODE_OPTIONS`, `DENO_TLS_CA_STORE`, ...).
+pub fn maybe_rewrite_node_arg0(args: Vec<OsString>) -> Vec<OsString> {
+  let Some(arg0) = args.first() else {
+    return args;
+  };
+  if !is_node_arg0(arg0) {
+    return args;
+  }
+
+  // node_shim operates on Strings. Node never passes non-UTF8 flags, and any
+  // entrypoint path is re-resolved by deno's own `run` resolution.
+  let node_args: Vec<String> = args[1..]
+    .iter()
+    .map(|a| a.to_string_lossy().into_owned())
+    .collect();
+
+  let parsed = match node_shim::parse_args(node_args) {
+    Ok(parsed) => parsed,
+    Err(errors) => {
+      // This runs before logging is initialized; mirror the standalone shim.
+      #[allow(clippy::print_stderr, reason = "node shim arg parse error")]
+      {
+        if errors.len() == 1 {
+          eprintln!("Error: {}", errors[0]);
+        } else if errors.len() > 1 {
+          eprintln!("Errors: {}", errors.join(", "));
+        }
+      }
+      deno_runtime::exit(1);
+    }
+  };
+
+  let options = node_shim::TranslateOptions::for_node_cli();
+  let result = node_shim::translate_to_deno_args(parsed, &options);
+
+  apply_env_side_effects(&result);
+
+  let mut deno_args = result.deno_args;
+
+  // Resolve the entrypoint for the run path the same way the standalone shim
+  // does, sharing a single implementation.
+  if deno_args.len() >= 3 && deno_args.get(1).map(|s| s.as_str()) == Some("run")
+  {
+    let entrypoint_idx = deno_args
+      .iter()
+      .enumerate()
+      .skip(2)
+      .find(|(_, arg)| !arg.starts_with('-'))
+      .map(|(i, _)| i);
+    if let Some(idx) = entrypoint_idx {
+      #[allow(
+        clippy::disallowed_methods,
+        reason = "resolving the node shim exe"
+      )]
+      let current_exe =
+        std::env::current_exe().unwrap_or_else(|_| PathBuf::from("deno"));
+      deno_args[idx] =
+        node_shim::resolve_entrypoint(&current_exe, &deno_args[idx]);
+    }
+  }
+
+  // `deno_args[0]` is the program-name slot ("node") that deno's flag parser
+  // skips; `deno_args[1..]` carry the real subcommand. Returning `deno_args`
+  // verbatim is exactly what the standalone shim feeds to deno.
+  deno_args.into_iter().map(OsString::from).collect()
+}
+
+fn apply_env_side_effects(result: &node_shim::TranslatedArgs) {
+  if result.use_system_ca {
+    // SAFETY: called before any threads are spawned.
+    unsafe { std::env::set_var("DENO_TLS_CA_STORE", "system") };
+  }
+  if !result.node_options.is_empty() {
+    let options = result.node_options.join(" ");
+    let merged = match std::env::var("NODE_OPTIONS") {
+      Ok(existing) if !existing.is_empty() => {
+        format!("{existing} {options}")
+      }
+      _ => options,
+    };
+    // SAFETY: called before any threads are spawned.
+    unsafe { std::env::set_var("NODE_OPTIONS", merged) };
+  }
+  if !result.trace_event_categories.is_empty() {
+    // SAFETY: called before any threads are spawned.
+    unsafe {
+      std::env::set_var(
+        "DENO_NODE_TRACE_EVENT_CATEGORIES",
+        &result.trace_event_categories,
+      )
+    };
+  }
+}
+
+/// Ensure a `node` executable that points back at the current deno binary is
+/// available on `PATH`, so child processes that spawn `node` natively can find
+/// one. Best-effort and no-op when a real `node` already exists, when disabled,
+/// or when the shim is already active.
+///
+/// Must be called before any threads are spawned (it mutates `PATH`).
+pub fn ensure_node_on_path(deno_dir_root: &Path) -> std::io::Result<()> {
+  if env_disabled() {
+    return Ok(());
+  }
+  // Re-entry guard: if a previously-prepended shim `node` re-invoked us, the
+  // shim itself is now on PATH; don't recurse or re-validate against ourselves.
+  if std::env::var(ACTIVE_ENV_VAR)
+    .map(|v| is_truthy(&v))
+    .unwrap_or(false)
+  {
+    return Ok(());
+  }
+  // Don't shadow a real Node.js install.
+  if which::which("node").is_ok() {
+    return Ok(());
+  }
+
+  #[allow(clippy::disallowed_methods, reason = "resolving the node shim exe")]
+  let current_exe = std::env::current_exe()?;
+  let current_exe =
+    crate::util::fs::canonicalize_path(&current_exe).unwrap_or(current_exe);
+
+  let shim_dir = deno_dir_root.join(SHIM_DIR_NAME);
+  let shim_name = if cfg!(windows) { "node.exe" } else { "node" };
+  let shim_path = shim_dir.join(shim_name);
+
+  if !shim_is_valid(&shim_path, &current_exe) {
+    std::fs::create_dir_all(&shim_dir)?;
+    create_shim(&shim_path, &current_exe)?;
+  }
+
+  prepend_self_path(&shim_dir);
+
+  // SAFETY: called before any threads are spawned.
+  unsafe { std::env::set_var(ACTIVE_ENV_VAR, "1") };
+
+  Ok(())
+}
+
+/// Whether an existing shim at `shim_path` already points at `current_exe`.
+fn shim_is_valid(shim_path: &Path, current_exe: &Path) -> bool {
+  #[cfg(unix)]
+  {
+    match std::fs::read_link(shim_path) {
+      Ok(target) => {
+        target == current_exe
+          || crate::util::fs::canonicalize_path(&target).ok().as_deref()
+            == Some(current_exe)
+      }
+      Err(_) => false,
+    }
+  }
+  #[cfg(windows)]
+  {
+    same_file::is_same_file(shim_path, current_exe).unwrap_or(false)
+  }
+  #[cfg(not(any(unix, windows)))]
+  {
+    let _ = (shim_path, current_exe);
+    false
+  }
+}
+
+#[cfg(unix)]
+fn create_shim(shim_path: &Path, current_exe: &Path) -> std::io::Result<()> {
+  match std::os::unix::fs::symlink(current_exe, shim_path) {
+    Ok(()) => Ok(()),
+    Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+      std::fs::remove_file(shim_path)?;
+      std::os::unix::fs::symlink(current_exe, shim_path)
+    }
+    Err(err) => Err(err),
+  }
+}
+
+#[cfg(windows)]
+fn create_shim(shim_path: &Path, current_exe: &Path) -> std::io::Result<()> {
+  // Native CreateProcess / Rust's Command PATH lookup only execute `.exe`, not
+  // `.cmd`, so the shim must be a real executable. A hardlink shares the deno
+  // binary's bytes with no extra disk; fall back to a copy across volumes.
+  if shim_path.exists() {
+    let _ = std::fs::remove_file(shim_path);
+  }
+  match std::fs::hard_link(current_exe, shim_path) {
+    Ok(()) => Ok(()),
+    Err(_) => {
+      // Copy via a unique temp file then atomically rename into place.
+      let tmp_path =
+        shim_path.with_extension(format!("exe.tmp-{}", std::process::id()));
+      std::fs::copy(current_exe, &tmp_path)?;
+      std::fs::rename(&tmp_path, shim_path)
+    }
+  }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_shim(_shim_path: &Path, _current_exe: &Path) -> std::io::Result<()> {
+  Err(std::io::Error::new(
+    std::io::ErrorKind::Unsupported,
+    "node shim is not supported on this platform",
+  ))
+}
+
+/// Prepend `dir` to the process's own `PATH` (idempotently), so spawned
+/// children inherit it.
+fn prepend_self_path(dir: &Path) {
+  let sep = if cfg!(windows) { ';' } else { ':' };
+  let current = std::env::var_os("PATH").unwrap_or_default();
+  // Idempotency: don't grow PATH if the dir is already present.
+  let already_present = std::env::split_paths(&current).any(|p| p == dir);
+  if already_present {
+    return;
+  }
+
+  let mut new_path = OsString::from(dir);
+  if !current.is_empty() {
+    new_path.push(sep.to_string());
+    new_path.push(&current);
+  }
+  // SAFETY: called before any threads are spawned.
+  unsafe { std::env::set_var("PATH", new_path) };
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn detects_node_arg0() {
+    assert!(is_node_arg0(&OsString::from("node")));
+    assert!(is_node_arg0(&OsString::from("/usr/local/bin/node")));
+    assert!(!is_node_arg0(&OsString::from("anode")));
+    assert!(!is_node_arg0(&OsString::from("/path/to/mynode")));
+    assert!(!is_node_arg0(&OsString::from("deno")));
+    assert!(!is_node_arg0(&OsString::from("/usr/bin/deno")));
+  }
+
+  #[test]
+  #[cfg(windows)]
+  fn detects_node_exe_arg0_on_windows() {
+    assert!(is_node_arg0(&OsString::from("node.exe")));
+    assert!(is_node_arg0(&OsString::from("NODE.EXE")));
+    assert!(!is_node_arg0(&OsString::from("deno.exe")));
+  }
+
+  #[test]
+  fn non_node_arg0_passes_through_unchanged() {
+    let args = vec![
+      OsString::from("/usr/bin/deno"),
+      OsString::from("run"),
+      OsString::from("main.ts"),
+    ];
+    let result = maybe_rewrite_node_arg0(args.clone());
+    assert_eq!(result, args);
+  }
+
+  #[test]
+  fn truthy_values() {
+    assert!(is_truthy("1"));
+    assert!(is_truthy("true"));
+    assert!(!is_truthy("0"));
+    assert!(!is_truthy(""));
+  }
+}

--- a/cli/node_compat_shim.rs
+++ b/cli/node_compat_shim.rs
@@ -34,13 +34,30 @@ const ACTIVE_ENV_VAR: &str = "DENO_NODE_SHIM_ACTIVE";
 const SHIM_DIR_NAME: &str = "node_compat_bin";
 
 fn is_truthy(value: &str) -> bool {
-  matches!(value, "1" | "true" | "TRUE" | "True")
+  matches!(
+    value.to_ascii_lowercase().as_str(),
+    "1" | "true" | "yes" | "on"
+  )
 }
 
 fn env_disabled() -> bool {
   std::env::var(DISABLE_ENV_VAR)
     .map(|v| is_truthy(&v))
     .unwrap_or(false)
+}
+
+/// Whether a subcommand can execute user code that might spawn a native `node`
+/// child process. Used to keep the `node` PATH scan (in [`ensure_node_on_path`])
+/// off the cold-start path of commands like `fmt`/`lint`/`check`/`lsp` that
+/// never spawn one.
+pub fn subcommand_may_spawn_node(
+  subcommand: &crate::args::DenoSubcommand,
+) -> bool {
+  use crate::args::DenoSubcommand::*;
+  matches!(
+    subcommand,
+    Run(_) | Task(_) | Test(_) | Bench(_) | Eval(_) | Repl(_) | Serve(_)
+  )
 }
 
 /// Returns whether `arg0`'s file name is exactly `node` (or `node.exe` on
@@ -72,6 +89,11 @@ pub fn maybe_rewrite_node_arg0(args: Vec<OsString>) -> Vec<OsString> {
     return args;
   };
   if !is_node_arg0(arg0) {
+    return args;
+  }
+  // Respect the opt-out: a stale `node` shim left on PATH from a previous run
+  // should pass through unchanged when the feature is disabled.
+  if env_disabled() {
     return args;
   }
 
@@ -106,26 +128,13 @@ pub fn maybe_rewrite_node_arg0(args: Vec<OsString>) -> Vec<OsString> {
   let mut deno_args = result.deno_args;
 
   // Resolve the entrypoint for the run path the same way the standalone shim
-  // does, sharing a single implementation.
-  if deno_args.len() >= 3 && deno_args.get(1).map(|s| s.as_str()) == Some("run")
-  {
-    let entrypoint_idx = deno_args
-      .iter()
-      .enumerate()
-      .skip(2)
-      .find(|(_, arg)| !arg.starts_with('-'))
-      .map(|(i, _)| i);
-    if let Some(idx) = entrypoint_idx {
-      #[allow(
-        clippy::disallowed_methods,
-        reason = "resolving the node shim exe"
-      )]
-      let current_exe =
-        std::env::current_exe().unwrap_or_else(|_| PathBuf::from("deno"));
-      deno_args[idx] =
-        node_shim::resolve_entrypoint(&current_exe, &deno_args[idx]);
-    }
-  }
+  // does, sharing a single implementation. `current_exe` resolves to the real
+  // deno binary (not the `node` symlink), so the resolution subprocess runs as
+  // plain `deno eval` without re-entering arg0 dispatch.
+  #[allow(clippy::disallowed_methods, reason = "resolving the node shim exe")]
+  let current_exe =
+    std::env::current_exe().unwrap_or_else(|_| PathBuf::from("deno"));
+  node_shim::resolve_run_entrypoint(&current_exe, &mut deno_args);
 
   // `deno_args[0]` is the program-name slot ("node") that deno's flag parser
   // skips; `deno_args[1..]` carry the real subcommand. Returning `deno_args`
@@ -231,13 +240,22 @@ fn shim_is_valid(shim_path: &Path, current_exe: &Path) -> bool {
 
 #[cfg(unix)]
 fn create_shim(shim_path: &Path, current_exe: &Path) -> std::io::Result<()> {
-  match std::os::unix::fs::symlink(current_exe, shim_path) {
+  // Symlink to a unique temp name first, then atomically `rename` it into
+  // place. This keeps a valid `node` visible at all times, so two concurrent
+  // deno invocations (e.g. editor + terminal) can't race into a window where
+  // the shim is momentarily missing.
+  let tmp_path =
+    shim_path.with_extension(format!("tmp-{}", std::process::id()));
+  // A leftover temp file from a crashed previous run would make `symlink`
+  // fail with AlreadyExists; clear it first.
+  let _ = std::fs::remove_file(&tmp_path);
+  std::os::unix::fs::symlink(current_exe, &tmp_path)?;
+  match std::fs::rename(&tmp_path, shim_path) {
     Ok(()) => Ok(()),
-    Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-      std::fs::remove_file(shim_path)?;
-      std::os::unix::fs::symlink(current_exe, shim_path)
+    Err(err) => {
+      let _ = std::fs::remove_file(&tmp_path);
+      Err(err)
     }
-    Err(err) => Err(err),
   }
 }
 
@@ -326,7 +344,13 @@ mod tests {
   fn truthy_values() {
     assert!(is_truthy("1"));
     assert!(is_truthy("true"));
+    assert!(is_truthy("TRUE"));
+    assert!(is_truthy("True"));
+    assert!(is_truthy("tRuE"));
+    assert!(is_truthy("yes"));
+    assert!(is_truthy("on"));
     assert!(!is_truthy("0"));
+    assert!(!is_truthy("false"));
     assert!(!is_truthy(""));
   }
 }

--- a/libs/node_shim/lib.rs
+++ b/libs/node_shim/lib.rs
@@ -3270,6 +3270,12 @@ pub fn is_deno_subcommand(arg: &str) -> bool {
 /// `deno_exe` is the path or name used to invoke deno for the resolution
 /// fallback. The standalone shim passes `"deno"` (relying on PATH); callers
 /// running inside the deno process should pass `std::env::current_exe()`.
+///
+/// Infrastructure failures (no current dir, can't spawn deno, non-UTF8 output)
+/// fall back to returning the entrypoint unchanged, letting deno's own `run`
+/// resolution surface a normal error rather than panicking. A non-zero exit
+/// from the resolution script itself is still propagated via process exit, as
+/// that carries the user-facing "module not found" diagnostic.
 #[allow(
   clippy::disallowed_methods,
   reason = "CLI shim resolving a node entrypoint, mirrors the standalone binary"
@@ -3280,17 +3286,22 @@ pub fn resolve_entrypoint(
 ) -> String {
   use std::process::Stdio;
 
-  let cwd = std::env::current_dir().unwrap();
+  let Ok(cwd) = std::env::current_dir() else {
+    return entrypoint.to_string();
+  };
   // If the entrypoint is either an absolute path, or a relative path that
   // exists, return it as is.
   if cwd.join(entrypoint).symlink_metadata().is_ok() {
     return entrypoint.to_string();
   }
 
-  let url = url::Url::from_file_path(cwd.join("$file.js")).unwrap();
+  let Ok(url) = url::Url::from_file_path(cwd.join("$file.js")) else {
+    return entrypoint.to_string();
+  };
 
   // Otherwise, shell out to `deno` to try to resolve the entrypoint.
-  let output = std::process::Command::new(deno_exe)
+  let mut command = std::process::Command::new(deno_exe);
+  command
     .arg("eval")
     .arg("--no-config")
     .arg(include_str!("./resolve.js"))
@@ -3298,16 +3309,26 @@ pub fn resolve_entrypoint(
     .arg(format!("./{}", entrypoint))
     .env_clear()
     .stdout(Stdio::piped())
-    .stderr(Stdio::inherit())
-    .output()
-    .expect("Failed to execute deno resolve script");
+    .stderr(Stdio::inherit());
+  // A fully-cleared environment breaks process creation / DLL loading on
+  // Windows, so keep the essential system variables.
+  #[cfg(windows)]
+  for key in ["SystemRoot", "SystemDrive"] {
+    if let Some(value) = std::env::var_os(key) {
+      command.env(key, value);
+    }
+  }
+  let output = match command.output() {
+    Ok(output) => output,
+    Err(_) => return entrypoint.to_string(),
+  };
   if !output.status.success() {
     std::process::exit(output.status.code().unwrap_or(1));
   }
-  String::from_utf8(output.stdout)
-    .expect("Failed to parse deno resolve output")
-    .trim()
-    .to_string()
+  match String::from_utf8(output.stdout) {
+    Ok(stdout) => stdout.trim().to_string(),
+    Err(_) => entrypoint.to_string(),
+  }
 }
 
 /// For a translated `deno run ...` argv, resolve the entrypoint argument in

--- a/libs/node_shim/lib.rs
+++ b/libs/node_shim/lib.rs
@@ -3260,6 +3260,56 @@ pub fn is_deno_subcommand(arg: &str) -> bool {
   DENO_SUBCOMMANDS.contains(&arg)
 }
 
+/// Resolve a Node-style entrypoint to a specifier that Deno's `run` subcommand
+/// understands.
+///
+/// If the entrypoint is an absolute path, or a relative path that exists on
+/// disk, it is returned unchanged. Otherwise we shell out to `deno_exe` to
+/// resolve it using Node's module resolution semantics (via `resolve.js`).
+///
+/// `deno_exe` is the path or name used to invoke deno for the resolution
+/// fallback. The standalone shim passes `"deno"` (relying on PATH); callers
+/// running inside the deno process should pass `std::env::current_exe()`.
+#[allow(
+  clippy::disallowed_methods,
+  reason = "CLI shim resolving a node entrypoint, mirrors the standalone binary"
+)]
+pub fn resolve_entrypoint(
+  deno_exe: &std::path::Path,
+  entrypoint: &str,
+) -> String {
+  use std::process::Stdio;
+
+  let cwd = std::env::current_dir().unwrap();
+  // If the entrypoint is either an absolute path, or a relative path that
+  // exists, return it as is.
+  if cwd.join(entrypoint).symlink_metadata().is_ok() {
+    return entrypoint.to_string();
+  }
+
+  let url = url::Url::from_file_path(cwd.join("$file.js")).unwrap();
+
+  // Otherwise, shell out to `deno` to try to resolve the entrypoint.
+  let output = std::process::Command::new(deno_exe)
+    .arg("eval")
+    .arg("--no-config")
+    .arg(include_str!("./resolve.js"))
+    .arg(url.to_string())
+    .arg(format!("./{}", entrypoint))
+    .env_clear()
+    .stdout(Stdio::piped())
+    .stderr(Stdio::inherit())
+    .output()
+    .expect("Failed to execute deno resolve script");
+  if !output.status.success() {
+    std::process::exit(output.status.code().unwrap_or(1));
+  }
+  String::from_utf8(output.stdout)
+    .expect("Failed to parse deno resolve output")
+    .trim()
+    .to_string()
+}
+
 /// Translate parsed Node.js CLI arguments to Deno CLI arguments.
 pub fn translate_to_deno_args(
   parsed_args: ParseResult,

--- a/libs/node_shim/lib.rs
+++ b/libs/node_shim/lib.rs
@@ -3310,6 +3310,31 @@ pub fn resolve_entrypoint(
     .to_string()
 }
 
+/// For a translated `deno run ...` argv, resolve the entrypoint argument in
+/// place using [`resolve_entrypoint`].
+///
+/// No-op unless `deno_args` is a `run` invocation with an entrypoint (the first
+/// non-flag argument after `run`). Shared by the standalone shim binary and the
+/// in-process arg0 dispatch so the entrypoint-finding logic lives in one place.
+pub fn resolve_run_entrypoint(
+  deno_exe: &std::path::Path,
+  deno_args: &mut [String],
+) {
+  if deno_args.len() < 3 || deno_args.get(1).map(|s| s.as_str()) != Some("run")
+  {
+    return;
+  }
+  let entrypoint_idx = deno_args
+    .iter()
+    .enumerate()
+    .skip(2)
+    .find(|(_, arg)| !arg.starts_with('-'))
+    .map(|(i, _)| i);
+  if let Some(idx) = entrypoint_idx {
+    deno_args[idx] = resolve_entrypoint(deno_exe, &deno_args[idx]);
+  }
+}
+
 /// Translate parsed Node.js CLI arguments to Deno CLI arguments.
 pub fn translate_to_deno_args(
   parsed_args: ParseResult,

--- a/libs/node_shim/main.rs
+++ b/libs/node_shim/main.rs
@@ -48,23 +48,10 @@ fn main() {
   let mut deno_args = result.deno_args;
 
   // Handle entrypoint resolution for run commands
-  if deno_args.len() >= 3 && deno_args.get(1) == Some(&"run".to_string()) {
-    // Find the entrypoint (first non-flag arg after "run")
-    let mut entrypoint_idx = None;
-    for (i, arg) in deno_args.iter().enumerate().skip(2) {
-      if !arg.starts_with('-') && !arg.starts_with("--") {
-        entrypoint_idx = Some(i);
-        break;
-      }
-    }
-
-    if let Some(idx) = entrypoint_idx {
-      let entrypoint = &deno_args[idx];
-      let resolved =
-        node_shim::resolve_entrypoint(std::path::Path::new("deno"), entrypoint);
-      deno_args[idx] = resolved;
-    }
-  }
+  node_shim::resolve_run_entrypoint(
+    std::path::Path::new("deno"),
+    &mut deno_args,
+  );
 
   if std::env::var("NODE_SHIM_DEBUG").is_ok() {
     eprintln!("deno {:?}", deno_args);

--- a/libs/node_shim/main.rs
+++ b/libs/node_shim/main.rs
@@ -5,7 +5,6 @@
 #![allow(clippy::disallowed_methods, reason = "CLI tool")]
 
 use std::env;
-use std::process::Stdio;
 use std::process::{self};
 
 use node_shim::TranslateOptions;
@@ -61,7 +60,8 @@ fn main() {
 
     if let Some(idx) = entrypoint_idx {
       let entrypoint = &deno_args[idx];
-      let resolved = resolve_entrypoint(entrypoint);
+      let resolved =
+        node_shim::resolve_entrypoint(std::path::Path::new("deno"), entrypoint);
       deno_args[idx] = resolved;
     }
   }
@@ -91,35 +91,4 @@ fn main() {
       .expect("Failed to execute deno");
     process::exit(status.code().unwrap_or(1));
   }
-}
-
-fn resolve_entrypoint(entrypoint: &str) -> String {
-  let cwd = env::current_dir().unwrap();
-  // If the entrypoint is either an absolute path, or a relative path that exists,
-  // return it as is.
-  if cwd.join(entrypoint).symlink_metadata().is_ok() {
-    return entrypoint.to_string();
-  }
-
-  let url = url::Url::from_file_path(cwd.join("$file.js")).unwrap();
-
-  // Otherwise, shell out to `deno` to try to resolve the entrypoint.
-  let output = process::Command::new("deno")
-    .arg("eval")
-    .arg("--no-config")
-    .arg(include_str!("./resolve.js"))
-    .arg(url.to_string())
-    .arg(format!("./{}", entrypoint))
-    .env_clear()
-    .stdout(Stdio::piped())
-    .stderr(Stdio::inherit())
-    .output()
-    .expect("Failed to execute deno resolve script");
-  if !output.status.success() {
-    std::process::exit(output.status.code().unwrap_or(1));
-  }
-  String::from_utf8(output.stdout)
-    .expect("Failed to parse deno resolve output")
-    .trim()
-    .to_string()
 }

--- a/tests/specs/node/node_compat_shim/__test__.jsonc
+++ b/tests/specs/node/node_compat_shim/__test__.jsonc
@@ -1,0 +1,25 @@
+{
+  "tempDir": true,
+  "tests": {
+    // With no real `node` on PATH, Deno provides itself as `node`, so a native
+    // PATH-based spawn of `node` succeeds.
+    "provides_node_when_absent": {
+      "if": "unix",
+      "args": "run -A spawn_node.mjs",
+      "envs": {
+        "PATH": ""
+      },
+      "output": "spawn_node.out"
+    },
+    // With the feature disabled, the spawn fails because there is no `node`.
+    "opt_out": {
+      "if": "unix",
+      "args": "run -A spawn_node.mjs",
+      "envs": {
+        "PATH": "",
+        "DENO_DISABLE_NODE_SHIM": "1"
+      },
+      "output": "spawn_node_disabled.out"
+    }
+  }
+}

--- a/tests/specs/node/node_compat_shim/__test__.jsonc
+++ b/tests/specs/node/node_compat_shim/__test__.jsonc
@@ -20,6 +20,12 @@
         "DENO_DISABLE_NODE_SHIM": "1"
       },
       "output": "spawn_node_disabled.out"
+    },
+    // A real `node` already on PATH must never be shadowed by the shim.
+    "real_node_not_shadowed": {
+      "if": "unix",
+      "args": "run -A real_node_not_shadowed.mjs",
+      "output": "real_node_not_shadowed.out"
     }
   }
 }

--- a/tests/specs/node/node_compat_shim/real_node_not_shadowed.mjs
+++ b/tests/specs/node/node_compat_shim/real_node_not_shadowed.mjs
@@ -1,0 +1,19 @@
+// When a real `node` is already on PATH, Deno must not shadow it. Stage a fake
+// `node`, re-run deno with only that directory on PATH, and confirm the native
+// spawn inside spawn_node.mjs reaches the fake binary rather than deno's shim
+// (which would have printed NODE_OK from the `-e` snippet).
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const binDir = mkdtempSync(join(tmpdir(), "fakenode-"));
+const fakeNode = join(binDir, "node");
+writeFileSync(fakeNode, "#!/bin/sh\necho REAL_NODE_USED\n");
+chmodSync(fakeNode, 0o755);
+
+const result = spawnSync(Deno.execPath(), ["run", "-A", "spawn_node.mjs"], {
+  encoding: "utf8",
+  env: { ...process.env, PATH: binDir },
+});
+process.stdout.write(result.stdout);

--- a/tests/specs/node/node_compat_shim/real_node_not_shadowed.out
+++ b/tests/specs/node/node_compat_shim/real_node_not_shadowed.out
@@ -1,0 +1,3 @@
+status: 0
+stdout: REAL_NODE_USED
+[WILDCARD]

--- a/tests/specs/node/node_compat_shim/spawn_node.mjs
+++ b/tests/specs/node/node_compat_shim/spawn_node.mjs
@@ -1,0 +1,15 @@
+// Spawns `node` the way native tools (e.g. Next.js Turbopack) do: a raw PATH
+// lookup that bypasses Deno's shell-level `node` interception. With no real
+// `node` on PATH, Deno should provide itself as `node` so this succeeds.
+import { spawnSync } from "node:child_process";
+
+const result = spawnSync("node", ["-e", "process.stdout.write('NODE_OK')"], {
+  encoding: "utf8",
+});
+
+if (result.error) {
+  console.log("spawn error:", result.error.code);
+} else {
+  console.log("status:", result.status);
+  console.log("stdout:", result.stdout);
+}

--- a/tests/specs/node/node_compat_shim/spawn_node.out
+++ b/tests/specs/node/node_compat_shim/spawn_node.out
@@ -1,0 +1,2 @@
+status: 0
+stdout: NODE_OK

--- a/tests/specs/node/node_compat_shim/spawn_node_disabled.out
+++ b/tests/specs/node/node_compat_shim/spawn_node_disabled.out
@@ -1,0 +1,1 @@
+spawn error: ENOENT


### PR DESCRIPTION
Some native tools resolve and spawn a `node` child process via a raw OS
PATH lookup, which bypasses the `node` interception Deno does at the
shell and `child_process` levels. The motivating case is Next.js 16:
Turbopack's native addon spawns a pool of `node` workers to run
webpack-style JS loaders (PostCSS/Tailwind, `next/font`), so
`deno task dev` fails CSS compilation with "spawning node pooled process
- No such file or directory" whenever no `node` binary is installed.

To make `node` unnecessary, Deno now stands in for it. When the deno
binary is invoked through a file named `node` it translates the Node CLI
arguments to Deno arguments and runs as if `deno node ...`; and on
startup it creates such a `node` executable under DENO_DIR (a symlink on
unix, a hardlink or copy on windows) and prepends that directory to its
own PATH so child processes, including native NAPI spawns, inherit it.
Both are best-effort and only activate when a real `node` is not already
on PATH, so existing Node installs are never shadowed; set
DENO_DISABLE_NODE_SHIM=1 to turn the behavior off.

Reported via denoland/docs#3185.