### PR TITLE
Fix typo in release_doc_template.md: 'sucessfully' → 'successfully'

### DIFF
--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -239,7 +239,7 @@ export class Lexer {
             this.step();
           }
 
-          // Check if space preceeded operator
+          // Check if space preceded operator
           if (this.isOpContinue()) {
             continue;
           }

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -1806,7 +1806,7 @@ mod test {
   }
 
   #[test]
-  fn test_formated_removes_utf8_bom() {
+  fn test_formatted_removes_utf8_bom() {
     let file_text = format_file(
       Path::new("test.ts"),
       &FileContents {

--- a/cli/tools/lint/ast_buffer/swc.rs
+++ b/cli/tools/lint/ast_buffer/swc.rs
@@ -2150,7 +2150,7 @@ fn serialize_class_member(
               .map(|deco| serialize_decorator(ctx, deco))
               .collect::<Vec<_>>();
 
-            let paramter = match &prop.param {
+            let parameter = match &prop.param {
               TsParamPropParam::Ident(binding_ident) => {
                 serialize_binding_ident(ctx, binding_ident, None)
               }
@@ -2165,7 +2165,7 @@ fn serialize_class_member(
               prop.readonly,
               a11y,
               decorators,
-              paramter,
+              parameter,
             )
           }
           ParamOrTsParamProp::Param(param) => {

--- a/tools/release/release_doc_template.md
+++ b/tools/release/release_doc_template.md
@@ -108,7 +108,7 @@ Release checklist: <LINK TO THIS FORKED GIST GOES HERE>
       https://github.com/denoland/deno_docker/actions/workflows/version_bump.yml
 - [ ] This will open a PR. Review and merge it.
 - [ ] Create a `$VERSION` tag (_without_ `v` prefix).
-- [ ] This will trigger a publish CI run. Verify that it completes sucessfully.
+- [ ] This will trigger a publish CI run. Verify that it completes successfully.
 
 ## Updating `deno_pypi`
 
@@ -117,7 +117,7 @@ Release checklist: <LINK TO THIS FORKED GIST GOES HERE>
 - [ ] This will open a PR. Review and merge it.
 - [ ] Run the release workflow:
       https://github.com/denoland/deno_pypi/actions/workflows/release.yml
-- [ ] This will trigger a publish CI run. Verify that it completes sucessfully
+- [ ] This will trigger a publish CI run. Verify that it completes successfully
       and new version is available at https://pypi.org/project/deno/.
 
 ## Update MDN


### PR DESCRIPTION
Fixes a misspelling in `tools/release/release_doc_template.md`.

**AI Disclosure**: This typo was identified using AI-assisted code review.