### PR TITLE
fix(runtime): keep lazy Deno namespace APIs writable

### DIFF
--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -124,12 +124,8 @@ defineLazyInternal("kExtraStdio", "ext:deno_process/40_process.js");
 const usageBuffer = new Float64Array(4);
 
 const denoNs = {
-  get Process() {
-    return lazyProcess().Process;
-  },
-  get run() {
-    return lazyProcess().run;
-  },
+  Process: undefined,
+  run: undefined,
   isatty: tty.isatty,
   writeFileSync: fs.writeFileSync,
   writeFile: fs.writeFile,
@@ -222,21 +218,13 @@ const denoNs = {
   permissions: permissions.permissions,
   Permissions: permissions.Permissions,
   PermissionStatus: permissions.PermissionStatus,
-  get serveHttp() {
-    return lazyHttp().serveHttp;
-  },
-  get serve() {
-    return lazyServe().serve;
-  },
+  serveHttp: undefined,
+  serve: undefined,
   resolveDns: net.resolveDns,
-  get upgradeWebSocket() {
-    return lazyWebsocket().upgradeWebSocket;
-  },
+  upgradeWebSocket: undefined,
   utime: fs.utime,
   utimeSync: fs.utimeSync,
-  get kill() {
-    return lazyProcess().kill;
-  },
+  kill: undefined,
   addSignalListener: signals.addSignalListener,
   removeSignalListener: signals.removeSignalListener,
   refTimer: timers.refTimer,
@@ -249,21 +237,11 @@ const denoNs = {
   consoleSize: tty.consoleSize,
   gid: os.gid,
   uid: os.uid,
-  get Command() {
-    return lazyProcess().Command;
-  },
-  get ChildProcess() {
-    return lazyProcess().ChildProcess;
-  },
-  get spawn() {
-    return lazyProcess().spawn;
-  },
-  get spawnAndWait() {
-    return lazyProcess().spawnAndWait;
-  },
-  get spawnAndWaitSync() {
-    return lazyProcess().spawnAndWaitSync;
-  },
+  Command: undefined,
+  ChildProcess: undefined,
+  spawn: undefined,
+  spawnAndWait: undefined,
+  spawnAndWaitSync: undefined,
   dlopen: ffi.dlopen,
   UnsafeCallback: ffi.UnsafeCallback,
   UnsafePointer: ffi.UnsafePointer,
@@ -274,6 +252,38 @@ const denoNs = {
   createHttpClient: httpClient.createHttpClient,
   telemetry: telemetry.telemetry,
 };
+
+core.defineGlobalProperties(denoNs, {
+  Process: core.propWritableLazyLoaded(
+    (process) => process.Process,
+    lazyProcess,
+  ),
+  run: core.propWritableLazyLoaded((process) => process.run, lazyProcess),
+  serveHttp: core.propWritableLazyLoaded((http) => http.serveHttp, lazyHttp),
+  serve: core.propWritableLazyLoaded((serve) => serve.serve, lazyServe),
+  upgradeWebSocket: core.propWritableLazyLoaded(
+    (websocket) => websocket.upgradeWebSocket,
+    lazyWebsocket,
+  ),
+  kill: core.propWritableLazyLoaded((process) => process.kill, lazyProcess),
+  Command: core.propWritableLazyLoaded(
+    (process) => process.Command,
+    lazyProcess,
+  ),
+  ChildProcess: core.propWritableLazyLoaded(
+    (process) => process.ChildProcess,
+    lazyProcess,
+  ),
+  spawn: core.propWritableLazyLoaded((process) => process.spawn, lazyProcess),
+  spawnAndWait: core.propWritableLazyLoaded(
+    (process) => process.spawnAndWait,
+    lazyProcess,
+  ),
+  spawnAndWaitSync: core.propWritableLazyLoaded(
+    (process) => process.spawnAndWaitSync,
+    lazyProcess,
+  ),
+});
 
 const denoNsUnstableById = { __proto__: null };
 

--- a/tests/unit/globals_test.ts
+++ b/tests/unit/globals_test.ts
@@ -48,6 +48,38 @@ Deno.test(function DenoNamespaceIsNotFrozen() {
   assert(!Object.isFrozen(Deno));
 });
 
+Deno.test(function DenoNamespaceLazyPropertiesAreWritable() {
+  const deno = Deno as unknown as Record<string, unknown>;
+  const lazyProperties = [
+    "serve",
+    "serveHttp",
+    "upgradeWebSocket",
+    "Command",
+  ];
+
+  for (const name of lazyProperties) {
+    const descriptor = Object.getOwnPropertyDescriptor(Deno, name);
+    assert(descriptor);
+    try {
+      const original = deno[name];
+      assert(typeof original === "function");
+      const replacement = new Proxy(original, {});
+
+      deno[name] = replacement;
+
+      assertEquals(deno[name], replacement);
+      const replacementDescriptor = Object.getOwnPropertyDescriptor(Deno, name);
+      assert(replacementDescriptor);
+      assertEquals(replacementDescriptor.value, replacement);
+      assert(replacementDescriptor.writable);
+      assert(replacementDescriptor.enumerable);
+      assert(replacementDescriptor.configurable);
+    } finally {
+      Object.defineProperty(Deno, name, descriptor);
+    }
+  }
+});
+
 Deno.test(function webAssemblyExists() {
   assert(typeof WebAssembly.compile === "function");
 });


### PR DESCRIPTION
## Summary

This keeps the lazy-loaded public `Deno` namespace APIs writable while preserving their lazy-load behavior.

The affected APIs were converted to getter-only accessors when they became lazy, which broke reassignment patterns used by shims and instrumentation such as `Deno.serve = new Proxy(Deno.serve, ...)`.

This changes the lazy public entries to use `core.propWritableLazyLoaded`, matching the existing writable lazy descriptor behavior used elsewhere, and adds regression coverage for `Deno.serve`, `Deno.serveHttp`, `Deno.upgradeWebSocket`, and `Deno.Command`.

## Validation

- `cargo build -p deno --bin deno`
- `./target/debug/deno eval 'Deno.serve = (h) => h; console.log("serve ok")'`\n- `./target/debug/deno eval 'Deno.serveHttp = (h) => h; console.log("serveHttp ok")'`\n- `./target/debug/deno eval 'Deno.upgradeWebSocket = (h) => h; console.log("upgradeWebSocket ok")'`\n- `./target/debug/deno eval 'Deno.Command = function Command() {}; console.log("Command ok")'`\n- `./target/debug/deno eval 'Deno.serve = new Proxy(Deno.serve, {}); console.log("proxy ok")'`\n- `./target/debug/deno test --config tests/config/deno.json --no-lock --unstable-net --unstable-vsock --location=http://127.0.0.1:4545/ --no-prompt -A tests/unit/globals_test.ts`\n- `./target/debug/deno run -A ./tools/format.js --check runtime/js/90_deno_ns.js tests/unit/globals_test.ts`