### PR TITLE
fix(http): handle raw h1 serve regressions

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -542,6 +542,41 @@ impl RawRequestHeaders {
     Some(&self.bytes[header.value_start..header.value_start + header.value_len])
   }
 
+  /// Removes all headers with the given (lowercase) name, returning the
+  /// value of the first removed header.
+  fn remove(&mut self, name: &[u8]) -> Option<Vec<u8>> {
+    let mut value = None;
+    let mut i = 0;
+    while i < self.entries.len() {
+      let header = &self.entries[i];
+      let header_name =
+        &self.bytes[header.name_start..header.name_start + header.name_len];
+      if header_name.eq_ignore_ascii_case(name) {
+        if value.is_none() {
+          value = Some(
+            self.bytes
+              [header.value_start..header.value_start + header.value_len]
+              .to_vec(),
+          );
+        }
+        self.entries.remove(i);
+        if let Some(index) = self.host_index
+          && index > i
+        {
+          self.host_index = Some(index - 1);
+        }
+        if let Some(index) = self.authorization_index
+          && index > i
+        {
+          self.authorization_index = Some(index - 1);
+        }
+      } else {
+        i += 1;
+      }
+    }
+    value
+  }
+
   fn get_joined(&self, name: &[u8], separator: &[u8]) -> Option<Vec<u8>> {
     let mut out = None::<Vec<u8>>;
     for header in self.iter() {
@@ -975,6 +1010,7 @@ enum RawRequestBody {
 
 struct RawHttpRecordInner {
   request_info: HttpConnectionProperties,
+  client_addr: Option<Vec<u8>>,
   method: RawMethod,
   path: String,
   headers: RawRequestHeaders,
@@ -1003,11 +1039,16 @@ impl RawHttpRecord {
     request_info: HttpConnectionProperties,
     method: RawMethod,
     path: String,
-    headers: RawRequestHeaders,
+    mut headers: RawRequestHeaders,
     request_body: Option<RawRequestBody>,
     upgrade: Option<Rc<RawUpgrade>>,
     request_size: u64,
   ) -> Rc<Self> {
+    let client_addr = if crate::service::trust_proxy_headers() {
+      headers.remove(b"x-deno-client-address")
+    } else {
+      None
+    };
     let otel_info = deno_telemetry::OTEL_GLOBALS
       .get()
       .filter(|o| o.has_metrics())
@@ -1022,6 +1063,7 @@ impl RawHttpRecord {
       });
     Rc::new(Self(RefCell::new(RawHttpRecordInner {
       request_info,
+      client_addr,
       method,
       path,
       headers,
@@ -1099,7 +1141,12 @@ impl RawHttpRecord {
         if inner.request_cancelled {
           return Poll::Ready(true);
         }
-        if inner.response_ready {
+        // Resolve only once the response body has been fully written, not
+        // when the response is merely dispatched: in legacy-abort mode the
+        // JS side aborts `Request.signal` as soon as this future resolves,
+        // which would tear down anything tied to the signal (e.g. a proxied
+        // `fetch` whose body is still streaming as the response).
+        if inner.response_body_finished {
           return Poll::Ready(false);
         }
         inner.request_cancel_waker = Some(cx.waker().clone());
@@ -1272,6 +1319,9 @@ impl RawHttpRecord {
     if let Some(waker) = inner.response_body_waker.take() {
       waker.wake();
     }
+    if let Some(waker) = inner.request_cancel_waker.take() {
+      waker.wake();
+    }
   }
 
   fn add_otel_response_size(&self, size: usize) {
@@ -1340,7 +1390,12 @@ impl RawHttpRecordCancelGuard {
   }
 
   fn disarm(&mut self) {
-    self.0 = None;
+    if let Some(record) = self.0.take() {
+      // The response (including its body, if any) has been written. Mark the
+      // body finished so `request_cancelled()` resolves; flat-response paths
+      // don't go through `RawResponseBodyFinishGuard`.
+      record.finish_response_body(false);
+    }
   }
 }
 
@@ -1994,14 +2049,25 @@ fn raw_request_remote_addr<'scope>(
   http: &RawHttpRecord,
 ) -> v8::Local<'scope, v8::Array> {
   let inner = http.0.borrow();
+  let (peer_ip, peer_port) = match &inner.client_addr {
+    Some(client_addr) => {
+      let addr: std::net::SocketAddr =
+        std::str::from_utf8(client_addr).unwrap().parse().unwrap();
+      (Rc::from(format!("{}", addr.ip())), Some(addr.port() as u32))
+    }
+    _ => (
+      inner.request_info.peer_address.clone(),
+      inner.request_info.peer_port,
+    ),
+  };
   let peer_ip: v8::Local<v8::Value> = v8::String::new_from_utf8(
     scope,
-    inner.request_info.peer_address.as_bytes(),
+    peer_ip.as_bytes(),
     v8::NewStringType::Normal,
   )
   .unwrap()
   .into();
-  let peer_port: v8::Local<v8::Value> = match inner.request_info.peer_port {
+  let peer_port: v8::Local<v8::Value> = match peer_port {
     Some(port) => v8::Number::new(scope, port.into()).into(),
     None => v8::undefined(scope).into(),
   };
@@ -3788,6 +3854,9 @@ where
     .await?;
     match event {
       RawResponseBodyEvent::PeerClosed => {
+        // The client went away mid-response; treat it as a cancellation so
+        // `Request.signal` aborts, like the hyper path does.
+        finish.record.cancel_request();
         abort_raw_response_body(&mut body);
         finish.finish(false);
         return Ok(());
@@ -3924,6 +3993,9 @@ where
     .await?;
     match event {
       RawResponseBodyEvent::PeerClosed => {
+        // The client went away mid-response; treat it as a cancellation so
+        // `Request.signal` aborts, like the hyper path does.
+        finish.record.cancel_request();
         abort_raw_response_body(&mut body);
         finish.finish(false);
         return Ok(());

--- a/ext/http/service.rs
+++ b/ext/http/service.rs
@@ -663,7 +663,7 @@ impl Drop for HttpRecord {
   }
 }
 
-fn trust_proxy_headers() -> bool {
+pub(crate) fn trust_proxy_headers() -> bool {
   static TRUST_PROXY_HEADERS: OnceLock<bool> = OnceLock::new();
 
   static VAR_NAME: &str = "DENO_TRUST_PROXY_HEADERS";

--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -46,7 +46,10 @@ const {
   SafeSetIterator,
   String,
   StringPrototypeIncludes,
+  StringPrototypeIndexOf,
+  StringPrototypeSlice,
   StringPrototypeSplit,
+  StringPrototypeStartsWith,
   Symbol,
   TypedArrayPrototypeGetBuffer,
   TypedArrayPrototypeGetByteLength,
@@ -899,6 +902,20 @@ function updateOutgoingData(socket, state, delta) {
 // ---- parserOnIncoming: creates ServerResponse, emits 'request' ----
 
 function parserOnIncoming(server, socket, state, req, keepAlive) {
+  // Connections accepted via the DENO_SERVE_ADDRESS override carry
+  // absolute-form request targets (the control plane forwards the full
+  // public URL, which is how Deno.serve() reconstructs request.url).
+  // Node applications expect origin-form, so strip scheme and authority.
+  if (
+    socket.isDenoServeAddressOverride &&
+    (StringPrototypeStartsWith(req.url, "http://") ||
+      StringPrototypeStartsWith(req.url, "https://"))
+  ) {
+    const schemeEnd = StringPrototypeIndexOf(req.url, "://") + 3;
+    const pathStart = StringPrototypeIndexOf(req.url, "/", schemeEnd);
+    req.url = pathStart === -1 ? "/" : StringPrototypeSlice(req.url, pathStart);
+  }
+
   resetSocketTimeout(server, socket, state, !req.upgrade);
 
   // Headers have been fully parsed; clear the headersTimeout watchdog and

--- a/ext/node/polyfills/internal/http/address_override.js
+++ b/ext/node/polyfills/internal/http/address_override.js
@@ -98,6 +98,7 @@ class OverrideSocket extends Duplex {
   #timeoutMsecs = 0;
   #timeoutTimer = null;
   // Node's HTTP server uses these directly.
+  isDenoServeAddressOverride = true;
   _paused = false;
   server = null;
   parser = null;

--- a/tests/specs/node/http_address_override_absolute_url/__test__.jsonc
+++ b/tests/specs/node/http_address_override_absolute_url/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "envs": {
+    "DENO_SERVE_ADDRESS": "duplicate,tcp:127.0.0.1:12470"
+  },
+  "args": "run -A main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/node/http_address_override_absolute_url/main.out
+++ b/tests/specs/node/http_address_override_absolute_url/main.out
@@ -1,0 +1,1 @@
+node req.url: "/some/path?q=1"

--- a/tests/specs/node/http_address_override_absolute_url/main.ts
+++ b/tests/specs/node/http_address_override_absolute_url/main.ts
@@ -1,0 +1,29 @@
+// Connections accepted via the DENO_SERVE_ADDRESS override carry
+// absolute-form request targets; node:http servers must see origin-form
+// req.url.
+import { createServer } from "node:http";
+
+const server = createServer((req, res) => {
+  res.setHeader("content-type", "application/json");
+  res.end(JSON.stringify(req.url));
+});
+server.listen(0, async () => {
+  const conn = await Deno.connect({ hostname: "127.0.0.1", port: 12470 });
+  await conn.write(
+    new TextEncoder().encode(
+      "GET https://app.example/some/path?q=1 HTTP/1.1\r\n" +
+        "Host: app.example\r\nConnection: close\r\n\r\n",
+    ),
+  );
+  const buf = new Uint8Array(65536);
+  let text = "";
+  while (true) {
+    const n = await conn.read(buf);
+    if (n === null) break;
+    text += new TextDecoder().decode(buf.subarray(0, n));
+  }
+  conn.close();
+  const body = text.slice(text.indexOf("\r\n\r\n") + 4);
+  console.log("node req.url:", body);
+  server.close(() => Deno.exit(0));
+});

--- a/tests/specs/serve/request_signal_streaming/__test__.jsonc
+++ b/tests/specs/serve/request_signal_streaming/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run -A main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/serve/request_signal_streaming/main.out
+++ b/tests/specs/serve/request_signal_streaming/main.out
@@ -1,0 +1,3 @@
+body: chunk1;chunk2;chunk3;chunk4;chunk5;
+aborted during stream: false
+aborted after completion: true

--- a/tests/specs/serve/request_signal_streaming/main.ts
+++ b/tests/specs/serve/request_signal_streaming/main.ts
@@ -1,0 +1,47 @@
+// Request.signal must not abort while the response body is still streaming.
+// (In legacy-abort mode the signal aborts when the request completes; that
+// must happen only after the response body has been fully written, otherwise
+// proxied bodies tied to the signal get torn down mid-stream.)
+let abortedDuringStream = false;
+const abortedAfterCompletion = Promise.withResolvers<void>();
+
+const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+  let i = 0;
+  const body = new ReadableStream({
+    async pull(controller) {
+      await new Promise((r) => setTimeout(r, 20));
+      if (req.signal.aborted) {
+        abortedDuringStream = true;
+        controller.error(new Error("request signal aborted mid-stream"));
+        return;
+      }
+      if (++i > 5) {
+        controller.close();
+        req.signal.addEventListener(
+          "abort",
+          () => abortedAfterCompletion.resolve(),
+        );
+        if (req.signal.aborted) abortedAfterCompletion.resolve();
+        return;
+      }
+      controller.enqueue(new TextEncoder().encode(`chunk${i};`));
+    },
+  });
+  return new Response(body);
+});
+
+const res = await fetch(`http://127.0.0.1:${server.addr.port}/`);
+const text = await res.text();
+console.log("body:", text);
+console.log("aborted during stream:", abortedDuringStream);
+
+// Legacy-abort mode still aborts the signal, but only after completion.
+let timer: number;
+const result = await Promise.race([
+  abortedAfterCompletion.promise.then(() => true),
+  new Promise((r) => timer = setTimeout(r, 3000)).then(() => false),
+]);
+clearTimeout(timer!);
+console.log("aborted after completion:", result);
+
+await server.shutdown();

--- a/tests/specs/serve/trust_proxy_headers/__test__.jsonc
+++ b/tests/specs/serve/trust_proxy_headers/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "envs": {
+    "DENO_TRUST_PROXY_HEADERS": "1"
+  },
+  "args": "run -A main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/serve/trust_proxy_headers/main.out
+++ b/tests/specs/serve/trust_proxy_headers/main.out
@@ -1,0 +1,4 @@
+remoteAddr: {"transport":"tcp","hostname":"10.1.2.3","port":4567}
+header visible: false
+remoteAddr: {"transport":"tcp","hostname":"10.1.2.3","port":4567}
+header visible: false

--- a/tests/specs/serve/trust_proxy_headers/main.ts
+++ b/tests/specs/serve/trust_proxy_headers/main.ts
@@ -1,0 +1,30 @@
+// With DENO_TRUST_PROXY_HEADERS=1, the x-deno-client-address request header
+// overrides the remote address reported to the handler and is stripped from
+// the request headers.
+const server = Deno.serve(
+  { port: 0, onListen: () => {} },
+  (req, info) => {
+    console.log("remoteAddr:", JSON.stringify(info.remoteAddr));
+    console.log(
+      "header visible:",
+      req.headers.has("x-deno-client-address"),
+    );
+    return new Response("ok");
+  },
+);
+
+const res = await fetch(`http://127.0.0.1:${server.addr.port}/`, {
+  headers: { "x-deno-client-address": "10.1.2.3:4567" },
+});
+await res.body?.cancel();
+
+// A request with a body exercises the streaming/prebuffered raw record
+// construction paths as well.
+const res2 = await fetch(`http://127.0.0.1:${server.addr.port}/`, {
+  method: "POST",
+  body: "hello",
+  headers: { "x-deno-client-address": "10.1.2.3:4567" },
+});
+await res2.body?.cancel();
+
+await server.shutdown();


### PR DESCRIPTION
## Summary

Fix three regressions in the Deno-owned HTTP/1.1 serve path and address-override node:http path:

- honor and strip `x-deno-client-address` when trusted proxy headers are enabled
- keep `Request.signal` alive until a streaming raw response body finishes
- normalize absolute-form request targets to origin-form `req.url` for node:http override sockets

## Testing

- `./x build`
- `cargo build --bin test_server`
- `./x test-spec trust_proxy_headers`
- `./x test-spec request_signal_streaming`
- `./x test-spec http_address_override_absolute_url`
- `cargo fmt --check -- ext/http/http_next.rs ext/http/service.rs`
- `./target/debug/deno fmt --check ext/node/polyfills/_http_server.js ext/node/polyfills/internal/http/address_override.js tests/specs/serve/trust_proxy_headers/main.ts tests/specs/serve/request_signal_streaming/main.ts tests/specs/node/http_address_override_absolute_url/main.ts tests/specs/serve/trust_proxy_headers/__test__.jsonc tests/specs/serve/request_signal_streaming/__test__.jsonc tests/specs/node/http_address_override_absolute_url/__test__.jsonc`