### PR TITLE
perf(ext/web): convert geometry.js from lazy_loaded_esm to lazy_loaded_js

### DIFF
--- a/ext/web/17_geometry.js
+++ b/ext/web/17_geometry.js
@@ -1,7 +1,8 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-import { core, primordials } from "ext:core/mod.js";
-import {
+(function () {
+const { core, primordials } = __bootstrap;
+const {
   DOMMatrix,
   DOMMatrixReadOnly,
   DOMPoint,
@@ -12,7 +13,7 @@ import {
   op_geometry_get_enable_css_parser_features,
   op_geometry_matrix_set_matrix_value,
   op_geometry_matrix_to_string,
-} from "ext:core/ops";
+} = core.ops;
 const {
   ObjectDefineProperty,
   ObjectPrototypeIsPrototypeOf,
@@ -180,7 +181,7 @@ if (op_geometry_get_enable_css_parser_features()) {
 webidl.configureInterface(DOMMatrix);
 webidl.configureInterface(DOMMatrixReadOnly);
 
-export {
+return {
   DOMMatrix,
   DOMMatrixPrototype,
   DOMMatrixReadOnly,
@@ -196,3 +197,4 @@ export {
   DOMRectReadOnly,
   DOMRectReadOnlyPrototype,
 };
+})();

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -137,7 +137,6 @@ deno_core::extension!(deno_web,
     image_data::ImageData,
   ],
   lazy_loaded_esm = [
-    "geometry.js",
     "webtransport.js",
   ],
   lazy_loaded_js = [
@@ -163,6 +162,7 @@ deno_core::extension!(deno_web,
     "14_compression.js",
     "15_performance.js",
     "16_image_data.js",
+    "17_geometry.js",
   ],
   options = {
     blob_store: Arc<BlobStore>,

--- a/runtime/js/98_global_scope_shared.js
+++ b/runtime/js/98_global_scope_shared.js
@@ -74,11 +74,14 @@ import { unstableIds } from "ext:runtime/90_deno_ns.js";
 
 const loadImage = core.createLazyLoader("ext:deno_image/01_image.js");
 const loadCanvas = core.createLazyLoader("ext:deno_canvas/01_canvas.js");
-const loadGeometry = core.createLazyLoader("ext:deno_web/geometry.js");
 let _imageDataMod;
 const loadImageData = () =>
   _imageDataMod ??
     (_imageDataMod = core.loadExtScript("ext:deno_web/16_image_data.js"));
+let _geometryMod;
+const loadGeometry = () =>
+  _geometryMod ??
+    (_geometryMod = core.loadExtScript("ext:deno_web/17_geometry.js"));
 const loadWebSocket = core.createLazyLoader(
   "ext:deno_websocket/01_websocket.js",
 );

--- a/tools/core_import_map.json
+++ b/tools/core_import_map.json
@@ -694,7 +694,7 @@
     "ext:deno_web/14_compression.js": "../ext/web/14_compression.js",
     "ext:deno_web/15_performance.js": "../ext/web/15_performance.js",
     "ext:deno_web/16_image_data.js": "../ext/web/16_image_data.js",
-    "ext:deno_web/geometry.js": "../ext/web/geometry.js",
+    "ext:deno_web/17_geometry.js": "../ext/web/17_geometry.js",
     "ext:deno_web/webtransport.js": "../ext/web/webtransport.js",
     "ext:deno_webidl/00_webidl.js": "../ext/webidl/00_webidl.js",
     "ext:deno_websocket/01_websocket.js": "../ext/websocket/01_websocket.js",


### PR DESCRIPTION
related: #33760, #34061

Rename geometry.js to 17_geometry.js and convert from ESM (import/export) to a plain IIFE script, moving it from lazy_loaded_esm to lazy_loaded_js in lib.rs and updating the consumer in 98_global_scope_shared.js to use `loadExtScript` instead of `createLazyLoader`.

generated by Claude Sonnet 4.6

<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
