### PR TITLE
feat(http): allow disabling serve compression

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1789,6 +1789,11 @@ static ENV_VARS: &[EnvVar] = &[
     ),
   },
   EnvVar {
+    name: "DENO_SERVE_AUTOMATIC_COMPRESSION",
+    description: "Set to 0 or false to disable automatic response body compression in Deno.serve by default.",
+    example: None,
+  },
+  EnvVar {
     name: "DENO_AUTO_SERVE",
     description: "If the entrypoint contains export default { fetch }, `deno run`\nbehaves like `deno serve`.",
     example: None,

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5607,6 +5607,14 @@ declare namespace Deno {
 
     /** The callback which is called when the server starts listening. */
     onListen?: (localAddr: Addr) => void;
+
+    /**
+     * Whether to automatically compress response bodies when the client accepts
+     * a supported encoding and the response is compressible.
+     *
+     * @default {true}
+     */
+    automaticCompression?: boolean;
   }
 
   /**

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -25,6 +25,7 @@ const {
   op_http_request_on_cancel,
   op_http_serve,
   op_http_serve_address_override,
+  op_http_serve_default_compression,
   op_http_serve_on,
   op_http_set_promise_complete,
   op_http_set_response_native,
@@ -1149,6 +1150,7 @@ type RawServeOptions = {
   onError?: (error: unknown) => Response | Promise<Response>;
   onListen?: (params: { hostname: string; port: number }) => void;
   handler?: RawHandler;
+  automaticCompression?: boolean;
 };
 
 const kLoadBalanced = Symbol("kLoadBalanced");
@@ -1214,7 +1216,12 @@ function serve(arg1, arg2) {
     serveAddressOverrideConsumed = true;
 
     let envOptions = duplicateListener
-      ? { __proto__: null, signal: options.signal, onError: options.onError }
+      ? {
+        __proto__: null,
+        signal: options.signal,
+        onError: options.onError,
+        automaticCompression: options.automaticCompression,
+      }
       : options;
 
     switch (overrideKind) {
@@ -1305,6 +1312,8 @@ function serveInner(options, handler) {
   const wantsUnix = ObjectHasOwn(options, "path");
   const wantsVsock = ObjectHasOwn(options, "cid");
   const wantsTunnel = options.tunnel === true;
+  const automaticCompression = options.automaticCompression ??
+    op_http_serve_default_compression();
   const signal = options.signal;
   const onError = options.onError ??
     function (error) {
@@ -1319,13 +1328,20 @@ function serveInner(options, handler) {
       [listenOptionApiName]: "Deno.serve",
     });
     const path = listener.addr.path;
-    return serveHttpOnListener(listener, signal, handler, onError, () => {
-      if (options.onListen) {
-        options.onListen(listener.addr);
-      } else {
-        internals.log("info", `Listening on ${path}`);
-      }
-    });
+    return serveHttpOnListener(
+      listener,
+      signal,
+      handler,
+      onError,
+      () => {
+        if (options.onListen) {
+          options.onListen(listener.addr);
+        } else {
+          internals.log("info", `Listening on ${path}`);
+        }
+      },
+      automaticCompression,
+    );
   }
 
   if (wantsVsock) {
@@ -1336,13 +1352,20 @@ function serveInner(options, handler) {
       [listenOptionApiName]: "Deno.serve",
     });
     const { cid, port } = listener.addr;
-    return serveHttpOnListener(listener, signal, handler, onError, () => {
-      if (options.onListen) {
-        options.onListen(listener.addr);
-      } else {
-        internals.log("info", `Listening on vsock:${cid}:${port}`);
-      }
-    });
+    return serveHttpOnListener(
+      listener,
+      signal,
+      handler,
+      onError,
+      () => {
+        if (options.onListen) {
+          options.onListen(listener.addr);
+        } else {
+          internals.log("info", `Listening on vsock:${cid}:${port}`);
+        }
+      },
+      automaticCompression,
+    );
   }
 
   if (wantsTunnel) {
@@ -1350,21 +1373,28 @@ function serveInner(options, handler) {
       transport: "tunnel",
       [listenOptionApiName]: "Deno.serve",
     });
-    return serveHttpOnListener(listener, signal, handler, onError, () => {
-      if (options.onListen) {
-        options.onListen(listener.addr);
-      } else {
-        const additional = listener.addr.port === 443
-          ? ""
-          : `:${listener.addr.port}`;
-        internals.log(
-          "info",
-          `Listening on https://${
-            formatHostName(listener.addr.hostname)
-          }${additional}`,
-        );
-      }
-    });
+    return serveHttpOnListener(
+      listener,
+      signal,
+      handler,
+      onError,
+      () => {
+        if (options.onListen) {
+          options.onListen(listener.addr);
+        } else {
+          const additional = listener.addr.port === 443
+            ? ""
+            : `:${listener.addr.port}`;
+          internals.log(
+            "info",
+            `Listening on https://${
+              formatHostName(listener.addr.hostname)
+            }${additional}`,
+          );
+        }
+      },
+      automaticCompression,
+    );
   }
 
   const listenOpts = {
@@ -1421,13 +1451,27 @@ function serveInner(options, handler) {
     }
   };
 
-  return serveHttpOnListener(listener, signal, handler, onError, onListen);
+  return serveHttpOnListener(
+    listener,
+    signal,
+    handler,
+    onError,
+    onListen,
+    automaticCompression,
+  );
 }
 
 /**
  * Serve HTTP/1.1 and/or HTTP/2 on an arbitrary listener.
  */
-function serveHttpOnListener(listener, signal, handler, onError, onListen) {
+function serveHttpOnListener(
+  listener,
+  signal,
+  handler,
+  onError,
+  onListen,
+  automaticCompression = op_http_serve_default_compression(),
+) {
   let serverContext = undefined;
   let callback = undefined;
   let nativeCallback = undefined;
@@ -1456,6 +1500,7 @@ function serveHttpOnListener(listener, signal, handler, onError, onListen) {
     signal,
     op_http_serve(
       listener[internalRidSymbol],
+      automaticCompression,
       dispatch,
       rawNoRequest,
       nativeDispatch,
@@ -1504,10 +1549,12 @@ function serveHttpOnConnection(connection, signal, handler, onError, onListen) {
     return nativeCallback(req, undefined);
   };
   const rawNoRequest = handler.length === 0 && nativeFastPath;
+  const automaticCompression = op_http_serve_default_compression();
   serverContext = new CallbackContext(
     signal,
     op_http_serve_on(
       connection[internalRidSymbol],
+      automaticCompression,
       dispatch,
       rawNoRequest,
       nativeDispatch,

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -837,11 +837,17 @@ fn raw_response_header<'a>(
     .map(|header| header.value.as_slice())
 }
 
-fn raw_response_is_compressible(inner: &RawHttpRecordInner) -> bool {
-  let Some(content_type) = inner.content_type.as_deref().or_else(|| {
-    raw_response_header(&inner.response_headers, CONTENT_TYPE.as_ref())
-  }) else {
-    return false;
+fn raw_response_metadata_is_compressible(
+  headers: &[RawHeader],
+  content_type: Option<&[u8]>,
+  default_text_content_type: bool,
+) -> bool {
+  let content_type = match content_type
+    .or_else(|| raw_response_header(headers, CONTENT_TYPE.as_ref()))
+  {
+    Some(content_type) => content_type,
+    None if default_text_content_type => b"text/plain;charset=UTF-8",
+    None => return false,
   };
 
   let Ok(content_type) = HeaderValue::from_bytes(content_type) else {
@@ -850,15 +856,13 @@ fn raw_response_is_compressible(inner: &RawHttpRecordInner) -> bool {
   if !is_content_compressible(&content_type) {
     return false;
   }
-  if raw_response_header(&inner.response_headers, CONTENT_ENCODING.as_ref())
-    .is_some()
-    || raw_response_header(&inner.response_headers, CONTENT_RANGE.as_ref())
-      .is_some()
+  if raw_response_header(headers, CONTENT_ENCODING.as_ref()).is_some()
+    || raw_response_header(headers, CONTENT_RANGE.as_ref()).is_some()
   {
     return false;
   }
   if let Some(cache_control) =
-    raw_response_header(&inner.response_headers, CACHE_CONTROL.as_ref())
+    raw_response_header(headers, CACHE_CONTROL.as_ref())
     && let Ok(cache_control) = std::str::from_utf8(cache_control)
     && let Some(no_transform) =
       crate::cache_control_has_no_transform(cache_control)
@@ -867,6 +871,33 @@ fn raw_response_is_compressible(inner: &RawHttpRecordInner) -> bool {
     return false;
   }
   true
+}
+
+fn raw_response_is_compressible(inner: &RawHttpRecordInner) -> bool {
+  raw_response_metadata_is_compressible(
+    &inner.response_headers,
+    inner.content_type.as_deref(),
+    inner.default_text_content_type,
+  )
+}
+
+fn apply_raw_response_compression_headers(
+  headers: &mut Vec<RawHeader>,
+  compression: &Compression,
+) {
+  headers.retain(|header| !header.name.eq_ignore_ascii_case(b"content-length"));
+  ensure_raw_vary_accept_encoding(headers);
+  weaken_raw_etag(headers);
+
+  let encoding = match compression {
+    Compression::Brotli => b"br".as_slice(),
+    Compression::GZip => b"gzip".as_slice(),
+    Compression::None => unreachable!(),
+  };
+  headers.push(RawHeader {
+    name: b"content-encoding".to_vec(),
+    value: encoding.to_vec(),
+  });
 }
 
 fn ensure_raw_vary_accept_encoding(headers: &mut Vec<RawHeader>) {
@@ -1067,6 +1098,13 @@ enum RawRequestBody {
   Streaming(Rc<RawH1RequestBody<RawH1Io>>),
 }
 
+struct RawHttpRecordOptions {
+  request_body: Option<RawRequestBody>,
+  upgrade: Option<Rc<RawUpgrade>>,
+  request_size: u64,
+  automatic_compression: bool,
+}
+
 struct RawHttpRecordInner {
   request_info: HttpConnectionProperties,
   client_addr: Option<Vec<u8>>,
@@ -1089,6 +1127,7 @@ struct RawHttpRecordInner {
   response_body_finished: bool,
   response_body_waker: Option<std::task::Waker>,
   otel_info: Option<OtelInfo>,
+  automatic_compression: bool,
 }
 
 struct RawHttpRecord(RefCell<RawHttpRecordInner>);
@@ -1099,9 +1138,7 @@ impl RawHttpRecord {
     method: RawMethod,
     path: String,
     mut headers: RawRequestHeaders,
-    request_body: Option<RawRequestBody>,
-    upgrade: Option<Rc<RawUpgrade>>,
-    request_size: u64,
+    options: RawHttpRecordOptions,
   ) -> Rc<Self> {
     let client_addr = if crate::service::trust_proxy_headers() {
       headers.remove(b"x-deno-client-address")
@@ -1115,7 +1152,7 @@ impl RawHttpRecord {
         OtelInfo::new(
           otel,
           std::time::Instant::now(),
-          request_size,
+          options.request_size,
           RawOtelInfoAttributes::new(&request_info, &method, &path, &headers)
             .into_attributes(),
         )
@@ -1126,8 +1163,8 @@ impl RawHttpRecord {
       method,
       path,
       headers,
-      request_body,
-      upgrade,
+      request_body: options.request_body,
+      upgrade: options.upgrade,
       response_status: 200,
       response_headers: Vec::new(),
       response_trailers: Vec::new(),
@@ -1142,6 +1179,7 @@ impl RawHttpRecord {
       response_body_finished: false,
       response_body_waker: None,
       otel_info,
+      automatic_compression: options.automatic_compression,
     })))
   }
 
@@ -1272,6 +1310,10 @@ impl RawHttpRecord {
   }
 
   fn prepare_stream_compression(&self, length: Option<usize>) -> Compression {
+    if !self.0.borrow().automatic_compression {
+      return Compression::None;
+    }
+
     if let Some(length) = length
       && length < 64
     {
@@ -1285,22 +1327,10 @@ impl RawHttpRecord {
       return Compression::None;
     }
 
-    inner
-      .response_headers
-      .retain(|header| !header.name.eq_ignore_ascii_case(b"content-length"));
-    ensure_raw_vary_accept_encoding(&mut inner.response_headers);
-    weaken_raw_etag(&mut inner.response_headers);
-
-    let encoding = match compression {
-      Compression::Brotli => b"br".as_slice(),
-      Compression::GZip => b"gzip".as_slice(),
-      Compression::None => unreachable!(),
-    };
-    inner.response_headers.push(RawHeader {
-      name: b"content-encoding".to_vec(),
-      value: encoding.to_vec(),
-    });
-
+    apply_raw_response_compression_headers(
+      &mut inner.response_headers,
+      &compression,
+    );
     compression
   }
 
@@ -2656,8 +2686,11 @@ fn set_response(
   // The request may have been cancelled by this point and if so, there's no need for us to
   // do all of this work to send the response.
   if !http.cancelled() {
-    let compression =
-      is_request_compressible(length, &http.request_parts().headers);
+    let compression = if http.automatic_compression() {
+      is_request_compressible(length, &http.request_parts().headers)
+    } else {
+      Compression::None
+    };
     let mut response_headers =
       std::cell::RefMut::map(http.response_parts(), |this| &mut this.headers);
     let compression =
@@ -2684,10 +2717,14 @@ fn set_static_response_vec(
   if !http.cancelled() {
     match &http {
       HttpRecordExternal::Hyper(record) => {
-        let compression = is_request_compressible(
-          Some(bytes.len()),
-          &record.request_parts().headers,
-        );
+        let compression = if record.automatic_compression() {
+          is_request_compressible(
+            Some(bytes.len()),
+            &record.request_parts().headers,
+          )
+        } else {
+          Compression::None
+        };
         let mut response_headers =
           std::cell::RefMut::map(record.response_parts(), |this| {
             &mut this.headers
@@ -2733,13 +2770,25 @@ fn set_static_response_bufview(
   buffer: JsBuffer,
   status: u16,
 ) {
+  set_static_response_bufview_inner(http, BufView::from(buffer), status);
+}
+
+fn set_static_response_bufview_inner(
+  http: HttpRecordExternal,
+  buffer: BufView,
+  status: u16,
+) {
   if !http.cancelled() {
     match &http {
       HttpRecordExternal::Hyper(record) => {
-        let compression = is_request_compressible(
-          Some(buffer.len()),
-          &record.request_parts().headers,
-        );
+        let compression = if record.automatic_compression() {
+          is_request_compressible(
+            Some(buffer.len()),
+            &record.request_parts().headers,
+          )
+        } else {
+          Compression::None
+        };
         let mut response_headers =
           std::cell::RefMut::map(record.response_parts(), |this| {
             &mut this.headers
@@ -2750,7 +2799,6 @@ fn set_static_response_bufview(
         );
         drop(response_headers);
         set_response_status(&http, status);
-        let buffer = BufView::from(buffer);
         if compression == Compression::None {
           http.set_flat_response_body(FlatResponseBody::Bytes(buffer));
         } else {
@@ -2763,7 +2811,6 @@ fn set_static_response_bufview(
       HttpRecordExternal::Raw(record) => {
         let compression = record.prepare_stream_compression(Some(buffer.len()));
         set_response_status(&http, status);
-        let buffer = BufView::from(buffer);
         if compression == Compression::None {
           http.set_flat_response_body(FlatResponseBody::Bytes(buffer));
         } else {
@@ -3291,8 +3338,9 @@ impl fmt::Write for RawH1DateCache {
 }
 
 fn raw_response_from_direct_response(
+  record: &RawHttpRecord,
   response: DirectResponse,
-) -> (RawResponseParts, FlatResponseBody) {
+) -> (RawResponseParts, RawResponseBody) {
   let mut parts = RawResponseParts {
     status: response.status,
     headers: Vec::new(),
@@ -3323,7 +3371,52 @@ fn raw_response_from_direct_response(
     DirectResponseBody::Empty => FlatResponseBody::Empty,
     DirectResponseBody::Bytes(body) => FlatResponseBody::Bytes(body),
   };
+  let compression = match &body {
+    FlatResponseBody::Empty => Compression::None,
+    FlatResponseBody::Bytes(body) => {
+      raw_direct_response_compression(record, Some(body.len()), &mut parts)
+    }
+  };
+  let body = match (compression, body) {
+    (Compression::None, body) => RawResponseBody::Flat(body),
+    (compression, FlatResponseBody::Bytes(body)) => RawResponseBody::Stream(
+      ResponseBytesInner::from_bufview(compression, body),
+    ),
+    (_, FlatResponseBody::Empty) => unreachable!(),
+  };
   (parts, body)
+}
+
+fn raw_direct_response_compression(
+  record: &RawHttpRecord,
+  length: Option<usize>,
+  parts: &mut RawResponseParts,
+) -> Compression {
+  if let Some(length) = length
+    && length < 64
+  {
+    return Compression::None;
+  }
+
+  let inner = record.0.borrow();
+  if !inner.automatic_compression {
+    return Compression::None;
+  }
+  let compression = raw_request_compression(&inner.headers);
+  drop(inner);
+
+  if compression == Compression::None
+    || !raw_response_metadata_is_compressible(
+      &parts.headers,
+      parts.content_type.as_deref(),
+      parts.default_text_content_type,
+    )
+  {
+    return Compression::None;
+  }
+
+  apply_raw_response_compression_headers(&mut parts.headers, &compression);
+  compression
 }
 
 fn set_direct_response(http: HttpRecordExternal, response: DirectResponse) {
@@ -3348,7 +3441,8 @@ fn set_direct_response(http: HttpRecordExternal, response: DirectResponse) {
         http.set_flat_response_body(FlatResponseBody::Empty);
       }
       DirectResponseBody::Bytes(body) => {
-        http.set_flat_response_body(FlatResponseBody::Bytes(body));
+        set_static_response_bufview_inner(http, body, response.status);
+        return;
       }
     }
   }
@@ -4115,6 +4209,7 @@ async fn serve_http11_raw(
   callback: Rc<ServerCallback>,
   cancel: Rc<CancelHandle>,
   _server_state: SignallingRc<HttpServerState>,
+  automatic_compression: bool,
 ) -> Result<(), HttpNextError> {
   let mut conn = h1::SharedConn::new(io);
   conn.set_allow_missing_host(true);
@@ -4173,9 +4268,12 @@ async fn serve_http11_raw(
         parsed.method,
         parsed.path,
         parsed.headers,
-        Some(RawRequestBody::Prebuffered(body)),
-        None,
-        parsed.request_size,
+        RawHttpRecordOptions {
+          request_body: Some(RawRequestBody::Prebuffered(body)),
+          upgrade: None,
+          request_size: parsed.request_size,
+          automatic_compression,
+        },
       );
       let mut record_cancel_guard =
         RawHttpRecordCancelGuard::new(record.clone());
@@ -4183,18 +4281,37 @@ async fn serve_http11_raw(
         dispatch_raw_to_native_response(&callback, record.clone());
       if let Some(response) = direct_response {
         let (response_parts, body) =
-          raw_response_from_direct_response(response);
+          raw_response_from_direct_response(&record, response);
         let response_status = response_parts.status;
-        write_h1_flat_response(
-          &mut conn,
-          &mut scratch,
-          parsed.version,
-          response_parts,
-          body,
-          keep_alive,
-          head,
-        )
-        .await?;
+        match body {
+          RawResponseBody::Flat(body) => {
+            write_h1_flat_response(
+              &mut conn,
+              &mut scratch,
+              parsed.version,
+              response_parts,
+              body,
+              keep_alive,
+              head,
+            )
+            .await?;
+          }
+          RawResponseBody::Stream(body) => {
+            write_h1_stream_response(
+              &mut conn,
+              &mut scratch,
+              response_context,
+              response_parts,
+              body,
+              record.clone(),
+            )
+            .await?;
+            if parsed.version == h1::Version::Http10 {
+              record_cancel_guard.disarm();
+              return Ok(());
+            }
+          }
+        }
         record_cancel_guard.disarm();
         if response_status == StatusCode::SWITCHING_PROTOCOLS.as_u16()
           || !keep_alive
@@ -4280,9 +4397,12 @@ async fn serve_http11_raw(
         parsed.method,
         parsed.path,
         parsed.headers,
-        request_body_resource.map(RawRequestBody::Streaming),
-        upgrade.clone(),
-        parsed.request_size,
+        RawHttpRecordOptions {
+          request_body: request_body_resource.map(RawRequestBody::Streaming),
+          upgrade: upgrade.clone(),
+          request_size: parsed.request_size,
+          automatic_compression,
+        },
       );
       let mut record_cancel_guard =
         RawHttpRecordCancelGuard::new(record.clone());
@@ -4294,23 +4414,47 @@ async fn serve_http11_raw(
       };
       if let Some(response) = direct_response {
         let (response_parts, body) =
-          raw_response_from_direct_response(response);
+          raw_response_from_direct_response(&record, response);
         let response_status = response_parts.status;
         let state = { body_conn.borrow_mut().take() };
         if let Some(state) = state {
           let mut local_conn = state.conn;
           let mut local_scratch = state.scratch;
           let keep_alive = keep_alive && !parsed.has_body;
-          write_h1_flat_response(
-            &mut local_conn,
-            &mut local_scratch,
-            parsed.version,
-            response_parts,
-            body,
-            keep_alive,
-            head,
-          )
-          .await?;
+          match body {
+            RawResponseBody::Flat(body) => {
+              write_h1_flat_response(
+                &mut local_conn,
+                &mut local_scratch,
+                parsed.version,
+                response_parts,
+                body,
+                keep_alive,
+                head,
+              )
+              .await?;
+            }
+            RawResponseBody::Stream(body) => {
+              let response_context = RawH1ResponseContext {
+                version: response_context.version,
+                keep_alive,
+                head: response_context.head,
+              };
+              write_h1_stream_response(
+                &mut local_conn,
+                &mut local_scratch,
+                response_context,
+                response_parts,
+                body,
+                record.clone(),
+              )
+              .await?;
+              if parsed.version == h1::Version::Http10 {
+                record_cancel_guard.disarm();
+                return Ok(());
+              }
+            }
+          }
           conn = local_conn;
           scratch = local_scratch;
           record_cancel_guard.disarm();
@@ -4444,25 +4588,48 @@ async fn serve_http11_raw(
       parsed.method,
       parsed.path,
       parsed.headers,
-      None,
-      None,
-      parsed.request_size,
+      RawHttpRecordOptions {
+        request_body: None,
+        upgrade: None,
+        request_size: parsed.request_size,
+        automatic_compression,
+      },
     );
     let mut record_cancel_guard = RawHttpRecordCancelGuard::new(record.clone());
     let direct_response =
       dispatch_raw_to_native_response(&callback, record.clone());
     if let Some(response) = direct_response {
-      let (response_parts, body) = raw_response_from_direct_response(response);
-      write_h1_flat_response(
-        &mut conn,
-        &mut scratch,
-        parsed.version,
-        response_parts,
-        body,
-        keep_alive,
-        head,
-      )
-      .await?;
+      let (response_parts, body) =
+        raw_response_from_direct_response(&record, response);
+      match body {
+        RawResponseBody::Flat(body) => {
+          write_h1_flat_response(
+            &mut conn,
+            &mut scratch,
+            parsed.version,
+            response_parts,
+            body,
+            keep_alive,
+            head,
+          )
+          .await?;
+        }
+        RawResponseBody::Stream(body) => {
+          write_h1_stream_response(
+            &mut conn,
+            &mut scratch,
+            response_context,
+            response_parts,
+            body,
+            record.clone(),
+          )
+          .await?;
+          if parsed.version == h1::Version::Http10 {
+            record_cancel_guard.disarm();
+            return Ok(());
+          }
+        }
+      }
       record_cancel_guard.disarm();
       if !keep_alive || cancel.is_canceled() {
         return Ok(());
@@ -4570,7 +4737,15 @@ async fn serve_http2_autodetect(
       .await
       .map_err(HttpNextError::Hyper)
   } else {
-    serve_http11_raw(io, request_info, callback, cancel, server_state).await
+    serve_http11_raw(
+      io,
+      request_info,
+      callback,
+      cancel,
+      server_state,
+      options.automatic_compression,
+    )
+    .await
   }
 }
 
@@ -4633,6 +4808,7 @@ fn serve_https(
   } = lifetime;
 
   let legacy_abort = !options.no_legacy_abort;
+  let automatic_compression = options.automatic_compression;
   let raw_request_info = request_info.clone();
   let raw_callback = callback.clone();
   let raw_server_state = server_state.clone();
@@ -4647,6 +4823,7 @@ fn serve_https(
         server_state,
         move |record| dispatch_to_js(&callback, record),
         legacy_abort,
+        automatic_compression,
       )
       .await
     }
@@ -4674,6 +4851,7 @@ fn serve_https(
           raw_callback,
           listen_cancel_handle,
           raw_server_state,
+          options.automatic_compression,
         )
         .await
       } else {
@@ -4708,6 +4886,7 @@ fn serve_http(
   } = lifetime;
 
   let legacy_abort = !options.no_legacy_abort;
+  let automatic_compression = options.automatic_compression;
   let raw_request_info = request_info.clone();
   let raw_callback = callback.clone();
   let raw_server_state = server_state.clone();
@@ -4722,6 +4901,7 @@ fn serve_http(
         server_state,
         move |record| dispatch_to_js(&callback, record),
         legacy_abort,
+        automatic_compression,
       )
       .await
     }
@@ -4761,6 +4941,7 @@ fn serve_http(
               raw_callback,
               listen_cancel_handle,
               raw_server_state,
+              options.automatic_compression,
             )
             .await
           }
@@ -4879,6 +5060,7 @@ pub fn op_http_serve<'scope, HTTP>(
   isolate: &mut v8::Isolate,
   state: Rc<RefCell<OpState>>,
   #[smi] listener_rid: ResourceId,
+  automatic_compression: bool,
   callback: v8::Local<'scope, v8::Function>,
   raw_no_request: bool,
   native_callback: v8::Local<'scope, v8::Function>,
@@ -4920,7 +5102,9 @@ where
 
   let options = {
     let state = state.borrow();
-    *state.borrow::<Options>()
+    let mut options = *state.borrow::<Options>();
+    options.automatic_compression = automatic_compression;
+    options
   };
 
   let listen_properties_clone: HttpListenProperties = listen_properties.clone();
@@ -4961,6 +5145,7 @@ pub fn op_http_serve_on<'scope, HTTP>(
   isolate: &mut v8::Isolate,
   state: Rc<RefCell<OpState>>,
   #[smi] connection_rid: ResourceId,
+  automatic_compression: bool,
   callback: v8::Local<'scope, v8::Function>,
   raw_no_request: bool,
   native_callback: v8::Local<'scope, v8::Function>,
@@ -4999,7 +5184,9 @@ where
 
   let options = {
     let state = state.borrow();
-    *state.borrow::<Options>()
+    let mut options = *state.borrow::<Options>();
+    options.automatic_compression = automatic_compression;
+    options
   };
 
   let handle = serve_http_on::<HTTP>(

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -180,7 +180,7 @@ static OTEL_COLLECTORS: OnceCell<OtelCollectors> = OnceCell::new();
 
 const HTTP2_PREFIX: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Options {
   /// By passing a hook function, the caller can customize various configuration
   /// options for the HTTP/2 server.
@@ -193,6 +193,19 @@ pub struct Options {
 
   /// If `false`, the server will abort the request when the response is dropped.
   pub no_legacy_abort: bool,
+
+  /// If `true`, responses may be compressed based on request and response headers.
+  pub automatic_compression: bool,
+}
+
+impl Default for Options {
+  fn default() -> Self {
+    Self {
+      http2_builder_hook: None,
+      no_legacy_abort: false,
+      automatic_compression: true,
+    }
+  }
 }
 
 #[cfg(not(feature = "default_property_extractor"))]
@@ -204,6 +217,7 @@ deno_core::extension!(
     op_http_accept,
     op_http_headers,
     op_http_serve_address_override,
+    op_http_serve_default_compression,
     op_http_shutdown,
     op_http_upgrade_websocket,
     op_http_websocket_accept_header,
@@ -269,6 +283,7 @@ deno_core::extension!(
     op_http_accept,
     op_http_headers,
     op_http_serve_address_override,
+    op_http_serve_default_compression,
     op_http_shutdown,
     op_http_upgrade_websocket,
     op_http_websocket_accept_header,
@@ -1839,6 +1854,14 @@ pub fn op_http_serve_address_override() -> (u8, String, u32, bool) {
   }
 
   (0, String::new(), 0, false)
+}
+
+#[op2(fast)]
+pub fn op_http_serve_default_compression() -> bool {
+  match std::env::var("DENO_SERVE_AUTOMATIC_COMPRESSION") {
+    Ok(value) => !matches!(value.to_ascii_lowercase().as_str(), "0" | "false"),
+    Err(_) => true,
+  }
 }
 
 fn parse_serve_address(input: &str) -> (u8, String, u32, bool) {

--- a/ext/http/service.rs
+++ b/ext/http/service.rs
@@ -548,6 +548,7 @@ pub(crate) async fn handle_request<F>(
   server_state: SignallingRc<HttpServerState>, // Keep server alive for duration of this future.
   dispatch: F,
   legacy_abort: bool,
+  automatic_compression: bool,
 ) -> Result<Response, hyper::Error>
 where
   F: FnOnce(Rc<HttpRecord>),
@@ -601,6 +602,7 @@ where
       server_state,
       otel_info,
       legacy_abort,
+      automatic_compression,
     ),
     HttpRecord::cancel,
   );
@@ -646,6 +648,7 @@ struct HttpRecordInner {
   finished: bool,
   needs_close_after_finish: bool,
   legacy_abort: bool,
+  automatic_compression: bool,
   otel_info: Option<OtelInfo>,
   client_addr: Option<http::HeaderValue>,
 }
@@ -686,6 +689,7 @@ impl HttpRecord {
     server_state: SignallingRc<HttpServerState>,
     otel_info: Option<OtelInfo>,
     legacy_abort: bool,
+    automatic_compression: bool,
   ) -> Rc<Self> {
     let (mut request_parts, request_body) = request.into_parts();
     let client_addr = if trust_proxy_headers() {
@@ -694,26 +698,7 @@ impl HttpRecord {
       None
     };
     let request_body = Some(BufferedIncoming::new(request_body).into());
-    Self::new_from_parts(
-      request_parts,
-      request_info,
-      server_state,
-      request_body,
-      otel_info,
-      client_addr,
-      legacy_abort,
-    )
-  }
 
-  fn new_from_parts(
-    request_parts: Parts,
-    request_info: HttpConnectionProperties,
-    server_state: SignallingRc<HttpServerState>,
-    request_body: Option<RequestBodyState>,
-    otel_info: Option<OtelInfo>,
-    client_addr: Option<http::HeaderValue>,
-    legacy_abort: bool,
-  ) -> Rc<Self> {
     let (mut response_parts, _) = http::Response::new(()).into_parts();
     let record = match server_state.borrow_mut().pool.pop() {
       Some((record, headers)) => {
@@ -750,6 +735,7 @@ impl HttpRecord {
       been_dropped: false,
       finished: false,
       legacy_abort,
+      automatic_compression,
       needs_close_after_finish: false,
       otel_info,
       client_addr,
@@ -976,6 +962,10 @@ impl HttpRecord {
   /// Get a reference to the request parts.
   pub fn request_parts(&self) -> Ref<'_, Parts> {
     Ref::map(self.self_ref(), |inner| &inner.request_parts)
+  }
+
+  pub fn automatic_compression(&self) -> bool {
+    self.self_ref().automatic_compression
   }
 
   /// Resolves when response head is ready.
@@ -1291,6 +1281,7 @@ mod tests {
         move |record| {
           tx.try_send(record).unwrap();
         },
+        true,
         true,
       )
     });

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -3391,6 +3391,211 @@ for (const testCase of compressionTestCases) {
 
 Deno.test(
   { permissions: { net: true } },
+  async function httpServerAutomaticCompressionSkippedForNoRequestFastPath() {
+    const body = "a".repeat(1000);
+    const listeningDeferred = Promise.withResolvers<void>();
+    const ac = new AbortController();
+
+    await using server = Deno.serve({
+      handler: () => {
+        return new Response(body, {
+          headers: { "content-type": "text/plain" },
+        });
+      },
+      port: servePort,
+      signal: ac.signal,
+      onListen: onListen(listeningDeferred.resolve),
+      onError: createOnErrorCb(ac),
+    });
+
+    try {
+      await listeningDeferred.promise;
+      const resp = await fetch(`http://127.0.0.1:${servePort}/`, {
+        headers: { "accept-encoding": "gzip" },
+      });
+      assertEquals(await resp.text(), body);
+      assertEquals(resp.headers.get("content-encoding"), null);
+      assertEquals(resp.headers.get("vary"), null);
+    } finally {
+      ac.abort();
+      await server.finished;
+    }
+  },
+);
+
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerAutomaticCompressionCanBeDisabled() {
+    const body = "a".repeat(1000);
+    const listeningDeferred = Promise.withResolvers<void>();
+    const ac = new AbortController();
+
+    await using server = Deno.serve({
+      automaticCompression: false,
+      handler: () => {
+        return new Response(body, {
+          headers: { "content-type": "text/plain" },
+        });
+      },
+      port: servePort,
+      signal: ac.signal,
+      onListen: onListen(listeningDeferred.resolve),
+      onError: createOnErrorCb(ac),
+    });
+
+    try {
+      await listeningDeferred.promise;
+      const resp = await fetch(`http://127.0.0.1:${servePort}/`, {
+        headers: { "accept-encoding": "gzip" },
+      });
+      assertEquals(await resp.text(), body);
+      assertEquals(resp.headers.get("content-encoding"), null);
+      assertEquals(resp.headers.get("vary"), null);
+    } finally {
+      ac.abort();
+      await server.finished;
+    }
+  },
+);
+
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerAutomaticCompressionCanBeDisabledHyper() {
+    const body = "a".repeat(1000);
+    const listeningDeferred = Promise.withResolvers<void>();
+    const ac = new AbortController();
+
+    await using server = Deno.serve({
+      automaticCompression: false,
+      handler: (_request) => {
+        return new Response(body, {
+          headers: { "content-type": "text/plain" },
+        });
+      },
+      port: servePort,
+      signal: ac.signal,
+      onListen: onListen(listeningDeferred.resolve),
+      onError: createOnErrorCb(ac),
+    });
+
+    try {
+      await listeningDeferred.promise;
+      const resp = await fetch(`http://127.0.0.1:${servePort}/`, {
+        headers: { "accept-encoding": "gzip" },
+      });
+      assertEquals(await resp.text(), body);
+      assertEquals(resp.headers.get("content-encoding"), null);
+      assertEquals(resp.headers.get("vary"), null);
+    } finally {
+      ac.abort();
+      await server.finished;
+    }
+  },
+);
+
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerAutomaticCompressionPostBodyDirectResponseCloses() {
+    const body = "a".repeat(1000);
+    const listeningDeferred = Promise.withResolvers<void>();
+    const ac = new AbortController();
+
+    await using server = Deno.serve({
+      handler: (_request) => {
+        return new Response(body, {
+          headers: { "content-type": "text/plain" },
+        });
+      },
+      port: servePort,
+      signal: ac.signal,
+      onListen: onListen(listeningDeferred.resolve),
+      onError: createOnErrorCb(ac),
+    });
+
+    await listeningDeferred.promise;
+    const conn = await Deno.connect({ port: servePort });
+    const encoder = new TextEncoder();
+    await writeAll(
+      conn,
+      encoder.encode(
+        `POST / HTTP/1.1\r\nHost: example.domain\r\nAccept-Encoding: gzip\r\nContent-Length: 5\r\n\r\n`,
+      ),
+    );
+
+    const reader = new BufReader(conn);
+    const textProtoReader = new TextProtoReader(reader);
+    const statusLine = await textProtoReader.readLine();
+    assertEquals(statusLine, "HTTP/1.1 200 OK");
+    const headers = await textProtoReader.readMimeHeader();
+    assert(headers !== null);
+    assertEquals(headers.get("content-encoding"), "gzip");
+    assertEquals(headers.get("transfer-encoding"), "chunked");
+    assertEquals(headers.get("connection"), "close");
+
+    conn.close();
+    ac.abort();
+    await server.finished;
+  },
+);
+
+Deno.test(
+  { permissions: { run: true } },
+  async function httpServerAutomaticCompressionEnvDefault() {
+    async function run(envValue: string): Promise<string[]> {
+      const { success, stdout } = await new Deno.Command(Deno.execPath(), {
+        args: [
+          "eval",
+          `
+          async function check(options) {
+            let server;
+            const finished = Promise.withResolvers();
+            server = Deno.serve({
+              ...options,
+              port: 0,
+              onListen: async ({ port }) => {
+                const resp = await fetch("http://127.0.0.1:" + port + "/", {
+                  headers: { "accept-encoding": "gzip" },
+                });
+                console.log(resp.headers.get("content-encoding") ?? "none");
+                await resp.text();
+                await server.shutdown();
+                finished.resolve();
+              },
+            }, (_request) => {
+              return new Response("a".repeat(1000), {
+                headers: { "content-type": "text/plain" },
+              });
+            });
+            await finished.promise;
+            await server.finished;
+          }
+
+          await check({});
+          await check({ automaticCompression: true });
+        `,
+        ],
+        env: { DENO_SERVE_AUTOMATIC_COMPRESSION: envValue },
+        stdout: "piped",
+        stderr: "inherit",
+      }).output();
+
+      assert(success);
+      return new TextDecoder().decode(stdout).trim().split("\n");
+    }
+
+    assertEquals(await run("0"), [
+      "none",
+      "gzip",
+    ]);
+    assertEquals(await run("False"), [
+      "none",
+      "gzip",
+    ]);
+  },
+);
+
+Deno.test(
+  { permissions: { net: true } },
   async function httpServerHttp2Compression() {
     const body = "a".repeat(1000);
     const listeningDeferred = Promise.withResolvers<void>();
@@ -3437,6 +3642,64 @@ Deno.test(
       assertEquals(headers["vary"], "Accept-Encoding");
       assertEquals(headers["content-length"], `${compressedLength}`);
       assert(compressedLength < body.length);
+    } finally {
+      client.close();
+      ac.abort();
+      await server.finished;
+    }
+  },
+);
+
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerHttp2AutomaticCompressionCanBeDisabled() {
+    const body = "a".repeat(1000);
+    const listeningDeferred = Promise.withResolvers<void>();
+    const ac = new AbortController();
+
+    await using server = Deno.serve({
+      automaticCompression: false,
+      handler: () => {
+        return new Response(body, {
+          headers: { "content-type": "text/plain" },
+        });
+      },
+      port: servePort,
+      signal: ac.signal,
+      onListen: onListen(listeningDeferred.resolve),
+      onError: createOnErrorCb(ac),
+    });
+
+    await listeningDeferred.promise;
+    const client = http2.connect(`http://localhost:${servePort}`);
+    try {
+      const req = client.request({
+        ":path": "/",
+        "accept-encoding": "br",
+      });
+      let headers: http2.IncomingHttpHeaders | undefined;
+      let responseBody = "";
+      req.setEncoding("utf8");
+      req.on("response", (responseHeaders) => {
+        headers = responseHeaders;
+      });
+      req.on("data", (chunk) => {
+        responseBody += chunk;
+      });
+
+      req.end();
+      await new Promise<void>((resolve, reject) => {
+        req.on("end", resolve);
+        req.on("error", reject);
+        client.on("error", reject);
+      });
+
+      assert(headers);
+      assertEquals(Number(headers[":status"]), 200);
+      assertEquals(headers["content-encoding"], undefined);
+      assertEquals(headers["vary"], undefined);
+      assertEquals(headers["content-length"], `${body.length}`);
+      assertEquals(responseBody, body);
     } finally {
       client.close();
       ac.abort();


### PR DESCRIPTION
Closes #13830.

## Summary
- add an `automaticCompression` option to `Deno.serve` for opting out of automatic response body compression
- add `DENO_SERVE_AUTOMATIC_COMPRESSION=0|false` as the process-wide default opt-out, parsed case-insensitively for `false`
- thread the setting through hyper and raw serve paths while preserving the raw no-request fast path

## Behavior note
Automatic compression remains skipped for the raw no-request fast path, because that path intentionally does not retain request headers and therefore cannot inspect `Accept-Encoding`. Handlers that receive the request can still use automatic compression by default, and `automaticCompression: false` or `DENO_SERVE_AUTOMATIC_COMPRESSION=0` disables it.

## Test
- `cargo check -p deno_http`
- `cargo fmt --check --all`
- `deno fmt --check tests/unit/serve_test.ts cli/tsc/dts/lib.deno.ns.d.ts`
- `cargo build --bin deno`
- `cargo build --bin test_server`
- `./x test-unit serve_test`
- `./tools/lint.js`
