### PR TITLE
Fix typo in fmt.rs: 'formated' → 'formatted'

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -1806,7 +1806,7 @@ mod test {
   }
 
   #[test]
-  fn test_formated_removes_utf8_bom() {
+  fn test_formatted_removes_utf8_bom() {
     let file_text = format_file(
       Path::new("test.ts"),
       &FileContents {


### PR DESCRIPTION
Fixes a misspelling in a test function name in `cli/tools/fmt.rs`.

**AI Disclosure**: This typo was identified using AI-assisted code review.