### PR TITLE
refactor(resolver): allow disabling verbatimModuleSyntax via env var

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1338,6 +1338,14 @@ impl CliFactory {
             ),
             source_map_base: None,
             preserve_jsx: false,
+            // Untyped execution environments (e.g. isolates running with
+            // --no-check) can opt out of verbatimModuleSyntax, which
+            // otherwise leaves dangling type-only re-exports that crash at
+            // runtime. Truthy values are `1` and `true`.
+            force_disable_verbatim_module_syntax: matches!(
+              std::env::var("DENO_DISABLE_VERBATIM_MODULE_SYNTAX").as_deref(),
+              Ok("1") | Ok("true")
+            ),
           },
           is_cjs_resolution_mode: if options.is_node_main()
             || options.unstable_detect_cjs()

--- a/libs/resolver/deno_json.rs
+++ b/libs/resolver/deno_json.rs
@@ -526,6 +526,17 @@ pub struct CompilerOptionsOverrides {
   ///
   /// This may be useful when bundling.
   pub preserve_jsx: bool,
+  /// Ignore the user's `verbatimModuleSyntax` and transpile as if it were
+  /// off.
+  ///
+  /// Untyped execution environments (e.g. isolates that run with
+  /// `--no-check`) cannot honor verbatim semantics safely: a type-only
+  /// import that is re-exported without the `type` modifier
+  /// (`import { type X }` + `export { X }`) is left as a dangling value
+  /// export and crashes at runtime. Falling back to heuristic import
+  /// elision matches the `deno compile` runtime, which forces verbatim
+  /// off too.
+  pub force_disable_verbatim_module_syntax: bool,
 }
 
 #[derive(Debug)]
@@ -1810,7 +1821,9 @@ fn compiler_options_to_transpile_and_emit_options(
     imports_not_used_as_values,
     jsx,
     var_decl_imports: false,
-    verbatim_module_syntax: options.verbatim_module_syntax,
+    // See `CompilerOptionsOverrides::force_disable_verbatim_module_syntax`.
+    verbatim_module_syntax: options.verbatim_module_syntax
+      && !overrides.force_disable_verbatim_module_syntax,
   };
   let emit = deno_ast::EmitOptions {
     inline_sources: options.inline_sources,

--- a/tests/specs/run/verbatim_module_syntax_type_reexport/__test__.jsonc
+++ b/tests/specs/run/verbatim_module_syntax_type_reexport/__test__.jsonc
@@ -1,0 +1,20 @@
+{
+  "tests": {
+    // With verbatimModuleSyntax honored, the dangling `export { Foo }`
+    // crashes at runtime with a SyntaxError (the regression).
+    "verbatim_dangling_reexport_crashes": {
+      "args": "run -A --no-check main.ts",
+      "output": "crash.out",
+      "exitCode": 1
+    },
+    // DENO_DISABLE_VERBATIM_MODULE_SYNTAX makes the emit path ignore
+    // verbatimModuleSyntax, eliding the dangling type-only re-export.
+    "env_disables_verbatim_and_runs": {
+      "args": "run -A --no-check main.ts",
+      "envs": {
+        "DENO_DISABLE_VERBATIM_MODULE_SYNTAX": "1"
+      },
+      "output": "ok.out"
+    }
+  }
+}

--- a/tests/specs/run/verbatim_module_syntax_type_reexport/crash.out
+++ b/tests/specs/run/verbatim_module_syntax_type_reexport/crash.out
@@ -1,0 +1,1 @@
+[WILDCARD]SyntaxError: Export 'Foo' is not defined in module[WILDCARD]

--- a/tests/specs/run/verbatim_module_syntax_type_reexport/deno.json
+++ b/tests/specs/run/verbatim_module_syntax_type_reexport/deno.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "verbatimModuleSyntax": true
+  }
+}

--- a/tests/specs/run/verbatim_module_syntax_type_reexport/fs.ts
+++ b/tests/specs/run/verbatim_module_syntax_type_reexport/fs.ts
@@ -1,0 +1,6 @@
+// `Foo` is imported type-only and then re-exported without the `type`
+// modifier. Under verbatimModuleSyntax the type-only import is elided but
+// the `export { Foo }` is kept as a value export, leaving it dangling.
+import { type Foo } from "./types.ts";
+export { Foo };
+export const value = 1;

--- a/tests/specs/run/verbatim_module_syntax_type_reexport/main.ts
+++ b/tests/specs/run/verbatim_module_syntax_type_reexport/main.ts
@@ -1,0 +1,2 @@
+import { value } from "./fs.ts";
+console.log("loaded ok:", value);

--- a/tests/specs/run/verbatim_module_syntax_type_reexport/ok.out
+++ b/tests/specs/run/verbatim_module_syntax_type_reexport/ok.out
@@ -1,0 +1,1 @@
+loaded ok: 1

--- a/tests/specs/run/verbatim_module_syntax_type_reexport/types.ts
+++ b/tests/specs/run/verbatim_module_syntax_type_reexport/types.ts
@@ -1,0 +1,3 @@
+export interface Foo {
+  x: number;
+}


### PR DESCRIPTION
This adds a `force_disable_verbatim_module_syntax` compiler-options
override, set from the `DENO_DISABLE_VERBATIM_MODULE_SYNTAX` environment
variable (truthy values `1` and `true`) when the resolver factory is
built. When enabled, the emit path ignores
`compilerOptions.verbatimModuleSyntax` and transpiles as if it were off.

Untyped execution environments that run with `--no-check` cannot honor
verbatim semantics safely: a type-only import that is re-exported
without the `type` modifier (`import { type X }` followed by
`export { X }`) is left as a dangling value export and crashes at
runtime with "Export 'X' is not defined in module". Falling back to
heuristic import elision matches the `deno compile` runtime, which
forces verbatim off too.

Defaults off, so the stock behavior is unchanged. A spec test covers
both the dangling-reexport crash with verbatim honored and the
successful run with the env var set.