### PR TITLE
refactor(runtime): allow disabling the OffscreenCanvas global via env var

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1281,6 +1281,15 @@ impl CliFactory {
       maybe_initial_cwd: Some(deno_path_util::url_from_directory_path(
         cli_options.initial_cwd(),
       )?),
+      // Deno 2.8 exposes an `OffscreenCanvas` global whose 2D context is
+      // unimplemented (`getContext("2d")` returns null). Libraries that
+      // feature-detect on the global's presence then crash. Setting this
+      // removes the global, restoring the pre-2.8 fallback path. Truthy
+      // values are `1` and `true`.
+      disable_offscreen_canvas: matches!(
+        std::env::var("DENO_DISABLE_OFFSCREEN_CANVAS").as_deref(),
+        Ok("1") | Ok("true")
+      ),
     })
   }
 

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -277,6 +277,8 @@ pub struct LibMainWorkerOptions {
   pub serve_host: Option<String>,
   pub close_on_idle: bool,
   pub maybe_initial_cwd: Option<Url>,
+  /// When true, the `OffscreenCanvas` global is removed at bootstrap.
+  pub disable_offscreen_canvas: bool,
 }
 
 #[derive(Default, Clone)]
@@ -474,6 +476,7 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
           otel_config: shared.options.otel_config.clone(),
           no_legacy_abort: shared.options.no_legacy_abort,
           close_on_idle: args.close_on_idle,
+          disable_offscreen_canvas: shared.options.disable_offscreen_canvas,
         },
         extensions: vec![],
         startup_snapshot: shared.options.startup_snapshot,
@@ -717,6 +720,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
         serve_host: shared.options.serve_host.clone(),
         otel_config: shared.options.otel_config.clone(),
         close_on_idle: shared.options.close_on_idle,
+        disable_offscreen_canvas: shared.options.disable_offscreen_canvas,
       },
       extensions: custom_extensions,
       startup_snapshot: shared.options.startup_snapshot,

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -1575,6 +1575,10 @@ pub async fn run_with_options(
     enable_raw_imports: metadata.unstable_config.raw_imports,
     close_on_idle: !options.auto_serve,
     maybe_initial_cwd: None,
+    disable_offscreen_canvas: matches!(
+      std::env::var("DENO_DISABLE_OFFSCREEN_CANVAS").as_deref(),
+      Ok("1") | Ok("true")
+    ),
   };
   let worker_factory = LibMainWorkerFactory::new(
     blob_store,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -834,6 +834,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
       16: autoServe,
       17: nodeClusterUniqueId,
       18: nodeClusterSchedPolicy,
+      19: disableOffscreenCanvas,
     } = runtimeOptions;
 
     denoNs.build.standalone = standalone;
@@ -950,6 +951,9 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
       close: core.propWritable(windowClose),
       closed: core.propGetterOnly(() => windowIsClosing),
     });
+    if (disableOffscreenCanvas) {
+      delete globalThis.OffscreenCanvas;
+    }
     exposeUnstableFeaturesForWindowOrWorkerGlobalScope(unstableFeatures);
     ObjectSetPrototypeOf(globalThis, Window.prototype);
 
@@ -1050,6 +1054,7 @@ function bootstrapWorkerRuntime(
       15: standalone,
       17: nodeClusterUniqueId,
       18: nodeClusterSchedPolicy,
+      19: disableOffscreenCanvas,
     } = runtimeOptions;
 
     denoNs.build.standalone = standalone;
@@ -1080,6 +1085,9 @@ function bootstrapWorkerRuntime(
       close: core.propNonEnumerable(workerClose),
       postMessage: core.propWritable(postMessage),
     });
+    if (disableOffscreenCanvas) {
+      delete globalThis.OffscreenCanvas;
+    }
     if (enableTestingFeaturesFlag) {
       ObjectDefineProperty(
         globalThis,

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -120,6 +120,8 @@ pub struct BootstrapOptions {
   pub auto_serve: bool,
   pub otel_config: OtelConfig,
   pub close_on_idle: bool,
+  /// When true, the `OffscreenCanvas` global is removed at bootstrap.
+  pub disable_offscreen_canvas: bool,
 }
 
 impl Default for BootstrapOptions {
@@ -159,6 +161,7 @@ impl Default for BootstrapOptions {
       serve_host: Default::default(),
       otel_config: Default::default(),
       close_on_idle: false,
+      disable_offscreen_canvas: false,
     }
   }
 }
@@ -212,6 +215,8 @@ struct BootstrapV8<'a>(
   Option<&'a str>,
   // node cluster scheduling policy (NODE_CLUSTER_SCHED_POLICY)
   Option<&'a str>,
+  // disable offscreen canvas
+  bool,
 );
 
 impl BootstrapOptions {
@@ -247,6 +252,7 @@ impl BootstrapOptions {
       self.auto_serve,
       self.node_cluster_unique_id.as_deref(),
       self.node_cluster_sched_policy.as_deref(),
+      self.disable_offscreen_canvas,
     );
 
     bootstrap.serialize(ser).unwrap()

--- a/tests/specs/run/offscreen_canvas_disable/__test__.jsonc
+++ b/tests/specs/run/offscreen_canvas_disable/__test__.jsonc
@@ -1,0 +1,27 @@
+{
+  "tests": {
+    // By default the `OffscreenCanvas` global is present (upstream 2.8
+    // behavior).
+    "offscreen_canvas_present_by_default": {
+      "args": "run main.js",
+      "output": "present.out"
+    },
+    // DENO_DISABLE_OFFSCREEN_CANVAS removes the global, restoring the
+    // pre-2.8 fallback path for libraries that feature-detect on it.
+    "env_removes_offscreen_canvas": {
+      "args": "run main.js",
+      "envs": {
+        "DENO_DISABLE_OFFSCREEN_CANVAS": "1"
+      },
+      "output": "absent.out"
+    },
+    // `true` is also accepted as a truthy value.
+    "env_true_removes_offscreen_canvas": {
+      "args": "run main.js",
+      "envs": {
+        "DENO_DISABLE_OFFSCREEN_CANVAS": "true"
+      },
+      "output": "absent.out"
+    }
+  }
+}

--- a/tests/specs/run/offscreen_canvas_disable/absent.out
+++ b/tests/specs/run/offscreen_canvas_disable/absent.out
@@ -1,0 +1,1 @@
+undefined

--- a/tests/specs/run/offscreen_canvas_disable/main.js
+++ b/tests/specs/run/offscreen_canvas_disable/main.js
@@ -1,0 +1,1 @@
+console.log(typeof globalThis.OffscreenCanvas);

--- a/tests/specs/run/offscreen_canvas_disable/present.out
+++ b/tests/specs/run/offscreen_canvas_disable/present.out
@@ -1,0 +1,1 @@
+function


### PR DESCRIPTION
Deno 2.8 exposes an `OffscreenCanvas` global whose 2D context is
unimplemented (`getContext("2d")` returns null). Libraries that
feature-detect on the global's presence and then assume a usable 2D
context crash; for example canvas-confetti does this at module init,
taking down servers that transitively import it.

This adds a `DENO_DISABLE_OFFSCREEN_CANVAS` environment variable (truthy
values `1` and `true`) that removes the `OffscreenCanvas` global at
runtime bootstrap, restoring the pre-2.8 fallback path those libraries
expect. It defaults off, so the stock behavior is unchanged, and it is
threaded through both the main worker and web worker bootstrap so the
two stay consistent. A spec test covers the global being present by
default and absent under both truthy values.