### PR TITLE
fix(install): remove stale root node_modules symlink on deno remove

### DIFF
--- a/libs/npm_installer/local.rs
+++ b/libs/npm_installer/local.rs
@@ -236,13 +236,17 @@ impl<
 
     // 1. Check if packages changed and clean up if needed
     if self.clean_on_install {
-      let packages_hash = calculate_packages_hash(&package_partitions);
+      let root_folder_names =
+        root_package_folder_names(snapshot, &self.npm_install_deps_provider);
+      let packages_hash =
+        calculate_packages_hash(&package_partitions, &root_folder_names);
       if setup_cache.packages_changed(packages_hash) {
         cleanup_unused_packages(
           sys.as_ref(),
           &self.root_node_modules_path,
           &deno_local_registry_dir,
           &package_partitions,
+          &root_folder_names,
           &mut setup_cache,
         );
       }
@@ -1665,6 +1669,7 @@ pub(crate) fn join_package_name(
 /// This allows us to detect when npm packages have been added, removed, or changed.
 fn calculate_packages_hash(
   package_partitions: &deno_npm::resolution::NpmPackagesPartitioned,
+  root_folder_names: &BTreeSet<String>,
 ) -> u64 {
   use std::hash::Hash;
   use std::hash::Hasher;
@@ -1676,7 +1681,54 @@ fn calculate_packages_hash(
     package.id.hash(&mut hasher);
   }
 
+  // also hash the packages expected at the root of node_modules so that
+  // cleanup runs when a direct dependency is removed but stays in the
+  // resolution as a transitive dependency
+  for folder_name in root_folder_names {
+    folder_name.hash(&mut hasher);
+  }
+
   hasher.finish()
+}
+
+/// Calculates the set of package folder names that are expected to have a
+/// symlink at the root of the node_modules directory (resolved package.json
+/// and import map dependencies plus the snapshot's top level packages).
+fn root_package_folder_names(
+  snapshot: &NpmResolutionSnapshot,
+  npm_install_deps_provider: &NpmInstallDepsProvider,
+) -> BTreeSet<String> {
+  let mut folder_names = BTreeSet::new();
+  for id in snapshot.top_level_packages() {
+    if let Some(package) = snapshot.package_from_id(id) {
+      folder_names.insert(get_package_folder_id_folder_name(
+        &package.get_package_cache_folder_id(),
+      ));
+    }
+  }
+  // resolve the same way as when creating the root symlinks for
+  // package.json dependencies
+  for remote in npm_install_deps_provider.remote_pkgs() {
+    let package = match snapshot.resolve_pkg_from_pkg_req(&remote.req) {
+      Ok(package) => package,
+      _ => {
+        if remote.req.version_req.tag().is_some() {
+          continue;
+        }
+        match snapshot
+          .resolve_best_package_id(&remote.req.name, &remote.req.version_req)
+          .and_then(|id| snapshot.package_from_id(&id))
+        {
+          Some(package) => package,
+          None => continue,
+        }
+      }
+    };
+    folder_names.insert(get_package_folder_id_folder_name(
+      &package.get_package_cache_folder_id(),
+    ));
+  }
+  folder_names
 }
 
 /// Cleans up unused packages from the node_modules/.deno directory.
@@ -1686,6 +1738,7 @@ fn cleanup_unused_packages<TSys: LocalNpmInstallSys>(
   root_node_modules_dir: &Path,
   deno_local_registry_dir: &Path,
   package_partitions: &deno_npm::resolution::NpmPackagesPartitioned,
+  root_folder_names: &BTreeSet<String>,
   setup_cache: &mut LocalSetupCache<TSys>,
 ) {
   // Collect all package folder names that should exist in .deno/
@@ -1734,11 +1787,16 @@ fn cleanup_unused_packages<TSys: LocalNpmInstallSys>(
     },
   );
 
-  // Clean up root node_modules/* symlinks for packages no longer needed
+  // Clean up root node_modules/* symlinks for packages that should no longer
+  // be linked at the root. Only direct dependencies and top level packages
+  // get a root symlink, so a package that remains in the resolution solely as
+  // a transitive dependency must not stay linked at the root (#35083).
+  let root_keep_names =
+    root_folder_names.iter().cloned().collect::<HashSet<_>>();
   let _ignore = remove_unused_node_modules_symlinks(
     sys,
     root_node_modules_dir,
-    &keep_names,
+    &root_keep_names,
     &mut |name, path| {
       setup_cache.remove_root_symlink(name);
       remove_existing_entry(sys, path)

--- a/tests/specs/remove/node_modules_cleanup_transitive/__test__.jsonc
+++ b/tests/specs/remove/node_modules_cleanup_transitive/__test__.jsonc
@@ -1,0 +1,48 @@
+{
+  "tempDir": true,
+  "tests": {
+    // a removed direct dependency that remains in the resolution as a
+    // transitive dependency should no longer be linked at the root of
+    // node_modules (https://github.com/denoland/deno/issues/35083)
+    "remove_direct_dep_that_stays_transitive": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": [
+            "eval",
+            "const exists = (path) => { try { Deno.lstatSync(path); return true; } catch { return false; } }; const denoEntries = Array.from(Deno.readDirSync('node_modules/.deno')).filter(e => !e.name.startsWith('.')).map(e => e.name); console.log(JSON.stringify({ binCache: denoEntries.some(e => e.includes('@denotest+bin@1.0.0')), binRoot: exists('node_modules/@denotest/bin'), transitiveBinRoot: exists('node_modules/@denotest/transitive-bin') }));"
+          ],
+          "output": "{\"binCache\":true,\"binRoot\":true,\"transitiveBinRoot\":true}\n"
+        },
+        {
+          "args": "remove bin",
+          "output": "[WILDCARD]"
+        },
+        // the package must stay in the .deno store (still required by
+        // @denotest/transitive-bin), but its root symlink must be removed
+        {
+          "args": [
+            "eval",
+            "const exists = (path) => { try { Deno.lstatSync(path); return true; } catch { return false; } }; const denoEntries = Array.from(Deno.readDirSync('node_modules/.deno')).filter(e => !e.name.startsWith('.')).map(e => e.name); console.log(JSON.stringify({ binCache: denoEntries.some(e => e.includes('@denotest+bin@1.0.0')), binRoot: exists('node_modules/@denotest/bin'), transitiveBinRoot: exists('node_modules/@denotest/transitive-bin') }));"
+          ],
+          "output": "{\"binCache\":true,\"binRoot\":false,\"transitiveBinRoot\":true}\n"
+        },
+        // re-adding the package must restore the root symlink
+        {
+          "args": "add npm:@denotest/bin@1.0.0",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": [
+            "eval",
+            "const exists = (path) => { try { Deno.lstatSync(path); return true; } catch { return false; } }; console.log(JSON.stringify({ binRoot: exists('node_modules/@denotest/bin') }));"
+          ],
+          "output": "{\"binRoot\":true}\n"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/remove/node_modules_cleanup_transitive/deno.json
+++ b/tests/specs/remove/node_modules_cleanup_transitive/deno.json
@@ -1,0 +1,7 @@
+{
+  "nodeModulesDir": "auto",
+  "imports": {
+    "bin": "npm:@denotest/bin@1.0.0",
+    "transitive-bin": "npm:@denotest/transitive-bin@1.0.0"
+  }
+}


### PR DESCRIPTION
In the pnpm-style local node_modules layout, only direct dependencies get a
symlink at the root of node_modules. However, when a direct dependency was
removed but remained in the resolution as a transitive dependency of another
package, "deno remove" left its root symlink behind, leaking it as a phantom
dependency. A fresh "deno install" after deleting node_modules correctly did
not link it at the root, confirming the leftover entry was a stale artifact.

This happened for two reasons: the cleanup pass kept any root symlink whose
target package was still anywhere in the resolution (instead of only packages
expected at the root), and the change-detection hash only covered package ids,
so removing an import that survived as a transitive dependency did not change
the hash and the cleanup never ran. The cleanup now keeps only the packages
expected at the root (resolved package.json and import map dependencies plus
the snapshot's top level packages) and the hash includes that set, matching
what pnpm does.

Fixes #35083