### PR TITLE
docs: fix double word 'from from' in Readable doc comment

### DIFF
--- a/libs/core/io/resource.rs
+++ b/libs/core/io/resource.rs
@@ -38,7 +38,7 @@ use crate::io::WriteOutcome;
 /// Readable resources are resources that can have data read from. Examples of
 /// this are files, sockets, or HTTP streams.
 ///
-/// Readables can be read from from either JS or Rust. In JS one can use
+/// Readables can be read from either JS or Rust. In JS one can use
 /// `Deno.core.read()` to read from a single chunk of data from a readable. In
 /// Rust one can directly call `read()` or `read_byob()`. The Rust side code is
 /// used to implement ops like `op_slice`.


### PR DESCRIPTION
## What do these changes do?

Fixes a double word typo in a doc comment: 'read from from either' → 'read from either'.

## Related issue number

N/A — trivial doc typo fix.

## Checklist

- [x] Ensure `./x fmt` passes
- [x] Ensure `./x lint` passes

Drafted with opencode; reviewed by human.