### PR TITLE
feat(run/serve): zero-config JSX with an in-binary Preact runtime

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -76,6 +76,48 @@ use crate::util::file_watcher::WatcherCommunicator;
 use crate::util::fs::canonicalize_path;
 use crate::util::progress_bar::ProgressBar;
 
+/// Embedded source of the in-binary JSX bridge served for the default
+/// `deno-jsx:preact/jsx-runtime` import source. See `jsx_bridge.js`.
+const JSX_BRIDGE_SOURCE: &str = include_str!("jsx_bridge.js");
+/// Development variant served for `deno-jsx:preact/jsx-dev-runtime`.
+const JSX_BRIDGE_DEV_SOURCE: &str = include_str!("jsx_bridge_dev.js");
+
+/// Wraps a `deno_graph` loader to serve the in-binary Preact JSX bridge for the
+/// reserved `deno-jsx:` scheme. Everything else is delegated to the inner
+/// loader unchanged. This makes the default JSX import source resolve to an
+/// embedded module instead of hitting the network.
+struct JsxBridgeLoader<'a>(&'a dyn Loader);
+
+impl Loader for JsxBridgeLoader<'_> {
+  fn load(
+    &self,
+    specifier: &ModuleSpecifier,
+    options: deno_graph::source::LoadOptions,
+  ) -> deno_graph::source::LoadFuture {
+    if specifier.scheme() == deno_resolver::deno_json::DENO_JSX_SCHEME {
+      let source = if specifier.as_str().ends_with("jsx-dev-runtime") {
+        JSX_BRIDGE_DEV_SOURCE
+      } else {
+        JSX_BRIDGE_SOURCE
+      };
+      let mut headers = std::collections::HashMap::with_capacity(1);
+      headers.insert(
+        "content-type".to_string(),
+        "application/javascript".to_string(),
+      );
+      return Box::pin(std::future::ready(Ok(Some(
+        deno_graph::source::LoadResponse::Module {
+          content: source.as_bytes().into(),
+          mtime: None,
+          specifier: specifier.clone(),
+          maybe_headers: Some(headers),
+        },
+      ))));
+    }
+    self.0.load(specifier, options)
+  }
+}
+
 #[derive(Clone)]
 pub struct GraphValidOptions<'a> {
   pub check_js: CheckJsOption<'a>,
@@ -862,7 +904,7 @@ impl ModuleGraphBuilder {
       .build_graph_with_npm_resolution_and_build_options(
         graph,
         request,
-        loader.as_loader(),
+        &JsxBridgeLoader(loader.as_loader()),
         build_options!(Some(self.npm_graph_resolver.as_ref()), &graph_resolver),
         options.npm_caching,
       )
@@ -887,7 +929,7 @@ impl ModuleGraphBuilder {
           .build_npm_packages(
             self.cli_options.start_dir.dir_url(),
             deno_graph::source::ResolutionKind::Types,
-            loader.as_loader(),
+            &JsxBridgeLoader(loader.as_loader()),
             build_options!(None, &graph_resolver),
           )
           .await;

--- a/cli/jsx_bridge.js
+++ b/cli/jsx_bridge.js
@@ -1,0 +1,27 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// In-binary JSX runtime bridge. This module is served by the CLI graph loader
+// for the reserved `deno-jsx:preact/jsx-runtime` specifier that Deno uses as
+// the default JSX import source. It wraps Preact's JSX runtime so that a
+// returned vnode renders to HTML when stringified, which makes the ergonomic
+// `new Response(<App />)` form work out of the box (without it, a raw Preact
+// vnode stringifies to "[object Object]"). The `npm:` imports below are
+// resolved and installed through the normal npm path.
+
+import { Fragment, jsx as _jsx, jsxs as _jsxs } from "npm:preact/jsx-runtime";
+import { render } from "npm:preact-render-to-string";
+
+function withHtml(vnode) {
+  if (vnode && typeof vnode === "object") {
+    Object.defineProperty(vnode, "toString", {
+      value: () => render(vnode),
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  return vnode;
+}
+
+export const jsx = (type, props, key) => withHtml(_jsx(type, props, key));
+export const jsxs = (type, props, key) => withHtml(_jsxs(type, props, key));
+export { Fragment };

--- a/cli/jsx_bridge_dev.js
+++ b/cli/jsx_bridge_dev.js
@@ -1,0 +1,23 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Development variant of the in-binary JSX runtime bridge. Served by the CLI
+// graph loader for `deno-jsx:preact/jsx-dev-runtime`. See `jsx_bridge.js` for
+// details on why the vnode is given an HTML-rendering `toString`.
+
+import { Fragment, jsxDEV as _jsxDEV } from "npm:preact/jsx-runtime";
+import { render } from "npm:preact-render-to-string";
+
+function withHtml(vnode) {
+  if (vnode && typeof vnode === "object") {
+    Object.defineProperty(vnode, "toString", {
+      value: () => render(vnode),
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  return vnode;
+}
+
+export const jsxDEV = (type, props, key, isStaticChildren, source, self) =>
+  withHtml(_jsxDEV(type, props, key, isStaticChildren, source, self));
+export { Fragment };

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -459,7 +459,9 @@ fn jsx_import_source_package_name(specifier: &str) -> String {
 /// but the library isn't declared yet, install it automatically so JSX works
 /// without a manual `deno install`. The renderer peer is installed too
 /// (`react-dom` for React) so server-side rendering works out of the box.
-async fn maybe_jsx_auto_install(flags: &Arc<Flags>) -> Result<(), AnyError> {
+pub async fn maybe_jsx_auto_install(
+  flags: &Arc<Flags>,
+) -> Result<(), AnyError> {
   let factory = CliFactory::from_flags(flags.clone());
   let cli_options = factory.cli_options()?;
   let workspace = cli_options.workspace();

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -176,6 +176,10 @@ pub async fn run_script(
     return run_with_watch(mode, flags, watch_flags).boxed_local().await;
   }
 
+  // If JSX is configured with an npm import source (e.g. React) that isn't
+  // installed yet, install it now so the factory created below resolves it.
+  maybe_jsx_auto_install(&flags).await?;
+
   // TODO(bartlomieju): actually I think it will also fail if there's an import
   // map specified and bare specifier is used on the command line
   let factory = CliFactory::from_flags(flags.clone());
@@ -432,6 +436,89 @@ pub async fn eval_command(
     .await?;
   let exit_code = worker.run().await?;
   Ok(exit_code)
+}
+
+/// Strip an `npm:` prefix, a version requirement, and any subpath from a JSX
+/// import source specifier to get the bare package name.
+/// e.g. `npm:react@^19/jsx-runtime` -> `react`, `preact` -> `preact`.
+fn jsx_import_source_package_name(specifier: &str) -> String {
+  let s = specifier.strip_prefix("npm:").unwrap_or(specifier);
+  // Keep a leading scope (`@scope/name`); split off any deeper subpath.
+  let (scope, rest) = if let Some(rest) = s.strip_prefix('@') {
+    ("@", rest)
+  } else {
+    ("", s)
+  };
+  let base = rest.split('/').next().unwrap_or(rest);
+  // Drop a version requirement (`name@^19` -> `name`).
+  let base = base.split('@').next().unwrap_or(base);
+  format!("{scope}{base}")
+}
+
+/// When JSX is configured with an `npm:` import source (most commonly React)
+/// but the library isn't declared yet, install it automatically so JSX works
+/// without a manual `deno install`. The renderer peer is installed too
+/// (`react-dom` for React) so server-side rendering works out of the box.
+async fn maybe_jsx_auto_install(flags: &Arc<Flags>) -> Result<(), AnyError> {
+  let factory = CliFactory::from_flags(flags.clone());
+  let cli_options = factory.cli_options()?;
+  let workspace = cli_options.workspace();
+  let Some(root) = workspace.root_deno_json() else {
+    return Ok(());
+  };
+
+  // Resolve the JSX import source the project is configured to use.
+  let resolver = factory.compiler_options_resolver()?;
+  let data = resolver.for_specifier(&root.specifier);
+  let Some(jsx_config) = data.jsx_import_source_config().ok().flatten() else {
+    return Ok(());
+  };
+  let Some(import_source) = jsx_config.import_source.as_ref() else {
+    return Ok(());
+  };
+  let package = jsx_import_source_package_name(&import_source.specifier);
+
+  // Only auto-install JSX libraries we know how to set up.
+  let packages: Vec<String> = match package.as_str() {
+    "react" => vec!["npm:react".to_string(), "npm:react-dom".to_string()],
+    "preact" => vec!["npm:preact".to_string()],
+    _ => return Ok(()),
+  };
+
+  // Skip if the import source is already declared in a deno.json.
+  let already_declared = workspace.deno_jsons().any(|c| {
+    c.json
+      .imports
+      .as_ref()
+      .and_then(|i| i.as_object())
+      .is_some_and(|imports| imports.contains_key(&package))
+  });
+  if already_declared {
+    return Ok(());
+  }
+
+  log::info!(
+    "{} auto-installing JSX dependencies ({})",
+    crate::colors::green("JSX"),
+    packages.join(", "),
+  );
+
+  let add_flags = crate::args::AddFlags {
+    packages,
+    dev: false,
+    default_registry: None,
+    lockfile_only: false,
+    save_exact: false,
+    package_json: false,
+  };
+  crate::tools::pm::add(
+    flags.clone(),
+    add_flags,
+    crate::tools::pm::AddCommandName::Add,
+  )
+  .await?;
+
+  Ok(())
 }
 
 pub async fn maybe_npm_install(factory: &CliFactory) -> Result<(), AnyError> {

--- a/cli/tools/serve.rs
+++ b/cli/tools/serve.rs
@@ -31,6 +31,11 @@ pub async fn serve(
 ) -> Result<i32, AnyError> {
   check_permission_before_script(&flags);
 
+  // If JSX is configured with an npm import source (e.g. React) that isn't
+  // installed yet, install it now so the factory created below resolves it.
+  // Zero-config JSX uses the in-binary Preact bridge and needs no install.
+  super::run::maybe_jsx_auto_install(&flags).await?;
+
   if let Some(watch_flags) = serve_flags.watch {
     return serve_with_watch(
       flags,

--- a/libs/resolver/deno_json.rs
+++ b/libs/resolver/deno_json.rs
@@ -237,6 +237,19 @@ impl JsxImportSourceConfig {
   }
 }
 
+/// Reserved URL scheme for the in-binary JSX bridge. When JSX is used without a
+/// configured `jsxImportSource`, Deno defaults the import source to a sentinel
+/// using this scheme (see [`DENO_JSX_DEFAULT_IMPORT_SOURCE`]). The CLI's graph
+/// loader intercepts this scheme and returns an embedded Preact bridge instead
+/// of going to the network, so `deno run foo.tsx` works with zero config. A
+/// reserved scheme (not `npm:`) is used so it never triggers an npm registry
+/// version lookup for a package that doesn't exist.
+pub const DENO_JSX_SCHEME: &str = "deno-jsx";
+
+/// The default `jsxImportSource` used when JSX is enabled but no import source
+/// has been configured. Resolves to the in-binary Preact bridge.
+pub const DENO_JSX_DEFAULT_IMPORT_SOURCE: &str = "deno-jsx:preact";
+
 #[allow(clippy::disallowed_types, reason = "definition")]
 pub type JsxImportSourceConfigRc =
   deno_maybe_sync::MaybeArc<JsxImportSourceConfig>;
@@ -306,7 +319,8 @@ pub fn get_base_compiler_options_for_emit(
       "inlineSourceMap": false,
       "inlineSources": false,
       "sourceMap": false,
-      "jsx": "react",
+      "jsx": "react-jsx",
+      "jsxImportSource": DENO_JSX_DEFAULT_IMPORT_SOURCE,
       "jsxFactory": "React.createElement",
       "jsxFragmentFactory": "React.Fragment",
       "module": "NodeNext",
@@ -319,7 +333,8 @@ pub fn get_base_compiler_options_for_emit(
       "emitDecoratorMetadata": false,
       "experimentalDecorators": false,
       "incremental": true,
-      "jsx": "react",
+      "jsx": "react-jsx",
+      "jsxImportSource": DENO_JSX_DEFAULT_IMPORT_SOURCE,
       "importsNotUsedAsValues": "remove",
       "inlineSourceMap": true,
       "inlineSources": true,
@@ -357,7 +372,8 @@ pub fn get_base_compiler_options_for_emit(
       "inlineSourceMap": true,
       "inlineSources": true,
       "sourceMap": false,
-      "jsx": "react",
+      "jsx": "react-jsx",
+      "jsxImportSource": DENO_JSX_DEFAULT_IMPORT_SOURCE,
       "jsxFactory": "React.createElement",
       "jsxFragmentFactory": "React.Fragment",
       "module": "NodeNext",
@@ -687,9 +703,13 @@ impl CompilerOptionsData {
   {
     let result = self.memoized.jsx_import_source_config.get_or_init(|| {
       let jsx = self.sources.iter().rev().find_map(|s| Some((s.compiler_options.as_ref()?.0.as_object()?.get("jsx")?.as_str()?, &s.specifier)));
+      // `None` (no `jsx` configured at all) is treated as the automatic
+      // runtime so that bare `.tsx` files work out of the box. The base emit
+      // compiler options default `jsx` to `react-jsx` to match (see
+      // `get_base_compiler_options_for_emit`).
       let is_jsx_automatic = matches!(
         jsx,
-        Some(("react-jsx" | "preserve" | "react-jsxdev" | "precompile", _)),
+        Some(("react-jsx" | "preserve" | "react-jsxdev" | "precompile", _)) | None,
       );
       let import_source = self.sources.iter().rev().find_map(|s| {
         Some(JsxImportSourceSpecifierConfig {
@@ -700,9 +720,12 @@ impl CompilerOptionsData {
         if !is_jsx_automatic {
           return None;
         }
+        // Default to the in-binary Preact bridge so JSX works with zero
+        // configuration. An explicit `jsxImportSource` (e.g. `react`) always
+        // takes precedence over this.
         Some(JsxImportSourceSpecifierConfig {
-          base: self.sources.last()?.specifier.as_ref().clone(),
-          specifier: "react".to_string()
+          base: self.workspace_dir_or_source_url()?.as_ref().clone(),
+          specifier: DENO_JSX_DEFAULT_IMPORT_SOURCE.to_string()
         })
       });
       let import_source_types = self.sources.iter().rev().find_map(|s| {
@@ -712,9 +735,9 @@ impl CompilerOptionsData {
         })
       }).or_else(|| import_source.clone());
       let module = match jsx {
-        Some(("react-jsx" | "preserve", _)) => "jsx-runtime".to_string(),
+        Some(("react-jsx" | "preserve", _)) | None => "jsx-runtime".to_string(),
         Some(("react-jsxdev", _)) => "jsx-dev-runtime".to_string(),
-        Some(("react", _)) | None => {
+        Some(("react", _)) => {
           if let Some(import_source) = &import_source {
             return Err(
               ToMaybeJsxImportSourceConfigError::InvalidJsxImportSourceValue(

--- a/libs/resolver/graph.rs
+++ b/libs/resolver/graph.rs
@@ -592,6 +592,19 @@ impl<
     referrer_range: &deno_graph::Range,
     resolution_kind: deno_graph::source::ResolutionKind,
   ) -> Result<Url, ResolveError> {
+    // The default JSX import source resolves to a reserved `deno-jsx:` sentinel
+    // (e.g. `deno-jsx:preact/jsx-runtime`) that is served by the in-binary JSX
+    // bridge loader rather than the network. Pass it through verbatim so the
+    // loader can intercept it by scheme.
+    if raw_specifier.starts_with(crate::deno_json::DENO_JSX_SCHEME)
+      && raw_specifier[crate::deno_json::DENO_JSX_SCHEME.len()..]
+        .starts_with(':')
+    {
+      return Url::parse(raw_specifier).map_err(|err| {
+        ResolveError::Other(deno_error::JsErrorBox::generic(err.to_string()))
+      });
+    }
+
     let resolution_mode = referrer_range
       .resolution_mode
       .map(node_resolver::ResolutionMode::from_deno_graph)


### PR DESCRIPTION
JSX does not work out of the box in Deno today. Running a bare `.tsx` file
with no configuration falls back to the classic transform and fails with
`React is not defined`, and even a project that configures the recommended
automatic runtime in deno.json still has to manually `deno install` the JSX
library before anything renders. On top of that, the ergonomic
`new Response(<App />)` form returns `[object Object]` because a raw vnode has
no HTML representation. This PR makes JSX work with zero configuration and zero
manual install by baking a small Preact-based JSX runtime into the binary.

## Zero-config default via an in-binary bridge

The default JSX import source now resolves to a reserved `deno-jsx:preact`
sentinel rather than `react`. The base emit/check compiler options default to
the automatic runtime (`"jsx": "react-jsx"`, `"jsxImportSource":
"deno-jsx:preact"`), and `jsx_import_source_config` treats the no-config case
(no `jsx` set anywhere) as the automatic runtime pointing at that sentinel. An
explicit `jsxImportSource` (e.g. `react`) always takes precedence, and an
explicit classic `"jsx": "react"` still emits `React.createElement` unchanged.

The `deno-jsx:` scheme is reserved (not `npm:`) so it never triggers an npm
registry version lookup for a package that does not exist. The graph resolver
passes `deno-jsx:` specifiers through verbatim, and a `JsxBridgeLoader` wrapped
around the module-graph loader intercepts that scheme and returns an embedded
module instead of going to the network. The embedded bridge (`cli/jsx_bridge.js`
and its dev variant) wraps Preact's `jsx-runtime` and attaches a non-enumerable
`toString` that renders the vnode with `preact-render-to-string`. That is what
makes `new Response(<App />)` return real HTML rather than `[object Object]`.
The bridge's own imports are ordinary `npm:preact` /
`npm:preact-render-to-string` specifiers, so they resolve and download through
the normal npm path on first run; no `deno.json` is created and no
`node_modules` is required.

End-to-end, with no deno.json, no node_modules, and nothing installed:

    // server.tsx
    function Page() {
      return <main><h1>Hello from Preact</h1></main>;
    }
    Deno.serve((_req) =>
      new Response(<Page />, { headers: { "content-type": "text/html" } })
    );

    $ deno run --allow-net server.tsx
    $ curl localhost:8000
    <main><h1>Hello from Preact</h1></main>

`deno serve` works the same way for a module that exports
`default { fetch }`. Both paths were verified against the built binary.

## Why Preact

Preact is Fresh-aligned, complete, and React-compatible through
`preact/compat`. It is exposed only through the in-binary bridge, not as a
separate npm/jsr package. Crucially, `preact-render-to-string` does not read
`process.env.NODE_ENV`, so unlike React it does not require `--allow-env` to
render. React hits a separate `NODE_ENV` / `--allow-env` papercut (see below),
and using Preact for the zero-config default sidesteps it entirely.

## Explicit-config auto-install (the original v1 behavior)

When a project explicitly configures `jsxImportSource: "react"` (or `preact`)
but has not declared the library, `maybe_jsx_auto_install` still installs it
via the existing `deno add` machinery before the graph is built (React also
pulls in `react-dom`). This now runs for both `deno run` and `deno serve`. It
is a no-op when the package is already declared and when the import source is
the zero-config sentinel (which needs no install).

## Limitations

- `toString` rendering is synchronous (`preact-render-to-string`'s `render`).
  Async Suspense would require an explicit `await renderAsync(...)`.
- Type checking a bare `.tsx` under the automatic runtime has no `.d.ts` for the
  in-binary bridge, so the JSX runtime is treated as untyped; `deno run` is
  unaffected since it does not type check by default.
