### PR TITLE
fix(repl): helpful error for Deno.lint.runPlugin outside deno test

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -1621,4 +1621,10 @@ function runLintPlugin(plugin, fileName, sourceText) {
   return diagnostics;
 }
 
-Deno.lint.runPlugin = runLintPlugin;
+// `op_lint_create_serialized_ast` is only available in the `deno test`
+// subcommand. In other subcommands that load this module (e.g. the REPL) the op
+// is missing, so keep the stub `Deno.lint.runPlugin` from 99_main.js which
+// throws a helpful error instead of a cryptic "op is not a function".
+if (op_lint_create_serialized_ast) {
+  Deno.lint.runPlugin = runLintPlugin;
+}

--- a/tests/integration/repl_tests.rs
+++ b/tests/integration/repl_tests.rs
@@ -1171,3 +1171,19 @@ server.on("exit", () => process.exit(0));
       console.write_raw(".exit\r");
     });
 }
+
+#[test(flaky)]
+fn pty_lint_run_plugin_disabled() {
+  // Regression test for https://github.com/denoland/deno/issues/28264
+  // `Deno.lint.runPlugin` is not available outside of `deno test`, so calling
+  // it in the REPL should throw a helpful error instead of a cryptic
+  // "op_lint_create_serialized_ast is not a function".
+  util::with_pty(&["repl"], |mut console| {
+    console.write_line(
+      "Deno.lint.runPlugin({ name: \"x\", rules: {} }, \"x.ts\", \"\");",
+    );
+    console.expect(
+      "`Deno.lint.runPlugin` is only available in `deno test` subcommand.",
+    );
+  });
+}


### PR DESCRIPTION
Calling `Deno.lint.runPlugin` in the REPL threw a cryptic
`TypeError: op_lint_create_serialized_ast is not a function` instead of a
helpful message explaining the API is only available under `deno test`.

The REPL (like `deno test`, `bench`, `jupyter`, `lint`, and the LSP) loads
`cli/js/40_lint.js`, which unconditionally overwrote the stub
`Deno.lint.runPlugin` defined in `runtime/js/99_main.js` with the real
implementation. That implementation calls `op_lint_create_serialized_ast`,
which is provided by `deno_lint_ext_for_test` and is only registered in the
`deno test` subcommand. Everywhere else the op is missing, so the override
turned the helpful stub error into an internal op failure.

The fix only installs the real `runPlugin` when the op is actually present,
leaving the stub (which throws "`Deno.lint.runPlugin` is only available in
`deno test` subcommand.") in place otherwise.

Adds a REPL regression test in `tests/integration/repl_tests.rs`.

Closes #28264
