### PR TITLE
fix(core): preserve custom .stack getters in error/test formatter

### DIFF
--- a/cli/tools/test/reporters/junit.rs
+++ b/cli/tools/test/reporters/junit.rs
@@ -751,6 +751,7 @@ mod tests {
       cause: None,
       aggregated: None,
       additional_properties: vec![],
+      stack_is_custom: false,
     };
 
     let step_result =

--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -503,6 +503,12 @@ pub struct JsError {
   pub source_line_frame_index: Option<usize>,
   pub aggregated: Option<Vec<JsError>>,
   pub additional_properties: Vec<(String, String)>,
+  /// True when the error's `.stack` was not produced by our
+  /// `prepareStackTrace` (e.g. a custom getter from libraries like Effect, or
+  /// a manually assigned value). In that case the structured `frames` are not
+  /// authoritative and formatters should preserve the custom `.stack` string.
+  #[serde(default)]
+  pub stack_is_custom: bool,
 }
 
 impl JsErrorClass for JsError {
@@ -952,6 +958,7 @@ impl JsError {
       stack: None,
       aggregated: None,
       additional_properties: vec![],
+      stack_is_custom: false,
     })
   }
 
@@ -1029,6 +1036,21 @@ impl JsError {
       // Ignore non-array values
       let frames_v8: Option<v8::Local<v8::Array>> =
         frames_v8.and_then(|a| a.try_into().ok());
+
+      // If accessing `.stack` above did not populate `#callSiteEvals`, the
+      // error's stack was not produced by our `prepareStackTrace`. This happens
+      // when the user overrides `.stack` with a custom getter (e.g. Effect,
+      // fiber runtimes) or assigns a plain string. In that case the structured
+      // frames are not authoritative, so we mark the stack as custom and let
+      // formatters preserve the `.stack` string. We only do this for multi-line
+      // stacks, to avoid treating a bare "Name: message" string as a stack.
+      let has_structured_frames =
+        frames_v8.map(|a| a.length() > 0).unwrap_or(false);
+      let stack_is_custom = !has_structured_frames
+        && stack
+          .as_ref()
+          .map(|s| s.lines().take(2).count() > 1)
+          .unwrap_or(false);
 
       // Convert them into Vec<JsStackFrame>
       let mut frames: Vec<JsStackFrame> = match frames_v8 {
@@ -1161,6 +1183,7 @@ impl JsError {
         stack,
         aggregated,
         additional_properties,
+        stack_is_custom,
       }
     } else {
       let exception_message = exception_message
@@ -1179,6 +1202,7 @@ impl JsError {
         stack: None,
         aggregated: None,
         additional_properties: vec![],
+        stack_is_custom: false,
       }
     }
   }
@@ -2655,6 +2679,7 @@ mod tests {
       source_line_frame_index: None,
       aggregated: None,
       additional_properties: vec![],
+      stack_is_custom: false,
     };
     let err = JsError {
       name: Some("TypeError".to_string()),
@@ -2669,6 +2694,7 @@ mod tests {
       source_line_frame_index: Some(0),
       aggregated: None,
       additional_properties: vec![("code".to_string(), "X1".to_string())],
+      stack_is_custom: false,
     };
 
     let v = err.clone().to_v8(scope).unwrap();
@@ -2687,6 +2713,7 @@ mod tests {
       "sourceLineFrameIndex",
       "aggregated",
       "additionalProperties",
+      "stackIsCustom",
     ];
     for key in expected_keys {
       let key_v = v8::String::new(scope, key).unwrap();

--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -1042,15 +1042,25 @@ impl JsError {
       // when the user overrides `.stack` with a custom getter (e.g. Effect,
       // fiber runtimes) or assigns a plain string. In that case the structured
       // frames are not authoritative, so we mark the stack as custom and let
-      // formatters preserve the `.stack` string. We only do this for multi-line
-      // stacks, to avoid treating a bare "Name: message" string as a stack.
+      // formatters preserve the `.stack` string.
+      //
+      // V8's default `.stack` for a frame-less error is exactly its
+      // "name: message" string (and `message` may itself be multi-line). We
+      // only treat the stack as custom when it carries content beyond that
+      // header, so a multi-line *message* isn't mistaken for a stack.
+      let default_stack = if message_prop.is_empty() {
+        name.clone()
+      } else if name.is_empty() {
+        message_prop.clone()
+      } else {
+        format!("{name}: {message_prop}")
+      };
       let has_structured_frames =
         frames_v8.map(|a| a.length() > 0).unwrap_or(false);
       let stack_is_custom = !has_structured_frames
-        && stack
-          .as_ref()
-          .map(|s| s.lines().take(2).count() > 1)
-          .unwrap_or(false);
+        && stack.as_ref().is_some_and(|s| {
+          s.lines().count() > 1 && s.trim_end() != default_stack.trim_end()
+        });
 
       // Convert them into Vec<JsStackFrame>
       let mut frames: Vec<JsStackFrame> = match frames_v8 {

--- a/runtime/fmt_errors.rs
+++ b/runtime/fmt_errors.rs
@@ -252,41 +252,53 @@ fn format_js_error_inner(
     s.push_str(&aggregated_message);
   }
 
-  let column_number = js_error
-    .source_line_frame_index
-    .and_then(|i| js_error.frames.get(i).unwrap().column_number);
-  s.push_str(&format_maybe_source_line(
-    if include_source_code {
-      js_error.source_line.as_deref()
-    } else {
-      None
-    },
-    column_number,
-    true,
-    0,
-  ));
-
-  let at_dimmed = Cow::Owned(colors::dimmed_gray("at ").to_string());
-  let at_normal = Cow::Borrowed("at ");
-  for frame in &js_error.frames {
-    let is_ext = stack_frame_is_ext(frame);
-    if filter_frames
-      && is_ext
-      && let Some(fn_name) = &frame.function_name
-      && (fn_name.starts_with("__node_internal_")
-        || fn_name == "eventLoopTick"
-        || fn_name == "denoErrorToNodeError"
-        || fn_name == "__drainNextTickAndMacrotasks")
-    {
-      continue;
+  if js_error.stack_is_custom {
+    // The error carries a custom `.stack` (e.g. from Effect or fiber runtimes)
+    // that our structured frames don't capture. Preserve it, matching Node.js.
+    // The first line of `.stack` is the "Name: message" header, which we
+    // already rendered as `exception_message`, so skip it and emit the rest.
+    if let Some(stack) = &js_error.stack {
+      for line in stack.lines().skip(1) {
+        write!(s, "\n{line}").unwrap();
+      }
     }
-    write!(
-      s,
-      "\n    {}{}",
-      if is_ext { &at_dimmed } else { &at_normal },
-      format_frame::<AnsiColors>(frame, initial_cwd)
-    )
-    .unwrap();
+  } else {
+    let column_number = js_error
+      .source_line_frame_index
+      .and_then(|i| js_error.frames.get(i).unwrap().column_number);
+    s.push_str(&format_maybe_source_line(
+      if include_source_code {
+        js_error.source_line.as_deref()
+      } else {
+        None
+      },
+      column_number,
+      true,
+      0,
+    ));
+
+    let at_dimmed = Cow::Owned(colors::dimmed_gray("at ").to_string());
+    let at_normal = Cow::Borrowed("at ");
+    for frame in &js_error.frames {
+      let is_ext = stack_frame_is_ext(frame);
+      if filter_frames
+        && is_ext
+        && let Some(fn_name) = &frame.function_name
+        && (fn_name.starts_with("__node_internal_")
+          || fn_name == "eventLoopTick"
+          || fn_name == "denoErrorToNodeError"
+          || fn_name == "__drainNextTickAndMacrotasks")
+      {
+        continue;
+      }
+      write!(
+        s,
+        "\n    {}{}",
+        if is_ext { &at_dimmed } else { &at_normal },
+        format_frame::<AnsiColors>(frame, initial_cwd)
+      )
+      .unwrap();
+    }
   }
   if let Some(cause) = &js_error.cause {
     let is_caused_by_circular = circular

--- a/tests/specs/run/custom_stack_getter/__test__.jsonc
+++ b/tests/specs/run/custom_stack_getter/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tests": {
+    "toplevel": {
+      "args": "run main.ts",
+      "output": "main.out",
+      "exitCode": 1
+    },
+    "test_formatter": {
+      "args": "test failing_test.ts",
+      "output": "failing_test.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/run/custom_stack_getter/failing_test.out
+++ b/tests/specs/run/custom_stack_getter/failing_test.out
@@ -1,0 +1,17 @@
+[WILDCARD]running 1 test from ./failing_test.ts
+custom stack getter ... FAILED [WILDLINE]
+
+ ERRORS 
+
+custom stack getter => ./failing_test.ts:1:6
+error: Error: boom
+    at fiberFrameA (effect://fiber:10:3)
+    at fiberFrameB (effect://fiber:20:5)
+
+ FAILURES 
+
+custom stack getter => ./failing_test.ts:1:6
+
+FAILED | 0 passed | 1 failed [WILDLINE]
+
+error: Test failed

--- a/tests/specs/run/custom_stack_getter/failing_test.ts
+++ b/tests/specs/run/custom_stack_getter/failing_test.ts
@@ -1,0 +1,9 @@
+Deno.test("custom stack getter", () => {
+  const err = new Error("boom");
+  Object.defineProperty(err, "stack", {
+    get() {
+      return "Error: boom\n    at fiberFrameA (effect://fiber:10:3)\n    at fiberFrameB (effect://fiber:20:5)";
+    },
+  });
+  throw err;
+});

--- a/tests/specs/run/custom_stack_getter/main.out
+++ b/tests/specs/run/custom_stack_getter/main.out
@@ -1,0 +1,3 @@
+error: Uncaught (in promise) Error: boom
+    at customFrameA (effect://fiber:1:1)
+    at customFrameB (effect://fiber:2:2)

--- a/tests/specs/run/custom_stack_getter/main.ts
+++ b/tests/specs/run/custom_stack_getter/main.ts
@@ -1,0 +1,10 @@
+// Libraries like Effect provide enhanced stack traces through a custom `.stack`
+// getter. Deno should display that custom stack instead of discarding it in
+// favor of internal call-site frames. See https://github.com/denoland/deno/issues/35243
+const err = new Error("boom");
+Object.defineProperty(err, "stack", {
+  get() {
+    return "Error: boom\n    at customFrameA (effect://fiber:1:1)\n    at customFrameB (effect://fiber:2:2)";
+  },
+});
+throw err;


### PR DESCRIPTION
Errors that expose a custom \`.stack\` getter, such as those produced by
Effect and other fiber runtimes, or a manually assigned \`.stack\` string,
were rendered with a single internal call-site frame instead of the
custom stack. \`console.error\` already showed the rich stack because it
formats via the \`.stack\` string, but letting the same error bubble to
the top-level handler or fail a test discarded it: those paths render
only the structured frames read from the private \`#callSiteEvals\` array,
which a custom \`.stack\` never populates.

When accessing \`.stack\` does not populate \`#callSiteEvals\`, the stack was
not produced by our \`prepareStackTrace\`, so the structured frames are not
authoritative. This marks such errors with a new \`stack_is_custom\` flag
on \`JsError\` and has the formatter emit the custom \`.stack\` string in
that case, matching Node.js.

Closes #35243