### PR TITLE
feat(test): show sub-millisecond test durations

### DIFF
--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -671,7 +671,8 @@ impl LspTestReporter {
     self.progress(lsp_custom::TestRunProgressMessage::Started { test });
   }
 
-  fn report_slow(&mut self, _desc: &test::TestDescription, _elapsed: u64) {}
+  fn report_slow(&mut self, _desc: &test::TestDescription, _elapsed: Duration) {
+  }
 
   fn report_output(&mut self, output: &[u8]) {
     let test = self
@@ -691,15 +692,16 @@ impl LspTestReporter {
     &mut self,
     desc: &test::TestDescription,
     result: &test::TestResult,
-    elapsed: u64,
+    elapsed: Duration,
   ) {
     self.current_test = None;
+    let elapsed = elapsed.as_millis() as u32;
     match result {
       test::TestResult::Ok => {
         let desc = self.tests.get(&desc.id).unwrap();
         self.progress(lsp_custom::TestRunProgressMessage::Passed {
           test: desc.as_test_identifier(&self.tests),
-          duration: Some(elapsed as u32),
+          duration: Some(elapsed),
         })
       }
       test::TestResult::Ignored => {
@@ -713,7 +715,7 @@ impl LspTestReporter {
         self.progress(lsp_custom::TestRunProgressMessage::Failed {
           test: desc.as_test_identifier(&self.tests),
           messages: vec![failure_to_test_message(failure)],
-          duration: Some(elapsed as u32),
+          duration: Some(elapsed),
         })
       }
       test::TestResult::Cancelled => {
@@ -721,7 +723,7 @@ impl LspTestReporter {
         self.progress(lsp_custom::TestRunProgressMessage::Failed {
           test: desc.as_test_identifier(&self.tests),
           messages: vec![],
-          duration: Some(elapsed as u32),
+          duration: Some(elapsed),
         })
       }
     }
@@ -864,8 +866,9 @@ impl LspTestReporter {
     &mut self,
     desc: &test::TestStepDescription,
     result: &test::TestStepResult,
-    elapsed: u64,
+    elapsed: Duration,
   ) {
+    let elapsed = elapsed.as_millis() as u32;
     if self.current_test == Some(desc.id) {
       self.current_test = Some(desc.parent_id);
     }
@@ -874,7 +877,7 @@ impl LspTestReporter {
       test::TestStepResult::Ok => {
         self.progress(lsp_custom::TestRunProgressMessage::Passed {
           test: desc.as_test_identifier(&self.tests),
-          duration: Some(elapsed as u32),
+          duration: Some(elapsed),
         })
       }
       test::TestStepResult::Ignored => {
@@ -886,7 +889,7 @@ impl LspTestReporter {
         self.progress(lsp_custom::TestRunProgressMessage::Failed {
           test: desc.as_test_identifier(&self.tests),
           messages: vec![failure_to_test_message(failure)],
-          duration: Some(elapsed as u32),
+          duration: Some(elapsed),
         })
       }
     }

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -2,6 +2,7 @@
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
@@ -231,7 +232,11 @@ fn op_test_event_step_result_ok(
 ) {
   let sender = state.borrow_mut::<TestEventSender>();
   sender
-    .send(TestEvent::StepResult(id, TestStepResult::Ok, duration))
+    .send(TestEvent::StepResult(
+      id,
+      TestStepResult::Ok,
+      Duration::from_millis(duration),
+    ))
     .ok();
 }
 
@@ -243,7 +248,11 @@ fn op_test_event_step_result_ignored(
 ) {
   let sender = state.borrow_mut::<TestEventSender>();
   sender
-    .send(TestEvent::StepResult(id, TestStepResult::Ignored, duration))
+    .send(TestEvent::StepResult(
+      id,
+      TestStepResult::Ignored,
+      Duration::from_millis(duration),
+    ))
     .ok();
 }
 
@@ -259,7 +268,7 @@ fn op_test_event_step_result_failed(
     .send(TestEvent::StepResult(
       id,
       TestStepResult::Failed(failure),
-      duration,
+      Duration::from_millis(duration),
     ))
     .ok();
 }

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -2401,7 +2401,7 @@ fn print_finished_message(
     deno_terminal::colors::green("Bundled"),
     metafile.inputs.len(),
     if metafile.inputs.len() == 1 { "" } else { "s" },
-    crate::display::human_elapsed(duration.as_millis()),
+    crate::display::human_elapsed(duration),
   ));
 
   let longest = output_infos

--- a/cli/tools/test/channel.rs
+++ b/cli/tools/test/channel.rs
@@ -619,7 +619,7 @@ mod tests {
           };
           assert_eq!(text, expected_text);
         } else {
-          let TestEvent::Result(index, TestResult::Ok, 0) = message else {
+          let TestEvent::Result(index, TestResult::Ok, _) = message else {
             panic!("Incorrect message: {message:?}");
           };
           assert_eq!(index, i / 2);
@@ -638,7 +638,7 @@ mod tests {
             .unwrap();
           worker
             .sender
-            .send(TestEvent::Result(i, TestResult::Ok, 0))
+            .send(TestEvent::Result(i, TestResult::Ok, Duration::default()))
             .unwrap();
         }
         eprintln!("Sent all messages");
@@ -656,7 +656,7 @@ mod tests {
       worker.stderr.write_all(b"hello").unwrap();
       worker
         .sender
-        .send(TestEvent::Result(0, TestResult::Ok, 0))
+        .send(TestEvent::Result(0, TestResult::Ok, Duration::default()))
         .unwrap();
       drop(worker);
       let (_, message) = receiver.recv().await.unwrap();

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -537,12 +537,12 @@ pub enum TestEvent {
   Plan(TestPlan),
   Wait(usize),
   Output(Vec<u8>),
-  Slow(usize, u64),
-  Result(usize, TestResult, u64),
+  Slow(usize, Duration),
+  Result(usize, TestResult, Duration),
   UncaughtError(String, Box<JsError>),
   StepRegister(TestStepDescription),
   StepWait(usize),
-  StepResult(usize, TestStepResult, u64),
+  StepResult(usize, TestStepResult, Duration),
   /// Indicates that this worker has completed running tests.
   Completed,
   /// Indicates that the user has cancelled the test run with Ctrl+C and
@@ -2311,7 +2311,7 @@ impl TestEventTracker {
     test_id: usize,
     duration: Duration,
   ) -> Result<(), ChannelClosedError> {
-    self.send_event(TestEvent::Slow(test_id, duration.as_millis() as _))
+    self.send_event(TestEvent::Slow(test_id, duration))
   }
 
   fn wait(&self, desc: &TestDescription) -> Result<(), ChannelClosedError> {
@@ -2319,14 +2319,22 @@ impl TestEventTracker {
   }
 
   fn ignored(&self, desc: &TestDescription) -> Result<(), ChannelClosedError> {
-    self.send_event(TestEvent::Result(desc.id, TestResult::Ignored, 0))
+    self.send_event(TestEvent::Result(
+      desc.id,
+      TestResult::Ignored,
+      Duration::default(),
+    ))
   }
 
   fn cancelled(
     &self,
     desc: &TestDescription,
   ) -> Result<(), ChannelClosedError> {
-    self.send_event(TestEvent::Result(desc.id, TestResult::Cancelled, 0))
+    self.send_event(TestEvent::Result(
+      desc.id,
+      TestResult::Cancelled,
+      Duration::default(),
+    ))
   }
 
   fn register(
@@ -2358,11 +2366,7 @@ impl TestEventTracker {
     test_result: TestResult,
     duration: Duration,
   ) -> Result<(), ChannelClosedError> {
-    self.send_event(TestEvent::Result(
-      desc.id,
-      test_result,
-      duration.as_millis() as u64,
-    ))
+    self.send_event(TestEvent::Result(desc.id, test_result, duration))
   }
 
   pub(crate) fn force_end_report(&self) -> Result<(), ChannelClosedError> {

--- a/cli/tools/test/reporters/common.rs
+++ b/cli/tools/test/reporters/common.rs
@@ -283,12 +283,18 @@ pub(super) fn report_summary(
     write!(summary_result, " | {} filtered out", summary.filtered_out).ok();
   };
 
+  // The summary is a whole-suite aggregate, so it stays at millisecond
+  // granularity. Sub-millisecond precision here would be noise and would make
+  // the output non-deterministic for fast or empty runs.
   writeln!(
     writer,
     "\n{} | {} {}",
     status,
     summary_result,
-    colors::gray(format!("({})", display::human_elapsed(*elapsed))),
+    colors::gray(format!(
+      "({})",
+      display::human_elapsed_with_ms_limit(elapsed.as_millis(), 1_000)
+    )),
   )
   .ok();
 }

--- a/cli/tools/test/reporters/common.rs
+++ b/cli/tools/test/reporters/common.rs
@@ -288,7 +288,7 @@ pub(super) fn report_summary(
     "\n{} | {} {}",
     status,
     summary_result,
-    colors::gray(format!("({})", display::human_elapsed(elapsed.as_millis()))),
+    colors::gray(format!("({})", display::human_elapsed(*elapsed))),
   )
   .ok();
 }

--- a/cli/tools/test/reporters/compound.rs
+++ b/cli/tools/test/reporters/compound.rs
@@ -31,7 +31,7 @@ impl TestReporter for CompoundTestReporter {
     }
   }
 
-  fn report_slow(&mut self, description: &TestDescription, elapsed: u64) {
+  fn report_slow(&mut self, description: &TestDescription, elapsed: Duration) {
     for reporter in &mut self.test_reporters {
       reporter.report_slow(description, elapsed);
     }
@@ -47,7 +47,7 @@ impl TestReporter for CompoundTestReporter {
     &mut self,
     description: &TestDescription,
     result: &TestResult,
-    elapsed: u64,
+    elapsed: Duration,
   ) {
     for reporter in &mut self.test_reporters {
       reporter.report_result(description, result, elapsed);
@@ -76,7 +76,7 @@ impl TestReporter for CompoundTestReporter {
     &mut self,
     desc: &TestStepDescription,
     result: &TestStepResult,
-    elapsed: u64,
+    elapsed: Duration,
     tests: &IndexMap<usize, TestDescription>,
     test_steps: &IndexMap<usize, TestStepDescription>,
   ) {

--- a/cli/tools/test/reporters/dot.rs
+++ b/cli/tools/test/reporters/dot.rs
@@ -100,14 +100,19 @@ impl TestReporter for DotTestReporter {
     std::io::stdout().flush().ok();
   }
 
-  fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
+  fn report_slow(
+    &mut self,
+    _description: &TestDescription,
+    _elapsed: Duration,
+  ) {
+  }
   fn report_output(&mut self, _output: &[u8]) {}
 
   fn report_result(
     &mut self,
     description: &TestDescription,
     result: &TestResult,
-    _elapsed: u64,
+    _elapsed: Duration,
   ) {
     match &result {
       TestResult::Ok => {
@@ -156,7 +161,7 @@ impl TestReporter for DotTestReporter {
     &mut self,
     desc: &TestStepDescription,
     result: &TestStepResult,
-    _elapsed: u64,
+    _elapsed: Duration,
     tests: &IndexMap<usize, TestDescription>,
     test_steps: &IndexMap<usize, TestStepDescription>,
   ) {

--- a/cli/tools/test/reporters/junit.rs
+++ b/cli/tools/test/reporters/junit.rs
@@ -118,7 +118,12 @@ impl TestReporter for JunitTestReporter {
 
   fn report_plan(&mut self, _plan: &TestPlan) {}
 
-  fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
+  fn report_slow(
+    &mut self,
+    _description: &TestDescription,
+    _elapsed: Duration,
+  ) {
+  }
   fn report_wait(&mut self, _description: &TestDescription) {}
 
   fn report_output(&mut self, _output: &[u8]) {
@@ -134,11 +139,11 @@ impl TestReporter for JunitTestReporter {
     &mut self,
     description: &TestDescription,
     result: &TestResult,
-    elapsed: u64,
+    elapsed: Duration,
   ) {
     if let Some(case) = self.cases.get_mut(&description.id) {
       case.status = Self::convert_status(result, &self.failure_format_options);
-      case.set_time(Duration::from_millis(elapsed));
+      case.set_time(elapsed);
     }
   }
 
@@ -172,14 +177,14 @@ impl TestReporter for JunitTestReporter {
     &mut self,
     description: &TestStepDescription,
     result: &TestStepResult,
-    elapsed: u64,
+    elapsed: Duration,
     _tests: &IndexMap<usize, TestDescription>,
     _test_steps: &IndexMap<usize, TestStepDescription>,
   ) {
     if let Some(case) = self.cases.get_mut(&description.id) {
       case.status =
         Self::convert_step_status(result, &self.failure_format_options);
-      case.set_time(Duration::from_millis(elapsed));
+      case.set_time(elapsed);
     }
   }
 
@@ -199,7 +204,11 @@ impl TestReporter for JunitTestReporter {
   ) {
     for id in tests_pending {
       if let Some(description) = tests.get(id) {
-        self.report_result(description, &TestResult::Cancelled, 0)
+        self.report_result(
+          description,
+          &TestResult::Cancelled,
+          Duration::default(),
+        )
       }
     }
   }
@@ -213,7 +222,11 @@ impl TestReporter for JunitTestReporter {
   ) {
     for id in tests_pending {
       if let Some(description) = tests.get(id) {
-        self.report_result(description, &TestResult::Cancelled, 0)
+        self.report_result(
+          description,
+          &TestResult::Cancelled,
+          Duration::default(),
+        )
       }
     }
   }

--- a/cli/tools/test/reporters/mod.rs
+++ b/cli/tools/test/reporters/mod.rs
@@ -19,13 +19,13 @@ pub trait TestReporter {
   fn report_register(&mut self, description: &TestDescription);
   fn report_plan(&mut self, plan: &TestPlan);
   fn report_wait(&mut self, description: &TestDescription);
-  fn report_slow(&mut self, description: &TestDescription, elapsed: u64);
+  fn report_slow(&mut self, description: &TestDescription, elapsed: Duration);
   fn report_output(&mut self, output: &[u8]);
   fn report_result(
     &mut self,
     description: &TestDescription,
     result: &TestResult,
-    elapsed: u64,
+    elapsed: Duration,
   );
   fn report_uncaught_error(&mut self, origin: &str, error: Box<JsError>);
   fn report_step_register(&mut self, description: &TestStepDescription);
@@ -34,7 +34,7 @@ pub trait TestReporter {
     &mut self,
     desc: &TestStepDescription,
     result: &TestStepResult,
-    elapsed: u64,
+    elapsed: Duration,
     tests: &IndexMap<usize, TestDescription>,
     test_steps: &IndexMap<usize, TestStepDescription>,
   );

--- a/cli/tools/test/reporters/pretty.rs
+++ b/cli/tools/test/reporters/pretty.rs
@@ -19,8 +19,10 @@ pub struct PrettyTestReporter {
   did_have_user_output: bool,
   started_tests: bool,
   ended_tests: bool,
-  child_results_buffer:
-    HashMap<usize, IndexMap<usize, (TestStepDescription, TestStepResult, u64)>>,
+  child_results_buffer: HashMap<
+    usize,
+    IndexMap<usize, (TestStepDescription, TestStepResult, Duration)>,
+  >,
   summary: TestSummary,
   writer: Box<dyn std::io::Write>,
   failure_format_options: TestFailureFormatOptions,
@@ -98,7 +100,7 @@ impl PrettyTestReporter {
     &mut self,
     description: &TestStepDescription,
     result: &TestStepResult,
-    elapsed: u64,
+    elapsed: Duration,
   ) {
     self.write_output_end();
     if self.in_new_line || self.scope_test_id != Some(description.id) {
@@ -141,7 +143,7 @@ impl PrettyTestReporter {
       write!(
         &mut self.writer,
         " {}",
-        colors::gray(format!("({})", display::human_elapsed(elapsed.into())))
+        colors::gray(format!("({})", display::human_elapsed(elapsed)))
       )
       .ok();
     }
@@ -208,14 +210,14 @@ impl TestReporter for PrettyTestReporter {
     self.started_tests = true;
   }
 
-  fn report_slow(&mut self, description: &TestDescription, elapsed: u64) {
+  fn report_slow(&mut self, description: &TestDescription, elapsed: Duration) {
     writeln!(
       &mut self.writer,
       "{}",
       colors::yellow_bold(format!(
         "'{}' has been running for over {}",
         description.name,
-        colors::gray(format!("({})", display::human_elapsed(elapsed.into()))),
+        colors::gray(format!("({})", display::human_elapsed(elapsed))),
       ))
     )
     .ok();
@@ -256,7 +258,7 @@ impl TestReporter for PrettyTestReporter {
     &mut self,
     description: &TestDescription,
     result: &TestResult,
-    elapsed: u64,
+    elapsed: Duration,
   ) {
     match &result {
       TestResult::Ok => {
@@ -321,7 +323,7 @@ impl TestReporter for PrettyTestReporter {
     writeln!(
       &mut self.writer,
       " {}",
-      colors::gray(format!("({})", display::human_elapsed(elapsed.into())))
+      colors::gray(format!("({})", display::human_elapsed(elapsed)))
     )
     .ok();
     self.in_new_line = true;
@@ -361,7 +363,7 @@ impl TestReporter for PrettyTestReporter {
     &mut self,
     desc: &TestStepDescription,
     result: &TestStepResult,
-    elapsed: u64,
+    elapsed: Duration,
     tests: &IndexMap<usize, TestDescription>,
     test_steps: &IndexMap<usize, TestStepDescription>,
   ) {

--- a/cli/tools/test/reporters/tap.rs
+++ b/cli/tools/test/reporters/tap.rs
@@ -147,14 +147,19 @@ impl TestReporter for TapTestReporter {
     std::io::stdout().flush().ok();
   }
 
-  fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
+  fn report_slow(
+    &mut self,
+    _description: &TestDescription,
+    _elapsed: Duration,
+  ) {
+  }
   fn report_output(&mut self, _output: &[u8]) {}
 
   fn report_result(
     &mut self,
     description: &TestDescription,
     result: &TestResult,
-    _elapsed: u64,
+    _elapsed: Duration,
   ) {
     if self.is_concurrent {
       let results = self.step_results.remove(&description.id);
@@ -202,7 +207,7 @@ impl TestReporter for TapTestReporter {
     &mut self,
     desc: &TestStepDescription,
     result: &TestStepResult,
-    _elapsed: u64,
+    _elapsed: Duration,
     _tests: &IndexMap<usize, TestDescription>,
     _test_steps: &IndexMap<usize, TestStepDescription>,
   ) {

--- a/cli/util/display.rs
+++ b/cli/util/display.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::io::Write;
+use std::time::Duration;
 
 use deno_core::error::AnyError;
 use deno_core::serde_json;
@@ -46,10 +47,26 @@ pub fn human_download_size(byte_count: u64, total_bytes: u64) -> String {
   }
 }
 
-/// A function that converts a millisecond elapsed time to a string that
+/// A function that converts an elapsed [`Duration`] to a string that
 /// represents a human readable version of that time.
-pub fn human_elapsed(elapsed: u128) -> String {
-  human_elapsed_with_ms_limit(elapsed, 1_000)
+///
+/// Durations under a millisecond are rendered with fractional millisecond
+/// precision (e.g. `0.5ms`, `0.052ms`) so that very fast operations aren't
+/// reported as `0ms`.
+pub fn human_elapsed(elapsed: Duration) -> String {
+  let millis = elapsed.as_millis();
+  if millis == 0 {
+    let micros = elapsed.as_micros();
+    if micros == 0 {
+      return "0ms".to_string();
+    }
+    // `micros` is in `1..1000` here. Render it as fractional milliseconds,
+    // trimming trailing zeros so e.g. `523µs` -> `0.523ms`, `50µs` -> `0.05ms`
+    // and `500µs` -> `0.5ms`.
+    let fraction = format!("{micros:03}");
+    return format!("0.{}ms", fraction.trim_end_matches('0'));
+  }
+  human_elapsed_with_ms_limit(millis, 1_000)
 }
 
 pub fn human_elapsed_with_ms_limit(elapsed: u128, ms_limit: u128) -> String {
@@ -135,12 +152,28 @@ mod tests {
 
   #[test]
   fn test_human_elapsed() {
-    assert_eq!(human_elapsed(1), "1ms");
-    assert_eq!(human_elapsed(256), "256ms");
-    assert_eq!(human_elapsed(1000), "1s");
-    assert_eq!(human_elapsed(1001), "1s");
-    assert_eq!(human_elapsed(1020), "1s");
-    assert_eq!(human_elapsed(70 * 1000), "1m10s");
-    assert_eq!(human_elapsed(86 * 1000 + 100), "1m26s");
+    assert_eq!(human_elapsed(Duration::from_millis(1)), "1ms");
+    assert_eq!(human_elapsed(Duration::from_millis(256)), "256ms");
+    assert_eq!(human_elapsed(Duration::from_millis(1000)), "1s");
+    assert_eq!(human_elapsed(Duration::from_millis(1001)), "1s");
+    assert_eq!(human_elapsed(Duration::from_millis(1020)), "1s");
+    assert_eq!(human_elapsed(Duration::from_millis(70 * 1000)), "1m10s");
+    assert_eq!(
+      human_elapsed(Duration::from_millis(86 * 1000 + 100)),
+      "1m26s"
+    );
+  }
+
+  #[test]
+  fn test_human_elapsed_sub_millisecond() {
+    assert_eq!(human_elapsed(Duration::ZERO), "0ms");
+    assert_eq!(human_elapsed(Duration::from_nanos(500)), "0ms");
+    assert_eq!(human_elapsed(Duration::from_micros(1)), "0.001ms");
+    assert_eq!(human_elapsed(Duration::from_micros(5)), "0.005ms");
+    assert_eq!(human_elapsed(Duration::from_micros(50)), "0.05ms");
+    assert_eq!(human_elapsed(Duration::from_micros(100)), "0.1ms");
+    assert_eq!(human_elapsed(Duration::from_micros(523)), "0.523ms");
+    assert_eq!(human_elapsed(Duration::from_micros(500)), "0.5ms");
+    assert_eq!(human_elapsed(Duration::from_micros(999)), "0.999ms");
   }
 }

--- a/cli/util/display.rs
+++ b/cli/util/display.rs
@@ -52,8 +52,15 @@ pub fn human_download_size(byte_count: u64, total_bytes: u64) -> String {
 ///
 /// Durations under a millisecond are rendered in microseconds (`µs`) or
 /// nanoseconds (`ns`) so that very fast operations aren't reported as `0ms`.
+///
+/// A zero duration is reported as `0ms` rather than `0ns`, since it represents
+/// "no measured time" (e.g. a cancelled or ignored test that never ran) rather
+/// than a sub-nanosecond measurement.
 pub fn human_elapsed(elapsed: Duration) -> String {
   let nanos = elapsed.as_nanos();
+  if nanos == 0 {
+    return "0ms".to_string();
+  }
   if nanos < 1_000 {
     return format!("{nanos}ns");
   }
@@ -161,7 +168,7 @@ mod tests {
 
   #[test]
   fn test_human_elapsed_sub_millisecond() {
-    assert_eq!(human_elapsed(Duration::ZERO), "0ns");
+    assert_eq!(human_elapsed(Duration::ZERO), "0ms");
     assert_eq!(human_elapsed(Duration::from_nanos(23)), "23ns");
     assert_eq!(human_elapsed(Duration::from_nanos(999)), "999ns");
     assert_eq!(human_elapsed(Duration::from_nanos(1000)), "1µs");

--- a/cli/util/display.rs
+++ b/cli/util/display.rs
@@ -50,23 +50,18 @@ pub fn human_download_size(byte_count: u64, total_bytes: u64) -> String {
 /// A function that converts an elapsed [`Duration`] to a string that
 /// represents a human readable version of that time.
 ///
-/// Durations under a millisecond are rendered with fractional millisecond
-/// precision (e.g. `0.5ms`, `0.052ms`) so that very fast operations aren't
-/// reported as `0ms`.
+/// Durations under a millisecond are rendered in microseconds (`µs`) or
+/// nanoseconds (`ns`) so that very fast operations aren't reported as `0ms`.
 pub fn human_elapsed(elapsed: Duration) -> String {
-  let millis = elapsed.as_millis();
-  if millis == 0 {
-    let micros = elapsed.as_micros();
-    if micros == 0 {
-      return "0ms".to_string();
-    }
-    // `micros` is in `1..1000` here. Render it as fractional milliseconds,
-    // trimming trailing zeros so e.g. `523µs` -> `0.523ms`, `50µs` -> `0.05ms`
-    // and `500µs` -> `0.5ms`.
-    let fraction = format!("{micros:03}");
-    return format!("0.{}ms", fraction.trim_end_matches('0'));
+  let nanos = elapsed.as_nanos();
+  if nanos < 1_000 {
+    return format!("{nanos}ns");
   }
-  human_elapsed_with_ms_limit(millis, 1_000)
+  let micros = elapsed.as_micros();
+  if micros < 1_000 {
+    return format!("{micros}µs");
+  }
+  human_elapsed_with_ms_limit(elapsed.as_millis(), 1_000)
 }
 
 pub fn human_elapsed_with_ms_limit(elapsed: u128, ms_limit: u128) -> String {
@@ -166,14 +161,13 @@ mod tests {
 
   #[test]
   fn test_human_elapsed_sub_millisecond() {
-    assert_eq!(human_elapsed(Duration::ZERO), "0ms");
-    assert_eq!(human_elapsed(Duration::from_nanos(500)), "0ms");
-    assert_eq!(human_elapsed(Duration::from_micros(1)), "0.001ms");
-    assert_eq!(human_elapsed(Duration::from_micros(5)), "0.005ms");
-    assert_eq!(human_elapsed(Duration::from_micros(50)), "0.05ms");
-    assert_eq!(human_elapsed(Duration::from_micros(100)), "0.1ms");
-    assert_eq!(human_elapsed(Duration::from_micros(523)), "0.523ms");
-    assert_eq!(human_elapsed(Duration::from_micros(500)), "0.5ms");
-    assert_eq!(human_elapsed(Duration::from_micros(999)), "0.999ms");
+    assert_eq!(human_elapsed(Duration::ZERO), "0ns");
+    assert_eq!(human_elapsed(Duration::from_nanos(23)), "23ns");
+    assert_eq!(human_elapsed(Duration::from_nanos(999)), "999ns");
+    assert_eq!(human_elapsed(Duration::from_nanos(1000)), "1µs");
+    assert_eq!(human_elapsed(Duration::from_micros(86)), "86µs");
+    assert_eq!(human_elapsed(Duration::from_nanos(86_500)), "86µs");
+    assert_eq!(human_elapsed(Duration::from_micros(999)), "999µs");
+    assert_eq!(human_elapsed(Duration::from_micros(1000)), "1ms");
   }
 }


### PR DESCRIPTION
## Problem

Test durations under 1ms were truncated to `0ms` in the test reporter output, because the elapsed time was converted with `duration.as_millis() as u64` before reaching the reporters. This made fast tests look like they took no time at all:

```
OrderStatusHistoryMapper → toDto should map entity to DTO ... ok (1ms)
OrderStatusHistoryMapper → toDtoArray should map multiple entities to an array ... ok (0ms)
```

Closes #30785