### PR TITLE
fix(ext/node): don't apply requestTimeout to active streaming responses

### DIFF
--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -251,6 +251,15 @@ class ConnectionsList {
         }
       }
       if (requestTimeout > 0 && elapsed >= requestTimeout) {
+        // requestTimeout only covers receiving the entire request from the
+        // client. Once the full request message has been parsed off the wire
+        // (req.complete is set in parserOnMessageComplete), the clock stops,
+        // mirroring Node resetting last_message_start_ in on_message_complete.
+        // Without this an actively streaming response (SSE/proxy) gets aborted
+        // at requestTimeout even though the request was long since received.
+        if (entry.req?.complete) {
+          continue;
+        }
         ArrayPrototypePush(result, { socket });
       }
     }

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4970,6 +4970,7 @@
     "parallel/test-http-server-request-timeout-delayed-body.js": {},
     "parallel/test-http-server-request-timeout-delayed-headers.js": {},
     "parallel/test-http-server-request-timeout-interrupted-body.js": {},
+    "parallel/test-http-server-request-timeout-keepalive.js": {},
     "parallel/test-http-server-request-timeout-pipelining.js": {},
     "parallel/test-http-set-timeout-server.js": {},
     "parallel/test-http-timeout-client-warning.js": {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4970,7 +4970,6 @@
     "parallel/test-http-server-request-timeout-delayed-body.js": {},
     "parallel/test-http-server-request-timeout-delayed-headers.js": {},
     "parallel/test-http-server-request-timeout-interrupted-body.js": {},
-    "parallel/test-http-server-request-timeout-keepalive.js": {},
     "parallel/test-http-server-request-timeout-pipelining.js": {},
     "parallel/test-http-set-timeout-server.js": {},
     "parallel/test-http-timeout-client-warning.js": {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -3143,6 +3143,68 @@ Deno.test(
   },
 );
 
+// Regression test: requestTimeout only covers receiving the full request from
+// the client, not the response lifetime. A response that streams for longer
+// than requestTimeout (SSE/proxy) must not be aborted, mirroring Node which
+// stops the requestTimeout clock once the request message is fully received.
+// Previously the ConnectionsList watchdog kept firing requestTimeout against
+// the active entry until the response finished, killing long-lived streams.
+// https://github.com/denoland/deno/issues/35289
+Deno.test(
+  "[node/http] streaming response does not trigger spurious requestTimeout",
+  async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+    const writeCount = 20;
+    const writeInterval = 50;
+    // requestTimeout is far shorter than the total streaming duration
+    // (20 * 50ms = ~1s) so the bug would abort the response mid-stream.
+    const server = http.createServer({
+      requestTimeout: 300,
+      connectionsCheckingInterval: 50,
+    }, (_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      let n = 0;
+      const interval = setInterval(() => {
+        n++;
+        res.write(`chunk ${n}\n`);
+        if (n === writeCount) {
+          clearInterval(interval);
+          res.end("done\n");
+        }
+      }, writeInterval);
+      res.on("close", () => clearInterval(interval));
+    });
+
+    server.on("clientError", (err: Error & { code?: string }) => {
+      reject(new Error(`unexpected clientError: ${err.code ?? err.message}`));
+    });
+
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      const req = http.get({ port, host: "127.0.0.1", path: "/" }, (res) => {
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (d) => data += d);
+        res.on("aborted", () => reject(new Error("response was aborted")));
+        res.on("end", () => {
+          assertEquals(res.statusCode, 200);
+          // All chunks plus the final "done" line must have arrived intact.
+          assertEquals(
+            data.trim().split("\n").filter(Boolean).length,
+            writeCount + 1,
+          );
+          assertStringIncludes(data, "done");
+          server.close(() => resolve());
+        });
+      });
+      req.on("error", reject);
+    });
+
+    await promise;
+  },
+);
+
 // Regression test for pipelined requests: when request 2's response finishes
 // after request 1's, resOnFinish for request 1 must not delete the active
 // ConnectionsList entry that now belongs to request 2 (otherwise


### PR DESCRIPTION
Node's server.requestTimeout only bounds the time taken to receive the
entire request from the client; once the request message has been fully
parsed off the wire, the clock stops and the response may stream for as
long as it likes. Deno's node:http compatibility layer instead kept
enforcing requestTimeout against the connection for the whole
request-and-response lifetime, so long-lived streaming responses (SSE,
proxies) were aborted with ECONNRESET around the 300s default timeout
even while bytes were actively being written.

The ConnectionsList watchdog now skips the requestTimeout check once the
tracked request is complete (req.complete, set by parserOnMessageComplete,
the polyfill's analog of Node's on_message_complete that resets
last_message_start_). Slow or incomplete request bodies still trip
requestTimeout as before. Adds a unit test for the streaming case and
enables the upstream test-http-server-request-timeout-keepalive.js compat
test.

Closes #35289