### PR TITLE
fix: cache 404 responses for remote modules

### DIFF
--- a/libs/cache_dir/cache.rs
+++ b/libs/cache_dir/cache.rs
@@ -40,6 +40,13 @@ impl GlobalToLocalCopy {
   }
 }
 
+/// Synthetic header stored on cache entries that record a 404 response
+/// from the remote server. This allows treating "not found" as cached
+/// information instead of re-requesting the URL on every process start.
+/// Similar to how redirects are stored as body-less entries distinguished
+/// by their "location" header.
+pub const NOT_FOUND_CACHE_HEADER: &str = "x-deno-not-found";
+
 #[derive(Debug, Error, JsError)]
 #[class(type)]
 #[error("Integrity check failed for {}\n\nActual: {}\nExpected: {}", .url, .actual, .expected)]

--- a/libs/cache_dir/file_fetcher/mod.rs
+++ b/libs/cache_dir/file_fetcher/mod.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 use std::time::SystemTime;
 
 use boxed_error::Boxed;
@@ -35,6 +36,7 @@ use crate::CacheReadFileError;
 use crate::Checksum;
 use crate::ChecksumIntegrityError;
 use crate::cache::HttpCacheRc;
+use crate::cache::NOT_FOUND_CACHE_HEADER;
 use crate::common::HeadersMap;
 
 mod auth_tokens;
@@ -48,6 +50,15 @@ pub use http::HeaderMap;
 pub use http::HeaderName;
 pub use http::HeaderValue;
 pub use http::StatusCode;
+
+/// How long a cached 404 response is considered fresh. Within this window
+/// a previously seen "not found" is served from the cache instead of
+/// re-requesting the URL on every process start (see
+/// https://github.com/denoland/deno/issues/25404). The TTL is intentionally
+/// short so that resources appearing on the remote server (e.g. a newly
+/// published package version that is still propagating) are picked up
+/// without requiring `--reload`.
+const NOT_FOUND_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
 
 /// Indicates how cached source files should be handled.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -386,6 +397,9 @@ pub enum FetchCachedErrorKind {
   #[class(inherit)]
   #[error(transparent)]
   TooManyRedirects(TooManyRedirectsError),
+  #[class("NotFound")]
+  #[error("Import '{0}' failed, not found.")]
+  NotFound(Url),
   #[class(inherit)]
   #[error(transparent)]
   ChecksumIntegrity(#[from] ChecksumIntegrityError),
@@ -428,6 +442,9 @@ struct FetchCachedNoFollowError(pub Box<FetchCachedNoFollowErrorKind>);
 
 #[derive(Debug, Error, JsError)]
 enum FetchCachedNoFollowErrorKind {
+  #[class("NotFound")]
+  #[error("Import '{0}' failed, not found.")]
+  NotFound(Url),
   #[class(inherit)]
   #[error(transparent)]
   ChecksumIntegrity(ChecksumIntegrityError),
@@ -442,6 +459,9 @@ enum FetchCachedNoFollowErrorKind {
 impl From<FetchCachedNoFollowError> for FetchCachedError {
   fn from(err: FetchCachedNoFollowError) -> Self {
     match err.into_kind() {
+      FetchCachedNoFollowErrorKind::NotFound(url) => {
+        FetchCachedErrorKind::NotFound(url).into_box()
+      }
       FetchCachedNoFollowErrorKind::ChecksumIntegrity(err) => err.into(),
       FetchCachedNoFollowErrorKind::CacheRead(err) => err.into(),
       FetchCachedNoFollowErrorKind::RedirectResolution(err) => err.into(),
@@ -452,6 +472,9 @@ impl From<FetchCachedNoFollowError> for FetchCachedError {
 impl From<FetchCachedNoFollowError> for FetchNoFollowError {
   fn from(err: FetchCachedNoFollowError) -> Self {
     match err.into_kind() {
+      FetchCachedNoFollowErrorKind::NotFound(url) => {
+        FetchNoFollowErrorKind::NotFound(url).into_box()
+      }
       FetchCachedNoFollowErrorKind::ChecksumIntegrity(err) => err.into(),
       FetchCachedNoFollowErrorKind::CacheRead(err) => err.into(),
       FetchCachedNoFollowErrorKind::RedirectResolution(err) => err.into(),
@@ -575,15 +598,23 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
 
     let mut url = Cow::Borrowed(url);
     for _ in 0..=redirect_limit {
-      match self.fetch_cached_no_follow(&url, None)? {
-        Some(FileOrRedirect::File(file)) => {
+      match self.fetch_cached_no_follow(&url, None) {
+        Ok(Some(FileOrRedirect::File(file))) => {
           return Ok(Some(file));
         }
-        Some(FileOrRedirect::Redirect(redirect_url)) => {
+        Ok(Some(FileOrRedirect::Redirect(redirect_url))) => {
           url = Cow::Owned(redirect_url);
         }
-        None => {
+        Ok(None) => {
           return Ok(None);
+        }
+        Err(err) => {
+          if matches!(err.as_kind(), FetchCachedNoFollowErrorKind::NotFound(_))
+          {
+            // a cached 404 means there is no usable cached file
+            return Ok(None);
+          }
+          return Err(err.into());
         }
       }
     }
@@ -690,6 +721,18 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
         })?;
     match self.http_cache.get(&cache_key, maybe_checksum) {
       Ok(Some(entry)) => {
+        if entry.metadata.headers.contains_key(NOT_FOUND_CACHE_HEADER) {
+          let download_time = entry
+            .metadata
+            .time
+            .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs(secs));
+          return if self.is_not_found_entry_fresh(download_time) {
+            Err(FetchCachedNoFollowErrorKind::NotFound(url.clone()).into_box())
+          } else {
+            // expired, treat as a cache miss so the URL is re-requested
+            Ok(None)
+          };
+        }
         Ok(Some(FileOrRedirect::from_deno_cache_entry(url, entry)?))
       }
       Ok(None) => Ok(None),
@@ -703,6 +746,25 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
       Err(CacheReadFileError::ChecksumIntegrity(err)) => {
         Err(FetchCachedNoFollowErrorKind::ChecksumIntegrity(*err).into_box())
       }
+    }
+  }
+
+  /// Returns if a cached 404 entry downloaded at the provided time is
+  /// still within [`NOT_FOUND_CACHE_TTL`] and may be served from the cache.
+  fn is_not_found_entry_fresh(
+    &self,
+    download_time: Option<SystemTime>,
+  ) -> bool {
+    let Some(download_time) = download_time else {
+      // no download time stored (ex. the vendor folder), so
+      // treat the entry as expired in order to re-request the URL
+      return false;
+    };
+    match self.sys.sys_time_now().duration_since(download_time) {
+      Ok(elapsed) => elapsed < NOT_FOUND_CACHE_TTL,
+      // the download time is in the future (clock changed), so
+      // consider the entry fresh
+      Err(_) => true,
     }
   }
 
@@ -824,6 +886,7 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
       });
 
     let maybe_auth_token = self.auth_tokens.get(url);
+    let is_authenticated = maybe_auth.is_some() || maybe_auth_token.is_some();
     match self
       .send_request(SendRequestArgs {
         url,
@@ -836,6 +899,23 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
       })
       .await?
     {
+      SendRequestResponse::NotFound => {
+        // Cache the 404 so subsequent processes don't re-request the URL
+        // until the entry expires (see NOT_FOUND_CACHE_TTL). Skip this for
+        // authenticated requests because a 404 may then depend on the
+        // provided credentials (ex. private registries respond with 404
+        // for unauthorized requests).
+        if !is_authenticated {
+          let headers = HashMap::from([(
+            NOT_FOUND_CACHE_HEADER.to_string(),
+            "404".to_string(),
+          )]);
+          if let Err(err) = self.http_cache.set(url, headers, &[]) {
+            debug!("Failed caching 404 for '{}': {:#}", url, err);
+          }
+        }
+        Err(FetchNoFollowErrorKind::NotFound(url.clone()).into_box())
+      }
       SendRequestResponse::NotModified => {
         let (cache_entry, _) = maybe_etag_cache_entry.unwrap();
         FileOrRedirect::from_deno_cache_entry(url, cache_entry).map_err(|err| {
@@ -983,9 +1063,7 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
           }
           .into_box(),
         ),
-        SendError::NotFound => {
-          Err(FetchNoFollowErrorKind::NotFound(args.url.clone()).into_box())
-        }
+        SendError::NotFound => Ok(SendRequestResponse::NotFound),
         SendError::StatusCode(status_code) => Err(
           FetchNoFollowErrorKind::ClientError {
             url: args.url.clone(),
@@ -1273,6 +1351,22 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
     else {
       return Ok(None);
     };
+    if headers.contains_key(NOT_FOUND_CACHE_HEADER) {
+      let download_time = self
+        .0
+        .http_cache
+        .read_download_time(&cache_key)
+        .map_err(|source| CacheReadError {
+          url: url.clone(),
+          source,
+        })?;
+      return if self.0.is_not_found_entry_fresh(download_time) {
+        Err(FetchCachedNoFollowErrorKind::NotFound(url.clone()).into_box())
+      } else {
+        // expired, treat as a cache miss so the URL is re-requested
+        Ok(None)
+      };
+    }
     if let Some(redirect_to) = headers.get("location") {
       let redirect =
         url
@@ -1313,6 +1407,10 @@ fn response_headers_to_headers_map(response_headers: HeaderMap) -> HeadersMap {
   // todo(dsherret): change to consume to avoid allocations
   for key in response_headers.keys() {
     let key_str = key.to_string();
+    if key_str == NOT_FOUND_CACHE_HEADER {
+      // reserved for internal use, never store it from a real response
+      continue;
+    }
     let values = response_headers.get_all(key);
     // todo(dsherret): this seems very strange storing them comma separated
     // like this... what happens if a value contains a comma?
@@ -1393,6 +1491,7 @@ struct SendRequestArgs<'a> {
 #[derive(Debug, Eq, PartialEq)]
 enum SendRequestResponse {
   Code(Vec<u8>, HeadersMap),
+  NotFound,
   NotModified,
   Redirect(Url, HeadersMap),
 }

--- a/libs/cache_dir/lib.rs
+++ b/libs/cache_dir/lib.rs
@@ -24,6 +24,7 @@ pub use cache::GlobalToLocalCopy;
 pub use cache::HttpCache;
 pub use cache::HttpCacheItemKey;
 pub use cache::HttpCacheRc;
+pub use cache::NOT_FOUND_CACHE_HEADER;
 pub use cache::SerializedCachedUrlMetadata;
 pub use cache::url_to_filename;
 pub use common::HeadersMap;

--- a/libs/cache_dir/local.rs
+++ b/libs/cache_dir/local.rs
@@ -38,6 +38,7 @@ use crate::SerializedCachedUrlMetadata;
 use crate::cache::CacheEntry;
 use crate::cache::CacheReadFileError;
 use crate::cache::GlobalToLocalCopy;
+use crate::cache::NOT_FOUND_CACHE_HEADER;
 use crate::global::GlobalHttpCacheRc;
 
 #[sys_traits::auto_impl]
@@ -306,8 +307,9 @@ impl<TSys: LocalHttpCacheSys> LocalHttpCache<TSys> {
     url: &Url,
   ) -> std::io::Result<Option<PathBuf>> {
     if let Some(headers) = self.get_url_headers(url)? {
-      let is_redirect = headers.contains_key("location");
-      if is_redirect {
+      let is_content_less = headers.contains_key("location")
+        || headers.contains_key(NOT_FOUND_CACHE_HEADER);
+      if is_content_less {
         return Ok(None);
       }
 
@@ -418,10 +420,12 @@ impl<TSys: LocalHttpCacheSys> HttpCache for LocalHttpCache<TSys> {
     headers: HeadersMap,
     content: &[u8],
   ) -> std::io::Result<()> {
-    let is_redirect = headers.contains_key("location");
+    // redirects and cached 404s have no content on disk
+    let is_content_less = headers.contains_key("location")
+      || headers.contains_key(NOT_FOUND_CACHE_HEADER);
     let sub_path = url_to_local_sub_path(url, headers_content_type(&headers))?;
 
-    if !is_redirect {
+    if !is_content_less {
       let content =
         self.transform_content_on_copy_to_local(url, Cow::Borrowed(content));
       // Cache content
@@ -449,9 +453,10 @@ impl<TSys: LocalHttpCacheSys> HttpCache for LocalHttpCache<TSys> {
     let maybe_headers = self.get_url_headers(key.url)?;
     match maybe_headers {
       Some(headers) => {
-        let is_redirect = headers.contains_key("location");
-        let bytes: Cow<'static, [u8]> = if is_redirect {
-          // return back an empty file for redirect
+        let is_content_less = headers.contains_key("location")
+          || headers.contains_key(NOT_FOUND_CACHE_HEADER);
+        let bytes: Cow<'static, [u8]> = if is_content_less {
+          // return back an empty file for redirects and cached 404s
           Cow::Borrowed(&[])
         } else {
           // if it's not a redirect, then it should have a file path
@@ -819,10 +824,11 @@ impl<
 
     let mut headers_subset = BTreeMap::new();
 
-    const HEADER_KEYS_TO_KEEP: [&str; 4] = [
+    const HEADER_KEYS_TO_KEEP: [&str; 5] = [
       // keep alphabetical for cleanliness in the output
       "content-type",
       "location",
+      NOT_FOUND_CACHE_HEADER,
       "x-deno-warning",
       "x-typescript-types",
     ];
@@ -920,6 +926,7 @@ mod manifest {
   use url::Url;
 
   use super::LocalCacheSubPath;
+  use super::NOT_FOUND_CACHE_HEADER;
   use super::url_to_local_sub_path;
 
   #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -976,7 +983,10 @@ mod manifest {
             .modules
             .iter()
             .filter_map(|(url, module)| {
-              if module.headers.contains_key("location") {
+              // redirects and cached 404s have no local file
+              if module.headers.contains_key("location")
+                || module.headers.contains_key(NOT_FOUND_CACHE_HEADER)
+              {
                 return None;
               }
               url_to_local_sub_path(url, module.content_type_header())

--- a/libs/cache_dir/tests/file_fetcher_test.rs
+++ b/libs/cache_dir/tests/file_fetcher_test.rs
@@ -311,3 +311,146 @@ async fn test_fetch_query_redirect_to_dts_is_cached() {
     "ensure_cached_no_follow must not issue HTTP requests for cached entries"
   );
 }
+
+// Regression test for https://github.com/denoland/deno/issues/25404.
+// A URL responding with 404 must be negatively cached so it's not
+// re-requested on every process start, until the entry expires or
+// the cache is reloaded.
+#[tokio::test]
+async fn test_fetch_not_found_is_negatively_cached() {
+  use std::sync::atomic::AtomicBool;
+  use std::sync::atomic::AtomicUsize;
+  use std::sync::atomic::Ordering;
+  use std::time::Duration;
+  use std::time::UNIX_EPOCH;
+
+  use deno_cache_dir::memory::MemoryHttpCache;
+
+  #[derive(Debug, Clone, Default)]
+  struct TestHttpClient {
+    #[allow(clippy::disallowed_types, reason = "arc wrapper type")]
+    request_count: deno_maybe_sync::MaybeArc<AtomicUsize>,
+    #[allow(clippy::disallowed_types, reason = "arc wrapper type")]
+    respond_success: deno_maybe_sync::MaybeArc<AtomicBool>,
+  }
+
+  #[async_trait::async_trait(?Send)]
+  impl HttpClient for TestHttpClient {
+    async fn send_no_follow(
+      &self,
+      _url: &Url,
+      _headers: HeaderMap,
+    ) -> Result<SendResponse, SendError> {
+      self.request_count.fetch_add(1, Ordering::SeqCst);
+      if self.respond_success.load(Ordering::SeqCst) {
+        let mut header_map = HeaderMap::new();
+        header_map
+          .insert("content-type", "application/typescript".parse().unwrap());
+        Ok(SendResponse::Success(header_map, b"export {};\n".to_vec()))
+      } else {
+        Err(SendError::NotFound)
+      }
+    }
+  }
+
+  fn assert_not_found(
+    result: Result<
+      FileOrRedirect,
+      deno_cache_dir::file_fetcher::FetchNoFollowError,
+    >,
+  ) {
+    match result.unwrap_err().into_kind() {
+      FetchNoFollowErrorKind::NotFound(_) => {}
+      err => unreachable!("{err:?}"),
+    }
+  }
+
+  let sys = InMemorySys::default();
+  sys.set_time(Some(UNIX_EPOCH));
+  let client = TestHttpClient::default();
+  let request_count = client.request_count.clone();
+  let respond_success = client.respond_success.clone();
+  let file_fetcher = FileFetcher::new(
+    NullBlobStore,
+    sys.clone(),
+    // share the clock between the cache and the file fetcher
+    new_rc(MemoryHttpCache::new(sys.clone())),
+    client,
+    new_rc(NullMemoryFiles),
+    FileFetcherOptions {
+      allow_remote: true,
+      cache_setting: CacheSetting::Use,
+      auth_tokens: AuthTokens::new(None),
+    },
+  );
+  let url = Url::parse("https://localhost/not_found.ts").unwrap();
+
+  // first fetch issues a request and caches the 404
+  assert_not_found(
+    file_fetcher
+      .fetch_no_follow(&url, FetchNoFollowOptions::default())
+      .await,
+  );
+  assert_eq!(request_count.load(Ordering::SeqCst), 1);
+
+  // subsequent fetches are served from the negative cache
+  assert_not_found(
+    file_fetcher
+      .fetch_no_follow(&url, FetchNoFollowOptions::default())
+      .await,
+  );
+  match file_fetcher
+    .ensure_cached_no_follow(&url, FetchNoFollowOptions::default())
+    .await
+    .unwrap_err()
+    .into_kind()
+  {
+    FetchNoFollowErrorKind::NotFound(_) => {}
+    err => unreachable!("{err:?}"),
+  }
+  assert_eq!(
+    request_count.load(Ordering::SeqCst),
+    1,
+    "a cached 404 should not issue any HTTP requests"
+  );
+
+  // fetch_cached reports a cached 404 as not having a usable cached file
+  assert_eq!(file_fetcher.fetch_cached(&url, 10).unwrap(), None);
+
+  // reloading bypasses the negative cache
+  assert_not_found(
+    file_fetcher
+      .fetch_no_follow(
+        &url,
+        FetchNoFollowOptions {
+          maybe_cache_setting: Some(&CacheSetting::ReloadAll),
+          ..Default::default()
+        },
+      )
+      .await,
+  );
+  assert_eq!(request_count.load(Ordering::SeqCst), 2);
+
+  // the URL now exists on the server, but the cached 404 is still fresh
+  respond_success.store(true, Ordering::SeqCst);
+  assert_not_found(
+    file_fetcher
+      .fetch_no_follow(&url, FetchNoFollowOptions::default())
+      .await,
+  );
+  assert_eq!(request_count.load(Ordering::SeqCst), 2);
+
+  // after the negative cache entry expires, the URL is re-requested
+  sys.set_time(Some(UNIX_EPOCH + Duration::from_secs(16 * 60)));
+  match file_fetcher
+    .fetch_no_follow(&url, FetchNoFollowOptions::default())
+    .await
+    .unwrap()
+  {
+    FileOrRedirect::File(file) => {
+      assert_eq!(&*file.source, b"export {};\n");
+    }
+    FileOrRedirect::Redirect(_) => unreachable!(),
+  }
+  assert_eq!(request_count.load(Ordering::SeqCst), 3);
+}

--- a/tests/specs/cache/not_found_negative_cache/__test__.jsonc
+++ b/tests/specs/cache/not_found_negative_cache/__test__.jsonc
@@ -1,0 +1,21 @@
+{
+  // Regression test for https://github.com/denoland/deno/issues/25404.
+  // A 404 from the remote server must be cached so the URL is not
+  // re-requested on every run, until `--reload` is used or the negative
+  // cache entry expires.
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "run --allow-import main.ts",
+      "output": "first.out"
+    },
+    {
+      "args": "run --allow-import main.ts",
+      "output": "second.out"
+    },
+    {
+      "args": "run --allow-import --reload main.ts",
+      "output": "first.out"
+    }
+  ]
+}

--- a/tests/specs/cache/not_found_negative_cache/first.out
+++ b/tests/specs/cache/not_found_negative_cache/first.out
@@ -1,0 +1,2 @@
+Download http://localhost:4545/this_module_does_not_exist.ts
+caught: [WILDLINE]

--- a/tests/specs/cache/not_found_negative_cache/main.ts
+++ b/tests/specs/cache/not_found_negative_cache/main.ts
@@ -1,0 +1,5 @@
+try {
+  await import("http://localhost:4545/this_module_does_not_exist.ts");
+} catch (err) {
+  console.log("caught:", (err as Error).message);
+}

--- a/tests/specs/cache/not_found_negative_cache/second.out
+++ b/tests/specs/cache/not_found_negative_cache/second.out
@@ -1,0 +1,1 @@
+caught: [WILDLINE]


### PR DESCRIPTION
A remote module that responds with 404 is never written to the HTTP cache,
so the URL is re-requested during graph resolution on every process start.
This shows up with published jsr packages whose JSDoc type references point
at non-existent files (every run of an installed CLI re-downloads the same
handful of 404ing URLs) and with dynamic imports that 404.

This stores a body-less cache entry marked with a synthetic
x-deno-not-found header, the same pattern used for redirects (body-less
entries detected via their location header), and serves "not found" from
the cache for 15 minutes. The TTL keeps a resource that appears on the
remote server later (e.g. a freshly published package version that is
still propagating) from being missed for long, while eliminating the
re-fetch on every run. Authenticated requests are not negatively cached
because a 404 can depend on the provided credentials (private registries
respond with 404 for unauthorized requests). --reload bypasses the
negative cache like it does everything else.

Closes #25404