### PR TITLE
fix(ext/node): single source of truth for emulated Node version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,7 @@ version = "0.182.0"
 dependencies = [
  "deno_core",
  "deno_error",
+ "deno_node",
  "deno_permissions",
  "denort_helper",
  "libc",

--- a/ext/napi/Cargo.toml
+++ b/ext/napi/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 [dependencies]
 deno_core.workspace = true
 deno_error.workspace = true
+deno_node.workspace = true
 deno_permissions.workspace = true
 denort_helper.workspace = true
 libc.workspace = true

--- a/ext/napi/node_api.rs
+++ b/ext/napi/node_api.rs
@@ -615,10 +615,34 @@ fn napi_get_node_version(
   let env = check_env!(env);
   check_arg!(env, result);
 
+  // Derive major/minor/patch at compile time from `deno_node::NODE_VERSION`,
+  // the single source of truth for the emulated Node.js version, so the value
+  // reported to native addons via `napi_get_node_version()` stays in sync with
+  // `process.version` / `process.versions.node`.
+  const fn parse_part(part: usize) -> u32 {
+    let bytes = deno_node::NODE_VERSION.as_bytes();
+    let mut seen_dots = 0;
+    let mut value = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+      let b = bytes[i];
+      if b == b'.' {
+        seen_dots += 1;
+        if seen_dots > part {
+          break;
+        }
+      } else if seen_dots == part && b.is_ascii_digit() {
+        value = value * 10 + (b - b'0') as u32;
+      }
+      i += 1;
+    }
+    value
+  }
+
   const NODE_VERSION: napi_node_version = napi_node_version {
-    major: 20,
-    minor: 11,
-    patch: 1,
+    major: parse_part(0),
+    minor: parse_part(1),
+    patch: parse_part(2),
     release: c"Deno".as_ptr(),
   };
 

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -44,6 +44,15 @@ pub use ops::vm::VM_CONTEXT_INDEX;
 pub use ops::vm::create_v8_context;
 pub use ops::vm::init_global_template;
 
+/// The Node.js version that Deno emulates. This is the single source of truth
+/// for the value reported through `process.version` / `process.versions.node`:
+/// the `__NODE_VERSION__` token in `_process/process.ts` is substituted with it
+/// at snapshot build time (see `maybe_transpile_source` in
+/// `runtime/transpile.rs`). Rust consumers can read it directly.
+///
+/// When bumping the emulated Node version, change it here only.
+pub const NODE_VERSION: &str = "26.3.0";
+
 pub fn is_builtin_node_module(module_name: &str) -> bool {
   DenoIsBuiltInNodeModuleChecker.is_builtin_node_module(module_name)
 }

--- a/ext/node/polyfills/_process/process.ts
+++ b/ext/node/polyfills/_process/process.ts
@@ -200,12 +200,17 @@ const env:
 /**
  * https://nodejs.org/api/process.html#process_process_version
  *
- * This value is hard coded to latest stable release of Node, as
- * some packages are checking it for compatibility. Previously
- * it pointed to Deno version, but that led to incompability
- * with some packages.
+ * This value tracks a stable release of Node, as some packages are
+ * checking it for compatibility. Previously it pointed to Deno version,
+ * but that led to incompability with some packages.
+ *
+ * The `__NODE_VERSION__` token is substituted at snapshot build time with
+ * `NODE_VERSION` from `ext/node/lib.rs` (see `maybe_transpile_source` in
+ * `runtime/transpile.rs`), which is the single source of truth, so the
+ * reported version can never drift from it.
  */
-const version = "v26.3.0";
+const nodeVersion = "__NODE_VERSION__";
+const version = `v${nodeVersion}`;
 
 /**
  * https://nodejs.org/api/process.html#process_process_versions
@@ -216,7 +221,7 @@ const version = "v26.3.0";
  * with some packages. Value of `v8` field is still taken from `Deno.version`.
  */
 const versions = {
-  node: "26.3.0",
+  node: nodeVersion,
   uv: "1.52.1",
   zlib: "1.3.1-e00f703",
   brotli: "1.2.0",

--- a/runtime/transpile.rs
+++ b/runtime/transpile.rs
@@ -37,12 +37,36 @@ pub fn maybe_transpile_and_minify_source(
   maybe_transpile_source_inner(name, source, true)
 }
 
+/// The `node:process` polyfill carries a `__NODE_VERSION__` placeholder so the
+/// reported `process.version` / `process.versions.node` stays bound to the
+/// single source of truth in `deno_node::NODE_VERSION` instead of duplicating
+/// the literal. Substitute it here, at snapshot build time, so the value is
+/// baked into the snapshot and no runtime work is needed.
+fn maybe_substitute_node_version(
+  name: &str,
+  source: ModuleCodeString,
+) -> ModuleCodeString {
+  const TOKEN: &str = "__NODE_VERSION__";
+  if !name.ends_with("deno_node/_process/process.ts") {
+    return source;
+  }
+  debug_assert!(
+    source.as_str().contains(TOKEN),
+    "expected `{TOKEN}` placeholder in {name}"
+  );
+  source
+    .as_str()
+    .replace(TOKEN, deno_node::NODE_VERSION)
+    .into()
+}
+
 fn maybe_transpile_source_inner(
   name: ModuleName,
   source: ModuleCodeString,
   minify: bool,
 ) -> Result<(ModuleCodeString, Option<SourceMapData>), JsErrorBox> {
   let name_string = name.to_string();
+  let source = maybe_substitute_node_version(&name_string, source);
   // Always transpile `node:` built-in modules, since they might be TypeScript.
   let media_type = if name.starts_with("node:") {
     MediaType::TypeScript

--- a/tests/napi/general_test.js
+++ b/tests/napi/general_test.js
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { assert, assertEquals, loadTestLibrary } from "./common.js";
+import process from "node:process";
 
 const lib = loadTestLibrary();
 
@@ -27,8 +28,10 @@ Deno.test("napi run_script", function () {
 });
 
 Deno.test("napi get_node_version", function () {
-  const major = lib.test_get_node_version();
-  assert(major >= 1);
+  // napi_get_node_version() must report the same emulated Node version as
+  // process.versions.node (both derive from the single source of truth).
+  const version = lib.test_get_node_version();
+  assertEquals(version, process.versions.node);
 });
 
 Deno.test("napi get_last_error_info", function () {

--- a/tests/napi/src/general.rs
+++ b/tests/napi/src/general.rs
@@ -65,11 +65,17 @@ extern "C" fn test_get_node_version(
 
   assert!(!node_version.is_null());
   let ver = unsafe { &*node_version };
-  // Major version should be reasonable (>= 1)
-  assert!(ver.major >= 1);
 
+  // Return "major.minor.patch" so the test can assert it matches the emulated
+  // Node version reported through process.versions.node.
+  let version = format!("{}.{}.{}", ver.major, ver.minor, ver.patch);
   let mut result: napi_value = ptr::null_mut();
-  assert_napi_ok!(napi_create_uint32(env, ver.major, &mut result));
+  assert_napi_ok!(napi_create_string_utf8(
+    env,
+    version.as_ptr() as *const std::os::raw::c_char,
+    version.len(),
+    &mut result
+  ));
   result
 }
 


### PR DESCRIPTION
`process.version` / `process.versions.node` were hard coded as string
literals in the `node:process` polyfill, with no value the rest of the
runtime could reference, so the reported Node version had to be kept in sync
by hand whenever it was bumped.

This defines the emulated Node version once as `NODE_VERSION` in
`ext/node/lib.rs`, and has the polyfill carry a `__NODE_VERSION__` token that
is substituted with that constant at snapshot build time (in
`maybe_transpile_source`). The substitution runs for both the snapshot build
and any non-snapshot runtime, and `_process/process.ts` is a lazy-loaded
script that passes through the transpiler, so the baked value is correct
everywhere. Rust code can now read the same constant directly instead of
duplicating the literal, so the reported version can no longer drift.

`napi_get_node_version`, exposed to native addons through the Node-API C
ABI, previously returned a hard coded `20.11.1` that was unrelated to and far
behind the emulated version. It now derives its major/minor/patch from the
same `NODE_VERSION` constant at compile time, so addons calling it observe
the same version as `process.versions.node`. The napi test asserts the two
agree.
