### PR TITLE
fix(npm): make peer dependency warning actionable and show importers

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -31,6 +32,7 @@ use deno_graph::source::Loader;
 use deno_graph::source::ResolveError;
 use deno_lib::util::result::downcast_ref_deno_resolve_error;
 use deno_npm_installer::PackageCaching;
+use deno_npm_installer::format_unmet_peer_dep_warning;
 use deno_npm_installer::graph::NpmCachingStrategy;
 use deno_path_util::url_to_file_path;
 use deno_resolver::cache::ParsedSourceCache;
@@ -48,6 +50,7 @@ use deno_resolver::npm::DenoInNpmPackageChecker;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_semver::SmallStackString;
 use deno_semver::jsr::JsrDepPackageReq;
+use deno_semver::npm::NpmPackageReqReference;
 use import_map::ImportMapErrorKind;
 use node_resolver::errors::NodeJsErrorCode;
 use sys_traits::FsMetadata;
@@ -988,7 +991,57 @@ impl ModuleGraphBuilder {
       }
     }
 
+    // Report any unmet peer dependency issues found during npm resolution. This
+    // is done here, after the graph is built, so the warning can point at the
+    // user modules that import the offending packages.
+    if let Some(npm_installer) = &self.npm_installer {
+      let diagnostics = npm_installer.take_unmet_peer_diagnostics();
+      if !diagnostics.is_empty() && log::log_enabled!(log::Level::Warn) {
+        let importers = self.npm_peer_dep_importers(graph);
+        log::warn!(
+          "{}",
+          format_unmet_peer_dep_warning(&diagnostics, &importers)
+        );
+      }
+    }
+
     Ok(())
+  }
+
+  /// Builds a map from a top-level npm package (`name@version`) to the user
+  /// modules that import it, used to annotate peer dependency warnings with the
+  /// source of a transitively introduced package.
+  fn npm_peer_dep_importers(
+    &self,
+    graph: &ModuleGraph,
+  ) -> HashMap<String, Vec<String>> {
+    let Some(managed) = self.npm_resolver.as_managed() else {
+      return HashMap::new();
+    };
+    let mut importers: HashMap<String, Vec<String>> = HashMap::new();
+    for module in graph.modules() {
+      let referrer = module.specifier();
+      for dep in module.dependencies().values() {
+        for specifier in [dep.get_code(), dep.get_type()].into_iter().flatten()
+        {
+          let Ok(npm_ref) = NpmPackageReqReference::from_specifier(specifier)
+          else {
+            continue;
+          };
+          let Ok(id) =
+            managed.resolve_pkg_id_from_deno_module_req(npm_ref.req())
+          else {
+            continue;
+          };
+          let entry = importers.entry(id.nv.to_string()).or_default();
+          let referrer = referrer.to_string();
+          if !entry.contains(&referrer) {
+            entry.push(referrer);
+          }
+        }
+      }
+    }
+    importers
   }
 
   pub fn build_fast_check_graph(

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -997,7 +997,13 @@ impl ModuleGraphBuilder {
     if let Some(npm_installer) = &self.npm_installer {
       let diagnostics = npm_installer.take_unmet_peer_diagnostics();
       if !diagnostics.is_empty() && log::log_enabled!(log::Level::Warn) {
-        let importers = self.npm_peer_dep_importers(graph);
+        // Only the top-level package of each diagnostic (its outermost
+        // ancestor) is annotated, so restrict the graph walk to those.
+        let wanted: HashSet<String> = diagnostics
+          .iter()
+          .filter_map(|d| d.ancestors.last().map(|nv| nv.to_string()))
+          .collect();
+        let importers = self.npm_peer_dep_importers(graph, &wanted);
         log::warn!(
           "{}",
           format_unmet_peer_dep_warning(&diagnostics, &importers)
@@ -1010,10 +1016,12 @@ impl ModuleGraphBuilder {
 
   /// Builds a map from a top-level npm package (`name@version`) to the user
   /// modules that import it, used to annotate peer dependency warnings with the
-  /// source of a transitively introduced package.
+  /// source of a transitively introduced package. Only packages in `wanted`
+  /// are resolved, to avoid a full sweep of the graph.
   fn npm_peer_dep_importers(
     &self,
     graph: &ModuleGraph,
+    wanted: &HashSet<String>,
   ) -> HashMap<String, Vec<String>> {
     let Some(managed) = self.npm_resolver.as_managed() else {
       return HashMap::new();
@@ -1033,7 +1041,11 @@ impl ModuleGraphBuilder {
           else {
             continue;
           };
-          let entry = importers.entry(id.nv.to_string()).or_default();
+          let nv = id.nv.to_string();
+          if !wanted.contains(&nv) {
+            continue;
+          }
+          let entry = importers.entry(nv).or_default();
           let referrer = referrer.to_string();
           if !entry.contains(&referrer) {
             entry.push(referrer);

--- a/libs/npm_installer/lib.rs
+++ b/libs/npm_installer/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -9,6 +10,7 @@ use deno_error::JsErrorBox;
 use deno_npm::NpmSystemInfo;
 use deno_npm::registry::NpmPackageInfo;
 use deno_npm::registry::NpmRegistryPackageInfoLoadError;
+use deno_npm::resolution::UnmetPeerDepDiagnostic;
 use deno_npm_cache::NpmCache;
 use deno_npm_cache::NpmCacheHttpClient;
 use deno_resolver::lockfile::LockfileLock;
@@ -63,6 +65,7 @@ use self::package_json::NpmInstallDepsProvider;
 use self::resolution::AddPkgReqsResult;
 use self::resolution::NpmResolutionInstaller;
 use self::resolution::NpmResolutionInstallerSys;
+pub use self::resolution::format_unmet_peer_dep_warning;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PackageCaching<'a> {
@@ -276,13 +279,14 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmInstallerSys>
     packages: &[PackageReq],
   ) -> Result<(), JsErrorBox> {
     self.npm_resolution_initializer.ensure_initialized().await?;
-    self
+    let result = self
       .add_package_reqs_raw(
         packages,
         Some(PackageCaching::Only(packages.into())),
       )
-      .await
-      .dependencies_result
+      .await;
+    self.warn_unmet_peer_diagnostics();
+    result.dependencies_result
   }
 
   pub async fn add_package_reqs_no_cache(
@@ -290,10 +294,9 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmInstallerSys>
     packages: &[PackageReq],
   ) -> Result<(), JsErrorBox> {
     self.npm_resolution_initializer.ensure_initialized().await?;
-    self
-      .add_package_reqs_raw(packages, None)
-      .await
-      .dependencies_result
+    let result = self.add_package_reqs_raw(packages, None).await;
+    self.warn_unmet_peer_diagnostics();
+    result.dependencies_result
   }
 
   pub async fn add_package_reqs(
@@ -302,10 +305,35 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmInstallerSys>
     caching: PackageCaching<'_>,
   ) -> Result<(), JsErrorBox> {
     self.npm_resolution_initializer.ensure_initialized().await?;
-    self
-      .add_package_reqs_raw(packages, Some(caching))
-      .await
-      .dependencies_result
+    let result = self.add_package_reqs_raw(packages, Some(caching)).await;
+    self.warn_unmet_peer_diagnostics();
+    result.dependencies_result
+  }
+
+  /// Drains the unmet peer dependency diagnostics collected during npm
+  /// resolution. Callers that have a module graph available should render these
+  /// with [`format_unmet_peer_dep_warning`] and an importer map; otherwise see
+  /// [`Self::warn_unmet_peer_diagnostics`].
+  pub fn take_unmet_peer_diagnostics(&self) -> Vec<UnmetPeerDepDiagnostic> {
+    self.npm_resolution_installer.take_unmet_peer_diagnostics()
+  }
+
+  /// Renders any pending unmet peer dependency diagnostics without importer
+  /// information. Used by resolution entry points that don't build a module
+  /// graph (the importing module isn't known there anyway).
+  fn warn_unmet_peer_diagnostics(&self) {
+    if !log::log_enabled!(log::Level::Warn) {
+      // still drain so the diagnostics don't accumulate
+      let _ = self.take_unmet_peer_diagnostics();
+      return;
+    }
+    let diagnostics = self.take_unmet_peer_diagnostics();
+    if !diagnostics.is_empty() {
+      log::warn!(
+        "{}",
+        format_unmet_peer_dep_warning(&diagnostics, &HashMap::new())
+      );
+    }
   }
 
   pub async fn add_package_reqs_raw(
@@ -494,6 +522,7 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmInstallerSys>
       .install_if_pending()
       .await
       .map_err(JsErrorBox::from_err)?;
+    self.warn_unmet_peer_diagnostics();
     Ok(())
   }
 }

--- a/libs/npm_installer/resolution.rs
+++ b/libs/npm_installer/resolution.rs
@@ -2,6 +2,8 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -35,6 +37,7 @@ use deno_semver::package::PackageReq;
 use deno_terminal::colors;
 use deno_unsync::sync::AtomicFlag;
 use deno_unsync::sync::TaskQueue;
+use parking_lot::Mutex;
 
 pub struct AddPkgReqsResult {
   /// Results from adding the individual packages.
@@ -69,6 +72,19 @@ impl HasJsExecutionStartedFlag {
 #[sys_traits::auto_impl]
 pub trait NpmResolutionInstallerSys: LockfileSys + NpmCacheSys {}
 
+/// Accumulates unmet peer dependency diagnostics produced during npm
+/// resolution so they can be rendered once, after the module graph (and thus
+/// the importing modules) is known. See `take_unmet_peer_diagnostics`.
+#[derive(Debug, Default)]
+struct UnmetPeerDiagnosticsState {
+  /// Diagnostics that have been collected but not yet drained for display.
+  pending: Vec<UnmetPeerDepDiagnostic>,
+  /// Every diagnostic ever collected, used to avoid reporting the same issue
+  /// more than once across the multiple resolution passes that happen while a
+  /// graph is built (each pass re-reports the full set).
+  seen: HashSet<UnmetPeerDepDiagnostic>,
+}
+
 /// Updates the npm resolution with the provided package requirements.
 #[derive(Debug)]
 pub struct NpmResolutionInstaller<
@@ -82,6 +98,7 @@ pub struct NpmResolutionInstaller<
   resolution: Arc<NpmResolutionCell>,
   maybe_lockfile: Option<Arc<LockfileLock<TSys>>>,
   update_queue: TaskQueue,
+  unmet_peer_diagnostics: Mutex<UnmetPeerDiagnosticsState>,
 }
 
 impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmResolutionInstallerSys>
@@ -105,7 +122,16 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmResolutionInstallerSys>
       resolution,
       maybe_lockfile,
       update_queue: Default::default(),
+      unmet_peer_diagnostics: Default::default(),
     }
+  }
+
+  /// Drains and returns the unmet peer dependency diagnostics collected since
+  /// the last call. Callers are expected to render these (see
+  /// [`format_unmet_peer_dep_warning`]); the diagnostics are deduplicated so a
+  /// given issue is only ever returned once for the lifetime of the installer.
+  pub fn take_unmet_peer_diagnostics(&self) -> Vec<UnmetPeerDepDiagnostic> {
+    std::mem::take(&mut self.unmet_peer_diagnostics.lock().pending)
   }
 
   pub async fn cache_package_info(
@@ -241,11 +267,18 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmResolutionInstallerSys>
       &filtered
     };
 
-    if !diagnostics.is_empty() && log::log_enabled!(log::Level::Warn) {
-      let root_node = peer_dep_diagnostics_to_display_tree(diagnostics);
-      let mut text = String::new();
-      _ = root_node.print(&mut text);
-      log::warn!("{}", text);
+    // Stash the diagnostics rather than printing them here. npm resolution
+    // happens deep inside the graph build and is re-run multiple times, and at
+    // this point we don't yet know which user module imported the offending
+    // package. The diagnostics are drained and rendered later, once the graph
+    // is available. See `take_unmet_peer_diagnostics`.
+    if !diagnostics.is_empty() {
+      let mut state = self.unmet_peer_diagnostics.lock();
+      for diagnostic in diagnostics {
+        if state.seen.insert(diagnostic.clone()) {
+          state.pending.push(diagnostic.clone());
+        }
+      }
     }
 
     if let Ok(snapshot) = &result.dep_graph_result {
@@ -357,8 +390,36 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmResolutionInstallerSys>
   }
 }
 
+/// Formats the unmet peer dependency diagnostics into a warning message ready
+/// to be logged.
+///
+/// `importers` optionally maps a top-level package (its `name@version` string)
+/// to the user modules that import it, so the warning can point at the source
+/// of a transitively introduced package. Pass an empty map when the importing
+/// modules are not known (e.g. when resolving `package.json` dependencies).
+pub fn format_unmet_peer_dep_warning(
+  diagnostics: &[UnmetPeerDepDiagnostic],
+  importers: &HashMap<String, Vec<String>>,
+) -> String {
+  let root_node = peer_dep_diagnostics_to_display_tree(diagnostics, importers);
+  let mut text = String::new();
+  _ = root_node.print(&mut text);
+  // Append a short, actionable explanation. The fix (an "overrides" entry) is
+  // otherwise undocumented from the warning itself. See
+  // https://github.com/denoland/deno/issues/35196.
+  text.push_str(
+    "\nThese packages were resolved to a version that does not satisfy a peer \
+     dependency constraint, which can cause runtime errors. To silence this \
+     warning, install a compatible version or add an \"overrides\" entry to \
+     your package.json or deno.json.\n",
+  );
+  text.push_str("Learn more: https://docs.deno.com/go/peer-deps");
+  text
+}
+
 fn peer_dep_diagnostics_to_display_tree(
   diagnostics: &[UnmetPeerDepDiagnostic],
+  importers: &HashMap<String, Vec<String>>,
 ) -> DisplayTreeNode {
   struct MergedNode {
     text: Rc<String>,
@@ -424,10 +485,42 @@ fn peer_dep_diagnostics_to_display_tree(
   }
 
   for top_level_node in top_level_nodes {
-    root_node.children.push(convert_node(&top_level_node));
+    let mut node = convert_node(&top_level_node);
+    // Annotate the top-level package with the user module(s) that import it,
+    // which is the part the warning otherwise omits.
+    if let Some(referrers) = importers.get(top_level_node.text.as_str()) {
+      node.text = format!("{} ({})", node.text, format_importers(referrers));
+    }
+    root_node.children.push(node);
   }
 
   root_node
+}
+
+/// Renders the list of importing modules for a package, capping the number
+/// shown so the warning stays readable.
+fn format_importers(referrers: &[String]) -> String {
+  const MAX_SHOWN: usize = 2;
+  let shown = referrers
+    .iter()
+    .take(MAX_SHOWN)
+    .cloned()
+    .collect::<Vec<_>>()
+    .join(", ");
+  if referrers.len() > MAX_SHOWN {
+    format!(
+      "imported by {} and {} other{}",
+      shown,
+      referrers.len() - MAX_SHOWN,
+      if referrers.len() - MAX_SHOWN == 1 {
+        ""
+      } else {
+        "s"
+      }
+    )
+  } else {
+    format!("imported by {}", shown)
+  }
 }
 
 #[cfg(test)]
@@ -452,8 +545,30 @@ mod test {
         resolved: Version::parse_standard("1.0.0").unwrap(),
       },
     ]);
-    let display_tree = peer_dep_diagnostics_to_display_tree(&peer_deps);
+    let display_tree =
+      peer_dep_diagnostics_to_display_tree(&peer_deps, &HashMap::new());
     assert_eq!(display_tree.children.len(), 1);
     assert_eq!(display_tree.children[0].children.len(), 2);
+  }
+
+  #[test]
+  fn annotates_top_level_importers() {
+    let peer_deps = Vec::from([UnmetPeerDepDiagnostic {
+      ancestors: vec![PackageNv::from_str("a@1.0.0").unwrap()],
+      dependency: PackageReq::from_str("b@*").unwrap(),
+      resolved: Version::parse_standard("1.0.0").unwrap(),
+    }]);
+    let mut importers = HashMap::new();
+    importers.insert(
+      "a@1.0.0".to_string(),
+      vec!["https://deno.land/x/dev/mod.js".to_string()],
+    );
+    let display_tree =
+      peer_dep_diagnostics_to_display_tree(&peer_deps, &importers);
+    assert_eq!(display_tree.children.len(), 1);
+    assert_eq!(
+      display_tree.children[0].text,
+      "a@1.0.0 (imported by https://deno.land/x/dev/mod.js)"
+    );
   }
 }

--- a/tests/specs/install/peer_dep_specific_constraint/install.out
+++ b/tests/specs/install/peer_dep_specific_constraint/install.out
@@ -4,6 +4,8 @@ Warning The following peer dependency issues were found:
 └─┬ @denotest/peer-dep-specific-constraint@1.0.0
   └── peer @denotest/add@0.5: resolved to 1.0.0
 
+These packages were resolved to a version that does not satisfy a peer dependency constraint, which can cause runtime errors. To silence this warning, install a compatible version or add an "overrides" entry to your package.json or deno.json.
+Learn more: https://docs.deno.com/go/peer-deps
 [UNORDERED_START]
 Download http://localhost:4260/@denotest/peer-dep-specific-constraint/1.0.0.tgz
 Download http://localhost:4260/@denotest/add/1.0.0.tgz

--- a/tests/specs/run/peer_dep_importer_warning/__test__.jsonc
+++ b/tests/specs/run/peer_dep_importer_warning/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "cache main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/run/peer_dep_importer_warning/main.out
+++ b/tests/specs/run/peer_dep_importer_warning/main.out
@@ -1,0 +1,7 @@
+[WILDCARD]Warning The following peer dependency issues were found:
+└─┬ @denotest/peer-dep-specific-constraint@1.0.0 (imported by file://[WILDCARD]/main.ts)
+  └── peer @denotest/add@0.5: resolved to 1.0.0
+
+These packages were resolved to a version that does not satisfy a peer dependency constraint, which can cause runtime errors. To silence this warning, install a compatible version or add an "overrides" entry to your package.json or deno.json.
+Learn more: https://docs.deno.com/go/peer-deps
+[WILDCARD]

--- a/tests/specs/run/peer_dep_importer_warning/main.ts
+++ b/tests/specs/run/peer_dep_importer_warning/main.ts
@@ -1,0 +1,8 @@
+// Importing a package with an unmet peer dependency together with an
+// incompatible version of that peer should warn, and the warning should point
+// at this module as the importer. See
+// https://github.com/denoland/deno/issues/35196.
+import "npm:@denotest/peer-dep-specific-constraint@1";
+import "npm:@denotest/add@1";
+
+console.log("done");

--- a/tests/specs/run/peer_dep_warning_package_json/__test__.jsonc
+++ b/tests/specs/run/peer_dep_warning_package_json/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "cache main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/run/peer_dep_warning_package_json/deno.json
+++ b/tests/specs/run/peer_dep_warning_package_json/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "auto"
+}

--- a/tests/specs/run/peer_dep_warning_package_json/main.out
+++ b/tests/specs/run/peer_dep_warning_package_json/main.out
@@ -1,0 +1,7 @@
+[WILDCARD]Warning The following peer dependency issues were found:
+└─┬ @denotest/peer-dep-specific-constraint@1.0.0
+  └── peer @denotest/add@0.5: resolved to 1.0.0
+
+These packages were resolved to a version that does not satisfy a peer dependency constraint, which can cause runtime errors. To silence this warning, install a compatible version or add an "overrides" entry to your package.json or deno.json.
+Learn more: https://docs.deno.com/go/peer-deps
+[WILDCARD]

--- a/tests/specs/run/peer_dep_warning_package_json/main.ts
+++ b/tests/specs/run/peer_dep_warning_package_json/main.ts
@@ -1,0 +1,6 @@
+// When the offending package is a declared package.json dependency, the
+// top-level install resolves (and warns about) it before the module graph is
+// built, so the warning is emitted without importer attribution even though
+// this module imports it. The package.json is the source in that case. See the
+// discussion on https://github.com/denoland/deno/pull/35242.
+import "npm:@denotest/peer-dep-specific-constraint";

--- a/tests/specs/run/peer_dep_warning_package_json/package.json
+++ b/tests/specs/run/peer_dep_warning_package_json/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@denotest/peer-dep-specific-constraint": "*",
+    "@denotest/add": "1"
+  }
+}


### PR DESCRIPTION
The "peer dependency issues were found" warning previously listed only the
transitive npm packages involved. It gave no indication of which of your
own imports pulled an offending package in, and no guidance on how to make
the warning go away, so resolving it meant bisecting imports by hand and
digging through old issues to discover that an "overrides" entry is the fix.

Peer dependency diagnostics are now collected during npm resolution and
rendered once the module graph is available, which lets the top-level
package be annotated with the user module(s) that import it. The warning
also gains a short footer explaining that it can be silenced by installing
a compatible version or adding an "overrides" entry, with a link to the
docs. Resolution entry points that have no module graph (such as installing
package.json dependencies) keep emitting the warning without importer
attribution, since there is no import to point at in that case.

Closes #35196