### PR TITLE
fix(ext/fs): clarify that Deno.symlink() needs unscoped permissions

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4826,7 +4826,12 @@ declare namespace Deno {
    * await Deno.symlink("old/name", "new/name");
    * ```
    *
-   * Requires full `allow-read` and `allow-write` permissions.
+   * Requires `allow-read` and `allow-write` permissions granted *without* a
+   * path scope (i.e. `--allow-read --allow-write`, not
+   * `--allow-read=./dir --allow-write=./dir`). A symlink's target may be a
+   * relative, absolute, or not-yet-existing path that is only resolved when the
+   * link is later traversed, so it cannot be checked against a path-scoped
+   * allow-list at creation time. Path-scoped grants are therefore rejected.
    *
    * @tags allow-read, allow-write
    * @category File System
@@ -4847,7 +4852,12 @@ declare namespace Deno {
    * Deno.symlinkSync("old/name", "new/name");
    * ```
    *
-   * Requires full `allow-read` and `allow-write` permissions.
+   * Requires `allow-read` and `allow-write` permissions granted *without* a
+   * path scope (i.e. `--allow-read --allow-write`, not
+   * `--allow-read=./dir --allow-write=./dir`). A symlink's target may be a
+   * relative, absolute, or not-yet-existing path that is only resolved when the
+   * link is later traversed, so it cannot be checked against a path-scoped
+   * allow-list at creation time. Path-scoped grants are therefore rejected.
    *
    * @tags allow-read, allow-write
    * @category File System

--- a/ext/fs/ops.rs
+++ b/ext/fs/ops.rs
@@ -885,6 +885,36 @@ pub async fn op_fs_link_async(
   Ok(())
 }
 
+// Symlink permissions cannot be path-scoped. A symlink's target (`oldpath`) is
+// just a string stored in the link: it may be relative, absolute, or not yet
+// exist, and it is only resolved when the link is later traversed. There is no
+// concrete path to validate against an allow-list at creation time, so we
+// require unscoped read+write rather than give a false sense of containment.
+// The generic "Requires write access" message does not convey that scoping is
+// the problem, so we replace it with a clearer one.
+fn check_symlink_permissions(
+  permissions: &deno_permissions::PermissionsContainer,
+  api_name: &str,
+) -> Result<(), FsOpsError> {
+  permissions
+    .check_write_all(api_name)
+    .and_then(|()| permissions.check_read_all(api_name))
+    .map_err(|err| {
+      let err = match err {
+        PermissionCheckError::PermissionDenied(mut denied)
+          if denied.custom_message.is_none() =>
+        {
+          denied.custom_message = Some(format!(
+            "{api_name} requires unscoped --allow-read and --allow-write permissions; path-scoped grants (e.g. --allow-write=<path>) are not supported because a symlink's target is only resolved when the link is traversed"
+          ));
+          PermissionCheckError::PermissionDenied(denied)
+        }
+        other => other,
+      };
+      FsOpsErrorKind::Permission(err).into_box()
+    })
+}
+
 #[op2(stack_trace)]
 pub fn op_fs_symlink_sync(
   state: &mut OpState,
@@ -894,8 +924,7 @@ pub fn op_fs_symlink_sync(
 ) -> Result<(), FsOpsError> {
   let permissions =
     state.borrow_mut::<deno_permissions::PermissionsContainer>();
-  permissions.check_write_all("Deno.symlinkSync()")?;
-  permissions.check_read_all("Deno.symlinkSync()")?;
+  check_symlink_permissions(permissions, "Deno.symlinkSync()")?;
 
   // PERMISSIONS: ok because we verified --allow-write and --allow-read above
   let oldpath = CheckedPath::unsafe_new(Cow::Borrowed(Path::new(oldpath)));
@@ -919,8 +948,7 @@ pub async fn op_fs_symlink_async(
     let mut state = state.borrow_mut();
     let permissions =
       state.borrow_mut::<deno_permissions::PermissionsContainer>();
-    permissions.check_write_all("Deno.symlink()")?;
-    permissions.check_read_all("Deno.symlink()")?;
+    check_symlink_permissions(permissions, "Deno.symlink()")?;
     state.borrow::<FileSystemRc>().clone()
   };
 

--- a/tests/specs/permission/symlink_scoped_write/__test__.jsonc
+++ b/tests/specs/permission/symlink_scoped_write/__test__.jsonc
@@ -1,0 +1,17 @@
+{
+  "tempDir": true,
+  "tests": {
+    // Path-scoped --allow-write/--allow-read is rejected for symlinks because a
+    // symlink's target is only resolved when the link is traversed. The error
+    // should explain that scoping is the problem. Regression test for #34988.
+    "scoped_write_rejected": {
+      "args": "run --quiet --no-prompt --allow-read=. --allow-write=. main.ts",
+      "output": "scoped.out"
+    },
+    // Unscoped permissions work.
+    "unscoped_ok": {
+      "args": "run --quiet -A main.ts",
+      "output": "ok\n"
+    }
+  }
+}

--- a/tests/specs/permission/symlink_scoped_write/main.ts
+++ b/tests/specs/permission/symlink_scoped_write/main.ts
@@ -1,0 +1,7 @@
+await Deno.writeTextFile("target.txt", "x");
+try {
+  await Deno.symlink("target.txt", "link.txt");
+  console.log("ok");
+} catch (e) {
+  console.log(`${(e as Error).constructor.name}: ${(e as Error).message}`);
+}

--- a/tests/specs/permission/symlink_scoped_write/scoped.out
+++ b/tests/specs/permission/symlink_scoped_write/scoped.out
@@ -1,0 +1,1 @@
+NotCapable: Deno.symlink() requires unscoped --allow-read and --allow-write permissions; path-scoped grants (e.g. --allow-write=<path>) are not supported because a symlink's target is only resolved when the link is traversed


### PR DESCRIPTION
Closes #34988.

`Deno.symlink()` deliberately requires `--allow-read` and `--allow-write`
to be granted without a path scope. It is the one filesystem op that does
not accept scoped grants, and that is intentional: unlike
`copyFile`/`link`/`rename`, a symlink's target (`oldpath`) is just a
string stored in the link. It may be a relative path, an absolute path
pointing anywhere, or a target that does not exist yet, and it is only
resolved when something later traverses the link. There is no concrete,
canonicalizable path to validate against an allow-list at creation time,
so checking it against a scope would give a false sense of containment.
The op therefore requires the broad grant.

The problem reported in #34988 is that this was undocumented and the
failure was confusing. The API docs only said the op requires "full"
permissions, which reads as "read plus write" rather than "unscoped", and
the `NotCapable` message ("Requires write access, run again with the
--allow-write flag") never conveyed that scoping was the actual problem.

This clarifies the `symlink` and `symlinkSync` JSDoc to state explicitly
that the permissions must be unscoped and why, and replaces the generic
permission error with one that says scoped grants are not supported and
explains the reason. A spec test covers both the rejected scoped case and
the working unscoped case.