### PR TITLE
fix(coverage): don't panic in summary reporter without a common root

### DIFF
--- a/cli/tools/coverage/reporter.rs
+++ b/cli/tools/coverage/reporter.rs
@@ -203,7 +203,13 @@ impl CoverageReporter for SummaryCoverageReporter {
     file_reports: &[(CoverageReport, String)],
   ) {
     let summary = self.collect_summary(file_reports);
-    let root_stats = summary.get("").unwrap();
+    // When the reports can't be reduced to a common file-system root (e.g. on
+    // Windows when coverage spans multiple drive letters), `collect_summary`
+    // returns an empty map without the "" root entry. There is nothing to
+    // print in that case, so bail out instead of panicking.
+    let Some(root_stats) = summary.get("") else {
+      return;
+    };
 
     let mut entries = summary
       .iter()
@@ -214,7 +220,7 @@ impl CoverageReporter for SummaryCoverageReporter {
       .iter()
       .map(|(node, _)| node.len())
       .max()
-      .unwrap()
+      .unwrap_or(0)
       .max("All files".len());
 
     let header = format!(
@@ -804,5 +810,35 @@ impl HtmlCoverageReporter {
     }
 
     breadcrumbs_html.into_iter().collect::<Vec<_>>().join(" / ")
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // Regression test for https://github.com/denoland/deno/issues/30924.
+  //
+  // When the reports cannot be reduced to a common file-system root (e.g. on
+  // Windows when coverage spans multiple drive letters), `collect_summary`
+  // returns an empty map without the "" root entry. The summary reporter used
+  // to `unwrap()` that entry and panic. It should instead skip the summary
+  // gracefully.
+  #[test]
+  fn summary_reporter_does_not_panic_without_common_root() {
+    let report = CoverageReport {
+      // A non-`file:` URL has no file-system path, so `find_root` cannot
+      // produce a usable root and `collect_summary` returns an empty map.
+      url: Url::parse("https://example.com/main.ts").unwrap(),
+      named_functions: Vec::new(),
+      branches: Vec::new(),
+      found_lines: vec![(0, 1)],
+      output: None,
+    };
+    let file_reports = vec![(report, "console.log(1);".to_string())];
+
+    let reporter = SummaryCoverageReporter::new();
+    // Must not panic.
+    reporter.done(Path::new("coverage"), &file_reports);
   }
 }

--- a/cli/tools/coverage/reporter.rs
+++ b/cli/tools/coverage/reporter.rs
@@ -206,8 +206,11 @@ impl CoverageReporter for SummaryCoverageReporter {
     // When the reports can't be reduced to a common file-system root (e.g. on
     // Windows when coverage spans multiple drive letters), `collect_summary`
     // returns an empty map without the "" root entry. There is nothing to
-    // print in that case, so bail out instead of panicking.
+    // print in that case, so warn and bail out instead of panicking.
     let Some(root_stats) = summary.get("") else {
+      log::warn!(
+        "Skipping coverage summary: reports span multiple file-system roots"
+      );
       return;
     };
 
@@ -216,6 +219,10 @@ impl CoverageReporter for SummaryCoverageReporter {
       .filter(|(_, stats)| stats.file_text.is_some())
       .collect::<Vec<_>>();
     entries.sort_by_key(|(node, _)| node.to_owned());
+    // `entries` is always non-empty here: reaching this point means the summary
+    // has a "" root, which only happens when `collect_summary` resolved a common
+    // root from non-empty `file_reports`, and each report inserts a leaf entry
+    // with `file_text: Some(..)`. `unwrap_or(0)` is just defense-in-depth.
     let node_max = entries
       .iter()
       .map(|(node, _)| node.len())


### PR DESCRIPTION
## Summary

Fixes the panic reported in #30924, which still reproduces on Deno 2.7.7 (and on `main`):

```
thread 'main' panicked at cli\tools\coverage\reporter.rs:206:38:
called `Option::unwrap()` on a `None` value
```

`SummaryCoverageReporter::done` called `summary.get("").unwrap()` on the result of `collect_summary`. `collect_summary` returns an **empty** map (without the `""` root entry) whenever the file reports can't be reduced to a common file-system root — i.e. when `find_root(...).and_then(|r| r.to_file_path().ok())` yields `None`.

On Windows this happens when coverage spans **multiple drive letters**: the temp test files live under `C:\Users\RUNNER~1\AppData\Local\Temp\` while the workspace is on `D:\...`. The character-wise common prefix collapses to `file:///`, which has no drive letter, so `to_file_path()` fails, `collect_summary` returns an empty map, and the reporter panics. This matches the panic URLs and `D:\a\...\cov\...` paths in the issue, and explains why it only reproduces on Windows.

(The simpler "all source files were skipped → empty `file_reports`" case is already handled gracefully upstream in `cover_files`, which returns `No covered files included in the report`.)

## Changes

- Bail out of the summary table when there is no `""` root entry instead of unwrapping.
- Guard the adjacent `.max().unwrap()` on the entries list (would panic on an empty list) with `.unwrap_or(0)`.
- Add a regression unit test that drives `done` with reports that have no common file-system root and asserts it doesn't panic. The test fails before this change and passes after.

## Test plan

- `cargo test -p deno --lib summary_reporter_does_not_panic` — passes with the fix, panics without it.
- `cargo clippy -p deno --lib` — clean.
- `rustfmt` — no changes.

Fixes #30924

https://claude.ai/code/session_01L957ioUbJpxDa8Sv9yCtEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01L957ioUbJpxDa8Sv9yCtEq)_