### PR TITLE
fix(serve): update request_signal_streaming spec for legacy abort warning

### DIFF
--- a/tests/specs/serve/request_signal_streaming/main.out
+++ b/tests/specs/serve/request_signal_streaming/main.out
@@ -1,3 +1,4 @@
+Deno.serve: request.signal aborts on successful responses (legacy behavior, see https://github.com/denoland/deno/issues/29111). Move cleanup to the handler's return path, or opt in to the new behavior with --unstable-no-legacy-abort. See https://docs.deno.com/runtime/reference/migrate-deprecations/
 body: chunk1;chunk2;chunk3;chunk4;chunk5;
 aborted during stream: false
 aborted after completion: true


### PR DESCRIPTION
PR #34397 added a deprecation `console.warn` that fires when a `Deno.serve`
handler reads `request.signal` and the request completes successfully while in
legacy-abort mode. The warning is emitted once per worker process.

The `request_signal_streaming` spec test (added by #35049) exercises exactly
that path: its handler reads `req.signal` and returns a successful streamed
response under the default legacy-abort mode. #34397 only touched
`ext/http/00_serve.ts` and `tests/unit/serve_test.ts`, so this spec test was
left with a stale `main.out` and started failing on `main`.

The two PRs were green independently (#34397 last ran CI against a `main` whose
checkout predated the new test), so the conflict only surfaced once both had
landed. Every PR that merges current `main` now fails this spec test.

This adds the warning line to `main.out`. The warning is intentional and the
test legitimately exercises the deprecated path, so accepting it in the
expected output is the correct fix. The warning goes to stderr and is emitted
server-side when the request completes, before the client logs the body, so it
appears first in the combined capture (consistent across all platforms in CI).

Refs #34397, #35049.