### PR TITLE
fix(x): add x.bat for Windows

### DIFF
--- a/tools/lint.js
+++ b/tools/lint.js
@@ -705,6 +705,7 @@ async function ensureNoNewTopLevelEntries() {
     ".devcontainer",
     ".github",
     "x",
+    "x.bat",
     "cli",
     "ext",
     "libs",

--- a/x.bat
+++ b/x.bat
@@ -1,0 +1,2 @@
+@echo off
+deno run --allow-all --ext=ts x %*


### PR DESCRIPTION
Fix #34995

Fixed a bug where `./x` or `.\x` could not be used on Windows. 

Previously, developers on Windows had to manually use `deno run --allow-all --ext=ts x` as a replacement for `./x`, which was very inconvenient.