### PR TITLE
fix(ext/node): restore Node binding signature for zlib write/writeSync

### DIFF
--- a/ext/node/polyfills/zlib.js
+++ b/ext/node/polyfills/zlib.js
@@ -752,6 +752,42 @@ function _close(engine) {
   engine._handle = null;
 }
 
+// The native write/writeSync ops take the write-state buffer (where the
+// post-write avail_out/avail_in values are stored) as a per-write argument
+// rather than caching a pointer to it, so that detaching the buffer is a
+// harmless no-op instead of a dangling write. Our own call sites always pass
+// it, but some npm packages (e.g. pngjs's sync inflate) call the low-level
+// `_handle.write()` / `_handle.writeSync()` directly using Node's binding
+// signature, which omits that trailing argument. Wrap the handle so those
+// external callers transparently get the stream's `_writeState` injected.
+function setupHandleWriteState(handle, writeState) {
+  const nativeWrite = handle.write;
+  const nativeWriteSync = handle.writeSync;
+  const wrap = (native) =>
+    function (flush, input, inOff, inLen, out, outOff, outLen, state) {
+      return ReflectApply(native, this, [
+        flush,
+        input,
+        inOff,
+        inLen,
+        out,
+        outOff,
+        outLen,
+        state === undefined ? writeState : state,
+      ]);
+    };
+  ObjectDefineProperty(handle, "write", {
+    value: wrap(nativeWrite),
+    writable: true,
+    configurable: true,
+  });
+  ObjectDefineProperty(handle, "writeSync", {
+    value: wrap(nativeWriteSync),
+    writable: true,
+    configurable: true,
+  });
+}
+
 const zlibDefaultOpts = {
   flush: Z_NO_FLUSH,
   finishFlush: Z_FINISH,
@@ -840,6 +876,7 @@ function Zlib(opts, mode) {
   // to come up with a good solution that doesn't break our internal API,
   // and with it all supported npm versions at the time of writing.
   this._writeState = new Uint32Array(2);
+  setupHandleWriteState(handle, this._writeState);
   handle.init(
     windowBits,
     level,
@@ -1011,6 +1048,7 @@ function Brotli(opts, mode) {
     : new binding.BrotliEncoder(mode);
 
   this._writeState = new Uint32Array(2);
+  setupHandleWriteState(handle, this._writeState);
   const success = handle.init(
     brotliInitParamsArray,
     processCallback,
@@ -1079,6 +1117,7 @@ class Zstd extends ZlibBase {
       : new binding.ZstdDecompress(mode);
 
     const writeState = new Uint32Array(2);
+    setupHandleWriteState(handle, writeState);
     // pledgedSrcSize is only used for compression, use -1 to indicate "not set"
     const pledgedSrcSize =
       mode === ZSTD_COMPRESS && opts?.pledgedSrcSize != null

--- a/ext/node/polyfills/zlib.js
+++ b/ext/node/polyfills/zlib.js
@@ -89,6 +89,11 @@ const { zlib: zlibConstants } = core.loadExtScript(
 
 const kFlushFlag = Symbol("kFlushFlag");
 const kError = Symbol("kError");
+// Hold the unwrapped native write/writeSync methods so our own call sites can
+// invoke them directly, bypassing the arity-compat wrapper (see
+// `setupHandleWriteState`).
+const kNativeWrite = Symbol("kNativeWrite");
+const kNativeWriteSync = Symbol("kNativeWriteSync");
 
 const {
   // Zlib flush levels
@@ -493,7 +498,7 @@ function processChunkSync(self, chunk, flushFlag) {
   }
 
   while (true) {
-    handle.writeSync(
+    handle[kNativeWriteSync](
       flushFlag,
       chunk, // in
       inOff, // in_off
@@ -578,7 +583,7 @@ function processChunk(self, chunk, flushFlag, cb) {
   handle._callbackPending = true;
 
   try {
-    handle.write(
+    handle[kNativeWrite](
       flushFlag,
       chunk, // in
       0, // in_off
@@ -674,7 +679,7 @@ function processCallback() {
           return;
         }
         handle._callbackPending = true;
-        this.write(
+        this[kNativeWrite](
           handle.flushFlag,
           this.buffer, // in
           handle.inOff, // in_off
@@ -699,7 +704,7 @@ function processCallback() {
             return;
           }
           handle._callbackPending = true;
-          this.write(
+          this[kNativeWrite](
             handle.flushFlag,
             this.buffer, // in
             handle.inOff, // in_off
@@ -760,9 +765,15 @@ function _close(engine) {
 // `_handle.write()` / `_handle.writeSync()` directly using Node's binding
 // signature, which omits that trailing argument. Wrap the handle so those
 // external callers transparently get the stream's `_writeState` injected.
+//
+// Our own call sites always pass the buffer, so they invoke the stashed native
+// methods (`handle[kNativeWrite]` / `handle[kNativeWriteSync]`) directly to skip
+// the wrapper's per-write frame and argument array on every chunk.
 function setupHandleWriteState(handle, writeState) {
   const nativeWrite = handle.write;
   const nativeWriteSync = handle.writeSync;
+  handle[kNativeWrite] = nativeWrite;
+  handle[kNativeWriteSync] = nativeWriteSync;
   const wrap = (native) =>
     function (flush, input, inOff, inLen, out, outOff, outLen, state) {
       return ReflectApply(native, this, [

--- a/tests/unit_node/zlib_test.ts
+++ b/tests/unit_node/zlib_test.ts
@@ -17,6 +17,7 @@ import {
   createDeflate,
   createGunzip,
   createGzip,
+  createInflate,
   createZstdCompress,
   createZstdDecompress,
   deflateSync,
@@ -459,4 +460,36 @@ Deno.test("zlib write does not write through a detached _writeState", () => {
     }
     assertEquals(state.buffer.byteLength, 0);
   }
+});
+
+// Some npm packages (e.g. pngjs's synchronous inflate) call the low-level
+// `_handle.writeSync()` directly using Node's binding signature, which omits
+// the trailing write-state buffer argument and instead reads the result back
+// from the stream's `_writeState`. Moving the result buffer to a per-write
+// argument must not break that calling convention: the handle injects the
+// stream's `_writeState` when the caller leaves it out.
+Deno.test("zlib writeSync works with the Node 7-argument signature", () => {
+  // zlib stream of an empty payload, decoded with the low-level handle.
+  const input = Buffer.from([0x78, 0x9c, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01]);
+  const output = Buffer.allocUnsafe(1024);
+  // deno-lint-ignore no-explicit-any
+  const stream = createInflate() as any;
+  const state = stream._writeState;
+  state[0] = 0xffffffff;
+  state[1] = 0xffffffff;
+  // Note: only seven arguments, no trailing write-state buffer.
+  stream._handle.writeSync(
+    constants.Z_FINISH,
+    input,
+    0,
+    input.length,
+    output,
+    0,
+    output.length,
+  );
+  // The avail_out/avail_in pair was written back into `_writeState`.
+  assert(state[0] !== 0xffffffff, "avail_out was not written");
+  assert(state[1] !== 0xffffffff, "avail_in was not written");
+  assert(state[0] <= output.length, "avail_out out of range");
+  assert(state[1] <= input.length, "avail_in out of range");
 });


### PR DESCRIPTION
PR #35043 fixed a use-after-free in the zlib, brotli and zstd bindings by
moving the result buffer (the stream's `_writeState`, where the post-write
`avail_out`/`avail_in` pair is stored) from a pointer cached at init time to
a per-write argument, so that detaching the buffer can no longer produce a
dangling write. A side effect was that the low-level `write`/`writeSync`
handle methods gained a required trailing argument, breaking their Node
binding signature. Some npm packages call those methods directly without it
(notably pngjs's synchronous inflate, used by png-to-ico and others), so on
2.8.3 they started throwing `expected typed ArrayBufferView`.

This wraps the native handle so `write`/`writeSync` inject the stream's own
`_writeState` when an external caller omits the trailing buffer, restoring the
Node-compatible arity. The native ops are unchanged and still take the buffer
per write and bounds check it, so a detached buffer remains a harmless no-op
and the original security fix is fully preserved.

Closes #35185