### PR TITLE
refactor(cli): restrict DENO_UNSTABLE_CONTROL_SOCK to local transports

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -1022,7 +1022,6 @@ fn wait_for_start(
     use tokio::io::AsyncWrite;
     use tokio::io::AsyncWriteExt;
     use tokio::io::BufReader;
-    use tokio::net::TcpListener;
     use tokio::net::UnixSocket;
     #[cfg(any(
       target_os = "android",
@@ -1061,12 +1060,6 @@ fn wait_for_start(
       Box<dyn AsyncRead + Unpin>,
       Box<dyn AsyncWrite + Send + Unpin>,
     ) = match addr.split_once(':') {
-      Some(("tcp", addr)) => {
-        let listener = TcpListener::bind(addr).await?;
-        let (stream, _) = listener.accept().await?;
-        let (rx, tx) = stream.into_split();
-        (Box::new(rx), Box::new(tx))
-      }
       Some(("unix", path)) => {
         let socket = UnixSocket::new_stream()?;
         socket.bind(path)?;


### PR DESCRIPTION
The unstable control socket (`DENO_UNSTABLE_CONTROL_SOCK`) accepted a `tcp:`
address in addition to `unix:` and `vsock:`. The control socket is an
orchestration primitive meant for local, single-host coordination between a
supervisor and the Deno process it manages, so a network-facing TCP listener
isn't a transport it should expose.

This drops the `tcp:` arm in `wait_for_start` (and the now-unused
`TcpListener` import). A `tcp:` address now falls through to the existing
"invalid control sock" error rather than binding a TCP port. The `unix:` and
`vsock:` transports are unchanged, and all existing control-socket specs use
`unix:`, so nothing in the test suite relies on the removed form.