### PR TITLE
fix(desktop): correct libdenort unpack path with non-executable extension

### DIFF
--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -341,10 +341,13 @@ impl<'a> DenoCompileBinaryWriter<'a> {
     };
     let temp_dir = tempfile::TempDir::new()?;
     let base_binary_path = archive::unpack_into_dir(archive::UnpackArgs {
-      exe_name: "denort",
+      exe_name: if target.contains("windows") {
+        "denort.exe"
+      } else {
+        "denort"
+      },
       archive_name: &binary_name,
       archive_data: &archive_data,
-      is_windows: target.contains("windows"),
       dest_path: temp_dir.path(),
     })?;
     let base_binary = read_file(&base_binary_path)?;
@@ -409,7 +412,6 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       exe_name: &lib_name,
       archive_name: &binary_name,
       archive_data: &archive_data,
-      is_windows: target.contains("windows"),
       dest_path: temp_dir.path(),
     })?;
     let base_binary = read_file(&base_binary_path)?;

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -1138,10 +1138,9 @@ pub async fn upgrade(
     );
 
     archive::unpack_into_dir(archive::UnpackArgs {
-      exe_name: "deno",
+      exe_name: if cfg!(windows) { "deno.exe" } else { "deno" },
       archive_name: &ARCHIVE_NAME,
       archive_data: &archive_data,
-      is_windows: cfg!(windows),
       dest_path: temp_dir.path(),
     })
     .context("failed to extract archive")?

--- a/cli/util/archive.rs
+++ b/cli/util/archive.rs
@@ -115,3 +115,68 @@ pub fn unpack_into_dir(args: UnpackArgs) -> Result<PathBuf, AnyError> {
   assert!(exe_path.exists());
   Ok(exe_path)
 }
+
+#[cfg(test)]
+mod tests {
+  use std::io::Write;
+
+  use super::*;
+
+  fn make_zip(file_name: &str, contents: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+    writer
+      .start_file(file_name, zip::write::SimpleFileOptions::default())
+      .unwrap();
+    writer.write_all(contents).unwrap();
+    writer.finish().unwrap();
+    buf
+  }
+
+  // The expected file name may carry a non-executable extension (e.g. a
+  // `.dylib`/`.so`/`.dll` library). Regression test for a panic where the
+  // extension was stripped and the unpacked file could not be found.
+  #[test]
+  fn unpacks_library_with_extension() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let data = make_zip("libdenort.dylib", b"fake dylib");
+    let path = unpack_into_dir(UnpackArgs {
+      exe_name: "libdenort.dylib",
+      archive_name: "libdenort-aarch64-apple-darwin.zip",
+      archive_data: &data,
+      dest_path: temp_dir.path(),
+    })
+    .unwrap();
+    assert_eq!(path, temp_dir.path().join("libdenort.dylib"));
+    assert_eq!(std::fs::read(&path).unwrap(), b"fake dylib");
+  }
+
+  #[test]
+  fn unpacks_executable_without_extension() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let data = make_zip("deno", b"fake exe");
+    let path = unpack_into_dir(UnpackArgs {
+      exe_name: "deno",
+      archive_name: "deno-aarch64-apple-darwin.zip",
+      archive_data: &data,
+      dest_path: temp_dir.path(),
+    })
+    .unwrap();
+    assert_eq!(path, temp_dir.path().join("deno"));
+    assert_eq!(std::fs::read(&path).unwrap(), b"fake exe");
+  }
+
+  #[test]
+  fn unpacks_executable_with_exe_extension() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let data = make_zip("deno.exe", b"fake exe");
+    let path = unpack_into_dir(UnpackArgs {
+      exe_name: "deno.exe",
+      archive_name: "deno-x86_64-pc-windows-msvc.zip",
+      archive_data: &data,
+      dest_path: temp_dir.path(),
+    })
+    .unwrap();
+    assert_eq!(path, temp_dir.path().join("deno.exe"));
+  }
+}

--- a/cli/util/archive.rs
+++ b/cli/util/archive.rs
@@ -72,10 +72,11 @@ fn unzip(
 }
 
 pub struct UnpackArgs<'a> {
+  /// The full file name of the file expected to be produced by unpacking the
+  /// archive (e.g. `deno`, `deno.exe`, `libdenort.dylib`).
   pub exe_name: &'a str,
   pub archive_name: &'a str,
   pub archive_data: &'a [u8],
-  pub is_windows: bool,
   pub dest_path: &'a Path,
 }
 
@@ -84,12 +85,10 @@ pub fn unpack_into_dir(args: UnpackArgs) -> Result<PathBuf, AnyError> {
     exe_name,
     archive_name,
     archive_data,
-    is_windows,
     dest_path,
   } = args;
-  let exe_ext = if is_windows { "exe" } else { "" };
   let archive_path = dest_path.join(exe_name).with_extension("zip");
-  let exe_path = dest_path.join(exe_name).with_extension(exe_ext);
+  let exe_path = dest_path.join(exe_name);
   assert!(!exe_path.exists());
 
   let archive_ext = Path::new(archive_name)


### PR DESCRIPTION
## Summary

`deno desktop` panics while unpacking the base runtime:

```
thread 'main' panicked at cli/util/archive.rs:116:3:
assertion failed: exe_path.exists()
```

`archive::unpack_into_dir` reconstructed the expected output file name from `exe_name` + `is_windows`, appending an *executable* extension (`""` on unix, `"exe"` on windows). The `deno desktop` path passes `libdenort.dylib`, so `dest.join("libdenort.dylib").with_extension("")` **strips** the `.dylib` and the function looks for a file named `libdenort` that never exists — even though the zip crate extracts `libdenort.dylib` correctly. That false negative triggers the shell `unzip` fallback (which prompts interactively for overwrite, hanging on non-TTY) and finally panics on `assert!(exe_path.exists())`.

## Fix

`UnpackArgs.exe_name` is now the **full** expected file name; the `is_windows`/extension-reconstruction logic is removed. Callers pass the complete name, matching the actual archive contents on every platform:

| archive | contains | `exe_name` |
|---|---|---|
| `deno-*-darwin.zip` | `deno` | `deno` |
| `deno-*-windows.zip` | `deno.exe` | `deno.exe` |
| `denort-*-windows.zip` | `denort.exe` | `denort.exe` |
| `libdenort-*-darwin.zip` | `libdenort.dylib` | `libdenort.dylib` |

The `deno`/`denort` paths are behavior-preserving (the old `with_extension("")`/`("exe")` round-tripped to the same names); only the dylib case is fixed. The fix also avoids the interactive `unzip` fallback entirely, since the zip crate now produces the expected path on the first try.