### PR TITLE
fix(install): preserve workspace member resolution in global install

### DIFF
--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -93,6 +93,17 @@ pub async fn install_global(
       .await;
   }
 
+  // When an explicit config is supplied, capture its workspace members so they
+  // can be flattened into the copied config's import map. The `workspace` field
+  // itself is dropped from the copy (it can't be discovered from the install
+  // dir), which would otherwise break resolution of member packages.
+  let workspace_member_imports =
+    if matches!(flags.config_flag, ConfigFlag::Path(_)) {
+      workspace_member_import_entries(cli_options.workspace())
+    } else {
+      Vec::new()
+    };
+
   // Validate every entry and default unprefixed bare package names to the npm
   // registry (matching `deno add` and local `deno install`) before installing
   // anything, so an error on entry N doesn't leave entries < N installed.
@@ -163,6 +174,7 @@ pub async fn install_global(
       &installation_dir,
       Some(&jsr_lockfile_fetcher),
       install_flags_global.force,
+      &workspace_member_imports,
     )
     .await?;
 
@@ -404,6 +416,7 @@ async fn setup_config_dir(
   installation_dir: &Path,
   jsr_lockfile_fetcher: Option<&JsrLockfileFetcher<'_>>,
   force: bool,
+  workspace_member_imports: &[(String, String)],
 ) -> Result<(), AnyError> {
   fn resolve_implicit_node_modules_dir(
     flags: &Flags,
@@ -479,6 +492,19 @@ async fn setup_config_dir(
   if let Some(original_config_url) = &original_config_url {
     rewrite_relative_import_map_paths(&config_obj, original_config_url);
   }
+  // Flatten workspace members into the import map. The `workspace` field is
+  // stripped below to stop discovery, which would otherwise break resolution of
+  // bare specifiers that point at member packages. Existing import map entries
+  // win, matching the runtime precedence of the import map over workspace
+  // members.
+  if !workspace_member_imports.is_empty() {
+    let imports = config_obj.object_value_or_set("imports");
+    for (specifier, target) in workspace_member_imports {
+      if imports.get(specifier).is_none() {
+        imports.append(specifier, CstInputValue::String(target.clone()));
+      }
+    }
+  }
   config_obj.append("workspace", CstInputValue::Array(Vec::new())); // stop workspace discovery
   if config_obj.get("nodeModulesDir").is_none()
     && let Some(mode) =
@@ -540,6 +566,38 @@ async fn setup_config_dir(
   .await?;
 
   Ok(())
+}
+
+/// Builds import map entries for each workspace member package so the copied
+/// config keeps resolving `@scope/member` specifiers after the `workspace`
+/// field is stripped.
+///
+/// `deno install -g -c deno.json` copies the workspace root config into a
+/// per-binary directory and removes the `workspace` field to stop workspace
+/// discovery. Without this, bare specifiers that point at workspace members
+/// (e.g. `import { x } from "@scope/member"`) can no longer be resolved. Each
+/// member's exports are flattened into absolute `file://` specifiers anchored
+/// at the member directory so the installed binary resolves them exactly as it
+/// would when invoked from the original workspace. See
+/// https://github.com/denoland/deno/issues/32057.
+fn workspace_member_import_entries(
+  workspace: &deno_config::workspace::Workspace,
+) -> Vec<(String, String)> {
+  let mut entries = Vec::new();
+  for pkg in workspace.resolver_jsr_pkgs() {
+    for (export_key, sub_path) in &pkg.exports {
+      // "." -> "@scope/name", "./sub" -> "@scope/name/sub"
+      let specifier = format!(
+        "{}{}",
+        pkg.name,
+        export_key.strip_prefix('.').unwrap_or(export_key)
+      );
+      if let Ok(target) = pkg.base.join(sub_path) {
+        entries.push((specifier, target.to_string()));
+      }
+    }
+  }
+  entries
 }
 
 /// Rewrites `./` and `../` paths inside `imports` and `scopes` to absolute
@@ -1346,6 +1404,7 @@ mod tests {
       &installation_dir,
       None,
       install_flags_global.force,
+      &[],
     )
     .await
     .unwrap();

--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -580,6 +580,11 @@ async fn setup_config_dir(
 /// at the member directory so the installed binary resolves them exactly as it
 /// would when invoked from the original workspace. See
 /// https://github.com/denoland/deno/issues/32057.
+///
+/// Only `deno.json` members (those with a `name` and `exports`) are flattened,
+/// since they are the ones resolved through the import map. `package.json`
+/// members resolve via `node_modules`, which is unaffected by stripping the
+/// `workspace` field, so they don't need an entry here.
 fn workspace_member_import_entries(
   workspace: &deno_config::workspace::Workspace,
 ) -> Vec<(String, String)> {

--- a/tests/specs/install/global/config_file_workspace_member_import_map_precedence/__test__.jsonc
+++ b/tests/specs/install/global/config_file_workspace_member_import_map_precedence/__test__.jsonc
@@ -1,0 +1,24 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "if": "unix",
+    "args": "install -g --root ./bins --config deno.json --name my-cli main.ts",
+    "output": "install.out"
+  }, {
+    "if": "unix",
+    "commandName": "./bins/bin/my-cli",
+    "args": [],
+    "output": "run.out",
+    "exitCode": 0
+  }, {
+    "if": "windows",
+    "args": "install -g --root ./bins --config deno.json --name my-cli main.ts",
+    "output": "install.out"
+  }, {
+    "if": "windows",
+    "commandName": "./bins/bin/my-cli.cmd",
+    "args": [],
+    "output": "run.out",
+    "exitCode": 0
+  }]
+}

--- a/tests/specs/install/global/config_file_workspace_member_import_map_precedence/deno.json
+++ b/tests/specs/install/global/config_file_workspace_member_import_map_precedence/deno.json
@@ -1,0 +1,6 @@
+{
+  "workspace": ["./libs/greet"],
+  "imports": {
+    "@scope/greet": "./override.ts"
+  }
+}

--- a/tests/specs/install/global/config_file_workspace_member_import_map_precedence/install.out
+++ b/tests/specs/install/global/config_file_workspace_member_import_map_precedence/install.out
@@ -1,0 +1,2 @@
+[WILDCARD]Successfully installed my-cli
+[WILDCARD]

--- a/tests/specs/install/global/config_file_workspace_member_import_map_precedence/libs/greet/deno.json
+++ b/tests/specs/install/global/config_file_workspace_member_import_map_precedence/libs/greet/deno.json
@@ -1,0 +1,7 @@
+{
+  "name": "@scope/greet",
+  "version": "0.1.0",
+  "exports": {
+    ".": "./mod.ts"
+  }
+}

--- a/tests/specs/install/global/config_file_workspace_member_import_map_precedence/libs/greet/mod.ts
+++ b/tests/specs/install/global/config_file_workspace_member_import_map_precedence/libs/greet/mod.ts
@@ -1,0 +1,5 @@
+// This is the workspace member's export. The root config maps "@scope/greet"
+// to ./override.ts, so this should be shadowed by the import map.
+export function greet(name) {
+  return "member: " + name;
+}

--- a/tests/specs/install/global/config_file_workspace_member_import_map_precedence/main.ts
+++ b/tests/specs/install/global/config_file_workspace_member_import_map_precedence/main.ts
@@ -1,0 +1,2 @@
+import { greet } from "@scope/greet";
+console.log(greet("world"));

--- a/tests/specs/install/global/config_file_workspace_member_import_map_precedence/override.ts
+++ b/tests/specs/install/global/config_file_workspace_member_import_map_precedence/override.ts
@@ -1,0 +1,6 @@
+// Mapped by the root config's import map for "@scope/greet". This must win over
+// the synthesized workspace member entry, matching how the import map takes
+// precedence over workspace members at runtime.
+export function greet(name) {
+  return "override: " + name;
+}

--- a/tests/specs/install/global/config_file_workspace_member_import_map_precedence/run.out
+++ b/tests/specs/install/global/config_file_workspace_member_import_map_precedence/run.out
@@ -1,0 +1,1 @@
+override: world

--- a/tests/specs/install/global/config_file_workspace_members/__test__.jsonc
+++ b/tests/specs/install/global/config_file_workspace_members/__test__.jsonc
@@ -1,0 +1,24 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "if": "unix",
+    "args": "install -g --root ./bins --config deno.json --name my-cli main.ts",
+    "output": "install.out"
+  }, {
+    "if": "unix",
+    "commandName": "./bins/bin/my-cli",
+    "args": [],
+    "output": "run.out",
+    "exitCode": 0
+  }, {
+    "if": "windows",
+    "args": "install -g --root ./bins --config deno.json --name my-cli main.ts",
+    "output": "install.out"
+  }, {
+    "if": "windows",
+    "commandName": "./bins/bin/my-cli.cmd",
+    "args": [],
+    "output": "run.out",
+    "exitCode": 0
+  }]
+}

--- a/tests/specs/install/global/config_file_workspace_members/deno.json
+++ b/tests/specs/install/global/config_file_workspace_members/deno.json
@@ -1,0 +1,6 @@
+{
+  "workspace": ["./libs/greet"],
+  "imports": {
+    "@app/util": "./util.ts"
+  }
+}

--- a/tests/specs/install/global/config_file_workspace_members/install.out
+++ b/tests/specs/install/global/config_file_workspace_members/install.out
@@ -1,0 +1,2 @@
+[WILDCARD]Successfully installed my-cli
+[WILDCARD]

--- a/tests/specs/install/global/config_file_workspace_members/libs/greet/deno.json
+++ b/tests/specs/install/global/config_file_workspace_members/libs/greet/deno.json
@@ -1,0 +1,8 @@
+{
+  "name": "@scope/greet",
+  "version": "0.1.0",
+  "exports": {
+    ".": "./mod.ts",
+    "./upper": "./upper.ts"
+  }
+}

--- a/tests/specs/install/global/config_file_workspace_members/libs/greet/mod.ts
+++ b/tests/specs/install/global/config_file_workspace_members/libs/greet/mod.ts
@@ -1,0 +1,3 @@
+export function greet(name) {
+  return "Hello, " + name;
+}

--- a/tests/specs/install/global/config_file_workspace_members/libs/greet/upper.ts
+++ b/tests/specs/install/global/config_file_workspace_members/libs/greet/upper.ts
@@ -1,0 +1,3 @@
+export function upper(s) {
+  return s.toUpperCase();
+}

--- a/tests/specs/install/global/config_file_workspace_members/main.ts
+++ b/tests/specs/install/global/config_file_workspace_members/main.ts
@@ -1,0 +1,4 @@
+import { greet } from "@scope/greet";
+import { upper } from "@scope/greet/upper";
+import { exclaim } from "@app/util";
+console.log(exclaim(upper(greet("world"))));

--- a/tests/specs/install/global/config_file_workspace_members/run.out
+++ b/tests/specs/install/global/config_file_workspace_members/run.out
@@ -1,0 +1,1 @@
+HELLO, WORLD!

--- a/tests/specs/install/global/config_file_workspace_members/util.ts
+++ b/tests/specs/install/global/config_file_workspace_members/util.ts
@@ -1,0 +1,3 @@
+export function exclaim(s) {
+  return s + "!";
+}


### PR DESCRIPTION
Global installing a script that lives in a workspace (with an explicit
`--config`) currently breaks resolution of the workspace's member packages.

`deno install -g -c deno.json` copies the supplied config into a per-binary
directory under the install root and strips the `workspace` field, since
workspace discovery can't work from that location. As a result, any bare
specifier that points at a workspace member (for example
`import { x } from "@scope/member"`) is no longer in the import map, and the
installed command fails to run.

This flattens each workspace member's exports into the copied config's import
map as absolute `file://` specifiers anchored at the member directory, so the
installed binary resolves member packages exactly as it would when invoked from
the original workspace. Both the root export (`.`) and subpath exports
(`./sub`) are handled. Existing import map entries take precedence over the
synthesized member entries, matching the runtime ordering of the import map over
workspace members.

This builds on the relative `imports`/`scopes` rewriting added in #34562, which
already handles the import-map-alias half of the issue.

Closes #32057
