### PR TITLE
Fix typo in process.rs: 'with with' → 'with'

### DIFF
--- a/ext/image/01_image.js
+++ b/ext/image/01_image.js
@@ -248,7 +248,7 @@ function createImageBitmap(
       } else {
         return PromiseReject(
           new DOMException(
-            `The the MIME type ${mimeTypeString} of source image is not a supported format\n
+            `The MIME type ${mimeTypeString} of source image is not a supported format\n
 info: The following MIME types are supported.
 docs: https://mimesniff.spec.whatwg.org/#image-type-pattern-matching-algorithm\n`,
             "InvalidStateError",

--- a/ext/node/polyfills/dgram.ts
+++ b/ext/node/polyfills/dgram.ts
@@ -451,7 +451,7 @@ class Socket extends EventEmitter {
       // across a "cluster" of Node processes to take advantage of multi-core
       // systems.
       //
-      // Though Deno has has a Worker capability from which we could simulate this,
+      // Though Deno has a Worker capability from which we could simulate this,
       // for now we assert that we are _always_ on the primary process.
 
       const type = guessHandleType(fd);
@@ -512,7 +512,7 @@ class Socket extends EventEmitter {
       // across a "cluster" of Node processes to take advantage of multi-core
       // systems.
       //
-      // Though Deno has has a Worker capability from which we could simulate this,
+      // Though Deno has a Worker capability from which we could simulate this,
       // for now we assert that we are _always_ on the primary process.
 
       if (!state.handle) {

--- a/runtime/subprocess_windows/src/process.rs
+++ b/runtime/subprocess_windows/src/process.rs
@@ -554,7 +554,7 @@ pub fn spawn(options: &SpawnOptions) -> Result<ChildProcess, std::io::Error> {
     // Inherit cwd
     #[allow(
       clippy::disallowed_methods,
-      reason = "use real, consider making with with a virtual cwd in future"
+      reason = "use real, consider making with a virtual cwd in future"
     )]
     let cwd = std::env::current_dir()?;
     WCString::new(cwd)


### PR DESCRIPTION
Fixes a duplicate word typo in `runtime/subprocess_windows/src/process.rs`.

**AI Disclosure**: This typo was identified using AI-assisted code review.