### PR TITLE
docs: fix 'seperately' typo in JsRuntime doc comments

### DIFF
--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -1944,7 +1944,7 @@ impl JsRuntime {
   /// event loop resolves the underlying promise. If the future rejects, the future will
   /// resolve with the underlying error.
   ///
-  /// The event loop must be polled seperately for this future to resolve. If the event loop
+  /// The event loop must be polled separately for this future to resolve. If the event loop
   /// is not polled, the future will never make progress.
   pub fn call(
     &mut self,
@@ -1959,7 +1959,7 @@ impl JsRuntime {
   /// event loop resolves the underlying promise. If the future rejects, the future will
   /// resolve with the underlying error.
   ///
-  /// The event loop must be polled seperately for this future to resolve. If the event loop
+  /// The event loop must be polled separately for this future to resolve. If the event loop
   /// is not polled, the future will never make progress.
   pub fn scoped_call(
     scope: &mut v8::PinScope,
@@ -1974,7 +1974,7 @@ impl JsRuntime {
   /// event loop resolves the underlying promise. If the future rejects, the future will
   /// resolve with the underlying error.
   ///
-  /// The event loop must be polled seperately for this future to resolve. If the event loop
+  /// The event loop must be polled separately for this future to resolve. If the event loop
   /// is not polled, the future will never make progress.
   pub fn call_with_args(
     &mut self,
@@ -1991,7 +1991,7 @@ impl JsRuntime {
   /// event loop resolves the underlying promise. If the future rejects, the future will
   /// resolve with the underlying error.
   ///
-  /// The event loop must be polled seperately for this future to resolve. If the event loop
+  /// The event loop must be polled separately for this future to resolve. If the event loop
   /// is not polled, the future will never make progress.
   pub fn scoped_call_with_args(
     scope: &mut v8::PinScope,


### PR DESCRIPTION
## What do these changes do?

Fixes the misspelling 'seperately' → 'separately' in four doc comments in `JsRuntime`.

## Related issue number

N/A — trivial doc typo fix.

## Checklist

- [x] Ensure `./x fmt` passes
- [x] Ensure `./x lint` passes

Drafted with opencode; reviewed by human.