### PR TITLE
perf: startup profiling instrumentation + clap fast-path

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1965,6 +1965,44 @@ pub fn flags_from_vec_with_initial_cwd(
   } else {
     args
   };
+  // Fast path: `deno run <file> [script args...]` with no deno-level flags.
+  // Building the full clap command tree (clap_root) costs ~5.5ms cold /
+  // ~0.86ms warm at startup; for the overwhelmingly common bare-run case we
+  // skip it entirely. Any deno flag (anything starting with `-` before the
+  // script) falls through to the full parser, preserving exact behavior.
+  // Config-file discovery still happens downstream in CliOptions, so this only
+  // skips argument parsing, not resolution.
+  if args.len() >= 3
+    && args[1] == "run"
+    && args[2] != "-"
+    && args[2].as_encoded_bytes().first() != Some(&b'-')
+    && let Some(script) = args[2].to_str()
+  {
+    let argv = args[3..]
+      .iter()
+      .map(|a| a.to_string_lossy().into_owned())
+      .collect::<Vec<_>>();
+    let mut flags = Flags {
+      subcommand: DenoSubcommand::Run(RunFlags {
+        script: script.to_string(),
+        watch: None,
+        bare: false,
+        coverage_dir: None,
+        print_task_list: false,
+      }),
+      argv,
+      // `flags.code_cache_enabled = !matches.get_flag("no-code-cache")` in
+      // the full `run_parse`; without any flags before the script that
+      // resolves to `true`. Match it here so downstream code-cache checks
+      // behave identically.
+      code_cache_enabled: true,
+      ..Default::default()
+    };
+    // NODE_OPTIONS / DENO_COMPAT etc. are handled here too, matching the
+    // tail of `flags_from_vec` after clap parsing.
+    apply_node_options(&mut flags);
+    return Ok(flags);
+  }
   let mut app = clap_root();
   let mut matches =
     app

--- a/cli/examples/startup_bench.rs
+++ b/cli/examples/startup_bench.rs
@@ -1,0 +1,159 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Minimal startup-time microbenchmark.
+//!
+//! Boots a `MainWorker` with the real CLI snapshot, executes a trivial
+//! script, then tears it down. Intended for fast iteration on startup-perf
+//! work — rebuilds only this example binary, not the full `deno` CLI.
+//!
+//! Usage:
+//!   cargo run --example startup_bench --release -- [iters]
+//!
+//! Env vars:
+//!   DENO_STARTUP_PHASES=1   Print per-phase breakdown of one iteration
+//!                           (V8 init, isolate+snapshot, ops, bootstrap JS).
+//!   DENO_STARTUP_PROFILE=1  Skip the warmup so the first iter shows in profile.
+//!
+//! Tips for fast iteration:
+//!   - Add a release-fast profile (lto=off, codegen-units=256, incremental=true)
+//!     and pass `--profile release-fast`.
+//!   - Use mold/lld to cut link time.
+//!   - Combine with `hyperfine -w 3 ./target/release/examples/startup_bench`
+//!     when measuring without rebuilding.
+
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use deno_core::FsModuleLoader;
+use deno_core::ModuleCodeString;
+use deno_core::resolve_path;
+use deno_resolver::npm::DenoInNpmPackageChecker;
+use deno_resolver::npm::NpmResolver;
+use deno_runtime::deno_fs::RealFs;
+use deno_runtime::deno_permissions::Permissions;
+use deno_runtime::deno_permissions::PermissionsContainer;
+use deno_runtime::permissions::RuntimePermissionDescriptorParser;
+use deno_runtime::worker::MainWorker;
+use deno_runtime::worker::WorkerOptions;
+use deno_runtime::worker::WorkerServiceOptions;
+
+#[allow(clippy::disallowed_types, reason = "example binary")]
+type Sys = sys_traits::impls::RealSys;
+
+fn bootstrap_once() -> MainWorker {
+  // Microbenchmark only — no resolver context, this is the simplest way to
+  // get a `Url` to pass `bootstrap_from_options`.
+  #[allow(
+    clippy::disallowed_methods,
+    reason = "example binary, no `initial_cwd` to thread"
+  )]
+  let cwd = std::env::current_dir().unwrap();
+  let main_module = resolve_path("./startup_bench.js", &cwd).unwrap();
+  let fs = Arc::new(RealFs);
+  let permission_desc_parser =
+    Arc::new(RuntimePermissionDescriptorParser::new(Sys::default()));
+
+  let options = WorkerOptions {
+    startup_snapshot: deno_snapshots::CLI_SNAPSHOT,
+    residual_lazy_js_sources: deno_snapshots::RESIDUAL_LAZY_JS,
+    residual_lazy_esm_sources: deno_snapshots::RESIDUAL_LAZY_ESM,
+    ..Default::default()
+  };
+
+  MainWorker::bootstrap_from_options::<
+    DenoInNpmPackageChecker,
+    NpmResolver<Sys>,
+    Sys,
+  >(
+    &main_module,
+    WorkerServiceOptions {
+      deno_rt_native_addon_loader: None,
+      module_loader: Rc::new(FsModuleLoader),
+      permissions: PermissionsContainer::new(
+        permission_desc_parser,
+        Permissions::none_without_prompt(),
+      ),
+      blob_store: std::sync::Arc::new(
+        deno_runtime::deno_web::BlobStore::default(),
+      )
+        as std::sync::Arc<dyn deno_runtime::deno_web::BlobStoreTrait>,
+      broadcast_channel: Default::default(),
+      feature_checker: Default::default(),
+      node_services: Default::default(),
+      npm_process_state_provider: Default::default(),
+      root_cert_store_provider: Default::default(),
+      fetch_dns_resolver: Default::default(),
+      shared_array_buffer_store: Default::default(),
+      compiled_wasm_module_store: Default::default(),
+      v8_code_cache: Default::default(),
+      fs,
+      bundle_provider: None,
+    },
+    options,
+  )
+}
+
+fn one_iter() -> Duration {
+  let start = Instant::now();
+  let mut worker = bootstrap_once();
+  // Trivial script. The bulk of the cost is bootstrap + first JS run; the
+  // arithmetic itself is negligible and just keeps V8 honest.
+  worker
+    .execute_script("[startup_bench]", ModuleCodeString::from_static("1 + 1"))
+    .expect("execute_script failed");
+  let elapsed = start.elapsed();
+  // Explicit drop so teardown is *not* counted in the next iteration.
+  drop(worker);
+  elapsed
+}
+
+fn summarize(label: &str, samples: &mut [Duration]) {
+  samples.sort();
+  let n = samples.len();
+  let min = samples[0];
+  let p50 = samples[n / 2];
+  let p95 = samples[(n * 95) / 100];
+  let max = samples[n - 1];
+  let sum: Duration = samples.iter().sum();
+  let mean = sum / n as u32;
+  #[allow(clippy::print_stdout, reason = "example output")]
+  {
+    println!(
+      "{label:>10}  n={n:<3}  min={:>7.2?}  p50={:>7.2?}  mean={:>7.2?}  p95={:>7.2?}  max={:>7.2?}",
+      min, p50, mean, p95, max,
+    );
+  }
+}
+
+fn main() {
+  let iters: usize = std::env::args()
+    .nth(1)
+    .and_then(|s| s.parse().ok())
+    .unwrap_or(20);
+
+  // tokio current-thread runtime is required: MainWorker holds `!Send` state.
+  let rt = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .unwrap();
+
+  let _guard = rt.enter();
+
+  // First iteration pays V8 platform init + lazy globals. Run it but report
+  // it separately so it doesn't skew the steady-state numbers.
+  let warmup = one_iter();
+  #[allow(clippy::print_stdout, reason = "example output")]
+  {
+    println!(
+      "    warmup  n=1    {warmup:?}  (V8 platform init + first bootstrap)"
+    );
+  }
+
+  let mut samples = Vec::with_capacity(iters);
+  for _ in 0..iters {
+    samples.push(one_iter());
+  }
+  summarize("steady", &mut samples);
+}

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -692,13 +692,35 @@ fn maybe_setup_permission_broker() {
 }
 
 #[inline(always)]
+pub(crate) fn boot_phase(label: &str) {
+  use std::sync::OnceLock;
+  use std::time::Instant;
+  static START: OnceLock<Instant> = OnceLock::new();
+  static ENABLED: OnceLock<bool> = OnceLock::new();
+  let start = START.get_or_init(Instant::now);
+  #[allow(
+    clippy::disallowed_methods,
+    reason = "diagnostic env var; startup profiling only"
+  )]
+  let enabled =
+    *ENABLED.get_or_init(|| std::env::var_os("DENO_STARTUP_PHASES").is_some());
+  if enabled {
+    #[allow(clippy::print_stderr, reason = "diagnostic")]
+    {
+      eprintln!("[boot] {label:>28}  {:?}", start.elapsed());
+    }
+  }
+}
+
 pub fn main() {
+  boot_phase("main start");
   #[cfg(feature = "dhat-heap")]
   let profiler = dhat::Profiler::new_heap();
 
   setup_panic_hook();
 
   init_logging(None, None);
+  boot_phase("after panic+logging");
 
   util::unix::raise_fd_limit();
   util::windows::ensure_stdio_open();
@@ -714,9 +736,11 @@ pub fn main() {
 
   maybe_setup_permission_broker();
 
+  boot_phase("before aws_lc install");
   rustls::crypto::aws_lc_rs::default_provider()
     .install_default()
     .unwrap();
+  boot_phase("after aws_lc install");
 
   let args: Vec<_> = env::args_os().collect();
   let future = async move {
@@ -768,6 +792,7 @@ pub fn main() {
     if waited_unconfigured_runtime.is_none() {
       init_v8(&flags);
     }
+    boot_phase("after init_v8");
 
     (
       run_subcommand(flags, waited_unconfigured_runtime, roots).await,
@@ -799,12 +824,17 @@ async fn resolve_flags_and_init(
     deno_runtime::exit(0);
   }
 
+  boot_phase("before clap parse");
   let mut flags =
     match flags_from_vec_with_initial_cwd(args, initial_cwd.clone()) {
-      Ok(flags) => flags,
+      Ok(flags) => {
+        boot_phase("after clap parse");
+        flags
+      }
       Err(err @ clap::Error { .. })
         if err.kind() == clap::error::ErrorKind::DisplayVersion =>
       {
+        boot_phase("clap parse (version exit)");
         // Ignore results to avoid BrokenPipe errors.
         let _ = err.print();
         deno_runtime::exit(0);

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -178,12 +178,16 @@ pub async fn run_script(
 
   // TODO(bartlomieju): actually I think it will also fail if there's an import
   // map specified and bare specifier is used on the command line
+  crate::boot_phase("run_script start");
   let factory = CliFactory::from_flags(flags.clone());
   let cli_options = factory.cli_options()?;
+  crate::boot_phase("after cli_options");
   let deno_dir = factory.deno_dir()?;
   let http_client = factory.http_client_provider();
   let workspace_resolver = factory.workspace_resolver().await?;
+  crate::boot_phase("after workspace_resolver");
   let node_resolver = factory.node_resolver().await?;
+  crate::boot_phase("after node_resolver");
   // Run a background task that checks for available upgrades or output
   // if an earlier run of this background task found a new version of Deno.
   #[cfg(feature = "upgrade")]
@@ -208,6 +212,8 @@ pub async fn run_script(
 
   maybe_npm_install(&factory).await?;
 
+  crate::boot_phase("after resolve main_module");
+
   if let Some(exit_code) =
     try_run_npm_bin_executable(&factory, &flags, main_module).await?
   {
@@ -217,6 +223,7 @@ pub async fn run_script(
   let worker_factory = factory
     .create_cli_main_worker_factory_with_roots(roots)
     .await?;
+  crate::boot_phase("after worker_factory");
   let mut worker = worker_factory
     .create_main_worker_with_unconfigured_runtime(
       mode,
@@ -227,11 +234,13 @@ pub async fn run_script(
     )
     .await
     .inspect_err(|e| deno_telemetry::report_event("boot_failure", e))?;
+  crate::boot_phase("after create_main_worker");
 
   let exit_code = worker
     .run()
     .await
     .inspect_err(|e| deno_telemetry::report_event("uncaught_exception", e))?;
+  crate::boot_phase("after worker.run (exit)");
   Ok(exit_code)
 }
 

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -1032,21 +1032,6 @@ impl JsRuntime {
 
       // Get module map data from the snapshot
       if let Some(raw_data) = sidecar_data {
-        if startup_phases_enabled() {
-          let d = &raw_data.snapshot_data;
-          #[allow(clippy::print_stderr, reason = "diagnostic")]
-          {
-            eprintln!(
-              "[startup]   snapshot counts: context_data_items={} op_count={} source_count={} addl_refs={} external_strings={} ext_source_maps={}",
-              raw_data.data_count,
-              d.op_count,
-              d.source_count,
-              d.addl_refs_count,
-              d.external_strings.len(),
-              d.ext_source_maps.len(),
-            );
-          }
-        }
         let _p_ld = startup_phase_begin();
         snapshotted_data = Some(snapshot::load_snapshotted_data_from_snapshot(
           scope, context, raw_data,

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -15,15 +15,53 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::task::Context;
 use std::task::Poll;
 use std::task::Waker;
+use std::time::Instant;
 
 use deno_error::JsErrorBox;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::task::AtomicWaker;
 use smallvec::SmallVec;
+
+fn startup_phases_enabled() -> bool {
+  static ENABLED: OnceLock<bool> = OnceLock::new();
+  *ENABLED.get_or_init(|| {
+    // Diagnostic env var — only consulted once per process. Bypassing
+    // `sys_traits` here is intentional: the snapshot/runtime layers don't
+    // thread an `EnvProvider` through this code path, and this opt-in
+    // tracing is only useful when running an actual `deno` binary anyway.
+    #[allow(
+      clippy::disallowed_methods,
+      reason = "diagnostic env var; not part of the sys_traits surface"
+    )]
+    let v = std::env::var_os("DENO_STARTUP_PHASES");
+    v.is_some_and(|v| !v.is_empty() && v != "0")
+  })
+}
+
+#[inline]
+fn startup_phase_begin() -> Option<Instant> {
+  if startup_phases_enabled() {
+    Some(Instant::now())
+  } else {
+    None
+  }
+}
+
+#[inline]
+fn startup_phase_end(t: Option<Instant>, label: &str) {
+  if let Some(start) = t {
+    let elapsed = start.elapsed();
+    #[allow(clippy::print_stderr, reason = "diagnostic")]
+    {
+      eprintln!("[startup] {label:>32}  {elapsed:?}");
+    }
+  }
+}
 
 use super::SnapshotStoreDataStore;
 use super::SnapshottedData;
@@ -689,11 +727,13 @@ impl JsRuntime {
   /// Only constructor, configuration is done through `options`.
   /// Returns an error if the runtime cannot be initialized.
   pub fn try_new(mut options: RuntimeOptions) -> Result<JsRuntime, CoreError> {
+    let _t0 = startup_phase_begin();
     setup::init_v8(
       options.v8_platform.take(),
       cfg!(test),
       options.unsafe_expose_natives_and_gc(),
     );
+    startup_phase_end(_t0, "init_v8");
     JsRuntime::new_inner(options, false)
   }
 
@@ -735,6 +775,7 @@ impl JsRuntime {
     mut options: RuntimeOptions,
     will_snapshot: bool,
   ) -> Result<JsRuntime, CoreError> {
+    let _phase_total = startup_phase_begin();
     let init_mode = InitMode::from_options(&options);
     let mut extensions = std::mem::take(&mut options.extensions);
     let mut isolate_allocations = IsolateAllocations::default();
@@ -748,11 +789,13 @@ impl JsRuntime {
       options.maybe_op_stack_trace_callback.is_some();
 
     // First let's create an `OpState` and contribute to it from extensions...
+    let _phase = startup_phase_begin();
     let mut op_state = OpState::new(options.maybe_op_stack_trace_callback);
     let unrefed_ops = op_state.unrefed_ops.clone();
 
     let lazy_extensions =
       extension_set::setup_op_state(&mut op_state, &mut extensions);
+    startup_phase_end(_phase, "setup_op_state");
 
     // Load the sources and source maps
     let mut files_loaded = Vec::with_capacity(128);
@@ -762,12 +805,15 @@ impl JsRuntime {
 
     let mut source_mapper = SourceMapper::new(loader.clone());
 
+    let _phase = startup_phase_begin();
     let (maybe_startup_snapshot, mut sidecar_data) = options
       .startup_snapshot
       .take()
       .map(snapshot::deconstruct)
       .unzip();
+    startup_phase_end(_phase, "snapshot::deconstruct");
 
+    let _phase = startup_phase_begin();
     let mut sources = extension_set::into_sources_and_source_maps(
       options.extension_transpiler.as_deref(),
       &extensions,
@@ -777,6 +823,7 @@ impl JsRuntime {
         mark_as_loaded_from_fs_during_snapshot(&mut files_loaded, &source.code)
       },
     )?;
+    startup_phase_end(_phase, "into_sources_and_source_maps");
 
     for loaded_source in sources
       .js
@@ -905,12 +952,14 @@ impl JsRuntime {
     );
 
     let has_snapshot = maybe_startup_snapshot.is_some();
+    let _phase = startup_phase_begin();
     let mut isolate = setup::create_isolate(
       will_snapshot,
       options.create_params.take(),
       maybe_startup_snapshot,
       external_references.into(),
     );
+    startup_phase_end(_phase, "create_isolate (v8 snapshot deser)");
 
     let isolate_ptr = unsafe { isolate.as_raw_isolate_ptr() };
 
@@ -961,6 +1010,7 @@ impl JsRuntime {
     op_state.borrow_mut().put(spawner);
 
     // ...and with `ContextState` available we can set up V8 context...
+    let _phase = startup_phase_begin();
     let mut snapshotted_data = None;
     let main_context = {
       v8::scope!(let scope, &mut isolate);
@@ -971,22 +1021,42 @@ impl JsRuntime {
         .borrow_mut()
         .replace(v8::Global::new(scope, cppgc_template));
 
+      let _p_ctx = startup_phase_begin();
       let context = create_context(
         scope,
         &global_template_middleware,
         &global_object_middlewares,
         has_snapshot,
       );
+      startup_phase_end(_p_ctx, "  V8 Context::from_snapshot");
 
       // Get module map data from the snapshot
       if let Some(raw_data) = sidecar_data {
+        if startup_phases_enabled() {
+          let d = &raw_data.snapshot_data;
+          #[allow(clippy::print_stderr, reason = "diagnostic")]
+          {
+            eprintln!(
+              "[startup]   snapshot counts: context_data_items={} op_count={} source_count={} addl_refs={} external_strings={} ext_source_maps={}",
+              raw_data.data_count,
+              d.op_count,
+              d.source_count,
+              d.addl_refs_count,
+              d.external_strings.len(),
+              d.ext_source_maps.len(),
+            );
+          }
+        }
+        let _p_ld = startup_phase_begin();
         snapshotted_data = Some(snapshot::load_snapshotted_data_from_snapshot(
           scope, context, raw_data,
         ));
+        startup_phase_end(_p_ld, "  load_data loop (get_context_data x N)");
       }
 
       v8::Global::new(scope, context)
     };
+    startup_phase_end(_phase, "create_context+load_data");
 
     let main_realm = {
       v8::scope_with_context!(context_scope, &mut isolate, &main_context);
@@ -1001,6 +1071,7 @@ impl JsRuntime {
 
       // ...followed by creation of `Deno.core` namespace, as well as internal
       // infrastructure to provide JavaScript bindings for ops...
+      let _phase = startup_phase_begin();
       if init_mode == InitMode::New {
         bindings::initialize_deno_core_namespace(scope, context, init_mode);
         bindings::initialize_primordials_and_infra(scope)?;
@@ -1030,6 +1101,7 @@ impl JsRuntime {
           methods_ctx_offset,
         );
       }
+      startup_phase_end(_phase, "ops_bindings (fast call upgrade)");
 
       // SAFETY: Initialize the context state slot.
       unsafe {
@@ -1062,6 +1134,7 @@ impl JsRuntime {
         will_snapshot,
       ));
 
+      let _phase = startup_phase_begin();
       if let Some((snapshotted_data, mut data_store)) = snapshotted_data {
         *exception_state.js_handled_promise_rejection_cb.borrow_mut() =
           snapshotted_data
@@ -1092,6 +1165,7 @@ impl JsRuntime {
           mapper.add_ext_source_map(ModuleName::from_static(key), map.into());
         }
       }
+      startup_phase_end(_phase, "load module map from snapshot");
 
       if context_state.ext_import_meta_proto.borrow().is_none() {
         let null = v8::null(scope);
@@ -1168,19 +1242,25 @@ impl JsRuntime {
       //   }
       // ) {
       if init_mode == InitMode::New {
+        let _phase = startup_phase_begin();
         js_runtime
           .execute_virtual_ops_module(context_global, module_map.clone());
+        startup_phase_end(_phase, "execute_virtual_ops_module");
       }
 
       if init_mode == InitMode::New {
+        let _phase = startup_phase_begin();
         js_runtime.execute_builtin_sources(
           &realm,
           &module_map,
           &mut files_loaded,
         )?;
+        startup_phase_end(_phase, "execute_builtin_sources");
       }
 
+      let _phase = startup_phase_begin();
       js_runtime.store_js_callbacks(&realm, will_snapshot);
+      startup_phase_end(_phase, "store_js_callbacks");
 
       // Register residual `lazy_loaded_*` sources from the snapshot bundle.
       // These are the files that were declared on extensions but were not
@@ -1201,13 +1281,17 @@ impl JsRuntime {
         );
       }
 
+      let _phase = startup_phase_begin();
       js_runtime.init_extension_js(
         &realm,
         &module_map,
         sources,
         options.extension_code_cache,
       )?;
+      startup_phase_end(_phase, "init_extension_js");
     }
+
+    startup_phase_end(_phase_total, "TOTAL JsRuntime::new_inner");
 
     if will_snapshot {
       js_runtime.files_loaded_from_fs_during_snapshot = files_loaded;


### PR DESCRIPTION
Split out of #34450 (the lazy-load startup PR) per review feedback — both pieces are independent of the lazy-load work and reviewed more easily on their own.

### 1. Startup-phase profiling

Gated on `DENO_STARTUP_PHASES` (zero cost when unset). `boot_phase` markers in `cli/lib.rs` + `cli/tools/run/mod.rs` and `startup_phase_*` markers in `libs/core/runtime/jsruntime.rs` attribute the cold-start budget across spawn / V8-init / snapshot-deser / bootstrap / run. Adds a `cli/examples/startup_bench.rs` harness.

```
DENO_STARTUP_PHASES=1 deno run empty.js
```

### 2. clap fast-path for bare `deno run <file>`

When no deno-level flag precedes the script, skip building the full clap command tree (~5.5ms cold / ~0.7ms warm) and construct the `Run` flags directly. Any flag before the script (`-A`, `--allow-net`, …) falls back to the normal parser, so behavior is unchanged.

Profiling (warm, `run --no-remote`, forces full parser): `clap_root()` build ~0.23ms, `try_get_matches` parse ~0.48ms — the fast-path skips both.

Both were originally part of #34450; moved here so that PR stays focused on the lazy-load change.