### PR TITLE
feat(lsp): support test coverage visualization with branch coverage

### DIFF
--- a/cli/lsp/client.rs
+++ b/cli/lsp/client.rs
@@ -23,6 +23,7 @@ pub enum TestingNotification {
   Module(testing_lsp_custom::TestModuleNotificationParams),
   DeleteModule(testing_lsp_custom::TestModuleDeleteNotificationParams),
   Progress(testing_lsp_custom::TestRunProgressParams),
+  Coverage(testing_lsp_custom::TestCoverageNotificationParams),
 }
 
 #[derive(Clone)]
@@ -269,6 +270,14 @@ impl ClientTrait for TowerClient {
         self
           .0
           .send_notification::<testing_lsp_custom::TestRunProgressNotification>(
+            params,
+          )
+          .await
+      }
+      TestingNotification::Coverage(params) => {
+        self
+          .0
+          .send_notification::<testing_lsp_custom::TestCoverageNotification>(
             params,
           )
           .await

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -29,6 +30,7 @@ use super::definitions::TestModule;
 use super::lsp_custom;
 use super::server::TestServerTests;
 use crate::args::DenoSubcommand;
+use crate::args::Flags;
 use crate::args::flags_from_vec;
 use crate::args::parallelism_count;
 use crate::factory::CliFactory;
@@ -39,6 +41,7 @@ use crate::lsp::logging::lsp_log;
 use crate::lsp::urls::uri_parse_unencoded;
 use crate::lsp::urls::uri_to_url;
 use crate::lsp::urls::url_to_uri;
+use crate::tools::coverage::collect_coverage_reports;
 use crate::tools::test;
 use crate::tools::test::FailFastTracker;
 use crate::tools::test::TestFailure;
@@ -227,12 +230,21 @@ impl TestRun {
     client: &Client,
     maybe_root_uri: Option<&ModuleSpecifier>,
   ) -> Result<(), AnyError> {
-    let args = self.get_args();
+    let coverage_dir = if self.kind == lsp_custom::TestRunKind::Coverage {
+      Some(
+        tempfile::Builder::new()
+          .prefix("deno_lsp_coverage_")
+          .tempdir()?,
+      )
+    } else {
+      None
+    };
+    let args = self.get_args(coverage_dir.as_ref().map(|dir| dir.path()));
     lsp_log!("Executing test run with arguments: {}", args.join(" "));
     let flags = Arc::new(flags_from_vec(
       args.into_iter().map(|s| From::from(s.as_ref())).collect(),
     )?);
-    let factory = CliFactory::from_flags(flags);
+    let factory = CliFactory::from_flags(flags.clone());
     let cli_options = factory.cli_options()?;
     let permission_desc_parser = factory.permission_desc_parser()?;
     let main_graph_container = factory.main_module_graph_container().await?;
@@ -473,12 +485,89 @@ impl TestRun {
       join_result??;
     }
 
-    result??;
+    let test_result = result?;
+
+    if let Some(coverage_dir) = coverage_dir.as_ref() {
+      if let Err(err) = self
+        .send_coverage_notification(client, flags, coverage_dir.path())
+        .await
+      {
+        lsp_log!("Failed to collect test coverage: {err:#}");
+      }
+    }
+
+    test_result?;
 
     Ok(())
   }
 
-  fn get_args(&self) -> Vec<Cow<'_, str>> {
+  async fn send_coverage_notification(
+    &self,
+    client: &Client,
+    flags: Arc<Flags>,
+    coverage_dir: &Path,
+  ) -> Result<(), AnyError> {
+    let coverage_dir = coverage_dir.to_string_lossy().into_owned();
+    let (_, reports) = spawn_blocking(move || {
+      collect_coverage_reports(
+        flags,
+        vec![coverage_dir],
+        vec![],
+        vec![],
+        vec![],
+        None,
+      )
+    })
+    .await??;
+    let files = reports
+      .into_iter()
+      .filter_map(|(report, _)| {
+        let uri = url_to_uri(report.url()).ok()?;
+        let lines = report
+          .found_lines()
+          .iter()
+          .filter_map(|(line, count)| {
+            Some(lsp_custom::TestCoverageLine {
+              line: u32::try_from(*line).ok()?,
+              count: u32::try_from((*count).max(0)).ok()?,
+            })
+          })
+          .collect::<Vec<_>>();
+
+        let branches = report
+          .branches()
+          .iter()
+          .filter_map(|b| {
+            Some(lsp_custom::TestCoverageBranch {
+              line: u32::try_from(b.line_index).ok()?,
+              branch: u32::try_from(b.branch_number).ok()?,
+              count: u32::try_from(b.taken.unwrap_or(0).max(0)).ok()?,
+            })
+          })
+          .collect::<Vec<_>>();
+
+        if lines.is_empty() && branches.is_empty() {
+          None
+        } else {
+          Some(lsp_custom::TestCoverageFile {
+            text_document: lsp::TextDocumentIdentifier { uri },
+            lines,
+            branches,
+          })
+        }
+      })
+      .collect::<Vec<_>>();
+
+    if !files.is_empty() {
+      client.send_test_notification(TestingNotification::Coverage(
+        lsp_custom::TestCoverageNotificationParams { id: self.id, files },
+      ));
+    }
+
+    Ok(())
+  }
+
+  fn get_args(&self, coverage_dir: Option<&Path>) -> Vec<Cow<'_, str>> {
     let mut args = vec![Cow::Borrowed("deno"), Cow::Borrowed("test")];
     args.extend(
       self
@@ -489,6 +578,13 @@ impl TestRun {
         .map(|s| Cow::Borrowed(s.as_str())),
     );
     args.push(Cow::Borrowed("--trace-leaks"));
+    if let Some(coverage_dir) = coverage_dir {
+      args.push(Cow::Owned(format!(
+        "--coverage={}",
+        coverage_dir.to_string_lossy()
+      )));
+      args.push(Cow::Borrowed("--coverage-raw-data-only"));
+    }
     for unstable_feature in self.workspace_settings.unstable.as_deref() {
       let flag = format!("--unstable-{unstable_feature}");
       if !args.contains(&Cow::Borrowed(&flag)) {

--- a/cli/lsp/testing/lsp_custom.rs
+++ b/cli/lsp/testing/lsp_custom.rs
@@ -186,3 +186,59 @@ impl lsp::notification::Notification for TestRunProgressNotification {
 
   const METHOD: &'static str = "deno/testRunProgress";
 }
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TestCoverageLine {
+  /// Zero-based line number matching LSP positions.
+  pub line: u32,
+  /// Number of times this line was executed.
+  pub count: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TestCoverageBranch {
+  /// Zero-based line number of the branch point.
+  pub line: u32,
+  /// Zero-based branch index (e.g., 0 for if, 1 for else).
+  pub branch: u32,
+  /// Number of times this branch was taken.
+  pub count: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TestCoverageFile {
+  /// The text document this coverage data relates to.
+  pub text_document: lsp::TextDocumentIdentifier,
+  /// Line-level coverage data.
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  #[serde(default)]
+  pub lines: Vec<TestCoverageLine>,
+  /// Branch-level coverage data.
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  #[serde(default)]
+  pub branches: Vec<TestCoverageBranch>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TestCoverageNotificationParams {
+  /// The ID of the test run this coverage data belongs to.
+  pub id: u32,
+  /// Coverage data for each file.
+  pub files: Vec<TestCoverageFile>,
+}
+
+/// Notification sent from the server to the client when test coverage
+/// data is available after a test run with coverage enabled.
+///
+/// This notification is sent after `deno/testRunProgress` with `End` message
+/// when the test run was initiated with `kind: "coverage"`.
+pub enum TestCoverageNotification {}
+
+impl lsp::notification::Notification for TestCoverageNotification {
+  type Params = TestCoverageNotificationParams;
+
+  const METHOD: &'static str = "deno/testCoverage";
+}

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -72,6 +72,20 @@ pub struct CoverageReport {
   output: Option<PathBuf>,
 }
 
+impl CoverageReport {
+  pub fn url(&self) -> &ModuleSpecifier {
+    &self.url
+  }
+
+  pub fn found_lines(&self) -> &[(usize, i64)] {
+    &self.found_lines
+  }
+
+  pub fn branches(&self) -> &[BranchCoverageItem] {
+    &self.branches
+  }
+}
+
 struct GenerateCoverageReportOptions<'a> {
   script_module_specifier: Url,
   script_media_type: MediaType,
@@ -588,15 +602,14 @@ fn filter_coverages(
     .collect::<Vec<cdp::ScriptCoverage>>()
 }
 
-pub fn cover_files(
+pub fn collect_coverage_reports(
   flags: Arc<Flags>,
   files_include: Vec<String>,
   files_ignore: Vec<String>,
   include: Vec<String>,
   exclude: Vec<String>,
   output: Option<String>,
-  reporters: &[&dyn CoverageReporter],
-) -> Result<(), AnyError> {
+) -> Result<(PathBuf, Vec<(CoverageReport, String)>), AnyError> {
   if files_include.is_empty() {
     return Err(anyhow!("No matching coverage profiles found"));
   }
@@ -765,6 +778,27 @@ pub fn cover_files(
   if file_reports.is_empty() {
     return Err(anyhow!("No covered files included in the report"));
   }
+
+  Ok((coverage_root, file_reports))
+}
+
+pub fn cover_files(
+  flags: Arc<Flags>,
+  files_include: Vec<String>,
+  files_ignore: Vec<String>,
+  include: Vec<String>,
+  exclude: Vec<String>,
+  output: Option<String>,
+  reporters: &[&dyn CoverageReporter],
+) -> Result<(), AnyError> {
+  let (coverage_root, file_reports) = collect_coverage_reports(
+    flags,
+    files_include,
+    files_ignore,
+    include,
+    exclude,
+    output,
+  )?;
 
   for reporter in reporters {
     reporter.done(&coverage_root, &file_reports);

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -16155,6 +16155,117 @@ Deno.test("test", async (testContext) => {
 }
 
 #[test(timeout = 300)]
+fn lsp_testing_api_coverage() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+
+  let mod_contents = r#"export const value = "covered";
+export function check(input: string) {
+  if (input === "covered") {
+    return true;
+  }
+  return false;
+}
+"#;
+  let contents = r#"import { check, value } from "./mod.ts";
+
+Deno.test("coverage", () => {
+  if (!check(value)) {
+    throw new Error("unexpected");
+  }
+});
+"#;
+  temp_dir.write("./mod.ts", mod_contents);
+  temp_dir.write("./test.ts", contents);
+  temp_dir.write("./deno.jsonc", "{}");
+  let uri = url_to_uri(&temp_dir.url().join("test.ts").unwrap()).unwrap();
+  let mod_uri = url_to_uri(&temp_dir.url().join("mod.ts").unwrap()).unwrap();
+
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.change_configuration(json!({
+    "deno": {
+      "enable": true,
+    },
+  }));
+
+  client.did_open(json!({
+    "textDocument": {
+      "uri": uri,
+      "languageId": "typescript",
+      "version": 1,
+      "text": contents,
+    }
+  }));
+
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testModule");
+  let params: TestModuleNotificationParams =
+    serde_json::from_value(notification.unwrap()).unwrap();
+  assert_eq!(params.text_document.uri.as_str(), uri.as_str());
+  assert_eq!(params.tests.len(), 1);
+
+  let res = client.write_request_with_res_as::<TestRunResponseParams>(
+    "deno/testRun",
+    json!({
+      "id": 2,
+      "kind": "coverage",
+    }),
+  );
+  assert_eq!(res.enqueued.len(), 1);
+
+  loop {
+    let notification =
+      client.read_notification_with_method::<Value>("deno/testRunProgress");
+    let notification = notification.unwrap();
+    let message_type = notification
+      .as_object()
+      .unwrap()
+      .get("message")
+      .unwrap()
+      .as_object()
+      .unwrap()
+      .get("type")
+      .unwrap()
+      .as_str()
+      .unwrap();
+    if message_type == "end" {
+      break;
+    }
+  }
+
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testCoverage");
+  let notification = notification.unwrap();
+  assert_eq!(notification.get("id"), Some(&json!(2)));
+  let files = notification
+    .get("files")
+    .and_then(|value| value.as_array())
+    .unwrap();
+  let file = files
+    .iter()
+    .find(|file| {
+      file.get("textDocument").and_then(|value| value.get("uri"))
+        == Some(&json!(mod_uri))
+    })
+    .unwrap();
+  let lines = file
+    .get("lines")
+    .and_then(|value| value.as_array())
+    .unwrap();
+  assert!(!lines.is_empty());
+  assert!(lines.iter().any(|line| {
+    line
+      .get("count")
+      .and_then(|value| value.as_u64())
+      .unwrap_or_default()
+      > 0
+  }));
+
+  client.shutdown();
+}
+
+#[test(timeout = 300)]
 fn lsp_testing_api_failure() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let temp_dir = context.temp_dir();


### PR DESCRIPTION
## Summary

Extends the Deno LSP to collect and report test coverage data after test runs initiated with `kind='coverage'`.

### Features
- **Line-level coverage** — hit counts per line
- **Branch-level coverage** — hit counts per branch point (if/else, ternary, etc.)
- **New LSP notification** — `deno/testCoverage` sent after test run completes
- **Integration test** — `lsp_testing_api_coverage`

### Why branch coverage?

The existing PR #35197 only implements line coverage. Branch coverage is essential for:
- Identifying untested code paths (e.g., else branches, error handlers)
- More accurate coverage metrics
- Better test quality insights

### Implementation

| File | Change |
|------|--------|
| `cli/lsp/testing/lsp_custom.rs` | Add `TestCoverageLine`, `TestCoverageBranch`, `TestCoverageFile`, `TestCoverageNotificationParams` types |
| `cli/lsp/testing/execution.rs` | Collect coverage after test run and send notification with line + branch data |
| `cli/lsp/client.rs` | Handle `Coverage` notification variant |
| `cli/tools/coverage/mod.rs` | Expose `branches()` accessor on `CoverageReport`, refactor `cover_files()` to `collect_coverage_reports()` |
| `tests/integration/lsp_tests.rs` | Add `lsp_testing_api_coverage` test |

### Notification Format

```typescript
interface TestCoverageNotificationParams {
  id: number;
  files: TestCoverageFile[];
}

interface TestCoverageFile {
  textDocument: TextDocumentIdentifier;
  lines?: TestCoverageLine[];
  branches?: TestCoverageBranch[];
}

interface TestCoverageLine {
  line: number;  // zero-based
  count: number;
}

interface TestCoverageBranch {
  line: number;    // zero-based
  branch: number;  // branch index
  count: number;
}
```

### Test Plan
- [x] Integration test passes
- [ ] Manual test with VSCode extension

Closes #18147