### PR TITLE
docs: update Chocolatey install link to community.chocolatey.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ irm https://deno.land/install.ps1 | iex
 brew install deno
 ```
 
-[Chocolatey](https://chocolatey.org/packages/deno) (Windows):
+[Chocolatey](https://community.chocolatey.org/packages/deno) (Windows):
 
 ```powershell
 choco install deno


### PR DESCRIPTION
## Summary

`README.md` links to `https://chocolatey.org/packages/deno` for the Windows install instructions. The Chocolatey project moved to a new domain — the old URL now 301 redirects to `https://community.chocolatey.org/packages/deno`, which is the new canonical host.

## Fix

```diff
-[Chocolatey](https://chocolatey.org/packages/deno) (Windows):
+[Chocolatey](https://community.chocolatey.org/packages/deno) (Windows):
```

## Verification

- Old URL: 301 → new URL (200).
- New URL: 200 directly.

No code changes.