### PR TITLE
chore(wpt): upgrade deno_dom to fix silent empty test bundles

### DIFF
--- a/tests/wpt/runner/expectations/fetch.json
+++ b/tests/wpt/runner/expectations/fetch.json
@@ -757,9 +757,9 @@
       },
       "block-mime-as-script.html": false,
       "request-referrer-redirected-worker.html": false,
-      "url-parsing.sub.html?encoding=utf8": false,
-      "url-parsing.sub.html?encoding=windows-1252": false,
-      "url-parsing.sub.html?encoding=x-cp1251": false,
+      "url-parsing.sub.html?encoding=utf8": true,
+      "url-parsing.sub.html?encoding=windows-1252": true,
+      "url-parsing.sub.html?encoding=x-cp1251": true,
       "gc.any.html": true,
       "gc.any.worker.html": true
     },
@@ -2232,7 +2232,13 @@
       "element-video.https.sub.html": false,
       "element-video.sub.html": false,
       "fetch.https.sub.html": false,
-      "fetch.sub.html": false,
+      "fetch.sub.html": {
+        "expectedFailures": [
+          "sec-fetch-site - HTTPS downgrade (header not sent), no init",
+          "sec-fetch-site - HTTPS upgrade, no init",
+          "sec-fetch-site - HTTPS downgrade-upgrade, no init"
+        ]
+      },
       "form-submission.https.sub.html": false,
       "form-submission.sub.html": false,
       "header-link.https.sub.html": false,
@@ -2241,7 +2247,13 @@
       "header-refresh.https.optional.sub.html": false,
       "header-refresh.optional.sub.html": false,
       "script-module-import-dynamic.https.sub.html": false,
-      "script-module-import-dynamic.sub.html": false,
+      "script-module-import-dynamic.sub.html": {
+        "expectedFailures": [
+          "sec-fetch-site - HTTPS downgrade (header not sent)",
+          "sec-fetch-site - HTTPS upgrade",
+          "sec-fetch-site - HTTPS downgrade-upgrade"
+        ]
+      },
       "script-module-import-static.https.sub.html": false,
       "script-module-import-static.sub.html": false,
       "svg-image.https.sub.html": false,
@@ -2251,7 +2263,7 @@
       "window-location.https.sub.html": false,
       "window-location.sub.html": false,
       "worker-dedicated-constructor.https.sub.html": false,
-      "worker-dedicated-constructor.sub.html": false,
+      "worker-dedicated-constructor.sub.html": true,
       "worker-dedicated-importscripts.https.sub.html": false,
       "worker-dedicated-importscripts.sub.html": false,
       "script-json-module-import-static.https.sub.html": false,
@@ -2402,7 +2414,7 @@
       "unknown-mime-type.sub.any.worker.html": true,
       "compressed-image-sniffing.sub.html": false,
       "img-mime-types-coverage.tentative.sub.html": false,
-      "script-unlabeled.sub.html": false,
+      "script-unlabeled.sub.html": true,
       "script-utf16-without-bom-hint-charset.sub.html": false,
       "status.sub.html": false
     }
@@ -2591,7 +2603,7 @@
     "script-html-js-polyglot.sub.html": false,
     "script-html-via-cross-origin-blob-url.sub.html": false,
     "script-js-mislabeled-as-html-nosniff.sub.html": false,
-    "script-js-mislabeled-as-html.sub.html": false,
+    "script-js-mislabeled-as-html.sub.html": true,
     "script-resource-with-json-parser-breaker.tentative.sub.html": false,
     "script-resource-with-nonsniffable-types.tentative.sub.html": false,
     "style-css-mislabeled-as-html-nosniff.sub.html": false,

--- a/tests/wpt/runner/expectations/wasm.json
+++ b/tests/wpt/runner/expectations/wasm.json
@@ -190,13 +190,23 @@
       "broadcastchannel-success.html": false,
       "cross-origin-module-sharing-fails.html": false,
       "identity-not-preserved.html": false,
-      "no-transferring.html": false,
+      "no-transferring.html": {
+        "expectedFailures": [
+          "Trying to transfer a WebAssembly.Module to this window throws"
+        ]
+      },
       "serialization-via-history.html": false,
       "share-module-cross-origin-fails.sub.html": false,
       "window-domain-success.sub.html": false,
-      "window-messagechannel-success.html": false,
+      "window-messagechannel-success.html": true,
       "window-similar-but-cross-origin-success.sub.html": false,
-      "window-simple-success.html": false
+      "window-simple-success.html": {
+        "expectedFailures": [
+          "postMessaging to a same-origin iframe allows them to instantiate",
+          "postMessaging to a same-origin deeply-nested iframe allows them to instantiate",
+          "postMessaging to a same-origin opened window allows them to instantiate"
+        ]
+      }
     },
     "arraybuffer": {
       "transfer.window.html": false

--- a/tests/wpt/runner/expectations/workers.json
+++ b/tests/wpt/runner/expectations/workers.json
@@ -33,9 +33,9 @@
           "Test invalid script URL."
         ]
       },
-      "ctor-1.html": false,
-      "ctor-null.html": false,
-      "ctor-undefined.html": false,
+      "ctor-1.html": true,
+      "ctor-null.html": true,
+      "ctor-undefined.html": true,
       "terminate.html": true,
       "use-base-url.html": false,
       "same-origin.html": {
@@ -76,7 +76,7 @@
   "examples": {
     "general.any.worker.html": true,
     "general.worker.html": true,
-    "fetch_tests_from_worker.html": false
+    "fetch_tests_from_worker.html": true
   },
   "importscripts_mime.any.worker.html": {
     "expectedFailures": [
@@ -112,7 +112,7 @@
         "redirect-module.html": false,
         "redirect.html": false,
         "setting-members.html": true,
-        "worker-separate-file.html": false
+        "worker-separate-file.html": true
       },
       "self.any.worker.html": true,
       "close": {

--- a/tests/wpt/runner/runner.ts
+++ b/tests/wpt/runner/runner.ts
@@ -7,7 +7,7 @@ import {
   toFileUrl,
 } from "../../../tools/util.js";
 import { assert, denoBinary, ManifestTestOptions, runPy } from "./utils.ts";
-import { DOMParser } from "https://deno.land/x/deno_dom@v0.1.3-alpha2/deno-dom-wasm.ts";
+import { DOMParser } from "jsr:@b-fuze/deno-dom@0.1.56/wasm";
 
 export async function runWithTestUtil<T>(
   verbose: boolean,

--- a/tools/deno.lock.json
+++ b/tools/deno.lock.json
@@ -1,6 +1,7 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@b-fuze/deno-dom@0.1.56": "0.1.56",
     "jsr:@david/console-static-text@0.3": "0.3.0",
     "jsr:@david/dax@0.42": "0.42.0",
     "jsr:@david/dax@~0.43.2": "0.43.2",
@@ -31,6 +32,9 @@
     "npm:octokit@^5.0.3": "5.0.3_@octokit+core@7.0.5"
   },
   "jsr": {
+    "@b-fuze/deno-dom@0.1.56": {
+      "integrity": "8030e2dc1d8750f1682b53462ab893d9c3470f2287feecbe22f44a88c54ab148"
+    },
     "@david/console-static-text@0.3.0": {
       "integrity": "2dfb46ecee525755f7989f94ece30bba85bd8ffe3e8666abc1bf926e1ee0698d"
     },
@@ -810,20 +814,5 @@
       ]
     }
   },
-  "remote": {
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/build/deno-wasm/deno-wasm.js": "82c270a48886f86e0e9ea6e5e70a6e37836181466cb9a41942420c884e0d3db9",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/deno-dom-wasm.ts": "097cb6382dd8a335f9409e899873a103d7fbe7cbe06b32fd11b5bbc58305f6dc",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/api.ts": "fe91e8c83ce491d0bd5fe5d0ae4c7c99754b88cb6e69e818683e10e43e01bf10",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/constructor-lock.ts": "4c07b7d2b102c1d71a57b404176b55e8680c99d6880acd210f9afe8b8fced441",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/deserialize.ts": "4fe99c4f11255e4868a865ed0c63aad3ca38e6356168e481cf195eda77dbdc44",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/dom/document.ts": "56fd98bdf465d54061b58c2879d43b6ee1b9f3f8026817678e1592e544556596",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/dom/dom-parser.ts": "312469f5d46c830fa8f506e3a2336d4d6f311f9a838d10670c5d05346273560f",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/dom/element.ts": "16f73441fc08514118fa80a7058a0f9d25e0f0de646ae3e550622d81f4035e50",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/dom/html-collection.ts": "f1aa6f452489557c0f1622e3415eaae15ad70bcee29c7305d29b91693e185837",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/dom/node-list.ts": "ba890ee68928c5b91c38bdf5c114f5b414e1ff20781e544b1b1f98feeec6ca36",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/dom/node.ts": "565e2382e4f0ed4ec2416e71280516103f90f43f6fa0d72ae3b270e39a588327",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/dom/nwsapi-types.ts": "54601c41f8ab524b565550cd764864d9cf109010619b8ce769cfa59cc3be4ed1",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/dom/nwsapi.js": "8a52f4d0b8d0371bfeefed5314f90b5623fcdfc2e4450b0ae54eb137f778a634",
-    "https://deno.land/x/deno_dom@v0.1.3-alpha2/src/parser.ts": "bda4ab4a1c9a2e156877f33ee4e60caac935a7c995a86bbe026bdc0f0d31b8c1"
-  }
+  "remote": {}
 }


### PR DESCRIPTION
The WPT runner uses deno_dom to extract `<script>` elements from `.html` test files when generating test bundles. The old version (`deno.land/x/deno_dom@v0.1.3-alpha2`) fails to parse some test files and finds no script elements in them, which silently produces empty test bundles that run zero test cases. The expectations for those files were recorded against this broken behavior.

This PR upgrades deno_dom to `jsr:@b-fuze/deno-dom@0.1.56` and updates the expectations accordingly.

To isolate the parser-caused changes from flaky/platform noise, I ran the full suite twice locally (once with the old parser, once with the new one) and diffed the per-case results: 140 test files changed their extracted script sets (almost all going from 0 cases to actually running their tests), spanning `fetch/`, `html/canvas`, `wasm/serialization`, `workers/`, `dom/`, and `encoding/`. Expectations were then regenerated for exactly those files with `./tests/wpt/wpt.ts update`. Most of them still fail wholesale (so their `false` entries are unchanged); the net expectation diff is limited to `fetch.json`, `wasm.json`, and `workers.json`, including a few tests that now genuinely pass.

The old `deno.land/x` entries are removed from `tools/deno.lock.json` and the new JSR entries added.

Verified locally with two filtered runs over the 140 affected files plus a full `--all` run, all green against the updated expectations (the only failure was a pre-existing machine-local timing flake in `dynamic-import/delay-load-event.html`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)