### PR TITLE
refactor: rename --unstable-unsafe-proto to --unsafe-proto

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -6743,6 +6743,12 @@ impl CommandExt for Command {
         arg = arg.alias("sloppy-imports");
       }
 
+      // The original flag name was annoyingly long; surface the shorter form
+      // in help/usage while keeping the old name as a hidden alias.
+      if feature.flag_name == "unstable-unsafe-proto" {
+        arg = arg.long("unsafe-proto").alias("unstable-unsafe-proto");
+      }
+
       arg = arg.long_help(long_help_val);
       cmd = cmd.arg(arg);
     }

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1452,7 +1452,7 @@ impl CliOptions {
     unstable_features
   }
 
-  /// Returns unstable feature flags as CLI arguments (e.g., "--unstable-unsafe-proto").
+  /// Returns unstable feature flags as CLI arguments (e.g., "--unstable-bundle").
   /// This includes features from both CLI flags and config file. Features that
   /// are only valid in `deno.json` (e.g. `fmt-component`, `fmt-sql`) and don't
   /// have a registered CLI flag are filtered out, otherwise child processes

--- a/cli/task_runner.rs
+++ b/cli/task_runner.rs
@@ -401,7 +401,7 @@ impl ShellCommand for NodeCommand {
       "--unstable-bare-node-builtins".into(),
       "--unstable-detect-cjs".into(),
       "--unstable-sloppy-imports".into(),
-      "--unstable-unsafe-proto".into(),
+      "--unsafe-proto".into(),
     ]);
     args.extend(context.args);
 

--- a/runtime/fmt_errors.rs
+++ b/runtime/fmt_errors.rs
@@ -14,7 +14,7 @@ use deno_core::url::Url;
 use deno_terminal::colors;
 
 /// Set to `true` when user code assigns to `Object.prototype.__proto__` while
-/// the accessor is disabled (the default, unless `--unstable-unsafe-proto`).
+/// the accessor is disabled (the default, unless `--unsafe-proto`).
 /// The assignment itself stays a silent no-op so fragile packages keep working
 /// (see denoland/deno#34730 / #34772, where throwing broke Playwright); this
 /// flag only lets the uncaught-error formatter nudge toward the escape hatch.
@@ -395,7 +395,7 @@ fn get_suggestions_for_terminal_errors(e: &JsError) -> Vec<FixSuggestion<'_>> {
   if let Some(info) = info {
     suggestions.push(FixSuggestion::info(info));
     suggestions.push(FixSuggestion::hint(cstr!(
-      "If this caused the error, run again with <u>--unstable-unsafe-proto</> to restore it."
+      "If this caused the error, run again with <u>--unsafe-proto</> to restore it."
     )));
   }
   suggestions

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -751,7 +751,7 @@ let protoGetRecorded = false;
 // semantics exactly (read -> `undefined`, write -> own data property, prototype
 // unchanged) but additionally records the first read and the first write. When
 // the program later crashes, the uncaught-error formatter (runtime/fmt_errors.rs)
-// reads those flags and suggests `--unstable-unsafe-proto`. A write surfaces
+// reads those flags and suggests `--unsafe-proto`. A write surfaces
 // downstream so any later crash triggers the nudge; a read crashes at the
 // access site, so the formatter additionally requires `__proto__` on the
 // failing line before nudging. The `__proto__` key in object literals (e.g.

--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -168,7 +168,7 @@ pub fn op_bootstrap_is_from_unconfigured_runtime(state: &mut OpState) -> bool {
 // Called (at most once) from the disabled `Object.prototype.__proto__` setter
 // in 99_main.js when user code assigns to `__proto__`. Records a process-global
 // flag so that, if the program later crashes, the uncaught-error formatter can
-// suggest `--unstable-unsafe-proto`. See `crate::fmt_errors::PROTO_SET_ATTEMPTED`.
+// suggest `--unsafe-proto`. See `crate::fmt_errors::PROTO_SET_ATTEMPTED`.
 #[op2(fast)]
 pub fn op_proto_set_attempted() {
   crate::fmt_errors::PROTO_SET_ATTEMPTED

--- a/tests/node_compat/mod.rs
+++ b/tests/node_compat/mod.rs
@@ -33,7 +33,7 @@ const RUN_ARGS: &[&str] = &[
   "run",
   "-A",
   "--quiet",
-  "--unstable-unsafe-proto",
+  "--unsafe-proto",
   "--unstable-bare-node-builtins",
 ];
 
@@ -41,7 +41,7 @@ const TEST_ARGS: &[&str] = &[
   "test",
   "-A",
   "--quiet",
-  "--unstable-unsafe-proto",
+  "--unsafe-proto",
   "--unstable-bare-node-builtins",
   "--no-check",
   "--unstable-detect-cjs",

--- a/tests/specs/run/unsafe_proto_flag/__test__.jsonc
+++ b/tests/specs/run/unsafe_proto_flag/__test__.jsonc
@@ -1,5 +1,14 @@
 {
-  "args": "run -A --unstable-unsafe-proto main.js",
-  "output": "main_with_unsafe_proto_flag.out",
-  "exitCode": 0
+  "tests": {
+    "new_flag_name": {
+      "args": "run -A --unsafe-proto main.js",
+      "output": "main_with_unsafe_proto_flag.out",
+      "exitCode": 0
+    },
+    "old_flag_name_still_works": {
+      "args": "run -A --unstable-unsafe-proto main.js",
+      "output": "main_with_unsafe_proto_flag.out",
+      "exitCode": 0
+    }
+  }
 }

--- a/tests/specs/run/unsafe_proto_flag/main.js
+++ b/tests/specs/run/unsafe_proto_flag/main.js
@@ -1,4 +1,4 @@
-// With --unstable-unsafe-proto the native accessor is restored, so reading
+// With --unsafe-proto the native accessor is restored, so reading
 // `__proto__` returns the prototype and this prints `true`.
 console.log(({}).__proto__ !== undefined);
 

--- a/tests/specs/run/unsafe_proto_suggestion/__test__.jsonc
+++ b/tests/specs/run/unsafe_proto_suggestion/__test__.jsonc
@@ -11,6 +11,11 @@
       "output": "throw_only.out"
     },
     "no_suggestion_with_unsafe_proto_flag": {
+      "args": "run --unsafe-proto set_and_throw.js",
+      "exitCode": 1,
+      "output": "set_and_throw_unsafe.out"
+    },
+    "old_flag_name_still_works": {
       "args": "run --unstable-unsafe-proto set_and_throw.js",
       "exitCode": 1,
       "output": "set_and_throw_unsafe.out"

--- a/tests/specs/run/unsafe_proto_suggestion/read_and_throw.js
+++ b/tests/specs/run/unsafe_proto_suggestion/read_and_throw.js
@@ -1,7 +1,7 @@
 // Reading `__proto__` returns `undefined` while the accessor is disabled (the
 // default), so `who.__proto__.constructor` throws right at the access site.
 // Because the crashing line itself mentions `__proto__`, the uncaught-error
-// formatter suggests `--unstable-unsafe-proto`. This mirrors the real-world
+// formatter suggests `--unsafe-proto`. This mirrors the real-world
 // crash in pnpm 11 (denoland/deno#34694).
 const who = {};
 who.__proto__.constructor;

--- a/tests/specs/run/unsafe_proto_suggestion/read_and_throw.out
+++ b/tests/specs/run/unsafe_proto_suggestion/read_and_throw.out
@@ -4,4 +4,4 @@ who.__proto__.constructor;
     at [WILDCARD]read_and_throw.js:7:15
 
     info: This program read Object.prototype.__proto__, which Deno disables by default (it returns undefined).
-    hint: If this caused the error, run again with --unstable-unsafe-proto to restore it.
+    hint: If this caused the error, run again with --unsafe-proto to restore it.

--- a/tests/specs/run/unsafe_proto_suggestion/set_and_throw.js
+++ b/tests/specs/run/unsafe_proto_suggestion/set_and_throw.js
@@ -1,6 +1,6 @@
 // Assigning to `__proto__` is a silent no-op while the accessor is disabled
 // (the default). Deno records that it happened so that, if the program then
-// crashes, the uncaught-error formatter can suggest `--unstable-unsafe-proto`.
+// crashes, the uncaught-error formatter can suggest `--unsafe-proto`.
 const obj = {};
 obj.__proto__ = { polluted: true };
 

--- a/tests/specs/run/unsafe_proto_suggestion/set_and_throw.out
+++ b/tests/specs/run/unsafe_proto_suggestion/set_and_throw.out
@@ -4,4 +4,4 @@ throw new Error("boom");
     at [WILDCARD]set_and_throw.js:7:7
 
     info: This program assigned to Object.prototype.__proto__, which Deno disables by default.
-    hint: If this caused the error, run again with --unstable-unsafe-proto to restore it.
+    hint: If this caused the error, run again with --unsafe-proto to restore it.

--- a/tests/specs/run/unsafe_proto_suggestion/throw_only.js
+++ b/tests/specs/run/unsafe_proto_suggestion/throw_only.js
@@ -1,3 +1,3 @@
 // This program never touches `__proto__`, so the crash must NOT carry the
-// `--unstable-unsafe-proto` suggestion.
+// `--unsafe-proto` suggestion.
 throw new Error("boom");

--- a/tests/specs/x/unstable_flags/__test__.jsonc
+++ b/tests/specs/x/unstable_flags/__test__.jsonc
@@ -6,6 +6,10 @@
       "output": "without_flag.out"
     },
     "with_flag": {
+      "args": "x -y --unsafe-proto npm:@denotest/unsafe-proto-bin",
+      "output": "with_flag.out"
+    },
+    "with_old_flag_name": {
       "args": "x -y --unstable-unsafe-proto npm:@denotest/unsafe-proto-bin",
       "output": "with_flag.out"
     },


### PR DESCRIPTION
## Summary

- Make `--unsafe-proto` the primary long name for the unstable feature and
  keep `--unstable-unsafe-proto` as a hidden alias for backwards compatibility.
- Switch user-facing strings (help text, error hint, comments,
  `tests/node_compat` runner args, `task_runner.rs` invocation) to the
  shorter `--unsafe-proto`.
- Each touched spec test now includes an explicit `old_flag_name_still_works`
  case that exercises `--unstable-unsafe-proto` to guard the alias.

`cli/args/mod.rs::unstable_args()` still emits `--unstable-unsafe-proto` to
child processes (it generically prefixes every feature with `--unstable-`);
children accept it via the alias, so this leaves the generic path alone.

`tests/util/std/{deno.json,toml/parse_test.ts}` still reference the old flag
because that tree is vendored stdlib; they pass via the alias.

## Test plan

- [x] `cargo build --bin deno` clean
- [x] `./tools/lint.js` clean
- [x] `deno eval --unsafe-proto '...'` enables `__proto__`
- [x] `deno eval --unstable-unsafe-proto '...'` still works
- [x] `deno run --help=unstable` shows `--unsafe-proto`
- [x] `cargo test -p specs_tests --test specs unsafe_proto` — 9/9 pass
- [x] `cargo test -p specs_tests --test specs x::unstable_flags` — 6/6 pass