### PR TITLE
chore: deprecate no-op --unstable-node-globals flag

### DIFF
--- a/ext/node/ops/node_cli_parser.rs
+++ b/ext/node/ops/node_cli_parser.rs
@@ -231,7 +231,6 @@ mod tests {
       svec![
         "run",
         "-A",
-        "--unstable-node-globals",
         "--unstable-bare-node-builtins",
         "--unstable-detect-cjs",
         "script.js"

--- a/libs/node_shim/lib.rs
+++ b/libs/node_shim/lib.rs
@@ -3143,8 +3143,8 @@ pub struct TranslateOptions {
   /// Use "deno node" as base command (for standalone CLI)
   /// When false, uses "deno run" (for child_process spawning)
   pub use_node_subcommand: bool,
-  /// Add unstable Node.js compat flags (--unstable-node-globals,
-  /// --unstable-bare-node-builtins, --unstable-detect-cjs)
+  /// Add unstable Node.js compat flags (--unstable-bare-node-builtins,
+  /// --unstable-detect-cjs)
   pub add_unstable_flags: bool,
   /// Add standalone config overrides (--node-modules-dir=manual, --no-config)
   /// Only appropriate for the standalone node shim CLI, not for child processes
@@ -3361,7 +3361,6 @@ pub fn translate_to_deno_args(
     // Note: deno eval has implicit permissions, so we don't add -A
 
     if options.add_unstable_flags {
-      deno_args.push("--unstable-node-globals".to_string());
       deno_args.push("--unstable-bare-node-builtins".to_string());
       deno_args.push("--unstable-detect-cjs".to_string());
     }
@@ -3441,7 +3440,6 @@ pub fn translate_to_deno_args(
     deno_args.push("-A".to_string());
 
     if options.add_unstable_flags {
-      deno_args.push("--unstable-node-globals".to_string());
       deno_args.push("--unstable-bare-node-builtins".to_string());
       deno_args.push("--unstable-detect-cjs".to_string());
     }
@@ -3488,7 +3486,6 @@ pub fn translate_to_deno_args(
   deno_args.push("-A".to_string());
 
   if options.add_unstable_flags {
-    deno_args.push("--unstable-node-globals".to_string());
     deno_args.push("--unstable-bare-node-builtins".to_string());
     deno_args.push("--unstable-detect-cjs".to_string());
   }
@@ -5123,7 +5120,6 @@ mod tests {
       "node",
       "run",
       "-A",
-      "--unstable-node-globals",
       "--unstable-bare-node-builtins",
       "--unstable-detect-cjs",
       "--node-modules-dir=manual",

--- a/runtime/features/data.rs
+++ b/runtime/features/data.rs
@@ -109,9 +109,11 @@ pub static FEATURE_DESCRIPTIONS: &[UnstableFeatureDescription] = &[
     env_var: None,
   },
   UnstableFeatureDescription {
+    // Deprecated: Node.js `setTimeout`/`setInterval` globals are now the
+    // default, so this flag is a no-op kept only for backwards compatibility.
     name: "node-globals",
-    help_text: "Prefer Node.js globals over Deno globals - currently this refers to `setTimeout` and `setInterval` APIs.",
-    show_in_help: true,
+    help_text: "Deprecated. Node.js `setTimeout` and `setInterval` globals are now always enabled, so this flag has no effect.",
+    show_in_help: false,
     kind: UnstableFeatureKind::Runtime,
     env_var: None,
   },

--- a/runtime/features/gen.rs
+++ b/runtime/features/gen.rs
@@ -122,8 +122,8 @@ pub static UNSTABLE_FEATURES: &[UnstableFeatureDefinition] = &[
   UnstableFeatureDefinition {
     name: "node-globals",
     flag_name: "unstable-node-globals",
-    help_text: "Prefer Node.js globals over Deno globals - currently this refers to `setTimeout` and `setInterval` APIs.",
-    show_in_help: true,
+    help_text: "Deprecated. Node.js `setTimeout` and `setInterval` globals are now always enabled, so this flag has no effect.",
+    show_in_help: false,
     id: 14,
     kind: UnstableFeatureKind::Runtime,
   },

--- a/runtime/js/98_global_scope_shared.js
+++ b/runtime/js/98_global_scope_shared.js
@@ -496,12 +496,6 @@ unstableForWindowOrWorkerGlobalScope[unstableIds.net] = {
   ),
 };
 
-unstableForWindowOrWorkerGlobalScope[unstableIds.nodeGlobals] = {
-  clearInterval: core.propWritable(nodeClearInterval),
-  clearTimeout: core.propWritable(nodeClearTimeout),
-  setInterval: core.propWritable(nodeSetInterval),
-  setTimeout: core.propWritable(nodeSetTimeout),
-};
 unstableForWindowOrWorkerGlobalScope[unstableIds.webgpu] = {};
 
 export { unstableForWindowOrWorkerGlobalScope, windowOrWorkerGlobalScope };


### PR DESCRIPTION
Node.js `setTimeout`, `setInterval`, `clearTimeout`, and `clearInterval`
globals became the default in #33249, so the `node-globals` unstable
feature now only re-installs the exact same functions that are already
present on the global scope. Enabling it does nothing, which makes the
`--unstable-node-globals` flag a no-op.

This hides the flag from `--help`, removes the dead runtime block that
re-installed the node timers, and stops the Node-compat argument
translator from emitting the redundant flag. The feature entry itself is
kept so existing callers passing `--unstable-node-globals` (or running
with `DENO_COMPAT=1`) continue to parse without erroring.