### PR TITLE
fix: correct 'seperate' typo in Releases.md

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -5375,7 +5375,7 @@ Read more: http://deno.com/blog/v1.44
 - fix(lsp): respect types dependencies for tsc roots (#23825)
 - fix(lsp): show reference code lens on methods (#23804)
 - fix(node): error when throwing `FS_EISDIR` (#23829)
-- fix(node): seperate worker module cache (#23634)
+- fix(node): separate worker module cache (#23634)
 - fix(node): stub `AsyncResource.emitDestroy()` (#23802)
 - fix(node): wrong `worker_threads.terminate()` return value (#23803)
 - fix(npm): handle null fields in npm registry JSON (#23785)


### PR DESCRIPTION
## What do these changes do?

Fixes a misspelling in Releases.md: 'seperate' → 'separate'.

## Related issue number

N/A — trivial typo fix.

## Checklist

- [x] Ensure `./x fmt` passes
- [x] Ensure `./x lint` passes

Drafted with opencode; reviewed by human.