### PR TITLE
fix: ignore 0 value for OTEL_METRIC_EXPORT_INTERVAL

### DIFF
--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -392,7 +392,12 @@ impl DenoPeriodicReader {
     let interval = sys
       .env_var(METRIC_EXPORT_INTERVAL_NAME)
       .ok()
-      .and_then(|v| v.parse().map(Duration::from_millis).ok())
+      .and_then(|v| {
+        v.parse()
+          .map(Duration::from_millis)
+          .ok()
+          .filter(|d| !d.is_zero())
+      })
       .unwrap_or(DEFAULT_INTERVAL);
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(256);

--- a/tests/specs/cli/otel_basic/__test__.jsonc
+++ b/tests/specs/cli/otel_basic/__test__.jsonc
@@ -31,6 +31,13 @@
       "args": "run -A main.ts metric.ts",
       "output": "metric.out"
     },
+    "metric_zero_interval": {
+      "envs": {
+        "OTEL_METRIC_EXPORT_INTERVAL": "0"
+      },
+      "args": "run -A main.ts metric_zero_interval.ts",
+      "output": "metric_zero_interval.out"
+    },
     "fetch": {
       "args": "run -A main.ts fetch.ts",
       "output": "fetch.out"

--- a/tests/specs/cli/otel_basic/metric_zero_interval.out
+++ b/tests/specs/cli/otel_basic/metric_zero_interval.out
@@ -1,0 +1,33 @@
+{
+  "spans": [],
+  "logs": [],
+  "metrics": [
+    {
+      "name": "counter",
+      "description": "Example of a Counter",
+      "unit": "",
+      "metadata": [],
+      "sum": {
+        "dataPoints": [
+          {
+            "attributes": [
+              {
+                "key": "attribute",
+                "value": {
+                  "doubleValue": 1
+                }
+              }
+            ],
+            "startTimeUnixNano": [WILDCARD],
+            "timeUnixNano": [WILDCARD],
+            "exemplars": [],
+            "flags": 0,
+            "asDouble": 1
+          }
+        ],
+        "aggregationTemporality": 2,
+        "isMonotonic": true
+      }
+    }
+  ]
+}

--- a/tests/specs/cli/otel_basic/metric_zero_interval.ts
+++ b/tests/specs/cli/otel_basic/metric_zero_interval.ts
@@ -1,0 +1,15 @@
+import { metrics } from "npm:@opentelemetry/api@1";
+
+// Regression test: OTEL_METRIC_EXPORT_INTERVAL=0 must not panic. A zero
+// interval falls back to the default, and the metric is still flushed on
+// shutdown. A plain counter (no observable callbacks) is used so the script
+// does not depend on a periodic collection to make progress.
+metrics.setGlobalMeterProvider(Deno.telemetry.meterProvider);
+
+const meter = metrics.getMeter("m");
+
+const counter = meter.createCounter("counter", {
+  description: "Example of a Counter",
+});
+
+counter.add(1, { attribute: 1 });


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/35048