### PR TITLE
feat(test): add json test reporter

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -621,6 +621,7 @@ pub enum TestReporterConfig {
   Dot,
   Junit,
   Tap,
+  Json,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -4952,7 +4953,7 @@ or <c>**/__tests__/**</>:
         Arg::new("reporter")
           .long("reporter")
           .help("Select reporter to use. Default to 'pretty'")
-          .value_parser(["pretty", "dot", "junit", "tap"])
+          .value_parser(["pretty", "dot", "junit", "tap", "json"])
           .help_heading(TEST_HEADING)
       )
       .arg(
@@ -8349,13 +8350,19 @@ fn test_parse(
         "junit" => TestReporterConfig::Junit,
         "dot" => TestReporterConfig::Dot,
         "tap" => TestReporterConfig::Tap,
+        "json" => TestReporterConfig::Json,
         _ => unreachable!(),
       }
     } else {
       TestReporterConfig::Pretty
     };
 
-  if matches!(reporter, TestReporterConfig::Dot | TestReporterConfig::Tap) {
+  if matches!(
+    reporter,
+    TestReporterConfig::Dot
+      | TestReporterConfig::Tap
+      | TestReporterConfig::Json
+  ) {
     flags.log_level = Some(Level::Error);
   }
 

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -636,6 +636,8 @@ pub struct TestFlags {
   pub permit_no_files: bool,
   pub filter: Option<String>,
   pub shuffle: Option<u64>,
+  pub retry: u32,
+  pub repeats: u32,
   pub trace_leaks: bool,
   pub sanitize_ops: bool,
   pub sanitize_resources: bool,
@@ -4876,6 +4878,22 @@ or <c>**/__tests__/**</>:
           .help_heading(TEST_HEADING),
       )
       .arg(
+        Arg::new("retry")
+          .long("retry")
+          .value_name("NUMBER")
+          .help("Re-run failing tests up to NUMBER times. A test passes if any attempt passes. Tests that set their own `retry` option take precedence")
+          .value_parser(value_parser!(u32))
+          .help_heading(TEST_HEADING),
+      )
+      .arg(
+        Arg::new("repeats")
+          .long("repeats")
+          .value_name("NUMBER")
+          .help("Run each test NUMBER additional times. Every repetition must pass. Tests that set their own `repeats` option take precedence")
+          .value_parser(value_parser!(u32))
+          .help_heading(TEST_HEADING),
+      )
+      .arg(
         Arg::new("coverage")
           .long("coverage")
           .value_name("DIR")
@@ -8353,6 +8371,8 @@ fn test_parse(
     files: FileFlags { include, ignore },
     filter,
     shuffle,
+    retry: matches.remove_one::<u32>("retry").unwrap_or(0),
+    repeats: matches.remove_one::<u32>("repeats").unwrap_or(0),
     permit_no_files: permit_no_files_parse(matches),
     parallel: matches.get_flag("parallel"),
     trace_leaks,
@@ -12772,6 +12792,8 @@ mod tests {
             ignore: vec![],
           },
           shuffle: None,
+          retry: 0,
+          repeats: 0,
           parallel: false,
           trace_leaks: true,
           sanitize_ops: false,
@@ -12877,6 +12899,8 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          retry: 0,
+          repeats: 0,
           files: FileFlags {
             include: vec![],
             ignore: vec![],
@@ -12923,6 +12947,8 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          retry: 0,
+          repeats: 0,
           files: FileFlags {
             include: vec![],
             ignore: vec![],
@@ -13063,6 +13089,49 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: Some(1),
+          retry: 0,
+          repeats: 0,
+          files: FileFlags {
+            include: vec![],
+            ignore: vec![],
+          },
+          parallel: false,
+          trace_leaks: false,
+          sanitize_ops: false,
+          sanitize_resources: false,
+          coverage_dir: None,
+          coverage_raw_data_only: false,
+          clean: false,
+          watch: Default::default(),
+          reporter: Default::default(),
+          junit_path: None,
+          hide_stacktraces: false,
+        }),
+        permissions: PermissionFlags {
+          no_prompt: true,
+          ..Default::default()
+        },
+        type_check_mode: TypeCheckMode::Local,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn test_retry_and_repeats() {
+    let r = flags_from_vec(svec!["deno", "test", "--retry=3", "--repeats=2"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Test(TestFlags {
+          no_run: false,
+          doc: false,
+          fail_fast: None,
+          filter: None,
+          permit_no_files: false,
+          shuffle: None,
+          retry: 3,
+          repeats: 2,
           files: FileFlags {
             include: vec![],
             ignore: vec![],
@@ -13102,6 +13171,8 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          retry: 0,
+          repeats: 0,
           files: FileFlags {
             include: vec![],
             ignore: vec![],
@@ -13140,6 +13211,8 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          retry: 0,
+          repeats: 0,
           files: FileFlags {
             include: vec!["./".to_string()],
             ignore: vec![],
@@ -13180,6 +13253,8 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          retry: 0,
+          repeats: 0,
           files: FileFlags {
             include: vec![],
             ignore: vec![],

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -202,6 +202,8 @@ pub struct WorkspaceTestOptions {
   pub permit_no_files: bool,
   pub filter: Option<String>,
   pub shuffle: Option<u64>,
+  pub retry: u32,
+  pub repeats: u32,
   pub concurrent_jobs: NonZeroUsize,
   pub trace_leaks: bool,
   pub sanitize_ops: bool,
@@ -234,6 +236,8 @@ impl WorkspaceTestOptions {
       filter: test_flags.filter.clone(),
       no_run: test_flags.no_run,
       shuffle: test_flags.shuffle,
+      retry: test_flags.retry,
+      repeats: test_flags.repeats,
       trace_leaks: test_flags.trace_leaks,
       sanitize_ops: test_flags.sanitize_ops
         || std::env::var("DENO_TEST_SANITIZE_OPS").ok().as_deref() == Some("1")

--- a/cli/js/40_test.js
+++ b/cli/js/40_test.js
@@ -216,6 +216,12 @@ function assertExit(fn, isTest, sanitizeExit) {
 
 function wrapOuter(fn, desc) {
   return async function outerWrapped() {
+    const state = MapPrototypeGet(testStates, desc.id);
+    // A test may be invoked more than once when `retry`/`repeats` are set.
+    // Reset any state left over from a previous invocation so steps can run
+    // again and stale children aren't reported as incomplete.
+    state.children = [];
+    state.completed = false;
     try {
       if (desc.ignore) {
         return "ignored";
@@ -224,7 +230,6 @@ function wrapOuter(fn, desc) {
     } catch (error) {
       return { failed: { jsError: core.destructureError(error) } };
     } finally {
-      const state = MapPrototypeGet(testStates, desc.id);
       for (const childDesc of state.children) {
         stepReportResult(childDesc, { failed: "incomplete" }, 0);
       }
@@ -316,6 +321,24 @@ function encodeTimeout(value) {
   return value;
 }
 
+// Validates the `retry`/`repeats` test options, which are non-negative integer
+// counts passed to the runner as u32 values (0 means the option is unset).
+function encodeCount(value, label) {
+  if (value === undefined || value === null) return 0;
+  if (
+    typeof value !== "number" || NumberIsNaN(value) ||
+    !NumberIsFinite(value) || !NumberIsInteger(value) || value < 0
+  ) {
+    throw new TypeError(`Test ${label} must be a non-negative integer`);
+  }
+  if (value > TIMEOUT_MAX) {
+    throw new TypeError(
+      `Test ${label} out of range (must be between 0 and 2147483647)`,
+    );
+  }
+  return value;
+}
+
 // As long as we're using one isolate per test, we can cache the origin since it won't change
 let cachedOrigin = undefined;
 
@@ -346,6 +369,8 @@ function testInner(
     sanitizeExit: true,
     permissions: null,
     timeout: undefined,
+    retry: 0,
+    repeats: 0,
   };
 
   if (typeof nameOrFnOrOptions === "string") {
@@ -447,6 +472,8 @@ function testInner(
     registerTestIdRetBufU8,
     testDesc.sanitizeOnly ?? true,
     encodeTimeout(testDesc.timeout),
+    encodeCount(testDesc.retry, "retry"),
+    encodeCount(testDesc.repeats, "repeats"),
   );
   testDesc.id = registerTestIdRetBuf[0];
   testDesc.origin = cachedOrigin;

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -439,6 +439,10 @@ impl TestRun {
                 );
               }
             }
+            test::TestEvent::Retry(..) => {
+              // Informational only; the test's terminal result is reported via
+              // `TestEvent::Result`.
+            }
             test::TestEvent::Completed => {
               reporter.report_completed();
             }

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -330,6 +330,8 @@ impl TestRun {
             test::TestSpecifierOptions {
               filter,
               shuffle: None,
+              retry: 0,
+              repeats: 0,
               trace_leaks: false,
               // LSP-driven test runs intentionally disable sanitizers — the
               // LSP UI doesn't surface op/resource leak failures usefully

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -128,6 +128,8 @@ fn op_register_test(
   #[buffer] ret_buf: &mut [u8],
   sanitize_only: bool,
   #[smi] timeout_ms: u32,
+  #[smi] retry: u32,
+  #[smi] repeats: u32,
 ) -> Result<(), JsErrorBox> {
   if ret_buf.len() != 4 {
     return Err(JsErrorBox::type_error(format!(
@@ -157,6 +159,8 @@ fn op_register_test(
       column_number,
     },
     timeout_ms,
+    retry,
+    repeats,
   };
   state
     .borrow_mut::<TestContainer>()

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -621,6 +621,12 @@ struct TestSpecifiersOptions {
 pub struct TestSpecifierOptions {
   pub shuffle: Option<u64>,
   pub filter: TestFilter,
+  /// Default number of retries applied to tests that don't set their own
+  /// `retry` option (from the `--retry` flag).
+  pub retry: u32,
+  /// Default number of repeats applied to tests that don't set their own
+  /// `repeats` option (from the `--repeats` flag).
+  pub repeats: u32,
   pub trace_leaks: bool,
   pub sanitize_ops: bool,
   pub sanitize_resources: bool,
@@ -1396,6 +1402,18 @@ async fn run_tests_for_worker_inner(
     event_tracker.wait(desc)?;
 
     let timeout_ms = desc.timeout_ms.filter(|&t| t > 0);
+    // A test's own `retry`/`repeats` option takes precedence; otherwise fall
+    // back to the `--retry`/`--repeats` flag defaults.
+    let retry = if desc.retry > 0 {
+      desc.retry
+    } else {
+      options.retry
+    };
+    let repeats = if desc.repeats > 0 {
+      desc.repeats
+    } else {
+      options.repeats
+    };
     let earlier = Instant::now();
 
     // The terminal result of the test once all repetitions/attempts settle.
@@ -1404,10 +1422,10 @@ async fn run_tests_for_worker_inner(
 
     // `repeats` requires every repetition to pass; `retry` allows each
     // repetition up to `1 + retry` attempts and passes on the first success.
-    'repetitions: for _repetition in 0..=desc.repeats {
+    'repetitions: for _repetition in 0..=repeats {
       let mut repetition_result = TestResult::Ok;
 
-      'attempts: for attempt in 0..=desc.retry {
+      'attempts: for attempt in 0..=retry {
         // Poll event loop once, to allow all ops that are already resolved, but
         // haven't responded, to settle.
         // TODO(mmastrac): we should provide an API to poll the event loop until
@@ -1528,7 +1546,7 @@ async fn run_tests_for_worker_inner(
         }
 
         match attempt_result {
-          TestResult::Failed(failure) if attempt < desc.retry => {
+          TestResult::Failed(failure) if attempt < retry => {
             // Attempts remain: surface the retry and try this repetition again.
             event_tracker.retry(desc, attempt, failure)?;
             continue 'attempts;
@@ -2087,6 +2105,8 @@ pub async fn run_tests(
       specifier: TestSpecifierOptions {
         filter: TestFilter::from_flag(&workspace_test_options.filter),
         shuffle: workspace_test_options.shuffle,
+        retry: workspace_test_options.retry,
+        repeats: workspace_test_options.repeats,
         trace_leaks: workspace_test_options.trace_leaks,
         sanitize_ops: workspace_test_options.sanitize_ops,
         sanitize_resources: workspace_test_options.sanitize_resources,
@@ -2337,6 +2357,8 @@ pub async fn run_tests_with_watch(
             specifier: TestSpecifierOptions {
               filter: TestFilter::from_flag(&workspace_test_options.filter),
               shuffle: workspace_test_options.shuffle,
+              retry: workspace_test_options.retry,
+              repeats: workspace_test_options.repeats,
               trace_leaks: workspace_test_options.trace_leaks,
               sanitize_ops: workspace_test_options.sanitize_ops,
               sanitize_resources: workspace_test_options.sanitize_resources,

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -102,6 +102,7 @@ use fmt::format_sanitizer_diff;
 pub use fmt::format_test_error;
 use reporters::CompoundTestReporter;
 use reporters::DotTestReporter;
+use reporters::JsonTestReporter;
 use reporters::JunitTestReporter;
 use reporters::PrettyTestReporter;
 use reporters::TapTestReporter;
@@ -687,6 +688,13 @@ fn get_test_reporter(options: &TestSpecifiersOptions) -> Box<dyn TestReporter> {
       options.cwd.clone(),
       options.concurrent_jobs > NonZeroUsize::new(1).unwrap(),
       failure_format_options,
+    )),
+    TestReporterConfig::Json => Box::new(JsonTestReporter::new(
+      options.cwd.clone(),
+      TestFailureFormatOptions {
+        strip_ascii_color: true,
+        ..failure_format_options
+      },
     )),
   };
 

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -300,6 +300,12 @@ pub struct TestDescription {
   pub sanitize_ops: bool,
   pub sanitize_resources: bool,
   pub timeout_ms: Option<u32>,
+  /// Number of times to re-run the test if it fails. The test passes if any
+  /// attempt passes (0 means no retries).
+  pub retry: u32,
+  /// Number of additional times to repeat the test. Every repetition must pass
+  /// for the test to pass (0 means run once).
+  pub repeats: u32,
 }
 
 /// May represent a failure of a test or test step.
@@ -532,6 +538,10 @@ pub enum TestEvent {
   Output(Vec<u8>),
   Slow(usize, u64),
   Result(usize, TestResult, u64),
+  /// A test attempt failed but will be retried (`retry` option). Carries the
+  /// test id, the zero-based attempt index that failed, and the failure. This
+  /// is informational only and does not count toward the test's final result.
+  Retry(usize, u32, TestFailure),
   UncaughtError(String, Box<JsError>),
   StepRegister(TestStepDescription),
   StepWait(usize),
@@ -565,6 +575,7 @@ impl TestEvent {
       self,
       TestEvent::Plan(..)
         | TestEvent::Result(..)
+        | TestEvent::Retry(..)
         | TestEvent::StepWait(..)
         | TestEvent::StepResult(..)
         | TestEvent::UncaughtError(..)
@@ -581,6 +592,8 @@ pub struct TestSummary {
   pub total: usize,
   pub passed: usize,
   pub failed: usize,
+  /// Number of tests that passed but only after one or more retries.
+  pub flaky: usize,
   pub ignored: usize,
   pub passed_steps: usize,
   pub failed_steps: usize,
@@ -619,6 +632,7 @@ impl TestSummary {
       total: 0,
       passed: 0,
       failed: 0,
+      flaky: 0,
       ignored: 0,
       passed_steps: 0,
       failed_steps: 0,
@@ -1230,6 +1244,96 @@ where
   Ok(())
 }
 
+/// The outcome of a single invocation of a test function (one attempt).
+enum AttemptInvocation {
+  /// The test function ran to completion and produced this result.
+  Completed(TestResult),
+  /// The test function threw an uncaught error that escaped the test wrapper.
+  /// The error has already been reported via the event tracker; the isolate is
+  /// considered poisoned and the test run should be abandoned.
+  Uncaught,
+}
+
+/// Runs the wrapped test function once, applying the timeout/watchdog handling.
+/// This is the unit that `retry`/`repeats` re-invoke.
+#[allow(clippy::too_many_arguments, reason = "internal helper")]
+async fn invoke_test_function(
+  worker: &mut MainWorker,
+  function: &v8::Global<v8::Function>,
+  timeout_ms: Option<u32>,
+  watchdog: &TestWatchdog,
+  event_tracker: &TestEventTracker,
+  test_id: usize,
+  specifier: &ModuleSpecifier,
+) -> Result<AttemptInvocation, RunTestsForWorkerErr> {
+  if let Some(ms) = timeout_ms {
+    watchdog.arm(ms);
+  }
+
+  let call = worker.js_runtime.call(function);
+
+  let slow_test_warning =
+    spawn(slow_test_watchdog(event_tracker.clone(), test_id));
+
+  let test_fut = worker
+    .js_runtime
+    .with_event_loop_promise(call, PollEventLoopOptions::default());
+
+  let raced = match timeout_ms {
+    Some(ms) => {
+      match tokio::time::timeout(Duration::from_millis(ms as u64), test_fut)
+        .await
+      {
+        Ok(r) => Ok(r),
+        Err(_elapsed) => Err(()),
+      }
+    }
+    None => Ok(test_fut.await),
+  };
+  slow_test_warning.abort();
+
+  // `disarm()` must run before any further JS executes on the isolate —
+  // a stale `Fired` flag would kill the next test. The
+  // `cancel_terminate_execution` below clears it; do not refactor this
+  // pair apart.
+  let watchdog_fired = timeout_ms.is_some() && watchdog.disarm();
+  if watchdog_fired {
+    worker.js_runtime.v8_isolate().cancel_terminate_execution();
+  }
+
+  // Tokio fires for async hangs; the watchdog fires for sync hot loops.
+  // If the test still produced a valid result, a watchdog fire must have
+  // raced after V8 was already done — preserve the result.
+  let timed_out = match &raced {
+    Err(_) => true,
+    Ok(Ok(_)) => false,
+    Ok(Err(_)) => watchdog_fired,
+  };
+
+  if timed_out {
+    return Ok(AttemptInvocation::Completed(TestResult::Failed(
+      TestFailure::TimedOut(timeout_ms.unwrap_or(0)),
+    )));
+  }
+
+  match raced.unwrap() {
+    Ok(r) => {
+      deno_core::scope!(scope, &mut worker.js_runtime);
+      let result = v8::Local::new(scope, r);
+      Ok(AttemptInvocation::Completed(
+        <TestResult as deno_core::FromV8>::from_v8(scope, result)?,
+      ))
+    }
+    Err(error) => match error.into_kind() {
+      CoreErrorKind::Js(js_error) => {
+        event_tracker.uncaught_error(specifier.to_string(), js_error)?;
+        Ok(AttemptInvocation::Uncaught)
+      }
+      err => Err(err.into_box().into()),
+    },
+  }
+}
+
 #[allow(clippy::too_many_arguments, reason = "TODO: cleanup")]
 async fn run_tests_for_worker_inner(
   worker: &mut MainWorker,
@@ -1291,162 +1395,164 @@ async fn run_tests_for_worker_inner(
     }
     event_tracker.wait(desc)?;
 
-    // Poll event loop once, to allow all ops that are already resolved, but haven't
-    // responded to settle.
-    // TODO(mmastrac): we should provide an API to poll the event loop until no further
-    // progress is made.
-    poll_event_loop(worker).await?;
-
-    // We always capture stats, regardless of sanitization state
-    let before_test_stats = sanitizer_helper.capture_stats();
-
+    let timeout_ms = desc.timeout_ms.filter(|&t| t > 0);
     let earlier = Instant::now();
 
-    // Execute beforeEach hooks (FIFO order)
-    let mut before_each_hook_errored = false;
+    // The terminal result of the test once all repetitions/attempts settle.
+    // `None` means an early exit (uncaught error) already reported a result.
+    let mut final_result: Option<TestResult> = None;
 
-    call_hooks(worker, test_hooks.before_each.iter(), |core_error| {
-      match core_error {
-        CoreErrorKind::Js(err) => {
-          before_each_hook_errored = true;
-          let test_result = TestResult::Failed(TestFailure::JsError(err));
-          fail_fast_tracker.add_failure();
-          event_tracker.result(desc, test_result, earlier.elapsed())?;
-          Ok(())
-        }
-        err => Err(err.into_box().into()),
-      }
-    })
-    .await?;
+    // `repeats` requires every repetition to pass; `retry` allows each
+    // repetition up to `1 + retry` attempts and passes on the first success.
+    'repetitions: for _repetition in 0..=desc.repeats {
+      let mut repetition_result = TestResult::Ok;
 
-    let result = if !before_each_hook_errored {
-      let timeout_ms = desc.timeout_ms.filter(|&t| t > 0);
+      'attempts: for attempt in 0..=desc.retry {
+        // Poll event loop once, to allow all ops that are already resolved, but
+        // haven't responded, to settle.
+        // TODO(mmastrac): we should provide an API to poll the event loop until
+        // no further progress is made.
+        poll_event_loop(worker).await?;
 
-      if let Some(ms) = timeout_ms {
-        watchdog.arm(ms);
-      }
+        // We always capture stats, regardless of sanitization state. A fresh
+        // baseline per attempt keeps each attempt's leak check independent of
+        // resources leaked by a previous, retried attempt.
+        let before_test_stats = sanitizer_helper.capture_stats();
 
-      let call = worker.js_runtime.call(&function);
-
-      let slow_test_warning =
-        spawn(slow_test_watchdog(event_tracker.clone(), desc.id));
-
-      let test_fut = worker
-        .js_runtime
-        .with_event_loop_promise(call, PollEventLoopOptions::default());
-
-      let raced = match timeout_ms {
-        Some(ms) => {
-          match tokio::time::timeout(Duration::from_millis(ms as u64), test_fut)
-            .await
-          {
-            Ok(r) => Ok(r),
-            Err(_elapsed) => Err(()),
-          }
-        }
-        None => Ok(test_fut.await),
-      };
-      slow_test_warning.abort();
-
-      // `disarm()` must run before any further JS executes on the isolate —
-      // a stale `Fired` flag would kill the next test. The
-      // `cancel_terminate_execution` below clears it; do not refactor this
-      // pair apart.
-      let watchdog_fired = timeout_ms.is_some() && watchdog.disarm();
-      if watchdog_fired {
-        worker.js_runtime.v8_isolate().cancel_terminate_execution();
-      }
-
-      // Tokio fires for async hangs; the watchdog fires for sync hot loops.
-      // If the test still produced a valid result, a watchdog fire must have
-      // raced after V8 was already done — preserve the result.
-      let timed_out = match &raced {
-        Err(_) => true,
-        Ok(Ok(_)) => false,
-        Ok(Err(_)) => watchdog_fired,
-      };
-
-      if timed_out {
-        TestResult::Failed(TestFailure::TimedOut(timeout_ms.unwrap_or(0)))
-      } else {
-        match raced.unwrap() {
-          Ok(r) => {
-            deno_core::scope!(scope, &mut worker.js_runtime);
-            let result = v8::Local::new(scope, r);
-            <TestResult as deno_core::FromV8>::from_v8(scope, result)?
-          }
-          Err(error) => match error.into_kind() {
-            CoreErrorKind::Js(js_error) => {
-              event_tracker.uncaught_error(specifier.to_string(), js_error)?;
-              fail_fast_tracker.add_failure();
-              event_tracker.cancelled(desc)?;
-              had_uncaught_error = true;
-              continue;
+        // Execute beforeEach hooks (FIFO order). A hook error is terminal and
+        // is not retried.
+        let mut before_each_failure: Option<Box<JsError>> = None;
+        call_hooks(worker, test_hooks.before_each.iter(), |core_error| {
+          match core_error {
+            CoreErrorKind::Js(err) => {
+              if before_each_failure.is_none() {
+                before_each_failure = Some(err);
+              }
+              Ok(())
             }
-            err => return Err(err.into_box().into()),
-          },
+            err => Err(err.into_box().into()),
+          }
+        })
+        .await?;
+
+        if let Some(err) = before_each_failure {
+          // Run afterEach for best-effort cleanup, ignoring its errors, then
+          // fail the test without retrying.
+          call_hooks(
+            worker,
+            test_hooks.after_each.iter().rev(),
+            |core_error| match core_error {
+              CoreErrorKind::Js(_) => Ok(()),
+              err => Err(err.into_box().into()),
+            },
+          )
+          .await?;
+          final_result = Some(TestResult::Failed(TestFailure::JsError(err)));
+          break 'repetitions;
+        }
+
+        let mut attempt_result = match invoke_test_function(
+          worker,
+          &function,
+          timeout_ms,
+          &watchdog,
+          event_tracker,
+          desc.id,
+          specifier,
+        )
+        .await?
+        {
+          AttemptInvocation::Completed(result) => result,
+          AttemptInvocation::Uncaught => {
+            fail_fast_tracker.add_failure();
+            event_tracker.cancelled(desc)?;
+            had_uncaught_error = true;
+            final_result = None;
+            break 'repetitions;
+          }
+        };
+
+        // Execute afterEach hooks (LIFO order). A hook error is terminal and is
+        // not retried.
+        let mut after_each_failure: Option<Box<JsError>> = None;
+        call_hooks(worker, test_hooks.after_each.iter().rev(), |core_error| {
+          match core_error {
+            CoreErrorKind::Js(err) => {
+              if after_each_failure.is_none() {
+                after_each_failure = Some(err);
+              }
+              Ok(())
+            }
+            err => Err(err.into_box().into()),
+          }
+        })
+        .await?;
+
+        // Close idle Node.js HTTP Agent connections to prevent cross-test
+        // pollution and false positive resource leak detection from pooled
+        // keepAlive connections. Defined in ext/node/polyfills/01_require.js.
+        _ = worker.js_runtime.execute_script(
+          located_script_name!(),
+          "Deno[Deno.internal].closeIdleConnections?.()",
+        );
+
+        // Await activity stabilization. A leak counts as a failure of the
+        // attempt, and is therefore retryable like any other failure. Only
+        // check when the test function itself passed and afterEach didn't error
+        // (a real failure takes precedence over a leak report).
+        if matches!(attempt_result, TestResult::Ok)
+          && after_each_failure.is_none()
+          && let Some(diff) = sanitizers::wait_for_activity_to_stabilize(
+            worker,
+            &sanitizer_helper,
+            before_test_stats,
+            desc.sanitize_ops,
+            desc.sanitize_resources,
+          )
+          .await?
+        {
+          let (formatted, trailer_notes) = format_sanitizer_diff(diff);
+          if !formatted.is_empty() {
+            attempt_result =
+              TestResult::Failed(TestFailure::Leaked(formatted, trailer_notes));
+          }
+        }
+
+        // An afterEach error is terminal, but only wins when the test itself
+        // passed (a test failure takes precedence, matching the old behavior).
+        if matches!(attempt_result, TestResult::Ok)
+          && let Some(err) = after_each_failure
+        {
+          final_result = Some(TestResult::Failed(TestFailure::JsError(err)));
+          break 'repetitions;
+        }
+
+        match attempt_result {
+          TestResult::Failed(failure) if attempt < desc.retry => {
+            // Attempts remain: surface the retry and try this repetition again.
+            event_tracker.retry(desc, attempt, failure)?;
+            continue 'attempts;
+          }
+          other => {
+            repetition_result = other;
+            break 'attempts;
+          }
         }
       }
-    } else {
-      TestResult::Ignored
-    };
 
-    if matches!(result, TestResult::Failed(_)) {
-      fail_fast_tracker.add_failure();
-      event_tracker.result(desc, result.clone(), earlier.elapsed())?;
-    }
-
-    // Execute afterEach hooks (LIFO order)
-    call_hooks(worker, test_hooks.after_each.iter().rev(), |core_error| {
-      match core_error {
-        CoreErrorKind::Js(err) => {
-          let test_result = TestResult::Failed(TestFailure::JsError(err));
-          fail_fast_tracker.add_failure();
-          event_tracker.result(desc, test_result, earlier.elapsed())?;
-          Ok(())
-        }
-        err => Err(err.into_box().into()),
+      if matches!(repetition_result, TestResult::Failed(_)) {
+        // This repetition failed definitively; the whole test fails.
+        final_result = Some(repetition_result);
+        break 'repetitions;
       }
-    })
-    .await?;
-
-    if matches!(result, TestResult::Failed(_)) {
-      continue;
+      // This repetition passed; carry on to the next one (if any).
+      final_result = Some(repetition_result);
     }
 
-    // Close idle Node.js HTTP Agent connections to prevent cross-test
-    // pollution and false positive resource leak detection from pooled
-    // keepAlive connections. Defined in ext/node/polyfills/01_require.js.
-    _ = worker.js_runtime.execute_script(
-      located_script_name!(),
-      "Deno[Deno.internal].closeIdleConnections?.()",
-    );
-
-    // Await activity stabilization
-    if let Some(diff) = sanitizers::wait_for_activity_to_stabilize(
-      worker,
-      &sanitizer_helper,
-      before_test_stats,
-      desc.sanitize_ops,
-      desc.sanitize_resources,
-    )
-    .await?
-    {
-      let (formatted, trailer_notes) = format_sanitizer_diff(diff);
-      if !formatted.is_empty() {
-        let failure = TestFailure::Leaked(formatted, trailer_notes);
+    if let Some(result) = final_result {
+      if matches!(result, TestResult::Failed(_)) {
         fail_fast_tracker.add_failure();
-        event_tracker.result(
-          desc,
-          TestResult::Failed(failure),
-          earlier.elapsed(),
-        )?;
-        continue;
       }
-    }
-
-    // TODO(bartlomieju): using `before_each_hook_errored` is fishy
-    if !before_each_hook_errored {
       event_tracker.result(desc, result, earlier.elapsed())?;
     }
   }
@@ -1609,6 +1715,11 @@ pub async fn report_tests(
           }
           reporter.report_result(tests.get(&id).unwrap(), &result, elapsed);
         }
+      }
+      TestEvent::Retry(id, attempt, failure) => {
+        // Informational only: a retried attempt does not produce a terminal
+        // result and is intentionally not gated by `tests_with_result`.
+        reporter.report_retry(tests.get(&id).unwrap(), attempt, &failure);
       }
       TestEvent::UncaughtError(origin, error) => {
         failed = true;
@@ -2350,6 +2461,15 @@ impl TestEventTracker {
       test_result,
       duration.as_millis() as u64,
     ))
+  }
+
+  fn retry(
+    &self,
+    desc: &TestDescription,
+    attempt: u32,
+    failure: TestFailure,
+  ) -> Result<(), ChannelClosedError> {
+    self.send_event(TestEvent::Retry(desc.id, attempt, failure))
   }
 
   pub(crate) fn force_end_report(&self) -> Result<(), ChannelClosedError> {

--- a/cli/tools/test/reporters/common.rs
+++ b/cli/tools/test/reporters/common.rs
@@ -4,6 +4,69 @@ use super::fmt::format_test_error;
 use super::fmt::to_relative_path_or_remote_url;
 use super::*;
 
+/// Step results are tallied into the summary only once the owning (root) test
+/// produces a terminal result. This lets a retried attempt's step results be
+/// discarded instead of counted, while the steps are still printed live as they
+/// run. Keyed by the root test id.
+pub(super) type PendingStepTally =
+  HashMap<usize, Vec<(TestStepResult, Option<TestFailureDescription>)>>;
+
+/// Buffers a step result for its root test instead of tallying it immediately.
+pub(super) fn record_step_result(
+  pending: &mut PendingStepTally,
+  desc: &TestStepDescription,
+  result: &TestStepResult,
+  tests: &IndexMap<usize, TestDescription>,
+  test_steps: &IndexMap<usize, TestStepDescription>,
+) {
+  let failure_desc = match result {
+    TestStepResult::Failed(_) => Some(TestFailureDescription {
+      id: desc.id,
+      name: format_test_step_ancestry(desc, tests, test_steps),
+      origin: desc.origin.clone(),
+      location: desc.location.clone(),
+    }),
+    _ => None,
+  };
+  pending
+    .entry(desc.root_id)
+    .or_default()
+    .push((result.clone(), failure_desc));
+}
+
+/// Commits the buffered step results for a root test into the summary. Called
+/// when the test produces its terminal result.
+pub(super) fn commit_step_results(
+  pending: &mut PendingStepTally,
+  summary: &mut TestSummary,
+  root_id: usize,
+) {
+  let Some(steps) = pending.remove(&root_id) else {
+    return;
+  };
+  for (result, failure_desc) in steps {
+    match result {
+      TestStepResult::Ok => summary.passed_steps += 1,
+      TestStepResult::Ignored => summary.ignored_steps += 1,
+      TestStepResult::Failed(failure) => {
+        summary.failed_steps += 1;
+        if let Some(failure_desc) = failure_desc {
+          summary.failures.push((failure_desc, failure));
+        }
+      }
+    }
+  }
+}
+
+/// Discards the buffered step results for a root test that is being retried, so
+/// the failed attempt's steps don't count toward the summary.
+pub(super) fn discard_step_results(
+  pending: &mut PendingStepTally,
+  root_id: usize,
+) {
+  pending.remove(&root_id);
+}
+
 pub(super) fn format_test_step_ancestry(
   desc: &TestStepDescription,
   tests: &IndexMap<usize, TestDescription>,
@@ -264,6 +327,10 @@ pub(super) fn report_summary(
     get_steps_text(summary.failed_steps),
   )
   .ok();
+
+  if summary.flaky > 0 {
+    write!(summary_result, " | {} flaky", summary.flaky).ok();
+  }
 
   let ignored_steps = get_steps_text(summary.ignored_steps);
   if summary.ignored > 0 || !ignored_steps.is_empty() {

--- a/cli/tools/test/reporters/compound.rs
+++ b/cli/tools/test/reporters/compound.rs
@@ -54,6 +54,17 @@ impl TestReporter for CompoundTestReporter {
     }
   }
 
+  fn report_retry(
+    &mut self,
+    description: &TestDescription,
+    attempt: u32,
+    failure: &TestFailure,
+  ) {
+    for reporter in &mut self.test_reporters {
+      reporter.report_retry(description, attempt, failure);
+    }
+  }
+
   fn report_uncaught_error(&mut self, origin: &str, error: Box<JsError>) {
     for reporter in &mut self.test_reporters {
       reporter.report_uncaught_error(origin, error.clone());

--- a/cli/tools/test/reporters/dot.rs
+++ b/cli/tools/test/reporters/dot.rs
@@ -8,6 +8,8 @@ pub struct DotTestReporter {
   n: usize,
   width: usize,
   cwd: Url,
+  retried_tests: HashSet<usize>,
+  pending_step_tally: common::PendingStepTally,
   summary: TestSummary,
   failure_format_options: TestFailureFormatOptions,
 }
@@ -29,6 +31,8 @@ impl DotTestReporter {
       n: 0,
       width: console_width,
       cwd,
+      retried_tests: Default::default(),
+      pending_step_tally: Default::default(),
       summary: TestSummary::new(),
       failure_format_options,
     }
@@ -109,9 +113,18 @@ impl TestReporter for DotTestReporter {
     result: &TestResult,
     _elapsed: u64,
   ) {
+    common::commit_step_results(
+      &mut self.pending_step_tally,
+      &mut self.summary,
+      description.id,
+    );
+
     match &result {
       TestResult::Ok => {
         self.summary.passed += 1;
+        if self.retried_tests.contains(&description.id) {
+          self.summary.flaky += 1;
+        }
       }
       TestResult::Ignored => {
         self.summary.ignored += 1;
@@ -129,6 +142,16 @@ impl TestReporter for DotTestReporter {
     }
 
     self.print_test_result(result);
+  }
+
+  fn report_retry(
+    &mut self,
+    description: &TestDescription,
+    _attempt: u32,
+    _failure: &TestFailure,
+  ) {
+    self.retried_tests.insert(description.id);
+    common::discard_step_results(&mut self.pending_step_tally, description.id);
   }
 
   fn report_uncaught_error(&mut self, origin: &str, error: Box<JsError>) {
@@ -160,26 +183,13 @@ impl TestReporter for DotTestReporter {
     tests: &IndexMap<usize, TestDescription>,
     test_steps: &IndexMap<usize, TestStepDescription>,
   ) {
-    match &result {
-      TestStepResult::Ok => {
-        self.summary.passed_steps += 1;
-      }
-      TestStepResult::Ignored => {
-        self.summary.ignored_steps += 1;
-      }
-      TestStepResult::Failed(failure) => {
-        self.summary.failed_steps += 1;
-        self.summary.failures.push((
-          TestFailureDescription {
-            id: desc.id,
-            name: common::format_test_step_ancestry(desc, tests, test_steps),
-            origin: desc.origin.clone(),
-            location: desc.location.clone(),
-          },
-          failure.clone(),
-        ))
-      }
-    }
+    common::record_step_result(
+      &mut self.pending_step_tally,
+      desc,
+      result,
+      tests,
+      test_steps,
+    );
 
     self.print_test_step_result(result);
   }

--- a/cli/tools/test/reporters/json.rs
+++ b/cli/tools/test/reporters/json.rs
@@ -1,0 +1,426 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+use std::collections::VecDeque;
+use std::io::Write;
+use std::time::SystemTime;
+
+use console_static_text::ansi::strip_ansi_codes;
+use deno_core::serde_json;
+use serde::Serialize;
+
+use super::fmt::to_relative_path_or_remote_url;
+use super::*;
+
+/// A test reporter that emits a single JSON document modelled on the output of
+/// Jest's (and Vitest's) `json` reporter, so existing tooling that consumes
+/// that shape can be reused. The document is written to stdout once the run
+/// completes.
+///
+/// Each Deno test and test step maps to an `assertionResult`; tests are grouped
+/// into `testResults` (one entry per file, i.e. a Jest "test suite"). Retried
+/// attempts of a test that ultimately passes are not surfaced; only the final
+/// outcome is reported.
+pub struct JsonTestReporter {
+  cwd: Url,
+  failure_format_options: TestFailureFormatOptions,
+  start_time_ms: u64,
+  // Collected results for tests and committed steps, keyed by id.
+  results: IndexMap<usize, CollectedResult>,
+  // Step results buffered per root test id until that test produces a terminal
+  // result, so a retried attempt's steps can be discarded rather than emitted.
+  pending_steps: IndexMap<usize, Vec<(usize, CollectedResult)>>,
+}
+
+struct CollectedResult {
+  status: ResultStatus,
+  duration: u64,
+  failure_messages: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+enum ResultStatus {
+  Passed,
+  Failed,
+  Skipped,
+}
+
+impl ResultStatus {
+  fn as_str(self) -> &'static str {
+    match self {
+      ResultStatus::Passed => "passed",
+      ResultStatus::Failed => "failed",
+      ResultStatus::Skipped => "skipped",
+    }
+  }
+}
+
+impl JsonTestReporter {
+  pub fn new(
+    cwd: Url,
+    failure_format_options: TestFailureFormatOptions,
+  ) -> Self {
+    let start_time_ms = SystemTime::now()
+      .duration_since(SystemTime::UNIX_EPOCH)
+      .map(|d| d.as_millis() as u64)
+      .unwrap_or(0);
+    Self {
+      cwd,
+      failure_format_options,
+      start_time_ms,
+      results: IndexMap::new(),
+      pending_steps: IndexMap::new(),
+    }
+  }
+
+  fn collect_failure(&self, failure: &TestFailure) -> Vec<String> {
+    let message = failure.format(&self.failure_format_options).into_owned();
+    vec![strip_ansi_codes(&message).into_owned()]
+  }
+}
+
+impl TestReporter for JsonTestReporter {
+  fn report_register(&mut self, description: &TestDescription) {
+    // Pre-register as skipped so tests that never run (e.g. cancelled) still
+    // appear; overwritten once a result arrives.
+    self.results.insert(
+      description.id,
+      CollectedResult {
+        status: ResultStatus::Skipped,
+        duration: 0,
+        failure_messages: vec![],
+      },
+    );
+  }
+
+  fn report_plan(&mut self, _plan: &TestPlan) {}
+  fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
+  fn report_wait(&mut self, _description: &TestDescription) {}
+  fn report_output(&mut self, _output: &[u8]) {}
+
+  fn report_result(
+    &mut self,
+    description: &TestDescription,
+    result: &TestResult,
+    elapsed: u64,
+  ) {
+    // Commit the final attempt's buffered steps now that the test is done.
+    if let Some(steps) = self.pending_steps.shift_remove(&description.id) {
+      for (id, collected) in steps {
+        self.results.insert(id, collected);
+      }
+    }
+
+    let collected = match result {
+      TestResult::Ok => CollectedResult {
+        status: ResultStatus::Passed,
+        duration: elapsed,
+        failure_messages: vec![],
+      },
+      TestResult::Ignored => CollectedResult {
+        status: ResultStatus::Skipped,
+        duration: elapsed,
+        failure_messages: vec![],
+      },
+      TestResult::Failed(failure) => CollectedResult {
+        status: ResultStatus::Failed,
+        duration: elapsed,
+        failure_messages: self.collect_failure(failure),
+      },
+      TestResult::Cancelled => CollectedResult {
+        status: ResultStatus::Failed,
+        duration: elapsed,
+        failure_messages: vec!["Cancelled".to_string()],
+      },
+    };
+    self.results.insert(description.id, collected);
+  }
+
+  fn report_retry(
+    &mut self,
+    description: &TestDescription,
+    _attempt: u32,
+    _failure: &TestFailure,
+  ) {
+    // Drop the failed attempt's buffered steps so they aren't reported.
+    self.pending_steps.shift_remove(&description.id);
+  }
+
+  fn report_uncaught_error(&mut self, _origin: &str, _error: Box<JsError>) {}
+
+  fn report_step_register(&mut self, _description: &TestStepDescription) {}
+  fn report_step_wait(&mut self, _description: &TestStepDescription) {}
+
+  fn report_step_result(
+    &mut self,
+    description: &TestStepDescription,
+    result: &TestStepResult,
+    elapsed: u64,
+    _tests: &IndexMap<usize, TestDescription>,
+    _test_steps: &IndexMap<usize, TestStepDescription>,
+  ) {
+    let collected = match result {
+      TestStepResult::Ok => CollectedResult {
+        status: ResultStatus::Passed,
+        duration: elapsed,
+        failure_messages: vec![],
+      },
+      TestStepResult::Ignored => CollectedResult {
+        status: ResultStatus::Skipped,
+        duration: elapsed,
+        failure_messages: vec![],
+      },
+      TestStepResult::Failed(failure) => CollectedResult {
+        status: ResultStatus::Failed,
+        duration: elapsed,
+        failure_messages: self.collect_failure(failure),
+      },
+    };
+    self
+      .pending_steps
+      .entry(description.root_id)
+      .or_default()
+      .push((description.id, collected));
+  }
+
+  fn report_summary(
+    &mut self,
+    _elapsed: &Duration,
+    _tests: &IndexMap<usize, TestDescription>,
+    _test_steps: &IndexMap<usize, TestStepDescription>,
+  ) {
+  }
+
+  fn report_sigint(
+    &mut self,
+    tests_pending: &HashSet<usize>,
+    tests: &IndexMap<usize, TestDescription>,
+    _test_steps: &IndexMap<usize, TestStepDescription>,
+  ) {
+    for id in tests_pending {
+      if let Some(description) = tests.get(id) {
+        self.report_result(description, &TestResult::Cancelled, 0);
+      }
+    }
+  }
+
+  fn report_exit(
+    &mut self,
+    _exit_code: i32,
+    tests_pending: &HashSet<usize>,
+    tests: &IndexMap<usize, TestDescription>,
+    _test_steps: &IndexMap<usize, TestStepDescription>,
+  ) {
+    for id in tests_pending {
+      if let Some(description) = tests.get(id) {
+        self.report_result(description, &TestResult::Cancelled, 0);
+      }
+    }
+  }
+
+  fn report_isolate_exit(&mut self, _origin: &str, _exit_code: i32) {}
+  fn report_completed(&mut self) {}
+
+  fn flush_report(
+    &mut self,
+    elapsed: &Duration,
+    tests: &IndexMap<usize, TestDescription>,
+    test_steps: &IndexMap<usize, TestStepDescription>,
+  ) -> anyhow::Result<()> {
+    let mut suites: IndexMap<String, JsonSuiteResult> = IndexMap::new();
+
+    for (id, collected) in &self.results {
+      let (location, ancestor_titles, title) = resolve(*id, tests, test_steps);
+      let Some(location) = location else {
+        continue;
+      };
+      let file = to_relative_path_or_remote_url(&self.cwd, &location.file_name);
+      let full_name = ancestor_titles
+        .iter()
+        .cloned()
+        .chain(std::iter::once(title.clone()))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+      let assertion = JsonAssertionResult {
+        ancestor_titles,
+        full_name,
+        title,
+        status: collected.status.as_str(),
+        duration: collected.duration,
+        failure_messages: collected.failure_messages.clone(),
+        location: JsonLocation {
+          line: location.line_number,
+          column: location.column_number,
+        },
+      };
+
+      suites
+        .entry(file.clone())
+        .or_insert_with(|| JsonSuiteResult::new(file))
+        .assertion_results
+        .push(assertion);
+    }
+
+    let mut report = JsonReport::new(self.start_time_ms, *elapsed);
+    for suite in suites.into_values() {
+      report.add_suite(suite);
+    }
+
+    let mut writer = std::io::stdout();
+    serde_json::to_writer_pretty(&mut writer, &report)?;
+    writeln!(writer)?;
+    Ok(())
+  }
+}
+
+/// Resolves the location, ancestor titles, and title for a test or step id.
+/// Returns `None` location for unknown ids (which are skipped).
+fn resolve(
+  id: usize,
+  tests: &IndexMap<usize, TestDescription>,
+  test_steps: &IndexMap<usize, TestStepDescription>,
+) -> (Option<TestLocation>, Vec<String>, String) {
+  if let Some(test) = tests.get(&id) {
+    return (Some(test.location.clone()), vec![], test.name.clone());
+  }
+  let Some(step) = test_steps.get(&id) else {
+    return (None, vec![], String::new());
+  };
+
+  let mut ancestors = VecDeque::new();
+  let mut parent = Some(step.parent_id);
+  while let Some(pid) = parent {
+    if let Some(parent_step) = test_steps.get(&pid) {
+      ancestors.push_front(parent_step.name.clone());
+      parent = Some(parent_step.parent_id);
+    } else if let Some(parent_test) = tests.get(&pid) {
+      ancestors.push_front(parent_test.name.clone());
+      parent = None;
+    } else {
+      parent = None;
+    }
+  }
+
+  (
+    Some(step.location.clone()),
+    ancestors.into(),
+    step.name.clone(),
+  )
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonReport {
+  num_total_test_suites: usize,
+  num_passed_test_suites: usize,
+  num_failed_test_suites: usize,
+  num_pending_test_suites: usize,
+  num_total_tests: usize,
+  num_passed_tests: usize,
+  num_failed_tests: usize,
+  num_pending_tests: usize,
+  num_todo_tests: usize,
+  start_time: u64,
+  success: bool,
+  was_interrupted: bool,
+  test_results: Vec<JsonSuiteResult>,
+  // Total run duration, folded into each suite's end time. Not serialized.
+  #[serde(skip)]
+  elapsed_ms: u64,
+}
+
+impl JsonReport {
+  fn new(start_time: u64, elapsed: Duration) -> Self {
+    Self {
+      num_total_test_suites: 0,
+      num_passed_test_suites: 0,
+      num_failed_test_suites: 0,
+      num_pending_test_suites: 0,
+      num_total_tests: 0,
+      num_passed_tests: 0,
+      num_failed_tests: 0,
+      num_pending_tests: 0,
+      num_todo_tests: 0,
+      start_time,
+      success: true,
+      was_interrupted: false,
+      test_results: Vec::new(),
+      elapsed_ms: elapsed.as_millis() as u64,
+    }
+  }
+
+  fn add_suite(&mut self, mut suite: JsonSuiteResult) {
+    self.num_total_test_suites += 1;
+    suite.start_time = self.start_time;
+    suite.end_time = self.start_time + self.elapsed_ms;
+
+    let mut suite_failed = false;
+    let mut failure_messages = Vec::new();
+    for assertion in &suite.assertion_results {
+      self.num_total_tests += 1;
+      match assertion.status {
+        "passed" => self.num_passed_tests += 1,
+        "failed" => {
+          self.num_failed_tests += 1;
+          suite_failed = true;
+          failure_messages.extend(assertion.failure_messages.iter().cloned());
+        }
+        _ => self.num_pending_tests += 1,
+      }
+    }
+
+    if suite_failed {
+      self.num_failed_test_suites += 1;
+      self.success = false;
+      suite.status = "failed";
+      suite.message = failure_messages.join("\n");
+    } else {
+      self.num_passed_test_suites += 1;
+    }
+
+    self.test_results.push(suite);
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonSuiteResult {
+  name: String,
+  status: &'static str,
+  start_time: u64,
+  end_time: u64,
+  message: String,
+  assertion_results: Vec<JsonAssertionResult>,
+}
+
+impl JsonSuiteResult {
+  fn new(name: String) -> Self {
+    Self {
+      name,
+      status: "passed",
+      start_time: 0,
+      end_time: 0,
+      message: String::new(),
+      assertion_results: Vec::new(),
+    }
+  }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonAssertionResult {
+  ancestor_titles: Vec<String>,
+  full_name: String,
+  title: String,
+  status: &'static str,
+  duration: u64,
+  failure_messages: Vec<String>,
+  location: JsonLocation,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonLocation {
+  line: u32,
+  column: u32,
+}

--- a/cli/tools/test/reporters/mod.rs
+++ b/cli/tools/test/reporters/mod.rs
@@ -27,6 +27,17 @@ pub trait TestReporter {
     result: &TestResult,
     elapsed: u64,
   );
+  /// Called when a test attempt failed but will be retried (`retry` option).
+  /// `attempt` is the zero-based index of the attempt that failed. This is
+  /// informational; the test's terminal result is still delivered via
+  /// [`Self::report_result`]. Defaults to a no-op.
+  fn report_retry(
+    &mut self,
+    _description: &TestDescription,
+    _attempt: u32,
+    _failure: &TestFailure,
+  ) {
+  }
   fn report_uncaught_error(&mut self, origin: &str, error: Box<JsError>);
   fn report_step_register(&mut self, description: &TestStepDescription);
   fn report_step_wait(&mut self, description: &TestStepDescription);

--- a/cli/tools/test/reporters/mod.rs
+++ b/cli/tools/test/reporters/mod.rs
@@ -5,12 +5,14 @@ use super::*;
 mod common;
 mod compound;
 mod dot;
+mod json;
 mod junit;
 mod pretty;
 mod tap;
 
 pub use compound::CompoundTestReporter;
 pub use dot::DotTestReporter;
+pub use json::JsonTestReporter;
 pub use junit::JunitTestReporter;
 pub use pretty::PrettyTestReporter;
 pub use tap::TapTestReporter;

--- a/cli/tools/test/reporters/pretty.rs
+++ b/cli/tools/test/reporters/pretty.rs
@@ -21,6 +21,12 @@ pub struct PrettyTestReporter {
   ended_tests: bool,
   child_results_buffer:
     HashMap<usize, IndexMap<usize, (TestStepDescription, TestStepResult, u64)>>,
+  /// Ids of tests that have been retried at least once, used to count flaky
+  /// tests (those that ultimately passed after a retry).
+  retried_tests: HashSet<usize>,
+  /// Step results buffered until the owning test produces a terminal result,
+  /// so a retried attempt's steps can be discarded rather than counted.
+  pending_step_tally: common::PendingStepTally,
   summary: TestSummary,
   writer: Box<dyn std::io::Write>,
   failure_format_options: TestFailureFormatOptions,
@@ -48,6 +54,8 @@ impl PrettyTestReporter {
       started_tests: false,
       ended_tests: false,
       child_results_buffer: Default::default(),
+      retried_tests: Default::default(),
+      pending_step_tally: Default::default(),
       summary: TestSummary::new(),
       writer: Box::new(std::io::stdout()),
       failure_format_options,
@@ -258,9 +266,20 @@ impl TestReporter for PrettyTestReporter {
     result: &TestResult,
     elapsed: u64,
   ) {
+    // Commit step results from the final attempt now that the test's fate is
+    // known (results from any retried attempt were already discarded).
+    common::commit_step_results(
+      &mut self.pending_step_tally,
+      &mut self.summary,
+      description.id,
+    );
+
     match &result {
       TestResult::Ok => {
         self.summary.passed += 1;
+        if self.retried_tests.contains(&description.id) {
+          self.summary.flaky += 1;
+        }
       }
       TestResult::Ignored => {
         self.summary.ignored += 1;
@@ -328,6 +347,36 @@ impl TestReporter for PrettyTestReporter {
     self.scope_test_id = None;
   }
 
+  fn report_retry(
+    &mut self,
+    description: &TestDescription,
+    attempt: u32,
+    failure: &TestFailure,
+  ) {
+    self.retried_tests.insert(description.id);
+    // Drop the failed attempt's step results so they don't count.
+    common::discard_step_results(&mut self.pending_step_tally, description.id);
+
+    if self.repl {
+      return;
+    }
+
+    self.write_output_end();
+    if self.in_new_line || self.scope_test_id != Some(description.id) {
+      self.force_report_wait(description);
+    }
+
+    writeln!(
+      &mut self.writer,
+      " {} {}",
+      colors::yellow(format!("retrying (attempt {} failed)", attempt + 1)),
+      colors::gray(format!("({})", failure.overview())),
+    )
+    .ok();
+    self.in_new_line = true;
+    self.scope_test_id = None;
+  }
+
   fn report_uncaught_error(&mut self, origin: &str, error: Box<JsError>) {
     self.summary.failed += 1;
     self
@@ -365,26 +414,13 @@ impl TestReporter for PrettyTestReporter {
     tests: &IndexMap<usize, TestDescription>,
     test_steps: &IndexMap<usize, TestStepDescription>,
   ) {
-    match &result {
-      TestStepResult::Ok => {
-        self.summary.passed_steps += 1;
-      }
-      TestStepResult::Ignored => {
-        self.summary.ignored_steps += 1;
-      }
-      TestStepResult::Failed(failure) => {
-        self.summary.failed_steps += 1;
-        self.summary.failures.push((
-          TestFailureDescription {
-            id: desc.id,
-            name: common::format_test_step_ancestry(desc, tests, test_steps),
-            origin: desc.origin.clone(),
-            location: desc.location.clone(),
-          },
-          failure.clone(),
-        ))
-      }
-    }
+    common::record_step_result(
+      &mut self.pending_step_tally,
+      desc,
+      result,
+      tests,
+      test_steps,
+    );
 
     if self.parallel {
       self.write_output_end();

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -869,6 +869,18 @@ declare namespace Deno {
      * If unset or `0`, the test runs without a deadline.
      */
     timeout?: number;
+    /** Number of times to re-run the test if it fails. The test is considered
+     * to have passed if any attempt passes. Useful for tolerating flaky tests.
+     *
+     * @default {0} */
+    retry?: number;
+    /** Number of additional times to run the test. Every repetition must pass
+     * for the test to pass. Useful for surfacing flaky tests. When combined
+     * with {@linkcode TestDefinition.retry}, each repetition may itself be
+     * retried.
+     *
+     * @default {0} */
+    repeats?: number;
   }
 
   /** Register a test which will be run when `deno test` is used on the command

--- a/tests/specs/test/json_reporter/__test__.jsonc
+++ b/tests/specs/test/json_reporter/__test__.jsonc
@@ -1,0 +1,10 @@
+{
+  "tempDir": true,
+  "tests": {
+    "basic": {
+      "args": "test --quiet --reporter=json basic.ts",
+      "exitCode": 1,
+      "output": "basic.out"
+    }
+  }
+}

--- a/tests/specs/test/json_reporter/basic.out
+++ b/tests/specs/test/json_reporter/basic.out
@@ -1,0 +1,64 @@
+{
+  "numTotalTestSuites": 1,
+  "numPassedTestSuites": 0,
+  "numFailedTestSuites": 1,
+  "numPendingTestSuites": 0,
+  "numTotalTests": 3,
+  "numPassedTests": 1,
+  "numFailedTests": 1,
+  "numPendingTests": 1,
+  "numTodoTests": 0,
+  "startTime": [WILDLINE]
+  "success": false,
+  "wasInterrupted": false,
+  "testResults": [
+    {
+      "name": "./basic.ts",
+      "status": "failed",
+      "startTime": [WILDLINE]
+      "endTime": [WILDLINE]
+      "message": [WILDLINE]
+      "assertionResults": [
+        {
+          "ancestorTitles": [],
+          "fullName": "alpha",
+          "title": "alpha",
+          "status": "passed",
+          "duration": [WILDLINE]
+          "failureMessages": [],
+          "location": {
+            "line": 1,
+            "column": 6
+          }
+        },
+        {
+          "ancestorTitles": [],
+          "fullName": "beta fails",
+          "title": "beta fails",
+          "status": "failed",
+          "duration": [WILDLINE]
+          "failureMessages": [
+[WILDLINE]
+          ],
+          "location": {
+            "line": 2,
+            "column": 6
+          }
+        },
+        {
+          "ancestorTitles": [],
+          "fullName": "gamma ignored",
+          "title": "gamma ignored",
+          "status": "skipped",
+          "duration": [WILDLINE]
+          "failureMessages": [],
+          "location": {
+            "line": 5,
+            "column": 6
+          }
+        }
+      ]
+    }
+  ]
+}
+error: Test failed

--- a/tests/specs/test/json_reporter/basic.ts
+++ b/tests/specs/test/json_reporter/basic.ts
@@ -1,0 +1,5 @@
+Deno.test("alpha", () => {});
+Deno.test("beta fails", () => {
+  throw new Error("boom");
+});
+Deno.test({ name: "gamma ignored", ignore: true, fn() {} });

--- a/tests/specs/test/retry/__test__.jsonc
+++ b/tests/specs/test/retry/__test__.jsonc
@@ -26,6 +26,11 @@
       "exitCode": 0,
       "output": "retry_steps.out"
     },
+    "cli_retry_flag": {
+      "args": "test --quiet --retry=2 cli_retry_flag.ts",
+      "exitCode": 0,
+      "output": "cli_retry_flag.out"
+    },
     "validation_negative": {
       "args": "test --quiet validation_negative.ts",
       "exitCode": 1,

--- a/tests/specs/test/retry/__test__.jsonc
+++ b/tests/specs/test/retry/__test__.jsonc
@@ -1,0 +1,35 @@
+{
+  "tempDir": true,
+  "tests": {
+    "retry_pass": {
+      "args": "test --quiet retry_pass.ts",
+      "exitCode": 0,
+      "output": "retry_pass.out"
+    },
+    "retry_exhausted": {
+      "args": "test --quiet retry_exhausted.ts",
+      "exitCode": 1,
+      "output": "retry_exhausted.out"
+    },
+    "repeats_pass": {
+      "args": "test --quiet repeats_pass.ts",
+      "exitCode": 0,
+      "output": "repeats_pass.out"
+    },
+    "repeats_fail": {
+      "args": "test --quiet repeats_fail.ts",
+      "exitCode": 1,
+      "output": "repeats_fail.out"
+    },
+    "retry_steps": {
+      "args": "test --quiet retry_steps.ts",
+      "exitCode": 0,
+      "output": "retry_steps.out"
+    },
+    "validation_negative": {
+      "args": "test --quiet validation_negative.ts",
+      "exitCode": 1,
+      "output": "validation_negative.out"
+    }
+  }
+}

--- a/tests/specs/test/retry/cli_retry_flag.out
+++ b/tests/specs/test/retry/cli_retry_flag.out
@@ -1,0 +1,6 @@
+running 1 test from ./cli_retry_flag.ts
+flaky ... retrying (attempt 1 failed) (Uncaught Error: not yet)
+flaky ... ok ([WILDCARD])
+
+ok | 1 passed | 0 failed | 1 flaky ([WILDCARD])
+

--- a/tests/specs/test/retry/cli_retry_flag.ts
+++ b/tests/specs/test/retry/cli_retry_flag.ts
@@ -1,0 +1,8 @@
+// The --retry flag provides a default retry count for tests that don't set
+// their own `retry` option.
+let attempts = 0;
+Deno.test("flaky", () => {
+  if (++attempts < 2) {
+    throw new Error("not yet");
+  }
+});

--- a/tests/specs/test/retry/repeats_fail.out
+++ b/tests/specs/test/retry/repeats_fail.out
@@ -1,0 +1,16 @@
+running 1 test from ./repeats_fail.ts
+repeated with failure ... FAILED ([WILDCARD])
+
+ ERRORS 
+
+repeated with failure => ./repeats_fail.ts:[WILDCARD]
+error: Error: second run fails
+[WILDCARD]
+
+ FAILURES 
+
+repeated with failure => ./repeats_fail.ts:[WILDCARD]
+
+FAILED | 0 passed | 1 failed ([WILDCARD])
+
+error: Test failed

--- a/tests/specs/test/retry/repeats_fail.ts
+++ b/tests/specs/test/retry/repeats_fail.ts
@@ -1,0 +1,12 @@
+// If any repetition fails, the whole test fails.
+let runs = 0;
+Deno.test({
+  name: "repeated with failure",
+  repeats: 3,
+  fn() {
+    runs++;
+    if (runs === 2) {
+      throw new Error("second run fails");
+    }
+  },
+});

--- a/tests/specs/test/retry/repeats_pass.out
+++ b/tests/specs/test/retry/repeats_pass.out
@@ -1,0 +1,5 @@
+running 1 test from ./repeats_pass.ts
+repeated ... ok ([WILDCARD])
+
+ok | 1 passed | 0 failed ([WILDCARD])
+

--- a/tests/specs/test/retry/repeats_pass.ts
+++ b/tests/specs/test/retry/repeats_pass.ts
@@ -1,0 +1,9 @@
+// A test with `repeats` runs 1 + repeats times; all repetitions pass here.
+let runs = 0;
+Deno.test({
+  name: "repeated",
+  repeats: 2,
+  fn() {
+    runs++;
+  },
+});

--- a/tests/specs/test/retry/retry_exhausted.out
+++ b/tests/specs/test/retry/retry_exhausted.out
@@ -1,0 +1,18 @@
+running 1 test from ./retry_exhausted.ts
+always fails ... retrying (attempt 1 failed) (Uncaught Error: boom)
+always fails ... retrying (attempt 2 failed) (Uncaught Error: boom)
+always fails ... FAILED ([WILDCARD])
+
+ ERRORS 
+
+always fails => ./retry_exhausted.ts:[WILDCARD]
+error: Error: boom
+[WILDCARD]
+
+ FAILURES 
+
+always fails => ./retry_exhausted.ts:[WILDCARD]
+
+FAILED | 0 passed | 1 failed ([WILDCARD])
+
+error: Test failed

--- a/tests/specs/test/retry/retry_exhausted.ts
+++ b/tests/specs/test/retry/retry_exhausted.ts
@@ -1,0 +1,8 @@
+// A test that always fails is retried until attempts are exhausted, then fails.
+Deno.test({
+  name: "always fails",
+  retry: 2,
+  fn() {
+    throw new Error("boom");
+  },
+});

--- a/tests/specs/test/retry/retry_pass.out
+++ b/tests/specs/test/retry/retry_pass.out
@@ -1,0 +1,7 @@
+running 1 test from ./retry_pass.ts
+flaky ... retrying (attempt 1 failed) (Uncaught Error: not yet)
+flaky ... retrying (attempt 2 failed) (Uncaught Error: not yet)
+flaky ... ok ([WILDCARD])
+
+ok | 1 passed | 0 failed | 1 flaky ([WILDCARD])
+

--- a/tests/specs/test/retry/retry_pass.ts
+++ b/tests/specs/test/retry/retry_pass.ts
@@ -1,0 +1,13 @@
+// A flaky test that fails twice and then passes is reported as passed and
+// counted as flaky.
+let attempts = 0;
+Deno.test({
+  name: "flaky",
+  retry: 3,
+  fn() {
+    attempts++;
+    if (attempts < 3) {
+      throw new Error("not yet");
+    }
+  },
+});

--- a/tests/specs/test/retry/retry_steps.out
+++ b/tests/specs/test/retry/retry_steps.out
@@ -1,0 +1,9 @@
+running 1 test from ./retry_steps.ts
+steps with retry ...
+  first ... ok ([WILDCARD])
+  second ... FAILED ([WILDCARD])
+steps with retry ... retrying (attempt 1 failed) (1 test step failed)
+steps with retry ... ok ([WILDCARD])
+
+ok | 1 passed (2 steps) | 0 failed | 1 flaky ([WILDCARD])
+

--- a/tests/specs/test/retry/retry_steps.ts
+++ b/tests/specs/test/retry/retry_steps.ts
@@ -1,0 +1,15 @@
+// A test using steps is re-invoked on retry; its steps must run cleanly again.
+let attempts = 0;
+Deno.test({
+  name: "steps with retry",
+  retry: 2,
+  fn: async (t) => {
+    attempts++;
+    await t.step("first", () => {});
+    await t.step("second", () => {
+      if (attempts < 2) {
+        throw new Error("step fails first time");
+      }
+    });
+  },
+});

--- a/tests/specs/test/retry/validation_negative.out
+++ b/tests/specs/test/retry/validation_negative.out
@@ -1,0 +1,1 @@
+[WILDCARD]TypeError: Test retry must be a non-negative integer[WILDCARD]

--- a/tests/specs/test/retry/validation_negative.ts
+++ b/tests/specs/test/retry/validation_negative.ts
@@ -1,0 +1,6 @@
+// Negative retry/repeats values must be rejected at registration time.
+Deno.test({
+  name: "should never run",
+  retry: -1,
+  fn() {},
+});


### PR DESCRIPTION
Tooling that ingests test results (CI dashboards, flaky-test trackers, IDE
integrations) commonly expects the JSON shape produced by Jest's and Vitest's
`json` reporter. `deno test` had no machine-readable reporter in that format,
which made it harder to drop Deno into pipelines built around those runners.

This adds `--reporter=json`, which buffers the run and writes a single JSON
document to stdout modelled on that shape: top-level counts (numTotalTests,
numPassedTests, ...), a `testResults` entry per file, and an `assertionResult`
per test and per step with `ancestorTitles`, `fullName`, `status`, `duration`,
`failureMessages`, and `location`. Like the other non-streaming reporters it
suppresses the normal progress output so stdout carries only the document.

This is stacked on the retry/repeats branch so it can reuse the `report_retry`
hook: step results from a retried attempt are buffered and discarded if the
test is retried, so a flaky test that ultimately passes doesn't leave phantom
failed assertions in the output. Retries themselves are not surfaced in the
JSON (only the final outcome), and Deno's per-file grouping means each file is
one "test suite" rather than each top-level test.