### PR TITLE
fix(ext/node): util.styleText() returns text unchanged when stream is not a TTY

### DIFF
--- a/ext/node/polyfills/internal/util/inspect.mjs
+++ b/ext/node/polyfills/internal/util/inspect.mjs
@@ -676,6 +676,14 @@ function styleText(format, text, options) {
         stream,
       );
     }
+    // Node's util.styleText returns the text unchanged when the target stream
+    // is not a TTY, so callers can pass any writable and only get color when
+    // the destination would render it.
+    if (
+      stream !== undefined && stream !== null && !stream.isTTY
+    ) {
+      return text;
+    }
   }
 
   const formatArray = ArrayIsArray(format) ? format : [format];

--- a/tests/unit_node/util_test.ts
+++ b/tests/unit_node/util_test.ts
@@ -271,6 +271,31 @@ Deno.test("[util] styleText() with array of formats", () => {
   assertEquals(colored, "\x1b[31m\x1b[32merror\x1b[39m\x1b[39m");
 });
 
+Deno.test("[util] styleText() respects stream.isTTY", () => {
+  const streamTTY = { write() {}, isTTY: true };
+  const streamNoTTY = { write() {}, isTTY: false };
+
+  assertEquals(
+    util.styleText("bgYellow", "TTY", { stream: streamTTY }),
+    "\x1b[43mTTY\x1b[49m",
+  );
+  assertEquals(
+    util.styleText("bgYellow", "No TTY", { stream: streamNoTTY }),
+    "No TTY",
+  );
+});
+
+Deno.test("[util] styleText() with validateStream: false bypasses isTTY check", () => {
+  const streamNoTTY = { write() {}, isTTY: false };
+  assertEquals(
+    util.styleText("bgYellow", "forced", {
+      stream: streamNoTTY,
+      validateStream: false,
+    }),
+    "\x1b[43mforced\x1b[49m",
+  );
+});
+
 Deno.test("[util] stripVTControlCharacters() removes OSC 8 hyperlinks", () => {
   // OSC 8 hyperlink with ESC \ (ST) terminator
   const input =


### PR DESCRIPTION
Closes #35203.

Node's `util.styleText()` returns the input text unchanged when the supplied `options.stream` is not a TTY; Deno's polyfill always emitted the ANSI escape codes regardless. The reporter's repro paints both the TTY and the non-TTY writable yellow, so output piped to a file (or any other non-TTY destination passed via `options.stream`) ships with raw escape codes that the user doesn't expect.

The polyfill already validates the stream shape; it just never consulted `stream.isTTY` after that. This adds the missing check: when `validateStream` is true and a stream is provided, return the unmodified `text` if `stream.isTTY` is falsy. The default-stream path (no `options.stream`) is unchanged, and `validateStream: false` still forces colorization — both consistent with the documented `node:util` semantics.

## Tests

`tests/unit_node/util_test.ts`:
- `styleText() respects stream.isTTY` — wraps when `isTTY: true`, returns plain text when `isTTY: false`. Pre-fix this returns the ANSI-wrapped string in both cases.
- `styleText() with validateStream: false bypasses isTTY check` — confirms the escape hatch still colors a non-TTY stream when the caller opts out of validation.

Existing `styleText()` / `styleText() with array of formats` tests still pass since neither passes a `stream`.