### PR TITLE
fix(ext/node): make registerHooks resolve hook work for nested imports

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1312,6 +1312,21 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
 
     deno_core::ModuleLoadResponse::Async(
       async move {
+        // A `registerHooks` resolve hook may have rewritten this specifier
+        // to a URL the initial graph preparation never saw (e.g. appended a
+        // fragment for cache busting), so prepare it on demand.
+        if inner.hook_registry.resolve_active()
+          && !matches!(
+            options.requested_module_type,
+            RequestedModuleType::Text | RequestedModuleType::Bytes
+          )
+          && !inner.shared.in_npm_pkg_checker.in_npm_package(&specifier)
+          && inner.graph_container.graph().get(&specifier).is_none()
+        {
+          inner
+            .prepare_hooked_specifier(&specifier, options.is_dynamic_import)
+            .await;
+        }
         inner
           .load_inner(
             &specifier,

--- a/ext/node/ops/module_hooks.rs
+++ b/ext/node/ops/module_hooks.rs
@@ -67,6 +67,11 @@ impl LoaderHookRegistry {
     id
   }
 
+  /// Whether a `registerHooks` resolve hook is currently installed.
+  pub fn resolve_active(&self) -> bool {
+    self.resolve_callback.borrow().is_some()
+  }
+
   /// Install the default-resolution callback used by the JS hook chain when
   /// the terminal `nextResolve` is reached. The embedder is expected to
   /// provide a function that performs the same resolution as a normal

--- a/tests/specs/node/module_register_hooks_esm/__test__.jsonc
+++ b/tests/specs/node/module_register_hooks_esm/__test__.jsonc
@@ -27,6 +27,11 @@
       "cwd": "redirect",
       "args": "run -A main.mjs",
       "output": "redirect/main.out"
+    },
+    "resolve_cache_bust": {
+      "cwd": "resolve_cache_bust",
+      "args": "run -A main.mjs",
+      "output": "resolve_cache_bust/main.out"
     }
   }
 }

--- a/tests/specs/node/module_register_hooks_esm/resolve_cache_bust/main.mjs
+++ b/tests/specs/node/module_register_hooks_esm/resolve_cache_bust/main.mjs
@@ -1,0 +1,22 @@
+// Regression test for https://github.com/denoland/deno/issues/35163
+// A resolve-only hook rewriting specifiers (e.g. appending a fragment for
+// cache busting) must work for nested imports too: the rewritten URLs are
+// never seen by the initial graph preparation pass.
+import module from "node:module";
+
+let gen = 0;
+module.registerHooks({
+  resolve(specifier, context, nextResolve) {
+    return nextResolve(`${specifier}#${gen}`, { ...context });
+  },
+});
+
+const a = await import("./src/data.ts");
+console.log("first:", a.title);
+
+// Bumping the generation re-resolves every module in the chain to fresh
+// URLs, forcing re-evaluation (HMR-style cache busting).
+gen++;
+const b = await import("./src/data.ts");
+console.log("second:", b.title);
+console.log("distinct module instances:", a !== b);

--- a/tests/specs/node/module_register_hooks_esm/resolve_cache_bust/main.out
+++ b/tests/specs/node/module_register_hooks_esm/resolve_cache_bust/main.out
@@ -1,0 +1,3 @@
+first: Value1
+second: Value2
+distinct module instances: true

--- a/tests/specs/node/module_register_hooks_esm/resolve_cache_bust/src/data.ts
+++ b/tests/specs/node/module_register_hooks_esm/resolve_cache_bust/src/data.ts
@@ -1,0 +1,3 @@
+import { other } from "./other.ts";
+
+export const title: string = other;

--- a/tests/specs/node/module_register_hooks_esm/resolve_cache_bust/src/other.ts
+++ b/tests/specs/node/module_register_hooks_esm/resolve_cache_bust/src/other.ts
@@ -1,0 +1,5 @@
+// deno-lint-ignore no-explicit-any
+const g = globalThis as any;
+g.evalCount = (g.evalCount ?? 0) + 1;
+
+export const other: string = `Value${g.evalCount}`;


### PR DESCRIPTION
A `module.registerHooks` resolve hook that rewrites specifiers (for example
appending a fragment for HMR-style cache busting) failed on nested imports
with "Loading unprepared module". The module graph is prepared using
deno_graph's own resolution, which doesn't invoke JS resolve hooks, so a
hook-rewritten URL for a nested import was never present in the graph when
deno_core later requested it.

When a resolve hook is active and the requested specifier is missing from
the graph, the loader now prepares it on demand before loading, the same
best-effort preparation already used for load hook redirects.

Fixes #35163