### PR TITLE
fix(lsp): make requests work for files opened from node_modules

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1409,14 +1409,34 @@ impl DocumentModules {
       || self.resolver.in_node_modules(&specifier)
       || self.cache.in_global_cache_directory(&specifier)
     {
-      let key = compiler_options_key?;
-      let value = self
-        .compiler_options_resolver
-        .for_key(key)
-        .expect("Key should be in sync with resolver.");
-      (key, value)
+      // Dependency files get their compiler options key from their referrer,
+      // passed in here when reached through resolution. If we don't have one
+      // (e.g. the document was opened directly in the editor), use the key
+      // previously assigned to it if any, or infer one from its path. See
+      // https://github.com/denoland/deno/issues/35170.
+      let key = compiler_options_key.cloned().or_else(|| {
+        let (assigned_scope, assigned_key) =
+          self.assigned_scopes.read().get(document.uri())?.clone();
+        (assigned_scope.as_deref() == scope).then_some(assigned_key)
+      });
+      match key {
+        Some(key) => {
+          let value = self
+            .compiler_options_resolver
+            .for_key(&key)
+            .expect("Key should be in sync with resolver.");
+          (key, value)
+        }
+        None if scheme == "file" => {
+          let (key, value) = self
+            .compiler_options_resolver
+            .entry_for_specifier(&specifier);
+          (key.clone(), value)
+        }
+        None => return None,
+      }
     } else {
-      self.compiler_options_resolver.entry_for_specifier(
+      let (key, value) = self.compiler_options_resolver.entry_for_specifier(
         if scheme != "file"
           && let Some(scope) = scope
         {
@@ -1424,12 +1444,13 @@ impl DocumentModules {
         } else {
           &specifier
         },
-      )
+      );
+      (key.clone(), value)
     };
     let module = Arc::new(DocumentModule::new(
       document,
       specifier,
-      compiler_options_key.clone(),
+      compiler_options_key,
       compiler_options_data,
       scope.cloned().map(Arc::new),
       &self.resolver,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -5745,6 +5745,18 @@ fn op_script_names(state: &mut OpState) -> ScriptNames {
           module.media_type,
           scope.as_deref(),
         ));
+        // The auto-import alias hides `node_modules/.deno` from tsc, but
+        // requests for open documents (diagnostics, hover, etc.) use the
+        // unaliased name. Include it as a root too so they don't fail with
+        // "Could not find source file". See
+        // https://github.com/denoland/deno/issues/35170.
+        if is_open {
+          script_names.insert(
+            state
+              .specifier_map
+              .denormalize(&module.specifier, module.media_type),
+          );
+        }
       }
     }
   }

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -20341,6 +20341,77 @@ fn lsp_byonm_js_import_resolves_to_dts() {
   client.shutdown();
 }
 
+// Regression test for https://github.com/denoland/deno/issues/35170.
+#[test(timeout = 300)]
+fn lsp_open_file_in_managed_node_modules_dir() {
+  let context = TestContextBuilder::for_npm().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write(
+    "deno.json",
+    json!({
+      "nodeModulesDir": "auto",
+      "imports": {
+        "add": "npm:@denotest/add@1",
+      },
+    })
+    .to_string(),
+  );
+  context.run_deno("install");
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  // The temp dir is symlinked on macos, and `node_modules` is canonicalized.
+  let canon_temp_dir =
+    Url::from_directory_path(temp_dir.path().canonicalize()).unwrap();
+  let dts_url = canon_temp_dir
+    .join("node_modules/.deno/@denotest+add@1.0.0/node_modules/@denotest/add/index.d.ts")
+    .unwrap();
+  // Open a file from the node_modules dir directly, like go-to-definition in
+  // the editor would, without anything importing it. The text contains an
+  // intentional type error to check that diagnostics are generated for it.
+  let diagnostics = client.did_open(json!({
+    "textDocument": {
+      "uri": url_to_uri(&dts_url).unwrap(),
+      "languageId": "typescript",
+      "version": 1,
+      "text": "export function add(a: number, b: number): number;\nexport const foo: strang;\n",
+    }
+  }));
+  assert_eq!(
+    json!(diagnostics.all()),
+    json!([{
+      "range": {
+        "start": { "line": 1, "character": 18 },
+        "end": { "line": 1, "character": 24 },
+      },
+      "severity": 1,
+      "code": 2552,
+      "source": "deno-ts",
+      "message": "Cannot find name 'strang'. Did you mean 'string'?",
+    }]),
+  );
+  let res = client.write_request(
+    "textDocument/hover",
+    json!({
+      "textDocument": { "uri": url_to_uri(&dts_url).unwrap() },
+      "position": { "line": 0, "character": 17 },
+    }),
+  );
+  assert_eq!(
+    res,
+    json!({
+      "contents": {
+        "kind": "markdown",
+        "value": "```tsx\nfunction add(a: number, b: number): number\n```\n",
+      },
+      "range": {
+        "start": { "line": 0, "character": 16 },
+        "end": { "line": 0, "character": 19 },
+      },
+    }),
+  );
+  client.shutdown();
+}
+
 #[test(timeout = 300)]
 fn decorators_tc39() {
   let context = TestContextBuilder::new().use_temp_cwd().build();


### PR DESCRIPTION
When a file inside node_modules was opened in the editor (e.g. through
go-to-definition into "node_modules/.deno/<pkg>@<version>/..." with a managed
node_modules dir), the LSP couldn't associate it with any tsc project. The
document never became a tsc root, so diagnostics silently no-oped and requests
like hover, code actions and refactors either returned nothing or failed with
"Could not find source file" errors. Despite the issue title mentioning the
"@" symbol, the path encoding was fine; "@" just appears in every ".deno"
cache path.

Two things needed fixing. Module entries for node_modules and global cache
files required a compiler options key from their referrer, which isn't
available when the document is opened directly, so we now fall back to the
key previously assigned through resolution, or infer one from the file path.
And in script names, open documents that are configured dependency entry
points were only rooted under the "$node_modules" auto-import alias, while
requests use the unaliased name, so the unaliased name is now included as a
root too.

Fixes #35170