### PR TITLE
fix(permissions): correct -A wording in raw-mode prompt message

### DIFF
--- a/runtime/permissions/prompter.rs
+++ b/runtime/permissions/prompter.rs
@@ -413,7 +413,7 @@ impl PermissionPrompter for TtyPrompter {
         escape_control_characters(message)
       );
       eprintln!(
-        "❌ Run again with --allow-{} to grant the permission up front, or with -A to skip all prompts.",
+        "❌ Run again with --allow-{} to grant the permission up front, or with -A to allow all permissions.",
         escape_control_characters(name)
       );
       return PromptResponse::Deny;


### PR DESCRIPTION
Follow-up to #34457, addressing review feedback in
https://github.com/denoland/deno/pull/34457#issuecomment-4659343472.

The raw-mode prompt-deny message told users to rerun "with -A to skip all
prompts", but -A grants all permissions rather than skipping prompts. This
changes the wording to "with -A to allow all permissions" so it matches what
the flag actually does.

The same comment also asked to sanity-check that no interactive path holds raw
mode across a permission request, since the new detection denies instead of
prompting when stdin is raw. The REPL is fine: read_line_and_poll runs
editor.readline() (rustyline) to completion before evaluate_line_and_get_output
runs (cli/tools/repl/mod.rs), and rustyline restores the terminal to its
original cooked mode when readline() returns. So a permission prompt triggered
during evaluation sees cooked mode and prompts normally. The only way raw mode
persists across a check is user code calling Deno.stdin.setRaw(true) without
resetting it before the same line triggers a permission request, which is the
correct case to deny (a line-based prompt cannot function in raw mode anyway).
No code change is needed for that.