### PR TITLE
docs: fix dead MDN link to Body interface

### DIFF
--- a/runtime/js/README.md
+++ b/runtime/js/README.md
@@ -30,7 +30,7 @@ Some Web APIs are using ops under the hood, eg. `console`, `performance`.
 - [fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch),
   [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request),
   [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response),
-  [Body](https://developer.mozilla.org/en-US/docs/Web/API/Body) and
+  [Body](https://developer.mozilla.org/en-US/docs/Web/API/Response/body) and
   [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers): modern
   Promise-based HTTP Request API.
 - [location](https://developer.mozilla.org/en-US/docs/Web/API/Window/location)


### PR DESCRIPTION
The `/Web/API/Body` MDN URL now 404s; the Body mixin was consolidated into the Response page. Point the link at `/Web/API/Response/body` (the Body property on Response) which is the canonical landing page for the Body mixin today.

Verified with HEAD requests: old URL returns 404, new URL returns 200.