### PR TITLE
Fix typo in util.d.cts: 'to to' → 'to'

### DIFF
--- a/cli/tsc/dts/node/perf_hooks.d.cts
+++ b/cli/tsc/dts/node/perf_hooks.d.cts
@@ -334,11 +334,11 @@ declare module "perf_hooks" {
          * A PerformanceMeasure is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'measure',
          * and whose performanceEntry.duration measures the number of milliseconds elapsed since startMark and endMark.
          *
-         * The startMark argument may identify any existing PerformanceMark in the the Performance Timeline, or may identify
+         * The startMark argument may identify any existing PerformanceMark in the Performance Timeline, or may identify
          * any of the timestamp properties provided by the PerformanceNodeTiming class. If the named startMark does not exist,
          * then startMark is set to timeOrigin by default.
          *
-         * The endMark argument must identify any existing PerformanceMark in the the Performance Timeline or any of the timestamp
+         * The endMark argument must identify any existing PerformanceMark in the Performance Timeline or any of the timestamp
          * properties provided by the PerformanceNodeTiming class. If the named endMark does not exist, an error will be thrown.
          * @param name
          * @param startMark

--- a/cli/tsc/dts/node/util.d.cts
+++ b/cli/tsc/dts/node/util.d.cts
@@ -1233,7 +1233,7 @@ declare module "util" {
      *
      * The full list of formats can be found in [modifiers](https://nodejs.org/docs/latest-v24.x/api/util.html#modifiers).
      * @param format A text format or an Array of text formats defined in `util.inspect.colors`.
-     * @param text The text to to be formatted.
+     * @param text The text to be formatted.
      * @since v20.12.0
      */
     export function styleText(

--- a/ext/image/01_image.js
+++ b/ext/image/01_image.js
@@ -248,7 +248,7 @@ function createImageBitmap(
       } else {
         return PromiseReject(
           new DOMException(
-            `The the MIME type ${mimeTypeString} of source image is not a supported format\n
+            `The MIME type ${mimeTypeString} of source image is not a supported format\n
 info: The following MIME types are supported.
 docs: https://mimesniff.spec.whatwg.org/#image-type-pattern-matching-algorithm\n`,
             "InvalidStateError",

--- a/ext/node/polyfills/dgram.ts
+++ b/ext/node/polyfills/dgram.ts
@@ -451,7 +451,7 @@ class Socket extends EventEmitter {
       // across a "cluster" of Node processes to take advantage of multi-core
       // systems.
       //
-      // Though Deno has has a Worker capability from which we could simulate this,
+      // Though Deno has a Worker capability from which we could simulate this,
       // for now we assert that we are _always_ on the primary process.
 
       const type = guessHandleType(fd);
@@ -512,7 +512,7 @@ class Socket extends EventEmitter {
       // across a "cluster" of Node processes to take advantage of multi-core
       // systems.
       //
-      // Though Deno has has a Worker capability from which we could simulate this,
+      // Though Deno has a Worker capability from which we could simulate this,
       // for now we assert that we are _always_ on the primary process.
 
       if (!state.handle) {

--- a/runtime/subprocess_windows/src/process.rs
+++ b/runtime/subprocess_windows/src/process.rs
@@ -554,7 +554,7 @@ pub fn spawn(options: &SpawnOptions) -> Result<ChildProcess, std::io::Error> {
     // Inherit cwd
     #[allow(
       clippy::disallowed_methods,
-      reason = "use real, consider making with with a virtual cwd in future"
+      reason = "use real, consider making with a virtual cwd in future"
     )]
     let cwd = std::env::current_dir()?;
     WCString::new(cwd)


### PR DESCRIPTION
Fixes a duplicate word typo in `cli/tsc/dts/node/util.d.cts`.

**AI Disclosure**: This typo was identified using AI-assisted code review.