### PR TITLE
fix(npm): support `catalog:` protocol in deno.json imports

### DIFF
--- a/cli/tools/pm/why.rs
+++ b/cli/tools/pm/why.rs
@@ -74,7 +74,7 @@ pub async fn why(
   let workspace = factory.cli_options()?.workspace();
   let mut root_reqs: HashSet<JsrDepPackageReq> = HashSet::new();
   for deno_json in workspace.deno_jsons() {
-    root_reqs.extend(deno_json.dependencies());
+    root_reqs.extend(deno_json.dependencies(workspace.catalogs()));
   }
   for pkg_json in workspace.package_jsons() {
     let deps = pkg_json.resolve_local_package_json_deps();

--- a/cli/tools/publish/unfurl.rs
+++ b/cli/tools/publish/unfurl.rs
@@ -726,7 +726,7 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
     ];
     for deno_json in deno_jsons.iter().flatten() {
       let deps = deno_json
-        .dependencies()
+        .dependencies(self.workspace_dir.workspace.catalogs())
         .into_iter()
         .collect::<BTreeSet<_>>();
       for dep in deps {

--- a/libs/config/deno_json/mod.rs
+++ b/libs/config/deno_json/mod.rs
@@ -11,7 +11,9 @@ use deno_error::JsError;
 use deno_path_util::url_from_file_path;
 use deno_path_util::url_parent;
 use deno_path_util::url_to_file_path;
+use deno_semver::VersionReq;
 use deno_semver::jsr::JsrDepPackageReq;
+use deno_semver::package::PackageReq;
 use import_map::ImportMapWithDiagnostics;
 use indexmap::IndexMap;
 use serde::Deserialize;
@@ -30,8 +32,8 @@ use url::Url;
 use crate::UrlToFilePathError;
 use crate::glob::FilePatterns;
 use crate::glob::PathOrPatternSet;
-use crate::import_map::imports_values;
-use crate::import_map::scope_values;
+use crate::import_map::imports_entries;
+use crate::import_map::scope_entries;
 use crate::import_map::value_to_dep_req;
 use crate::util::is_skippable_io_error;
 
@@ -2413,10 +2415,34 @@ impl ConfigFile {
     }
   }
 
-  pub fn dependencies(&self) -> HashSet<JsrDepPackageReq> {
-    let mut set = imports_values(self.json.imports.as_ref())
-      .chain(scope_values(self.json.scopes.as_ref()))
-      .filter_map(value_to_dep_req)
+  pub fn dependencies(
+    &self,
+    catalogs: &IndexMap<String, IndexMap<String, String>>,
+  ) -> HashSet<JsrDepPackageReq> {
+    let entry_to_dep_req = |(key, value): (&str, &str)| {
+      if let Some(catalog_name) = value.strip_prefix("catalog:") {
+        // `catalog:`/`catalog:<name>` entries resolve to the version
+        // requirement defined in the workspace root's catalog
+        let catalog_name = if catalog_name.is_empty() {
+          "default"
+        } else {
+          catalog_name
+        };
+        let name = key.strip_suffix('/').unwrap_or(key);
+        let version_req_str =
+          catalogs.get(catalog_name).and_then(|c| c.get(name))?;
+        let version_req = VersionReq::parse_from_npm(version_req_str).ok()?;
+        Some(JsrDepPackageReq::npm(PackageReq {
+          name: name.into(),
+          version_req,
+        }))
+      } else {
+        value_to_dep_req(value)
+      }
+    };
+    let mut set = imports_entries(self.json.imports.as_ref())
+      .chain(scope_entries(self.json.scopes.as_ref()))
+      .filter_map(entry_to_dep_req)
       .collect::<HashSet<_>>();
 
     if let Some(serde_json::Value::Object(compiler_options)) =

--- a/libs/config/import_map.rs
+++ b/libs/config/import_map.rs
@@ -36,11 +36,23 @@ pub fn import_map_deps_from_value(
 pub(crate) fn imports_values(
   value: Option<&serde_json::Value>,
 ) -> impl Iterator<Item = &str> {
+  imports_entries(value).map(|(_, v)| v)
+}
+
+pub(crate) fn scope_values(
+  value: Option<&serde_json::Value>,
+) -> impl Iterator<Item = &str> {
+  scope_entries(value).map(|(_, v)| v)
+}
+
+pub(crate) fn imports_entries(
+  value: Option<&serde_json::Value>,
+) -> impl Iterator<Item = (&str, &str)> {
   value
     .and_then(|v| v.as_object())
     .map(|obj| {
-      obj.values().filter_map(|v| match v {
-        serde_json::Value::String(value) => Some(value.as_ref()),
+      obj.iter().filter_map(|(k, v)| match v {
+        serde_json::Value::String(value) => Some((k.as_str(), value.as_ref())),
         _ => None,
       })
     })
@@ -48,12 +60,12 @@ pub(crate) fn imports_values(
     .flatten()
 }
 
-pub(crate) fn scope_values(
+pub(crate) fn scope_entries(
   value: Option<&serde_json::Value>,
-) -> impl Iterator<Item = &str> {
+) -> impl Iterator<Item = (&str, &str)> {
   value
     .and_then(|v| v.as_object())
-    .map(|obj| obj.values().flat_map(|v| imports_values(Some(v))))
+    .map(|obj| obj.values().flat_map(|v| imports_entries(Some(v))))
     .into_iter()
     .flatten()
 }

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -811,7 +811,7 @@ impl Workspace {
         deps: folder
           .deno_json
           .as_ref()
-          .map(|d| d.dependencies().into_iter().map(Dep::Req))
+          .map(|d| d.dependencies(catalogs).into_iter().map(Dep::Req))
           .into_iter()
           .flatten()
           .chain(

--- a/libs/npm_installer/package_json.rs
+++ b/libs/npm_installer/package_json.rs
@@ -166,15 +166,43 @@ impl NpmInstallDepsProvider {
         // should inline their import map to get this behaviour
         if let Some(serde_json::Value::Object(obj)) = &deno_json.json.imports {
           let mut pkg_pkgs = Vec::with_capacity(obj.len());
-          for (_alias, value) in obj {
+          for (alias, value) in obj {
             let serde_json::Value::String(specifier) = value else {
               continue;
             };
-            let Ok(npm_req_ref) = NpmPackageReqReference::from_str(specifier)
-            else {
-              continue;
+            let pkg_req = if let Some(catalog_name) =
+              specifier.strip_prefix("catalog:")
+            {
+              // `catalog:`/`catalog:<name>` entries resolve to the version
+              // requirement defined in the workspace root's catalog
+              let catalog_name = if catalog_name.is_empty() {
+                "default"
+              } else {
+                catalog_name
+              };
+              let name = alias.strip_suffix('/').unwrap_or(alias);
+              let Some(version_req_str) = workspace
+                .catalogs()
+                .get(catalog_name)
+                .and_then(|catalog| catalog.get(name))
+              else {
+                continue;
+              };
+              let Ok(version_req) = VersionReq::parse_from_npm(version_req_str)
+              else {
+                continue;
+              };
+              PackageReq {
+                name: PackageName::from_str(name),
+                version_req,
+              }
+            } else {
+              let Ok(npm_req_ref) = NpmPackageReqReference::from_str(specifier)
+              else {
+                continue;
+              };
+              npm_req_ref.into_inner().req
             };
-            let pkg_req = npm_req_ref.into_inner().req;
 
             if skip_types && pkg_req.name.starts_with("@types/") {
               continue;

--- a/libs/resolver/lockfile.rs
+++ b/libs/resolver/lockfile.rs
@@ -367,7 +367,7 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
           root_folder
             .deno_json
             .as_deref()
-            .map(|d| d.dependencies())
+            .map(|d| d.dependencies(workspace.catalogs()))
             .unwrap_or_default()
         },
       },
@@ -396,7 +396,7 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
                 dependencies: folder
                   .deno_json
                   .as_deref()
-                  .map(|d| d.dependencies())
+                  .map(|d| d.dependencies(workspace.catalogs()))
                   .unwrap_or_default(),
               };
               if config.package_json_deps.is_empty()
@@ -474,7 +474,8 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
           })
           .unwrap();
           let value = deno_lockfile::LockfileLinkContent {
-            dependencies: deno_json.dependencies(),
+            // not this workspace's catalogs, so don't resolve against them
+            dependencies: deno_json.dependencies(&Default::default()),
             optional_dependencies: Default::default(),
             peer_dependencies: Default::default(),
             peer_dependencies_meta: Default::default(),

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -83,6 +83,9 @@ pub enum WorkspaceResolverCreateError {
     #[inherit]
     ImportMapError,
   ),
+  #[class(type)]
+  #[error("Package '{name}' not found in catalog")]
+  CatalogPackageNotFound { name: String },
 }
 
 /// Whether to resolve dependencies by reading the dependencies list
@@ -861,6 +864,94 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
       specified_import_map: Option<SpecifiedImportMap>,
     ) -> Result<Option<ImportMapWithDiagnostics>, WorkspaceResolverCreateError>
     {
+      // Replaces `catalog:`/`catalog:<name>` string values in an import map
+      // value's `imports` and `scopes` with the `npm:<name>@<version_req>`
+      // specifier from the workspace root's catalog, so everything downstream
+      // (resolution, installation, the lockfile) sees a regular npm specifier.
+      // A trailing slash entry is added for "directory" imports, mirroring the
+      // expansion `to_import_map_value` applies to inline `npm:` specifiers.
+      fn expand_catalog_specifiers(
+        value: serde_json::Value,
+        catalogs: &IndexMap<String, IndexMap<String, String>>,
+      ) -> Result<serde_json::Value, WorkspaceResolverCreateError> {
+        fn expand_entries(
+          obj: serde_json::Map<String, serde_json::Value>,
+          catalogs: &IndexMap<String, IndexMap<String, String>>,
+        ) -> Result<
+          serde_json::Map<String, serde_json::Value>,
+          WorkspaceResolverCreateError,
+        > {
+          let mut result = serde_json::Map::with_capacity(obj.len());
+          for (key, value) in &obj {
+            let maybe_catalog_name =
+              value.as_str().and_then(|s| s.strip_prefix("catalog:"));
+            let Some(catalog_name) = maybe_catalog_name else {
+              result.insert(key.clone(), value.clone());
+              continue;
+            };
+            let catalog_name = if catalog_name.is_empty() {
+              "default"
+            } else {
+              catalog_name
+            };
+            let name = key.strip_suffix('/').unwrap_or(key);
+            let version_req = catalogs
+              .get(catalog_name)
+              .and_then(|catalog| catalog.get(name))
+              .ok_or_else(|| {
+                WorkspaceResolverCreateError::CatalogPackageNotFound {
+                  name: name.to_string(),
+                }
+              })?;
+            if key.ends_with('/') {
+              result.insert(
+                key.clone(),
+                format!("npm:/{}@{}/", name, version_req).into(),
+              );
+            } else {
+              result.insert(
+                key.clone(),
+                format!("npm:{}@{}", name, version_req).into(),
+              );
+              let key_with_slash = format!("{}/", key);
+              if !obj.contains_key(&key_with_slash) {
+                result.insert(
+                  key_with_slash,
+                  format!("npm:/{}@{}/", name, version_req).into(),
+                );
+              }
+            }
+          }
+          Ok(result)
+        }
+
+        let serde_json::Value::Object(mut map) = value else {
+          return Ok(value);
+        };
+        if let Some(serde_json::Value::Object(imports)) = map.remove("imports")
+        {
+          map.insert(
+            "imports".to_string(),
+            expand_entries(imports, catalogs)?.into(),
+          );
+        }
+        if let Some(serde_json::Value::Object(scopes)) = map.remove("scopes") {
+          let mut expanded_scopes =
+            serde_json::Map::with_capacity(scopes.len());
+          for (scope_key, scope_value) in scopes {
+            let scope_value = match scope_value {
+              serde_json::Value::Object(obj) => {
+                expand_entries(obj, catalogs)?.into()
+              }
+              _ => scope_value,
+            };
+            expanded_scopes.insert(scope_key, scope_value);
+          }
+          map.insert("scopes".to_string(), expanded_scopes.into());
+        }
+        Ok(serde_json::Value::Object(map))
+      }
+
       // Builds the import map scope contributed by a workspace member or linked
       // package. The member's `imports` (not its `scopes`) are layered into the
       // synthetic map; this follows an external `importMap` file when the
@@ -870,7 +961,9 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
       fn child_import_map_config(
         sys: &impl FsRead,
         config: &ConfigFileRc,
-      ) -> import_map::ext::ImportMapConfig {
+        catalogs: &IndexMap<String, IndexMap<String, String>>,
+      ) -> Result<import_map::ext::ImportMapConfig, WorkspaceResolverCreateError>
+      {
         let (base_url, value) = match config.to_import_map_value(sys) {
           Ok(Some((specifier, value))) => (specifier.into_owned(), value),
           Ok(None) => (
@@ -895,10 +988,17 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
         {
           imports_only.insert("imports".to_string(), imports);
         }
-        import_map::ext::ImportMapConfig {
+        // catalog expansion only applies to inline imports, not to
+        // external import map files
+        let import_map_value = if config.is_an_import_map() {
+          expand_catalog_specifiers(imports_only.into(), catalogs)?
+        } else {
+          imports_only.into()
+        };
+        Ok(import_map::ext::ImportMapConfig {
           base_url,
-          import_map_value: imports_only.into(),
-        }
+          import_map_value,
+        })
       }
 
       let root_deno_json = workspace.root_deno_json();
@@ -952,6 +1052,16 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
               serde_json::Value::Object(Default::default()),
             ),
           };
+          // catalog expansion only applies to inline imports, not to
+          // external import map files
+          let value = if root_deno_json
+            .as_ref()
+            .is_some_and(|d| d.is_an_import_map())
+          {
+            expand_catalog_specifiers(value, workspace.catalogs())?
+          } else {
+            value
+          };
           import_map::ext::ImportMapConfig {
             base_url,
             import_map_value: value,
@@ -964,8 +1074,10 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
         .filter(|f| {
           Some(&f.specifier) != root_deno_json.as_ref().map(|c| &c.specifier)
         })
-        .map(|config| child_import_map_config(sys, config))
-        .collect::<Vec<_>>();
+        .map(|config| {
+          child_import_map_config(sys, config, workspace.catalogs())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
       let (import_map_url, import_map) =
         ::import_map::ext::create_synthetic_import_map(
           base_import_map_config,

--- a/tests/specs/install/catalog_deno_json_imports/__test__.jsonc
+++ b/tests/specs/install/catalog_deno_json_imports/__test__.jsonc
@@ -1,0 +1,34 @@
+{
+  "tempDir": true,
+  "tests": {
+    "install_catalog_imports": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "install.out"
+        },
+        {
+          // ensure the packages were materialized into node_modules
+          "args": [
+            "eval",
+            "console.log(Deno.statSync('node_modules/@denotest/esm-basic').isDirectory, Deno.statSync('node_modules/@denotest/add').isDirectory)"
+          ],
+          "output": "true true\n"
+        },
+        {
+          "args": "run -A main.js",
+          "output": "42\n"
+        }
+      ]
+    },
+    "run_catalog_imports_no_install": {
+      "steps": [
+        {
+          // no node_modules dir, resolves straight from the global cache
+          "args": "run -A --node-modules-dir=none main.js",
+          "output": "[WILDCARD]42\n"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/install/catalog_deno_json_imports/deno.json
+++ b/tests/specs/install/catalog_deno_json_imports/deno.json
@@ -1,0 +1,15 @@
+{
+  "catalog": {
+    "@denotest/esm-basic": "^1.0.0"
+  },
+  "catalogs": {
+    "my-deps": {
+      "@denotest/add": "^1.0.0"
+    }
+  },
+  "imports": {
+    "@denotest/esm-basic": "catalog:",
+    "@denotest/add": "catalog:my-deps"
+  },
+  "nodeModulesDir": "manual"
+}

--- a/tests/specs/install/catalog_deno_json_imports/install.out
+++ b/tests/specs/install/catalog_deno_json_imports/install.out
@@ -1,0 +1,4 @@
+[WILDCARD]Dependencies:
++ npm:@denotest/add 1.0.0
++ npm:@denotest/esm-basic 1.0.0
+[WILDCARD]

--- a/tests/specs/install/catalog_deno_json_imports/main.js
+++ b/tests/specs/install/catalog_deno_json_imports/main.js
@@ -1,0 +1,4 @@
+import { getValue, setValue } from "@denotest/esm-basic";
+import { add } from "@denotest/add";
+setValue(add(40, 2));
+console.log(getValue());

--- a/tests/specs/install/catalog_deno_json_imports_missing/__test__.jsonc
+++ b/tests/specs/install/catalog_deno_json_imports_missing/__test__.jsonc
@@ -1,0 +1,10 @@
+{
+  "tempDir": true,
+  "tests": {
+    "missing_catalog_import": {
+      "args": "run -A main.js",
+      "output": "error: Package '@denotest/add' not found in catalog\n",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/install/catalog_deno_json_imports_missing/deno.json
+++ b/tests/specs/install/catalog_deno_json_imports_missing/deno.json
@@ -1,0 +1,8 @@
+{
+  "catalog": {
+    "@denotest/esm-basic": "^1.0.0"
+  },
+  "imports": {
+    "@denotest/add": "catalog:"
+  }
+}

--- a/tests/specs/install/catalog_deno_json_imports_missing/main.js
+++ b/tests/specs/install/catalog_deno_json_imports_missing/main.js
@@ -1,0 +1,2 @@
+import { add } from "@denotest/add";
+console.log(add(1, 2));


### PR DESCRIPTION
Previously `catalog:` was only supported in `package.json` dependencies. Using it in deno.json `imports` was silently broken everywhere: `deno run` failed with `Unsupported scheme "catalog" for module "catalog:"`, and `deno install` skipped the entry entirely, so the package was never materialized into `node_modules` (and its CLI bin entries were never created).

This PR makes `catalog:` / `catalog:<name>` work in deno.json `imports` (and `scopes`):

- **Import map expansion** (`libs/resolver/workspace.rs`): when building the synthetic import map, `catalog:` values are replaced with the `npm:<name>@<version_req>` specifier from the workspace root catalog (package name taken from the import key, matching pnpm semantics). A trailing-slash entry is added so subpath imports work, mirroring the existing `npm:` expansion. A missing catalog entry fails with the same error already used for package.json catalog deps: `Package '<name>' not found in catalog`. External import map files are not expanded, consistent with how the bare specifier expansion only applies to inline imports.
- **Install dep collection** (`libs/npm_installer/package_json.rs`): `NpmInstallDepsProvider` resolves `catalog:` values in deno.json imports so `deno install` materializes the package (and its bin entries) into `node_modules` in `auto` and `manual` modes.
- **Lockfile workspace deps** (`libs/config`, `libs/resolver/lockfile.rs`): `ConfigFile::dependencies()` now takes the workspace catalogs and resolves `catalog:` import entries, so the resolved req is tracked under the lockfile's `workspace` config (previously the entry was dropped). Linked packages pass empty catalogs since another workspace's catalog shouldn't apply to them.

Verified that `deno run`, `deno install` (none/auto/manual), subpath imports, workspace members referencing the root catalog, named catalogs, and `deno compile` all work, with behavior matching plain `npm:` import map entries.

Spec tests added for install materialization in `manual` mode (including a named catalog), running without a node_modules dir, and the missing-catalog-entry error.

Fixes #35165