### PR TITLE
fix(npm): slim cached full packument when minimumDependencyAge is set

### DIFF
--- a/libs/npm_cache/registry_info.rs
+++ b/libs/npm_cache/registry_info.rs
@@ -296,10 +296,26 @@ impl<THttpClient: NpmCacheHttpClient, TSys: NpmCacheSys>
         },
         NpmCacheHttpClientResponse::NotFound => Ok(FutureResult::PackageNotExists),
         NpmCacheHttpClientResponse::Bytes(response) => {
+          let packument_format = downloader.packument_format;
           let future_result = spawn_blocking(
             move || -> Result<FutureResult, JsErrorBox> {
               let mut package_info: SerializedCachedPackageInfo = serde_json::from_slice(&response.bytes).map_err(JsErrorBox::from_err)?;
               package_info.etag = response.etag;
+              if packument_format == NpmPackumentFormat::Full {
+                // The full packument is only requested because the abbreviated
+                // install manifest omits the `time` field needed by
+                // `minimumDependencyAge`. The full format additionally carries a
+                // complete `scripts` map for every version, which for frequently
+                // published packages can balloon the cached `registry.json` to
+                // hundreds of megabytes and spike RSS when it's reparsed on every
+                // run. Reduce each version to the abbreviated shape (drop
+                // `scripts`, keep a `hasInstallScript` flag) so only the `time`
+                // field is retained on top of what the abbreviated format would
+                // have stored. The installer reads the real scripts from the
+                // extracted package.json, exactly as it does for the abbreviated
+                // format.
+                slim_full_packument(&mut package_info.info);
+              }
               match downloader.cache.save_package_info(&name, &package_info) {
                 Ok(()) => {
                   Ok(FutureResult::SavedFsCache(Arc::new(package_info.info)))
@@ -340,6 +356,29 @@ impl<THttpClient: NpmCacheHttpClient, TSys: NpmCacheSys>
     } else {
       false
     }
+  }
+}
+
+/// Reduces a full packument to the same shape as the abbreviated install
+/// manifest, keeping only the additional `time` field that the abbreviated
+/// format omits. For every version this drops the `scripts` map (replacing it
+/// with a `hasInstallScript` flag derived from the install lifecycle scripts),
+/// matching what the npm registry returns for the abbreviated format. This
+/// keeps the cached `registry.json` small for packages with many versions while
+/// still providing the publish dates needed by `minimumDependencyAge`.
+fn slim_full_packument(info: &mut NpmPackageInfo) {
+  for version in info.versions.values_mut() {
+    if version.scripts.is_empty() {
+      continue;
+    }
+    if version.has_install_script.is_none() {
+      version.has_install_script = Some(
+        version.scripts.contains_key("preinstall")
+          || version.scripts.contains_key("install")
+          || version.scripts.contains_key("postinstall"),
+      );
+    }
+    version.scripts.clear();
   }
 }
 

--- a/tests/registry/npm/@denotest/scripts-with-publish-date/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/scripts-with-publish-date/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = "scripts-with-publish-date";

--- a/tests/registry/npm/@denotest/scripts-with-publish-date/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/scripts-with-publish-date/1.0.0/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@denotest/scripts-with-publish-date",
+  "version": "1.0.0",
+  "main": "index.js",
+  "publishDate": "2020-01-01T00:00:00.000Z",
+  "scripts": {
+    "postinstall": "echo postinstall",
+    "build": "echo build"
+  }
+}

--- a/tests/specs/install/minimum_dependency_age_slim_packument/__test__.jsonc
+++ b/tests/specs/install/minimum_dependency_age_slim_packument/__test__.jsonc
@@ -1,0 +1,20 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_DIR": "$PWD/deno_dir"
+  },
+  "steps": [
+    {
+      // minimumDependencyAge forces the full packument to be requested, since
+      // the abbreviated install manifest omits the `time` field. The full
+      // packument carries a `scripts` map for every version, which should be
+      // stripped before it is cached so the cached registry.json stays small.
+      "args": "install npm:@denotest/scripts-with-publish-date",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "run -A check.ts",
+      "output": "check.out"
+    }
+  ]
+}

--- a/tests/specs/install/minimum_dependency_age_slim_packument/check.out
+++ b/tests/specs/install/minimum_dependency_age_slim_packument/check.out
@@ -1,0 +1,3 @@
+has time field: true
+has scripts: false
+hasInstallScript: true

--- a/tests/specs/install/minimum_dependency_age_slim_packument/check.ts
+++ b/tests/specs/install/minimum_dependency_age_slim_packument/check.ts
@@ -1,0 +1,15 @@
+// Verifies that the cached full packument was slimmed down before being
+// written to disk: the `time` field (needed by minimumDependencyAge) is kept,
+// while the per-version `scripts` map is dropped in favor of a
+// `hasInstallScript` flag, matching the abbreviated install manifest shape.
+const registryJson = JSON.parse(
+  Deno.readTextFileSync(
+    "deno_dir/npm/localhost_4260/@denotest/scripts-with-publish-date/registry.json",
+  ),
+);
+
+const version = registryJson.versions["1.0.0"];
+
+console.log("has time field:", "time" in registryJson);
+console.log("has scripts:", "scripts" in version);
+console.log("hasInstallScript:", version.hasInstallScript);

--- a/tests/specs/install/minimum_dependency_age_slim_packument/deno.json
+++ b/tests/specs/install/minimum_dependency_age_slim_packument/deno.json
@@ -1,0 +1,3 @@
+{
+  "minimumDependencyAge": "2025-01-01T00:00:00.000Z"
+}


### PR DESCRIPTION
Setting `minimumDependencyAge` in `deno.json` forces Deno to request the
full npm packument instead of the abbreviated install manifest, because
the age check needs each version's publish date (the `time` field) and
the abbreviated format omits it. The full packument also carries a
complete `scripts` map for every published version. For packages that
publish very frequently (the reporter hit this with `drizzle-orm`) that
inflates the cached `registry.json` to around 100MB, and because that
file is re-read and deserialized on every `deno run` (not just on
install), parsing it spikes resident memory to roughly 900MB. With the
setting off the same app sits around 80MB. In memory-constrained
environments like a container with a 512MB limit this is enough to
OOM-crash the process on boot.

This slims the full packument down to the abbreviated shape before it is
written to the cache: for each version the `scripts` map is dropped and
replaced with a `hasInstallScript` flag derived from the install
lifecycle scripts (`preinstall`/`install`/`postinstall`), while the
`time` field is kept. That is exactly the representation the registry
returns for the abbreviated format, so the only thing the cache now
retains beyond a normal abbreviated packument is the `time` field that
`minimumDependencyAge` actually needs.

The change is safe because it makes a full-format cache behave the same
as an abbreviated-format cache, which is already the default. Resolution
only uses versions, dependencies and dist info, none of which are
touched. The installer reads real lifecycle scripts from the extracted
package's `package.json` (`get_package_extra_info` /
`fetch_from_package_json`), falling back to a registry refetch only for
the deprecated string, a missing `bin`, or a `binding.gyp` `node-gyp`
case, which is identical to how the abbreviated format already works.
`has_scripts` is computed from either `hasInstallScript` or the presence
of install scripts in the map, so detection is preserved.

A spec test adds a registry package that has both a `publishDate` and a
`scripts` section, installs it with `minimumDependencyAge` set, and
asserts that the cached `registry.json` keeps the `time` field, drops the
per-version `scripts` map, and records `hasInstallScript`.

Fixes #35281