### PR TITLE
fix(ext/node): don't cache a pointer to the zlib result buffer

### DIFF
--- a/ext/node/ops/zlib/mod.rs
+++ b/ext/node/ops/zlib/mod.rs
@@ -50,7 +50,6 @@ struct ZlibInner {
   write_in_progress: bool,
   pending_close: bool,
   gzib_id_bytes_read: u32,
-  result_buffer: Option<*mut u32>,
   callback: Option<v8::Global<v8::Function>>,
   strm: StreamWrapper,
 }
@@ -380,7 +379,6 @@ impl Zlib {
     #[smi] level: i32,
     #[smi] mem_level: i32,
     #[smi] strategy: i32,
-    #[buffer] write_result: &mut [u32],
     #[scoped] callback: v8::Global<v8::Function>,
     #[buffer] dictionary: Option<&[u8]>,
   ) -> Result<i32, ZlibError> {
@@ -418,7 +416,6 @@ impl Zlib {
 
     zlib.dictionary = dictionary.map(|buf| buf.to_vec());
 
-    zlib.result_buffer = Some(write_result.as_mut_ptr());
     zlib.callback = Some(callback);
 
     Ok(zlib.err)
@@ -437,6 +434,7 @@ impl Zlib {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), ZlibError> {
     let err_info = {
       let mut zlib = self.inner.borrow_mut();
@@ -446,12 +444,10 @@ impl Zlib {
       zlib.start_write(input, in_off, in_len, out, out_off, out_len, flush)?;
       zlib.do_write(flush)?;
 
-      // SAFETY: `zlib.result_buffer` is a valid pointer to a mutable slice of u32 of length 2.
-      let result = unsafe {
-        std::slice::from_raw_parts_mut(zlib.result_buffer.unwrap(), 2)
-      };
-      result[0] = zlib.strm.avail_out;
-      result[1] = zlib.strm.avail_in;
+      if write_result.len() >= 2 {
+        write_result[0] = zlib.strm.avail_out;
+        write_result[1] = zlib.strm.avail_in;
+      }
       zlib.get_error_info()
     };
 
@@ -472,6 +468,7 @@ impl Zlib {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), ZlibError> {
     let err_info = {
       let mut zlib = self.inner.borrow_mut();
@@ -481,12 +478,10 @@ impl Zlib {
       zlib.start_write(input, in_off, in_len, out, out_off, out_len, flush)?;
       zlib.do_write(flush)?;
 
-      // SAFETY: `zlib.result_buffer` is a valid pointer to a mutable slice of u32 of length 2.
-      let result = unsafe {
-        std::slice::from_raw_parts_mut(zlib.result_buffer.unwrap(), 2)
-      };
-      result[0] = zlib.strm.avail_out;
-      result[1] = zlib.strm.avail_in;
+      if write_result.len() >= 2 {
+        write_result[0] = zlib.strm.avail_out;
+        write_result[1] = zlib.strm.avail_in;
+      }
       zlib.get_error_info()
     };
 
@@ -565,7 +560,6 @@ pub fn op_zlib_close_if_pending(
 
 struct BrotliEncoderCtx {
   inst: BrotliEncoderStateStruct<StandardAlloc>,
-  write_result: *mut u32,
   callback: v8::Global<v8::Function>,
 }
 
@@ -606,13 +600,8 @@ impl BrotliEncoder {
   fn init(
     &self,
     #[buffer] params: &[u32],
-    #[buffer] write_result: &mut [u32],
     #[scoped] callback: v8::Global<v8::Function>,
   ) -> bool {
-    if write_result.len() < 2 {
-      return false;
-    }
-
     let inst = {
       let mut state = BrotliEncoderStateStruct::new(StandardAlloc::default());
 
@@ -628,11 +617,10 @@ impl BrotliEncoder {
       state
     };
 
-    self.ctx.borrow_mut().replace(BrotliEncoderCtx {
-      inst,
-      write_result: write_result.as_mut_ptr(),
-      callback,
-    });
+    self
+      .ctx
+      .borrow_mut()
+      .replace(BrotliEncoderCtx { inst, callback });
     true
   }
 
@@ -657,6 +645,7 @@ impl BrotliEncoder {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
     let mut avail_in = in_len as usize;
     let mut avail_out = out_len as usize;
@@ -677,10 +666,10 @@ impl BrotliEncoder {
         &mut |_, _, _, _| (),
       );
 
-      // SAFETY: `write_result` is a valid pointer to a mutable slice of u32 of length 2.
-      let result = std::slice::from_raw_parts_mut(ctx.write_result, 2);
-      result[0] = avail_out as u32;
-      result[1] = avail_in as u32;
+      if write_result.len() >= 2 {
+        write_result[0] = avail_out as u32;
+        write_result[1] = avail_in as u32;
+      }
 
       v8::Local::new(scope, &ctx.callback)
     };
@@ -700,6 +689,7 @@ impl BrotliEncoder {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
     let mut ctx = self.ctx.borrow_mut();
     let ctx = ctx.as_mut().expect("BrotliEncoder not initialized");
@@ -719,12 +709,12 @@ impl BrotliEncoder {
         &mut None,
         &mut |_, _, _, _| (),
       );
-
-      // SAFETY: `ctx.write_result` is a valid pointer to a mutable slice of u32 of length 2.
-      let result = std::slice::from_raw_parts_mut(ctx.write_result, 2);
-      result[0] = avail_out as u32;
-      result[1] = avail_in as u32;
     };
+
+    if write_result.len() >= 2 {
+      write_result[0] = avail_out as u32;
+      write_result[1] = avail_in as u32;
+    }
 
     Ok(())
   }
@@ -740,7 +730,6 @@ impl BrotliEncoder {
 
 struct BrotliDecoderCtx {
   inst: *mut ffi::decompressor::ffi::BrotliDecoderState,
-  write_result: *mut u32,
   callback: v8::Global<v8::Function>,
 }
 
@@ -788,13 +777,8 @@ impl BrotliDecoder {
   fn init(
     &self,
     #[buffer] params: &[u32],
-    #[buffer] write_result: &mut [u32],
     #[scoped] callback: v8::Global<v8::Function>,
   ) -> bool {
-    if write_result.len() < 2 {
-      return false;
-    }
-
     // SAFETY: creates new brotli decoder instance. `params` is a valid slice of u32 values.
     let inst = unsafe {
       let state = ffi::decompressor::ffi::BrotliDecoderCreateInstance(
@@ -813,11 +797,10 @@ impl BrotliDecoder {
       state
     };
 
-    self.ctx.borrow_mut().replace(BrotliDecoderCtx {
-      inst,
-      write_result: write_result.as_mut_ptr(),
-      callback,
-    });
+    self
+      .ctx
+      .borrow_mut()
+      .replace(BrotliDecoderCtx { inst, callback });
     true
   }
 
@@ -842,6 +825,7 @@ impl BrotliDecoder {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
     let (error_info, callback) = {
       let ctx = self.ctx.borrow();
@@ -870,10 +854,10 @@ impl BrotliDecoder {
           std::ptr::null_mut(),
         );
 
-        // SAFETY: `write_result` is a valid pointer to a mutable slice of u32 of length 2.
-        let result = std::slice::from_raw_parts_mut(ctx.write_result, 2);
-        result[0] = avail_out as u32;
-        result[1] = avail_in as u32;
+        if write_result.len() >= 2 {
+          write_result[0] = avail_out as u32;
+          write_result[1] = avail_in as u32;
+        }
 
         if matches!(
           res,
@@ -930,6 +914,7 @@ impl BrotliDecoder {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
     let mut ctx = self.ctx.borrow_mut();
     let ctx = ctx.as_mut().expect("BrotliDecoder not initialized");
@@ -956,11 +941,11 @@ impl BrotliDecoder {
         &mut next_out,
         std::ptr::null_mut(),
       );
+    }
 
-      // SAFETY: `ctx.write_result` is a valid pointer to a mutable slice of u32 of length 2.
-      let result = std::slice::from_raw_parts_mut(ctx.write_result, 2);
-      result[0] = avail_out as u32;
-      result[1] = avail_in as u32;
+    if write_result.len() >= 2 {
+      write_result[0] = avail_out as u32;
+      write_result[1] = avail_in as u32;
     }
 
     Ok(())
@@ -985,7 +970,6 @@ use zstd::stream::raw::Operation; // Trait for run/flush/finish methods
 
 struct ZstdCompressCtx {
   encoder: ZstdRawEncoder<'static>,
-  write_result: *mut u32,
   callback: v8::Global<v8::Function>,
 }
 
@@ -1015,14 +999,9 @@ impl ZstdCompress {
   fn init(
     &self,
     #[buffer] params: &[u32],
-    #[buffer] write_result: &mut [u32],
     #[scoped] callback: v8::Global<v8::Function>,
     pledged_src_size: f64,
   ) -> bool {
-    if write_result.len() < 2 {
-      return false;
-    }
-
     // Default compression level is 3
     let Ok(mut encoder) = ZstdRawEncoder::new(3) else {
       return false;
@@ -1088,11 +1067,10 @@ impl ZstdCompress {
       }
     }
 
-    self.ctx.borrow_mut().replace(ZstdCompressCtx {
-      encoder,
-      write_result: write_result.as_mut_ptr(),
-      callback,
-    });
+    self
+      .ctx
+      .borrow_mut()
+      .replace(ZstdCompressCtx { encoder, callback });
     true
   }
 
@@ -1122,6 +1100,7 @@ impl ZstdCompress {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
     use zstd::stream::raw::InBuffer;
     use zstd::stream::raw::OutBuffer;
@@ -1186,11 +1165,9 @@ impl ZstdCompress {
       let avail_in = in_len as usize - in_buffer.pos();
       let avail_out = out_len as usize - out_buffer.pos();
 
-      // SAFETY: `write_result` is a valid pointer to a mutable slice of u32 of length 2.
-      unsafe {
-        let result = std::slice::from_raw_parts_mut(ctx.write_result, 2);
-        result[0] = avail_out as u32;
-        result[1] = avail_in as u32;
+      if write_result.len() >= 2 {
+        write_result[0] = avail_out as u32;
+        write_result[1] = avail_in as u32;
       }
 
       v8::Local::new(scope, &ctx.callback)
@@ -1212,6 +1189,7 @@ impl ZstdCompress {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
     use zstd::stream::raw::InBuffer;
     use zstd::stream::raw::OutBuffer;
@@ -1275,11 +1253,9 @@ impl ZstdCompress {
     let avail_in = in_len as usize - in_buffer.pos();
     let avail_out = out_len as usize - out_buffer.pos();
 
-    // SAFETY: `write_result` is a valid pointer to a mutable slice of u32 of length 2.
-    unsafe {
-      let result = std::slice::from_raw_parts_mut(ctx.write_result, 2);
-      result[0] = avail_out as u32;
-      result[1] = avail_in as u32;
+    if write_result.len() >= 2 {
+      write_result[0] = avail_out as u32;
+      write_result[1] = avail_in as u32;
     }
 
     Ok(())
@@ -1294,7 +1270,6 @@ impl ZstdCompress {
 
 struct ZstdDecompressCtx {
   decoder: ZstdRawDecoder<'static>,
-  write_result: *mut u32,
   callback: v8::Global<v8::Function>,
 }
 
@@ -1324,14 +1299,9 @@ impl ZstdDecompress {
   fn init(
     &self,
     #[buffer] params: &[u32],
-    #[buffer] write_result: &mut [u32],
     #[scoped] callback: v8::Global<v8::Function>,
     _pledged_src_size: f64, // Unused for decompression, but needed for API consistency
   ) -> bool {
-    if write_result.len() < 2 {
-      return false;
-    }
-
     use zstd::zstd_safe::DParameter;
 
     let Ok(mut decoder) = ZstdRawDecoder::new() else {
@@ -1353,11 +1323,10 @@ impl ZstdDecompress {
       }
     }
 
-    self.ctx.borrow_mut().replace(ZstdDecompressCtx {
-      decoder,
-      write_result: write_result.as_mut_ptr(),
-      callback,
-    });
+    self
+      .ctx
+      .borrow_mut()
+      .replace(ZstdDecompressCtx { decoder, callback });
     true
   }
 
@@ -1387,6 +1356,7 @@ impl ZstdDecompress {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
     use zstd::stream::raw::InBuffer;
     use zstd::stream::raw::OutBuffer;
@@ -1415,11 +1385,9 @@ impl ZstdDecompress {
       let avail_in = in_len as usize - in_buffer.pos();
       let avail_out = out_len as usize - out_buffer.pos();
 
-      // SAFETY: `write_result` is a valid pointer to a mutable slice of u32 of length 2.
-      unsafe {
-        let result = std::slice::from_raw_parts_mut(ctx.write_result, 2);
-        result[0] = avail_out as u32;
-        result[1] = avail_in as u32;
+      if write_result.len() >= 2 {
+        write_result[0] = avail_out as u32;
+        write_result[1] = avail_in as u32;
       }
 
       v8::Local::new(scope, &ctx.callback)
@@ -1441,6 +1409,7 @@ impl ZstdDecompress {
     #[buffer] out: &mut [u8],
     #[smi] out_off: u32,
     #[smi] out_len: u32,
+    #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
     use zstd::stream::raw::InBuffer;
     use zstd::stream::raw::OutBuffer;
@@ -1468,11 +1437,9 @@ impl ZstdDecompress {
     let avail_in = in_len as usize - in_buffer.pos();
     let avail_out = out_len as usize - out_buffer.pos();
 
-    // SAFETY: `write_result` is a valid pointer to a mutable slice of u32 of length 2.
-    unsafe {
-      let result = std::slice::from_raw_parts_mut(ctx.write_result, 2);
-      result[0] = avail_out as u32;
-      result[1] = avail_in as u32;
+    if write_result.len() >= 2 {
+      write_result[0] = avail_out as u32;
+      write_result[1] = avail_in as u32;
     }
 
     Ok(())

--- a/ext/node/polyfills/zlib.js
+++ b/ext/node/polyfills/zlib.js
@@ -500,8 +500,9 @@ function processChunkSync(self, chunk, flushFlag) {
       availInBefore, // in_len
       buffer, // out
       offset, // out_off
-      availOutBefore,
-    ); // out_len
+      availOutBefore, // out_len
+      state,
+    );
     if (error) {
       throw error;
     } else if (self[kError]) {
@@ -584,8 +585,9 @@ function processChunk(self, chunk, flushFlag, cb) {
       handle.availInBefore, // in_len
       self._outBuffer, // out
       self._outOffset, // out_off
-      handle.availOutBefore,
-    ); // out_len
+      handle.availOutBefore, // out_len
+      self._writeState,
+    );
   } catch (err) {
     // Set appropriate error code for zstd errors
     if (err.message && err.message.includes("Src size is incorrect")) {
@@ -841,7 +843,6 @@ function Zlib(opts, mode) {
     level,
     memLevel,
     strategy,
-    this._writeState,
     processCallback,
     dictionary,
   );
@@ -1010,7 +1011,6 @@ function Brotli(opts, mode) {
   this._writeState = new Uint32Array(2);
   const success = handle.init(
     brotliInitParamsArray,
-    this._writeState,
     processCallback,
   );
   if (!success) {
@@ -1084,7 +1084,6 @@ class Zstd extends ZlibBase {
         : -1;
     const success = handle.init(
       initParamsArray,
-      writeState,
       processCallback,
       pledgedSrcSize,
     );

--- a/ext/node/polyfills/zlib.js
+++ b/ext/node/polyfills/zlib.js
@@ -681,8 +681,9 @@ function processCallback() {
           handle.availInBefore, // in_len
           self._outBuffer, // out
           self._outOffset, // out_off
-          self._chunkSize,
-        ); // out_len
+          self._chunkSize, // out_len
+          self._writeState,
+        );
         if (handle._callbackPending) {
           processCallback.call(this);
         }
@@ -705,8 +706,9 @@ function processCallback() {
             handle.availInBefore, // in_len
             self._outBuffer, // out
             self._outOffset, // out_off
-            self._chunkSize,
-          ); // out_len
+            self._chunkSize, // out_len
+            self._writeState,
+          );
           if (handle._callbackPending && !self[kError]) {
             processCallback.call(this);
           }

--- a/tests/unit_node/zlib_test.ts
+++ b/tests/unit_node/zlib_test.ts
@@ -15,11 +15,16 @@ import {
   createBrotliCompress,
   createBrotliDecompress,
   createDeflate,
+  createGunzip,
+  createGzip,
+  createZstdCompress,
+  createZstdDecompress,
   deflateSync,
   gunzip,
   gzip,
   gzipSync,
   unzipSync,
+  zstdCompressSync,
 } from "node:zlib";
 import { Buffer } from "node:buffer";
 import { createReadStream, createWriteStream } from "node:fs";
@@ -324,35 +329,93 @@ Deno.test("gunzip doesn't cause stack overflow with 64MiB data", async () => {
   await promise;
 });
 
+// Every compression/decompression backend whose native handle writes the
+// post-write avail_out/avail_in pair back into `_writeState`. Decoders are
+// paired with valid compressed input so the write reaches the result buffer
+// instead of bailing out on a decode error.
+const raw = new Uint8Array(16).fill(0x61);
+const writeStateCases: [() => unknown, Uint8Array][] = [
+  [createDeflate, raw],
+  [createGzip, raw],
+  [createGunzip, gzipSync(raw)],
+  [createBrotliCompress, raw],
+  [createBrotliDecompress, brotliCompressSync(raw)],
+  [createZstdCompress, raw],
+  [createZstdDecompress, zstdCompressSync(raw)],
+];
+
 // The native zlib/brotli/zstd bindings must not retain a pointer into the JS
 // `_writeState` buffer across calls. The result buffer is passed per write and
 // bounds checked, so detaching it (e.g. via a structuredClone transfer) before
 // a write is harmless rather than writing into a freed backing store.
 Deno.test("zlib writeSync does not write through a detached _writeState", () => {
-  // deno-lint-ignore no-explicit-any
-  const make = (factory: () => any) => {
-    const stream = factory();
+  const output = new Uint8Array(128);
+
+  // Each of these would crash or corrupt the heap before the fix. With the
+  // buffer detached the result write must be a no-op; the only thing asserted
+  // is that the process survives and nothing lands in the freed backing store.
+  for (const [factory, input] of writeStateCases) {
+    // deno-lint-ignore no-explicit-any
+    const stream = factory() as any;
     const handle = stream._handle;
     const state = stream._writeState;
     // Detach the underlying ArrayBuffer, freeing the backing store.
     structuredClone(state.buffer, { transfer: [state.buffer] });
-    return { handle, state };
-  };
+    assertEquals(state.buffer.byteLength, 0);
+    handle.writeSync(
+      0,
+      input,
+      0,
+      input.length,
+      output,
+      0,
+      output.length,
+      state,
+    );
+    assertEquals(state.buffer.byteLength, 0);
+  }
+});
 
-  const input = new Uint8Array(10);
-  const output = new Uint8Array(64);
+// Guards the other direction: with a live buffer the per-write result must
+// actually be written. A regression that dropped or misrouted the argument
+// would silently leave `_writeState` untouched and pass the detach test above.
+Deno.test("zlib writeSync populates _writeState per call", () => {
+  const SENTINEL = 0xffffffff;
+  const input = new Uint8Array(32).fill(0x61);
+  const output = new Uint8Array(128);
 
-  // Each of these would crash or corrupt the heap before the fix. The
-  // assertion is simply that the process survives the write.
+  // Decoders need valid input to reach the result write, so only the encoders
+  // are exercised here; the shared native path covers the decoders.
   for (
     const factory of [
-      createBrotliCompress,
-      createBrotliDecompress,
       createDeflate,
+      createGzip,
+      createBrotliCompress,
+      createZstdCompress,
     ]
   ) {
-    const { handle, state } = make(factory);
-    handle.writeSync(0, input, 0, 10, output, 0, 64, state);
-    assertEquals(state.buffer.byteLength, 0);
+    // deno-lint-ignore no-explicit-any
+    const stream = factory() as any;
+    const handle = stream._handle;
+    const state = stream._writeState;
+    state[0] = SENTINEL;
+    state[1] = SENTINEL;
+    // flush 0 means "process / no flush" across zlib, brotli and zstd.
+    handle.writeSync(
+      0,
+      input,
+      0,
+      input.length,
+      output,
+      0,
+      output.length,
+      state,
+    );
+    // avail_out and avail_in were written, replacing the sentinel, and stay
+    // within the bounds of the output and input buffers.
+    assert(state[0] !== SENTINEL, "avail_out was not written");
+    assert(state[1] !== SENTINEL, "avail_in was not written");
+    assert(state[0] <= output.length, "avail_out out of range");
+    assert(state[1] <= input.length, "avail_in out of range");
   }
 });

--- a/tests/unit_node/zlib_test.ts
+++ b/tests/unit_node/zlib_test.ts
@@ -419,3 +419,44 @@ Deno.test("zlib writeSync populates _writeState per call", () => {
     assert(state[1] <= input.length, "avail_in out of range");
   }
 });
+
+// Same regression as the writeSync detach test above, but for the async
+// `handle.write` op. That op is a separately duplicated native function which
+// also writes the result pair back into `_writeState`, so it carries its own
+// copy of the bounds check and needs its own coverage. The op is invoked
+// directly (rather than through the stream) so the detach is observed against
+// the freed backing store before any other state mutates. brotli/zstd run
+// `processCallback` synchronously from the op, which then reads the now-detached
+// state and throws downstream; that throw is unrelated to the native result
+// write under test and is swallowed. Surviving the call with the buffer still
+// detached is the assertion.
+Deno.test("zlib write does not write through a detached _writeState", () => {
+  const output = new Uint8Array(128);
+
+  for (const [factory, input] of writeStateCases) {
+    // deno-lint-ignore no-explicit-any
+    const stream = factory() as any;
+    const handle = stream._handle;
+    const state = stream._writeState;
+    // Detach the underlying ArrayBuffer, freeing the backing store.
+    structuredClone(state.buffer, { transfer: [state.buffer] });
+    assertEquals(state.buffer.byteLength, 0);
+    try {
+      handle.write(
+        0,
+        input,
+        0,
+        input.length,
+        output,
+        0,
+        output.length,
+        state,
+      );
+    } catch {
+      // Expected for the engines whose op runs processCallback synchronously:
+      // it reads the detached state and throws. The native result write (the
+      // thing under test) already happened as a no-op before the callback.
+    }
+    assertEquals(state.buffer.byteLength, 0);
+  }
+});

--- a/tests/unit_node/zlib_test.ts
+++ b/tests/unit_node/zlib_test.ts
@@ -323,3 +323,36 @@ Deno.test("gunzip doesn't cause stack overflow with 64MiB data", async () => {
 
   await promise;
 });
+
+// The native zlib/brotli/zstd bindings must not retain a pointer into the JS
+// `_writeState` buffer across calls. The result buffer is passed per write and
+// bounds checked, so detaching it (e.g. via a structuredClone transfer) before
+// a write is harmless rather than writing into a freed backing store.
+Deno.test("zlib writeSync does not write through a detached _writeState", () => {
+  // deno-lint-ignore no-explicit-any
+  const make = (factory: () => any) => {
+    const stream = factory();
+    const handle = stream._handle;
+    const state = stream._writeState;
+    // Detach the underlying ArrayBuffer, freeing the backing store.
+    structuredClone(state.buffer, { transfer: [state.buffer] });
+    return { handle, state };
+  };
+
+  const input = new Uint8Array(10);
+  const output = new Uint8Array(64);
+
+  // Each of these would crash or corrupt the heap before the fix. The
+  // assertion is simply that the process survives the write.
+  for (
+    const factory of [
+      createBrotliCompress,
+      createBrotliDecompress,
+      createDeflate,
+    ]
+  ) {
+    const { handle, state } = make(factory);
+    handle.writeSync(0, input, 0, 10, output, 0, 64, state);
+    assertEquals(state.buffer.byteLength, 0);
+  }
+});


### PR DESCRIPTION
The native zlib, brotli and zstd bindings stored a raw pointer to the
JavaScript _writeState buffer when the stream was initialized and wrote
the post-write avail_out/avail_in values through it on every call. That
pointer outlived the op call, so detaching the buffer's ArrayBuffer (for
example with a structuredClone transfer) before a subsequent write left
it dangling and the write landed in freed memory.

Unlike Node, where an async write finishes on a libuv threadpool thread
after the call returns, Deno performs the compression synchronously
inside the op, so the result buffer never needs to outlive a single
call. Pass it as a per-write argument and bounds check it, which keeps
the existing zero-copy behavior while making a detached buffer a
harmless no-op.