### PR TITLE
feat(test): add --shard flag to split a test run across machines

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -636,6 +636,9 @@ pub struct TestFlags {
   pub permit_no_files: bool,
   pub filter: Option<String>,
   pub shuffle: Option<u64>,
+  /// Run only a subset of test files, as `(index, count)` with a 1-based
+  /// index. Used to split a run across machines, e.g. `--shard=2/3`.
+  pub shard: Option<(usize, usize)>,
   pub trace_leaks: bool,
   pub sanitize_ops: bool,
   pub sanitize_resources: bool,
@@ -4786,6 +4789,26 @@ fn complete_available_tasks() -> Vec<CompletionCandidate> {
   }
 }
 
+/// Parses a `--shard` value of the form `<index>/<count>` (1-based index).
+fn parse_test_shard(value: &str) -> Result<(usize, usize), String> {
+  let (index, count) = value.split_once('/').ok_or_else(|| {
+    format!("expected format <index>/<count>, but got '{value}'")
+  })?;
+  let index: usize = index
+    .parse()
+    .map_err(|_| format!("invalid shard index '{index}'"))?;
+  let count: usize = count
+    .parse()
+    .map_err(|_| format!("invalid shard count '{count}'"))?;
+  if count == 0 {
+    return Err("shard count must be greater than 0".to_string());
+  }
+  if index == 0 || index > count {
+    return Err(format!("shard index must be between 1 and {count}"));
+  }
+  Ok((index, count))
+}
+
 fn test_subcommand() -> Command {
   command("test",
       cstr!("Run tests using Deno's built-in test runner.
@@ -4873,6 +4896,16 @@ or <c>**/__tests__/**</>:
           .num_args(0..=1)
           .require_equals(true)
           .value_parser(value_parser!(u64))
+          .help_heading(TEST_HEADING),
+      )
+      .arg(
+        Arg::new("shard")
+          .long("shard")
+          .value_name("INDEX/COUNT")
+          .help(cstr!("Run only the test files for shard INDEX of COUNT, e.g. --shard=2/3.
+  <p(245)>The discovered test files are sorted and split into COUNT consecutive groups; INDEX is 1-based. Useful for splitting a run across machines.</>"))
+          .require_equals(true)
+          .value_parser(parse_test_shard)
           .help_heading(TEST_HEADING),
       )
       .arg(
@@ -8353,6 +8386,7 @@ fn test_parse(
     files: FileFlags { include, ignore },
     filter,
     shuffle,
+    shard: matches.remove_one::<(usize, usize)>("shard"),
     permit_no_files: permit_no_files_parse(matches),
     parallel: matches.get_flag("parallel"),
     trace_leaks,
@@ -12772,6 +12806,7 @@ mod tests {
             ignore: vec![],
           },
           shuffle: None,
+          shard: None,
           parallel: false,
           trace_leaks: true,
           sanitize_ops: false,
@@ -12877,6 +12912,7 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          shard: None,
           files: FileFlags {
             include: vec![],
             ignore: vec![],
@@ -12923,6 +12959,7 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          shard: None,
           files: FileFlags {
             include: vec![],
             ignore: vec![],
@@ -13063,6 +13100,7 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: Some(1),
+          shard: None,
           files: FileFlags {
             include: vec![],
             ignore: vec![],
@@ -13090,6 +13128,25 @@ mod tests {
   }
 
   #[test]
+  fn test_shard() {
+    let r = flags_from_vec(svec!["deno", "test", "--shard=2/3"]);
+    let flags = r.unwrap();
+    assert!(matches!(
+      flags.subcommand,
+      DenoSubcommand::Test(TestFlags {
+        shard: Some((2, 3)),
+        ..
+      })
+    ));
+
+    // Invalid shard values are rejected at parse time.
+    assert!(flags_from_vec(svec!["deno", "test", "--shard=3/2"]).is_err());
+    assert!(flags_from_vec(svec!["deno", "test", "--shard=0/2"]).is_err());
+    assert!(flags_from_vec(svec!["deno", "test", "--shard=1/0"]).is_err());
+    assert!(flags_from_vec(svec!["deno", "test", "--shard=foo"]).is_err());
+  }
+
+  #[test]
   fn test_watch() {
     let r = flags_from_vec(svec!["deno", "test", "--watch"]);
     assert_eq!(
@@ -13102,6 +13159,7 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          shard: None,
           files: FileFlags {
             include: vec![],
             ignore: vec![],
@@ -13140,6 +13198,7 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          shard: None,
           files: FileFlags {
             include: vec!["./".to_string()],
             ignore: vec![],
@@ -13180,6 +13239,7 @@ mod tests {
           filter: None,
           permit_no_files: false,
           shuffle: None,
+          shard: None,
           files: FileFlags {
             include: vec![],
             ignore: vec![],

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -202,6 +202,7 @@ pub struct WorkspaceTestOptions {
   pub permit_no_files: bool,
   pub filter: Option<String>,
   pub shuffle: Option<u64>,
+  pub shard: Option<(usize, usize)>,
   pub concurrent_jobs: NonZeroUsize,
   pub trace_leaks: bool,
   pub sanitize_ops: bool,
@@ -234,6 +235,7 @@ impl WorkspaceTestOptions {
       filter: test_flags.filter.clone(),
       no_run: test_flags.no_run,
       shuffle: test_flags.shuffle,
+      shard: test_flags.shard,
       trace_leaks: test_flags.trace_leaks,
       sanitize_ops: test_flags.sanitize_ops
         || std::env::var("DENO_TEST_SANITIZE_OPS").ok().as_deref() == Some("1")

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -602,6 +602,9 @@ struct TestSpecifiersOptions {
   reporter: TestReporterConfig,
   junit_path: Option<String>,
   hide_stacktraces: bool,
+  /// `(index, count)` with a 1-based index, from `--shard`. Selects a subset
+  /// of test files so a run can be split across machines.
+  shard: Option<(usize, usize)>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -1471,6 +1474,24 @@ async fn run_tests_for_worker_inner(
 static HAS_TEST_RUN_SIGINT_HANDLER: AtomicBool = AtomicBool::new(false);
 
 /// Test a collection of specifiers with test modes concurrently.
+/// Selects the test files belonging to shard `index` of `count` (1-based).
+/// The files are sorted for a stable order, then split into `count`
+/// consecutive, balanced groups. Assumes `1 <= index <= count` (validated at
+/// flag-parse time).
+fn shard_specifiers(
+  mut specifiers: Vec<ModuleSpecifier>,
+  index: usize,
+  count: usize,
+) -> Vec<ModuleSpecifier> {
+  specifiers.sort();
+  let total = specifiers.len();
+  // Balanced split: shard i covers [total*(i-1)/count, total*i/count). This
+  // partitions every file into exactly one shard with sizes differing by <= 1.
+  let start = total * (index - 1) / count;
+  let end = total * index / count;
+  specifiers.into_iter().take(end).skip(start).collect()
+}
+
 async fn test_specifiers(
   worker_factory: Arc<CliMainWorkerFactory>,
   cli_options: &Arc<CliOptions>,
@@ -1480,6 +1501,14 @@ async fn test_specifiers(
   require_modules: Vec<ModuleSpecifier>,
   options: TestSpecifiersOptions,
 ) -> Result<(), AnyError> {
+  // Select this shard's files first (on a stable sorted order) so the split is
+  // deterministic across machines regardless of any later shuffling.
+  let specifiers = if let Some((index, count)) = options.shard {
+    shard_specifiers(specifiers, index, count)
+  } else {
+    specifiers
+  };
+
   let specifiers = if let Some(seed) = options.specifier.shuffle {
     let mut rng = SmallRng::seed_from_u64(seed);
     let mut specifiers = specifiers;
@@ -1973,6 +2002,7 @@ pub async fn run_tests(
       reporter: workspace_test_options.reporter,
       junit_path: workspace_test_options.junit_path,
       hide_stacktraces: workspace_test_options.hide_stacktraces,
+      shard: workspace_test_options.shard,
       specifier: TestSpecifierOptions {
         filter: TestFilter::from_flag(&workspace_test_options.filter),
         shuffle: workspace_test_options.shuffle,
@@ -2223,6 +2253,7 @@ pub async fn run_tests_with_watch(
             reporter: workspace_test_options.reporter,
             junit_path: workspace_test_options.junit_path,
             hide_stacktraces: workspace_test_options.hide_stacktraces,
+            shard: workspace_test_options.shard,
             specifier: TestSpecifierOptions {
               filter: TestFilter::from_flag(&workspace_test_options.filter),
               shuffle: workspace_test_options.shuffle,

--- a/tests/specs/test/shard/__test__.jsonc
+++ b/tests/specs/test/shard/__test__.jsonc
@@ -13,6 +13,10 @@
       "args": "test --quiet --shard=1/1",
       "output": "shard_all.out"
     },
+    "shard_more_than_files": {
+      "args": "test --quiet --shard=1/5",
+      "output": "shard_empty.out"
+    },
     "invalid_shard_index": {
       "args": "test --shard=3/2 a.test.ts",
       "output": "invalid.out",

--- a/tests/specs/test/shard/__test__.jsonc
+++ b/tests/specs/test/shard/__test__.jsonc
@@ -1,0 +1,22 @@
+{
+  "tempDir": true,
+  "tests": {
+    "shard_1_of_2": {
+      "args": "test --quiet --shard=1/2",
+      "output": "shard1.out"
+    },
+    "shard_2_of_2": {
+      "args": "test --quiet --shard=2/2",
+      "output": "shard2.out"
+    },
+    "shard_all_in_one": {
+      "args": "test --quiet --shard=1/1",
+      "output": "shard_all.out"
+    },
+    "invalid_shard_index": {
+      "args": "test --shard=3/2 a.test.ts",
+      "output": "invalid.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/test/shard/a.test.ts
+++ b/tests/specs/test/shard/a.test.ts
@@ -1,0 +1,1 @@
+Deno.test("test_a", () => {});

--- a/tests/specs/test/shard/b.test.ts
+++ b/tests/specs/test/shard/b.test.ts
@@ -1,0 +1,1 @@
+Deno.test("test_b", () => {});

--- a/tests/specs/test/shard/c.test.ts
+++ b/tests/specs/test/shard/c.test.ts
@@ -1,0 +1,1 @@
+Deno.test("test_c", () => {});

--- a/tests/specs/test/shard/d.test.ts
+++ b/tests/specs/test/shard/d.test.ts
@@ -1,0 +1,1 @@
+Deno.test("test_d", () => {});

--- a/tests/specs/test/shard/invalid.out
+++ b/tests/specs/test/shard/invalid.out
@@ -1,0 +1,1 @@
+error: invalid value '3/2' for '--shard=<INDEX/COUNT>': shard index must be between 1 and 2[WILDCARD]

--- a/tests/specs/test/shard/shard1.out
+++ b/tests/specs/test/shard/shard1.out
@@ -1,0 +1,7 @@
+running 1 test from ./a.test.ts
+test_a ... ok ([WILDCARD])
+running 1 test from ./b.test.ts
+test_b ... ok ([WILDCARD])
+
+ok | 2 passed | 0 failed ([WILDCARD])
+

--- a/tests/specs/test/shard/shard2.out
+++ b/tests/specs/test/shard/shard2.out
@@ -1,0 +1,7 @@
+running 1 test from ./c.test.ts
+test_c ... ok ([WILDCARD])
+running 1 test from ./d.test.ts
+test_d ... ok ([WILDCARD])
+
+ok | 2 passed | 0 failed ([WILDCARD])
+

--- a/tests/specs/test/shard/shard_all.out
+++ b/tests/specs/test/shard/shard_all.out
@@ -1,0 +1,2 @@
+[WILDCARD]ok | 4 passed | 0 failed ([WILDCARD])
+

--- a/tests/specs/test/shard/shard_empty.out
+++ b/tests/specs/test/shard/shard_empty.out
@@ -1,0 +1,2 @@
+[WILDCARD]ok | 0 passed | 0 failed ([WILDCARD])
+


### PR DESCRIPTION
Large test suites are commonly split across CI machines, which Vitest, Jest,
and Playwright all support with a `--shard` flag. `deno test` had no
equivalent, so the whole suite had to run on one machine.

This adds `deno test --shard=<index>/<count>` (1-based index). The discovered
test files are sorted for a stable order, then split into `<count>`
consecutive, balanced groups, and only the files for `<index>` are run. Every
file lands in exactly one shard and group sizes differ by at most one. The
selection happens before any `--shuffle`, so a given shard runs the same files
on every machine regardless of the shuffle seed. Invalid values
(`index > count`, `index` or `count` of 0, missing `/`) are rejected at
flag-parse time.

Sharding is a pre-filter on the discovered file list, independent of how files
are executed, so it composes cleanly with filtering and any future test-runner
isolation/pooling changes.

Over-sharding is intentionally lenient: if `count` exceeds the number of
discovered files, the empty shards run zero tests and exit successfully rather
than erroring. This is the behavior that fixed-shard-count CI setups want
(Vitest instead errors and requires `--passWithNoTests`).

For now the shard is selected at run time, after the module graph for the full
suite has already been built and type-checked, so every machine still pays the
graph-build and type-check cost for the whole suite and only test execution is
parallelized. Moving the shard pre-filter ahead of type-checking, so each
machine only loads and checks its own subset, is a natural follow-up.

This intentionally does not include cross-shard result merging (a combined
summary across shards); each shard reports its own subset and fails its own CI
job, and a merge step pairs naturally with the json reporter as a follow-up.
