### PR TITLE
fix(inspector): attribute idle event-loop wait to (idle) in CPU profiles

### DIFF
--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2269,14 +2269,34 @@ impl JsRuntime {
     cx: &mut Context,
     poll_options: PollEventLoopOptions,
   ) -> Poll<Result<(), CoreError>> {
+    let has_inspector = self.inner.state.has_inspector.get();
+
     // SAFETY: We know this isolate is valid and non-null at this time
     let mut isolate =
       unsafe { v8::Isolate::from_raw_isolate_ptr(self.v8_isolate_ptr()) };
-    v8::scope!(let isolate_scope, &mut isolate);
-    let context =
-      v8::Local::new(isolate_scope, self.inner.main_realm.context());
-    let mut scope = v8::ContextScope::new(isolate_scope, context);
-    self.poll_event_loop_inner(cx, &mut scope, poll_options)
+
+    let result = {
+      v8::scope!(let isolate_scope, &mut isolate);
+      let context =
+        v8::Local::new(isolate_scope, self.inner.main_realm.context());
+      let mut scope = v8::ContextScope::new(isolate_scope, context);
+      self.poll_event_loop_inner(cx, &mut scope, poll_options)
+    };
+
+    // Tell V8's CPU profiler whether we're about to go idle. When the event
+    // loop has no immediate work it returns `Poll::Pending` and the task parks
+    // until an external event (timer, I/O) wakes it. Marking the isolate idle
+    // makes the profiler attribute that wait to the `(idle)` node instead of
+    // `(program)`, which otherwise makes an idle process look like it is using
+    // 100% CPU in DevTools (https://github.com/denoland/deno/issues/21620).
+    //
+    // This must happen *after* the `v8::ContextScope` above is dropped: tearing
+    // the scope down calls `Isolate::Exit`, which restores the VM state that was
+    // saved on entry and would clobber the idle state if we set it any earlier.
+    if has_inspector {
+      isolate.set_idle(result.is_pending());
+    }
+    result
   }
 
   /// Phase-based event loop tick, loosely following libuv's architecture:

--- a/tests/testdata/inspector/idle.js
+++ b/tests/testdata/inspector/idle.js
@@ -1,0 +1,13 @@
+// Keeps the event loop alive but idle: every iteration just awaits a timer, so
+// the process spends virtually all of its time parked waiting rather than
+// running JS. Used to verify that the CPU profiler attributes this wait time to
+// the "(idle)" node instead of "(program)". See
+// https://github.com/denoland/deno/issues/21620.
+async function main() {
+  while (true) {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+}
+
+console.log("hello!");
+main();

--- a/tests/unit/inspector_test.ts
+++ b/tests/unit/inspector_test.ts
@@ -748,6 +748,74 @@ Deno.test("inspector_profile", async () => {
   }
 });
 
+// Regression test for https://github.com/denoland/deno/issues/21620: an idle
+// process (one that only awaits timers) must report its wait time as the
+// "(idle)" node in a CPU profile, not as "(program)"/"Scripting" which made
+// DevTools show ~100% CPU usage for a process doing nothing. This relies on
+// the event loop telling V8's CPU profiler it is idle (Isolate::SetIdle)
+// whenever it parks waiting for external events.
+Deno.test("inspector_profile_idle", async () => {
+  const script = `${testdataPath}/idle.js`;
+  // Use --inspect (not --inspect-brk) so the program runs straight into its
+  // idle loop, matching how the issue is reproduced (`deno run --inspect`).
+  const tester = await InspectorTester.create(
+    ["run", "-A", "--inspect=0", script],
+    { notificationFilter: ignoreScriptParsed },
+  );
+
+  try {
+    tester.sendMany([
+      { id: 1, method: "Runtime.enable" },
+      { id: 2, method: "Profiler.enable" },
+      {
+        id: 3,
+        method: "Profiler.setSamplingInterval",
+        params: { interval: 100 },
+      },
+      { id: 4, method: "Profiler.start", params: {} },
+    ]);
+    await tester.expectResponse(1);
+    await tester.expectResponse(2);
+    await tester.expectResponse(3);
+    await tester.expectResponse(4);
+
+    // Let the (idle) process run for a while so plenty of idle samples land.
+    await new Promise((r) => setTimeout(r, 1000));
+
+    tester.send({ id: 5, method: "Profiler.stop", params: {} });
+    const profileResult = await tester.expectResponse(5);
+    const result = profileResult.result as Record<string, unknown>;
+    const profile = result.profile as {
+      nodes: Array<
+        { hitCount?: number; callFrame: { functionName: string } }
+      >;
+    };
+
+    const hitsFor = (name: string) =>
+      profile.nodes
+        .filter((n) => n.callFrame.functionName === name)
+        .reduce((sum, n) => sum + (n.hitCount ?? 0), 0);
+
+    const idleHits = hitsFor("(idle)");
+    const programHits = hitsFor("(program)");
+
+    // The wait time must be attributed to "(idle)", not "(program)". Without the
+    // SetIdle notification these samples all land in "(program)".
+    assert(
+      idleHits > 0,
+      `Expected idle samples in profile, got idle=${idleHits} program=${programHits}`,
+    );
+    assert(
+      idleHits > programHits,
+      `Expected idle samples to dominate, got idle=${idleHits} program=${programHits}`,
+    );
+  } finally {
+    await tester.close();
+    tester.kill();
+    await tester.waitForExit();
+  }
+});
+
 Deno.test("inspector_multiple_workers", async () => {
   const script = `${testdataPath}/multi_worker_main.js`;
   const tester = await InspectorTester.create(


### PR DESCRIPTION
Profiling a Deno process over the inspector reported time spent parked in
the event loop, waiting for timers or I/O, under the (program) node rather
than (idle). The result was that a process doing nothing appeared to use
~100% CPU in Chrome DevTools, making CPU profiles of mostly-idle programs
useless.

The event loop now calls Isolate::SetIdle to tell V8's CPU profiler when it
is about to park, so that wait is attributed to (idle). The call has to
happen after the per-poll v8::ContextScope is torn down, because dropping the
scope runs Isolate::Exit, which restores the VM state saved on entry and
would otherwise immediately clobber the idle state before the loop parks.
This matches how Node marks idle time. Note that the attribution only takes
effect for `deno run --inspect`; once the debugger has actually paused
(`--inspect-brk`) V8 keeps the isolate out of the idle state.

Closes #21620