### PR TITLE
fix(ext/node): keep dns.lookup permission token internal

### DIFF
--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -473,6 +473,18 @@ impl NetPermToken {
   pub fn includes(&self, addr: &str) -> bool {
     self.resolved_ips.iter().any(|ip| ip == addr)
   }
+
+  /// Returns the host that `--allow-net` should be checked against for a
+  /// connection to `address`: the token's original hostname when `address` is
+  /// one of the IPs this token resolved, otherwise the literal `address`. This
+  /// keeps the hostname from being grafted onto an unrelated IP.
+  pub fn check_host<'a>(&'a self, address: &'a str) -> &'a str {
+    if self.includes(address) {
+      &self.hostname
+    } else {
+      address
+    }
+  }
 }
 
 #[op2]
@@ -504,8 +516,8 @@ pub async fn op_net_connect_tcp_inner(
     // If token exists and the address matches to its resolved ips,
     // then we can check net permission against token.hostname, instead of addr.hostname
     let hostname_to_check = match net_perm_token {
-      Some(token) if token.includes(&addr.hostname) => token.hostname.clone(),
-      _ => addr.hostname.clone(),
+      Some(token) => token.check_host(&addr.hostname).to_string(),
+      None => addr.hostname.clone(),
     };
     state_
       .borrow_mut::<PermissionsContainer>()

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -166,15 +166,6 @@ unsafe extern "C" fn connect_cb(req: *mut UvConnect, status: i32) {
 
 // -- TCPWrap struct --
 
-/// Permission token data captured from a `node:dns.lookup()` call, kept so
-/// `connect()` can decide whether to check permissions against the original
-/// hostname. We store the resolved IP set, not just the hostname, so the
-/// hostname is only honored for an address that lookup actually resolved.
-struct NetPermTokenInfo {
-  hostname: String,
-  resolved_ips: Vec<String>,
-}
-
 #[derive(CppgcInherits)]
 #[cppgc_inherits_from(LibUvStreamWrap)]
 #[repr(C)]
@@ -185,7 +176,7 @@ pub struct TCPWrap {
   /// Permission token from DNS lookup. When set, connect() checks
   /// permissions against the original hostname, but only for an address
   /// that is among the token's resolved IPs.
-  net_perm_token: RefCell<Option<NetPermTokenInfo>>,
+  net_perm_token: RefCell<Option<deno_net::ops::NetPermToken>>,
 }
 
 // SAFETY: TCPWrap is a cppgc-managed object; the GC traces it via the base field.
@@ -318,10 +309,8 @@ impl TCPWrap {
   /// custom `lookup` callback, and mirrors `op_net_connect_tcp`.
   fn net_perm_check_host(&self, address: &str) -> String {
     match &*self.net_perm_token.borrow() {
-      Some(token) if token.resolved_ips.iter().any(|ip| ip == address) => {
-        token.hostname.clone()
-      }
-      _ => address.to_string(),
+      Some(token) => token.check_host(address).to_string(),
+      None => address.to_string(),
     }
   }
 
@@ -683,8 +672,9 @@ impl TCPWrap {
   /// matching Node.js netPermToken behavior.
   #[nofast]
   fn set_net_perm_token(&self, #[cppgc] token: &deno_net::ops::NetPermToken) {
-    *self.net_perm_token.borrow_mut() = Some(NetPermTokenInfo {
+    *self.net_perm_token.borrow_mut() = Some(deno_net::ops::NetPermToken {
       hostname: token.hostname.clone(),
+      port: token.port,
       resolved_ips: token.resolved_ips.clone(),
     });
   }

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -166,6 +166,15 @@ unsafe extern "C" fn connect_cb(req: *mut UvConnect, status: i32) {
 
 // -- TCPWrap struct --
 
+/// Permission token data captured from a `node:dns.lookup()` call, kept so
+/// `connect()` can decide whether to check permissions against the original
+/// hostname. We store the resolved IP set, not just the hostname, so the
+/// hostname is only honored for an address that lookup actually resolved.
+struct NetPermTokenInfo {
+  hostname: String,
+  resolved_ips: Vec<String>,
+}
+
 #[derive(CppgcInherits)]
 #[cppgc_inherits_from(LibUvStreamWrap)]
 #[repr(C)]
@@ -174,8 +183,9 @@ pub struct TCPWrap {
   handle: Cell<Option<OwnedPtr<UvTcp>>>,
   socket_type: Cell<SocketType>,
   /// Permission token from DNS lookup. When set, connect() checks
-  /// permissions against the original hostname instead of the resolved IP.
-  net_perm_hostname: RefCell<Option<String>>,
+  /// permissions against the original hostname, but only for an address
+  /// that is among the token's resolved IPs.
+  net_perm_token: RefCell<Option<NetPermTokenInfo>>,
 }
 
 // SAFETY: TCPWrap is a cppgc-managed object; the GC traces it via the base field.
@@ -233,7 +243,7 @@ impl TCPWrap {
         base,
         handle: Cell::new(Some(tcp)),
         socket_type: Cell::new(socket_type),
-        net_perm_hostname: RefCell::new(None),
+        net_perm_token: RefCell::new(None),
       }
     } else {
       // Error path - create with null handle
@@ -262,7 +272,7 @@ impl TCPWrap {
         ),
         handle: Cell::new(None),
         socket_type: Cell::new(socket_type),
-        net_perm_hostname: RefCell::new(None),
+        net_perm_token: RefCell::new(None),
       }
     }
   }
@@ -297,6 +307,22 @@ impl TCPWrap {
   /// to the TCP stream for encrypted I/O.
   pub fn stream_ptr(&self) -> *mut UvStream {
     self.base.stream_ptr()
+  }
+
+  /// Decide which host to check `--allow-net` against when connecting to
+  /// `address`. If a `node:dns.lookup()` token was installed and `address`
+  /// is one of the IPs that lookup resolved, the original hostname is used
+  /// (so e.g. `--allow-net=example.com` authorizes example.com's real IPs).
+  /// Otherwise the literal `address` is checked. This prevents a token
+  /// obtained for one host from being grafted onto an unrelated IP via a
+  /// custom `lookup` callback, and mirrors `op_net_connect_tcp`.
+  fn net_perm_check_host(&self, address: &str) -> String {
+    match &*self.net_perm_token.borrow() {
+      Some(token) if token.resolved_ips.iter().any(|ip| ip == address) => {
+        token.hostname.clone()
+      }
+      _ => address.to_string(),
+    }
   }
 
   fn bind_inner(
@@ -650,12 +676,17 @@ impl TCPWrap {
     unsafe { uv_compat::uv_tcp_reset(tcp) }
   }
 
-  /// Store the original hostname from DNS lookup for permission checks.
-  /// When set, connect() checks permissions against this hostname
-  /// instead of the resolved IP, matching Node.js netPermToken behavior.
+  /// Store the DNS-lookup permission token for later permission checks.
+  /// We keep both the original hostname and the set of IPs that lookup
+  /// resolved, so connect() can check against the hostname only for an
+  /// address the token actually resolved (see `net_perm_check_host`),
+  /// matching Node.js netPermToken behavior.
   #[nofast]
   fn set_net_perm_token(&self, #[cppgc] token: &deno_net::ops::NetPermToken) {
-    *self.net_perm_hostname.borrow_mut() = Some(token.hostname.clone());
+    *self.net_perm_token.borrow_mut() = Some(NetPermTokenInfo {
+      hostname: token.hostname.clone(),
+      resolved_ips: token.resolved_ips.clone(),
+    });
   }
 
   /// Connect to an address. Takes (req, address, port) where req is a
@@ -670,12 +701,9 @@ impl TCPWrap {
     scope: &mut v8::PinScope,
   ) -> Result<i32, deno_permissions::PermissionCheckError> {
     // If a hostname was stored from DNS lookup, check permissions against
-    // the original hostname instead of the resolved IP address.
-    let check_host = self
-      .net_perm_hostname
-      .borrow()
-      .clone()
-      .unwrap_or_else(|| address.to_string());
+    // the original hostname instead of the resolved IP address, but only
+    // when `address` is one of the token's resolved IPs.
+    let check_host = self.net_perm_check_host(address);
     state.borrow_mut::<PermissionsContainer>().check_net(
       &(check_host.as_str(), Some(port as u16)),
       "node:net.connect()",
@@ -743,11 +771,7 @@ impl TCPWrap {
     #[smi] port: i32,
     scope: &mut v8::PinScope,
   ) -> Result<i32, deno_permissions::PermissionCheckError> {
-    let check_host = self
-      .net_perm_hostname
-      .borrow()
-      .clone()
-      .unwrap_or_else(|| address.to_string());
+    let check_host = self.net_perm_check_host(address);
     state.borrow_mut::<PermissionsContainer>().check_net(
       &(check_host.as_str(), Some(port as u16)),
       "node:net.connect()",

--- a/ext/node/polyfills/dns.ts
+++ b/ext/node/polyfills/dns.ts
@@ -71,6 +71,7 @@ const {
   GetAddrInfoReqWrap,
   GetNameInfoReqWrap,
   QueryReqWrap,
+  kPermTokenSink,
 } = core.loadExtScript("ext:deno_node/internal_binding/cares_wrap.ts");
 const { domainToASCII } = core.loadExtScript(
   "ext:deno_node/internal/idna.ts",
@@ -93,12 +94,19 @@ function onlookup(
     return this.callback(dnsException(err, "getaddrinfo", this.hostname));
   }
 
-  this.callback(
-    null,
-    addresses[0],
-    this.family || isIP(addresses[0]),
-    netPermToken,
-  );
+  // The NetPermToken is only handed to net.connect's built-in lookup, which
+  // tags its callback with `kPermTokenSink`. User-supplied callbacks never
+  // bear the marker and so never observe the token (GHSA-fhjh-jqv7-m238).
+  if (this.callback[kPermTokenSink]) {
+    this.callback(
+      null,
+      addresses[0],
+      this.family || isIP(addresses[0]),
+      netPermToken,
+    );
+  } else {
+    this.callback(null, addresses[0], this.family || isIP(addresses[0]));
+  }
 }
 
 function onlookupall(
@@ -122,7 +130,9 @@ function onlookupall(
     };
   }
 
-  if (this.callback.length > 1) {
+  // Only net.connect's built-in lookup (tagged with `kPermTokenSink`) is given
+  // the NetPermToken; user-supplied callbacks never observe it.
+  if (this.callback[kPermTokenSink]) {
     this.callback(null, parsedAddresses, undefined, netPermToken);
   } else {
     this.callback(null, parsedAddresses);

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -53,6 +53,7 @@ const {
   StringPrototypePadStart,
   StringPrototypeReplace,
   StringPrototypeSplit,
+  Symbol,
 } = primordials;
 const {
   op_dns_resolve,
@@ -91,6 +92,14 @@ interface ErrnoException extends Error {
 const DNS_ORDER_VERBATIM = 0;
 const DNS_ORDER_IPV4_FIRST = 1;
 const DNS_ORDER_IPV6_FIRST = 2;
+
+// Module-private marker placed on the getaddrinfo completion callback used by
+// net.connect's *built-in* lookup. Only a callback bearing this symbol is
+// handed the NetPermToken from a lookup, so the token never escapes to a
+// user-supplied dns.lookup callback or a custom net.connect `lookup` function.
+// User code cannot reference this symbol, so it can neither receive the token
+// nor forge the marker. See GHSA-fhjh-jqv7-m238.
+const kPermTokenSink = Symbol("kPermTokenSink");
 
 class GetAddrInfoReqWrap extends AsyncWrap {
   family!: number;
@@ -907,6 +916,7 @@ return {
   QueryReqWrap,
   ChannelWrap,
   strerror,
+  kPermTokenSink,
   default: {
     DNS_ORDER_VERBATIM,
     DNS_ORDER_IPV4_FIRST,

--- a/ext/node/polyfills/net.ts
+++ b/ext/node/polyfills/net.ts
@@ -112,6 +112,9 @@ const { default: assert } = core.loadExtScript("ext:deno_node/assert.ts");
 const { isWindows } = core.loadExtScript("ext:deno_node/_util/os.ts");
 const { ADDRCONFIG, lookup: dnsLookup } = core.createLazyLoader("node:dns")()
   .default;
+const { kPermTokenSink } = core.loadExtScript(
+  "ext:deno_node/internal_binding/cares_wrap.ts",
+);
 const {
   codeMap,
   UV_ECANCELED,
@@ -1100,6 +1103,11 @@ function _lookupAndConnect(self: Socket, options: TcpSocketConnectOptions) {
   debug("connect: find host", host);
   debug("connect: dns options", dnsOpts);
   self._host = host;
+  // Only the built-in DNS lookup is trusted to install a NetPermToken on the
+  // handle (so `--allow-net=<host>` keeps authorizing the IPs Deno resolved
+  // for it). A custom `lookup` returns arbitrary IPs, so its result is checked
+  // against the literal IP with no hostname substitution (GHSA-fhjh-jqv7-m238).
+  const usingDefaultLookup = options.lookup === undefined;
   const lookup = options.lookup || dnsLookup;
   const getLookupDnsOpts = () => {
     if (options.lookup === undefined) {
@@ -1133,6 +1141,7 @@ function _lookupAndConnect(self: Socket, options: TcpSocketConnectOptions) {
         localAddress,
         localPort,
         autoSelectFamilyAttemptTimeout,
+        usingDefaultLookup,
       );
     });
 
@@ -1140,66 +1149,73 @@ function _lookupAndConnect(self: Socket, options: TcpSocketConnectOptions) {
   }
 
   defaultTriggerAsyncIdScope(self[asyncIdSymbol], function () {
-    lookup(
-      host,
-      getLookupDnsOpts(),
-      function emitLookup(
-        err: ErrnoException | null,
-        ip: string,
-        addressType: number,
-        netPermToken,
+    function emitLookup(
+      err: ErrnoException | null,
+      ip: string,
+      addressType: number,
+      netPermToken,
+    ) {
+      // Store the permission token from the built-in DNS lookup so connect()
+      // checks permissions against the original hostname instead of the
+      // resolved IP. Only honored on the default-lookup path; a custom lookup
+      // never installs a token (its IPs are checked literally).
+      if (
+        usingDefaultLookup && netPermToken && self._handle?.setNetPermToken
       ) {
-        // Store the permission token from DNS lookup so connect() checks
-        // permissions against the original hostname instead of the resolved IP.
-        if (netPermToken && self._handle?.setNetPermToken) {
-          self._handle.setNetPermToken(netPermToken);
-        }
-        self.emit("lookup", err, ip, addressType, host);
+        self._handle.setNetPermToken(netPermToken);
+      }
+      self.emit("lookup", err, ip, addressType, host);
 
-        // It's possible we were destroyed while looking this up.
-        // XXX it would be great if we could cancel the promise returned by
-        // the look up.
-        if (!self.connecting) {
-          return;
-        }
+      // It's possible we were destroyed while looking this up.
+      // XXX it would be great if we could cancel the promise returned by
+      // the look up.
+      if (!self.connecting) {
+        return;
+      }
 
-        if (err) {
-          // net.createConnection() creates a net.Socket object and immediately
-          // calls net.Socket.connect() on it (that's us). There are no event
-          // listeners registered yet so defer the error event to the next tick.
-          nextTick(_connectErrorNT, self, err);
-        } else if (!isIP(ip)) {
-          err = new ERR_INVALID_IP_ADDRESS(ip);
+      if (err) {
+        // net.createConnection() creates a net.Socket object and immediately
+        // calls net.Socket.connect() on it (that's us). There are no event
+        // listeners registered yet so defer the error event to the next tick.
+        nextTick(_connectErrorNT, self, err);
+      } else if (!isIP(ip)) {
+        err = new ERR_INVALID_IP_ADDRESS(ip);
 
-          nextTick(_connectErrorNT, self, err);
-        } else if (addressType !== 4 && addressType !== 6) {
-          err = new ERR_INVALID_ADDRESS_FAMILY(
-            `${addressType}`,
-            options.host!,
-            options.port,
-          );
+        nextTick(_connectErrorNT, self, err);
+      } else if (addressType !== 4 && addressType !== 6) {
+        err = new ERR_INVALID_ADDRESS_FAMILY(
+          `${addressType}`,
+          options.host!,
+          options.port,
+        );
 
-          nextTick(_connectErrorNT, self, err);
-        } else {
-          self._unrefTimer();
+        nextTick(_connectErrorNT, self, err);
+      } else {
+        self._unrefTimer();
 
-          defaultTriggerAsyncIdScope(self[asyncIdSymbol], nextTick, () => {
-            if (self.connecting) {
-              defaultTriggerAsyncIdScope(
-                self[asyncIdSymbol],
-                _internalConnect,
-                self,
-                ip,
-                port,
-                addressType,
-                localAddress,
-                localPort,
-              );
-            }
-          });
-        }
-      },
-    );
+        defaultTriggerAsyncIdScope(self[asyncIdSymbol], nextTick, () => {
+          if (self.connecting) {
+            defaultTriggerAsyncIdScope(
+              self[asyncIdSymbol],
+              _internalConnect,
+              self,
+              ip,
+              port,
+              addressType,
+              localAddress,
+              localPort,
+            );
+          }
+        });
+      }
+    }
+
+    // Tag the trusted callback so the built-in dns.lookup hands it the
+    // NetPermToken; user-supplied lookups never receive it.
+    if (usingDefaultLookup) {
+      emitLookup[kPermTokenSink] = true;
+    }
+    lookup(host, getLookupDnsOpts(), emitLookup);
   });
 }
 
@@ -1214,141 +1230,146 @@ function _lookupAndConnectMultiple(
   localAddress: string,
   localPort: number,
   timeout: number | undefined,
+  usingDefaultLookup: boolean,
 ) {
-  defaultTriggerAsyncIdScope(self[asyncIdSymbol], function emitLookup() {
-    lookup(
-      host,
-      dnsopts,
-      function emitLookup(err, addresses, _, netPermToken) {
-        if (netPermToken && self._handle?.setNetPermToken) {
-          self._handle.setNetPermToken(netPermToken);
-        }
+  defaultTriggerAsyncIdScope(self[asyncIdSymbol], function () {
+    function emitLookup(err, addresses, _, netPermToken) {
+      // Only the built-in lookup installs a token (see _lookupAndConnect).
+      if (
+        usingDefaultLookup && netPermToken && self._handle?.setNetPermToken
+      ) {
+        self._handle.setNetPermToken(netPermToken);
+      }
+      // It's possible we were destroyed while looking this up.
+      // XXX it would be great if we could cancel the promise returned by
+      // the look up.
+      if (!self.connecting) {
+        return;
+      } else if (err) {
+        self.emit("lookup", err, undefined, undefined, host);
+
+        // net.createConnection() creates a net.Socket object and immediately
+        // calls net.Socket.connect() on it (that's us). There are no event
+        // listeners registered yet so defer the error event to the next tick.
+        nextTick(_connectErrorNT, self, err);
+        return;
+      }
+
+      // Filter addresses by only keeping the one which are either IPv4 or IPV6.
+      // The first valid address determines which group has preference on the
+      // alternate family sorting which happens later.
+      const validAddresses = [[], []];
+      const validIps = [[], []];
+      let destinations;
+      for (let i = 0, l = addresses.length; i < l; i++) {
+        const address = addresses[i];
+        const { address: ip, family: addressType } = address;
+        self.emit("lookup", err, ip, addressType, host);
         // It's possible we were destroyed while looking this up.
-        // XXX it would be great if we could cancel the promise returned by
-        // the look up.
         if (!self.connecting) {
           return;
-        } else if (err) {
-          self.emit("lookup", err, undefined, undefined, host);
+        }
+        if (isIP(ip) && (addressType === 4 || addressType === 6)) {
+          destinations ||= addressType === 6 ? { 6: 0, 4: 1 } : { 4: 0, 6: 1 };
 
-          // net.createConnection() creates a net.Socket object and immediately
-          // calls net.Socket.connect() on it (that's us). There are no event
-          // listeners registered yet so defer the error event to the next tick.
+          const destination = destinations[addressType];
+
+          // Only try an address once
+          if (!ArrayPrototypeIncludes(validIps[destination], ip)) {
+            ArrayPrototypePush(validAddresses[destination], address);
+            ArrayPrototypePush(validIps[destination], ip);
+          }
+        }
+      }
+
+      // When no AAAA or A records are available, fail on the first one
+      if (!validAddresses[0].length && !validAddresses[1].length) {
+        const { address: firstIp, family: firstAddressType } = addresses[0];
+
+        if (!isIP(firstIp)) {
+          err = new ERR_INVALID_IP_ADDRESS(firstIp);
           nextTick(_connectErrorNT, self, err);
-          return;
-        }
-
-        // Filter addresses by only keeping the one which are either IPv4 or IPV6.
-        // The first valid address determines which group has preference on the
-        // alternate family sorting which happens later.
-        const validAddresses = [[], []];
-        const validIps = [[], []];
-        let destinations;
-        for (let i = 0, l = addresses.length; i < l; i++) {
-          const address = addresses[i];
-          const { address: ip, family: addressType } = address;
-          self.emit("lookup", err, ip, addressType, host);
-          // It's possible we were destroyed while looking this up.
-          if (!self.connecting) {
-            return;
-          }
-          if (isIP(ip) && (addressType === 4 || addressType === 6)) {
-            destinations ||= addressType === 6
-              ? { 6: 0, 4: 1 }
-              : { 4: 0, 6: 1 };
-
-            const destination = destinations[addressType];
-
-            // Only try an address once
-            if (!ArrayPrototypeIncludes(validIps[destination], ip)) {
-              ArrayPrototypePush(validAddresses[destination], address);
-              ArrayPrototypePush(validIps[destination], ip);
-            }
-          }
-        }
-
-        // When no AAAA or A records are available, fail on the first one
-        if (!validAddresses[0].length && !validAddresses[1].length) {
-          const { address: firstIp, family: firstAddressType } = addresses[0];
-
-          if (!isIP(firstIp)) {
-            err = new ERR_INVALID_IP_ADDRESS(firstIp);
-            nextTick(_connectErrorNT, self, err);
-          } else if (firstAddressType !== 4 && firstAddressType !== 6) {
-            err = new ERR_INVALID_ADDRESS_FAMILY(
-              firstAddressType,
-              options.host,
-              options.port,
-            );
-            nextTick(_connectErrorNT, self, err);
-          }
-
-          return;
-        }
-
-        // Sort addresses alternating families
-        const toAttempt = [];
-        for (
-          let i = 0,
-            l = MathMax(validAddresses[0].length, validAddresses[1].length);
-          i < l;
-          i++
-        ) {
-          if (ObjectHasOwn(validAddresses[0], i)) {
-            ArrayPrototypePush(toAttempt, validAddresses[0][i]);
-          }
-          if (ObjectHasOwn(validAddresses[1], i)) {
-            ArrayPrototypePush(toAttempt, validAddresses[1][i]);
-          }
-        }
-
-        if (toAttempt.length === 1) {
-          debug(
-            "connect/multiple: only one address found, switching back to single connection",
+        } else if (firstAddressType !== 4 && firstAddressType !== 6) {
+          err = new ERR_INVALID_ADDRESS_FAMILY(
+            firstAddressType,
+            options.host,
+            options.port,
           );
-          const { address: ip, family: addressType } = toAttempt[0];
-
-          self._unrefTimer();
-          defaultTriggerAsyncIdScope(
-            self[asyncIdSymbol],
-            _internalConnect,
-            self,
-            ip,
-            port,
-            addressType,
-            localAddress,
-            localPort,
-          );
-
-          return;
+          nextTick(_connectErrorNT, self, err);
         }
 
-        self.autoSelectFamilyAttemptedAddresses = [];
+        return;
+      }
+
+      // Sort addresses alternating families
+      const toAttempt = [];
+      for (
+        let i = 0,
+          l = MathMax(validAddresses[0].length, validAddresses[1].length);
+        i < l;
+        i++
+      ) {
+        if (ObjectHasOwn(validAddresses[0], i)) {
+          ArrayPrototypePush(toAttempt, validAddresses[0][i]);
+        }
+        if (ObjectHasOwn(validAddresses[1], i)) {
+          ArrayPrototypePush(toAttempt, validAddresses[1][i]);
+        }
+      }
+
+      if (toAttempt.length === 1) {
         debug(
-          "connect/multiple: will try the following addresses",
-          toAttempt,
+          "connect/multiple: only one address found, switching back to single connection",
         );
-
-        const context = {
-          socket: self,
-          addresses: toAttempt,
-          current: 0,
-          port,
-          localPort,
-          flags: 0,
-          timeout,
-          [kTimeout]: null,
-          errors: [],
-        };
+        const { address: ip, family: addressType } = toAttempt[0];
 
         self._unrefTimer();
         defaultTriggerAsyncIdScope(
           self[asyncIdSymbol],
-          _internalConnectMultiple,
-          context,
+          _internalConnect,
+          self,
+          ip,
+          port,
+          addressType,
+          localAddress,
+          localPort,
         );
-      },
-    );
+
+        return;
+      }
+
+      self.autoSelectFamilyAttemptedAddresses = [];
+      debug(
+        "connect/multiple: will try the following addresses",
+        toAttempt,
+      );
+
+      const context = {
+        socket: self,
+        addresses: toAttempt,
+        current: 0,
+        port,
+        localPort,
+        flags: 0,
+        timeout,
+        [kTimeout]: null,
+        errors: [],
+      };
+
+      self._unrefTimer();
+      defaultTriggerAsyncIdScope(
+        self[asyncIdSymbol],
+        _internalConnectMultiple,
+        context,
+      );
+    }
+
+    // Tag the trusted callback so the built-in dns.lookup hands it the
+    // NetPermToken; user-supplied lookups never receive it.
+    if (usingDefaultLookup) {
+      emitLookup[kPermTokenSink] = true;
+    }
+    lookup(host, dnsopts, emitLookup);
   });
 }
 

--- a/ext/node/polyfills/net.ts
+++ b/ext/node/polyfills/net.ts
@@ -1107,10 +1107,13 @@ function _lookupAndConnect(self: Socket, options: TcpSocketConnectOptions) {
   // handle (so `--allow-net=<host>` keeps authorizing the IPs Deno resolved
   // for it). A custom `lookup` returns arbitrary IPs, so its result is checked
   // against the literal IP with no hostname substitution (GHSA-fhjh-jqv7-m238).
-  const usingDefaultLookup = options.lookup === undefined;
+  // This must stay in sync with the `lookup` selection below: any falsy
+  // `options.lookup` falls back to the built-in resolver, so it is also the
+  // default-lookup path for token purposes.
   const lookup = options.lookup || dnsLookup;
+  const usingDefaultLookup = lookup === dnsLookup;
   const getLookupDnsOpts = () => {
-    if (options.lookup === undefined) {
+    if (usingDefaultLookup) {
       return { ...dnsOpts, port };
     }
     return {

--- a/tests/specs/permission/node_net_perm_token_graft/__test__.jsonc
+++ b/tests/specs/permission/node_net_perm_token_graft/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "node_net_perm_token_graft": {
+      "args": "run --allow-net=localhost main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/permission/node_net_perm_token_graft/main.out
+++ b/tests/specs/permission/node_net_perm_token_graft/main.out
@@ -1,0 +1,3 @@
+PASS: dns.lookup did not leak a perm token
+PASS: custom lookup to 127.0.0.2 denied
+PASS: built-in lookup authorized localhost's resolved IP

--- a/tests/specs/permission/node_net_perm_token_graft/main.ts
+++ b/tests/specs/permission/node_net_perm_token_graft/main.ts
@@ -1,0 +1,72 @@
+// Regression test for GHSA-fhjh-jqv7-m238.
+//
+// The NetPermToken produced by a DNS lookup must never be observable by user
+// code, and a custom `net.connect` `lookup` must not be able to authorize a
+// connection to an arbitrary IP. The built-in lookup must still let
+// `--allow-net=<host>` authorize the IPs that host resolves to.
+//
+// This process is granted only `--allow-net=localhost` (resolves to 127.0.0.1).
+
+import net from "node:net";
+import dns from "node:dns";
+
+const PORT = 45999;
+
+// Grab whatever a user dns.lookup callback receives in the 4th argument slot.
+function lookupToken(host: string): Promise<unknown> {
+  return new Promise((resolve) =>
+    dns.lookup(host, { family: 4 }, (_e, _a, _f, token) => resolve(token))
+  );
+}
+
+// Attempt a node:net connection. With a custom `lookup`, the lookup decides the
+// IP (and may try to inject a token); without one, the built-in lookup is used.
+function connect(lookup?: unknown): Promise<string> {
+  return new Promise((resolve) => {
+    const socket = net.connect({
+      host: "localhost",
+      port: PORT,
+      family: 4,
+      lookup,
+    });
+    socket.on("connect", () => {
+      socket.destroy();
+      resolve("connected");
+    });
+    socket.on("error", (e: Error) => {
+      const msg = `${e.name}: ${e.message}`;
+      resolve(
+        e.name === "NotCapable" || msg.includes("Requires net access")
+          ? "perm-denied"
+          : "other",
+      );
+    });
+  });
+}
+
+// 1. dns.lookup must not hand a permission token to user callbacks.
+const stolen = await lookupToken("localhost");
+console.log(
+  stolen === undefined
+    ? "PASS: dns.lookup did not leak a perm token"
+    : `FAIL: dns.lookup leaked ${typeof stolen}`,
+);
+
+// 2. A custom lookup cannot graft access to an unrelated IP, even when it tries
+//    to pass something in the token slot.
+const graft = await connect((_h, _o, cb) => cb(null, "127.0.0.2", 4, stolen));
+console.log(
+  graft === "perm-denied"
+    ? "PASS: custom lookup to 127.0.0.2 denied"
+    : `FAIL: custom lookup to 127.0.0.2 was ${graft}`,
+);
+
+// 3. The built-in lookup still lets --allow-net=localhost authorize the IPs
+//    localhost resolves to (127.0.0.1). The socket then fails to connect with
+//    no server present, which is past the permission check and therefore fine.
+const legit = await connect();
+console.log(
+  legit !== "perm-denied"
+    ? "PASS: built-in lookup authorized localhost's resolved IP"
+    : "FAIL: built-in lookup denied localhost",
+);


### PR DESCRIPTION
node:dns.lookup() was handing an internal Deno permission token to the
lookup callback as a fourth argument. Node's lookup callback only receives
(err, address, family), so this was both a compatibility wart and an
internal implementation detail leaking into user space.

The token exists only so that node:net.connect() can check --allow-net
against the hostname that was resolved, rather than against the resolved
IP, when Deno itself performed the DNS resolution. It has no meaning to
user code, and it should not be reusable through a custom net.connect()
`lookup` function, where the returned addresses are arbitrary.

This routes the token through a module-private symbol defined in the
internal cares_wrap binding. dns.lookup() only attaches the token when the
receiving callback carries that marker, and net.connect() tags its
internal callback only on the built-in lookup path. As a result, user
dns.lookup() callbacks now see exactly Node's (err, address, family)
signature, and a custom net.connect() `lookup` has its addresses checked
against the literal IP with no hostname substitution.

As an additional safeguard, TCPWrap now retains the resolved-IP set from
the token and only substitutes the original hostname for an address that
the token actually resolved, matching the behavior already implemented in
the native op_net_connect_tcp path.

A spec test under tests/specs/permission covers three cases: that
dns.lookup() exposes no token, that a custom net.connect() lookup cannot
authorize an unrelated IP, and that the built-in lookup still lets
--allow-net=<host> reach the IPs that host resolves to.