### PR TITLE
fix(cli): enforce worker import permissions for static remote imports

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1704,6 +1704,26 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
         )?;
       }
 
+      // A Web Worker's own statically analyzable remote imports must be checked
+      // against the worker's own permissions, not the parent thread's to honor
+      // the specified `deno.permissions.import` and match behavior with main
+      // graph. Dynamic `import()` is already checked against the worker's
+      // permissions while the graph is built.
+      if inner.is_worker && !options.is_dynamic_import {
+        let graph = graph_container.graph();
+        for module in graph.modules() {
+          let specifier = module.specifier();
+          if matches!(specifier.scheme(), "http" | "https")
+            && !graph.roots.contains(specifier)
+            && let Err(err) = inner
+              .permissions
+              .check_specifier(specifier, CheckSpecifierKind::Static)
+          {
+            return Err(JsErrorBox::from_err(err));
+          }
+        }
+      }
+
       Ok(())
     };
 

--- a/tests/specs/worker/worker_permissions_static_remote_local/__test__.jsonc
+++ b/tests/specs/worker/worker_permissions_static_remote_local/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run --quiet --reload --allow-read --allow-import --unstable-worker-options parent.ts",
+  "output": "parent.ts.out",
+  "exitCode": 1
+}

--- a/tests/specs/worker/worker_permissions_static_remote_local/parent.ts
+++ b/tests/specs/worker/worker_permissions_static_remote_local/parent.ts
@@ -1,0 +1,13 @@
+// The parent holds full `--allow-import`, but spawns a worker that is
+// explicitly restricted with `import: false`. The worker is loaded from a
+// local file and statically imports a remote module. Statically analyzable
+// imports in a worker must be checked against the worker's own (restricted)
+// permissions, not the parent's, so the remote import is denied.
+new Worker(import.meta.resolve("./worker.ts"), {
+  type: "module",
+  deno: {
+    permissions: {
+      import: false,
+    },
+  },
+});

--- a/tests/specs/worker/worker_permissions_static_remote_local/parent.ts.out
+++ b/tests/specs/worker/worker_permissions_static_remote_local/parent.ts.out
@@ -1,0 +1,3 @@
+error: Uncaught (in worker "") Requires import access to "localhost:4545", run again with the --allow-import flag
+error: Uncaught (in promise) Error: Unhandled error in child worker.
+    at Worker.#pollControl [WILDCARD]

--- a/tests/specs/worker/worker_permissions_static_remote_local/worker.ts
+++ b/tests/specs/worker/worker_permissions_static_remote_local/worker.ts
@@ -1,0 +1,8 @@
+// This module is loaded from a local file, so loading the worker entry itself
+// only requires the parent's read access. It then statically imports a remote
+// module. The worker was created with `import: false`, so this must be denied
+// even though the parent thread has `--allow-import`.
+import { add } from "http://localhost:4545/add.ts";
+
+console.log("FAIL: import:false worker was able to import a remote module");
+console.log(add(1, 2));


### PR DESCRIPTION
Fixes the fact that statically analyzable import were checked in parent context rather than web worker context.
Now a worker with `{ permissions: { import: false } }` will reject import in a way that matches what happens for main thread (see #31992 for full details)

- Close https://github.com/denoland/deno/issues/29503
- Close https://github.com/denoland/deno/issues/31992

| Context | Static import | Dynamic import | Dynamic import (non statically analyzable) |
| - | - | - | - |
| Main --allow-import | ✔ | ✔ | ✔ |
| Main --deny-import | ✘ | ✘ | ✘ | 
| Worker --allow-import | ✔ | ✔ | ✔ |
| Worker --deny-import | ✔→✘ | ✔→✘ |  ✘ |

I added a `inheritStaticImports` option on the way, which lets the worker reuse module already imported by the main graph (useful to create worker scripts that are not allowed to import new dependencies by itself, but still requires packages already used by the app itself, e.g. `jsr:@std`)

- Related https://github.com/denoland/deno/issues/31967

Disclaimer: PR AI-assisted with claude