### PR TITLE
fix(ext/web): repair text_decoder_stream bench after BlobStoreTrait change

### DIFF
--- a/ext/web/benches/text_decoder_stream.rs
+++ b/ext/web/benches/text_decoder_stream.rs
@@ -1,10 +1,13 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+use std::sync::Arc;
+
 use deno_bench_util::bench_js_sync;
 use deno_bench_util::bench_or_profile;
 use deno_bench_util::bencher::Bencher;
 use deno_bench_util::bencher::benchmark_group;
 use deno_core::Extension;
+use deno_web::BlobStore;
 
 fn setup() -> Vec<Extension> {
   // 08_text_encoding.js exposes `TextDecoder` via `core.loadExtScript`, so the
@@ -43,7 +46,7 @@ fn setup() -> Vec<Extension> {
   vec![
     deno_webidl::deno_webidl::init(),
     deno_web::deno_web::init(
-      Default::default(),
+      Arc::new(BlobStore::default()),
       None,
       Default::default(),
       Default::default(),


### PR DESCRIPTION
#34000 changed deno_web::init to accept an Arc<dyn BlobStoreTrait> for
its blob store argument. The text_decoder_stream benchmark still passed
Default::default() there, which no longer satisfies the trait bound, so
the bench failed to compile and broke the lint job on every PR.

Construct the blob store explicitly with Arc::new(BlobStore::default()),
matching how the runtime sets it up elsewhere.