### PR TITLE
ci: guard release snapshot flags

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -374,7 +374,7 @@ jobs:
       - name: Build debug
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-        run: cargo build --locked --bin deno --bin denort --bin test_server --features=panic-trace
+        run: cargo build --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
       - name: Check deno binary
         env:
           NO_COLOR: 1
@@ -761,7 +761,7 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         run: |-
           df -h
-          cargo build --release --locked --bin deno --bin denort --bin test_server --features=panic-trace
+          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
           df -h
       - name: Generate symcache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
@@ -1220,7 +1220,7 @@ jobs:
       - name: Build debug
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-        run: cargo build --locked --bin deno --bin denort --bin test_server --features=panic-trace
+        run: cargo build --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
       - name: Check deno binary
         env:
           NO_COLOR: 1
@@ -1768,7 +1768,7 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         run: |-
           df -h
-          cargo build --release --locked --bin deno --bin denort --bin test_server --features=panic-trace
+          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
           df -h
       - name: Generate symcache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
@@ -2224,7 +2224,7 @@ jobs:
       - name: Build debug
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-        run: cargo build --locked --bin deno --bin denort --bin test_server --features=panic-trace
+        run: cargo build --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
       - name: Check deno binary
         env:
           NO_COLOR: 1
@@ -2705,7 +2705,7 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         run: |-
           df -h
-          cargo build --release --locked --bin deno --bin denort --bin test_server --features=panic-trace
+          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
           df -h
       - name: Generate symcache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
@@ -3163,7 +3163,7 @@ jobs:
       - name: Build debug
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-        run: cargo build --locked --bin deno --bin denort --bin test_server --features=panic-trace
+        run: cargo build --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
       - name: Check deno binary
         env:
           NO_COLOR: 1
@@ -3525,7 +3525,7 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         run: |-
           df -h
-          cargo build --release --locked --bin deno --bin denort --bin test_server --features=panic-trace
+          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
           df -h
       - name: Generate symcache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
@@ -4087,8 +4087,14 @@ jobs:
       - name: Build release
         run: |-
           df -h
-          cargo build --release --locked --bin deno --bin denort --bin test_server --features=panic-trace
+          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
           df -h
+      - name: Check release snapshot flags
+        run: |-
+          if strings target/release/deno | grep -F -- '--no-lazy --no-lazy-eval --no-lazy-streaming'; then
+            echo "release deno binary contains eager snapshot flags"
+            exit 1
+          fi
       - name: Generate symcache
         env:
           NO_COLOR: 1
@@ -4861,7 +4867,7 @@ jobs:
       - name: Build debug
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-        run: cargo build --locked --bin deno --bin denort --bin test_server --features=panic-trace
+        run: cargo build --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
       - name: Check deno binary
         env:
           NO_COLOR: 1
@@ -5435,7 +5441,7 @@ jobs:
       - name: Build debug
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-        run: cargo build --locked --bin deno --bin denort --bin test_server --features=panic-trace
+        run: cargo build --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
       - name: Check deno binary
         env:
           NO_COLOR: 1
@@ -6030,8 +6036,15 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: |-
           df -h
-          cargo build --release --locked --bin deno --bin denort --bin test_server --features=panic-trace
+          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
           df -h
+      - name: Check release snapshot flags
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        run: |-
+          if strings target/release/deno | grep -F -- '--no-lazy --no-lazy-eval --no-lazy-streaming'; then
+            echo "release deno binary contains eager snapshot flags"
+            exit 1
+          fi
       - name: Generate symcache
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         env:

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -864,6 +864,8 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             ],
           }),
         );
+        const packagesToBuild = ["deno", "denort", "test_server"]
+          .map((name) => `-p ${name}`).join(" ");
         const binsToBuild = ["deno", "denort", "test_server"]
           .map((name) => `--bin ${name}`).join(" ");
         const cargoBuildReleaseStep = step
@@ -887,8 +889,18 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               run: [
                 // output fs space before and after building
                 "df -h",
-                `cargo build --release --locked ${binsToBuild} --features=panic-trace`,
+                `cargo build --release --locked ${packagesToBuild} ${binsToBuild} --features=deno/panic-trace`,
                 "df -h",
+              ],
+            },
+            {
+              name: "Check release snapshot flags",
+              if: isLinux,
+              run: [
+                "if strings target/release/deno | grep -F -- '--no-lazy --no-lazy-eval --no-lazy-streaming'; then",
+                '  echo "release deno binary contains eager snapshot flags"',
+                "  exit 1",
+                "fi",
               ],
             },
             {
@@ -922,7 +934,8 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             {
               name: "Build debug",
               if: isDebug,
-              run: `cargo build --locked ${binsToBuild} --features=panic-trace`,
+              run:
+                `cargo build --locked ${packagesToBuild} ${binsToBuild} --features=deno/panic-trace`,
               env: { CARGO_PROFILE_DEV_DEBUG: 0 },
             },
             cargoBuildReleaseStep,


### PR DESCRIPTION
## Summary

This adds a release-build smoke check that fails if the Linux `target/release/deno` binary embeds V8 eager snapshot parsing flags:

```text
--no-lazy --no-lazy-eval --no-lazy-streaming
```

It also scopes the CI binary build command to the intended packages (`deno`, `denort`, and `test_server`) instead of selecting binaries from the workspace root.

## Issue

Cargo feature unification can make release snapshot creation pick up test-only `deno_core` features when the build is invoked from the workspace root with only `--bin ...` selectors. In particular, `deno_core_testing` enables `deno_core/snapshot_flags_eager_parse`, which appends V8 eager parsing flags during snapshot creation.

When those flags leak into a release build, the startup snapshot serializes substantially more parsed/code state. The resulting `CLI_SNAPSHOT.bin` is much larger, and the produced binary contains the eager flag string, making this easy to smoke-test after building.

## Snapshot Size Evidence

Existing local artifacts showed this `CLI_SNAPSHOT.bin` size difference:

| Profile | Eager flags | Non-eager | Delta |
| --- | ---: | ---: | ---: |
| release | 7,976,313 | 6,206,593 | -1,769,720 bytes (-22.19%) |
| release-lite | 7,976,329 | 6,206,561 | -1,769,768 bytes (-22.19%) |
| debug | 8,920,000 | 7,148,424 | -1,771,576 bytes (-19.86%) |

## Validation

- Regenerated `.github/workflows/ci.generated.yml` from `.github/workflows/ci.ts`.
- `deno fmt --check .github/workflows/ci.ts`
- Inspected generated Linux release jobs to confirm the smoke check runs after `Build release` and before symcache generation.