### PR TITLE
fix(outdated): include catalog dependencies in deno outdated/update

### DIFF
--- a/cli/tools/pm/deps.rs
+++ b/cli/tools/pm/deps.rs
@@ -438,10 +438,9 @@ fn add_deps_from_catalogs(
   // Mirror `Workspace`'s own resolution: a root package.json catalog takes
   // precedence over deno.json, and if it's present deno.json catalogs are
   // ignored entirely.
-  let pkg_json = workspace.root_pkg_json().filter(|pj| {
-    pj.catalog.as_ref().is_some_and(|c| !c.is_empty())
-      || pj.catalogs.as_ref().is_some_and(|c| !c.is_empty())
-  });
+  let pkg_json = workspace
+    .root_pkg_json()
+    .filter(|pj| pj.catalog.is_some() || pj.catalogs.is_some());
 
   let (path, kind, catalog, catalogs, nested) = if let Some(pj) = pkg_json {
     (

--- a/cli/tools/pm/deps.rs
+++ b/cli/tools/pm/deps.rs
@@ -483,6 +483,8 @@ fn add_deps_from_catalogs(
       name: name.into(),
       version_req,
     };
+    // Catalog entries are keyed by the package name itself, so there is no
+    // separate alias.
     if !filter.should_include(None, &req, DepKind::Npm) {
       return;
     }

--- a/cli/tools/pm/deps.rs
+++ b/cli/tools/pm/deps.rs
@@ -63,6 +63,17 @@ pub enum ImportMapKind {
 pub enum DepLocation {
   DenoJson(ConfigFileRc, KeyPath, ImportMapKind),
   PackageJson(PackageJsonRc, KeyPath),
+  /// A `catalog`/`catalogs` entry defined in the workspace root config
+  /// (deno.json or package.json). Unlike the other locations the value is a
+  /// bare version requirement (e.g. `^1.0.0`) rather than a full specifier.
+  /// `key_paths` lists candidate paths to the entry; the first one that
+  /// resolves is updated (package.json may declare catalogs at the top level
+  /// or nested under `workspaces`).
+  Catalog {
+    path: PathBuf,
+    kind: super::ConfigKind,
+    key_paths: Vec<KeyPath>,
+  },
 }
 
 impl DepLocation {
@@ -79,12 +90,14 @@ impl DepLocation {
         ImportMapKind::Outline(path) => Cow::Borrowed(path.as_path()),
       },
       DepLocation::PackageJson(arc, _) => Cow::Borrowed(arc.path.as_ref()),
+      DepLocation::Catalog { path, .. } => Cow::Borrowed(path.as_path()),
     }
   }
   fn config_kind(&self) -> super::ConfigKind {
     match self {
       DepLocation::DenoJson(_, _, _) => super::ConfigKind::DenoJson,
       DepLocation::PackageJson(_, _) => super::ConfigKind::PackageJson,
+      DepLocation::Catalog { kind, .. } => *kind,
     }
   }
 }
@@ -121,6 +134,16 @@ impl std::fmt::Debug for DepLocation {
         let mut debug = f.debug_tuple("PackageJson");
         debug.field(&DebugAdapter(arc)).field(key_path).finish()
       }
+      DepLocation::Catalog {
+        path,
+        kind,
+        key_paths,
+      } => f
+        .debug_struct("Catalog")
+        .field("path", path)
+        .field("kind", kind)
+        .field("key_paths", key_paths)
+        .finish(),
     }
   }
 }
@@ -403,6 +426,119 @@ fn add_deps_from_package_json(
   );
 }
 
+/// Collects dependencies declared in the workspace root `catalog`/`catalogs`
+/// (referenced from members via the `catalog:` protocol). These live in a
+/// single place in the root config, so they are gathered once here rather than
+/// per member reference.
+fn add_deps_from_catalogs(
+  workspace: &Workspace,
+  mut filter: impl DepFilter,
+  deps: &mut Vec<Dep>,
+) {
+  // Mirror `Workspace`'s own resolution: a root package.json catalog takes
+  // precedence over deno.json, and if it's present deno.json catalogs are
+  // ignored entirely.
+  let pkg_json = workspace.root_pkg_json().filter(|pj| {
+    pj.catalog.as_ref().is_some_and(|c| !c.is_empty())
+      || pj.catalogs.as_ref().is_some_and(|c| !c.is_empty())
+  });
+
+  let (path, kind, catalog, catalogs, nested) = if let Some(pj) = pkg_json {
+    (
+      pj.path.clone(),
+      super::ConfigKind::PackageJson,
+      pj.catalog.as_ref(),
+      pj.catalogs.as_ref(),
+      // package.json may declare catalogs nested under `workspaces`.
+      true,
+    )
+  } else if let Some(dj) = workspace.root_deno_json() {
+    let Ok(path) = dj.specifier.to_file_path() else {
+      return;
+    };
+    (
+      path,
+      super::ConfigKind::DenoJson,
+      dj.catalog(),
+      dj.catalogs(),
+      false,
+    )
+  } else {
+    return;
+  };
+
+  let mut add_entry = |name: &str,
+                       version_req_str: &str,
+                       key_paths: Vec<KeyPath>| {
+    let version_req = match VersionReq::parse_from_npm(version_req_str) {
+      Ok(version_req) => version_req,
+      Err(err) => {
+        log::warn!(
+          "failed to parse catalog version requirement \"{version_req_str}\" for \"{name}\": {err}"
+        );
+        return;
+      }
+    };
+    let req = PackageReq {
+      name: name.into(),
+      version_req,
+    };
+    if !filter.should_include(None, &req, DepKind::Npm) {
+      return;
+    }
+    let id = DepId(deps.len());
+    deps.push(Dep {
+      id,
+      kind: DepKind::Npm,
+      location: DepLocation::Catalog {
+        path: path.clone(),
+        kind,
+        key_paths,
+      },
+      req,
+      alias: None,
+    });
+  };
+
+  if let Some(catalog) = catalog {
+    for (name, version_req) in catalog {
+      let mut key_paths = vec![KeyPath::from_parts([
+        KeyPart::String("catalog".into()),
+        KeyPart::String(name.as_str().into()),
+      ])];
+      if nested {
+        key_paths.push(KeyPath::from_parts([
+          KeyPart::String("workspaces".into()),
+          KeyPart::String("catalog".into()),
+          KeyPart::String(name.as_str().into()),
+        ]));
+      }
+      add_entry(name, version_req, key_paths);
+    }
+  }
+
+  if let Some(catalogs) = catalogs {
+    for (catalog_name, entries) in catalogs {
+      for (name, version_req) in entries {
+        let mut key_paths = vec![KeyPath::from_parts([
+          KeyPart::String("catalogs".into()),
+          KeyPart::String(catalog_name.as_str().into()),
+          KeyPart::String(name.as_str().into()),
+        ])];
+        if nested {
+          key_paths.push(KeyPath::from_parts([
+            KeyPart::String("workspaces".into()),
+            KeyPart::String("catalogs".into()),
+            KeyPart::String(catalog_name.as_str().into()),
+            KeyPart::String(name.as_str().into()),
+          ]));
+        }
+        add_entry(name, version_req, key_paths);
+      }
+    }
+  }
+}
+
 fn deps_from_workspace(
   workspace: &Arc<Workspace>,
   dep_filter: impl DepFilter,
@@ -414,6 +550,7 @@ fn deps_from_workspace(
   for package_json in workspace.package_jsons() {
     add_deps_from_package_json(package_json, dep_filter, &mut deps);
   }
+  add_deps_from_catalogs(workspace, dep_filter, &mut deps);
 
   Ok(deps)
 }
@@ -545,6 +682,11 @@ impl DepManager {
     }
     if let Some(package_json) = workspace_dir.member_pkg_json() {
       add_deps_from_package_json(package_json, dep_filter, &mut deps);
+    }
+    // Catalogs are a workspace-root concept, so only include them when running
+    // in the root directory (the recursive path handles them via the workspace).
+    if workspace_dir.dir_path() == workspace_dir.workspace.root_dir_path() {
+      add_deps_from_catalogs(&workspace_dir.workspace, dep_filter, &mut deps);
     }
 
     Ok(Self::with_deps_args(deps, args))
@@ -972,6 +1114,21 @@ impl DepManager {
               };
               property
                 .set_value(jsonc_parser::cst::CstInputValue::String(new_value));
+            }
+            DepLocation::Catalog {
+              path, key_paths, ..
+            } => {
+              let updater =
+                get_or_create_updater(&mut config_updaters, &dep.location)?;
+              if !updater
+                .update_catalog_entry(key_paths, &version_req.to_string())
+              {
+                log::warn!(
+                  "failed to find catalog entry for \"{}\" in {}",
+                  dep.req.name,
+                  path.display()
+                );
+              }
             }
           }
         }

--- a/cli/tools/pm/mod.rs
+++ b/cli/tools/pm/mod.rs
@@ -51,7 +51,7 @@ pub use outdated::outdated;
 pub use why::why;
 
 #[derive(Debug, Copy, Clone, Hash)]
-enum ConfigKind {
+pub(crate) enum ConfigKind {
   DenoJson,
   PackageJson,
 }
@@ -121,6 +121,41 @@ impl ConfigUpdater {
     }
 
     None
+  }
+
+  /// Looks up a property by key path without marking the file as modified.
+  fn get_existing_property(&self, key_path: &KeyPath) -> Option<CstObjectProp> {
+    let mut current_node = self.root_object.clone();
+    for (i, part) in key_path.parts.iter().enumerate() {
+      let s = part.as_str();
+      if i < key_path.parts.len().saturating_sub(1) {
+        current_node = current_node.object_value(s)?;
+      } else {
+        return current_node.get(s);
+      }
+    }
+    None
+  }
+
+  /// Updates a catalog entry's bare version requirement. `key_paths` lists
+  /// candidate locations (e.g. top-level `catalog` vs `workspaces.catalog` in
+  /// package.json); the first one that exists is updated. Returns whether an
+  /// entry was found and updated.
+  fn update_catalog_entry(
+    &mut self,
+    key_paths: &[KeyPath],
+    new_value: &str,
+  ) -> bool {
+    for key_path in key_paths {
+      if let Some(property) = self.get_existing_property(key_path) {
+        property.set_value(jsonc_parser::cst::CstInputValue::String(
+          new_value.to_string(),
+        ));
+        self.modified = true;
+        return true;
+      }
+    }
+    false
   }
 
   fn add(&mut self, selected: SelectedPackage, dev: bool) {

--- a/tests/specs/outdated/catalog/__test__.jsonc
+++ b/tests/specs/outdated/catalog/__test__.jsonc
@@ -16,6 +16,20 @@
         }
       ]
     },
+    // Catalogs are a workspace-root concept, so a non-recursive `deno outdated`
+    // run from the root still reports them.
+    "print_outdated_root": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "outdated",
+          "output": "outdated.out"
+        }
+      ]
+    },
     // `deno update --latest` should write the new version requirement back to
     // the catalog definition in the root config.
     "update_latest_recursive": {

--- a/tests/specs/outdated/catalog/__test__.jsonc
+++ b/tests/specs/outdated/catalog/__test__.jsonc
@@ -1,0 +1,38 @@
+{
+  "tempDir": true,
+  "tests": {
+    // Catalog dependencies (referenced via the `catalog:` protocol) should be
+    // reported by `deno outdated`, resolving their version from the root
+    // `catalog`/`catalogs`.
+    "print_outdated_recursive": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "outdated --recursive",
+          "output": "outdated.out"
+        }
+      ]
+    },
+    // `deno update --latest` should write the new version requirement back to
+    // the catalog definition in the root config.
+    "update_latest_recursive": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "outdated --update --latest --recursive",
+          "output": "update.out"
+        },
+        {
+          "args": "-A print_file.ts ./deno.json",
+          "output": "deno.json.out"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/outdated/catalog/deno.json
+++ b/tests/specs/outdated/catalog/deno.json
@@ -1,0 +1,11 @@
+{
+  "workspace": ["./member"],
+  "catalog": {
+    "@denotest/has-patch-versions": "0.1.0"
+  },
+  "catalogs": {
+    "testing": {
+      "@denotest/breaking-change-between-versions": "1.0.0"
+    }
+  }
+}

--- a/tests/specs/outdated/catalog/deno.json.out
+++ b/tests/specs/outdated/catalog/deno.json.out
@@ -1,0 +1,11 @@
+{
+  "workspace": ["./member"],
+  "catalog": {
+    "@denotest/has-patch-versions": "0.2.0"
+  },
+  "catalogs": {
+    "testing": {
+      "@denotest/breaking-change-between-versions": "2.0.0"
+    }
+  }
+}

--- a/tests/specs/outdated/catalog/member/package.json
+++ b/tests/specs/outdated/catalog/member/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/member",
+  "version": "0.1.0",
+  "dependencies": {
+    "@denotest/has-patch-versions": "catalog:",
+    "@denotest/breaking-change-between-versions": "catalog:testing"
+  }
+}

--- a/tests/specs/outdated/catalog/outdated.out
+++ b/tests/specs/outdated/catalog/outdated.out
@@ -1,0 +1,10 @@
+┌────────────────────────────────────────────────┬─────────┬────────┬────────┐
+│ Package                                        │ Current │ Update │ Latest │
+├────────────────────────────────────────────────┼─────────┼────────┼────────┤
+│ npm:@denotest/has-patch-versions               │ 0.1.0   │ 0.1.0  │ 0.2.0  │
+├────────────────────────────────────────────────┼─────────┼────────┼────────┤
+│ npm:@denotest/breaking-change-between-versions │ 1.0.0   │ 1.0.0  │ 2.0.0  │
+└────────────────────────────────────────────────┴─────────┴────────┴────────┘
+
+Run deno update --latest to update to the latest available versions,
+or deno outdated --help for more information.

--- a/tests/specs/outdated/catalog/print_file.ts
+++ b/tests/specs/outdated/catalog/print_file.ts
@@ -1,0 +1,2 @@
+const file = Deno.args[0];
+console.log(Deno.readTextFileSync(file).trim());

--- a/tests/specs/outdated/catalog/update.out
+++ b/tests/specs/outdated/catalog/update.out
@@ -1,0 +1,3 @@
+[WILDCARD]Updated 2 dependencies:
+ - npm:@denotest/breaking-change-between-versions 1.0.0 -> 2.0.0
+ - npm:@denotest/has-patch-versions               0.1.0 -> 0.2.0

--- a/tests/specs/outdated/catalog_pkg_json/__test__.jsonc
+++ b/tests/specs/outdated/catalog_pkg_json/__test__.jsonc
@@ -1,0 +1,38 @@
+{
+  "tempDir": true,
+  "tests": {
+    // Catalogs declared in the root package.json: a top-level `catalog` plus a
+    // `catalogs` nested under the `workspaces` object (Bun/Yarn form). Both
+    // should be reported by `deno outdated`.
+    "print_outdated_recursive": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "outdated --recursive",
+          "output": "outdated.out"
+        }
+      ]
+    },
+    // `deno update --latest` should write back to both the top-level `catalog`
+    // entry and the `workspaces`-nested `catalogs` entry.
+    "update_latest_recursive": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "outdated --update --latest --recursive",
+          "output": "update.out"
+        },
+        {
+          "args": "-A print_file.ts ./package.json",
+          "output": "package.json.out"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/outdated/catalog_pkg_json/deno.json
+++ b/tests/specs/outdated/catalog_pkg_json/deno.json
@@ -1,0 +1,3 @@
+{
+  "workspace": ["./member"]
+}

--- a/tests/specs/outdated/catalog_pkg_json/member/package.json
+++ b/tests/specs/outdated/catalog_pkg_json/member/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/member",
+  "version": "0.1.0",
+  "dependencies": {
+    "@denotest/has-patch-versions": "catalog:",
+    "@denotest/breaking-change-between-versions": "catalog:testing"
+  }
+}

--- a/tests/specs/outdated/catalog_pkg_json/outdated.out
+++ b/tests/specs/outdated/catalog_pkg_json/outdated.out
@@ -1,0 +1,10 @@
+┌────────────────────────────────────────────────┬─────────┬────────┬────────┐
+│ Package                                        │ Current │ Update │ Latest │
+├────────────────────────────────────────────────┼─────────┼────────┼────────┤
+│ npm:@denotest/has-patch-versions               │ 0.1.0   │ 0.1.0  │ 0.2.0  │
+├────────────────────────────────────────────────┼─────────┼────────┼────────┤
+│ npm:@denotest/breaking-change-between-versions │ 1.0.0   │ 1.0.0  │ 2.0.0  │
+└────────────────────────────────────────────────┴─────────┴────────┴────────┘
+
+Run deno update --latest to update to the latest available versions,
+or deno outdated --help for more information.

--- a/tests/specs/outdated/catalog_pkg_json/package.json
+++ b/tests/specs/outdated/catalog_pkg_json/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "root",
+  "catalog": {
+    "@denotest/has-patch-versions": "0.1.0"
+  },
+  "workspaces": {
+    "catalogs": {
+      "testing": {
+        "@denotest/breaking-change-between-versions": "1.0.0"
+      }
+    }
+  }
+}

--- a/tests/specs/outdated/catalog_pkg_json/package.json.out
+++ b/tests/specs/outdated/catalog_pkg_json/package.json.out
@@ -1,0 +1,13 @@
+{
+  "name": "root",
+  "catalog": {
+    "@denotest/has-patch-versions": "0.2.0"
+  },
+  "workspaces": {
+    "catalogs": {
+      "testing": {
+        "@denotest/breaking-change-between-versions": "2.0.0"
+      }
+    }
+  }
+}

--- a/tests/specs/outdated/catalog_pkg_json/print_file.ts
+++ b/tests/specs/outdated/catalog_pkg_json/print_file.ts
@@ -1,0 +1,2 @@
+const file = Deno.args[0];
+console.log(Deno.readTextFileSync(file).trim());

--- a/tests/specs/outdated/catalog_pkg_json/update.out
+++ b/tests/specs/outdated/catalog_pkg_json/update.out
@@ -1,0 +1,3 @@
+[WILDCARD]Updated 2 dependencies:
+ - npm:@denotest/breaking-change-between-versions 1.0.0 -> 2.0.0
+ - npm:@denotest/has-patch-versions               0.1.0 -> 0.2.0


### PR DESCRIPTION
`deno outdated` and `deno update` silently ignored dependencies declared
through the `catalog:` protocol. In a workspace where a package is pinned
via a root `catalog`/`catalogs` entry and referenced from a member with
`"pkg": "catalog:"`, the package never showed up in `deno outdated` and was
never touched by `deno update`, even when a newer version was available.

The cause was in the pm dependency collector. When walking a member's
package.json it dropped the `Catalog` dependency value, and when walking
deno.json it only read the `imports` map, never the `catalog`/`catalogs`
config fields. So catalog entries were collected from nowhere.

This change collects catalog entries once from the workspace root config,
since that is the single place their version requirements live. It follows
the same precedence the workspace itself uses (a root package.json catalog
takes precedence over deno.json), resolves each entry as an npm dependency,
and reports it like any other. `deno update --latest` writes the new
requirement back to the catalog definition rather than to the member
references. Both the top-level `catalog`/`catalogs` form and the
package.json `workspaces`-nested form are handled on write-back.

Spec tests under `tests/specs/outdated/catalog` and
`tests/specs/outdated/catalog_pkg_json` cover reporting and writing back
updates for the deno.json form, the package.json top-level form, and the
package.json `workspaces`-nested form, across both the default catalog and
a named catalog.

Closes #34975
