### PR TITLE
fix(ext/http): join split request headers consistently

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -656,6 +656,14 @@ fn split_authority(authority: &str) -> (&str, Option<u16>) {
   (address, Some(port))
 }
 
+fn request_header_value_separator(name: &[u8]) -> &'static [u8] {
+  if name.eq_ignore_ascii_case(COOKIE.as_ref()) {
+    b"; "
+  } else {
+    b", "
+  }
+}
+
 fn raw_request_header_to_v8<'scope>(
   scope: &mut v8::PinScope<'scope, '_>,
   headers: &RawRequestHeaders,
@@ -672,11 +680,7 @@ fn raw_request_header_to_v8<'scope>(
     .unwrap()
     .into();
   }
-  let separator = if name.eq_ignore_ascii_case(b"cookie") {
-    b"; ".as_slice()
-  } else {
-    b", ".as_slice()
-  };
+  let separator = request_header_value_separator(name);
   let mut first = None::<&[u8]>;
   let mut out = None::<Vec<u8>>;
   for header in headers.iter() {
@@ -2134,6 +2138,7 @@ pub fn op_http_get_request_header<'scope>(
       let Ok(name) = HeaderName::from_bytes(&name) else {
         return v8::null(scope).into();
       };
+      let separator = request_header_value_separator(name.as_ref());
       let request_parts = http.request_parts();
       let mut values = request_parts.headers.get_all(name).iter();
       let Some(first) = values.next() else {
@@ -2148,12 +2153,14 @@ pub fn op_http_get_request_header<'scope>(
         .unwrap()
         .into();
       };
-      let mut value = Vec::with_capacity(first.as_bytes().len() + 2);
+      let mut value = Vec::with_capacity(
+        first.as_bytes().len() + separator.len() + next.as_bytes().len(),
+      );
       value.extend_from_slice(first.as_bytes());
-      value.extend_from_slice(b", ");
+      value.extend_from_slice(separator);
       value.extend_from_slice(next.as_bytes());
       for next in values {
-        value.extend_from_slice(b", ");
+        value.extend_from_slice(separator);
         value.extend_from_slice(next.as_bytes());
       }
       v8::String::new_from_one_byte(scope, &value, v8::NewStringType::Normal)
@@ -2221,7 +2228,9 @@ pub fn op_http_get_request_headers<'scope>(
       vec.push(
         v8::String::new_from_one_byte(
           scope,
-          cookies.join(b"; ".as_slice()).as_ref(),
+          cookies
+            .join(request_header_value_separator(COOKIE.as_ref()))
+            .as_ref(),
           v8::NewStringType::Normal,
         )
         .unwrap()
@@ -2274,8 +2283,6 @@ pub fn op_http_get_request_headers<'scope>(
   // semicolons.
   // TODO(mmastrac): This should probably happen on the JS side on-demand
   if let Some(cookies) = cookies {
-    let cookie_sep = "; ".as_bytes();
-
     vec.push(
       v8::String::new_external_onebyte_static(scope, COOKIE.as_ref())
         .unwrap()
@@ -2284,7 +2291,9 @@ pub fn op_http_get_request_headers<'scope>(
     vec.push(
       v8::String::new_from_one_byte(
         scope,
-        cookies.join(cookie_sep).as_ref(),
+        cookies
+          .join(request_header_value_separator(COOKIE.as_ref()))
+          .as_ref(),
         v8::NewStringType::Normal,
       )
       .unwrap()

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -2280,6 +2280,135 @@ Deno.test(
   },
 );
 
+type SplitHeaderResult = {
+  cookieGet: string | null;
+  cookieIter: string | undefined;
+  xTestGet: string | null;
+  xTestIter: string | undefined;
+};
+
+const expectedSplitHeaderResult = {
+  cookieGet: "a=1; b=2",
+  cookieIter: "a=1; b=2",
+  xTestGet: "one, two",
+  xTestIter: "one, two",
+} as const;
+
+function readSplitHeaders(req: Request): SplitHeaderResult {
+  const iterHeaders = new Map(req.headers);
+  return {
+    cookieGet: req.headers.get("cookie"),
+    cookieIter: iterHeaders.get("cookie"),
+    xTestGet: req.headers.get("x-test"),
+    xTestIter: iterHeaders.get("x-test"),
+  };
+}
+
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerHttp1SplitHeaderConcatenation() {
+    const ac = new AbortController();
+    const listening = Promise.withResolvers<void>();
+    const headers = Promise.withResolvers<SplitHeaderResult>();
+
+    await using server = Deno.serve({
+      port: servePort,
+      signal: ac.signal,
+      onListen: onListen(listening.resolve),
+      handler: (req) => {
+        headers.resolve(readSplitHeaders(req));
+        return new Response("ok");
+      },
+    });
+    await listening.promise;
+
+    const conn = await Deno.connect({ port: servePort });
+    const encoder = new TextEncoder();
+    await writeAll(
+      conn,
+      encoder.encode(
+        `GET / HTTP/1.1\r\nHost: localhost:${servePort}\r\nCookie: a=1\r\nCookie: b=2\r\nX-Test: one\r\nX-Test: two\r\nConnection: close\r\n\r\n`,
+      ),
+    );
+
+    assertEquals(await headers.promise, expectedSplitHeaderResult);
+
+    conn.close();
+    ac.abort();
+    await server.finished;
+  },
+);
+
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerHttp2SplitHeaderConcatenation() {
+    const ac = new AbortController();
+    const listening = Promise.withResolvers<void>();
+    const headers = Promise.withResolvers<SplitHeaderResult>();
+
+    await using server = Deno.serve({
+      port: servePort,
+      signal: ac.signal,
+      onListen: onListen(listening.resolve),
+      handler: (req) => {
+        headers.resolve(readSplitHeaders(req));
+        return new Response("ok");
+      },
+    });
+    await listening.promise;
+
+    const conn = await Deno.connect({ port: servePort });
+    const encoder = new TextEncoder();
+
+    await writeAll(conn, encoder.encode("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"));
+    await writeAll(conn, new Uint8Array([0, 0, 0, 4, 0, 0, 0, 0, 0]));
+
+    const literalHeader = (name: string, value: string): number[] => {
+      const encodedName = encoder.encode(name);
+      const encodedValue = encoder.encode(value);
+      return [
+        0x00,
+        encodedName.length,
+        ...encodedName,
+        encodedValue.length,
+        ...encodedValue,
+      ];
+    };
+    const block = [
+      ...literalHeader(":method", "GET"),
+      ...literalHeader(":path", "/"),
+      ...literalHeader(":scheme", "http"),
+      ...literalHeader(":authority", `localhost:${servePort}`),
+      ...literalHeader("cookie", "a=1"),
+      ...literalHeader("cookie", "b=2"),
+      ...literalHeader("x-test", "one"),
+      ...literalHeader("x-test", "two"),
+    ];
+    const len = block.length;
+    await writeAll(
+      conn,
+      new Uint8Array([
+        (len >> 16) & 0xff,
+        (len >> 8) & 0xff,
+        len & 0xff,
+        0x01, // HEADERS
+        0x05, // END_STREAM | END_HEADERS
+        0,
+        0,
+        0,
+        1,
+        ...block,
+      ]),
+    );
+
+    assertEquals(await headers.promise, expectedSplitHeaderResult);
+
+    conn.close();
+    ac.abort();
+    await server.finished;
+  },
+);
+
 // https://github.com/denoland/deno/issues/12741
 // https://github.com/denoland/deno/pull/12746
 // https://github.com/denoland/deno/pull/12798


### PR DESCRIPTION
Browsers can send split `Cookie` fields over HTTP/2. Deno already joined cookies with `"; "` for bulk request-header exposure and the raw backend, but the hyper-backed single-header getter used the generic `", "` separator. That made `req.headers.get("cookie")` disagree with iteration and broke cookie parsing for frameworks that read cookies through `get()`.

This change centralizes request-header value separator selection, applies it to the hyper single-header getter, and keeps the raw and bulk paths on the same rule. It also adds raw HTTP/1 and raw HTTP/2 tests that send physically split `Cookie` and generic `X-Test` fields, then assert both `headers.get()` and header iteration produce consistent combined values.

Validation:

```sh
deno run --allow-read --allow-write --allow-run --allow-net ./tools/format.js
cargo build -p deno --bin deno
./target/debug/deno test --config tests/config/deno.json --no-lock --allow-all --location=http://js-unit-tests/foo/bar --filter httpServerHttp1SplitHeaderConcatenation tests/unit/serve_test.ts
./target/debug/deno test --config tests/config/deno.json --no-lock --allow-all --location=http://js-unit-tests/foo/bar --filter httpServerHttp2SplitHeaderConcatenation tests/unit/serve_test.ts
```