### PR TITLE
fix(watch): keep watcher alive when script calls Deno.exit()

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1157,11 +1157,14 @@ impl CliFactory {
     let fs = self.fs();
     let node_resolver = self.node_resolver().await?;
     let npm_resolver = self.npm_resolver().await?;
-    let maybe_file_watcher_communicator = if cli_options.has_hmr() {
-      Some(self.watcher_communicator.clone().unwrap())
-    } else {
-      None
-    };
+    // Provide the watcher communicator whenever running under the file watcher,
+    // not just for HMR. `CliMainWorker::run()` uses its presence to detect that
+    // it is under a watcher and route `Deno.exit()` through isolate termination
+    // instead of `std::process::exit()`, which keeps `deno serve --watch` (which
+    // goes through `run()` rather than `run_for_watcher`) alive across exits.
+    // HMR-specific behaviour is gated separately on `create_hmr_runner`. See
+    // issue #7590.
+    let maybe_file_watcher_communicator = self.watcher_communicator.clone();
     let pkg_json_resolver = self.pkg_json_resolver()?;
     let module_loader_factory = self.create_module_loader_factory().await?;
     self.maybe_start_inspector_server()?;

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -547,7 +547,9 @@ async fn bundle_watch(
             watcher_communicator.watch_paths(current_roots.borrow().clone());
         }
 
-        Ok(())
+        // `deno bundle --watch` has no per-run exit code (and disables the
+        // "finished" message above), so report 0 to the watcher.
+        Ok(0)
       })
     },
   )

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -329,13 +329,13 @@ async fn run_with_watch(
           )
           .await?;
 
-        if watch_flags.hmr {
-          worker.run().await?;
+        let exit_code = if watch_flags.hmr {
+          worker.run().await?
         } else {
-          worker.run_for_watcher().await?;
-        }
+          worker.run_for_watcher().await?
+        };
 
-        Ok(())
+        Ok(exit_code)
       })
     },
   )

--- a/cli/tools/serve.rs
+++ b/cli/tools/serve.rs
@@ -160,8 +160,7 @@ async fn run_worker(
     )
     .await?;
   if hmr {
-    worker.run_for_watcher().await?;
-    Ok(0)
+    worker.run_for_watcher().await.map_err(Into::into)
   } else {
     worker.run().await.map_err(Into::into)
   }
@@ -204,7 +203,7 @@ async fn serve_with_watch(
         let worker_factory =
           Arc::new(factory.create_cli_main_worker_factory().await?);
 
-        do_serve(
+        let exit_code = do_serve(
           worker_factory,
           main_module.clone(),
           parallelism_count,
@@ -213,7 +212,7 @@ async fn serve_with_watch(
         )
         .await?;
 
-        Ok(())
+        Ok(exit_code)
       })
     },
   )

--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -80,27 +80,29 @@ impl DebouncedReceiver {
   }
 }
 
+/// Runs a single watched operation, returning its exit code on success or
+/// `None` if the operation errored (after logging the error).
 async fn error_handler<F>(
   watch_future: F,
   initial_cwd_url: Option<&Url>,
-) -> bool
+) -> Option<i32>
 where
-  F: Future<Output = Result<(), AnyError>>,
+  F: Future<Output = Result<i32, AnyError>>,
 {
-  let result = watch_future.await;
-  if let Err(err) = result {
-    let error_string = match js_error_downcast_ref(&err) {
-      Some(e) => format_js_error(e, initial_cwd_url),
-      None => format!("{err:?}"),
-    };
-    log::error!(
-      "{}: {}",
-      colors::red_bold("error"),
-      error_string.trim_start_matches("error: ")
-    );
-    false
-  } else {
-    true
+  match watch_future.await {
+    Ok(exit_code) => Some(exit_code),
+    Err(err) => {
+      let error_string = match js_error_downcast_ref(&err) {
+        Some(e) => format_js_error(e, initial_cwd_url),
+        None => format!("{err:?}"),
+      };
+      log::error!(
+        "{}: {}",
+        colors::red_bold("error"),
+        error_string.trim_start_matches("error: ")
+      );
+      None
+    }
   }
 }
 
@@ -255,7 +257,7 @@ impl WatcherCommunicator {
 pub async fn watch_func<O, F>(
   flags: Arc<Flags>,
   print_config: PrintConfig,
-  operation: O,
+  mut operation: O,
 ) -> Result<(), AnyError>
 where
   O: FnMut(
@@ -269,7 +271,13 @@ where
     flags,
     print_config,
     WatcherRestartMode::Automatic,
-    operation,
+    move |flags, communicator, changed_paths| {
+      // Tools driven by `watch_func` have no meaningful per-run exit code, so
+      // report 0 to `watch_recv`. Only `deno run` / `deno serve` surface a
+      // real exit code (e.g. one set via `Deno.exit()`).
+      let operation_future = operation(flags, communicator, changed_paths)?;
+      Ok(async move { operation_future.await.map(|()| 0) })
+    },
   )
   .boxed_local();
 
@@ -303,7 +311,7 @@ where
     Arc<WatcherCommunicator>,
     Option<Vec<PathBuf>>,
   ) -> Result<F, AnyError>,
-  F: Future<Output = Result<(), AnyError>>,
+  F: Future<Output = Result<i32, AnyError>>,
 {
   let initial_cwd = crate::util::env::resolve_cwd(flags.initial_cwd.as_deref())
     .map(|cwd| cwd.into_owned())
@@ -456,19 +464,19 @@ where
         print_after_restart();
         continue;
       },
-      success = &mut operation_future => {
+      exit_code = &mut operation_future => {
         consume_paths_to_watch(&mut watcher, &mut paths_to_watch_rx, &exclude_set);
         if print_finished {
-          // TODO(bartlomieju): print exit code here?
+          let status = match exit_code {
+            Some(0) => Cow::Borrowed("finished"),
+            Some(code) => Cow::Owned(format!("finished with exit code {code}")),
+            None => Cow::Borrowed("failed"),
+          };
           info!(
             "{} {} {}. Restarting on file change...",
             colors::intense_blue(banner),
             job_name,
-            if success {
-              "finished"
-            } else {
-              "failed"
-            }
+            status,
           );
         }
       },

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -25,7 +25,7 @@ use deno_runtime::cpu_prof_filename;
 use deno_runtime::cpu_profiler::CpuProfiler;
 use deno_runtime::deno_os::OpExitCallbacks;
 use deno_runtime::deno_os::WatcherExitHandle;
-use deno_runtime::deno_os::WatcherExitInfo;
+use deno_runtime::deno_os::WatcherExited;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_runtime::worker::MainWorker;
 use deno_semver::npm::NpmPackageReqReference;
@@ -135,6 +135,51 @@ impl CliMainWorker {
     // WARNING: Remember to update cli/lib/worker.rs to align with
     // changes made here so that they affect deno_compile as well.
 
+    // Under `deno run --watch-hmr` / `deno serve --watch`, install the isolate
+    // handle so a script calling `Deno.exit()` terminates this isolate instead
+    // of the whole process, allowing the file watcher to survive and restart on
+    // the next change. The regular `--watch` path uses `run_for_watcher`, which
+    // installs it separately. See issue #7590.
+    let under_watcher = self.shared.maybe_file_watcher_communicator.is_some();
+    if under_watcher {
+      self.install_watcher_exit_handle();
+    }
+
+    let mut result = self
+      .run_to_completion(&mut maybe_hmr_runner, has_coverage)
+      .await;
+
+    // If the script called `Deno.exit()` under a watcher, `op_exit` terminated
+    // the isolate instead of the process. Treat it as a normal end of run:
+    // clear V8's termination flag so the worker can be dropped cleanly. The
+    // exit code recorded by `Deno.exit()` is reported below. See issue #7590.
+    if result.is_err() && under_watcher && self.exited_via_watcher() {
+      self.cancel_terminate_execution();
+      result = Ok(());
+    }
+
+    if let Some(mut coverage_collector) = coverage_cell.borrow_mut().take() {
+      coverage_collector.stop_collecting()?;
+    }
+    if let Some(mut cpu_profiler) = profiler_cell.borrow_mut().take() {
+      cpu_profiler.stop_profiling()?;
+    }
+    if let Some(hmr_runner) = maybe_hmr_runner.as_mut() {
+      hmr_runner.stop();
+    }
+
+    result?;
+    Ok(self.worker.exit_code())
+  }
+
+  /// Runs the main module to completion: preload + main module, lifecycle
+  /// events, and the event loop (including the HMR loop when `maybe_hmr_runner`
+  /// is set).
+  async fn run_to_completion(
+    &mut self,
+    maybe_hmr_runner: &mut Option<HmrRunner>,
+    has_coverage: bool,
+  ) -> Result<(), CoreError> {
     log::debug!("main_module {}", self.worker.main_module());
 
     // Run preload modules first if they were defined
@@ -183,28 +228,14 @@ impl CliMainWorker {
     self.worker.dispatch_process_exit_event()?;
     self.worker.run_napi_ref_finalizers();
 
-    if let Some(mut coverage_collector) = coverage_cell.borrow_mut().take() {
-      coverage_collector.stop_collecting()?;
-    }
-    if let Some(mut cpu_profiler) = profiler_cell.borrow_mut().take() {
-      cpu_profiler.stop_profiling()?;
-    }
-    if let Some(hmr_runner) = maybe_hmr_runner.as_mut() {
-      hmr_runner.stop();
-    }
-
-    Ok(self.worker.exit_code())
+    Ok(())
   }
 
-  pub async fn run_for_watcher(mut self) -> Result<(), CoreError> {
+  pub async fn run_for_watcher(mut self) -> Result<i32, CoreError> {
     // Install the isolate handle so that a script calling `Deno.exit()`
     // terminates this isolate instead of the whole process, allowing the file
     // watcher to survive and restart on the next change. See issue #7590.
-    let isolate_handle = self.v8_isolate_handle();
-    self
-      .op_state()
-      .borrow_mut()
-      .put(WatcherExitHandle(isolate_handle));
+    self.install_watcher_exit_handle();
 
     /// The FileWatcherModuleExecutor provides module execution with safe dispatching of life-cycle events by tracking the
     /// state of any pending events and emitting accordingly on drop in the case of a future
@@ -276,16 +307,16 @@ impl CliMainWorker {
 
     // If the script called `Deno.exit()`, `op_exit` terminated the isolate
     // instead of the process. Treat it as a normal end of run: clear V8's
-    // termination flag so the worker can be dropped cleanly, and let the
-    // watcher wait for the next file change rather than propagating the
-    // termination as an error. See issue #7590.
-    let exited = executor.inner.op_state().borrow().has::<WatcherExitInfo>();
-    if exited {
+    // termination flag so the worker can be dropped cleanly, and report the
+    // requested exit code rather than propagating the termination as an error.
+    // The watcher then waits for the next file change. See issue #7590.
+    if executor.inner.exited_via_watcher() {
       executor.inner.cancel_terminate_execution();
-      return Ok(());
+      return Ok(executor.inner.worker.exit_code());
     }
 
-    result
+    result?;
+    Ok(executor.inner.worker.exit_code())
   }
 
   #[inline]
@@ -323,6 +354,26 @@ impl CliMainWorker {
       .js_runtime()
       .v8_isolate()
       .cancel_terminate_execution();
+  }
+
+  /// Install the isolate handle so that a script calling `Deno.exit()`
+  /// terminates this isolate instead of the whole process. Used by the file
+  /// watcher paths (`deno run --watch[-hmr]`, `deno serve --watch`) so a script
+  /// calling `Deno.exit()` ends the current run without killing the watcher.
+  /// See issue #7590.
+  fn install_watcher_exit_handle(&mut self) {
+    let isolate_handle = self.v8_isolate_handle();
+    self
+      .op_state()
+      .borrow_mut()
+      .put(WatcherExitHandle(isolate_handle));
+  }
+
+  /// Whether the current run ended because the script called `Deno.exit()` while
+  /// a [`WatcherExitHandle`] was installed, i.e. `op_exit` terminated the
+  /// isolate instead of the process. See [`install_watcher_exit_handle`].
+  fn exited_via_watcher(&mut self) -> bool {
+    self.op_state().borrow().has::<WatcherExited>()
   }
 
   pub fn maybe_setup_hmr_runner(&mut self) -> Option<HmrRunner> {

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -24,6 +24,8 @@ use deno_runtime::coverage::CoverageCollector;
 use deno_runtime::cpu_prof_filename;
 use deno_runtime::cpu_profiler::CpuProfiler;
 use deno_runtime::deno_os::OpExitCallbacks;
+use deno_runtime::deno_os::WatcherExitHandle;
+use deno_runtime::deno_os::WatcherExitInfo;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_runtime::worker::MainWorker;
 use deno_semver::npm::NpmPackageReqReference;
@@ -194,7 +196,16 @@ impl CliMainWorker {
     Ok(self.worker.exit_code())
   }
 
-  pub async fn run_for_watcher(self) -> Result<(), CoreError> {
+  pub async fn run_for_watcher(mut self) -> Result<(), CoreError> {
+    // Install the isolate handle so that a script calling `Deno.exit()`
+    // terminates this isolate instead of the whole process, allowing the file
+    // watcher to survive and restart on the next change. See issue #7590.
+    let isolate_handle = self.v8_isolate_handle();
+    self
+      .op_state()
+      .borrow_mut()
+      .put(WatcherExitHandle(isolate_handle));
+
     /// The FileWatcherModuleExecutor provides module execution with safe dispatching of life-cycle events by tracking the
     /// state of any pending events and emitting accordingly on drop in the case of a future
     /// cancellation.
@@ -261,7 +272,20 @@ impl CliMainWorker {
     }
 
     let mut executor = FileWatcherModuleExecutor::new(self);
-    executor.execute().await
+    let result = executor.execute().await;
+
+    // If the script called `Deno.exit()`, `op_exit` terminated the isolate
+    // instead of the process. Treat it as a normal end of run: clear V8's
+    // termination flag so the worker can be dropped cleanly, and let the
+    // watcher wait for the next file change rather than propagating the
+    // termination as an error. See issue #7590.
+    let exited = executor.inner.op_state().borrow().has::<WatcherExitInfo>();
+    if exited {
+      executor.inner.cancel_terminate_execution();
+      return Ok(());
+    }
+
+    result
   }
 
   #[inline]

--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -70,6 +70,21 @@ impl OpExitCallbacks {
   }
 }
 
+/// Holds the main isolate's handle so that `op_exit` (i.e. `Deno.exit()`) can
+/// terminate the current isolate instead of the whole process. Installed by
+/// `deno run --watch` / `deno serve --watch` so a script calling `Deno.exit()`
+/// ends the current run without killing the file watcher. See issue #7590.
+pub struct WatcherExitHandle(pub v8::IsolateHandle);
+
+/// Set by `op_exit` when a [`WatcherExitHandle`] is present to record that the
+/// script called `Deno.exit()`. The watcher reads this after the run to learn
+/// the requested exit code and to confirm the V8 termination it observes was
+/// caused by `Deno.exit()` rather than another error.
+#[derive(Clone, Copy, Debug)]
+pub struct WatcherExitInfo {
+  pub exit_code: i32,
+}
+
 deno_core::extension!(
   deno_os,
   ops = [
@@ -352,6 +367,21 @@ fn op_get_exit_code(state: &mut OpState) -> i32 {
 
 #[op2(fast)]
 fn op_exit(state: &mut OpState) {
+  // Under `deno run --watch`, terminate the current V8 isolate instead of
+  // exiting the process so the file watcher survives and can restart the
+  // script on the next file change. See issue #7590.
+  if let Some(handle) =
+    state.try_borrow::<WatcherExitHandle>().map(|h| h.0.clone())
+  {
+    let code = state
+      .try_borrow::<ExitCode>()
+      .map(|exit_code| exit_code.get())
+      .unwrap_or_default();
+    state.put(WatcherExitInfo { exit_code: code });
+    handle.terminate_execution();
+    return;
+  }
+
   if let Some(cbs) = state.try_borrow_mut::<OpExitCallbacks>() {
     cbs.run();
   }

--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -76,14 +76,13 @@ impl OpExitCallbacks {
 /// ends the current run without killing the file watcher. See issue #7590.
 pub struct WatcherExitHandle(pub v8::IsolateHandle);
 
-/// Set by `op_exit` when a [`WatcherExitHandle`] is present to record that the
-/// script called `Deno.exit()`. The watcher reads this after the run to learn
-/// the requested exit code and to confirm the V8 termination it observes was
-/// caused by `Deno.exit()` rather than another error.
+/// Marker set by `op_exit` when a [`WatcherExitHandle`] is present, recording
+/// that the script called `Deno.exit()`. The watcher reads this after the run
+/// to confirm the V8 termination it observes was caused by `Deno.exit()` rather
+/// than another error; the requested exit code is read separately from the
+/// worker's `ExitCode` (set by `Deno.exit()` before `op_exit` runs).
 #[derive(Clone, Copy, Debug)]
-pub struct WatcherExitInfo {
-  pub exit_code: i32,
-}
+pub struct WatcherExited;
 
 deno_core::extension!(
   deno_os,
@@ -373,11 +372,7 @@ fn op_exit(state: &mut OpState) {
   if let Some(handle) =
     state.try_borrow::<WatcherExitHandle>().map(|h| h.0.clone())
   {
-    let code = state
-      .try_borrow::<ExitCode>()
-      .map(|exit_code| exit_code.get())
-      .unwrap_or_default();
-    state.put(WatcherExitInfo { exit_code: code });
+    state.put(WatcherExited);
     handle.terminate_execution();
     return;
   }

--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -369,6 +369,12 @@ fn op_exit(state: &mut OpState) {
   // Under `deno run --watch`, terminate the current V8 isolate instead of
   // exiting the process so the file watcher survives and can restart the
   // script on the next file change. See issue #7590.
+  //
+  // We intentionally return before running `OpExitCallbacks` here: those flush
+  // coverage/profiler data and notify the inspector as the process is about to
+  // disappear. Under a watcher the process keeps running, so that teardown is
+  // not wanted; the watcher run paths stop the coverage collector and profiler
+  // themselves after the run completes.
   if let Some(handle) =
     state.try_borrow::<WatcherExitHandle>().map(|h| h.0.clone())
   {

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -1829,6 +1829,55 @@ async fn run_watch_process_exit_on_restart() {
   check_alive_then_kill(child);
 }
 
+/// Test that a script calling `Deno.exit()` under `--watch` ends the current
+/// run without killing the watcher, which keeps watching and restarts the
+/// script on the next file change. See https://github.com/denoland/deno/issues/7590.
+#[test(flaky)]
+async fn run_watch_deno_exit() {
+  let t = TempDir::new();
+  let file_to_watch = t.path().join("file_to_watch.js");
+  file_to_watch.write(
+    r#"
+      globalThis.addEventListener("unload", () => {
+        console.log("unload event fired");
+      });
+      console.log("started");
+      Deno.exit(42);
+      console.log("not reached");
+    "#,
+  );
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch")
+    .arg("-L")
+    .arg("debug")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_contains("Process started", &mut stderr_lines).await;
+  wait_contains("started", &mut stdout_lines).await;
+  // `Deno.exit()` still dispatches the `unload` event, and code after it does
+  // not run.
+  wait_contains("unload event fired", &mut stdout_lines).await;
+  // The watcher must survive `Deno.exit()` instead of terminating the process.
+  wait_contains("Process finished", &mut stderr_lines).await;
+  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+
+  // Editing the file restarts the run, proving the watcher is still alive.
+  file_to_watch.write("console.log('restarted');");
+
+  wait_contains("Restarting", &mut stderr_lines).await;
+  wait_contains("restarted", &mut stdout_lines).await;
+  wait_contains("Process finished", &mut stderr_lines).await;
+  check_alive_then_kill(child);
+}
+
 /// Test that SIGTERM is dispatched to JS signal handlers on watch restart,
 /// giving the process a chance to clean up before restarting.
 #[test(flaky)]

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -1865,8 +1865,9 @@ async fn run_watch_deno_exit() {
   // `Deno.exit()` still dispatches the `unload` event, and code after it does
   // not run.
   wait_contains("unload event fired", &mut stdout_lines).await;
-  // The watcher must survive `Deno.exit()` instead of terminating the process.
-  wait_contains("Process finished", &mut stderr_lines).await;
+  // The watcher must survive `Deno.exit()` instead of terminating the process,
+  // and the requested exit code is surfaced in the finished message.
+  wait_contains("Process finished with exit code 42", &mut stderr_lines).await;
   wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
 
   // Editing the file restarts the run, proving the watcher is still alive.
@@ -1874,7 +1875,57 @@ async fn run_watch_deno_exit() {
 
   wait_contains("Restarting", &mut stderr_lines).await;
   wait_contains("restarted", &mut stdout_lines).await;
-  wait_contains("Process finished", &mut stderr_lines).await;
+  // A normal exit (code 0) prints the plain finished message.
+  wait_contains("Process finished. Restarting", &mut stderr_lines).await;
+  check_alive_then_kill(child);
+}
+
+/// Like [`run_watch_deno_exit`], but for HMR mode (`--watch-hmr`), which runs
+/// through `worker.run()` rather than `run_for_watcher`. A script calling
+/// `Deno.exit()` must still keep the watcher alive. See
+/// https://github.com/denoland/deno/issues/7590.
+#[test(flaky)]
+async fn run_watch_hmr_deno_exit() {
+  let t = TempDir::new();
+  let file_to_watch = t.path().join("file_to_watch.js");
+  file_to_watch.write(
+    r#"
+      globalThis.addEventListener("unload", () => {
+        console.log("unload event fired");
+      });
+      console.log("started");
+      Deno.exit(42);
+      console.log("not reached");
+    "#,
+  );
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch-hmr")
+    .arg("-L")
+    .arg("debug")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_contains("Process started", &mut stderr_lines).await;
+  wait_contains("started", &mut stdout_lines).await;
+  // `Deno.exit()` still dispatches the `unload` event, and code after it does
+  // not run.
+  wait_contains("unload event fired", &mut stdout_lines).await;
+  // The watcher must survive `Deno.exit()` instead of terminating the process.
+  wait_contains("Process finished with exit code 42", &mut stderr_lines).await;
+  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+
+  // Editing the file restarts the run, proving the watcher is still alive.
+  file_to_watch.write("console.log('restarted');");
+
+  wait_contains("Restarting", &mut stderr_lines).await;
+  wait_contains("restarted", &mut stdout_lines).await;
   check_alive_then_kill(child);
 }
 

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -1829,30 +1829,78 @@ async fn run_watch_process_exit_on_restart() {
   check_alive_then_kill(child);
 }
 
-/// Test that a script calling `Deno.exit()` under `--watch` ends the current
-/// run without killing the watcher, which keeps watching and restarts the
-/// script on the next file change. See https://github.com/denoland/deno/issues/7590.
-#[test(flaky)]
-async fn run_watch_deno_exit() {
+/// Wait, in either order, for the watcher to both report the requested exit
+/// code and start watching `file_name`.
+///
+/// The "Process finished with exit code N" line (printed by the watcher when
+/// the run ends) and the "Watching paths" line (emitted asynchronously by the
+/// watcher thread) race on stderr, so a fixed-order wait is flaky. Waiting for
+/// both before touching files ensures the exit code was surfaced and the
+/// watcher is ready, so a subsequent edit is not missed.
+async fn wait_for_exit_code_and_watcher<R>(
+  exit_code: i32,
+  file_name: &str,
+  stderr_lines: &mut LoggingLines<R>,
+) where
+  R: tokio::io::AsyncBufRead + Unpin,
+{
+  let finished = format!("Process finished with exit code {exit_code}");
+  let saw_finished = std::cell::Cell::new(false);
+  let saw_watching = std::cell::Cell::new(false);
+  let result = tokio::time::timeout(
+    tokio::time::Duration::from_secs(60),
+    wait_for(
+      |line| {
+        if line.contains(finished.as_str()) {
+          saw_finished.set(true);
+        }
+        if line.contains("Watching paths") && line.contains(file_name) {
+          saw_watching.set(true);
+        }
+        saw_finished.get() && saw_watching.get()
+      },
+      stderr_lines,
+    ),
+  )
+  .await;
+  match result {
+    Ok(Some(_)) => {}
+    Ok(None) => panic!(
+      "output ended before the watcher reported exit code {exit_code} and started watching \"{file_name}\""
+    ),
+    Err(_) => panic!(
+      "watcher did not report exit code {exit_code} and start watching \"{file_name}\" within 60 seconds"
+    ),
+  }
+}
+
+/// Shared body for the `Deno.exit()` / `process.exit()` under-watch tests: the
+/// exit call ends the current run with the requested code, the `unload` event
+/// still fires, code after the exit call does not run, and the watcher stays
+/// alive and restarts on the next file change.
+/// See https://github.com/denoland/deno/issues/7590.
+async fn run_watch_exit_keeps_watcher_alive(watch_flag: &str, exit_call: &str) {
   let t = TempDir::new();
   let file_to_watch = t.path().join("file_to_watch.js");
-  file_to_watch.write(
+  file_to_watch.write(format!(
     r#"
-      globalThis.addEventListener("unload", () => {
+      import process from "node:process";
+      globalThis.addEventListener("unload", () => {{
         console.log("unload event fired");
-      });
+      }});
       console.log("started");
-      Deno.exit(42);
+      {exit_call};
       console.log("not reached");
-    "#,
-  );
+    "#
+  ));
 
   let mut child = util::deno_cmd()
     .current_dir(t.path())
     .arg("run")
-    .arg("--watch")
+    .arg(watch_flag)
     .arg("-L")
     .arg("debug")
+    .arg("--allow-all")
     .arg(&file_to_watch)
     .env("NO_COLOR", "1")
     .piped_output()
@@ -1862,22 +1910,35 @@ async fn run_watch_deno_exit() {
 
   wait_contains("Process started", &mut stderr_lines).await;
   wait_contains("started", &mut stdout_lines).await;
-  // `Deno.exit()` still dispatches the `unload` event, and code after it does
+  // The exit call still dispatches the `unload` event, and code after it does
   // not run.
   wait_contains("unload event fired", &mut stdout_lines).await;
-  // The watcher must survive `Deno.exit()` instead of terminating the process,
-  // and the requested exit code is surfaced in the finished message.
-  wait_contains("Process finished with exit code 42", &mut stderr_lines).await;
-  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+  // The watcher must survive the exit instead of terminating the process, and
+  // the requested exit code is surfaced in the finished message.
+  wait_for_exit_code_and_watcher(42, "file_to_watch.js", &mut stderr_lines)
+    .await;
 
   // Editing the file restarts the run, proving the watcher is still alive.
   file_to_watch.write("console.log('restarted');");
 
   wait_contains("Restarting", &mut stderr_lines).await;
   wait_contains("restarted", &mut stdout_lines).await;
-  // A normal exit (code 0) prints the plain finished message.
-  wait_contains("Process finished. Restarting", &mut stderr_lines).await;
   check_alive_then_kill(child);
+}
+
+/// Test that a script calling `Deno.exit()` under `--watch` ends the current
+/// run without killing the watcher, which keeps watching and restarts the
+/// script on the next file change. See https://github.com/denoland/deno/issues/7590.
+#[test(flaky)]
+async fn run_watch_deno_exit() {
+  run_watch_exit_keeps_watcher_alive("--watch", "Deno.exit(42)").await;
+}
+
+/// Like [`run_watch_deno_exit`], but using `process.exit()` from `node:process`,
+/// which routes through the same `op_exit` chokepoint.
+#[test(flaky)]
+async fn run_watch_process_exit() {
+  run_watch_exit_keeps_watcher_alive("--watch", "process.exit(42)").await;
 }
 
 /// Like [`run_watch_deno_exit`], but for HMR mode (`--watch-hmr`), which runs
@@ -1886,26 +1947,36 @@ async fn run_watch_deno_exit() {
 /// https://github.com/denoland/deno/issues/7590.
 #[test(flaky)]
 async fn run_watch_hmr_deno_exit() {
+  run_watch_exit_keeps_watcher_alive("--watch-hmr", "Deno.exit(42)").await;
+}
+
+/// Test that a served module calling `Deno.exit()` under `deno serve --watch`
+/// ends the current run without killing the watcher, which keeps watching and
+/// restarts on the next file change. `deno serve --watch` shares the same exit
+/// handling as `deno run --watch`. See https://github.com/denoland/deno/issues/7590.
+#[test(flaky)]
+async fn serve_watch_deno_exit() {
   let t = TempDir::new();
-  let file_to_watch = t.path().join("file_to_watch.js");
-  file_to_watch.write(
+  let main_file_to_watch = t.path().join("main_file_to_watch.js");
+  main_file_to_watch.write(
     r#"
-      globalThis.addEventListener("unload", () => {
-        console.log("unload event fired");
-      });
       console.log("started");
       Deno.exit(42);
-      console.log("not reached");
+      export default {
+        fetch(_request) {
+          return new Response("not reached");
+        },
+      };
     "#,
   );
 
   let mut child = util::deno_cmd()
     .current_dir(t.path())
-    .arg("run")
-    .arg("--watch-hmr")
+    .arg("serve")
+    .arg("--watch")
     .arg("-L")
     .arg("debug")
-    .arg(&file_to_watch)
+    .arg(&main_file_to_watch)
     .env("NO_COLOR", "1")
     .piped_output()
     .spawn()
@@ -1914,18 +1985,29 @@ async fn run_watch_hmr_deno_exit() {
 
   wait_contains("Process started", &mut stderr_lines).await;
   wait_contains("started", &mut stdout_lines).await;
-  // `Deno.exit()` still dispatches the `unload` event, and code after it does
-  // not run.
-  wait_contains("unload event fired", &mut stdout_lines).await;
-  // The watcher must survive `Deno.exit()` instead of terminating the process.
-  wait_contains("Process finished with exit code 42", &mut stderr_lines).await;
-  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+  // The watcher must survive `Deno.exit()` instead of terminating the process,
+  // and the requested exit code is surfaced in the finished message.
+  wait_for_exit_code_and_watcher(
+    42,
+    "main_file_to_watch.js",
+    &mut stderr_lines,
+  )
+  .await;
 
-  // Editing the file restarts the run, proving the watcher is still alive.
-  file_to_watch.write("console.log('restarted');");
+  // Editing the file restarts the run with a working server, proving the
+  // watcher is still alive.
+  main_file_to_watch.write(
+    r#"
+      export default {
+        fetch(_request) {
+          return new Response("ok");
+        },
+      };
+    "#,
+  );
 
   wait_contains("Restarting", &mut stderr_lines).await;
-  wait_contains("restarted", &mut stdout_lines).await;
+  wait_for_watcher("main_file_to_watch.js", &mut stderr_lines).await;
   check_alive_then_kill(child);
 }
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -5263,7 +5263,10 @@
       "darwin": false,
       "reason": "Mismatched <anonymous> function calls. Expected exactly 1, actual 0."
     },
-    "parallel/test-watch-mode-kill-signal-default.mjs": {},
+    "parallel/test-watch-mode-kill-signal-default.mjs": {
+      "ignore": true,
+      "reason": "Node runs --watch in a separate child process, so the test kills the watcher with SIGTERM while the script's own process.exit() stays independent. Deno runs --watch in the same process and, per #7590, process.exit()/Deno.exit() under --watch terminates the isolate so the watcher survives; the watcher process therefore never exits and the test times out"
+    },
     "parallel/test-watch-mode-kill-signal-invalid.mjs": {
       "linux": false,
       "darwin": false,


### PR DESCRIPTION
Fixes #7590. Also closes #33043.

When a script run with `deno run --watch` called `Deno.exit()`, the entire
watcher process was terminated instead of just the current run. The expected
behaviour, like nodemon, is for the watcher to keep running and restart the
script on the next file change.

The cause is that `Deno.exit()` goes through `op_exit`, which calls
`std::process::exit()` directly. Under `--watch` that takes the watcher process
down with it, so the watcher never reaches the branch where it waits for the
next file change.

The test runner already faces the same situation: a test calling `Deno.exit()`
must not kill `deno test`. It solves this by terminating the V8 isolate rather
than the process. This change mirrors that approach for watch mode. When a
watcher is active, the isolate handle is installed in `OpState`, so `op_exit`
terminates the current isolate instead of the process and records the requested
exit code. After the run, the watcher clears V8's termination flag and treats it
as a normal end of run, then waits for the next change. The non-watch exit path
is unchanged.

This covers all three watch paths:

- `deno run --watch` installs the handle in `run_for_watcher`.
- `deno run --watch-hmr` installs it in `run()`.
- `deno serve --watch` also goes through `run()`. To make `run()` recognise it
  is under a watcher, the watcher communicator is now provided to the worker
  whenever running under the file watcher rather than only for HMR (HMR-specific
  behaviour stays gated on `create_hmr_runner`).

The watcher reports the requested exit code in its finished message, e.g.
`Process finished with exit code 42`.

Integration tests `run_watch_deno_exit`, `run_watch_process_exit`,
`run_watch_hmr_deno_exit`, and `serve_watch_deno_exit` verify that the run ends,
the `unload` event still fires, code after the exit call does not run, the
requested exit code is surfaced, the watcher survives, and a subsequent file
edit restarts the script.
