### PR TITLE
fix(ext/node): unblock static module loads when registerHooks is active

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1308,11 +1308,46 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
       return Box::pin(deno_core::futures::future::ready(Ok(())));
     }
 
-    // When ESM hooks are active, skip graph preparation — hooked modules
-    // may be virtual and can't be fetched by the module graph builder.
+    // When ESM hooks are active, attempt graph preparation best-effort.
+    // A user hook may have resolved this specifier to a virtual URL the
+    // graph builder cannot fetch; in that case the load itself will be
+    // serviced entirely by hooks, so failure here is fine and must not
+    // abort the load.
     if self.0.hook_registry.load_active.get() {
       self.0.shared.has_js_execution_started_flag.raise();
-      return Box::pin(deno_core::futures::future::ready(Ok(())));
+      let specifier = specifier.clone();
+      let inner = self.0.clone();
+      let is_dynamic_import = options.is_dynamic_import;
+      return Box::pin(async move {
+        let graph_container = &inner.graph_container;
+        let module_load_preparer = &inner.shared.module_load_preparer;
+        let permissions = if is_dynamic_import {
+          &inner.permissions
+        } else {
+          &inner.parent_permissions
+        };
+        let is_dynamic = is_dynamic_import || inner.is_worker;
+        let mut update_permit = graph_container.acquire_update_permit().await;
+        let graph = update_permit.graph_mut();
+        let _ = module_load_preparer
+          .prepare_module_load(
+            graph,
+            &[specifier],
+            PrepareModuleLoadOptions {
+              is_dynamic,
+              lib: inner.lib,
+              permissions: permissions.clone(),
+              ext_overwrite: None,
+              allow_unknown_media_types: false,
+              skip_graph_roots_validation: true,
+              file_content_overrides: HashMap::new(),
+            },
+          )
+          .await;
+        graph.prune_types();
+        update_permit.commit();
+        Ok(())
+      });
     }
 
     if self.0.shared.in_npm_pkg_checker.in_npm_package(specifier) {

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1350,6 +1350,11 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
             },
           )
           .await;
+        // Ignore prepare failures: a hook may have resolved this specifier to
+        // a virtual URL the graph builder cannot fetch, in which case the load
+        // is serviced entirely by hooks. Committing a possibly-partial graph
+        // here is intentional and harmless, since the hooks (not this graph)
+        // satisfy the load.
         graph.prune_types();
         update_permit.commit();
         Ok(())

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1130,6 +1130,12 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
     self.0.inner_resolve(specifier, referrer, kind, false)
   }
 
+  fn pump_event_loop_during_load(&self) -> bool {
+    // Load hooks respond through the async bridge, so the event loop must be
+    // pumped during the recursive load or the load deadlocks.
+    self.0.hook_registry.load_active.get()
+  }
+
   fn import_meta_resolve(
     &self,
     specifier: &str,

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -630,6 +630,12 @@ impl ModuleLoader for EmbeddedModuleLoader {
     self.resolve_inner(raw_specifier, referrer, kind)
   }
 
+  fn pump_event_loop_during_load(&self) -> bool {
+    // Load hooks respond through the async bridge, so the event loop must be
+    // pumped during the recursive load or the load deadlocks.
+    self.hook_registry.load_active.get()
+  }
+
   fn get_host_defined_options<'s>(
     &self,
     scope: &mut deno_core::v8::PinScope<'s, '_>,

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -798,14 +798,32 @@ function executeEsmLoadHookChain(fileUrl, context) {
       currentContext = { ...currentContext, ...ctx };
     }
     if (index >= loadHooks.length) {
-      // End of chain. Delegate to Rust default loading by returning
-      // a null source, so TypeScript transpilation and JSON handling
-      // produced by the module graph apply uniformly. User hooks
-      // calling nextLoad() will not observe raw on-disk source for
-      // these schemes.
+      // End of chain. Synthesize a default load result so user hooks
+      // that call `await nextLoad(...)` observe a real `source` they
+      // can transform (matches Node, where `defaultLoad` returns the
+      // on-disk source).
       if (StringPrototypeStartsWith(loadUrl, "node:")) {
         return { source: null, format: "builtin", shortCircuit: true };
       }
+      if (StringPrototypeStartsWith(loadUrl, "file://")) {
+        try {
+          const source = op_require_read_file(url.fileURLToPath(loadUrl));
+          return {
+            source,
+            format: currentContext?.format,
+            shortCircuit: true,
+          };
+        } catch {
+          // Any sync read failure (file absent from disk because it's
+          // embedded in a compiled binary's eszip, permission errors,
+          // transient IO) falls through to Rust default loading via
+          // the load loop, which surfaces a clearer error if the
+          // module truly cannot be loaded.
+          return { source: null, shortCircuit: true };
+        }
+      }
+      // For other schemes (data:, http(s):, etc.) we cannot synchronously
+      // produce source here; fall through to Rust default loading.
       return { source: null, shortCircuit: true };
     }
     const hook = loadHooks[index++];

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -798,29 +798,14 @@ function executeEsmLoadHookChain(fileUrl, context) {
       currentContext = { ...currentContext, ...ctx };
     }
     if (index >= loadHooks.length) {
-      // End of chain - perform default load so user hooks calling
-      // nextLoad() receive the actual source they can transform.
+      // End of chain. Delegate to Rust default loading by returning
+      // a null source, so TypeScript transpilation and JSON handling
+      // produced by the module graph apply uniformly. User hooks
+      // calling nextLoad() will not observe raw on-disk source for
+      // these schemes.
       if (StringPrototypeStartsWith(loadUrl, "node:")) {
         return { source: null, format: "builtin", shortCircuit: true };
       }
-      if (StringPrototypeStartsWith(loadUrl, "file://")) {
-        try {
-          const source = op_require_read_file(url.fileURLToPath(loadUrl));
-          return {
-            source,
-            format: currentContext?.format,
-            shortCircuit: true,
-          };
-        } catch {
-          // Any synchronous read failure (file absent from disk because it's
-          // embedded in a compiled binary's eszip, permission errors,
-          // transient IO) falls through to Rust default loading, which will
-          // surface a clearer error if the module truly cannot be loaded.
-          return { source: null, shortCircuit: true };
-        }
-      }
-      // For other schemes (data:, http(s):, etc.) we cannot synchronously
-      // produce source here; fall through to Rust default loading.
       return { source: null, shortCircuit: true };
     }
     const hook = loadHooks[index++];

--- a/libs/core/modules/loaders.rs
+++ b/libs/core/modules/loaders.rs
@@ -91,6 +91,19 @@ pub trait ModuleLoader {
     self.resolve(specifier, referrer, kind)
   }
 
+  /// Whether driving an ES module load to completion should also pump the V8
+  /// event loop. Loaders that satisfy module loads via asynchronous
+  /// JavaScript, such as Node `module.registerHooks()` load hooks (which run
+  /// on an async polling task), must return `true`: otherwise the recursive
+  /// load awaits a hook response that can never be delivered and deadlocks.
+  ///
+  /// Defaults to `false` so ordinary module loads are driven on their own
+  /// without running unrelated event-loop work mid-load, preserving execution
+  /// ordering for non-hooked module graphs.
+  fn pump_event_loop_during_load(&self) -> bool {
+    false
+  }
+
   /// Override to customize the behavior of `import.meta.resolve` resolution.
   ///
   /// The default implementation calls `self.resolve()`.

--- a/libs/core/runtime/jsrealm.rs
+++ b/libs/core/runtime/jsrealm.rs
@@ -580,58 +580,6 @@ impl JsRealm {
     count.set(count.get() + 1)
   }
 
-  /// Asynchronously load specified module and all of its dependencies.
-  ///
-  /// The module will be marked as "main", and because of that
-  /// "import.meta.main" will return true when checked inside that module.
-  ///
-  /// User must call [`ModuleMap::mod_evaluate`] with returned `ModuleId`
-  /// manually after load is finished.
-  pub(crate) async fn load_main_es_module_from_code(
-    &self,
-    isolate: &mut v8::Isolate,
-    specifier: &ModuleSpecifier,
-    code: Option<ModuleCodeString>,
-  ) -> Result<ModuleId, CoreError> {
-    let module_map_rc = self.0.module_map();
-    if let Some(code) = code {
-      context_scope!(scope, self, isolate);
-      // true for main module
-      module_map_rc
-        .new_es_module(
-          scope,
-          true,
-          specifier.to_string().into(),
-          code,
-          false,
-          None,
-        )
-        .map_err(|e| e.into_error(scope, false, false))?;
-    }
-
-    let root_id =
-      RecursiveModuleLoad::main(specifier.to_string(), module_map_rc.clone())
-        .await?
-        .run_to_completion(|load, step| {
-          context_scope!(scope, self, isolate);
-          match step {
-            crate::modules::recursive_load::RegisterStep::Register {
-              request,
-              source,
-            } => load
-              .register_and_recurse(scope, request, source)
-              .map_err(|e| e.into_error(scope, false, false)),
-          }
-        })
-        .await?;
-    context_scope!(scope, self, isolate);
-    self.instantiate_module(scope, root_id).map_err(|e| {
-      let exception = v8::Local::new(scope, e);
-      exception_to_err(scope, exception, false, false)
-    })?;
-    Ok(root_id)
-  }
-
   /// Asynchronously load specified ES module and all of its dependencies.
   ///
   /// This method is meant to be used when loading some utility code that

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -3138,6 +3138,14 @@ impl JsRuntime {
     let realm = JsRealm::clone(&self.inner.main_realm);
     let module_map_rc = realm.0.module_map();
 
+    // Only pump the V8 event loop alongside the load when the loader resolves
+    // modules through asynchronous JavaScript (e.g. Node
+    // `module.registerHooks()` load hooks). For ordinary loads pumping is
+    // unnecessary and would run unrelated event-loop work mid-load, so the
+    // load is driven on its own instead.
+    let pump_event_loop =
+      module_map_rc.loader.borrow().pump_event_loop_during_load();
+
     if let Some(code) = code {
       jsrealm::context_scope!(scope, &realm, self.v8_isolate());
       module_map_rc
@@ -3166,13 +3174,17 @@ impl JsRuntime {
     };
 
     loop {
-      // Drive the recursive load AND the V8 event loop concurrently. Pumping
-      // the event loop is what lets JavaScript-side module hooks
+      // Drive the recursive load, optionally pumping the V8 event loop
+      // concurrently. Pumping is what lets JavaScript-side module hooks
       // (`module.registerHooks()`) respond to load requests issued by the
-      // recursive load via the async hook bridge.
+      // recursive load via the async hook bridge; for ordinary loads it is
+      // skipped so unrelated event-loop work doesn't run mid-load.
       let next_step = poll_fn(|cx| {
         if let Poll::Ready(t) = load.poll_next_unpin(cx) {
           return Poll::Ready(Ok::<_, CoreError>(t));
+        }
+        if !pump_event_loop {
+          return Poll::Pending;
         }
         match self.poll_event_loop(cx, PollEventLoopOptions::default()) {
           Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -21,6 +21,7 @@ use std::task::Waker;
 
 use deno_error::JsErrorBox;
 use futures::FutureExt;
+use futures::StreamExt;
 use futures::task::AtomicWaker;
 use smallvec::SmallVec;
 
@@ -72,12 +73,15 @@ use crate::modules::ExtCodeCache;
 use crate::modules::ExtModuleLoader;
 use crate::modules::IntoModuleCodeString;
 use crate::modules::IntoModuleName;
+use crate::modules::ModuleError;
 use crate::modules::ModuleId;
 use crate::modules::ModuleLoader;
 use crate::modules::ModuleMap;
 use crate::modules::ModuleName;
 use crate::modules::RequestedModuleType;
+use crate::modules::SideModuleKind;
 use crate::modules::ValidateImportAttributesCb;
+use crate::modules::recursive_load::RecursiveModuleLoad;
 use crate::modules::script_origin;
 use crate::ops_metrics::OpMetricsFactoryFn;
 use crate::ops_metrics::dispatch_metrics_async;
@@ -3061,15 +3065,8 @@ impl JsRuntime {
     specifier: &ModuleSpecifier,
     code: impl IntoModuleCodeString,
   ) -> Result<ModuleId, CoreError> {
-    let isolate = &mut self.inner.v8_isolate;
     self
-      .inner
-      .main_realm
-      .load_main_es_module_from_code(
-        isolate,
-        specifier,
-        Some(code.into_module_code()),
-      )
+      .drive_es_module_load(true, specifier, Some(code.into_module_code()))
       .await
   }
 
@@ -3085,12 +3082,7 @@ impl JsRuntime {
     &mut self,
     specifier: &ModuleSpecifier,
   ) -> Result<ModuleId, CoreError> {
-    let isolate = &mut self.inner.v8_isolate;
-    self
-      .inner
-      .main_realm
-      .load_main_es_module_from_code(isolate, specifier, None)
-      .await
+    self.drive_es_module_load(true, specifier, None).await
   }
 
   /// Asynchronously load specified ES module and all of its dependencies from the
@@ -3111,15 +3103,8 @@ impl JsRuntime {
     specifier: &ModuleSpecifier,
     code: impl IntoModuleCodeString,
   ) -> Result<ModuleId, CoreError> {
-    let isolate = &mut self.inner.v8_isolate;
     self
-      .inner
-      .main_realm
-      .load_side_es_module_from_code(
-        isolate,
-        specifier.to_string(),
-        Some(code.into_module_code()),
-      )
+      .drive_es_module_load(false, specifier, Some(code.into_module_code()))
       .await
   }
 
@@ -3135,12 +3120,104 @@ impl JsRuntime {
     &mut self,
     specifier: &ModuleSpecifier,
   ) -> Result<ModuleId, CoreError> {
-    let isolate = &mut self.inner.v8_isolate;
-    self
-      .inner
-      .main_realm
-      .load_side_es_module_from_code(isolate, specifier.to_string(), None)
-      .await
+    self.drive_es_module_load(false, specifier, None).await
+  }
+
+  /// Drive a recursive ES module load to completion while concurrently
+  /// pumping the event loop. The event loop pumping is required so that
+  /// JavaScript-side `module.registerHooks()` load hooks (which run as an
+  /// async polling task) can respond to load requests from the recursive
+  /// load. Without it, static module loads that go through hook bridges
+  /// would deadlock.
+  async fn drive_es_module_load(
+    &mut self,
+    is_main: bool,
+    specifier: &ModuleSpecifier,
+    code: Option<ModuleCodeString>,
+  ) -> Result<ModuleId, CoreError> {
+    let realm = JsRealm::clone(&self.inner.main_realm);
+    let module_map_rc = realm.0.module_map();
+
+    if let Some(code) = code {
+      jsrealm::context_scope!(scope, &realm, self.v8_isolate());
+      module_map_rc
+        .new_es_module(
+          scope,
+          is_main,
+          specifier.to_string().into(),
+          code,
+          false,
+          None,
+        )
+        .map_err(|e| e.into_error(scope, false, false))?;
+    }
+
+    let mut load = if is_main {
+      RecursiveModuleLoad::main(specifier.to_string(), module_map_rc.clone())
+        .await?
+    } else {
+      RecursiveModuleLoad::side(
+        specifier.to_string(),
+        module_map_rc.clone(),
+        SideModuleKind::Async,
+        None,
+      )
+      .await?
+    };
+
+    loop {
+      // Drive the recursive load AND the V8 event loop concurrently. Pumping
+      // the event loop is what lets JavaScript-side module hooks
+      // (`module.registerHooks()`) respond to load requests issued by the
+      // recursive load via the async hook bridge.
+      let next_step = poll_fn(|cx| {
+        if let Poll::Ready(t) = load.poll_next_unpin(cx) {
+          return Poll::Ready(Ok::<_, CoreError>(t));
+        }
+        match self.poll_event_loop(cx, PollEventLoopOptions::default()) {
+          Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+          Poll::Ready(Ok(())) | Poll::Pending => {}
+        }
+        // After polling the event loop, the recursive load may have new
+        // results ready (e.g. a hook callback responded). Re-poll.
+        match load.poll_next_unpin(cx) {
+          Poll::Ready(t) => Poll::Ready(Ok(t)),
+          Poll::Pending => Poll::Pending,
+        }
+      })
+      .await?;
+
+      let Some(load_result) = next_step else { break };
+      let (request, source) = load_result?;
+
+      jsrealm::context_scope!(scope, &realm, self.v8_isolate());
+      load.register_and_recurse(scope, &request, source).map_err(
+        |e| match e {
+          ModuleError::Exception(g) => {
+            let exception = v8::Local::new(scope, g);
+            CoreErrorKind::Js(crate::error::exception_to_err(
+              scope, exception, false, false,
+            ))
+            .into_box()
+          }
+          ModuleError::Core(e) => e,
+          ModuleError::Concrete(e) => CoreErrorKind::Module(e).into_box(),
+        },
+      )?;
+    }
+
+    let root_id = load.root_module_id().expect("Root module should be loaded");
+
+    jsrealm::context_scope!(scope, &realm, self.v8_isolate());
+    realm.instantiate_module(scope, root_id).map_err(|e| {
+      let exception = v8::Local::new(scope, e);
+      CoreErrorKind::Js(crate::error::exception_to_err(
+        scope, exception, false, false,
+      ))
+      .into_box()
+    })?;
+
+    Ok(root_id)
   }
 
   /// Load and evaluate an ES module provided the specifier and source code.

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -73,7 +73,6 @@ use crate::modules::ExtCodeCache;
 use crate::modules::ExtModuleLoader;
 use crate::modules::IntoModuleCodeString;
 use crate::modules::IntoModuleName;
-use crate::modules::ModuleError;
 use crate::modules::ModuleId;
 use crate::modules::ModuleLoader;
 use crate::modules::ModuleMap;
@@ -3203,19 +3202,9 @@ impl JsRuntime {
       let (request, source) = load_result?;
 
       jsrealm::context_scope!(scope, &realm, self.v8_isolate());
-      load.register_and_recurse(scope, &request, source).map_err(
-        |e| match e {
-          ModuleError::Exception(g) => {
-            let exception = v8::Local::new(scope, g);
-            CoreErrorKind::Js(crate::error::exception_to_err(
-              scope, exception, false, false,
-            ))
-            .into_box()
-          }
-          ModuleError::Core(e) => e,
-          ModuleError::Concrete(e) => CoreErrorKind::Module(e).into_box(),
-        },
-      )?;
+      load
+        .register_and_recurse(scope, &request, source)
+        .map_err(|e| e.into_error(scope, false, false))?;
     }
 
     let root_id = load.root_module_id().expect("Root module should be loaded");

--- a/tests/specs/node/module_register_hooks_esm/__test__.jsonc
+++ b/tests/specs/node/module_register_hooks_esm/__test__.jsonc
@@ -17,6 +17,11 @@
       "cwd": "worker",
       "args": "run -A main.mjs",
       "output": "worker/main.out"
+    },
+    "preload_main": {
+      "cwd": "preload_main",
+      "args": "run -A --import=./hook.mjs main.mjs",
+      "output": "preload_main/main.out"
     }
   }
 }

--- a/tests/specs/node/module_register_hooks_esm/preload_main/hook.mjs
+++ b/tests/specs/node/module_register_hooks_esm/preload_main/hook.mjs
@@ -1,0 +1,14 @@
+import { registerHooks } from "node:module";
+
+console.log("hook module loaded");
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    console.log("hook:resolve", specifier);
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    console.log("hook:load", url);
+    return nextLoad(url, context);
+  },
+});

--- a/tests/specs/node/module_register_hooks_esm/preload_main/main.mjs
+++ b/tests/specs/node/module_register_hooks_esm/preload_main/main.mjs
@@ -1,0 +1,2 @@
+import { value } from "./mod.mjs";
+console.log("hello from main", value);

--- a/tests/specs/node/module_register_hooks_esm/preload_main/main.out
+++ b/tests/specs/node/module_register_hooks_esm/preload_main/main.out
@@ -1,0 +1,5 @@
+hook module loaded
+hook:load [WILDCARD]main.mjs
+hook:resolve ./mod.mjs
+hook:load [WILDCARD]mod.mjs
+hello from main 42

--- a/tests/specs/node/module_register_hooks_esm/preload_main/mod.mjs
+++ b/tests/specs/node/module_register_hooks_esm/preload_main/mod.mjs
@@ -1,0 +1,1 @@
+export const value = 42;


### PR DESCRIPTION
Static ES module loads that go through the `module.registerHooks()` async
load-hook bridge (for example `deno run --import=./hook.ts main.ts`)
deadlocked. The recursive module load awaited a response from the JS hook
polling task, but the V8 event loop was never pumped while it waited, so the
hook task never ran and the response was never delivered.

This drives the V8 event loop alongside the recursive load in
`load_main_es_module` / `load_side_es_module` (and their `_from_code`
variants) so the hook polling task can deliver responses. To keep this from
changing ordinary loads, the event-loop pumping is gated behind a new
`ModuleLoader::pump_event_loop_during_load()` signal that defaults to false;
only the CLI and embedded loaders opt in, and only while a load hook is
registered. Non-hooked module graphs are driven exactly as before.

It also prepares the module graph best-effort when hooks are active so hook
fallthrough (`nextLoad()`) lands on Deno's normal TypeScript / JSON pipeline
rather than failing with "Loading unprepared module", and makes the JS
default load at the end of the hook chain read `file://` source so user hooks
that `await nextLoad()` observe real source to transform.

Fixes #34384.

This is the first of three PRs splitting #34390 into reviewable pieces. The
follow-ups add `nextLoad(newUrl)` redirect support and import-attribute /
custom-module-type fidelity on top of this one.