### PR TITLE
feat: stabilize "links" field in deno.json

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -1104,7 +1104,7 @@
       "items": {
         "type": "string"
       },
-      "description": "UNSTABLE: List of paths, file URLs, or glob patterns to folders containing JSR packages to use local versions of."
+      "description": "List of paths, file URLs, or glob patterns to folders containing JSR packages to use local versions of."
     },
     "workspace": {
       "oneOf": [


### PR DESCRIPTION
The "links" field in deno.json (formerly "patch") lets a project point at a
local copy of a JSR package and use it in place of the registry version. It
has never been gated behind an unstable flag in the runtime, has shipped and
been documented under the "links" name since Deno 2.3.6, and is covered by
spec tests that exercise it without any flag. The only thing still marking it
unstable was the leftover "UNSTABLE:" prefix on its JSON schema description,
which is misleading given the feature is already usable by everyone today.

This drops that prefix so the schema reflects reality. The remaining items on
the tracking issue (linking git repositories and remote specifiers) are
additive extensions that can be pursued separately and are not blockers for
the local-path linking that already works.

Closes #25110