### PR TITLE
fix(ext/fetch): require --allow-net for Unix proxy in createHttpClient

### DIFF
--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -878,6 +878,13 @@ pub fn op_fetch_custom_client(
             Some("Deno.createHttpClient()"),
           )?
           .into_path();
+        // Unix sockets are an outbound network primitive, so a Unix proxy
+        // requires an `--allow-net=unix:<path>` rule in addition to the
+        // filesystem check above, mirroring the direct Unix socket ops.
+        permissions.check_net_unix_socket(
+          &resolved_path,
+          Some("Deno.createHttpClient()"),
+        )?;
         if path != resolved_path {
           *original_path = resolved_path.to_string_lossy().into_owned();
         }

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -2378,7 +2378,9 @@ Deno.test(
 // An `--allow-net=unix:<path>` rule scoped to the exact socket path grants the
 // Unix proxy access. Run in a subprocess so the dynamic socket path can be
 // passed in the allow-net rule. The temp dir is canonicalized up front so the
-// resolved socket path matches the rule exactly.
+// resolved socket path matches the rule exactly. The `localhost` grant is also
+// required: routing through the Unix proxy still issues `fetch()` against the
+// request URL, whose host (`localhost`) goes through the normal net check.
 Deno.test(
   {
     ignore: Deno.build.os === "windows",
@@ -2407,7 +2409,7 @@ Deno.test(
       "run",
       "--allow-read",
       "--allow-write",
-      `--allow-net=unix:${socketPath}`,
+      `--allow-net=unix:${socketPath},localhost`,
       scriptPath,
     ]).finished();
     assertEquals(status, 0);

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -9,7 +9,9 @@ import {
   assertStringIncludes,
   assertThrows,
   delay,
+  execCode3,
   fail,
+  tmpUnixSocketPath,
   unimplemented,
 } from "./test_util.ts";
 import { Buffer } from "@std/io/buffer";
@@ -2326,6 +2328,90 @@ Deno.test(
     const resp2 = await fetch("http://localhost/not-found", { client });
     assertEquals(resp2.status, 404);
     assertEquals(await resp2.text(), "Not found");
+  },
+);
+
+// A Unix-socket proxy is an outbound network primitive, so it requires an
+// `--allow-net=unix:<path>` rule in addition to filesystem access on the
+// socket path. Filesystem read/write alone must not let a custom client route
+// fetch traffic to a local Unix socket.
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
+  function fetchUnixProxyRequiresAllowNet() {
+    const socketPath = tmpUnixSocketPath();
+    assertThrows(
+      () =>
+        Deno.createHttpClient({
+          proxy: { transport: "unix", path: socketPath },
+        }),
+      Deno.errors.NotCapable,
+    );
+  },
+);
+
+// The scoped form must match the exact path: an `--allow-net=unix:<path>` rule
+// for a different socket does not grant the Unix proxy access to this one.
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: {
+      read: true,
+      write: true,
+      net: ["unix:/some/other/path.sock"],
+    },
+  },
+  function fetchUnixProxyScopedAllowNetMatchesExactly() {
+    const socketPath = tmpUnixSocketPath();
+    assertThrows(
+      () =>
+        Deno.createHttpClient({
+          proxy: { transport: "unix", path: socketPath },
+        }),
+      Deno.errors.NotCapable,
+    );
+  },
+);
+
+// An `--allow-net=unix:<path>` rule scoped to the exact socket path grants the
+// Unix proxy access. Run in a subprocess so the dynamic socket path can be
+// passed in the allow-net rule. The temp dir is canonicalized up front so the
+// resolved socket path matches the rule exactly.
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true, run: true },
+  },
+  async function fetchUnixProxyScopedAllowNetGrantsAccess() {
+    const folder = Deno.realPathSync(Deno.makeTempDirSync());
+    const socketPath = `${folder}/socket`;
+    const scriptPath = Deno.makeTempFileSync({ suffix: ".js" });
+    Deno.writeTextFileSync(
+      scriptPath,
+      `
+      await using _server = Deno.serve({
+        path: ${JSON.stringify(socketPath)},
+        transport: "unix",
+        onListen: () => {},
+      }, () => new Response("OK"));
+      using client = Deno.createHttpClient({
+        proxy: { transport: "unix", path: ${JSON.stringify(socketPath)} },
+      });
+      const resp = await fetch("http://localhost/", { client });
+      console.log(await resp.text());
+      `,
+    );
+    const [status, output] = await execCode3(Deno.execPath(), [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      `--allow-net=unix:${socketPath}`,
+      scriptPath,
+    ]).finished();
+    assertEquals(status, 0);
+    assertStringIncludes(output, "OK");
   },
 );
 


### PR DESCRIPTION
PR #34395 added a Unix-domain-socket network boundary: Unix socket endpoints
are represented as `--allow-net=unix:<absolute-path>`, and the direct Unix
socket ops (`Deno.connect`, `Deno.listen`, `Deno.listenDatagram`, and
`DatagramConn.send`) now require that grant in addition to the existing
filesystem check on the socket path.

`Deno.createHttpClient({ proxy: { transport: "unix", path } })` is a sibling
Unix-socket transport that the original change did not cover. The `Proxy::Unix`
branch in `op_fetch_custom_client` only performed the filesystem `check_open`
on the socket path and never called `check_net_unix_socket`, so a custom client
could route `fetch()` traffic to a local Unix socket with filesystem access
alone, without an `--allow-net=unix:<path>` grant. The two neighboring branches
in the same match already do the right thing: `Proxy::Tcp` calls `check_net`
and `Proxy::Vsock` calls `check_net_vsock`.

This makes the Unix proxy connector consistent with its siblings and with the
direct Unix socket ops: after resolving the socket path with `check_open`, it
now also calls `check_net_unix_socket` before storing the normalized path.

Added regression tests covering a Unix-proxy `createHttpClient` denied with
read/write but no `--allow-net=unix:<path>`, denial when the scoped rule names
a different socket path, and success when the rule matches the exact path. The
existing `fetchUnixSocket` test continues to exercise the allowed path under
unscoped `--allow-net`.
