### PR TITLE
fix(ext/node): keep v8.serialize output readable by Node.js

### DIFF
--- a/ext/node/polyfills/v8.ts
+++ b/ext/node/polyfills/v8.ts
@@ -300,9 +300,11 @@ function deserialize(buffer: Buffer | ArrayBufferView | DataView) {
 }
 
 const kHandle = Symbol("kHandle");
+const kHeaderWritten = Symbol("kHeaderWritten");
 
 class Serializer {
   [kHandle]: object;
+  [kHeaderWritten] = false;
   constructor() {
     this[kHandle] = op_v8_new_serializer(this);
   }
@@ -312,7 +314,22 @@ class Serializer {
   }
 
   releaseBuffer(): Buffer {
-    return Buffer.from(op_v8_release_buffer(this[kHandle]));
+    const buf = Buffer.from(op_v8_release_buffer(this[kHandle]));
+    // V8 14.9 bumped the ValueSerializer wire format version from 15 to
+    // 16 to support ArrayBuffers larger than 4GB. Node.js cannot
+    // deserialize format 16, which breaks consumers that feed
+    // `v8.serialize` output to a Node.js process. For payloads smaller
+    // than 4GB both formats encode identical bytes after the two-byte
+    // header, so relabel the header as version 15 to keep the output
+    // readable by Node.js. See
+    // https://github.com/denoland/deno/issues/35113.
+    if (
+      this[kHeaderWritten] && getViewByteLength(buf) < 0x100000000 &&
+      buf[0] === 0xFF && buf[1] === 0x10
+    ) {
+      buf[1] = 0x0F;
+    }
+    return buf;
   }
 
   transferArrayBuffer(_id: number, _arrayBuffer: ArrayBuffer): void {
@@ -325,6 +342,7 @@ class Serializer {
 
   writeHeader(): void {
     op_v8_write_header(this[kHandle]);
+    this[kHeaderWritten] = true;
   }
 
   writeRawBytes(source: ArrayBufferView): void {

--- a/tests/unit_node/v8_test.ts
+++ b/tests/unit_node/v8_test.ts
@@ -72,6 +72,32 @@ Deno.test({
   },
 });
 
+// https://github.com/denoland/deno/issues/35113
+Deno.test({
+  name: "serialize emits wire format version 15 for Node.js interop",
+  fn() {
+    const values = [
+      { a: 1 },
+      "string",
+      123n,
+      new Uint8Array([1, 2, 3]),
+      new Map([["a", new ArrayBuffer(16)]]),
+    ];
+    for (const value of values) {
+      const s = v8.serialize(value);
+      assertEquals(s[0], 0xFF);
+      assertEquals(s[1], 0x0F);
+      assertEquals(v8.deserialize(s), value);
+    }
+
+    // A serializer without a header is left untouched.
+    const ser = new v8.Serializer();
+    ser.writeUint32(42);
+    const raw = ser.releaseBuffer();
+    assertEquals(raw[0], 42);
+  },
+});
+
 Deno.test({
   name: "Deserializer keeps delegate alive across GC",
   fn() {


### PR DESCRIPTION
The V8 14.9 upgrade in Deno 2.8.0 bumped V8's ValueSerializer wire format
version from 15 to 16 (64-bit ArrayBuffer lengths). The format is not
forwards-compatible and no released Node.js or Electron can read version
16, so any `v8.serialize` output crossing the Deno -> Node.js boundary now
throws "Unable to deserialize cloned data due to invalid or unsupported
version" on the Node.js side. This broke the Vitest VS Code extension,
whose extension-host RPC v8-serializes every message exchanged with the
`deno -A worker.js` process it spawns: the JSON handshake succeeds, then
the first serialized RPC response is rejected and test discovery stalls
forever.

For payloads smaller than 4GB the version 16 byte stream is identical to
version 15 except for the version byte in the header (length fields are
varints either way, and varint<size_t> equals varint<uint32_t> for values
below 2^32), so the serializer now relabels the header as version 15 when
the output is below 4GB. Larger outputs keep the version 16 header since
they cannot be represented in version 15 at all.

Fixes #35113