### PR TITLE
feat(ext/cron): timezone support for Deno.cron

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2189,7 @@ version = "0.130.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "chrono-tz",
  "deno_core",
  "deno_error",
  "deno_features",
@@ -7350,6 +7361,15 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
@@ -7412,6 +7432,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher 0.3.11",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher 1.0.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ cbc = { version = "=0.1.2", features = ["alloc"] }
 # Note: Do not use the "clock" feature of chrono, as it links us to CoreFoundation on macOS.
 #       Instead use util::time::utc_now()
 chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
+chrono-tz = { version = "0.10", default-features = false }
 color-print = "0.3.5"
 cooked-waker = "5"
 criterion = "0.5"

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -479,13 +479,30 @@ declare namespace Deno {
    * second, 5 seconds, and 10 seconds delay between each retry. There is a
    * limit of 5 retries and a maximum interval of 1 hour (3600000 milliseconds).
    *
+   * The `timezone` option can be used to interpret the schedule in a specific
+   * IANA timezone (e.g. `"America/New_York"`) instead of UTC. Daylight saving
+   * transitions are handled by the runtime: ambiguous local times fire at the
+   * earliest occurrence and nonexistent local times are skipped.
+   *
+   * ```ts
+   * Deno.cron("nightly", "0 0 * * *", {
+   *   timezone: "America/New_York",
+   * }, () => {
+   *   console.log("runs at midnight in New York");
+   * });
+   * ```
+   *
    * @category Cloud
    * @experimental
    */
   export function cron(
     name: string,
     schedule: string | CronSchedule,
-    options: { backoffSchedule?: number[]; signal?: AbortSignal },
+    options: {
+      backoffSchedule?: number[];
+      signal?: AbortSignal;
+      timezone?: string;
+    },
     handler: () => Promise<void> | void,
   ): Promise<void>;
 

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -24,6 +24,8 @@ use deno_runtime::coverage::CoverageCollector;
 use deno_runtime::cpu_prof_filename;
 use deno_runtime::cpu_profiler::CpuProfiler;
 use deno_runtime::deno_os::OpExitCallbacks;
+use deno_runtime::deno_os::WatcherExitHandle;
+use deno_runtime::deno_os::WatcherExitInfo;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_runtime::worker::MainWorker;
 use deno_semver::npm::NpmPackageReqReference;
@@ -194,7 +196,16 @@ impl CliMainWorker {
     Ok(self.worker.exit_code())
   }
 
-  pub async fn run_for_watcher(self) -> Result<(), CoreError> {
+  pub async fn run_for_watcher(mut self) -> Result<(), CoreError> {
+    // Install the isolate handle so that a script calling `Deno.exit()`
+    // terminates this isolate instead of the whole process, allowing the file
+    // watcher to survive and restart on the next change. See issue #7590.
+    let isolate_handle = self.v8_isolate_handle();
+    self
+      .op_state()
+      .borrow_mut()
+      .put(WatcherExitHandle(isolate_handle));
+
     /// The FileWatcherModuleExecutor provides module execution with safe dispatching of life-cycle events by tracking the
     /// state of any pending events and emitting accordingly on drop in the case of a future
     /// cancellation.
@@ -261,7 +272,20 @@ impl CliMainWorker {
     }
 
     let mut executor = FileWatcherModuleExecutor::new(self);
-    executor.execute().await
+    let result = executor.execute().await;
+
+    // If the script called `Deno.exit()`, `op_exit` terminated the isolate
+    // instead of the process. Treat it as a normal end of run: clear V8's
+    // termination flag so the worker can be dropped cleanly, and let the
+    // watcher wait for the next file change rather than propagating the
+    // termination as an error. See issue #7590.
+    let exited = executor.inner.op_state().borrow().has::<WatcherExitInfo>();
+    if exited {
+      executor.inner.cancel_terminate_execution();
+      return Ok(());
+    }
+
+    result
   }
 
   #[inline]

--- a/ext/cron/01_cron.ts
+++ b/ext/cron/01_cron.ts
@@ -110,7 +110,7 @@ function cron(
   schedule: string | Deno.CronSchedule,
   handlerOrOptions1:
     | (() => Promise<void> | void)
-    | ({ backoffSchedule?: number[]; signal?: AbortSignal }),
+    | ({ backoffSchedule?: number[]; signal?: AbortSignal; timezone?: string }),
   handler2?: () => Promise<void> | void,
 ) {
   if (name === undefined) {
@@ -128,7 +128,7 @@ function cron(
 
   let handler: () => Promise<void> | void;
   let options:
-    | { backoffSchedule?: number[]; signal?: AbortSignal }
+    | { backoffSchedule?: number[]; signal?: AbortSignal; timezone?: string }
     | undefined = undefined;
 
   if (typeof handlerOrOptions1 === "function") {
@@ -149,6 +149,7 @@ function cron(
     name,
     schedule,
     options?.backoffSchedule,
+    options?.timezone,
   );
 
   if (options?.signal) {

--- a/ext/cron/Cargo.toml
+++ b/ext/cron/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, features = ["now"] }
+chrono-tz.workspace = true
 deno_core.workspace = true
 deno_error.workspace = true
 deno_features.workspace = true

--- a/ext/cron/cron.rs
+++ b/ext/cron/cron.rs
@@ -5,10 +5,14 @@ use std::str::FromStr;
 use chrono::DateTime;
 use chrono::Datelike;
 use chrono::Duration;
+use chrono::LocalResult;
+use chrono::NaiveDate;
+use chrono::NaiveDateTime;
 use chrono::TimeZone;
 use chrono::Timelike;
 use chrono::Utc;
 use chrono::Weekday;
+use chrono_tz::Tz;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParseError;
@@ -117,7 +121,43 @@ impl FromStr for Schedule {
 }
 
 impl Schedule {
+  /// Find the next execution time strictly after `date`, interpreting the
+  /// schedule in UTC.
   pub fn next_after(&self, date: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    let next = self.next_naive(date.naive_utc())?;
+    Some(Utc.from_utc_datetime(&next))
+  }
+
+  /// Find the next execution time strictly after `date`, interpreting the
+  /// schedule as wall-clock time in the given IANA timezone `tz`.
+  ///
+  /// Cron fields describe a wall clock, so the search runs in the timezone's
+  /// local time and the matching instant is then resolved back to UTC. DST
+  /// transitions are handled as follows:
+  /// - Ambiguous local times (fall back, the clock repeats an hour) fire at the
+  ///   earliest occurrence.
+  /// - Nonexistent local times (spring forward, the clock skips an hour) are
+  ///   skipped; the search continues to the next matching wall-clock time.
+  pub fn next_after_tz(
+    &self,
+    date: DateTime<Utc>,
+    tz: Tz,
+  ) -> Option<DateTime<Utc>> {
+    let mut cursor = date.with_timezone(&tz).naive_local();
+    loop {
+      let candidate = self.next_naive(cursor)?;
+      match tz.from_local_datetime(&candidate) {
+        LocalResult::Single(dt) => return Some(dt.with_timezone(&Utc)),
+        LocalResult::Ambiguous(earliest, _) => {
+          return Some(earliest.with_timezone(&Utc));
+        }
+        LocalResult::None => cursor = candidate,
+      }
+    }
+  }
+
+  /// Core search loop over wall-clock time, independent of any timezone.
+  fn next_naive(&self, date: NaiveDateTime) -> Option<NaiveDateTime> {
     // Rare schedules such as 5th Fridays in February can have multi-decade
     // gaps. Keep the bounded search broad enough to preserve saffron behavior.
     const MAX_SEARCH_DAYS: i64 = 366 * 100;
@@ -150,14 +190,14 @@ impl Schedule {
     None
   }
 
-  fn contains(&self, date: DateTime<Utc>) -> bool {
+  fn contains(&self, date: NaiveDateTime) -> bool {
     (self.minutes & (1u64 << date.minute())) != 0
       && (self.hours & (1u32 << date.hour())) != 0
       && (self.months & (1u16 << date.month())) != 0
       && self.matches_day(date)
   }
 
-  fn matches_day(&self, date: DateTime<Utc>) -> bool {
+  fn matches_day(&self, date: NaiveDateTime) -> bool {
     match (self.days_of_month.is_any(), self.days_of_week.is_any()) {
       (true, true) => true,
       (true, false) => self.days_of_week.contains(date),
@@ -170,8 +210,8 @@ impl Schedule {
 
   fn next_matching_month_start(
     &self,
-    date: DateTime<Utc>,
-  ) -> Option<DateTime<Utc>> {
+    date: NaiveDateTime,
+  ) -> Option<NaiveDateTime> {
     let mut year = date.year();
     let mut month = date.month().checked_add(1)?;
 
@@ -190,8 +230,8 @@ impl Schedule {
 
   fn next_matching_hour_start(
     &self,
-    date: DateTime<Utc>,
-  ) -> Option<DateTime<Utc>> {
+    date: NaiveDateTime,
+  ) -> Option<NaiveDateTime> {
     for hour in date.hour()..=23 {
       if (self.hours & (1u32 << hour)) != 0 {
         return date.with_hour(hour)?.with_minute(0);
@@ -206,8 +246,8 @@ impl Schedule {
 
   fn next_matching_minute_start(
     &self,
-    date: DateTime<Utc>,
-  ) -> Option<DateTime<Utc>> {
+    date: NaiveDateTime,
+  ) -> Option<NaiveDateTime> {
     for minute in date.minute()..=59 {
       if (self.minutes & (1u64 << minute)) != 0 {
         return date.with_minute(minute);
@@ -223,7 +263,7 @@ impl DaysOfMonth {
     matches!(self, Self::Any)
   }
 
-  fn contains(&self, date: DateTime<Utc>) -> bool {
+  fn contains(&self, date: NaiveDateTime) -> bool {
     let day = date.day();
     let days_in_month = days_in_month(date.year(), date.month());
     match *self {
@@ -254,7 +294,7 @@ impl DaysOfWeek {
     matches!(self, Self::Any)
   }
 
-  fn contains(&self, date: DateTime<Utc>) -> bool {
+  fn contains(&self, date: NaiveDateTime) -> bool {
     let weekday = date.weekday().num_days_from_sunday();
     match *self {
       Self::Any => true,
@@ -471,10 +511,8 @@ fn ymd_hms(
   hour: u32,
   minute: u32,
   second: u32,
-) -> Option<DateTime<Utc>> {
-  Utc
-    .with_ymd_and_hms(year, month, day, hour, minute, second)
-    .single()
+) -> Option<NaiveDateTime> {
+  NaiveDate::from_ymd_opt(year, month, day)?.and_hms_opt(hour, minute, second)
 }
 
 fn is_leap_year(year: i32) -> bool {
@@ -521,6 +559,61 @@ mod tests {
       .unwrap()
       .next_after(date)
       .unwrap()
+  }
+
+  fn next_tz(schedule: &str, date: DateTime<Utc>, tz: &str) -> DateTime<Utc> {
+    schedule
+      .parse::<Schedule>()
+      .unwrap()
+      .next_after_tz(date, tz.parse().unwrap())
+      .unwrap()
+  }
+
+  #[test]
+  fn next_after_tz_standard_time() {
+    // Noon in New York during EST (UTC-5) is 17:00 UTC.
+    assert_eq!(
+      next_tz("0 12 * * *", dt(2024, 1, 15, 0, 0), "America/New_York"),
+      dt(2024, 1, 15, 17, 0)
+    );
+  }
+
+  #[test]
+  fn next_after_tz_daylight_time() {
+    // Noon in New York during EDT (UTC-4) is 16:00 UTC.
+    assert_eq!(
+      next_tz("0 12 * * *", dt(2024, 7, 15, 0, 0), "America/New_York"),
+      dt(2024, 7, 15, 16, 0)
+    );
+  }
+
+  #[test]
+  fn next_after_tz_spring_forward_gap_is_skipped() {
+    // On 2024-03-10 New York jumps from 02:00 to 03:00, so 02:30 local does
+    // not exist. The 02:30 firing is skipped and the next match is the
+    // following day at 02:30 EDT (UTC-4) = 06:30 UTC.
+    assert_eq!(
+      next_tz("30 2 * * *", dt(2024, 3, 10, 0, 0), "America/New_York"),
+      dt(2024, 3, 11, 6, 30)
+    );
+  }
+
+  #[test]
+  fn next_after_tz_fall_back_picks_earliest() {
+    // On 2024-11-03 New York repeats 01:00-02:00. The 01:30 firing resolves to
+    // the earliest occurrence, still EDT (UTC-4) = 05:30 UTC.
+    assert_eq!(
+      next_tz("30 1 * * *", dt(2024, 11, 3, 0, 0), "America/New_York"),
+      dt(2024, 11, 3, 5, 30)
+    );
+  }
+
+  #[test]
+  fn next_after_tz_utc_matches_plain() {
+    assert_eq!(
+      next_tz("30 4 * * *", dt(2024, 6, 1, 0, 0), "UTC"),
+      next("30 4 * * *", dt(2024, 6, 1, 0, 0))
+    );
   }
 
   #[test]
@@ -629,7 +722,11 @@ mod tests {
       ("0 0 31-1 * *", dt(2020, 1, 2, 0, 0), false),
     ] {
       let schedule = schedule.parse::<Schedule>().unwrap();
-      assert_eq!(schedule.contains(date), expected, "{schedule:?} {date}");
+      assert_eq!(
+        schedule.contains(date.naive_utc()),
+        expected,
+        "{schedule:?} {date}"
+      );
     }
   }
 
@@ -669,7 +766,11 @@ mod tests {
       ("0 0 13 * TUE", dt(2024, 5, 15, 0, 0), false),
     ] {
       let schedule = schedule.parse::<Schedule>().unwrap();
-      assert_eq!(schedule.contains(date), expected, "{schedule:?} {date}");
+      assert_eq!(
+        schedule.contains(date.naive_utc()),
+        expected,
+        "{schedule:?} {date}"
+      );
     }
   }
 
@@ -677,7 +778,7 @@ mod tests {
   fn invalid_derived_dates_do_not_panic_or_match() {
     let schedule = "0 0 L-30W APR *".parse::<Schedule>().unwrap();
     for day in 1..=30 {
-      assert!(!schedule.contains(dt(2021, 4, day, 0, 0)));
+      assert!(!schedule.contains(dt(2021, 4, day, 0, 0).naive_utc()));
     }
     assert_eq!(
       schedule.next_after(dt(2021, 4, 1, 0, 0)),

--- a/ext/cron/interface.rs
+++ b/ext/cron/interface.rs
@@ -38,5 +38,8 @@ pub trait CronHandle {
 pub struct CronSpec {
   pub name: String,
   pub cron_schedule: String,
+  /// Optional IANA timezone name (e.g. "America/New_York") the schedule is
+  /// interpreted in. `None` means UTC.
+  pub timezone: Option<String>,
   pub backoff_schedule: Option<Vec<u32>>,
 }

--- a/ext/cron/lib.rs
+++ b/ext/cron/lib.rs
@@ -77,6 +77,9 @@ pub enum CronError {
   #[error("Invalid cron schedule")]
   InvalidCron,
   #[class(type)]
+  #[error("Invalid cron timezone: {0}")]
+  InvalidTimezone(String),
+  #[class(type)]
   #[error("Invalid backoff schedule")]
   InvalidBackoff,
   #[class(generic)]
@@ -100,6 +103,7 @@ fn op_cron_create(
   #[string] name: String,
   #[string] cron_schedule: String,
   #[scoped] backoff_schedule: Option<Vec<u32>>,
+  #[string] timezone: Option<String>,
 ) -> Result<ResourceId, CronError> {
   let cron_handler = {
     let state = state.borrow();
@@ -111,9 +115,18 @@ fn op_cron_create(
 
   validate_cron_name(&name)?;
 
+  // Validate the timezone eagerly so a bad IANA name is reported regardless of
+  // which handler backend ends up computing the schedule.
+  if let Some(timezone) = &timezone {
+    timezone
+      .parse::<chrono_tz::Tz>()
+      .map_err(|_| CronError::InvalidTimezone(timezone.clone()))?;
+  }
+
   let handle = cron_handler.create(CronSpec {
     name,
     cron_schedule,
+    timezone,
     backoff_schedule,
   })?;
 

--- a/ext/cron/local.rs
+++ b/ext/cron/local.rs
@@ -126,7 +126,7 @@ impl LocalCronHandler {
             cron.current_execution_retries += 1;
             now + backoff_ms as u64
           } else {
-            let next_ts = compute_next_deadline(&cron.spec.cron_schedule)?;
+            let next_ts = compute_next_deadline(&cron.spec)?;
             cron.current_execution_retries = 0;
             next_ts
           };
@@ -321,7 +321,7 @@ impl CronHandle for CronExecutionHandle {
   }
 }
 
-fn compute_next_deadline(cron_expression: &str) -> Result<u64, CronError> {
+fn compute_next_deadline(spec: &CronSpec) -> Result<u64, CronError> {
   let now = chrono::Utc::now();
 
   if let Ok(test_schedule) = env::var("DENO_CRON_TEST_SCHEDULE_OFFSET")
@@ -330,10 +330,20 @@ fn compute_next_deadline(cron_expression: &str) -> Result<u64, CronError> {
     return Ok(now.timestamp_millis() as u64 + offset);
   }
 
-  let cron = cron_expression
+  let cron = spec
+    .cron_schedule
     .parse::<Schedule>()
     .map_err(|_| CronError::InvalidCron)?;
-  let Some(next_deadline) = cron.next_after(now) else {
+  let next_deadline = match &spec.timezone {
+    Some(timezone) => {
+      let tz = timezone
+        .parse::<chrono_tz::Tz>()
+        .map_err(|_| CronError::InvalidTimezone(timezone.clone()))?;
+      cron.next_after_tz(now, tz)
+    }
+    None => cron.next_after(now),
+  };
+  let Some(next_deadline) = next_deadline else {
     return Err(CronError::InvalidCron);
   };
   Ok(next_deadline.timestamp_millis() as u64)
@@ -357,11 +367,28 @@ mod tests {
 
   #[test]
   fn test_compute_next_deadline() {
+    fn spec(schedule: &str, timezone: Option<&str>) -> CronSpec {
+      CronSpec {
+        name: "test".to_string(),
+        cron_schedule: schedule.to_string(),
+        timezone: timezone.map(|s| s.to_string()),
+        backoff_schedule: None,
+      }
+    }
+
     let now = chrono::Utc::now().timestamp_millis() as u64;
-    assert!(compute_next_deadline("*/1 * * * *").unwrap() > now);
-    assert!(compute_next_deadline("* * * * *").unwrap() > now);
-    assert!(compute_next_deadline("bogus").is_err());
-    assert!(compute_next_deadline("* * * * * *").is_err());
-    assert!(compute_next_deadline("* * *").is_err());
+    assert!(compute_next_deadline(&spec("*/1 * * * *", None)).unwrap() > now);
+    assert!(compute_next_deadline(&spec("* * * * *", None)).unwrap() > now);
+    assert!(
+      compute_next_deadline(&spec("0 12 * * *", Some("America/New_York")))
+        .unwrap()
+        > now
+    );
+    assert!(compute_next_deadline(&spec("bogus", None)).is_err());
+    assert!(compute_next_deadline(&spec("* * * * * *", None)).is_err());
+    assert!(compute_next_deadline(&spec("* * *", None)).is_err());
+    assert!(
+      compute_next_deadline(&spec("* * * * *", Some("Not/AZone"))).is_err()
+    );
   }
 }

--- a/ext/cron/socket.rs
+++ b/ext/cron/socket.rs
@@ -56,6 +56,8 @@ struct CronRegistration<'a> {
   name: &'a str,
   schedule: &'a str,
   #[serde(skip_serializing_if = "Option::is_none")]
+  timezone: Option<&'a str>,
+  #[serde(skip_serializing_if = "Option::is_none")]
   backoff_schedule: Option<&'a [u32]>,
 }
 
@@ -418,6 +420,7 @@ async fn register_cron(
   let cron = CronRegistration {
     name: &spec.name,
     schedule: &spec.cron_schedule,
+    timezone: spec.timezone.as_deref(),
     backoff_schedule: spec.backoff_schedule.as_deref(),
   };
 

--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -70,6 +70,21 @@ impl OpExitCallbacks {
   }
 }
 
+/// Holds the main isolate's handle so that `op_exit` (i.e. `Deno.exit()`) can
+/// terminate the current isolate instead of the whole process. Installed by
+/// `deno run --watch` / `deno serve --watch` so a script calling `Deno.exit()`
+/// ends the current run without killing the file watcher. See issue #7590.
+pub struct WatcherExitHandle(pub v8::IsolateHandle);
+
+/// Set by `op_exit` when a [`WatcherExitHandle`] is present to record that the
+/// script called `Deno.exit()`. The watcher reads this after the run to learn
+/// the requested exit code and to confirm the V8 termination it observes was
+/// caused by `Deno.exit()` rather than another error.
+#[derive(Clone, Copy, Debug)]
+pub struct WatcherExitInfo {
+  pub exit_code: i32,
+}
+
 deno_core::extension!(
   deno_os,
   ops = [
@@ -352,6 +367,21 @@ fn op_get_exit_code(state: &mut OpState) -> i32 {
 
 #[op2(fast)]
 fn op_exit(state: &mut OpState) {
+  // Under `deno run --watch`, terminate the current V8 isolate instead of
+  // exiting the process so the file watcher survives and can restart the
+  // script on the next file change. See issue #7590.
+  if let Some(handle) =
+    state.try_borrow::<WatcherExitHandle>().map(|h| h.0.clone())
+  {
+    let code = state
+      .try_borrow::<ExitCode>()
+      .map(|exit_code| exit_code.get())
+      .unwrap_or_default();
+    state.put(WatcherExitInfo { exit_code: code });
+    handle.terminate_execution();
+    return;
+  }
+
   if let Some(cbs) = state.try_borrow_mut::<OpExitCallbacks>() {
     cbs.run();
   }

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -1829,6 +1829,55 @@ async fn run_watch_process_exit_on_restart() {
   check_alive_then_kill(child);
 }
 
+/// Test that a script calling `Deno.exit()` under `--watch` ends the current
+/// run without killing the watcher, which keeps watching and restarts the
+/// script on the next file change. See https://github.com/denoland/deno/issues/7590.
+#[test(flaky)]
+async fn run_watch_deno_exit() {
+  let t = TempDir::new();
+  let file_to_watch = t.path().join("file_to_watch.js");
+  file_to_watch.write(
+    r#"
+      globalThis.addEventListener("unload", () => {
+        console.log("unload event fired");
+      });
+      console.log("started");
+      Deno.exit(42);
+      console.log("not reached");
+    "#,
+  );
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch")
+    .arg("-L")
+    .arg("debug")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_contains("Process started", &mut stderr_lines).await;
+  wait_contains("started", &mut stdout_lines).await;
+  // `Deno.exit()` still dispatches the `unload` event, and code after it does
+  // not run.
+  wait_contains("unload event fired", &mut stdout_lines).await;
+  // The watcher must survive `Deno.exit()` instead of terminating the process.
+  wait_contains("Process finished", &mut stderr_lines).await;
+  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+
+  // Editing the file restarts the run, proving the watcher is still alive.
+  file_to_watch.write("console.log('restarted');");
+
+  wait_contains("Restarting", &mut stderr_lines).await;
+  wait_contains("restarted", &mut stdout_lines).await;
+  wait_contains("Process finished", &mut stderr_lines).await;
+  check_alive_then_kill(child);
+}
+
 /// Test that SIGTERM is dispatched to JS signal handlers on watch restart,
 /// giving the process a chance to clean up before restarting.
 #[test(flaky)]

--- a/tests/unit/cron_test.ts
+++ b/tests/unit/cron_test.ts
@@ -113,6 +113,45 @@ Deno.test(function invalidBackoffScheduleTest() {
   );
 });
 
+Deno.test(function invalidTimezoneTest() {
+  assertThrows(
+    () =>
+      Deno.cron(
+        "abc",
+        "*/1 * * * *",
+        { timezone: "Not/AZone" },
+        () => {},
+      ),
+    TypeError,
+    "Invalid cron timezone",
+  );
+});
+
+Deno.test(async function basicTestWithTimezone() {
+  Deno.env.set("DENO_CRON_TEST_SCHEDULE_OFFSET", "100");
+
+  let count = 0;
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const ac = new AbortController();
+  const c = Deno.cron(
+    "abc",
+    "0 12 * * *",
+    { signal: ac.signal, timezone: "America/New_York" },
+    () => {
+      count++;
+      if (count > 5) {
+        resolve();
+      }
+    },
+  );
+  try {
+    await promise;
+  } finally {
+    ac.abort();
+    await c;
+  }
+});
+
 Deno.test(async function tooManyCrons() {
   const crons: Promise<void>[] = [];
   const ac = new AbortController();


### PR DESCRIPTION
Closes #21562.

Adds an optional `timezone` to `Deno.cron` options so a schedule can be
interpreted in a specific IANA timezone instead of always UTC:

```ts
Deno.cron("nightly", "0 0 * * *", { timezone: "America/New_York" }, () => {
  // fires at local midnight in New York, following DST
});
```

Cron fields describe a wall clock, so the matcher was refactored to search
in naive (timezone-free) local time and then resolve the matched wall-clock
instant back to UTC through the zone using `chrono-tz`. This keeps the
existing UTC path byte-for-byte identical (`next_after` delegates to the new
naive search) while adding `next_after_tz` for the zoned case. Daylight
saving transitions are handled as follows: ambiguous local times (the fall
back hour that repeats) fire at the earliest occurrence, and nonexistent
local times (the spring forward hour that is skipped) are skipped to the
next matching wall-clock time.

This is opened as a draft because only the OSS local handler is fully
functional. The socket handler forwards the new `timezone` field in its
registration message, but the Deno Deploy backend computes schedules
independently and needs a matching wall-clock plus DST implementation
before this is correct in Deploy. If the two diverge on a DST edge case a
job would fire at a different instant depending on where it runs, so the
three DST rules above should be treated as a shared contract between the two
implementations.

On testing: the deterministic correctness lives in the `next_after_tz` unit
tests, which pin fixed dates to expected UTC instants (standard time,
daylight time, the spring forward gap, the fall back ambiguity, and UTC
parity), so they are reproducible and not wall-clock dependent. True
end-to-end timing ("did the job actually fire at local midnight") is
inherently time dependent and not reliably testable without time mocking;
note that `DENO_CRON_TEST_SCHEDULE_OFFSET` bypasses schedule computation
entirely, so the added JS test only proves the option is wired through. A
good next step would be to extract the four DST cases into a shared test
vector fixture that both this implementation and the Deploy backend run
against.
