### PR TITLE
Fix typo in swc.rs: 'paramter' → 'parameter'

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -1806,7 +1806,7 @@ mod test {
   }
 
   #[test]
-  fn test_formated_removes_utf8_bom() {
+  fn test_formatted_removes_utf8_bom() {
     let file_text = format_file(
       Path::new("test.ts"),
       &FileContents {

--- a/cli/tools/lint/ast_buffer/swc.rs
+++ b/cli/tools/lint/ast_buffer/swc.rs
@@ -2150,7 +2150,7 @@ fn serialize_class_member(
               .map(|deco| serialize_decorator(ctx, deco))
               .collect::<Vec<_>>();
 
-            let paramter = match &prop.param {
+            let parameter = match &prop.param {
               TsParamPropParam::Ident(binding_ident) => {
                 serialize_binding_ident(ctx, binding_ident, None)
               }
@@ -2165,7 +2165,7 @@ fn serialize_class_member(
               prop.readonly,
               a11y,
               decorators,
-              paramter,
+              parameter,
             )
           }
           ParamOrTsParamProp::Param(param) => {


### PR DESCRIPTION
Fixes a misspelling in `cli/tools/lint/ast_buffer/swc.rs`.

**AI Disclosure**: This typo was identified using AI-assisted code review.