### PR TITLE
chore: upgrade v8 to 149.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10638,9 +10638,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "149.2.0"
+version = "149.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dccf61a364b61bbaac70a8ba64a1a1006e87123b7d62eaeec999a3ba31ecdb"
+checksum = "65a9ff61a9b12e7b2559a7b1e5e1515e379a999c97a65b9356b936307b7f687a"
 dependencies = [
  "bindgen 0.72.1",
  "bitflags 2.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ deno_task_shell = "=0.33.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"
-v8 = { version = "149.2.0", default-features = false, features = ["simdutf"] }
+v8 = { version = "149.3.0", default-features = false, features = ["simdutf"] }
 
 denokv_proto = "0.13.0"
 denokv_remote = "0.13.0"


### PR DESCRIPTION
Updates the `v8` crate from 149.2.0 to 149.3.0.

- `Cargo.toml`: bump `v8` to `149.3.0`
- `Cargo.lock`: regenerated via `cargo update -p v8 --precise 149.3.0`