### PR TITLE
fix(serve): shut down old workers on watcher restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5840,6 +5840,7 @@ dependencies = [
  "deno_unsync",
  "fastwebsockets 0.8.1",
  "file_test_runner",
+ "futures",
  "hickory-proto",
  "hickory-server",
  "hmac",

--- a/cli/tools/serve.rs
+++ b/cli/tools/serve.rs
@@ -10,6 +10,7 @@ use deno_core::futures::FutureExt;
 use deno_core::futures::TryFutureExt;
 use deno_lib::worker::LibWorkerFactoryRoots;
 use deno_runtime::UnconfiguredRuntime;
+use tokio_util::sync::CancellationToken;
 
 use super::run::check_permission_before_script;
 use super::run::maybe_npm_install;
@@ -109,32 +110,42 @@ async fn do_serve(
     c => c,
   };
 
-  let main = deno_core::unsync::spawn(async move { worker.run().await });
+  // If this future is dropped before completing (e.g. the file watcher
+  // restarting on a file change), the guard cancels the token so the worker
+  // threads shut down instead of continuing to serve the old code.
+  let shutdown_token = CancellationToken::new();
+  let _shutdown_guard = shutdown_token.clone().drop_guard();
 
   let mut channels = Vec::with_capacity(worker_count);
   for i in 0..worker_count {
     let worker_factory = worker_factory.clone();
     let main_module = main_module.clone();
+    let shutdown_token = shutdown_token.clone();
     let (tx, rx) = tokio::sync::oneshot::channel();
     channels.push(rx);
     std::thread::Builder::new()
       .name(format!("serve-worker-{}", i + 1))
       .spawn(move || {
         deno_runtime::tokio_util::create_and_run_current_thread(async move {
-          let result = run_worker(i, worker_factory, main_module, hmr).await;
+          let result = tokio::select! {
+            result = run_worker(i, worker_factory, main_module, hmr) => result,
+            _ = shutdown_token.cancelled() => Ok(0),
+          };
           let _ = tx.send(result);
         });
       })?;
   }
 
+  // Poll the main worker directly instead of spawning it so that dropping
+  // this future cancels it as well.
   let (main_result, worker_results) = tokio::try_join!(
-    main.map_err(AnyError::from),
+    worker.run().map_err(AnyError::from),
     deno_core::futures::future::try_join_all(
       channels.into_iter().map(|r| r.map_err(AnyError::from))
     )
   )?;
 
-  let mut exit_code = main_result?;
+  let mut exit_code = main_result;
   for res in worker_results {
     let ret = res?;
     if ret != 0 && exit_code == 0 {

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -28,6 +28,7 @@ deno_semver.workspace = true
 deno_unsync = { workspace = true, features = ["tokio"] }
 fastwebsockets = { workspace = true, features = ["upgrade", "unstable-split"] }
 file_test_runner.workspace = true
+futures.workspace = true
 hickory-proto.workspace = true
 hickory-server.workspace = true
 hmac.workspace = true

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -915,6 +915,11 @@ async fn serve_watch_parallel_stops_old_workers() {
     // disable connection pooling so we create a new connection per request
     // which allows us to distribute requests across workers
     .pool_max_idle_per_host(0)
+    // bound every request; reqwest has no default timeout, so without this a
+    // request to a socket that connects but never responds (e.g. a dying old
+    // worker generation's listener backlog) hangs the test forever
+    .connect_timeout(std::time::Duration::from_secs(5))
+    .timeout(std::time::Duration::from_secs(10))
     .build()
     .unwrap();
 
@@ -940,39 +945,62 @@ async fn serve_watch_parallel_stops_old_workers() {
   let line = wait_contains("Listening on", &mut stderr_lines).await;
   let new_port = port_regex.captures(&line).unwrap()[1].to_string();
 
-  // The new generation serves the new code.
-  for _ in 0..8 {
-    let body = client
+  // The old generation may keep serving the old code briefly while winding
+  // down, and with `--parallel` both generations can even share the same port
+  // (SO_REUSEPORT), so responses can interleave right after the restart.
+  // Eventually only the new code must be served; before the fix the old
+  // workers kept serving "v1" forever.
+  let start = std::time::Instant::now();
+  let mut consecutive_v2 = 0;
+  while consecutive_v2 < 20 {
+    match client
       .get(format!("http://127.0.0.1:{new_port}/"))
       .send()
       .await
-      .unwrap()
-      .text()
-      .await
-      .unwrap();
-    assert_eq!(body, "v2");
-  }
-
-  // All workers of the old generation must shut down and release the old
-  // port. Before the fix they kept serving the old code forever.
-  let start = std::time::Instant::now();
-  loop {
-    match client
-      .get(format!("http://127.0.0.1:{old_port}/"))
-      .send()
-      .await
     {
-      // Connection error: the old workers are gone.
-      Err(_) => break,
-      // Old workers may still serve while winding down, but only old code.
       Ok(response) => {
-        assert_eq!(response.text().await.unwrap(), "v1");
+        let body = response.text().await.unwrap();
+        if body == "v2" {
+          consecutive_v2 += 1;
+        } else {
+          // Only the old or the new code may respond, nothing else.
+          assert_eq!(body, "v1");
+          consecutive_v2 = 0;
+        }
+      }
+      // Transient connection errors can happen mid-restart.
+      Err(_) => {
+        consecutive_v2 = 0;
       }
     }
     if start.elapsed() > std::time::Duration::from_secs(30) {
       panic!("old workers are still serving 30s after the restart");
     }
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+  }
+
+  // If the new generation got a different port, the old generation must shut
+  // down and release the old port.
+  if new_port != old_port {
+    let start = std::time::Instant::now();
+    loop {
+      match client
+        .get(format!("http://127.0.0.1:{old_port}/"))
+        .send()
+        .await
+      {
+        // Connection error or timeout: the old workers no longer serve.
+        Err(_) => break,
+        // Old workers may still serve while winding down, but only old code.
+        Ok(response) => {
+          assert_eq!(response.text().await.unwrap(), "v1");
+        }
+      }
+      if start.elapsed() > std::time::Duration::from_secs(30) {
+        panic!("old workers are still serving 30s after the restart");
+      }
+      tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
   }
 
   check_alive_then_kill(child);

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -873,6 +873,111 @@ async fn serve_watch_with_import_map() {
   check_alive_then_kill(child);
 }
 
+// Regression test for https://github.com/denoland/deno/issues/26052
+// On a watcher restart, `deno serve --parallel` used to leave the previous
+// generation of workers running (the worker threads were never signalled and
+// the main worker task was detached), so requests kept being served by the old
+// code and the process would eventually panic with an isolate mismatch.
+#[test(flaky)]
+async fn serve_watch_parallel_stops_old_workers() {
+  let t = TempDir::new();
+  let file_to_watch = t.path().join("server_file_to_watch.js");
+  file_to_watch.write(
+    "export default {
+      fetch(_request) {
+        return new Response(\"v1\");
+      },
+    };",
+  );
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("serve")
+    .arg("--parallel")
+    .arg("--watch")
+    .arg("--port")
+    .arg("0")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .env("DENO_JOBS", "4")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (_stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  let port_regex =
+    regex::Regex::new(r"Listening on https?:[^:]+:(\d+)/").unwrap();
+
+  let line = wait_contains("Listening on", &mut stderr_lines).await;
+  let old_port = port_regex.captures(&line).unwrap()[1].to_string();
+
+  let client = reqwest::Client::builder()
+    // disable connection pooling so we create a new connection per request
+    // which allows us to distribute requests across workers
+    .pool_max_idle_per_host(0)
+    .build()
+    .unwrap();
+
+  let body = client
+    .get(format!("http://127.0.0.1:{old_port}/"))
+    .send()
+    .await
+    .unwrap()
+    .text()
+    .await
+    .unwrap();
+  assert_eq!(body, "v1");
+
+  file_to_watch.write(
+    "export default {
+      fetch(_request) {
+        return new Response(\"v2\");
+      },
+    };",
+  );
+
+  wait_contains("Restarting", &mut stderr_lines).await;
+  let line = wait_contains("Listening on", &mut stderr_lines).await;
+  let new_port = port_regex.captures(&line).unwrap()[1].to_string();
+
+  // The new generation serves the new code.
+  for _ in 0..8 {
+    let body = client
+      .get(format!("http://127.0.0.1:{new_port}/"))
+      .send()
+      .await
+      .unwrap()
+      .text()
+      .await
+      .unwrap();
+    assert_eq!(body, "v2");
+  }
+
+  // All workers of the old generation must shut down and release the old
+  // port. Before the fix they kept serving the old code forever.
+  let start = std::time::Instant::now();
+  loop {
+    match client
+      .get(format!("http://127.0.0.1:{old_port}/"))
+      .send()
+      .await
+    {
+      // Connection error: the old workers are gone.
+      Err(_) => break,
+      // Old workers may still serve while winding down, but only old code.
+      Ok(response) => {
+        assert_eq!(response.text().await.unwrap(), "v1");
+      }
+    }
+    if start.elapsed() > std::time::Duration::from_secs(30) {
+      panic!("old workers are still serving 30s after the restart");
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+  }
+
+  check_alive_then_kill(child);
+}
+
 // Regression test for https://github.com/denoland/deno/issues/30046
 // `deno serve` used to ignore `--watch-exclude` entirely, so writing to an
 // excluded file that's part of the module graph would trigger a restart.

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -903,7 +903,31 @@ async fn serve_watch_parallel_stops_old_workers() {
     .piped_output()
     .spawn()
     .unwrap();
-  let (_stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  // If anything in the test body panics (a timeout, a failed assertion), the
+  // child must still be killed before unwinding: a leaked `deno serve --watch`
+  // child never exits on its own, and on Windows tokio reads child pipes with
+  // blocking threads, so dropping the test runtime during the unwind waits
+  // forever on a stderr read that never completes. This wedged CI for the
+  // full job timeout instead of reporting the failure.
+  let result = futures::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(
+    serve_watch_parallel_stops_old_workers_inner(&t, &mut child),
+  ))
+  .await;
+  if let Err(panic) = result {
+    let _ = child.kill();
+    std::panic::resume_unwind(panic);
+  }
+
+  check_alive_then_kill(child);
+}
+
+async fn serve_watch_parallel_stops_old_workers_inner(
+  t: &TempDir,
+  child: &mut DenoChild,
+) {
+  let file_to_watch = t.path().join("server_file_to_watch.js");
+  let (_stdout_lines, mut stderr_lines) = child_lines(child);
 
   let port_regex =
     regex::Regex::new(r"Listening on https?:[^:]+:(\d+)/").unwrap();
@@ -959,13 +983,15 @@ async fn serve_watch_parallel_stops_old_workers() {
       .await
     {
       Ok(response) => {
-        let body = response.text().await.unwrap();
-        if body == "v2" {
-          consecutive_v2 += 1;
-        } else {
+        match response.text().await {
+          Ok(body) if body == "v2" => consecutive_v2 += 1,
           // Only the old or the new code may respond, nothing else.
-          assert_eq!(body, "v1");
-          consecutive_v2 = 0;
+          Ok(body) => {
+            assert_eq!(body, "v1");
+            consecutive_v2 = 0;
+          }
+          // The connection can die mid-response during the restart.
+          Err(_) => consecutive_v2 = 0,
         }
       }
       // Transient connection errors can happen mid-restart.
@@ -991,9 +1017,22 @@ async fn serve_watch_parallel_stops_old_workers() {
       {
         // Connection error or timeout: the old workers no longer serve.
         Err(_) => break,
-        // Old workers may still serve while winding down, but only old code.
         Ok(response) => {
-          assert_eq!(response.text().await.unwrap(), "v1");
+          match response.text().await {
+            // Old workers may still serve the old code while winding down.
+            Ok(body) if body == "v1" => {}
+            // Seeing the new code here is fine too: on platforms without
+            // SO_REUSEPORT load balancing (e.g. Windows) every worker binds
+            // its own ephemeral port, and the OS can hand the just-released
+            // old port to a worker of the new generation. Either way the old
+            // listener is gone.
+            Ok(body) if body == "v2" => break,
+            // Only the old or the new code may respond, nothing else.
+            Ok(body) => panic!("unexpected response body: {body}"),
+            // The connection can die mid-response while the old generation
+            // winds down.
+            Err(_) => {}
+          }
         }
       }
       if start.elapsed() > std::time::Duration::from_secs(30) {
@@ -1002,8 +1041,6 @@ async fn serve_watch_parallel_stops_old_workers() {
       tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
   }
-
-  check_alive_then_kill(child);
 }
 
 // Regression test for https://github.com/denoland/deno/issues/30046


### PR DESCRIPTION
With `deno serve --parallel --watch`, a watcher restart only dropped the
`do_serve` future, but the previous generation of workers kept running: the
main worker was detached via `deno_core::unsync::spawn` (dropping a tokio
`JoinHandle` detaches the task) and the `serve-worker-N` OS threads were never
signalled. The old workers kept accepting connections on the shared socket, so
after editing a file a portion of requests was still served by the old code,
and the leaked main worker task eventually crashed the process with a
"PinnedRef and Context do not belong to the same Isolate" panic.

The main worker is now polled directly inside the `try_join!` so dropping the
future cancels it, and the worker threads select on a `CancellationToken` that
is cancelled by a drop guard when the future is dropped. In normal
(non-watch) operation the token never fires, so nothing changes there.

Fixes #26052