### PR TITLE
chore: upgrade deno_graph to 0.108.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.108.2"
+version = "0.108.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf8dde12e88c720eceb649d7aa38abb202840b5e780ee8b1bb12250f0668266"
+checksum = "a1e2d6066179bfe8ccec9454db2cc0edaa2c402ab75fd8a959969e8b8f5600ba"
 dependencies = [
  "async-trait",
  "boxed_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.108.3"
+version = "0.108.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e2d6066179bfe8ccec9454db2cc0edaa2c402ab75fd8a959969e8b8f5600ba"
+checksum = "21d2b976d342f56afb862e2291e891a13391e07771baf6d266aee16bfd758285"
 dependencies = [
  "async-trait",
  "boxed_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ deno_ast = { version = "=0.53.2", features = ["transpiling"] }
 deno_core_icudata = "0.77.0"
 deno_doc = "=0.199.0"
 deno_error = "=0.7.1"
-deno_graph = { version = "=0.108.2", default-features = false }
+deno_graph = { version = "=0.108.3", default-features = false }
 deno_lint = "=0.84.1"
 deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ deno_ast = { version = "=0.53.2", features = ["transpiling"] }
 deno_core_icudata = "0.77.0"
 deno_doc = "=0.199.0"
 deno_error = "=0.7.1"
-deno_graph = { version = "=0.108.3", default-features = false }
+deno_graph = { version = "=0.108.4", default-features = false }
 deno_lint = "=0.84.1"
 deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"

--- a/cli/lsp/jsr.rs
+++ b/cli/lsp/jsr.rs
@@ -96,6 +96,7 @@ impl JsrCacheResolver {
           )]
           .into_iter()
           .collect(),
+          latest: Some(nv.version.clone()),
         })),
       );
       info_by_nv.insert(nv.clone(), Some(version_info));


### PR DESCRIPTION
Upgrades deno_graph from 0.108.2 to 0.108.4, which pulls in several fast
check and JSDoc analysis fixes that affect `deno publish`.

The fixes stop fast check from flagging a private value that shares a name
with an exported type, preserve a module's default export when it is reached
both through `export *` and a default import, deduplicate nested JSDoc
`import()` type references so an mjs file no longer fails to publish, and
strip decorators from private `declare` fields so they don't produce invalid
public API type output.

Closes #26673
Closes #28293
Closes #29767
Closes #33753