### PR TITLE
fix(serde_v8): add recursion depth limit to deserializer

### DIFF
--- a/libs/serde_v8/de.rs
+++ b/libs/serde_v8/de.rs
@@ -502,7 +502,6 @@ struct MapObjectAccess<'a, 's, 'i> {
   obj: v8::Local<'a, v8::Object>,
   keys: SeqAccess<'a, 's, 'i>,
   next_value: Option<v8::Local<'s, v8::Value>>,
-  remaining_depth: usize,
 }
 
 impl<'a, 's, 'i> MapObjectAccess<'a, 's, 'i> {
@@ -527,7 +526,6 @@ impl<'a, 's, 'i> MapObjectAccess<'a, 's, 'i> {
       obj,
       keys,
       next_value: None,
-      remaining_depth,
     }
   }
 }
@@ -550,7 +548,7 @@ impl<'de> de::MapAccess<'de> for MapObjectAccess<'_, '_, '_> {
         self.keys.scope,
         key.v8_value,
         None,
-        self.remaining_depth,
+        self.keys.remaining_depth,
       );
       return seed.deserialize(&mut deserializer).map(Some);
     }
@@ -569,7 +567,7 @@ impl<'de> de::MapAccess<'de> for MapObjectAccess<'_, '_, '_> {
       self.keys.scope,
       v8_val,
       None,
-      self.remaining_depth,
+      self.keys.remaining_depth,
     );
     seed.deserialize(&mut deserializer)
   }

--- a/libs/serde_v8/de.rs
+++ b/libs/serde_v8/de.rs
@@ -22,10 +22,20 @@ use crate::magic::transl8::MagicType;
 use crate::magic::transl8::visit_magic;
 use crate::payload::ValueType;
 
+// Maximum nesting depth permitted while deserializing a V8 value. serde_v8
+// recurses on the Rust stack for each nested container, so without a bound a
+// deeply nested object or array (cheaply built from untrusted JS) would
+// overflow the stack and abort the process. We return an error instead once
+// this depth is reached. Matches the default used by serde_json.
+const RECURSION_LIMIT: usize = 128;
+
 pub struct Deserializer<'b, 's, 'i> {
   input: v8::Local<'s, v8::Value>,
   scope: &'b mut v8::PinScope<'s, 'i>,
   _key_cache: Option<&'b mut KeyCache>,
+  // Remaining nesting budget. Each child deserializer is created with one less
+  // than its parent; reaching zero before descending yields an error.
+  remaining_depth: usize,
 }
 
 impl<'b, 's, 'i> Deserializer<'b, 's, 'i> {
@@ -34,11 +44,31 @@ impl<'b, 's, 'i> Deserializer<'b, 's, 'i> {
     input: v8::Local<'s, v8::Value>,
     key_cache: Option<&'b mut KeyCache>,
   ) -> Self {
+    Self::with_depth(scope, input, key_cache, RECURSION_LIMIT)
+  }
+
+  fn with_depth(
+    scope: &'b mut v8::PinScope<'s, 'i>,
+    input: v8::Local<'s, v8::Value>,
+    key_cache: Option<&'b mut KeyCache>,
+    remaining_depth: usize,
+  ) -> Self {
     Deserializer {
       input,
       scope,
       _key_cache: key_cache,
+      remaining_depth,
     }
+  }
+
+  // Returns the nesting budget to hand to a child deserializer, or an error if
+  // the recursion limit has been reached. Call once per descent into a nested
+  // container.
+  fn child_depth(&self) -> Result<usize> {
+    self
+      .remaining_depth
+      .checked_sub(1)
+      .ok_or(Error::RecursionLimitExceeded)
   }
 }
 
@@ -255,9 +285,15 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
   where
     V: Visitor<'de>,
   {
+    let depth = self.child_depth()?;
     let arr = v8::Local::<v8::Array>::try_from(self.input)
       .map_err(|_| Error::ExpectedArray(self.input.type_repr()))?;
-    visitor.visit_seq(SeqAccess::new(arr.into(), self.scope, 0..arr.length()))
+    visitor.visit_seq(SeqAccess::new(
+      arr.into(),
+      self.scope,
+      0..arr.length(),
+      depth,
+    ))
   }
 
   // Like deserialize_seq except it prefers tuple's length over input array's length
@@ -265,6 +301,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
   where
     V: Visitor<'de>,
   {
+    let depth = self.child_depth()?;
     let obj = v8::Local::<v8::Object>::try_from(self.input)
       .map_err(|_| Error::ExpectedObject(self.input.type_repr()))?;
     if let Ok(array) = v8::Local::<v8::Array>::try_from(obj) {
@@ -274,7 +311,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
         return Err(Error::LengthMismatch(array_len, len));
       }
     }
-    visitor.visit_seq(SeqAccess::new(obj, self.scope, 0..len as u32))
+    visitor.visit_seq(SeqAccess::new(obj, self.scope, 0..len as u32, depth))
   }
 
   // Tuple structs look just like sequences in JSON.
@@ -294,6 +331,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
   where
     V: de::Visitor<'de>,
   {
+    let depth = self.child_depth()?;
     // Assume object, then get_own_property_names
     let obj = v8::Local::<v8::Object>::try_from(self.input)
       .map_err(|_| Error::ExpectedObject(self.input.type_repr()))?;
@@ -305,10 +343,11 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
         len: pairs_array.length(),
         obj: pairs_array,
         scope: self.scope,
+        remaining_depth: depth,
       };
       visitor.visit_map(map)
     } else {
-      visitor.visit_map(MapObjectAccess::new(obj, self.scope))
+      visitor.visit_map(MapObjectAccess::new(obj, self.scope, depth))
     }
   }
 
@@ -351,19 +390,21 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
         visit_magic(visitor, AnyValue::from_v8(self.scope, self.input)?)
       }
       _ => {
+        let depth = self.child_depth()?;
         // Regular struct
         let obj = v8::Local::<v8::Object>::try_from(self.input)
           .map_err(|_| Error::ExpectedObject(self.input.type_repr()))?;
 
         // Fields names are a hint and must be inferred when not provided
         if fields.is_empty() {
-          visitor.visit_map(MapObjectAccess::new(obj, self.scope))
+          visitor.visit_map(MapObjectAccess::new(obj, self.scope, depth))
         } else {
           visitor.visit_map(StructAccess {
             obj,
             scope: self.scope,
             keys: fields.iter(),
             next_value: None,
+            remaining_depth: depth,
           })
         }
       }
@@ -382,6 +423,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
   where
     V: Visitor<'de>,
   {
+    let depth = self.child_depth()?;
     // Unit variant
     if self.input.is_string() || self.input.is_string_object() {
       let payload = v8::undefined(self.scope).into();
@@ -389,6 +431,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
         scope: self.scope,
         tag: self.input,
         payload,
+        remaining_depth: depth,
       })
     }
     // Struct or tuple variant
@@ -413,6 +456,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
         scope: self.scope,
         tag,
         payload,
+        remaining_depth: depth,
       })
     } else {
       Err(Error::ExpectedEnum(self.input.type_repr()))
@@ -458,12 +502,14 @@ struct MapObjectAccess<'a, 's, 'i> {
   obj: v8::Local<'a, v8::Object>,
   keys: SeqAccess<'a, 's, 'i>,
   next_value: Option<v8::Local<'s, v8::Value>>,
+  remaining_depth: usize,
 }
 
 impl<'a, 's, 'i> MapObjectAccess<'a, 's, 'i> {
   pub fn new(
     obj: v8::Local<'a, v8::Object>,
     scope: &'a mut v8::PinScope<'s, 'i>,
+    remaining_depth: usize,
   ) -> Self {
     let keys = match obj.get_own_property_names(
       scope,
@@ -471,14 +517,17 @@ impl<'a, 's, 'i> MapObjectAccess<'a, 's, 'i> {
         .key_conversion(v8::KeyConversionMode::ConvertToString)
         .build(),
     ) {
-      Some(keys) => SeqAccess::new(keys.into(), scope, 0..keys.length()),
-      None => SeqAccess::new(obj, scope, 0..0),
+      Some(keys) => {
+        SeqAccess::new(keys.into(), scope, 0..keys.length(), remaining_depth)
+      }
+      None => SeqAccess::new(obj, scope, 0..0, remaining_depth),
     };
 
     Self {
       obj,
       keys,
       next_value: None,
+      remaining_depth,
     }
   }
 }
@@ -497,8 +546,12 @@ impl<'de> de::MapAccess<'de> for MapObjectAccess<'_, '_, '_> {
         continue;
       }
       self.next_value = Some(v8_val);
-      let mut deserializer =
-        Deserializer::new(self.keys.scope, key.v8_value, None);
+      let mut deserializer = Deserializer::with_depth(
+        self.keys.scope,
+        key.v8_value,
+        None,
+        self.remaining_depth,
+      );
       return seed.deserialize(&mut deserializer).map(Some);
     }
     Ok(None)
@@ -512,7 +565,12 @@ impl<'de> de::MapAccess<'de> for MapObjectAccess<'_, '_, '_> {
       .next_value
       .take()
       .expect("Call next_key_seed before next_value_seed");
-    let mut deserializer = Deserializer::new(self.keys.scope, v8_val, None);
+    let mut deserializer = Deserializer::with_depth(
+      self.keys.scope,
+      v8_val,
+      None,
+      self.remaining_depth,
+    );
     seed.deserialize(&mut deserializer)
   }
 
@@ -526,6 +584,7 @@ struct MapPairsAccess<'a, 's, 'i> {
   pos: u32,
   len: u32,
   scope: &'a mut v8::PinScope<'s, 'i>,
+  remaining_depth: usize,
 }
 
 impl<'de> de::MapAccess<'de> for MapPairsAccess<'_, '_, '_> {
@@ -538,7 +597,12 @@ impl<'de> de::MapAccess<'de> for MapPairsAccess<'_, '_, '_> {
     if self.pos < self.len {
       let v8_key = self.obj.get_index(self.scope, self.pos).unwrap();
       self.pos += 1;
-      let mut deserializer = Deserializer::new(self.scope, v8_key, None);
+      let mut deserializer = Deserializer::with_depth(
+        self.scope,
+        v8_key,
+        None,
+        self.remaining_depth,
+      );
       let k = seed.deserialize(&mut deserializer)?;
       Ok(Some(k))
     } else {
@@ -553,7 +617,8 @@ impl<'de> de::MapAccess<'de> for MapPairsAccess<'_, '_, '_> {
     debug_assert!(self.pos < self.len);
     let v8_val = self.obj.get_index(self.scope, self.pos).unwrap();
     self.pos += 1;
-    let mut deserializer = Deserializer::new(self.scope, v8_val, None);
+    let mut deserializer =
+      Deserializer::with_depth(self.scope, v8_val, None, self.remaining_depth);
     seed.deserialize(&mut deserializer)
   }
 
@@ -567,6 +632,7 @@ struct StructAccess<'a, 's, 'i> {
   scope: &'a mut v8::PinScope<'s, 'i>,
   keys: std::slice::Iter<'static, &'static str>,
   next_value: Option<v8::Local<'s, v8::Value>>,
+  remaining_depth: usize,
 }
 
 impl<'de> de::MapAccess<'de> for StructAccess<'_, '_, '_> {
@@ -584,7 +650,8 @@ impl<'de> de::MapAccess<'de> for StructAccess<'_, '_, '_> {
         continue;
       }
       self.next_value = Some(val);
-      let mut deserializer = Deserializer::new(self.scope, key, None);
+      let mut deserializer =
+        Deserializer::with_depth(self.scope, key, None, self.remaining_depth);
       return seed.deserialize(&mut deserializer).map(Some);
     }
     Ok(None)
@@ -598,7 +665,8 @@ impl<'de> de::MapAccess<'de> for StructAccess<'_, '_, '_> {
       .next_value
       .take()
       .expect("Call next_key_seed before next_value_seed");
-    let mut deserializer = Deserializer::new(self.scope, val, None);
+    let mut deserializer =
+      Deserializer::with_depth(self.scope, val, None, self.remaining_depth);
     seed.deserialize(&mut deserializer)
   }
 }
@@ -607,6 +675,7 @@ struct SeqAccess<'a, 's, 'i> {
   obj: v8::Local<'a, v8::Object>,
   scope: &'a mut v8::PinScope<'s, 'i>,
   range: std::ops::Range<u32>,
+  remaining_depth: usize,
 }
 
 impl<'a, 's, 'i> SeqAccess<'a, 's, 'i> {
@@ -614,8 +683,14 @@ impl<'a, 's, 'i> SeqAccess<'a, 's, 'i> {
     obj: v8::Local<'a, v8::Object>,
     scope: &'a mut v8::PinScope<'s, 'i>,
     range: std::ops::Range<u32>,
+    remaining_depth: usize,
   ) -> Self {
-    Self { obj, scope, range }
+    Self {
+      obj,
+      scope,
+      range,
+      remaining_depth,
+    }
   }
 }
 
@@ -629,7 +704,8 @@ impl<'de> de::SeqAccess<'de> for SeqAccess<'_, '_, '_> {
     if let Some(pos) = self.range.next() {
       // fixme: this unwrap  is not safe because of proxies
       let val = self.obj.get_index(self.scope, pos).unwrap();
-      let mut deserializer = Deserializer::new(self.scope, val, None);
+      let mut deserializer =
+        Deserializer::with_depth(self.scope, val, None, self.remaining_depth);
       seed.deserialize(&mut deserializer).map(Some)
     } else {
       Ok(None)
@@ -645,6 +721,7 @@ struct EnumAccess<'b, 's, 'i> {
   tag: v8::Local<'s, v8::Value>,
   payload: v8::Local<'s, v8::Value>,
   scope: &'b mut v8::PinScope<'s, 'i>,
+  remaining_depth: usize,
   // p1: std::marker::PhantomData<&'x ()>,
 }
 
@@ -657,12 +734,18 @@ impl<'de, 'b, 's, 'i> de::EnumAccess<'de> for EnumAccess<'b, 's, 'i> {
     seed: V,
   ) -> Result<(V::Value, Self::Variant)> {
     let seed = {
-      let mut dtag = Deserializer::new(self.scope, self.tag, None);
+      let mut dtag = Deserializer::with_depth(
+        self.scope,
+        self.tag,
+        None,
+        self.remaining_depth,
+      );
       seed.deserialize(&mut dtag)
     };
     let dpayload = VariantDeserializer::<'b, 's, 'i> {
       scope: self.scope,
       value: self.payload,
+      remaining_depth: self.remaining_depth,
     };
 
     Ok((seed?, dpayload))
@@ -672,13 +755,19 @@ impl<'de, 'b, 's, 'i> de::EnumAccess<'de> for EnumAccess<'b, 's, 'i> {
 struct VariantDeserializer<'b, 's, 'i> {
   value: v8::Local<'s, v8::Value>,
   scope: &'b mut v8::PinScope<'s, 'i>,
+  remaining_depth: usize,
 }
 
 impl<'de> de::VariantAccess<'de> for VariantDeserializer<'_, '_, '_> {
   type Error = Error;
 
   fn unit_variant(self) -> Result<()> {
-    let mut d = Deserializer::new(self.scope, self.value, None);
+    let mut d = Deserializer::with_depth(
+      self.scope,
+      self.value,
+      None,
+      self.remaining_depth,
+    );
     de::Deserialize::deserialize(&mut d)
   }
 
@@ -686,7 +775,12 @@ impl<'de> de::VariantAccess<'de> for VariantDeserializer<'_, '_, '_> {
     self,
     seed: T,
   ) -> Result<T::Value> {
-    let mut d = Deserializer::new(self.scope, self.value, None);
+    let mut d = Deserializer::with_depth(
+      self.scope,
+      self.value,
+      None,
+      self.remaining_depth,
+    );
     seed.deserialize(&mut d)
   }
 
@@ -695,7 +789,12 @@ impl<'de> de::VariantAccess<'de> for VariantDeserializer<'_, '_, '_> {
     len: usize,
     visitor: V,
   ) -> Result<V::Value> {
-    let mut d = Deserializer::new(self.scope, self.value, None);
+    let mut d = Deserializer::with_depth(
+      self.scope,
+      self.value,
+      None,
+      self.remaining_depth,
+    );
     de::Deserializer::deserialize_tuple(&mut d, len, visitor)
   }
 
@@ -704,7 +803,12 @@ impl<'de> de::VariantAccess<'de> for VariantDeserializer<'_, '_, '_> {
     fields: &'static [&'static str],
     visitor: V,
   ) -> Result<V::Value> {
-    let mut d = Deserializer::new(self.scope, self.value, None);
+    let mut d = Deserializer::with_depth(
+      self.scope,
+      self.value,
+      None,
+      self.remaining_depth,
+    );
     de::Deserializer::deserialize_struct(&mut d, "", fields, visitor)
   }
 }

--- a/libs/serde_v8/error.rs
+++ b/libs/serde_v8/error.rs
@@ -58,6 +58,9 @@ pub enum Error {
   #[error("serde_v8 error: length mismatch, got: {0}, expected: {1}")]
   LengthMismatch(usize, usize),
 
+  #[error("serde_v8 error: recursion limit exceeded")]
+  RecursionLimitExceeded,
+
   #[error("serde_v8 error: can't create slice from resizable ArrayBuffer")]
   ResizableBackingStoreNotSupported,
 

--- a/libs/serde_v8/tests/de.rs
+++ b/libs/serde_v8/tests/de.rs
@@ -622,3 +622,62 @@ detest!(
   "-170141183460469231731687303715884105728n",
   num_bigint::BigInt::from(-170141183460469231731687303715884105728i128).into()
 );
+
+// Recursion limit: deeply nested input must error, not overflow the stack.
+//
+// Builds nesting with a flat loop so the JS stack stays O(1); the depth is far
+// past serde_v8's recursion limit. Before the limit existed this overflowed the
+// Rust stack and aborted the process; now it must return an error.
+fn build_nested(scope: &mut v8::PinScope, code: &str) -> bool {
+  let v = js_exec(scope, code);
+  let res: serde_v8::Result<serde_json::Value> = serde_v8::from_v8(scope, v);
+  matches!(res, Err(Error::RecursionLimitExceeded))
+}
+
+#[test]
+fn de_deeply_nested_object_errors() {
+  dedo("({})", |scope, _| {
+    assert!(build_nested(
+      scope,
+      r#"(() => {
+        let obj = {};
+        let cur = obj;
+        for (let i = 0; i < 100000; i++) { cur.x = {}; cur = cur.x; }
+        return obj;
+      })()"#,
+    ));
+  });
+}
+
+#[test]
+fn de_deeply_nested_array_errors() {
+  dedo("({})", |scope, _| {
+    assert!(build_nested(
+      scope,
+      r#"(() => {
+        let arr = [];
+        let cur = arr;
+        for (let i = 0; i < 100000; i++) { const next = []; cur.push(next); cur = next; }
+        return arr;
+      })()"#,
+    ));
+  });
+}
+
+// Nesting within the limit must still deserialize successfully.
+#[test]
+fn de_shallow_nesting_ok() {
+  dedo("({})", |scope, _| {
+    let v = js_exec(
+      scope,
+      r#"(() => {
+        let obj = {};
+        let cur = obj;
+        for (let i = 0; i < 64; i++) { cur.x = {}; cur = cur.x; }
+        return obj;
+      })()"#,
+    );
+    let res: serde_v8::Result<serde_json::Value> = serde_v8::from_v8(scope, v);
+    assert!(res.is_ok(), "shallow nesting should deserialize: {res:?}");
+  });
+}


### PR DESCRIPTION
serde_v8's `Deserializer` recurses on the Rust stack once per nested
container, with no depth limit. Deserializing a deeply nested V8 object or
array overflows the Rust stack and aborts the process with `SIGABRT`. The
nesting can be built with O(1) JS stack using a flat loop and then passed
to any `#[op2]` function that takes a `#[serde]` parameter.

A deserializer at an op boundary should return an error on such input
rather than abort the process, so this bounds the recursion. It threads a
remaining-depth budget through the deserializer and every `Access` type,
decrementing it on each descent into a nested container (seq, tuple, map,
struct, enum). Reaching the limit returns `Error::RecursionLimitExceeded`
instead of overflowing the stack. The limit is 128, matching serde_json's
default.

Behavior change: any op caller that previously passed a structure deeper
than 128 now receives `Error::RecursionLimitExceeded` instead of
succeeding. Since the prior behavior at the overflow point was a process
abort, this is strictly an improvement, and 128 matches serde_json's
default.

Tests cover deeply nested objects and arrays (which must now error) and
shallow nesting within the limit (which must still deserialize).
