### PR TITLE
fix(ext/http): close upgraded websockets when Deno.serve signal aborts

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -58,6 +58,8 @@ const {
   SafeArrayIterator,
   SafePromisePrototypeFinally,
   SafePromiseAll,
+  SafeSet,
+  SafeSetIterator,
   PromisePrototypeThen,
   StringPrototypeIncludes,
   StringPrototypeSlice,
@@ -270,8 +272,19 @@ class InnerRequest {
 
       this.#upgraded = true;
 
-      return op_http_upgrade_websocket_next(external);
+      const context = this.#context;
+      return PromisePrototypeThen(
+        op_http_upgrade_websocket_next(external),
+        (wsRid) => {
+          context.trackUpgradedWebSocket(wsRid);
+          return wsRid;
+        },
+      );
     }
+  }
+
+  _untrackUpgradedWebSocket(rid) {
+    this.#context.untrackUpgradedWebSocket(rid);
   }
 
   url() {
@@ -455,11 +468,14 @@ class CallbackContext {
   fallbackHost;
   serverRid;
   closed;
+  aborted;
   /** @type {Promise<void> | undefined} */
   closing;
   listener;
   asyncContextSnapshot;
   legacyAbort;
+  /** @type {SafeSet<number>} */
+  upgradedWebSocketRids;
 
   constructor(signal, args, listener) {
     this.asyncContextSnapshot = currentSnapshot();
@@ -467,7 +483,15 @@ class CallbackContext {
     signal?.addEventListener(
       "abort",
       () => {
+        this.aborted = true;
         op_http_cancel(this.serverRid, false);
+        // Connections that were upgraded to websockets are no longer
+        // tracked by the server once their stream is taken over, so a
+        // non-graceful shutdown must close them explicitly (#25792).
+        for (const rid of new SafeSetIterator(this.upgradedWebSocketRids)) {
+          core.tryClose(rid);
+        }
+        this.upgradedWebSocketRids.clear();
       },
       { once: true },
     );
@@ -477,7 +501,23 @@ class CallbackContext {
     this.fallbackHost = args[2];
     this.legacyAbort = args[3] == false;
     this.closed = false;
+    this.aborted = false;
     this.listener = listener;
+    this.upgradedWebSocketRids = new SafeSet();
+  }
+
+  trackUpgradedWebSocket(rid) {
+    // If the server was already aborted while the upgrade was in flight,
+    // close the websocket immediately.
+    if (this.aborted) {
+      core.tryClose(rid);
+      return;
+    }
+    this.upgradedWebSocketRids.add(rid);
+  }
+
+  untrackUpgradedWebSocket(rid) {
+    this.upgradedWebSocketRids.delete(rid);
   }
 
   close() {

--- a/ext/http/02_websocket.ts
+++ b/ext/http/02_websocket.ts
@@ -121,6 +121,10 @@ function upgradeWebSocket(request, options = { __proto__: null }) {
         socket[_rid] = wsRid;
         socket[_readyState] = WebSocket.OPEN;
         installServerInspector(socket, request.url);
+        socket.addEventListener(
+          "close",
+          () => inner._untrackUpgradedWebSocket(wsRid),
+        );
         const event = new Event("open");
         socket.dispatchEvent(event);
 

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 use bytes::Bytes;
 use deno_core::AsyncMutFuture;
 use deno_core::AsyncRefCell;
+use deno_core::CancelFuture;
 use deno_core::CancelHandle;
 use deno_core::CancelTryFuture;
 use deno_core::OpState;
@@ -565,6 +566,7 @@ pub struct ServerWebSocket {
   string: Cell<Option<String>>,
   ws_read: AsyncRefCell<FragmentCollectorRead<ReadHalf<WebSocketStream>>>,
   ws_write: AsyncRefCell<WebSocketWrite<WriteHalf<WebSocketStream>>>,
+  cancel: CancelHandle,
 }
 
 impl ServerWebSocket {
@@ -579,6 +581,7 @@ impl ServerWebSocket {
       string: Cell::new(None),
       ws_read: AsyncRefCell::new(FragmentCollectorRead::new(ws_read)),
       ws_write: AsyncRefCell::new(ws_write),
+      cancel: CancelHandle::new(),
     }
   }
 
@@ -617,6 +620,13 @@ impl ServerWebSocket {
 impl Resource for ServerWebSocket {
   fn name(&self) -> Cow<'_, str> {
     "serverWebSocket".into()
+  }
+
+  fn close(self: Rc<Self>) {
+    // Interrupt any pending reads so the underlying stream can be dropped.
+    // This makes `core.tryClose(rid)` on an open websocket act as a forceful
+    // close instead of leaking the connection.
+    self.cancel.cancel();
   }
 }
 
@@ -867,12 +877,20 @@ pub async fn op_ws_next_event(
 
   let mut ws = RcRef::map(&resource, |r| &r.ws_read).borrow_mut().await;
   let writer = RcRef::map(&resource, |r| &r.ws_write);
+  let cancel = RcRef::map(&resource, |r| &r.cancel);
   let mut sender = move |frame| {
     let writer = writer.clone();
     async move { writer.borrow_mut().await.write_frame(frame).await }
   };
   loop {
-    let res = ws.read_frame(&mut sender).await;
+    let res = match ws.read_frame(&mut sender).or_cancel(cancel.clone()).await {
+      Ok(res) => res,
+      Err(_) => {
+        // The resource was closed while the read was pending (e.g. a
+        // forceful server shutdown). Report closed status to JavaScript.
+        return MessageKind::ClosedDefault as u16;
+      }
+    };
     let val = match res {
       Ok(val) => val,
       Err(err) => {

--- a/tests/specs/serve/abort_upgraded_websocket/__test__.jsonc
+++ b/tests/specs/serve/abort_upgraded_websocket/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "force_close_on_abort": {
+      "args": "run -A main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/serve/abort_upgraded_websocket/main.out
+++ b/tests/specs/serve/abort_upgraded_websocket/main.out
@@ -1,0 +1,7 @@
+[UNORDERED_START]
+server: ws open
+client: ws open
+server: ws closed
+client: ws closed
+server finished
+[UNORDERED_END]

--- a/tests/specs/serve/abort_upgraded_websocket/main.ts
+++ b/tests/specs/serve/abort_upgraded_websocket/main.ts
@@ -1,0 +1,38 @@
+// Regression test for https://github.com/denoland/deno/issues/25792
+// Aborting the signal passed to `Deno.serve()` must also close connections
+// that were upgraded to websockets, otherwise the process never exits.
+const controller = new AbortController();
+
+const server = Deno.serve({
+  port: 0,
+  signal: controller.signal,
+  onListen({ port }) {
+    connect(port);
+  },
+}, (req) => {
+  const { response, socket } = Deno.upgradeWebSocket(req);
+  socket.onopen = () => console.log("server: ws open");
+  socket.onclose = () => console.log("server: ws closed");
+  return response;
+});
+
+function connect(port: number) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  ws.onopen = () => {
+    console.log("client: ws open");
+    controller.abort();
+  };
+  ws.onclose = () => console.log("client: ws closed");
+}
+
+await server.finished;
+console.log("server finished");
+
+// Safety timeout (unref'd so it does not keep the process alive): if the
+// websocket is not force closed it keeps the event loop alive forever and
+// the test would hang without this.
+const t = setTimeout(() => {
+  console.error("timeout: websocket was not closed on abort");
+  Deno.exit(1);
+}, 60000);
+Deno.unrefTimer(t);


### PR DESCRIPTION
Aborting the signal passed to `Deno.serve()` is supposed to be a forceful
shutdown, but connections that had been upgraded with
`Deno.upgradeWebSocket()` were left open forever: the upgrade takes the
stream out of hyper and re-registers it as a standalone websocket resource,
so the server's connection cancel handle no longer covers it. As a result
`server.finished` resolved while the sockets stayed alive, neither peer ever
got a close event, and the process never exited.

The server context now tracks the resource ids of upgraded websockets and
force-closes them when the abort signal fires. To make that possible,
`ServerWebSocket` gained a cancel handle that interrupts a pending read when
the resource is closed; previously closing the resource left the in-flight
read holding the stream open indefinitely.

Fixes #25792