### PR TITLE
fix(ext/node): surface ECONNREFUSED from node:dns custom resolvers

### DIFF
--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -1237,7 +1237,16 @@ pub async fn op_dns_resolve(
   // cancellation (they are not aborted by the cancel handle itself).
   if cancel_rid.is_some() {
     opts.timeout = std::time::Duration::from_secs(1);
-    opts.attempts = 1;
+    // For the connected-UDP path (an explicit name server), perform a single
+    // attempt with no internal retry. hickory's `RetryDnsHandle` reports the
+    // *last* attempt's error, so a refused server can surface `ECONNREFUSED`
+    // on the first attempt only to have an immediate second attempt time out
+    // (Linux rate-limits the ICMP "port unreachable") and clobber it with a
+    // timeout. c-ares (used by Node.js) instead preserves the connection
+    // error and only times out when no real error occurred. The `node:dns`
+    // layer already retries, so dropping the redundant internal retry both
+    // fixes the error reporting and avoids a wasted, rate-limited retry.
+    opts.attempts = if has_custom_name_server { 0 } else { 1 };
   }
 
   {

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -2,11 +2,15 @@
 
 use std::borrow::Cow;
 use std::cell::RefCell;
+use std::future::Future;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::rc::Rc;
 use std::str::FromStr;
+use std::task::Context;
+use std::task::Poll;
 use std::time::Duration;
 
 use deno_core::AsyncRefCell;
@@ -27,11 +31,17 @@ use hickory_proto::ProtoError;
 use hickory_proto::ProtoErrorKind;
 use hickory_proto::rr::record_data::RData;
 use hickory_proto::rr::record_type::RecordType;
+use hickory_proto::runtime::RuntimeProvider;
+use hickory_proto::runtime::TokioRuntimeProvider;
+use hickory_proto::runtime::TokioTime;
+use hickory_proto::udp::DnsUdpSocket;
 use hickory_resolver::ResolveError;
 use hickory_resolver::ResolveErrorKind;
 use hickory_resolver::config::NameServerConfigGroup;
 use hickory_resolver::config::ResolverConfig;
 use hickory_resolver::config::ResolverOpts;
+use hickory_resolver::name_server::ConnectionProvider;
+use hickory_resolver::name_server::GenericConnector;
 use hickory_resolver::name_server::TokioConnectionProvider;
 use hickory_resolver::system_conf;
 use quinn::rustls;
@@ -154,6 +164,9 @@ pub enum NetError {
   #[class("NotConnected")]
   #[error("{0}")]
   DnsNotConnected(ResolveError),
+  #[class("ConnectionRefused")]
+  #[error("{0}")]
+  DnsConnectionRefused(ResolveError),
   #[class("TimedOut")]
   #[error("{0}")]
   DnsTimedOut(ResolveError),
@@ -1040,6 +1053,151 @@ pub struct NameServer {
   port: u16,
 }
 
+/// A hickory [`RuntimeProvider`] that hands out UDP sockets which are
+/// `connect()`ed to the name server.
+///
+/// hickory's default UDP socket is unconnected, so when the configured name
+/// server refuses the connection the ICMP "port unreachable" response is never
+/// delivered to the socket and the query silently times out. Connecting the
+/// socket makes the kernel surface that as `ECONNREFUSED`, matching the
+/// behaviour of c-ares (used by Node.js). This is used for the `node:dns`
+/// `Resolver.setServers()` code path.
+#[derive(Clone, Default)]
+struct ConnectedUdpRuntimeProvider(TokioRuntimeProvider);
+
+impl RuntimeProvider for ConnectedUdpRuntimeProvider {
+  type Handle = <TokioRuntimeProvider as RuntimeProvider>::Handle;
+  type Timer = <TokioRuntimeProvider as RuntimeProvider>::Timer;
+  type Udp = ConnectedUdpSocket;
+  type Tcp = <TokioRuntimeProvider as RuntimeProvider>::Tcp;
+
+  fn create_handle(&self) -> Self::Handle {
+    self.0.create_handle()
+  }
+
+  fn connect_tcp(
+    &self,
+    server_addr: SocketAddr,
+    bind_addr: Option<SocketAddr>,
+    timeout: Option<Duration>,
+  ) -> Pin<Box<dyn Send + Future<Output = std::io::Result<Self::Tcp>>>> {
+    self.0.connect_tcp(server_addr, bind_addr, timeout)
+  }
+
+  fn bind_udp(
+    &self,
+    local_addr: SocketAddr,
+    server_addr: SocketAddr,
+  ) -> Pin<Box<dyn Send + Future<Output = std::io::Result<Self::Udp>>>> {
+    Box::pin(async move {
+      let socket = tokio::net::UdpSocket::bind(local_addr).await?;
+      socket.connect(server_addr).await?;
+      Ok(ConnectedUdpSocket(socket))
+    })
+  }
+}
+
+/// A connected UDP socket adapter for [`ConnectedUdpRuntimeProvider`].
+struct ConnectedUdpSocket(tokio::net::UdpSocket);
+
+impl DnsUdpSocket for ConnectedUdpSocket {
+  type Time = TokioTime;
+
+  fn poll_recv_from(
+    &self,
+    cx: &mut Context<'_>,
+    buf: &mut [u8],
+  ) -> Poll<std::io::Result<(usize, SocketAddr)>> {
+    let mut read_buf = tokio::io::ReadBuf::new(buf);
+    std::task::ready!(self.0.poll_recv(cx, &mut read_buf))?;
+    let len = read_buf.filled().len();
+    // The socket is connected, so all datagrams come from the name server.
+    let addr = self.0.peer_addr()?;
+    Poll::Ready(Ok((len, addr)))
+  }
+
+  fn poll_send_to(
+    &self,
+    cx: &mut Context<'_>,
+    buf: &[u8],
+    _target: SocketAddr,
+  ) -> Poll<std::io::Result<usize>> {
+    // The socket is connected, so the target is implied.
+    self.0.poll_send(cx, buf)
+  }
+}
+
+fn map_resolve_error(e: ResolveError) -> NetError {
+  match e.kind() {
+    ResolveErrorKind::Proto(ProtoError { kind, .. })
+      if matches!(**kind, ProtoErrorKind::NoRecordsFound { .. }) =>
+    {
+      NetError::DnsNotFound(e)
+    }
+    ResolveErrorKind::Proto(ProtoError { kind, .. })
+      if matches!(**kind, ProtoErrorKind::NoConnections) =>
+    {
+      NetError::DnsNotConnected(e)
+    }
+    ResolveErrorKind::Proto(ProtoError { kind, .. })
+      if matches!(
+        &**kind,
+        ProtoErrorKind::Io(io)
+          if io.kind() == std::io::ErrorKind::ConnectionRefused
+      ) =>
+    {
+      NetError::DnsConnectionRefused(e)
+    }
+    ResolveErrorKind::Proto(ProtoError { kind, .. })
+      if matches!(**kind, ProtoErrorKind::Timeout) =>
+    {
+      NetError::DnsTimedOut(e)
+    }
+    _ => NetError::Dns(e),
+  }
+}
+
+async fn resolve_lookup<P: ConnectionProvider>(
+  state: &Rc<RefCell<OpState>>,
+  provider: P,
+  config: ResolverConfig,
+  opts: ResolverOpts,
+  query: String,
+  record_type: RecordType,
+  cancel_rid: Option<ResourceId>,
+) -> Result<hickory_resolver::lookup::Lookup, NetError> {
+  let resolver =
+    hickory_resolver::Resolver::builder_with_config(config, provider)
+      .with_options(opts)
+      .build();
+
+  let lookup_fut = resolver.lookup(query, record_type);
+
+  let cancel_handle = cancel_rid.and_then(|rid| {
+    state
+      .borrow_mut()
+      .resource_table
+      .get::<CancelHandle>(rid)
+      .ok()
+  });
+
+  let lookup = if let Some(cancel_handle) = cancel_handle {
+    let lookup_rv = lookup_fut.or_cancel(cancel_handle).await;
+
+    if let Some(cancel_rid) = cancel_rid
+      && let Ok(res) = state.borrow_mut().resource_table.take_any(cancel_rid)
+    {
+      res.close();
+    };
+
+    lookup_rv?
+  } else {
+    lookup_fut.await
+  };
+
+  lookup.map_err(map_resolve_error)
+}
+
 #[op2(stack_trace)]
 pub async fn op_dns_resolve(
   state: Rc<RefCell<OpState>>,
@@ -1053,9 +1211,11 @@ pub async fn op_dns_resolve(
     cancel_rid,
   } = args;
 
-  let (config, mut opts) = if let Some(name_server) =
-    options.as_ref().and_then(|o| o.name_server.as_ref())
-  {
+  let custom_name_server =
+    options.as_ref().and_then(|o| o.name_server.as_ref());
+  let has_custom_name_server = custom_name_server.is_some();
+
+  let (config, mut opts) = if let Some(name_server) = custom_name_server {
     let group = NameServerConfigGroup::from_ips_clear(
       &[name_server.ip_addr.parse()?],
       name_server.port,
@@ -1093,55 +1253,34 @@ pub async fn op_dns_resolve(
     }
   }
 
-  let provider = TokioConnectionProvider::default();
-  let resolver =
-    hickory_resolver::Resolver::builder_with_config(config, provider)
-      .with_options(opts)
-      .build();
-
-  let lookup_fut = resolver.lookup(query, record_type);
-
-  let cancel_handle = cancel_rid.and_then(|rid| {
-    state
-      .borrow_mut()
-      .resource_table
-      .get::<CancelHandle>(rid)
-      .ok()
-  });
-
-  let lookup = if let Some(cancel_handle) = cancel_handle {
-    let lookup_rv = lookup_fut.or_cancel(cancel_handle).await;
-
-    if let Some(cancel_rid) = cancel_rid
-      && let Ok(res) = state.borrow_mut().resource_table.take_any(cancel_rid)
-    {
-      res.close();
-    };
-
-    lookup_rv?
+  // When the caller configured an explicit name server (e.g. via
+  // `node:dns` `Resolver.setServers()`), use a connected UDP socket so that a
+  // refused connection surfaces as `ECONNREFUSED` instead of timing out.
+  let lookup = if has_custom_name_server {
+    resolve_lookup(
+      &state,
+      GenericConnector::new(ConnectedUdpRuntimeProvider::default()),
+      config,
+      opts,
+      query,
+      record_type,
+      cancel_rid,
+    )
+    .await?
   } else {
-    lookup_fut.await
+    resolve_lookup(
+      &state,
+      TokioConnectionProvider::default(),
+      config,
+      opts,
+      query,
+      record_type,
+      cancel_rid,
+    )
+    .await?
   };
 
   lookup
-    .map_err(|e| match e.kind() {
-      ResolveErrorKind::Proto(ProtoError { kind, .. })
-        if matches!(**kind, ProtoErrorKind::NoRecordsFound { .. }) =>
-      {
-        NetError::DnsNotFound(e)
-      }
-      ResolveErrorKind::Proto(ProtoError { kind, .. })
-        if matches!(**kind, ProtoErrorKind::NoConnections) =>
-      {
-        NetError::DnsNotConnected(e)
-      }
-      ResolveErrorKind::Proto(ProtoError { kind, .. })
-        if matches!(**kind, ProtoErrorKind::Timeout) =>
-      {
-        NetError::DnsTimedOut(e)
-      }
-      _ => NetError::Dns(e),
-    })?
     .records()
     .iter()
     .filter_map(|rec| {

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -421,6 +421,14 @@ class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
           ObjectPrototypeIsPrototypeOf(Deno.errors.NotFound.prototype, e)
         ) {
           code = codeMap.get("EAI_NODATA")!;
+        } else if (
+          ObjectPrototypeIsPrototypeOf(
+            Deno.errors.ConnectionRefused.prototype,
+            e,
+          )
+        ) {
+          // The name server refused the connection.
+          code = codeMap.get("ECONNREFUSED")!;
         } else {
           // TODO(cmorten): map errors to appropriate error codes.
           code = codeMap.get("UNKNOWN")!;

--- a/tests/unit_node/dns_test.ts
+++ b/tests/unit_node/dns_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { assert, assertEquals, fail } from "@std/assert";
+import { assert, assertEquals, assertRejects, fail } from "@std/assert";
 import dns, { getDefaultResultOrder, lookupService } from "node:dns";
 import dnsPromises, {
   getDefaultResultOrder as getDefaultResultOrderPromise,
@@ -252,4 +252,31 @@ Deno.test("[node/dns] lookup of a missing host reports ENOTFOUND", async () => {
   assertEquals(err.errno, -3008);
   assertEquals(err.syscall, "getaddrinfo");
   assertEquals(err.hostname, "nonexistent-host.invalid");
+});
+
+// Regression test for https://github.com/denoland/deno/issues/35173
+// Querying a name server that refuses the connection must fail promptly with
+// ECONNREFUSED (like c-ares/Node.js), instead of silently timing out.
+// Windows surfaces a connected-UDP ICMP "port unreachable" as ECONNRESET
+// rather than ECONNREFUSED, so this is gated to other platforms.
+Deno.test({
+  name: "[node/dns] resolve against a refused name server reports ECONNREFUSED",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const resolver = new dnsPromises.Resolver();
+    // Nothing is listening on this loopback port.
+    resolver.setServers(["127.0.0.1:56789"]);
+
+    const start = Date.now();
+    const err = await assertRejects(() =>
+      resolver.resolve4("example.com")
+    ) as ErrnoException;
+    assertEquals(err.code, "ECONNREFUSED");
+    assertEquals(err.syscall, "queryA");
+    // Should fail fast rather than hang on the resolver timeout.
+    assert(
+      Date.now() - start < 2000,
+      "expected the query to fail promptly",
+    );
+  },
 });

--- a/tools/lint_plugins/no_deno_api_in_polyfills.ts
+++ b/tools/lint_plugins/no_deno_api_in_polyfills.ts
@@ -27,7 +27,7 @@ export const EXPECTED_VIOLATIONS: Record<string, number> = {
   "ext/node/polyfills/_fs/_fs_lstat.ts": 4,
   "ext/node/polyfills/testing.ts": 3,
   "ext/node/polyfills/internal/tty.js": 2,
-  "ext/node/polyfills/internal_binding/cares_wrap.ts": 4,
+  "ext/node/polyfills/internal_binding/cares_wrap.ts": 5,
   "ext/node/polyfills/_fs/_fs_dir.ts": 2,
   "ext/node/polyfills/child_process.ts": 2,
   "ext/node/polyfills/worker_threads.ts": 1,


### PR DESCRIPTION
Fixes #35173.

When a `node:dns` resolver is pointed at a name server that refuses the
connection, for example `resolver.setServers(['127.0.0.1'])` with nothing
listening on port 53, Deno hangs until the resolver timeout fires and then
reports `ETIMEOUT`. Node.js fails immediately with `ECONNREFUSED`:

```
dns-fail { elapsedMs: 1, code: 'ECONNREFUSED', message: 'queryA ECONNREFUSED ...' }
```

The root cause is in how the underlying query is sent. hickory (which backs
`Deno.resolveDns`, and therefore the `node:dns` `Resolver` query path) leaves
its UDP socket unconnected by default. Because the socket is not connected, the
ICMP "port unreachable" the kernel produces for a refused server is never
delivered back to the socket, so the query just sits there until it times out.
c-ares, which Node.js uses, connects its UDP sockets, which is exactly how it
notices the refusal right away.

This adds a small hickory `RuntimeProvider` that hands out connected UDP
sockets, and uses it only for the explicit-name-server path (the custom
`Resolver` case). With a connected socket the kernel surfaces the refusal as a
`ConnectionRefused` IO error, which is then mapped through to the JS layer as
`ECONNREFUSED`. The system resolver path keeps using the default provider and
is unchanged.

After the fix the reproduction from the issue matches Node:

```
dns-fail { elapsedMs: 7, code: "ECONNREFUSED", message: "queryA ECONNREFUSED mirror.archlinuxarm.org" }
```

A regression test is added in `tests/unit_node/dns_test.ts`. It is skipped on
Windows, where a connected-UDP ICMP "port unreachable" surfaces as
`ECONNRESET` rather than `ECONNREFUSED`.
