### PR TITLE
fix(ext/fs): truncate should not follow a terminal symlink

### DIFF
--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -1259,7 +1259,19 @@ fn symlink(
 }
 
 fn truncate(path: &Path, len: u64) -> FsResult<()> {
-  let file = fs::OpenOptions::new().write(true).open(path)?;
+  let mut open_options = fs::OpenOptions::new();
+  open_options.write(true);
+  // The permission check for truncate is performed no-follow (against the
+  // named path, without canonicalization). Refuse to follow a terminal symlink
+  // here so a writable symlink inside an allowed scope cannot be used to zero
+  // out a file it points to outside that scope. O_NOFOLLOW makes the open fail
+  // with ELOOP when the final component is a symlink.
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::OpenOptionsExt;
+    open_options.custom_flags(libc::O_NOFOLLOW);
+  }
+  let file = open_options.open(path)?;
   file.set_len(len)?;
   Ok(())
 }

--- a/tests/unit/truncate_test.ts
+++ b/tests/unit/truncate_test.ts
@@ -115,7 +115,9 @@ Deno.test(
 
 // truncate does not follow a terminal symlink: the permission check is done
 // no-follow, so a symlink at an allowed path must not be usable to zero out a
-// file it points to. The open uses O_NOFOLLOW and fails on a symlink target.
+// file it points to. The open uses O_NOFOLLOW and fails with FilesystemLoop
+// (ELOOP) on a symlink target, rather than a permission error or silently
+// truncating the link's target.
 Deno.test(
   {
     permissions: { read: true, write: true },
@@ -128,7 +130,10 @@ Deno.test(
     Deno.writeFileSync(target, new Uint8Array([1, 2, 3, 4, 5]));
     Deno.symlinkSync(target, link);
 
-    assertThrows(() => Deno.truncateSync(link, 0));
+    assertThrows(
+      () => Deno.truncateSync(link, 0),
+      Deno.errors.FilesystemLoop,
+    );
     assertEquals(Deno.readFileSync(target).byteLength, 5);
   },
 );
@@ -145,7 +150,51 @@ Deno.test(
     await Deno.writeFile(target, new Uint8Array([1, 2, 3, 4, 5]));
     await Deno.symlink(target, link);
 
-    await assertRejects(() => Deno.truncate(link, 0));
+    await assertRejects(
+      () => Deno.truncate(link, 0),
+      Deno.errors.FilesystemLoop,
+    );
     assertEquals((await Deno.readFile(target)).byteLength, 5);
+  },
+);
+
+// O_NOFOLLOW only protects the final path component. A symlink in an ancestor
+// directory is still resolved, so truncating a regular file reached through a
+// symlinked directory continues to work.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function truncateSyncFollowsIntermediateSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const realDir = dir + "/real";
+    Deno.mkdirSync(realDir);
+    const file = realDir + "/data.txt";
+    Deno.writeFileSync(file, new Uint8Array([1, 2, 3, 4, 5]));
+    const linkDir = dir + "/linkdir";
+    Deno.symlinkSync(realDir, linkDir);
+
+    Deno.truncateSync(linkDir + "/data.txt", 2);
+    assertEquals(Deno.readFileSync(file).byteLength, 2);
+  },
+);
+
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  async function truncateFollowsIntermediateSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const realDir = dir + "/real";
+    await Deno.mkdir(realDir);
+    const file = realDir + "/data.txt";
+    await Deno.writeFile(file, new Uint8Array([1, 2, 3, 4, 5]));
+    const linkDir = dir + "/linkdir";
+    await Deno.symlink(realDir, linkDir);
+
+    await Deno.truncate(linkDir + "/data.txt", 2);
+    assertEquals((await Deno.readFile(file)).byteLength, 2);
   },
 );

--- a/tests/unit/truncate_test.ts
+++ b/tests/unit/truncate_test.ts
@@ -112,3 +112,40 @@ Deno.test(
     );
   },
 );
+
+// truncate does not follow a terminal symlink: the permission check is done
+// no-follow, so a symlink at an allowed path must not be usable to zero out a
+// file it points to. The open uses O_NOFOLLOW and fails on a symlink target.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function truncateSyncDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    Deno.writeFileSync(target, new Uint8Array([1, 2, 3, 4, 5]));
+    Deno.symlinkSync(target, link);
+
+    assertThrows(() => Deno.truncateSync(link, 0));
+    assertEquals(Deno.readFileSync(target).byteLength, 5);
+  },
+);
+
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  async function truncateDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    await Deno.writeFile(target, new Uint8Array([1, 2, 3, 4, 5]));
+    await Deno.symlink(target, link);
+
+    await assertRejects(() => Deno.truncate(link, 0));
+    assertEquals((await Deno.readFile(target)).byteLength, 5);
+  },
+);


### PR DESCRIPTION
The permission check for `Deno.truncate` / `Deno.truncateSync` is performed
no-follow: it is checked against the path you name, without canonicalizing
symlinks. The implementation, however, opened the path with a plain
`OpenOptions::write(true).open(path)`, which follows symlinks on Unix. A
writable symlink sitting at a path inside an allowed scope could therefore be
used to truncate (zero out) the file it points to, even when the target lives
outside that scope.

This opens the path with `O_NOFOLLOW` on Unix so that truncating through a
terminal symlink fails with `ELOOP` rather than silently truncating the link's
target. Truncating a regular file is unchanged, and only the final path
component is affected (intermediate symlinks are still resolved, matching the
existing path model). Windows behavior is unchanged.

Added unit tests covering both the sync and async paths: a symlink whose target
holds data is truncated through the link, and the operation now throws while
the target is left untouched.
