### PR TITLE
fix(ext/node): guard TCPWrap.open against adopting tracked fds

### DIFF
--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -249,7 +249,6 @@ impl LibUvStreamWrap {
     self.stream as *mut uv_stream_t
   }
 
-  #[allow(dead_code, reason = "used by upcoming TCPWrap/TLSWrap")]
   pub(crate) fn set_fd(&self, fd: i32) {
     self.fd.set(fd);
   }
@@ -258,7 +257,6 @@ impl LibUvStreamWrap {
     self.fd.get()
   }
 
-  #[allow(dead_code, reason = "used by upcoming TCPWrap/TLSWrap")]
   pub(crate) fn handle_wrap(&self) -> &HandleWrap {
     &self.base
   }

--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -254,7 +254,6 @@ impl LibUvStreamWrap {
     self.fd.set(fd);
   }
 
-  #[cfg(windows)]
   pub(crate) fn get_fd(&self) -> i32 {
     self.fd.get()
   }

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -417,6 +417,12 @@ impl TCPWrap {
         .borrow_mut()
         .borrow_mut::<deno_io::FdTable>()
         .remove(fd);
+      // Clear the cached fd so the removal is one-shot. `close_handle()`
+      // guards against double frees of the libuv handle, but a second
+      // `close()` would still re-run this TCP-specific removal and could
+      // drop an unrelated FdTable entry if the OS has since reused the fd
+      // number.
+      self.base.set_fd(-1);
     }
     self.base.clear_js_handle();
     self

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -8,11 +8,13 @@
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::net::ToSocketAddrs;
+use std::rc::Rc;
 
 use deno_core::CppgcInherits;
 use deno_core::GarbageCollected;
 use deno_core::OpState;
 use deno_core::ResourceId;
+use deno_core::error::ResourceError;
 use deno_core::op2;
 use deno_core::uv_compat;
 use deno_core::uv_compat::UvConnect;
@@ -343,9 +345,18 @@ impl TCPWrap {
   }
 
   #[fast]
-  fn open(&self, #[smi] fd: i32) -> i32 {
+  fn open(&self, state: &mut OpState, #[smi] fd: i32) -> i32 {
     if fd < 0 {
       return uv_compat::UV_EBADF;
+    }
+    // Refuse to adopt a descriptor Deno already tracks. Stdio (0-2) is
+    // pre-registered and may be re-opened; any other fd already in the
+    // FdTable is rejected, matching `PipeWrap::open`.
+    {
+      let fd_table = state.borrow::<deno_io::FdTable>();
+      if fd_table.contains(fd) && !(0..=2).contains(&fd) {
+        return -libc::EEXIST;
+      }
     }
     let tcp = self.tcp_ptr();
     if tcp.is_null() {
@@ -353,12 +364,22 @@ impl TCPWrap {
     }
     // SAFETY: tcp handle is valid (null-checked above); fd is validated above.
     // Platform-specific non-blocking setup and uv_tcp_open are safe with valid args.
-    unsafe {
+    let ret = unsafe {
       #[cfg(unix)]
       {
         let flags = libc::fcntl(fd, libc::F_GETFL);
         if flags != -1 {
           libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+        }
+        // Match Node: a wrap constructed with `new TCP(SERVER)` opens the
+        // fd as a listener; `new TCP(SOCKET)` as a connected stream. Node's
+        // libuv layer doesn't autodetect — it uses the wrap's intent to
+        // decide how to register the fd, then `listen()` on a listening fd
+        // is a no-op at the kernel level.
+        if self.socket_type.get() == SocketType::Server {
+          uv_compat::uv_tcp_open_listener(tcp, fd)
+        } else {
+          uv_compat::uv_tcp_open(tcp, fd)
         }
       }
       #[cfg(windows)]
@@ -367,18 +388,41 @@ impl TCPWrap {
         use windows_sys::Win32::Networking::WinSock::ioctlsocket;
         let mut nonblocking: u32 = 1;
         ioctlsocket(fd as usize, FIONBIO, &mut nonblocking);
+        uv_compat::uv_tcp_open(tcp, fd)
       }
-      // Match Node: a wrap constructed with `new TCP(SERVER)` opens the
-      // fd as a listener; `new TCP(SOCKET)` as a connected stream. Node's
-      // libuv layer doesn't autodetect — it uses the wrap's intent to
-      // decide how to register the fd, then `listen()` on a listening fd
-      // is a no-op at the kernel level.
-      #[cfg(unix)]
-      if self.socket_type.get() == SocketType::Server {
-        return uv_compat::uv_tcp_open_listener(tcp, fd);
-      }
-      uv_compat::uv_tcp_open(tcp, fd)
+    };
+    // Track the adopted fd so it can't be re-adopted by another wrap and is
+    // dropped from the FdTable on close.
+    if ret == 0 {
+      state.borrow_mut::<deno_io::FdTable>().register_uv_owned(fd);
+      self.base.set_fd(fd);
     }
+    ret
+  }
+
+  /// Override the base close to drop the `FdTable` entry registered by
+  /// `open()` before `uv_close` frees the fd. A no-op for sockets that were
+  /// never adopted via `open()` — their fd stays -1.
+  #[reentrant]
+  fn close(
+    &self,
+    op_state: Rc<RefCell<OpState>>,
+    #[this] this: v8::Global<v8::Object>,
+    scope: &mut v8::PinScope<'_, '_>,
+    #[scoped] cb: Option<v8::Global<v8::Function>>,
+  ) -> Result<(), ResourceError> {
+    let fd = self.base.get_fd();
+    if fd >= 0 {
+      op_state
+        .borrow_mut()
+        .borrow_mut::<deno_io::FdTable>()
+        .remove(fd);
+    }
+    self.base.clear_js_handle();
+    self
+      .base
+      .handle_wrap()
+      .close_handle(op_state, this, scope, cb)
   }
 
   #[fast]

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -373,7 +373,7 @@ impl TCPWrap {
         }
         // Match Node: a wrap constructed with `new TCP(SERVER)` opens the
         // fd as a listener; `new TCP(SOCKET)` as a connected stream. Node's
-        // libuv layer doesn't autodetect — it uses the wrap's intent to
+        // libuv layer doesn't autodetect; it uses the wrap's intent to
         // decide how to register the fd, then `listen()` on a listening fd
         // is a no-op at the kernel level.
         if self.socket_type.get() == SocketType::Server {
@@ -402,7 +402,7 @@ impl TCPWrap {
 
   /// Override the base close to drop the `FdTable` entry registered by
   /// `open()` before `uv_close` frees the fd. A no-op for sockets that were
-  /// never adopted via `open()` — their fd stays -1.
+  /// never adopted via `open()`; their fd stays -1.
   #[reentrant]
   fn close(
     &self,

--- a/tests/specs/node/net_socket_fd/__test__.jsonc
+++ b/tests/specs/node/net_socket_fd/__test__.jsonc
@@ -17,6 +17,10 @@
     "tcp_open": {
       "args": "run -A --unstable-ffi tcp_open.ts",
       "output": "tcp_open.out"
+    },
+    "duplicate_fd": {
+      "args": "run -A duplicate_fd.ts",
+      "output": "duplicate_fd.out"
     }
   }
 }

--- a/tests/specs/node/net_socket_fd/__test__.jsonc
+++ b/tests/specs/node/net_socket_fd/__test__.jsonc
@@ -21,6 +21,11 @@
     "duplicate_fd": {
       "args": "run -A duplicate_fd.ts",
       "output": "duplicate_fd.out"
+    },
+    "double_close_fd_reuse": {
+      "if": "unix",
+      "args": "run -A --unstable-ffi double_close_fd_reuse.ts",
+      "output": "double_close_fd_reuse.out"
     }
   }
 }

--- a/tests/specs/node/net_socket_fd/double_close_fd_reuse.out
+++ b/tests/specs/node/net_socket_fd/double_close_fd_reuse.out
@@ -1,0 +1,1 @@
+[WILDCARD]PASS: reused fd still valid after double close

--- a/tests/specs/node/net_socket_fd/double_close_fd_reuse.out
+++ b/tests/specs/node/net_socket_fd/double_close_fd_reuse.out
@@ -1,1 +1,1 @@
-[WILDCARD]PASS: reused fd still valid after double close
+[WILDCARD]PASS: reused fd still valid after double close[WILDCARD]

--- a/tests/specs/node/net_socket_fd/double_close_fd_reuse.ts
+++ b/tests/specs/node/net_socket_fd/double_close_fd_reuse.ts
@@ -1,0 +1,91 @@
+// Regression test: closing a TCP handle that adopted a fd via TCP.open()
+// must remove that fd from the FdTable exactly once. A second close() must
+// not re-run the removal, because the OS may have reused the old fd number
+// for an unrelated file in the meantime; dropping that entry would close
+// the unrelated fd out from under its owner (EBADF).
+//
+// Repro:
+//   1. Open a raw TCP socket fd and adopt it with TCP.open(fd).
+//   2. Close the handle (frees the OS fd).
+//   3. Open files until the OS reuses the same fd number for a real file.
+//   4. Close the handle a second time.
+//   5. The reused file fd must still be valid (no EBADF).
+import { createRequire } from "node:module";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const require = createRequire(import.meta.url);
+const { TCP, constants: TCPConstants } = require("internal/test/binding")
+  .internalBinding("tcp_wrap");
+
+const libName = Deno.build.os === "darwin" ? "libSystem.B.dylib" : "libc.so.6";
+const lib = Deno.dlopen(libName, {
+  socket: { parameters: ["i32", "i32", "i32"], result: "i32" },
+  close: { parameters: ["i32"], result: "i32" },
+});
+
+const AF_INET = 2;
+const SOCK_STREAM = 1;
+
+// Create a raw TCP socket fd and adopt it into a TCP handle.
+const sockFd = lib.symbols.socket(AF_INET, SOCK_STREAM, 0) as number;
+if (sockFd < 0) {
+  console.log("FAIL: socket() failed");
+  Deno.exit(1);
+}
+
+const tcp = new TCP(TCPConstants.SOCKET);
+if (tcp.open(sockFd) !== 0) {
+  console.log("FAIL: TCP.open(fd) returned error");
+  lib.symbols.close(sockFd);
+  Deno.exit(1);
+}
+
+// First close: drops the UvOwned entry and frees the OS fd. Wait for the
+// uv_close callback so the descriptor is actually released before we try
+// to make the OS reuse its number.
+await new Promise<void>((resolve) => tcp.close(() => resolve()));
+
+// Force the OS to reuse the freed fd number for a real (TableOwned) file.
+const tmpFile = path.join(os.tmpdir(), `deno-tcp-doubleclose-${process.pid}`);
+fs.writeFileSync(tmpFile, "test data");
+const openedFds: number[] = [];
+let reusedFd = -1;
+for (let i = 0; i < 4096; i++) {
+  const fd = fs.openSync(tmpFile, "r");
+  openedFds.push(fd);
+  if (fd === sockFd) {
+    reusedFd = fd;
+    break;
+  }
+}
+
+if (reusedFd === -1) {
+  console.log("SKIP: could not force fd reuse");
+} else {
+  // Second close: with the bug, this synchronously re-removes sockFd from the
+  // FdTable and drops the unrelated file's File, closing reusedFd at the OS
+  // level. (The libuv side is already closed, so no callback fires here.)
+  tcp.close();
+
+  // The reused file fd must still be valid.
+  try {
+    fs.fstatSync(reusedFd);
+    console.log("PASS: reused fd still valid after double close");
+  } catch (e) {
+    console.log(
+      `FAIL: reused fd invalidated by double close: ${(e as Error).message}`,
+    );
+  }
+}
+
+for (const fd of openedFds) {
+  try {
+    fs.closeSync(fd);
+  } catch {
+    // The bug already closed reusedFd; ignore.
+  }
+}
+fs.unlinkSync(tmpFile);
+lib.close();

--- a/tests/specs/node/net_socket_fd/duplicate_fd.out
+++ b/tests/specs/node/net_socket_fd/duplicate_fd.out
@@ -1,0 +1,4 @@
+fs.openSync returned fd: [WILDCARD]
+TCP.open([WILDCARD]) returned: [WILDCARD]
+PASS: TCP.open() correctly rejected already-registered fd
+(node:[WILDCARD]) internal/test/binding: These APIs are for internal testing only. Do not use them.

--- a/tests/specs/node/net_socket_fd/duplicate_fd.ts
+++ b/tests/specs/node/net_socket_fd/duplicate_fd.ts
@@ -1,0 +1,33 @@
+// Regression test: opening a file with fs.openSync() and then trying to
+// TCP.open() the same fd should be rejected by the FdTable guard, matching
+// Pipe.open(). Without the guard, TCPWrap.open() would blindly adopt any
+// descriptor already tracked by Deno.
+import { createRequire } from "node:module";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const require = createRequire(import.meta.url);
+const { TCP, constants: TCPConstants } = require("internal/test/binding")
+  .internalBinding("tcp_wrap");
+
+// Create a temp file and open it via fs.openSync (registers in the FdTable)
+const tmpFile = path.join(os.tmpdir(), `deno-tcp-dup-test-${process.pid}`);
+fs.writeFileSync(tmpFile, "test data");
+const fd = fs.openSync(tmpFile, "r");
+console.log(`fs.openSync returned fd: ${fd}`);
+
+// TCP.open() on the same fd should fail because it is already registered
+const tcp = new TCP(TCPConstants.SOCKET);
+const result = tcp.open(fd);
+console.log(`TCP.open(${fd}) returned: ${result}`);
+
+if (result !== 0) {
+  console.log("PASS: TCP.open() correctly rejected already-registered fd");
+} else {
+  console.log("FAIL: TCP.open() should reject already-registered fd");
+}
+
+// Clean up
+fs.closeSync(fd);
+fs.unlinkSync(tmpFile);


### PR DESCRIPTION
`TCPWrap::open(fd)` adopted any integer file descriptor and handed it
straight to `uv_tcp_open` without consulting the `FdTable`. `PipeWrap::open`
already guards against this: it rejects a non-stdio descriptor that Deno
is already tracking (returning `EEXIST`), registers the adopted fd, and
drops it from the table on close. The TCP path was missing that
symmetry.

This wires the same behavior into `TCPWrap`. Before adopting, `open()`
now checks the `FdTable` and refuses a descriptor already owned by another
wrap or registered as a Deno resource, so a tracked fd can't be
re-adopted out from under its owner. On success the fd is registered as
`UvOwned`, and a `close()` override removes it again before `uv_close`
frees it. To make the close path work on Unix, `LibUvStreamWrap::get_fd`
is no longer Windows-only (the supporting `set_fd`/`handle_wrap` helpers
were already added for this purpose).

Stdio (0-2) stays re-openable, and genuinely external or inherited
descriptors are still adoptable, so legitimate Node patterns (descriptor
passing, listening-socket inheritance) are unaffected. This is a
defense-in-depth consistency fix, not a change to which descriptors a
script can reach.

A regression test in `tests/specs/node/net_socket_fd` opens a file with
`fs.openSync` (which registers the fd) and confirms `TCP.open` on that
same fd is now rejected, mirroring the existing pipe `duplicate_fd` test.
The existing `tcp_open`, `fd_not_stolen`, and net compatibility tests
continue to pass.