### PR TITLE
fix(ext/node): support HTTP/2 on the DENO_SERVE_ADDRESS override listener

### DIFF
--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -1587,14 +1587,17 @@ Server.prototype.closeIdleConnections = function closeIdleConnections() {
 };
 
 export {
+  applyAddressOverride,
   connectionListener as _connectionListener,
   httpServerPreClose,
   kConnectionsCheckingInterval,
   kIncomingMessage,
   kServerResponse,
+  notifyAddressOverrideServing,
   Server,
   ServerResponse,
   setupConnectionsTracking,
+  startOverrideListener,
   STATUS_CODES,
   storeHTTPOptions,
 };

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -16,7 +16,9 @@ const {
   ArrayPrototypeUnshift,
   ArrayBuffer,
   ArrayBufferIsView,
+  ArrayPrototypeSlice,
   Error,
+  FunctionPrototypeApply,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
   MathMin,
@@ -67,9 +69,12 @@ const http = lazyHttp().default;
 const { AsyncResource } = core.loadExtScript("ext:deno_node/async_hooks.ts");
 const {
   _connectionListener: httpConnectionListener,
+  applyAddressOverride,
   httpServerPreClose,
   kIncomingMessage,
   kServerResponse,
+  notifyAddressOverrideServing,
+  startOverrideListener,
   Server: HttpServer,
   setupConnectionsTracking,
   STATUS_CODES,
@@ -5190,6 +5195,57 @@ class Http2Server extends net.Server {
     http2ServerOnCaptureRejection(net.Server, this, err, event, args);
   }
 }
+
+// Applies the DENO_SERVE_ADDRESS override before delegating to
+// net.Server.prototype.listen, like node:http's Server.listen does.
+//
+// Connections accepted from the override listener carry the sniffed
+// protocol as `socket.alpnProtocol`, so `connectionListener` performs the
+// same h2 / http1.1 routing it would for a TLS+ALPN connection. HTTP/2
+// stays HTTP/2 end-to-end (native trailers and flow control).
+Http2Server.prototype.listen = function listen(...args) {
+  const applied = applyAddressOverride();
+
+  switch (applied.mode) {
+    case "none":
+      return FunctionPrototypeApply(net.Server.prototype.listen, this, args);
+
+    case "tcp": {
+      let cb;
+      const last = args[args.length - 1];
+      if (typeof last === "function") {
+        cb = last;
+        args = ArrayPrototypeSlice(args, 0, -1);
+      }
+      const rewritten = [{ host: applied.host, port: applied.port }];
+      if (cb) ArrayPrototypePush(rewritten, cb);
+      this.once("listening", notifyAddressOverrideServing);
+      return FunctionPrototypeApply(
+        net.Server.prototype.listen,
+        this,
+        rewritten,
+      );
+    }
+
+    case "override-only": {
+      const last = args[args.length - 1];
+      if (typeof last === "function") this.once("listening", last);
+      this._handle = {
+        close() {},
+        ref() {},
+        unref() {},
+      };
+      startOverrideListener(this, applied.override, connectionListener, true);
+      process.nextTick(() => this.emit("listening"));
+      return this;
+    }
+
+    case "duplicate": {
+      startOverrideListener(this, applied.override, connectionListener, true);
+      return FunctionPrototypeApply(net.Server.prototype.listen, this, args);
+    }
+  }
+};
 
 function createSecureServer(options, handler) {
   return new Http2SecureServer(options, handler);

--- a/ext/node/polyfills/internal/http/address_override.js
+++ b/ext/node/polyfills/internal/http/address_override.js
@@ -400,9 +400,12 @@ function h2ShadowServer(server) {
     // The target server's listeners were written for node:http requests:
     // hide the HTTP/2 pseudo-headers (frameworks commonly copy req.headers
     // into a web Headers object, which rejects ":"-prefixed names) and
-    // synthesize the host header an HTTP/1.1 request would carry. The
-    // internal headers object is left untouched -- req.method / req.url
-    // read the pseudo-headers from it.
+    // synthesize the host header an HTTP/1.1 request would carry. Hiding
+    // them from the public `req.headers` view below is safe because
+    // Http2ServerRequest.method / .url read `:method` / `:path` straight
+    // from the internal kHeaders object (see internal/http2/compat.js), not
+    // through the `headers` getter we override -- so the internal object is
+    // left untouched and those accessors keep working.
     const headers = req.headers;
     // Note: a plain Object.prototype-backed object and settable
     // properties, matching the http1 IncomingMessage the listener was
@@ -410,7 +413,22 @@ function h2ShadowServer(server) {
     // req.headers.hasOwnProperty()).
     let headersView = {};
     for (const name in headers) {
-      if (name[0] !== ":") headersView[name] = headers[name];
+      if (name[0] === ":") continue;
+      if (name === "__proto__") {
+        // `headersView[name] = ...` would hit Object.prototype's `__proto__`
+        // setter and silently drop the header, leaving it present in
+        // rawHeaders but missing from headers. Define a real own property so
+        // the two views stay consistent.
+        ObjectDefineProperty(headersView, name, {
+          __proto__: null,
+          value: headers[name],
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
+      } else {
+        headersView[name] = headers[name];
+      }
     }
     if (
       headersView.host === undefined && headers[":authority"] !== undefined

--- a/ext/node/polyfills/internal/http/address_override.js
+++ b/ext/node/polyfills/internal/http/address_override.js
@@ -24,20 +24,29 @@ import {
 
 import { Buffer } from "node:buffer";
 import { Duplex } from "node:stream";
+import { clearTimeout, setTimeout } from "node:timers";
 
 const {
+  ArrayPrototypePush,
   Error,
   FunctionPrototypeCall,
+  ObjectDefineProperty,
   Number,
   Promise,
+  PromisePrototypeCatch,
   PromisePrototypeThen,
+  SafePromiseRace,
   Symbol,
   SymbolAsyncIterator,
+  TypedArrayPrototypeSubarray,
   Uint8Array,
 } = primordials;
 
 const { nextTick } = core.loadExtScript("ext:deno_node/_next_tick.ts");
 const { listen: denoListen } = core.loadExtScript("ext:deno_net/01_net.js");
+const { ERR_SOCKET_CLOSED } = core.loadExtScript(
+  "ext:deno_node/internal/errors.ts",
+);
 
 // Has the process-global override been consumed by some server yet?
 let addressOverrideConsumed = false;
@@ -94,11 +103,15 @@ function overrideToListenArgs(override) {
 class OverrideSocket extends Duplex {
   #conn;
   #closed = false;
+  #initialChunk = null;
   #readBuf = new Uint8Array(64 * 1024);
   #timeoutMsecs = 0;
   #timeoutTimer = null;
   // Node's HTTP server uses these directly.
   isDenoServeAddressOverride = true;
+  // Set by the alpn-routing dispatch (node:http2 servers) to the sniffed
+  // protocol, mirroring what a TLS socket would report.
+  alpnProtocol = undefined;
   _paused = false;
   server = null;
   parser = null;
@@ -108,9 +121,10 @@ class OverrideSocket extends Duplex {
   remotePort = null;
   remoteFamily = null;
 
-  constructor(conn) {
+  constructor(conn, initialChunk) {
     super({ allowHalfOpen: true });
     this.#conn = conn;
+    this.#initialChunk = initialChunk;
 
     const remote = conn.remoteAddr;
     if (remote && remote.transport === "tcp") {
@@ -139,6 +153,19 @@ class OverrideSocket extends Duplex {
 
   async #readLoop() {
     try {
+      if (this.#initialChunk !== null && this.#initialChunk.length > 0) {
+        const chunk = Buffer.from(this.#initialChunk);
+        this.#initialChunk = null;
+        // deno-lint-ignore prefer-primordials
+        if (!this.push(chunk)) {
+          await new Promise((resolve) => {
+            this._readResume = resolve;
+          });
+          this._readResume = null;
+        }
+      } else {
+        this.#initialChunk = null;
+      }
       while (!this.#closed) {
         let n;
         try {
@@ -180,13 +207,29 @@ class OverrideSocket extends Duplex {
     }
   }
 
+  // Deno.Conn.write() is a single syscall-like write: it may write fewer
+  // bytes than provided (e.g. when the transport send buffer is full --
+  // vsock buffers are 64 KiB). Loop until the whole chunk is flushed.
+  async #writeAll(bytes) {
+    let nwritten = await this.#conn.write(bytes);
+    while (nwritten < bytes.length) {
+      const n = await this.#conn.write(
+        TypedArrayPrototypeSubarray(bytes, nwritten, bytes.length),
+      );
+      if (n === 0) {
+        throw new ERR_SOCKET_CLOSED();
+      }
+      nwritten += n;
+    }
+  }
+
   _write(chunk, encoding, callback) {
     const bytes = typeof chunk === "string"
       ? Buffer.from(chunk, encoding)
       : chunk;
     // Any outgoing byte resets the idle timer too, matching net.Socket.
     this.#armTimer();
-    PromisePrototypeThen(this.#conn.write(bytes), () => callback(), callback);
+    PromisePrototypeThen(this.#writeAll(bytes), () => callback(), callback);
   }
 
   _final(callback) {
@@ -261,13 +304,195 @@ class OverrideSocket extends Duplex {
   }
 }
 
+// The HTTP/2 client connection preface: "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".
+// Control planes (e.g. Deno Deploy's deployd) forward HTTP/2 requests to the
+// override listener with prior knowledge, so node:http servers must accept
+// both HTTP/1.1 and HTTP/2 connections here, like Deno.serve() does.
+// deno-fmt-ignore
+const H2_PREFACE = [
+  0x50, 0x52, 0x49, 0x20, 0x2a, 0x20, 0x48, 0x54, 0x54, 0x50, 0x2f, 0x32,
+  0x2e, 0x30, 0x0d, 0x0a, 0x0d, 0x0a, 0x53, 0x4d, 0x0d, 0x0a, 0x0d, 0x0a,
+];
+
+// How long a freshly accepted connection may take to send enough bytes to
+// identify its protocol before it is dropped. The node server's own header
+// timeouts only start once the connection is handed to it, so this guards
+// the sniffing window against connections that never send anything.
+const SNIFF_TIMEOUT_MS = 60_000;
+
+// Reads just enough of the connection to decide whether the client is
+// speaking HTTP/2 (prior knowledge) or HTTP/1.x. Never reads past the
+// 24-byte HTTP/2 preface. Returns the consumed bytes so the HTTP/1.x
+// path can replay them into the parser. Throws on timeout.
+async function sniffConnection(conn) {
+  const buf = new Uint8Array(H2_PREFACE.length);
+  let filled = 0;
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("protocol sniffing timed out")),
+      SNIFF_TIMEOUT_MS,
+    );
+  });
+  try {
+    while (filled < H2_PREFACE.length) {
+      let n;
+      try {
+        n = await SafePromiseRace([
+          conn.read(TypedArrayPrototypeSubarray(buf, filled)),
+          timeout,
+        ]);
+      } catch (err) {
+        if (err?.message === "protocol sniffing timed out") throw err;
+        return {
+          isH2: false,
+          initial: TypedArrayPrototypeSubarray(buf, 0, filled),
+        };
+      }
+      if (n === null) {
+        return {
+          isH2: false,
+          initial: TypedArrayPrototypeSubarray(buf, 0, filled),
+        };
+      }
+      for (let i = filled; i < filled + n; i++) {
+        if (buf[i] !== H2_PREFACE[i]) {
+          return {
+            isH2: false,
+            initial: TypedArrayPrototypeSubarray(buf, 0, filled + n),
+          };
+        }
+      }
+      filled += n;
+    }
+    return { isH2: true, initial: buf };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// HTTP/2 connections accepted on the override listener are served by a
+// real node:http2 server session over the same socket wrapper: HTTP/2
+// stays HTTP/2 (native trailers, flow control), and requests reach the
+// node server's "request" listeners as Http2ServerRequest /
+// Http2ServerResponse compat objects -- the same objects node delivers
+// for `http2.createSecureServer({ allowHTTP1: true })` servers.
+//
+// node:http2 is loaded lazily to avoid a module cycle (http2 depends on
+// node:http internals).
+let lazyHttp2;
+function loadHttp2() {
+  lazyHttp2 ??= core.loadExtScript("ext:deno_node/http2.ts");
+  return lazyHttp2;
+}
+
+const kH2Shadow = Symbol("http.overrideH2Shadow");
+
+// Returns a non-listening Http2Server bound to `server` that forwards
+// requests (and the events frameworks commonly use) to it.
+function h2ShadowServer(server) {
+  let shadow = server[kH2Shadow];
+  if (shadow !== undefined) return shadow;
+  const http2 = loadHttp2();
+  shadow = http2.createServer({});
+  server[kH2Shadow] = shadow;
+  shadow.on("request", (req, res) => {
+    // The target server's listeners were written for node:http requests:
+    // hide the HTTP/2 pseudo-headers (frameworks commonly copy req.headers
+    // into a web Headers object, which rejects ":"-prefixed names) and
+    // synthesize the host header an HTTP/1.1 request would carry. The
+    // internal headers object is left untouched -- req.method / req.url
+    // read the pseudo-headers from it.
+    const headers = req.headers;
+    // Note: a plain Object.prototype-backed object and settable
+    // properties, matching the http1 IncomingMessage the listener was
+    // written against (frameworks reassign req.headers and call
+    // req.headers.hasOwnProperty()).
+    let headersView = {};
+    for (const name in headers) {
+      if (name[0] !== ":") headersView[name] = headers[name];
+    }
+    if (
+      headersView.host === undefined && headers[":authority"] !== undefined
+    ) {
+      headersView.host = headers[":authority"];
+    }
+    ObjectDefineProperty(req, "headers", {
+      __proto__: null,
+      configurable: true,
+      enumerable: true,
+      get: () => headersView,
+      set: (value) => {
+        headersView = value;
+      },
+    });
+    const rawHeaders = req.rawHeaders;
+    let hasHost = false;
+    let rawView = [];
+    for (let i = 0; i < rawHeaders.length; i += 2) {
+      const name = rawHeaders[i];
+      if (name[0] === ":") continue;
+      if (name === "host") hasHost = true;
+      ArrayPrototypePush(rawView, name, rawHeaders[i + 1]);
+    }
+    if (!hasHost && headersView.host !== undefined) {
+      ArrayPrototypePush(rawView, "host", headersView.host);
+    }
+    ObjectDefineProperty(req, "rawHeaders", {
+      __proto__: null,
+      configurable: true,
+      enumerable: true,
+      get: () => rawView,
+      set: (value) => {
+        rawView = value;
+      },
+    });
+    server.emit("request", req, res);
+  });
+  // Surface session/stream errors on the http.Server like client
+  // connection errors; never let them become uncaught "error" events on
+  // the shadow.
+  shadow.on("sessionError", (err, session) => {
+    const socket = session?.socket;
+    // Only surface as clientError when there is a socket for the
+    // listener to act on; otherwise (and when unhandled) tear the
+    // session down directly.
+    if (!socket || !server.emit("clientError", err, socket)) {
+      session?.destroy(err);
+    }
+  });
+  server.once("close", () => {
+    shadow.close();
+  });
+  return shadow;
+}
+
+function startH2OverrideConnection(server, conn, initialChunk) {
+  const socket = new OverrideSocket(conn, initialChunk);
+  const shadow = h2ShadowServer(server);
+  // net.Server registers its connection listener for the "connection"
+  // event; emitting it runs the full HTTP/2 session setup on `socket`.
+  shadow.emit("connection", socket);
+}
+
 // Run a Deno listener on the override address, handing each accepted
 // connection to `connectionListener` so the HTTP parser picks it up
 // the same way a regular net.Server connection would. For https.Server
 // the caller should pass the plain http _connectionListener so the
 // override channel stays cleartext (typical Deno Deploy / desktop
 // runtime use case: trusted local vsock/unix transport).
-function startOverrideListener(server, override, connectionListener) {
+// `alpnRouting` is used by node:http2 servers: instead of the
+// http.Server-specific dispatch (h1 parser path / shadow HTTP/2 session),
+// the sniffed protocol is exposed as `socket.alpnProtocol` ("h2" or
+// "http/1.1") and every connection is handed to `connectionListener`,
+// which performs its own protocol routing exactly like it would for a
+// TLS+ALPN connection.
+function startOverrideListener(
+  server,
+  override,
+  connectionListener,
+  alpnRouting = false,
+) {
   let denoListener;
   try {
     denoListener = denoListen(overrideToListenArgs(override));
@@ -296,8 +521,39 @@ function startOverrideListener(server, override, connectionListener) {
           }
           break;
         }
-        const socket = new OverrideSocket(conn);
-        FunctionPrototypeCall(connectionListener, server, socket);
+        // Sniff the protocol off the accept loop so a slow client can't
+        // stall other connections.
+        PromisePrototypeCatch(
+          (async () => {
+            const { isH2, initial } = await sniffConnection(conn);
+            if (server[kOverrideClosed]) {
+              try {
+                conn.close();
+              } catch (_) {
+                // ignore
+              }
+              return;
+            }
+            if (alpnRouting) {
+              const socket = new OverrideSocket(conn, initial);
+              socket.server = server;
+              socket.alpnProtocol = isH2 ? "h2" : "http/1.1";
+              FunctionPrototypeCall(connectionListener, server, socket);
+            } else if (isH2) {
+              startH2OverrideConnection(server, conn, initial);
+            } else {
+              const socket = new OverrideSocket(conn, initial);
+              FunctionPrototypeCall(connectionListener, server, socket);
+            }
+          })(),
+          (_err) => {
+            try {
+              conn.close();
+            } catch (_) {
+              // ignore
+            }
+          },
+        );
       }
     } catch (err) {
       // Ignore BadResource on close.

--- a/ext/node/polyfills/internal/http2/compat.js
+++ b/ext/node/polyfills/internal/http2/compat.js
@@ -746,6 +746,12 @@ class Http2ServerResponse extends lazyStream().default {
     }
   }
 
+  // Express and middleware like `compression` call this to flush implicit
+  // headers; node's Http2ServerResponse provides it for http1 compat.
+  _implicitHeader() {
+    this.writeHead(this[kState].statusCode);
+  }
+
   writeHead(statusCode, statusMessage, headers) {
     const state = this[kState];
 

--- a/tests/specs/node/http2_address_override/__test__.jsonc
+++ b/tests/specs/node/http2_address_override/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "envs": {
+    "DENO_SERVE_ADDRESS": "duplicate,tcp:127.0.0.1:12472"
+  },
+  "args": "run -A main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/node/http2_address_override/main.out
+++ b/tests/specs/node/http2_address_override/main.out
@@ -1,0 +1,5 @@
+status: 200
+content-type: application/grpc
+body: {"path":"/pkg.Service/Method","bodyLen":16}
+grpc-status: 0
+grpc-message: OK

--- a/tests/specs/node/http2_address_override/main.ts
+++ b/tests/specs/node/http2_address_override/main.ts
@@ -1,0 +1,49 @@
+// node:http2 servers honor the DENO_SERVE_ADDRESS override, and HTTP/2 is
+// forwarded natively (no downgrade): response trailers -- which only exist
+// in HTTP/2 framing and are what gRPC rides on -- must survive the trip.
+import http2 from "node:http2";
+
+const server = http2.createServer();
+server.on("stream", (stream, headers) => {
+  let body = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk: string) => body += chunk);
+  stream.on("end", () => {
+    stream.respond({
+      ":status": 200,
+      "content-type": "application/grpc",
+    }, { waitForTrailers: true });
+    stream.on("wantTrailers", () => {
+      stream.sendTrailers({ "grpc-status": "0", "grpc-message": "OK" });
+    });
+    stream.end(
+      JSON.stringify({ path: headers[":path"], bodyLen: body.length }),
+    );
+  });
+});
+
+server.listen(0, () => {
+  const client = http2.connect("http://127.0.0.1:12472");
+  const stream = client.request({
+    ":method": "POST",
+    ":path": "/pkg.Service/Method",
+  });
+
+  let resHeaders: http2.IncomingHttpHeaders = {};
+  let trailers: http2.IncomingHttpHeaders = {};
+  let resBody = "";
+  stream.on("response", (h) => resHeaders = h);
+  stream.on("trailers", (t) => trailers = t);
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk: string) => resBody += chunk);
+  stream.on("end", () => {
+    console.log("status:", resHeaders[":status"]);
+    console.log("content-type:", resHeaders["content-type"]);
+    console.log("body:", resBody);
+    console.log("grpc-status:", trailers["grpc-status"]);
+    console.log("grpc-message:", trailers["grpc-message"]);
+    client.close();
+    server.close(() => Deno.exit(0));
+  });
+  stream.end("grpc-frame-bytes");
+});

--- a/tests/specs/node/http_address_override_h2/__test__.jsonc
+++ b/tests/specs/node/http_address_override_h2/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "envs": {
+    "DENO_SERVE_ADDRESS": "duplicate,tcp:127.0.0.1:12471"
+  },
+  "args": "run -A main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/node/http_address_override_h2/main.out
+++ b/tests/specs/node/http_address_override_h2/main.out
@@ -1,0 +1,9 @@
+status: 200
+x-echo-method: POST
+body: {"url":"/some/path?q=1","bodyLen":10,"pseudo":[],"rawPseudo":[],"host":"127.0.0.1:12471"}
+status: 200
+x-echo-method: POST
+body: {"url":"/chunked","bodyLen":16,"pseudo":[],"rawPseudo":[],"host":"127.0.0.1:12471"}
+status: 200
+x-echo-method: GET
+body: {"url":"/get","bodyLen":0,"pseudo":[],"rawPseudo":[],"host":"127.0.0.1:12471"}

--- a/tests/specs/node/http_address_override_h2/main.ts
+++ b/tests/specs/node/http_address_override_h2/main.ts
@@ -1,0 +1,92 @@
+// Control planes forward HTTP/2 requests (prior knowledge) to the
+// DENO_SERVE_ADDRESS override listener, so node:http servers must accept
+// both HTTP/1.1 and HTTP/2 connections there, like Deno.serve() does.
+import { createServer } from "node:http";
+import http2 from "node:http2";
+
+const server = createServer((req, res) => {
+  let body = "";
+  req.on("data", (chunk) => body += chunk);
+  req.on("end", () => {
+    // node:http listeners must not observe HTTP/2 pseudo-headers, and
+    // frameworks commonly copy req.headers into a web Headers object
+    // (which rejects ":"-prefixed names) -- this must not throw.
+    new Headers(req.headers as Record<string, string>);
+    // http1 IncomingMessage parity: Object.prototype-backed and settable.
+    if (typeof req.headers.hasOwnProperty !== "function") {
+      throw new Error("req.headers must be Object.prototype-backed");
+    }
+    const savedHeaders = req.headers;
+    req.headers = { replaced: "yes" };
+    if (req.headers.replaced !== "yes") {
+      throw new Error("req.headers must be assignable");
+    }
+    req.headers = savedHeaders;
+    const savedRaw = req.rawHeaders;
+    req.rawHeaders = [];
+    if (req.rawHeaders.length !== 0) {
+      throw new Error("req.rawHeaders must be assignable");
+    }
+    req.rawHeaders = savedRaw;
+    const pseudo = Object.keys(req.headers).filter((k) => k[0] === ":");
+    const rawPseudo = req.rawHeaders.filter((h, i) =>
+      i % 2 === 0 && h[0] === ":"
+    );
+    res.setHeader("x-echo-method", req.method!);
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      url: req.url,
+      bodyLen: body.length,
+      pseudo,
+      rawPseudo,
+      host: req.headers.host ?? null,
+    }));
+  });
+});
+
+async function doRequest(
+  client: http2.ClientHttp2Session,
+  headers: http2.OutgoingHttpHeaders,
+  body: string | null,
+): Promise<void> {
+  const stream = client.request(headers);
+  if (body !== null) {
+    stream.write(body.slice(0, 5));
+    stream.end(body.slice(5));
+  } else {
+    stream.end();
+  }
+  const resHeaders = await new Promise<http2.IncomingHttpHeaders>((resolve) =>
+    stream.on("response", resolve)
+  );
+  let resBody = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk: string) => resBody += chunk);
+  await new Promise((resolve) => stream.on("end", resolve));
+  console.log("status:", resHeaders[":status"]);
+  console.log("x-echo-method:", resHeaders["x-echo-method"]);
+  console.log("body:", resBody);
+}
+
+server.listen(0, async () => {
+  const client = http2.connect("http://127.0.0.1:12471");
+
+  // POST with explicit content-length.
+  await doRequest(client, {
+    ":method": "POST",
+    ":path": "/some/path?q=1",
+    "content-length": "10",
+  }, "0123456789");
+
+  // POST without content-length: exercises the chunked request bridge.
+  await doRequest(client, {
+    ":method": "POST",
+    ":path": "/chunked",
+  }, "abcdefghijklmnop");
+
+  // GET with no body.
+  await doRequest(client, { ":method": "GET", ":path": "/get" }, null);
+
+  client.close();
+  server.close(() => Deno.exit(0));
+});

--- a/tests/specs/node/http_address_override_large_body/__test__.jsonc
+++ b/tests/specs/node/http_address_override_large_body/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run -A main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/node/http_address_override_large_body/main.out
+++ b/tests/specs/node/http_address_override_large_body/main.out
@@ -1,0 +1,2 @@
+/content-length: status=200 size_ok=true content_ok=true
+/chunked: status=200 size_ok=true content_ok=true

--- a/tests/specs/node/http_address_override_large_body/main.ts
+++ b/tests/specs/node/http_address_override_large_body/main.ts
@@ -1,0 +1,50 @@
+// Tests that large response bodies are fully delivered through the
+// DENO_SERVE_ADDRESS override listener, with and without a known
+// content-length. Deno.Conn.write() may perform partial writes when the
+// transport send buffer fills up (vsock buffers are 64 KiB), which the
+// override socket must handle.
+const OVERRIDE_PORT = 12473;
+const SIZE = 32 * 1024 * 1024;
+
+const child = new Deno.Command(Deno.execPath(), {
+  args: ["run", "-A", "server.mjs"],
+  env: {
+    DENO_SERVE_ADDRESS: `duplicate,tcp:127.0.0.1:${OVERRIDE_PORT}`,
+  },
+  cwd: new URL(".", import.meta.url).pathname,
+  stdout: "piped",
+  stderr: "inherit",
+}).spawn();
+
+// Wait for the server to report readiness on stdout.
+const reader = child.stdout.getReader();
+let buf = "";
+while (!buf.includes("listening")) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  buf += new TextDecoder().decode(value);
+}
+
+try {
+  for (const path of ["/content-length", "/chunked"]) {
+    const res = await fetch(`http://127.0.0.1:${OVERRIDE_PORT}${path}`, {
+      headers: { "accept-encoding": "identity" },
+    });
+    const body = new Uint8Array(await res.arrayBuffer());
+    let valid = true;
+    for (let i = 0; i < body.length; i++) {
+      if (body[i] !== 97) {
+        valid = false;
+        break;
+      }
+    }
+    console.log(
+      `${path}: status=${res.status} size_ok=${
+        body.length === SIZE
+      } content_ok=${valid}`,
+    );
+  }
+} finally {
+  child.kill();
+  await child.status;
+}

--- a/tests/specs/node/http_address_override_large_body/main.ts
+++ b/tests/specs/node/http_address_override_large_body/main.ts
@@ -11,7 +11,7 @@ const child = new Deno.Command(Deno.execPath(), {
   env: {
     DENO_SERVE_ADDRESS: `duplicate,tcp:127.0.0.1:${OVERRIDE_PORT}`,
   },
-  cwd: new URL(".", import.meta.url).pathname,
+  cwd: import.meta.dirname,
   stdout: "piped",
   stderr: "inherit",
 }).spawn();

--- a/tests/specs/node/http_address_override_large_body/server.mjs
+++ b/tests/specs/node/http_address_override_large_body/server.mjs
@@ -1,0 +1,18 @@
+import { createServer } from "node:http";
+const SIZE = 32 * 1024 * 1024;
+const big = Buffer.alloc(SIZE, "a");
+const server = createServer((req, res) => {
+  res.setHeader("content-type", "application/octet-stream");
+  if (req.url === "/chunked") {
+    // No content-length: chunked transfer encoding, written in pieces
+    // large enough to hit partial transport writes.
+    for (let i = 0; i < SIZE; i += 1024 * 1024) {
+      res.write(big.subarray(i, i + 1024 * 1024));
+    }
+    res.end();
+  } else {
+    res.setHeader("content-length", SIZE);
+    res.end(big);
+  }
+});
+server.listen(8000, () => console.log("listening"));


### PR DESCRIPTION
Control planes forward HTTP/2 requests with prior knowledge to the
DENO_SERVE_ADDRESS override listener, so node servers must accept both
HTTP/1.1 and HTTP/2 connections there, just like Deno.serve() does. The
override listener fed raw connection bytes straight into the node
HTTP/1.1 parser, which answered the HTTP/2 client connection preface
with an HTTP/1.1 error, breaking every node:http-based app (e.g.
Next.js) sitting behind HTTP/2 ingress.

Each accepted override connection is now sniffed, reading at most the
24-byte HTTP/2 client preface with a timeout. HTTP/1.x connections take
the existing node parser path with the sniffed bytes replayed. HTTP/2
connections are served by a real node:http2 server session (a
non-listening shadow Http2Server per http.Server) and dispatched to the
server's request listeners as Http2ServerRequest / Http2ServerResponse
compat objects, the same objects node delivers for allowHTTP1
dual-protocol servers, so HTTP/2 stays HTTP/2 end-to-end with native
trailers and flow control.

Requests bridged into a plain http.Server hide the :method, :path,
:scheme and :authority pseudo-headers from req.headers / req.rawHeaders
and synthesize a host header from :authority, matching what an HTTP/1.1
request carries, since frameworks commonly copy req.headers into a web
Headers object that rejects ':'-prefixed names. node:http2 servers keep
the full pseudo-header view that is their documented API. Http2Server's
own listen() is wired into the override the same way node:http's
Server.listen is, exposing the sniffed protocol as socket.alpnProtocol
so existing h2 / http1.1 routing applies and response trailers survive.
Http2ServerResponse also gains _implicitHeader() for express-style
middleware (e.g. compression) that flushes implicit headers before
writing.