### PR TITLE
docs: fix 'for for' double word in debug assertion

### DIFF
--- a/libs/core/runtime/stats.rs
+++ b/libs/core/runtime/stats.rs
@@ -55,7 +55,7 @@ impl RuntimeActivityTraces {
     debug_assert_ne!(
       activity_type,
       RuntimeActivityType::Interval,
-      "Use Timer for for timers and intervals"
+      "Use Timer for timers and intervals"
     );
     self.traces.borrow_mut()[activity_type as usize].insert(id, trace.into());
   }
@@ -347,7 +347,7 @@ impl RuntimeActivityStats {
     debug_assert_ne!(
       activity_type,
       RuntimeActivityType::Interval,
-      "Use Timer for for timers and intervals"
+      "Use Timer for timers and intervals"
     );
     self.activity_traces[activity_type as u8 as usize]
       .get(&id)


### PR DESCRIPTION
## What do these changes do?

Fixes a double word 'for for' → 'for' in a debug assertion message in `runtime/stats.rs`.

## Related issue number

N/A — trivial doc fix.

## Checklist

- [x] Ensure `./x fmt` passes
- [x] Ensure `./x lint` passes

Drafted with opencode; reviewed by human.