### PR TITLE
feat(test): capture stdout/stderr in JUnit reporter

### DIFF
--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -382,8 +382,8 @@ impl TestRun {
             test::TestEvent::Wait(id) => {
               reporter.report_wait(tests.read().get(&id).unwrap());
             }
-            test::TestEvent::Output(output) => {
-              reporter.report_output(&output);
+            test::TestEvent::Output(stream, output) => {
+              reporter.report_output(stream, &output);
             }
             test::TestEvent::Slow(id, elapsed) => {
               reporter.report_slow(tests.read().get(&id).unwrap(), elapsed);
@@ -673,7 +673,7 @@ impl LspTestReporter {
 
   fn report_slow(&mut self, _desc: &test::TestDescription, _elapsed: u64) {}
 
-  fn report_output(&mut self, output: &[u8]) {
+  fn report_output(&mut self, _stream: test::TestStdioStream, output: &[u8]) {
     let test = self
       .current_test
       .as_ref()

--- a/cli/tools/test/channel.rs
+++ b/cli/tools/test/channel.rs
@@ -27,6 +27,7 @@ use tokio::sync::mpsc::WeakUnboundedSender;
 use tokio::sync::mpsc::error::SendError;
 
 use super::TestEvent;
+use super::TestStdioStream;
 
 /// 8-byte sync marker that is unlikely to appear in normal output. Equivalent
 /// to the string `"\u{200B}\0\u{200B}\0"`.
@@ -106,6 +107,7 @@ impl TestEventReceiver {
 
 struct TestStream {
   id: usize,
+  stream: TestStdioStream,
   read_opt: Option<AsyncPipeRead>,
   sender: UnboundedSender<(usize, TestEvent)>,
 }
@@ -113,6 +115,7 @@ struct TestStream {
 impl TestStream {
   fn new(
     id: usize,
+    stream: TestStdioStream,
     pipe_reader: PipeRead,
     sender: UnboundedSender<(usize, TestEvent)>,
   ) -> std::io::Result<Self> {
@@ -120,6 +123,7 @@ impl TestStream {
     let read_opt = Some(pipe_reader.into_async()?);
     Ok(Self {
       id,
+      stream,
       read_opt,
       sender,
     })
@@ -133,7 +137,7 @@ impl TestStream {
       true
     } else if self
       .sender
-      .send((self.id, TestEvent::Output(buffer)))
+      .send((self.id, TestEvent::Output(self.stream, buffer)))
       .is_err()
     {
       self.read_opt.take();
@@ -274,9 +278,14 @@ impl TestEventSenderFactory {
         .build()
         .unwrap();
       runtime.block_on(tokio::task::unconstrained(async move {
-        let mut test_stdout =
-          TestStream::new(id, stdout_reader, sender.clone())?;
-        let mut test_stderr = TestStream::new(id, stderr_reader, sender)?;
+        let mut test_stdout = TestStream::new(
+          id,
+          TestStdioStream::Stdout,
+          stdout_reader,
+          sender.clone(),
+        )?;
+        let mut test_stderr =
+          TestStream::new(id, TestStdioStream::Stderr, stderr_reader, sender)?;
 
         // This ensures that the stdout and stderr streams in the select! loop below cannot starve each
         // other.
@@ -483,7 +492,7 @@ mod tests {
     let mut count = 0;
     for message in messages {
       match message {
-        TestEvent::Output(vec) => {
+        TestEvent::Output(_, vec) => {
           assert_eq!(vec[0], expected);
           count += vec.len();
         }
@@ -614,7 +623,7 @@ mod tests {
       while let Some((_, message)) = receiver.recv().await {
         if i % 2 == 0 {
           let expected_text = format!("{:08x}", i / 2).into_bytes();
-          let TestEvent::Output(text) = message else {
+          let TestEvent::Output(_, text) = message else {
             panic!("Incorrect message: {message:?}");
           };
           assert_eq!(text, expected_text);
@@ -660,7 +669,7 @@ mod tests {
         .unwrap();
       drop(worker);
       let (_, message) = receiver.recv().await.unwrap();
-      let TestEvent::Output(text) = message else {
+      let TestEvent::Output(_, text) = message else {
         panic!("Incorrect message: {message:?}");
       };
       assert_eq!(text.as_slice(), b"hello");

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -531,12 +531,19 @@ pub struct TestPlan {
   pub used_only: bool,
 }
 
+/// Identifies which standard stream produced a chunk of captured test output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestStdioStream {
+  Stdout,
+  Stderr,
+}
+
 #[derive(Debug)]
 pub enum TestEvent {
   Register(Arc<TestDescriptions>),
   Plan(TestPlan),
   Wait(usize),
-  Output(Vec<u8>),
+  Output(TestStdioStream, Vec<u8>),
   Slow(usize, u64),
   Result(usize, TestResult, u64),
   UncaughtError(String, Box<JsError>),
@@ -1603,8 +1610,8 @@ pub async fn report_tests(
           reporter.report_wait(tests.get(&id).unwrap());
         }
       }
-      TestEvent::Output(output) => {
-        reporter.report_output(&output);
+      TestEvent::Output(stream, output) => {
+        reporter.report_output(stream, &output);
       }
       TestEvent::Slow(id, elapsed) => {
         reporter.report_slow(tests.get(&id).unwrap(), elapsed);

--- a/cli/tools/test/reporters/compound.rs
+++ b/cli/tools/test/reporters/compound.rs
@@ -37,9 +37,9 @@ impl TestReporter for CompoundTestReporter {
     }
   }
 
-  fn report_output(&mut self, output: &[u8]) {
+  fn report_output(&mut self, stream: TestStdioStream, output: &[u8]) {
     for reporter in &mut self.test_reporters {
-      reporter.report_output(output);
+      reporter.report_output(stream, output);
     }
   }
 

--- a/cli/tools/test/reporters/dot.rs
+++ b/cli/tools/test/reporters/dot.rs
@@ -101,7 +101,7 @@ impl TestReporter for DotTestReporter {
   }
 
   fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
-  fn report_output(&mut self, _output: &[u8]) {}
+  fn report_output(&mut self, _stream: TestStdioStream, _output: &[u8]) {}
 
   fn report_result(
     &mut self,

--- a/cli/tools/test/reporters/junit.rs
+++ b/cli/tools/test/reporters/junit.rs
@@ -19,6 +19,10 @@ pub struct JunitTestReporter {
   // hierarchy.
   test_name_tree: TestNameTree,
   failure_format_options: TestFailureFormatOptions,
+  // The ID of the test or step that is currently executing. Captured
+  // stdout/stderr output is attributed to this test case so that it can be
+  // emitted as `<system-out>`/`<system-err>` in the report.
+  current_test: Option<usize>,
 }
 
 impl JunitTestReporter {
@@ -33,6 +37,7 @@ impl JunitTestReporter {
       cases: IndexMap::new(),
       test_name_tree: TestNameTree::new(),
       failure_format_options,
+      current_test: None,
     }
   }
 
@@ -119,15 +124,20 @@ impl TestReporter for JunitTestReporter {
   fn report_plan(&mut self, _plan: &TestPlan) {}
 
   fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
-  fn report_wait(&mut self, _description: &TestDescription) {}
+  fn report_wait(&mut self, description: &TestDescription) {
+    self.current_test = Some(description.id);
+  }
 
-  fn report_output(&mut self, _output: &[u8]) {
-    /*
-     TODO(skycoop): Right now I can't include stdout/stderr in the report because
-     we have a global pair of output streams that don't differentiate between the
-     output of different tests. This is a nice to have feature, so we can come
-     back to it later
-    */
+  fn report_output(&mut self, stream: TestStdioStream, output: &[u8]) {
+    let Some(id) = self.current_test else {
+      // Output produced outside of any running test (e.g. top-level code) can't
+      // be attributed to a test case, so it is dropped from the report.
+      return;
+    };
+    let Some(case) = self.cases.get_mut(&id) else {
+      return;
+    };
+    case.push_output(stream, output, &self.failure_format_options);
   }
 
   fn report_result(
@@ -136,6 +146,9 @@ impl TestReporter for JunitTestReporter {
     result: &TestResult,
     elapsed: u64,
   ) {
+    if self.current_test == Some(description.id) {
+      self.current_test = None;
+    }
     if let Some(case) = self.cases.get_mut(&description.id) {
       case.status = Self::convert_status(result, &self.failure_format_options);
       case.set_time(Duration::from_millis(elapsed));
@@ -166,7 +179,11 @@ impl TestReporter for JunitTestReporter {
     self.cases.insert(description.id, case);
   }
 
-  fn report_step_wait(&mut self, _description: &TestStepDescription) {}
+  fn report_step_wait(&mut self, description: &TestStepDescription) {
+    if self.current_test == Some(description.parent_id) {
+      self.current_test = Some(description.id);
+    }
+  }
 
   fn report_step_result(
     &mut self,
@@ -176,6 +193,9 @@ impl TestReporter for JunitTestReporter {
     _tests: &IndexMap<usize, TestDescription>,
     _test_steps: &IndexMap<usize, TestStepDescription>,
   ) {
+    if self.current_test == Some(description.id) {
+      self.current_test = Some(description.parent_id);
+    }
     if let Some(case) = self.cases.get_mut(&description.id) {
       case.status =
         Self::convert_step_status(result, &self.failure_format_options);
@@ -374,6 +394,8 @@ struct JunitTestCase {
   time: Option<Duration>,
   status: JunitTestCaseStatus,
   extra: IndexMap<String, String>,
+  system_out: String,
+  system_err: String,
 }
 
 impl JunitTestCase {
@@ -384,11 +406,35 @@ impl JunitTestCase {
       time: None,
       status,
       extra: IndexMap::new(),
+      system_out: String::new(),
+      system_err: String::new(),
     }
   }
 
   fn set_time(&mut self, time: Duration) {
     self.time = Some(time);
+  }
+
+  /// Appends captured stdout/stderr output to this test case. ANSI escape
+  /// sequences are stripped when the report is configured to do so, keeping the
+  /// XML free of control characters.
+  fn push_output(
+    &mut self,
+    stream: TestStdioStream,
+    output: &[u8],
+    failure_format_options: &TestFailureFormatOptions,
+  ) {
+    let text = String::from_utf8_lossy(output);
+    let text = if failure_format_options.strip_ascii_color {
+      strip_ansi_codes(&text)
+    } else {
+      text
+    };
+    let buffer = match stream {
+      TestStdioStream::Stdout => &mut self.system_out,
+      TestStdioStream::Stderr => &mut self.system_err,
+    };
+    buffer.push_str(&text);
   }
 
   fn serialize(&self, mut writer: impl Write) -> std::io::Result<()> {
@@ -405,6 +451,16 @@ impl JunitTestCase {
     }
     writeln!(writer, ">")?;
     self.status.serialize(&mut writer)?;
+    if !self.system_out.is_empty() {
+      write!(writer, "            <system-out>")?;
+      write_escaped(&mut writer, &self.system_out)?;
+      writeln!(writer, "</system-out>")?;
+    }
+    if !self.system_err.is_empty() {
+      write!(writer, "            <system-err>")?;
+      write_escaped(&mut writer, &self.system_err)?;
+      writeln!(writer, "</system-err>")?;
+    }
     writeln!(writer, "        </testcase>")
   }
 }

--- a/cli/tools/test/reporters/mod.rs
+++ b/cli/tools/test/reporters/mod.rs
@@ -20,7 +20,7 @@ pub trait TestReporter {
   fn report_plan(&mut self, plan: &TestPlan);
   fn report_wait(&mut self, description: &TestDescription);
   fn report_slow(&mut self, description: &TestDescription, elapsed: u64);
-  fn report_output(&mut self, output: &[u8]);
+  fn report_output(&mut self, stream: TestStdioStream, output: &[u8]);
   fn report_result(
     &mut self,
     description: &TestDescription,

--- a/cli/tools/test/reporters/pretty.rs
+++ b/cli/tools/test/reporters/pretty.rs
@@ -220,7 +220,7 @@ impl TestReporter for PrettyTestReporter {
     )
     .ok();
   }
-  fn report_output(&mut self, output: &[u8]) {
+  fn report_output(&mut self, _stream: TestStdioStream, output: &[u8]) {
     if !self.echo_output {
       return;
     }

--- a/cli/tools/test/reporters/tap.rs
+++ b/cli/tools/test/reporters/tap.rs
@@ -148,7 +148,7 @@ impl TestReporter for TapTestReporter {
   }
 
   fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
-  fn report_output(&mut self, _output: &[u8]) {}
+  fn report_output(&mut self, _stream: TestStdioStream, _output: &[u8]) {}
 
   fn report_result(
     &mut self,

--- a/tests/specs/test/junit/main.out
+++ b/tests/specs/test/junit/main.out
@@ -19,20 +19,36 @@ Check [WILDCARD]main.ts
         <testcase name="test 7" classname="./main.ts" time="[WILDCARD]" line="8" col="6">
         </testcase>
         <testcase name="test 8" classname="./main.ts" time="[WILDCARD]" line="9" col="6">
+            <system-out>console.log
+</system-out>
         </testcase>
         <testcase name="test 9" classname="./main.ts" time="[WILDCARD]" line="12" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\b" classname="./main.ts" time="[WILDCARD]" line="16" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\f" classname="./main.ts" time="[WILDCARD]" line="19" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\t" classname="./main.ts" time="[WILDCARD]" line="23" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\n" classname="./main.ts" time="[WILDCARD]" line="27" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\r" classname="./main.ts" time="[WILDCARD]" line="31" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\v" classname="./main.ts" time="[WILDCARD]" line="35" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
     </testsuite>
 </testsuites>

--- a/tests/specs/test/junit_capture_output/__test__.jsonc
+++ b/tests/specs/test/junit_capture_output/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "test --reporter junit main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/test/junit_capture_output/main.out
+++ b/tests/specs/test/junit_capture_output/main.out
@@ -1,0 +1,25 @@
+Check [WILDCARD]main.ts
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="deno test" tests="4" failures="0" errors="0" time="[WILDCARD]">
+    <testsuite name="./main.ts" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="captures stdout and stderr" classname="./main.ts" time="[WILDCARD]" line="1" col="6">
+            <system-out>log line
+</system-out>
+            <system-err>error line
+</system-err>
+        </testcase>
+        <testcase name="attributes output to steps" classname="./main.ts" time="[WILDCARD]" line="6" col="6">
+            <system-out>before step
+after step
+</system-out>
+        </testcase>
+        <testcase name="no output" classname="./main.ts" time="[WILDCARD]" line="15" col="6">
+        </testcase>
+        <testcase name="attributes output to steps &gt; inner step" classname="./main.ts" time="[WILDCARD]" line="8" col="11">
+            <system-out>inside step
+</system-out>
+            <system-err>step error
+</system-err>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/tests/specs/test/junit_capture_output/main.ts
+++ b/tests/specs/test/junit_capture_output/main.ts
@@ -1,0 +1,15 @@
+Deno.test("captures stdout and stderr", () => {
+  console.log("log line");
+  console.error("error line");
+});
+
+Deno.test("attributes output to steps", async (t) => {
+  console.log("before step");
+  await t.step("inner step", () => {
+    console.log("inside step");
+    console.error("step error");
+  });
+  console.log("after step");
+});
+
+Deno.test("no output", () => {});

--- a/tests/specs/test/junit_multiple_test_files/main.out
+++ b/tests/specs/test/junit_multiple_test_files/main.out
@@ -20,20 +20,36 @@ Check [WILDCARD]fail.ts
         <testcase name="test 7" classname="./pass.ts" time="[WILDCARD]" line="8" col="6">
         </testcase>
         <testcase name="test 8" classname="./pass.ts" time="[WILDCARD]" line="9" col="6">
+            <system-out>console.log
+</system-out>
         </testcase>
         <testcase name="test 9" classname="./pass.ts" time="[WILDCARD]" line="12" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\b" classname="./pass.ts" time="[WILDCARD]" line="16" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\f" classname="./pass.ts" time="[WILDCARD]" line="19" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\t" classname="./pass.ts" time="[WILDCARD]" line="23" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\n" classname="./pass.ts" time="[WILDCARD]" line="27" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\r" classname="./pass.ts" time="[WILDCARD]" line="31" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
         <testcase name="test\v" classname="./pass.ts" time="[WILDCARD]" line="35" col="6">
+            <system-err>console.error
+</system-err>
         </testcase>
     </testsuite>
     <testsuite name="./fail.ts" tests="10" disabled="0" errors="0" failures="10">


### PR DESCRIPTION
Closes #20152.

## Problem

The JUnit reporter dropped all test output. The captured stdout/stderr arrived as a single global stream with no way to tell which test or step produced it, so `report_output` was a no-op with a TODO.

## Solution

Within a worker, tests run sequentially, so output between a test's `Wait` and `Result` belongs to that test — and the channel's existing stdio-sync mechanism already guarantees correct interleaving of output and lifecycle events. The LSP reporter already relies on this to attribute output to a `current_test`; this PR applies the same approach to the JUnit reporter.

- **Tag output with its stream.** `TestEvent::Output(Vec<u8>)` becomes `TestEvent::Output(TestStdioStream, Vec<u8>)`, where the new `TestStdioStream` enum distinguishes `Stdout`/`Stderr`. Each `TestStream` now records which stream it reads from.
- **Track the active test/step in the JUnit reporter.** `current_test` is set on `report_wait`/`report_step_wait` and restored/cleared on the corresponding results (mirroring the LSP reporter's stack-like handling), so step output is attributed to the step and pre/post-step output to the parent test.
- **Emit the output.** Captured bytes are appended (ANSI-stripped, as the JUnit reporter already strips color) to per-case `system_out`/`system_err` buffers and serialized as `<system-out>`/`<system-err>` elements — matching the convention used by other JUnit producers such as Vitest.
- Updated the `report_output` trait signature across all reporters; pretty/dot/tap/compound/LSP ignore the stream and keep their prior behavior.

### Example

```ts
Deno.test("captures stdout and stderr", () => {
  console.log("log line");
  console.error("error line");
});
```

```xml
<testcase name="captures stdout and stderr" classname="./main.ts" time="0.019" line="1" col="6">
    <system-out>log line
</system-out>
    <system-err>error line
</system-err>
</testcase>
```

## Tests

- New spec test `junit_capture_output` covering stdout, stderr, and per-step attribution.
- Updated `junit` and `junit_multiple_test_files` `.out` files, whose existing `console.log`/`console.error` tests now show captured output.
- Verified `hide_stacktraces`, `junit_nested`, `junit_console_formatting`, and the `junit_path` integration test are unaffected.

https://claude.ai/code/session_013BQKi6tsSyAeFT3UsBgAfR

---
_Generated by [Claude Code](https://claude.ai/code/session_013BQKi6tsSyAeFT3UsBgAfR)_