### PR TITLE
fix(ext/node): implement worker_threads.isInternalThread

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -2219,6 +2219,9 @@ ObjectAssign(exportsObj, {
   threadId: 0,
   workerData: null,
   isMainThread: true,
+  // Deno has no internal Node worker threads (e.g. module loader threads),
+  // so this is always false in the main thread and user-created workers.
+  isInternalThread: false,
   resourceLimits: undefined,
   threadName: "",
   markAsUncloneable,

--- a/tests/unit_node/worker_threads_test.ts
+++ b/tests/unit_node/worker_threads_test.ts
@@ -9,6 +9,7 @@ import {
 } from "@std/assert";
 import { fromFileUrl, relative, SEPARATOR } from "@std/path";
 import * as workerThreads from "node:worker_threads";
+import { isInternalThread } from "node:worker_threads";
 import { EventEmitter, once } from "node:events";
 import process from "node:process";
 
@@ -29,6 +30,17 @@ Deno.test({
   name: "[node/worker_threads] isMainThread",
   fn() {
     assertEquals(workerThreads.isMainThread, true);
+  },
+});
+
+Deno.test({
+  name: "[node/worker_threads] isInternalThread",
+  fn() {
+    // Both the named export and the property on the module object must
+    // resolve, and be false in the main thread (Deno has no internal
+    // Node worker threads). Regression test for #35149.
+    assertEquals(isInternalThread, false);
+    assertEquals(workerThreads.isInternalThread, false);
   },
 });
 


### PR DESCRIPTION
`node:worker_threads` did not implement `isInternalThread`, so both the
named import and the property on the default/`require` object were
missing:

```js
import { isInternalThread } from "node:worker_threads";
// error: Uncaught SyntaxError: The requested module
// 'node:worker_threads' does not provide an export named
// 'isInternalThread'
```

`isInternalThread` was added in Node v23.7.0 / v22.14.0. It is a boolean
indicating whether the code runs inside an internal Node worker thread
(such as a module loader thread), as distinct from `isMainThread`. It is
`false` in the main thread and in user-created workers.

In the polyfill the synthetic ESM export names are derived from the keys
of the exports object, so adding `isInternalThread` there exposes it both
as a named export and as a property of the default/`require` object.
Deno has no internal Node worker threads, so the value is a constant
`false`.

Closes #35149
