### PR TITLE
fix(npm): enable BYONM for package.json in a workspace member

### DIFF
--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1446,7 +1446,9 @@ impl ConfigData {
       member_dir.workspace.node_modules_dir().unwrap_or_default();
     let byonm = match node_modules_dir {
       Some(mode) => mode == NodeModulesDirMode::Manual,
-      None => member_dir.workspace.root_pkg_json().is_some(),
+      // Enable BYONM if there's a package.json anywhere in the workspace,
+      // whether at the root or in a member (matches the CLI behavior).
+      None => member_dir.workspace.package_jsons().next().is_some(),
     };
     if byonm {
       lsp_log!("  Enabled 'bring your own node_modules'.");

--- a/libs/resolver/factory.rs
+++ b/libs/resolver/factory.rs
@@ -355,20 +355,23 @@ impl<TSys: WorkspaceFactorySys> WorkspaceFactory<TSys> {
 
     let workspace = &self.workspace_directory()?.workspace;
 
-    if let Some(pkg_json) = workspace.root_pkg_json() {
-      if let Ok(deno_dir) = self.deno_dir() {
-        let deno_dir = &deno_dir.root;
-        // `deno_dir` can be symlink in macOS or on the CI
-        if let Ok(deno_dir) =
-          canonicalize_path_maybe_not_exists(&self.sys, deno_dir)
-          && pkg_json.path.starts_with(deno_dir)
-        {
-          // if the package.json is in deno_dir, then do not use node_modules
-          // next to it as local node_modules dir
-          return Ok(NodeModulesDirMode::None);
-        }
-      }
+    // `deno_dir` can be symlink in macOS or on the CI
+    let canonicalized_deno_dir = self.deno_dir().ok().and_then(|deno_dir| {
+      canonicalize_path_maybe_not_exists(&self.sys, &deno_dir.root).ok()
+    });
+    // Enable BYONM if there's a package.json anywhere in the workspace, whether
+    // it's at the root or in a member. A package.json located inside deno_dir
+    // is ignored because the global npm cache may contain package.json files
+    // that should not enable a local node_modules directory next to them.
+    let has_workspace_pkg_json =
+      workspace
+        .package_jsons()
+        .any(|pkg_json| match &canonicalized_deno_dir {
+          Some(deno_dir) => !pkg_json.path.starts_with(deno_dir),
+          None => true,
+        });
 
+    if has_workspace_pkg_json {
       Ok(NodeModulesDirMode::Manual)
     } else if workspace.vendor_dir_path().is_some() {
       Ok(NodeModulesDirMode::Auto)

--- a/tests/specs/npm/workspace_member_package_json/__test__.jsonc
+++ b/tests/specs/npm/workspace_member_package_json/__test__.jsonc
@@ -1,0 +1,15 @@
+{
+  "tempDir": true,
+  "tests": {
+    "byonm_from_member": {
+      "steps": [{
+        "args": "install",
+        "cwd": "member",
+        "output": "install.out"
+      }, {
+        "args": "run -A member/main.ts",
+        "output": "run.out"
+      }]
+    }
+  }
+}

--- a/tests/specs/npm/workspace_member_package_json/deno.json
+++ b/tests/specs/npm/workspace_member_package_json/deno.json
@@ -1,0 +1,3 @@
+{
+  "workspace": ["./member"]
+}

--- a/tests/specs/npm/workspace_member_package_json/install.out
+++ b/tests/specs/npm/workspace_member_package_json/install.out
@@ -1,0 +1,4 @@
+[WILDCARD]
+Dependencies:
++ npm:@denotest/esm-basic 1.0.0
+[WILDCARD]

--- a/tests/specs/npm/workspace_member_package_json/member/main.ts
+++ b/tests/specs/npm/workspace_member_package_json/member/main.ts
@@ -1,0 +1,10 @@
+import { getValue, setValue } from "@denotest/esm-basic";
+
+setValue(5);
+console.log(getValue());
+
+// The workspace has no root package.json, only this member does. BYONM should
+// still be enabled, so a node_modules directory is created at the workspace
+// root rather than silently falling back to the global cache (issue #26146).
+const rootNodeModules = new URL("../node_modules", import.meta.url);
+console.log("root node_modules:", Deno.statSync(rootNodeModules).isDirectory);

--- a/tests/specs/npm/workspace_member_package_json/member/package.json
+++ b/tests/specs/npm/workspace_member_package_json/member/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "member",
+  "version": "1.0.0",
+  "dependencies": {
+    "@denotest/esm-basic": "1.0.0"
+  }
+}

--- a/tests/specs/npm/workspace_member_package_json/run.out
+++ b/tests/specs/npm/workspace_member_package_json/run.out
@@ -1,0 +1,2 @@
+5
+root node_modules: true


### PR DESCRIPTION
BYONM (Bring Your Own node_modules) was only enabled when a package.json
existed at the workspace root. When a package.json lived only in a
workspace member, Deno silently fell back to the global cache and never
created a local node_modules directory, which led to confusing
dependency resolution such as running Next.js inside a Deno workspace.
BYONM is now enabled whenever a package.json exists anywhere in the
workspace, root or member, with the same node_modules directory placed
at the workspace root. The language server's parallel check is updated
to match so editor diagnostics stay consistent with the CLI.

Note this makes a member package.json behave exactly like a root one: it
now requires a prior `deno install` rather than silently resolving from
the global cache, so `deno run` reports that node_modules is out of date
if you skip the install step.

Closes #26146