### PR TITLE
feat(env): load .env cascade and add --mode for --env-file

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1137,6 +1137,10 @@ pub struct Flags {
   pub ignore: Vec<String>,
   pub import_map_path: Option<String>,
   pub env_file: Option<Vec<String>>,
+  /// The mode used to resolve the `.env.<mode>` cascade files when
+  /// `--env-file` is used. Falls back to the `DENO_ENV` environment variable
+  /// when unset.
+  pub mode: Option<String>,
   pub inspect_brk: Option<SocketAddr>,
   pub inspect_wait: Option<SocketAddr>,
   pub inspect: Option<SocketAddr>,
@@ -2939,6 +2943,7 @@ If you specify a directory instead of a file, the path is expanded to all contai
       .arg(no_clear_screen_arg())
       .arg(script_arg().last(true))
       .arg(env_file_arg())
+      .arg(mode_arg())
       .arg(executable_ext_arg())
   })
 }
@@ -3798,7 +3803,8 @@ This command has implicit access to all permissions.
             .value_name("CODE_ARG")
             .required_unless_present("help"),
         )
-        .arg(env_file_arg()),
+        .arg(env_file_arg())
+        .arg(mode_arg()),
     )
   })
 }
@@ -4778,6 +4784,7 @@ TypeScript is supported, however it is not type-checked, only transpiled."
                        <p(245)>[default: $DENO_DIR/deno_history.txt]</>"))
     })
     .arg(env_file_arg())
+    .arg(mode_arg())
     .arg(
       Arg::new("args")
         .num_args(0..)
@@ -4802,6 +4809,7 @@ fn run_args(command: Command, top_level: bool) -> Command {
         script_arg().trailing_var_arg(true)
       })
       .arg(env_file_arg())
+      .arg(mode_arg())
       .arg(no_code_cache_arg())
       .arg(coverage_arg()),
   )
@@ -4976,6 +4984,7 @@ Start a server defined in server.ts, watching for changes and running on port 50
         .trailing_var_arg(true),
     )
     .arg(env_file_arg())
+    .arg(mode_arg())
     .arg(no_code_cache_arg()),
   )
   .arg(tunnel_arg())
@@ -5040,6 +5049,7 @@ Evaluate a task from string:
           .action(ArgAction::SetTrue),
       )
       .arg(env_file_arg())
+      .arg(mode_arg())
       .arg(node_modules_dir_arg())
       .arg(node_modules_linker_arg())
       .arg(tunnel_arg())
@@ -5320,6 +5330,7 @@ or <c>**/__tests__/**</>:
           .action(ArgAction::SetTrue)
       )
       .arg(env_file_arg())
+      .arg(mode_arg())
       .arg(executable_ext_arg())
     )
 }
@@ -6444,13 +6455,26 @@ fn env_file_arg() -> Arg {
       "Load environment variables from local file
   <p(245)>Only the first environment variable with a given key is used.
   Existing process environment variables are not overwritten, so if variables with the same names already exist in the environment, their values will be preserved.
-  Where multiple declarations for the same environment variable exist in your .env file, the first one encountered is applied. This is determined by the order of the files you pass as arguments.</>"
+  Where multiple declarations for the same environment variable exist in your .env file, the first one encountered is applied. This is determined by the order of the files you pass as arguments.
+  For each file passed, the conventional cascade is also loaded from the same directory, in increasing precedence: the file itself, then its '.mode', '.local', and '.mode.local' siblings. The mode comes from --mode or the DENO_ENV environment variable; when neither is set only the file and its '.local' sibling are loaded. Missing cascade files are ignored.</>"
     ))
     .value_hint(ValueHint::FilePath)
     .default_missing_value(".env")
     .require_equals(true)
     .num_args(0..=1)
     .action(ArgAction::Append)
+}
+
+fn mode_arg() -> Arg {
+  Arg::new("mode")
+    .long("mode")
+    .value_name("MODE")
+    .help(cstr!(
+      "Set the mode used to resolve the --env-file cascade
+  <p(245)>Selects the '.mode' and '.mode.local' files loaded alongside each --env-file. Defaults to the DENO_ENV environment variable when unset.</>"
+    ))
+    .require_equals(true)
+    .num_args(1)
 }
 
 fn use_env_proxy_arg() -> Arg {
@@ -9322,6 +9346,14 @@ fn env_file_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   flags.env_file = matches
     .get_many::<String>("env-file")
     .map(|values| values.cloned().collect());
+  // `--mode` is only registered on the commands that run user code, so parse
+  // it defensively: `try_get_one` returns an error (swallowed here) rather
+  // than panicking when the argument isn't defined on the current command.
+  flags.mode = matches
+    .try_get_one::<String>("mode")
+    .ok()
+    .flatten()
+    .cloned();
 }
 
 fn reload_arg_parse(
@@ -12395,6 +12427,35 @@ mod tests {
         ..Flags::default()
       }
     );
+  }
+
+  #[test]
+  fn run_env_file_with_mode() {
+    let r = flags_from_vec(svec![
+      "deno",
+      "run",
+      "--env-file",
+      "--mode=production",
+      "script.ts"
+    ]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Run(RunFlags::new_default(
+          "script.ts".to_string(),
+        )),
+        env_file: Some(svec![".env"]),
+        mode: Some("production".to_string()),
+        code_cache_enabled: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn run_mode_without_env_file() {
+    let r = flags_from_vec(svec!["deno", "run", "--mode=staging", "script.ts"]);
+    assert_eq!(r.unwrap().mode, Some("staging".to_string()));
   }
 
   // The dependency and registry subcommands also accept --env-file so that

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -731,12 +731,20 @@ impl CliOptions {
   pub fn possible_env_file_paths_for_watch(
     &self,
   ) -> impl Iterator<Item = PathBuf> {
-    self
-      .env_file_names()
-      .flat_map(|env_file| {
-        deno_dotenv::candidate_paths(&self.initial_cwd, env_file)
-      })
-      .filter_map(|p| canonicalize_path(&p).ok())
+    let mode =
+      crate::util::env::resolve_env_file_mode(self.flags.mode.as_deref());
+    let mut paths = Vec::new();
+    for base in self.env_file_names() {
+      for spec in deno_dotenv::cascade_paths(base, mode.as_deref()) {
+        for candidate in deno_dotenv::candidate_paths(&self.initial_cwd, &spec)
+        {
+          if let Ok(path) = canonicalize_path(&candidate) {
+            paths.push(path);
+          }
+        }
+      }
+    }
+    paths.into_iter()
   }
 
   pub fn preload_modules(&self) -> Result<Vec<ModuleSpecifier>, AnyError> {
@@ -1526,11 +1534,17 @@ impl CliOptions {
     }
 
     if let Some(env_file_names) = &self.flags.env_file {
-      // Only watch the exact environment files specified
+      // Watch the specified environment files along with their cascade
+      // siblings (.env.local, .env.<mode>, etc.).
+      let mode =
+        crate::util::env::resolve_env_file_mode(self.flags.mode.as_deref());
       full_paths.extend(
-        env_file_names
-          .iter()
-          .map(|name| self.initial_cwd.join(name)),
+        crate::util::env::expand_env_file_cascade(
+          env_file_names,
+          mode.as_deref(),
+        )
+        .iter()
+        .map(|name| self.initial_cwd.join(name)),
       );
     }
 

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -74,7 +74,9 @@ use crate::args::flags_from_vec_with_initial_cwd;
 use crate::args::get_default_v8_flags;
 use crate::util::display;
 use crate::util::env::WatchEnvTracker;
+use crate::util::env::expand_env_file_cascade;
 use crate::util::env::load_env_variables_from_env_files;
+use crate::util::env::resolve_env_file_mode;
 use crate::util::v8::get_v8_flags_from_env;
 use crate::util::v8::init_v8_flags;
 
@@ -866,7 +868,9 @@ async fn resolve_flags_and_init(
         Err(_) => Cow::Owned(PathBuf::from(".")),
       },
     };
-    load_env_variables_from_env_files(&cwd, files, flags.log_level);
+    let mode = resolve_env_file_mode(flags.mode.as_deref());
+    let files = expand_env_file_cascade(files, mode.as_deref());
+    load_env_variables_from_env_files(&cwd, &files, flags.log_level);
   }
 
   let sys = crate::sys::CliSys::default();

--- a/cli/util/env.rs
+++ b/cli/util/env.rs
@@ -57,6 +57,30 @@ pub fn handle_denied_env_file_key(
   }
 }
 
+/// Resolves the mode used to select the `--env-file` cascade files. Prefers
+/// the explicit `--mode` flag, falling back to the `DENO_ENV` environment
+/// variable, and otherwise leaving the mode unset (only `.env` and
+/// `.env.local` are loaded).
+pub fn resolve_env_file_mode(flag_mode: Option<&str>) -> Option<String> {
+  flag_mode
+    .map(str::to_string)
+    .or_else(|| env::var("DENO_ENV").ok().filter(|value| !value.is_empty()))
+}
+
+/// Expands each base `--env-file` specifier into its conventional cascade
+/// (see [`deno_dotenv::cascade_paths`]), preserving the order of the passed
+/// files. The resulting list is in increasing precedence order, which is what
+/// [`load_env_variables_from_env_files`] expects.
+pub fn expand_env_file_cascade(
+  env_files: &[String],
+  mode: Option<&str>,
+) -> Vec<String> {
+  env_files
+    .iter()
+    .flat_map(|base| deno_dotenv::cascade_paths(base, mode))
+    .collect()
+}
+
 pub fn resolve_cwd(
   initial_cwd: Option<&Path>,
 ) -> Result<Cow<'_, Path>, std::io::Error> {

--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -34,6 +34,8 @@ use tokio::sync::mpsc::error::SendError;
 use tokio::time::sleep;
 
 use super::env::WatchEnvTracker;
+use super::env::expand_env_file_cascade;
+use super::env::resolve_env_file_mode;
 use crate::args::Flags;
 use crate::colors;
 use crate::util::fs::canonicalize_path;
@@ -393,9 +395,11 @@ where
         .as_deref()
         .map(Cow::Borrowed)
         .unwrap_or_else(|| Cow::Owned(PathBuf::from(".")));
+      let mode = resolve_env_file_mode(flags.mode.as_deref());
+      let env_files = expand_env_file_cascade(env_files, mode.as_deref());
       snapshot.load_env_variables_from_env_files(
         &cwd,
-        env_files,
+        &env_files,
         flags.log_level,
       );
     }

--- a/libs/dotenv/lib.rs
+++ b/libs/dotenv/lib.rs
@@ -91,6 +91,32 @@ pub fn find_path_and_content(
   Ok(None)
 }
 
+/// Expands an env file specifier into its conventional cascade, returned in
+/// increasing precedence order (later entries are meant to override earlier
+/// ones):
+///
+/// ```text
+/// <base>
+/// <base>.<mode>          (only when `mode` is `Some`)
+/// <base>.local
+/// <base>.<mode>.local    (only when `mode` is `Some`)
+/// ```
+///
+/// The suffixes are appended to the full specifier, so both bare names like
+/// `.env` and explicit paths like `config/app.env` cascade the same way.
+pub fn cascade_paths(base: &str, mode: Option<&str>) -> Vec<String> {
+  let mut paths = Vec::with_capacity(if mode.is_some() { 4 } else { 2 });
+  paths.push(base.to_string());
+  if let Some(mode) = mode {
+    paths.push(format!("{base}.{mode}"));
+  }
+  paths.push(format!("{base}.local"));
+  if let Some(mode) = mode {
+    paths.push(format!("{base}.{mode}.local"));
+  }
+  paths
+}
+
 #[derive(Debug, Error)]
 #[error("Error parsing line at index {index}: {line}")]
 pub struct ParseError {
@@ -1065,6 +1091,37 @@ u4QuUoobAgMBAAE=
       // `KEY1_2` is the whole variable name and is undefined, so it resolves
       // to an empty string
       &[("KEY2", ""), ("KEY", "><><")],
+    );
+  }
+
+  #[test]
+  fn cascade_paths_without_mode() {
+    assert_eq!(cascade_paths(".env", None), vec![".env", ".env.local"]);
+  }
+
+  #[test]
+  fn cascade_paths_with_mode() {
+    assert_eq!(
+      cascade_paths(".env", Some("production")),
+      vec![
+        ".env",
+        ".env.production",
+        ".env.local",
+        ".env.production.local",
+      ]
+    );
+  }
+
+  #[test]
+  fn cascade_paths_explicit_path() {
+    assert_eq!(
+      cascade_paths("config/app.env", Some("dev")),
+      vec![
+        "config/app.env",
+        "config/app.env.dev",
+        "config/app.env.local",
+        "config/app.env.dev.local",
+      ]
     );
   }
 

--- a/tests/specs/run/env_file_cascade/.env
+++ b/tests/specs/run/env_file_cascade/.env
@@ -1,0 +1,4 @@
+A=base
+B=base
+C=base
+D=base

--- a/tests/specs/run/env_file_cascade/.env.local
+++ b/tests/specs/run/env_file_cascade/.env.local
@@ -1,0 +1,2 @@
+B=local
+D=local

--- a/tests/specs/run/env_file_cascade/.env.production
+++ b/tests/specs/run/env_file_cascade/.env.production
@@ -1,0 +1,2 @@
+C=prodmode
+D=prodmode

--- a/tests/specs/run/env_file_cascade/.env.production.local
+++ b/tests/specs/run/env_file_cascade/.env.production.local
@@ -1,0 +1,1 @@
+D=prodlocal

--- a/tests/specs/run/env_file_cascade/__test__.jsonc
+++ b/tests/specs/run/env_file_cascade/__test__.jsonc
@@ -1,0 +1,28 @@
+{
+  "tests": {
+    "no_mode": {
+      // Without a mode only `.env` and `.env.local` are loaded, with
+      // `.env.local` overriding `.env`.
+      "args": "run --allow-env --env-file main.js",
+      "output": "no_mode.out"
+    },
+    "mode_flag": {
+      // `--mode production` adds `.env.production` and
+      // `.env.production.local`, each overriding the lower-precedence files.
+      "args": "run --allow-env --env-file --mode=production main.js",
+      "output": "mode.out"
+    },
+    "mode_from_deno_env": {
+      // `DENO_ENV` provides the mode when `--mode` is absent.
+      "args": "run --allow-env --env-file main.js",
+      "envs": { "DENO_ENV": "production" },
+      "output": "mode.out"
+    },
+    "process_env_wins": {
+      // Process environment variables always take precedence over any file.
+      "args": "run --allow-env --env-file --mode=production main.js",
+      "envs": { "B": "proc", "D": "proc" },
+      "output": "process_env_wins.out"
+    }
+  }
+}

--- a/tests/specs/run/env_file_cascade/main.js
+++ b/tests/specs/run/env_file_cascade/main.js
@@ -1,0 +1,3 @@
+for (const key of ["A", "B", "C", "D"]) {
+  console.log(`${key}=${Deno.env.get(key)}`);
+}

--- a/tests/specs/run/env_file_cascade/mode.out
+++ b/tests/specs/run/env_file_cascade/mode.out
@@ -1,0 +1,4 @@
+A=base
+B=local
+C=prodmode
+D=prodlocal

--- a/tests/specs/run/env_file_cascade/no_mode.out
+++ b/tests/specs/run/env_file_cascade/no_mode.out
@@ -1,0 +1,4 @@
+A=base
+B=local
+C=base
+D=local

--- a/tests/specs/run/env_file_cascade/process_env_wins.out
+++ b/tests/specs/run/env_file_cascade/process_env_wins.out
@@ -1,0 +1,4 @@
+A=base
+B=proc
+C=prodmode
+D=proc


### PR DESCRIPTION
Today `--env-file` loads exactly the files passed and never picks up the
conventional cascade that users expect from tools like Vite and Next.
This adds that cascade: when `--env-file` is used, Deno additionally
loads the sibling files for each base, in increasing precedence (later
overrides earlier, and the process environment always wins):

    <file>
    <file>.<mode>
    <file>.local
    <file>.<mode>.local

The mode is taken from the new `--mode` flag, falling back to the
`DENO_ENV` environment variable; when neither is set only `<file>` and
`<file>.local` are loaded. Missing cascade files are silently ignored,
and a passed-but-missing explicit `--env-file` keeps today's behavior.
The suffixes are appended to the full specifier, so the bare/default
`.env` and explicit paths such as `config/app.env` cascade the same way.

The expansion is centralized and shared by the runtime load path, watch
mode, and watch-path discovery, so `deno run`, `deno serve`, `deno
task`, and `deno test` all behave identically. `deno compile` keeps
embedding only the literal files, so local overrides are not baked into
distributed binaries. This only changes behavior for users who already
opt in with `--env-file`; auto-loading without the flag remains out of
scope.

Closes #35302