### PR TITLE
docs: update usage examples for ext crates

### DIFF
--- a/ext/crypto/README.md
+++ b/ext/crypto/README.md
@@ -10,7 +10,9 @@ From javascript, include the extension's source, and assign `CryptoKey`,
 `crypto`, `Crypto`, and `SubtleCrypto` to the global scope:
 
 ```javascript
-import * as crypto from "ext:deno_crypto/00_crypto.js";
+import { core } from "ext:core/mod.js";
+
+const crypto = core.loadExtScript("ext:deno_crypto/00_crypto.js");
 
 Object.defineProperty(globalThis, "CryptoKey", {
   value: crypto.CryptoKey,
@@ -65,15 +67,28 @@ Following ops are provided, which can be accessed through `Deno.ops`:
 - op_crypto_encrypt
 - op_crypto_decrypt
 - op_crypto_subtle_digest
+- op_crypto_subtle_digest_xof
 - op_crypto_random_uuid
 - op_crypto_wrap_key
 - op_crypto_unwrap_key
 - op_crypto_base64url_decode
 - op_crypto_base64url_encode
+- key_store::op_crypto_key_store_insert
+- key_store::op_crypto_key_store_get
 - x25519::op_crypto_generate_x25519_keypair
+- x25519::op_crypto_x25519_public_key
 - x25519::op_crypto_derive_bits_x25519
 - x25519::op_crypto_import_spki_x25519
 - x25519::op_crypto_import_pkcs8_x25519
+- x25519::op_crypto_export_spki_x25519
+- x25519::op_crypto_export_pkcs8_x25519
+- x448::op_crypto_generate_x448_keypair
+- x448::op_crypto_derive_bits_x448
+- x448::op_crypto_import_spki_x448
+- x448::op_crypto_import_pkcs8_x448
+- x448::op_crypto_x448_public_key
+- x448::op_crypto_export_spki_x448
+- x448::op_crypto_export_pkcs8_x448
 - ed25519::op_crypto_generate_ed25519_keypair
 - ed25519::op_crypto_import_spki_ed25519
 - ed25519::op_crypto_import_pkcs8_ed25519
@@ -82,5 +97,19 @@ Following ops are provided, which can be accessed through `Deno.ops`:
 - ed25519::op_crypto_export_spki_ed25519
 - ed25519::op_crypto_export_pkcs8_ed25519
 - ed25519::op_crypto_jwk_x_ed25519
-- x25519::op_crypto_export_spki_x25519
-- x25519::op_crypto_export_pkcs8_x25519
+- mldsa::op_crypto_mldsa_from_seed
+- mldsa::op_crypto_mldsa_from_pkcs8
+- mldsa::op_crypto_mldsa_from_spki
+- mldsa::op_crypto_mldsa_export_pkcs8
+- mldsa::op_crypto_mldsa_export_spki
+- mldsa::op_crypto_sign_mldsa
+- mldsa::op_crypto_verify_mldsa
+- mlkem::op_crypto_ml_kem_from_seed
+- mlkem::op_crypto_ml_kem_encapsulate
+- mlkem::op_crypto_ml_kem_decapsulate
+- mlkem::op_crypto_ml_kem_import_spki
+- mlkem::op_crypto_ml_kem_import_pkcs8
+- mlkem::op_crypto_ml_kem_export_spki
+- mlkem::op_crypto_ml_kem_export_pkcs8
+- mlkem::op_crypto_ml_kem_get_public_key
+- mlkem::op_crypto_ml_kem_validate_public_key

--- a/ext/fetch/README.md
+++ b/ext/fetch/README.md
@@ -10,15 +10,17 @@ From javascript, include the extension's source, and assign the following
 properties to the global scope:
 
 ```javascript
-import * as headers from "ext:deno_fetch/20_headers.js";
-import * as formData from "ext:deno_fetch/21_formdata.js";
-import * as request from "ext:deno_fetch/23_request.js";
-import * as response from "ext:deno_fetch/23_response.js";
-import * as fetch from "ext:deno_fetch/26_fetch.js";
-import * as eventSource from "ext:deno_fetch/27_eventsource.js";
+import { core } from "ext:core/mod.js";
+
+const headers = core.loadExtScript("ext:deno_fetch/20_headers.js");
+const formData = core.loadExtScript("ext:deno_fetch/21_formdata.js");
+const request = core.loadExtScript("ext:deno_fetch/23_request.js");
+const response = core.loadExtScript("ext:deno_fetch/23_response.js");
+const fetch = core.loadExtScript("ext:deno_fetch/26_fetch.js");
+const eventSource = core.loadExtScript("ext:deno_fetch/27_eventsource.js");
 
 // Set up the callback for Wasm streaming ops
-Deno.core.setWasmStreamingCallback(fetch.handleWasmStreaming);
+core.setWasmStreamingCallback(fetch.handleWasmStreaming);
 
 Object.defineProperty(globalThis, "fetch", {
   value: fetch.fetch,
@@ -56,13 +58,11 @@ Object.defineProperty(globalThis, "FormData", {
 });
 ```
 
-Then from rust, provide
-`deno_fetch::deno_fetch::init<Permissions>(Default::default())` in the
-`extensions` field of your `RuntimeOptions`
+Then from rust, provide `deno_fetch::deno_fetch::init(Default::default())` in
+the `extensions` field of your `RuntimeOptions`
 
 Where:
 
-- Permissions: a struct implementing `deno_fetch::FetchPermissions`
 - Options: `deno_fetch::Options`, which implements `Default`
 
 ## Dependencies
@@ -79,3 +79,4 @@ Following ops are provided, which can be accessed through `Deno.ops`:
 - op_fetch_send
 - op_utf8_to_byte_string
 - op_fetch_custom_client
+- op_fetch_promise_is_settled

--- a/ext/io/README.md
+++ b/ext/io/README.md
@@ -8,7 +8,9 @@ stdio streams and abstraction over File System files.**
 From javascript, include the extension's source:
 
 ```javascript
-import * as io from "ext:deno_io/12_io.js";
+import { core } from "ext:core/mod.js";
+
+const io = core.loadExtScript("ext:deno_io/12_io.js");
 ```
 
 Then from rust, provide: `deno_io::deno_io::init(Option<deno_io::Stdio>)` in the

--- a/ext/net/README.md
+++ b/ext/net/README.md
@@ -7,19 +7,22 @@
 From javascript, include the extension's source:
 
 ```javascript
-import * as webidl from "ext:deno_webidl/00_webidl.js";
-import * as net from "ext:deno_net/01_net.js";
-import * as tls from "ext:deno_net/02_tls.js";
+import { core } from "ext:core/mod.js";
+
+const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
+const net = core.loadExtScript("ext:deno_net/01_net.js");
+const tls = core.loadExtScript("ext:deno_net/02_tls.js");
+const loadQuic = core.createLazyLoader("ext:deno_net/03_quic.js");
+const quic = loadQuic();
 ```
 
 Then from rust, provide:
-`deno_net::deno_net::init::<Permissions>(root_cert_store_provider, unsafely_ignore_certificate_errors)`
+`deno_net::deno_net::init(root_cert_store_provider, unsafely_ignore_certificate_errors)`
 
 Where:
 
 - root_cert_store_provider: `Option<Arc<dyn RootCertStoreProvider>>`
 - unsafely_ignore_certificate_errors: `Option<Vec<String>>`
-- Permissions: A struct implementing `deno_net::NetPermissions`
 
 In the `extensions` field of your `RuntimeOptions`
 
@@ -35,38 +38,87 @@ Following ops are provided, which can be accessed through `Deno.ops`:
 ### Net
 
 - op_net_accept_tcp
-- op_net_accept_unix
+- op_net_get_ips_from_perm_token
 - op_net_connect_tcp
-- op_net_connect_unix
 - op_net_listen_tcp
 - op_net_listen_udp
-- op_net_listen_unix
-- op_net_listen_unixpacket
 - op_net_recv_udp
-- op_net_recv_unixpacket
 - op_net_send_udp
-- op_net_send_unixpacket
-- op_net_connect_tls
-- op_net_listen_tls
-- op_net_accept_tls
 - op_net_join_multi_v4_udp
 - op_net_join_multi_v6_udp
 - op_net_leave_multi_v4_udp
 - op_net_leave_multi_v6_udp
 - op_net_set_multi_loopback_udp
 - op_net_set_multi_ttl_udp
+- op_net_set_broadcast_udp
+- op_net_validate_multicast
+- op_net_get_system_dns_servers
+- op_net_listen_vsock
+- op_net_accept_vsock
+- op_net_connect_vsock
+- op_net_listen_tunnel
+- op_net_accept_tunnel
+- op_net_connect_tls
+- op_net_listen_tls
+- op_net_accept_tls
+- op_net_accept_unix
+- op_net_connect_unix
+- op_net_listen_unix
+- op_net_listen_unixpacket
+- op_net_recv_unixpacket
+- op_net_send_unixpacket
 
 ### TLS
 
-- op_tls_start
-- op_tls_handshake
 - op_tls_key_null
 - op_tls_key_static
-- op_tls_key_static_from_file
 - op_tls_cert_resolver_create
 - op_tls_cert_resolver_poll
 - op_tls_cert_resolver_resolve
 - op_tls_cert_resolver_resolve_error
+- op_tls_start
+- op_tls_handshake
+
+### QUIC
+
+- op_quic_connecting_0rtt
+- op_quic_connecting_1rtt
+- op_quic_connection_accept_bi
+- op_quic_connection_accept_uni
+- op_quic_connection_close
+- op_quic_connection_closed
+- op_quic_connection_get_protocol
+- op_quic_connection_get_remote_addr
+- op_quic_connection_get_server_name
+- op_quic_connection_handshake
+- op_quic_connection_open_bi
+- op_quic_connection_open_uni
+- op_quic_connection_get_max_datagram_size
+- op_quic_connection_read_datagram
+- op_quic_connection_send_datagram
+- op_quic_endpoint_close
+- op_quic_endpoint_connect
+- op_quic_endpoint_create
+- op_quic_endpoint_get_addr
+- op_quic_endpoint_listen
+- op_quic_incoming_accept
+- op_quic_incoming_accept_0rtt
+- op_quic_incoming_ignore
+- op_quic_incoming_local_ip
+- op_quic_incoming_refuse
+- op_quic_incoming_remote_addr
+- op_quic_incoming_remote_addr_validated
+- op_quic_listener_accept
+- op_quic_listener_stop
+- op_quic_recv_stream_get_id
+- op_quic_send_stream_get_id
+- op_quic_send_stream_get_priority
+- op_quic_send_stream_set_priority
+
+### WebTransport
+
+- op_webtransport_accept
+- op_webtransport_connect
 
 ### Other
 

--- a/ext/web/README.md
+++ b/ext/web/README.md
@@ -14,24 +14,40 @@ _Note: Testing for text encoding is done via WPT in cli/._
 From javascript, include the extension's source:
 
 ```javascript
-import * as infra from "ext:deno_web/00_infra.js";
-import * as DOMException from "ext:deno_web/01_dom_exception.js";
-import * as mimesniff from "ext:deno_web/01_mimesniff.js";
-import * as event from "ext:deno_web/02_event.js";
-import * as structuredClone from "ext:deno_web/02_structured_clone.js";
-import * as timers from "ext:deno_web/02_timers.js";
-import * as abortSignal from "ext:deno_web/03_abort_signal.js";
-import * as globalInterfaces from "ext:deno_web/04_global_interfaces.js";
-import * as base64 from "ext:deno_web/05_base64.js";
-import * as streams from "ext:deno_web/06_streams.js";
-import * as encoding from "ext:deno_web/08_text_encoding.js";
-import * as file from "ext:deno_web/09_file.js";
-import * as fileReader from "ext:deno_web/10_filereader.js";
-import * as location from "ext:deno_web/12_location.js";
-import * as messagePort from "ext:deno_web/13_message_port.js";
-import * as compression from "ext:deno_web/14_compression.js";
-import * as performance from "ext:deno_web/15_performance.js";
-import * as imageData from "ext:deno_web/16_image_data.js";
+import { core } from "ext:core/mod.js";
+
+const infra = core.loadExtScript("ext:deno_web/00_infra.js");
+const url = core.loadExtScript("ext:deno_web/00_url.js");
+const broadcastChannel = core.loadExtScript(
+  "ext:deno_web/01_broadcast_channel.js",
+);
+const console = core.loadExtScript("ext:deno_web/01_console.js");
+const DOMException = core.loadExtScript("ext:deno_web/01_dom_exception.js");
+const mimesniff = core.loadExtScript("ext:deno_web/01_mimesniff.js");
+const urlPattern = core.loadExtScript("ext:deno_web/01_urlpattern.js");
+const event = core.loadExtScript("ext:deno_web/02_event.js");
+const structuredClone = core.loadExtScript(
+  "ext:deno_web/02_structured_clone.js",
+);
+const timers = core.loadExtScript("ext:deno_web/02_timers.js");
+const abortSignal = core.loadExtScript("ext:deno_web/03_abort_signal.js");
+const globalInterfaces = core.loadExtScript(
+  "ext:deno_web/04_global_interfaces.js",
+);
+const base64 = core.loadExtScript("ext:deno_web/05_base64.js");
+const streams = core.loadExtScript("ext:deno_web/06_streams.js");
+const encoding = core.loadExtScript("ext:deno_web/08_text_encoding.js");
+const file = core.loadExtScript("ext:deno_web/09_file.js");
+const fileReader = core.loadExtScript("ext:deno_web/10_filereader.js");
+const location = core.loadExtScript("ext:deno_web/12_location.js");
+const messagePort = core.loadExtScript("ext:deno_web/13_message_port.js");
+const compression = core.loadExtScript("ext:deno_web/14_compression.js");
+const performance = core.loadExtScript("ext:deno_web/15_performance.js");
+const imageData = core.loadExtScript("ext:deno_web/16_image_data.js");
+const loadGeometry = core.createLazyLoader("ext:deno_web/geometry.js");
+const loadWebTransport = core.createLazyLoader("ext:deno_web/webtransport.js");
+const geometry = loadGeometry();
+const webTransport = loadWebTransport();
 ```
 
 Then assign the properties below to the global scope like this example:
@@ -50,6 +66,7 @@ Object.defineProperty(globalThis, "AbortController", {
 | AbortController                  | abortSignal.AbortController              | false      | true         | true      |
 | AbortSignal                      | abortSignal.AbortSignal                  | false      | true         | true      |
 | Blob                             | file.Blob                                | false      | true         | true      |
+| BroadcastChannel                 | broadcastChannel.BroadcastChannel        | false      | true         | true      |
 | ByteLengthQueuingStrategy        | streams.ByteLengthQueuingStrategy        |            |              |           |
 | CloseEvent                       | event.CloseEvent                         | false      | true         | true      |
 | CompressionStream                | compression.CompressionStream            | false      | true         | true      |
@@ -76,6 +93,9 @@ Object.defineProperty(globalThis, "AbortController", {
 | TextDecoderStream                | encoding.TextDecoderStream               | false      | true         | true      |
 | TextEncoderStream                | encoding.TextEncoderStream               | false      | true         | true      |
 | TransformStream                  | streams.TransformStream                  | false      | true         | true      |
+| URL                              | url.URL                                  | false      | true         | true      |
+| URLPattern                       | urlPattern.URLPattern                    | false      | true         | true      |
+| URLSearchParams                  | url.URLSearchParams                      | false      | true         | true      |
 | MessageChannel                   | messagePort.MessageChannel               | false      | true         | true      |
 | MessagePort                      | messagePort.MessagePort                  | false      | true         | true      |
 | WritableStream                   | streams.WritableStream                   | false      | true         | true      |
@@ -91,6 +111,7 @@ Object.defineProperty(globalThis, "AbortController", {
 | btoa                             | base64.btoa                              | true       | true         | true      |
 | clearInterval                    | timers.clearInterval                     | true       | true         | true      |
 | clearTimeout                     | timers.clearTimeout                      | true       | true         | true      |
+| console                          | new console.Console(printer)             | false      | true         | true      |
 | performance                      | performance.performance                  | true       | true         | true      |
 | reportError                      | event.reportError                        | true       | true         | true      |
 | setInterval                      | timers.setInterval                       | true       | true         | true      |
@@ -98,12 +119,11 @@ Object.defineProperty(globalThis, "AbortController", {
 | structuredClone                  | messagePort.structuredClone              | true       | true         | true      |
 
 Then from rust, provide:
-`deno_web::deno_web::init::<Permissions>(Arc<BlobStore>, Option<Url>, bool, InMemoryBroadcastChannel)`
+`deno_web::deno_web::init(Arc<BlobStore>, Option<Url>, bool, InMemoryBroadcastChannel)`
 in the `extensions` field of your `RuntimeOptions`
 
 Where:
 
-- `Permissions` is a struct implementing `deno_web::TimersPermission`
 - `Arc<BlobStore>` can be provided by `Default::default()`
 - `Option<Url>` provides an optional base URL for certain ops
 - `bool` indicates whether window features are enabled at initialization
@@ -118,7 +138,9 @@ Where:
 Following ops are provided, which can be accessed through `Deno.ops`:
 
 - op_base64_decode
+- op_base64_decode_into
 - op_base64_encode
+- op_base64_encode_from_buffer
 - op_base64_atob
 - op_base64_btoa
 - op_encoding_normalize_label
@@ -127,21 +149,25 @@ Following ops are provided, which can be accessed through `Deno.ops`:
 - op_encoding_new_decoder
 - op_encoding_decode
 - op_encoding_encode_into
+- op_encoding_encode_into_fallback
 - op_blob_create_part
 - op_blob_slice_part
 - op_blob_read_part
 - op_blob_remove_part
+- op_blob_clone_part
 - op_blob_create_object_url
 - op_blob_revoke_object_url
 - op_blob_from_object_url
 - op_message_port_create_entangled
 - op_message_port_post_message
+- op_message_port_post_message_raw
 - op_message_port_recv_message
 - op_message_port_recv_message_sync
 - op_compression_new
 - op_compression_write
 - op_compression_finish
 - op_now
+- op_time_origin
 - op_defer
 - op_geometry_get_enable_css_parser_features
 - op_geometry_matrix_set_matrix_value
@@ -154,6 +180,22 @@ Following ops are provided, which can be accessed through `Deno.ops`:
 - op_readable_stream_resource_write_sync
 - op_readable_stream_resource_close
 - op_readable_stream_resource_await_close
+- op_url_reparse
+- op_url_parse
+- op_url_get_serialization
+- op_url_parse_with_base
+- op_url_parse_search_params
+- op_url_stringify_search_params
+- op_urlpattern_parse
+- op_urlpattern_process_match_input
+- op_preview_entries
+- op_broadcast_subscribe
+- op_broadcast_unsubscribe
+- op_broadcast_serialize
+- op_broadcast_deserialize
+- op_broadcast_free
+- op_broadcast_send
+- op_broadcast_recv
 - DOMPointReadOnly
 - DOMPoint
 - DOMRectReadOnly
@@ -161,3 +203,4 @@ Following ops are provided, which can be accessed through `Deno.ops`:
 - DOMQuad
 - DOMMatrixReadOnly
 - DOMMatrix
+- ImageData

--- a/ext/webidl/README.md
+++ b/ext/webidl/README.md
@@ -11,7 +11,9 @@ From javascript, include the extension's source, and assign the following to the
 global scope:
 
 ```javascript
-import * as webidl from "ext:deno_webidl/00_webidl.js";
+import { core } from "ext:core/mod.js";
+
+const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
 Object.defineProperty(globalThis, webidl.brand, {
   value: webidl.brand,
   enumerable: false,
@@ -20,5 +22,5 @@ Object.defineProperty(globalThis, webidl.brand, {
 });
 ```
 
-Then from rust, provide `init_webidl::init_webidl::init()` in the `extensions`
+Then from rust, provide `deno_webidl::deno_webidl::init()` in the `extensions`
 field of your `RuntimeOptions`


### PR DESCRIPTION
Fixes #34973 

- Ext-provided JS files are now either `lazy_loaded_js` or `lazy_loaded_esm `:
  - examples now show how to use `core.loadExtScript` for the former;
  - and `core.createLazyLoader` for the latter;
  - the `core` object is imported from `ext:core/mod.js` per the module's own [stated purpose](https://github.com/denoland/deno/blob/bda41c558f4b5651100e324e5fdf838541a7f063/libs/core/mod.js#L2-L3).
- Added new scripts to the javascript snippets:
  - ext/web now shows `geometry.js` and `webtransport.js` as lazy loaded ESM;
  - ext/net shows `03_quic.js` the same way;
- Missing global namespace members added to the table in ext/web: `BroadcastChannel`, `URL`, `URLPattern`, `URLSearchParams`, `console`, with descriptor params marching `98_global_scope_shared.js`.
- `deno_web::init` signature and parameters description updated:
  - `Permissions` type parameter is removed;
  - `init_webidl` is changed to `deno_webidl` to match the actual crate name.
- Provided ops lists are synced with what's currently provided.

Had Claude to identify provided ops and make the edits. Reviewed edits myself, but did not re-check each listed op manually — only via additional agentic review runs.