### PR TITLE
feat(task): add --reporter ndjson for machine-readable task output

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -668,6 +668,17 @@ pub struct TaskFlags {
   pub filter: Option<String>,
   pub eval: bool,
   pub no_prefix: bool,
+  pub reporter: TaskReporter,
+}
+
+/// Output format for `deno task` lifecycle reporting.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TaskReporter {
+  /// Human-oriented, colored, package-prefixed output (the default).
+  #[default]
+  Pretty,
+  /// One JSON object per line describing task lifecycle events.
+  Ndjson,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5039,6 +5050,19 @@ Evaluate a task from string:
           )
           .action(ArgAction::SetTrue),
       )
+      .arg(
+        Arg::new("reporter")
+          .long("reporter")
+          .help(
+            "Select the reporter for task lifecycle output:
+  - pretty (default): human-oriented, colored, package-prefixed output
+  - ndjson: one JSON object per line for each task lifecycle event
+    (taskStart, taskOutput, taskEnd); task stdout/stderr is captured
+    and emitted as taskOutput events so stdout stays valid NDJSON",
+          )
+          .value_parser(["pretty", "ndjson"])
+          .default_value("pretty"),
+      )
       .arg(env_file_arg())
       .arg(node_modules_dir_arg())
       .arg(node_modules_linker_arg())
@@ -8603,6 +8627,10 @@ fn task_parse(
     filter,
     eval: matches.get_flag("eval"),
     no_prefix: matches.get_flag("no-prefix"),
+    reporter: match matches.remove_one::<String>("reporter").as_deref() {
+      Some("ndjson") => TaskReporter::Ndjson,
+      _ => TaskReporter::Pretty,
+    },
   };
 
   match matches.remove_subcommand() {
@@ -14784,6 +14812,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         argv: svec!["hello", "world"],
         ..Flags::default()
@@ -14802,6 +14831,26 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
+        }),
+        ..Flags::default()
+      }
+    );
+
+    let r =
+      flags_from_vec(svec!["deno", "task", "--reporter", "ndjson", "build"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Task(TaskFlags {
+          cwd: None,
+          task: Some("build".to_string()),
+          is_run: false,
+          recursive: false,
+          filter: None,
+          eval: false,
+          no_prefix: false,
+          reporter: TaskReporter::Ndjson,
         }),
         ..Flags::default()
       }
@@ -14819,6 +14868,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         ..Flags::default()
       }
@@ -14836,6 +14886,7 @@ mod tests {
           filter: Some("*".to_string()),
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         ..Flags::default()
       }
@@ -14853,6 +14904,7 @@ mod tests {
           filter: Some("*".to_string()),
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         ..Flags::default()
       }
@@ -14870,6 +14922,7 @@ mod tests {
           filter: Some("*".to_string()),
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         ..Flags::default()
       }
@@ -14887,6 +14940,7 @@ mod tests {
           filter: None,
           eval: true,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         ..Flags::default()
       }
@@ -14919,6 +14973,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         argv: svec!["--", "hello", "world"],
         config_flag: ConfigFlag::Path("deno.json".to_owned()),
@@ -14940,6 +14995,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         argv: svec!["--", "hello", "world"],
         ..Flags::default()
@@ -14962,6 +15018,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         argv: svec!["--"],
         ..Flags::default()
@@ -14983,6 +15040,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         argv: svec!["-1", "--test"],
         ..Flags::default()
@@ -15004,6 +15062,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         argv: svec!["--test"],
         ..Flags::default()
@@ -15026,6 +15085,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         log_level: Some(log::Level::Error),
         ..Flags::default()
@@ -15047,6 +15107,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         ..Flags::default()
       }
@@ -15067,6 +15128,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         config_flag: ConfigFlag::Path("deno.jsonc".to_string()),
         ..Flags::default()
@@ -15088,6 +15150,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         config_flag: ConfigFlag::Path("deno.jsonc".to_string()),
         ..Flags::default()
@@ -15118,6 +15181,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         env_file: Some(vec![".env".to_owned()]),
         ..Flags::default()
@@ -15142,6 +15206,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: TaskReporter::Pretty,
         }),
         env_file: Some(vec![".env.dev".to_owned(), ".env.local".to_owned()]),
         ..Flags::default()

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -291,6 +291,7 @@ async fn run_subcommand(
           filter: None,
           eval: false,
           no_prefix: false,
+          reporter: Default::default(),
         };
         let mut flags = flags;
         flags.subcommand = DenoSubcommand::Task(task_flags.clone());
@@ -403,6 +404,7 @@ async fn run_subcommand(
                   filter: None,
                   eval: false,
                   no_prefix: false,
+                  reporter: Default::default(),
                 };
                 new_flags.subcommand = DenoSubcommand::Task(task_flags.clone());
                 let result = tools::task::execute_script(

--- a/cli/task_runner.rs
+++ b/cli/task_runner.rs
@@ -123,6 +123,37 @@ pub fn make_prefixed_task_io(prefix: String) -> (TaskIo, Vec<JoinHandle<()>>) {
   )
 }
 
+/// Build a [`TaskIo`] that pipes the task's stdout and stderr into the given
+/// writers (run on blocking threads). Used by the ndjson reporter to capture
+/// task output and wrap it in structured events instead of writing it raw.
+pub fn make_captured_task_io(
+  stdout_writer: Box<dyn std::io::Write + Send>,
+  stderr_writer: Box<dyn std::io::Write + Send>,
+) -> (TaskIo, Vec<JoinHandle<()>>) {
+  let (out_r, out_w) = deno_task_shell::pipe();
+  let (err_r, err_w) = deno_task_shell::pipe();
+
+  let out_handle = tokio::task::spawn_blocking(move || {
+    let mut writer = stdout_writer;
+    let _ = out_r.pipe_to(&mut *writer);
+    let _ = writer.flush();
+  });
+
+  let err_handle = tokio::task::spawn_blocking(move || {
+    let mut writer = stderr_writer;
+    let _ = err_r.pipe_to(&mut *writer);
+    let _ = writer.flush();
+  });
+
+  (
+    TaskIo {
+      stdout: TaskStdio(None, out_w),
+      stderr: TaskStdio(None, err_w),
+    },
+    vec![out_handle, err_handle],
+  )
+}
+
 impl TaskStdio {
   pub fn stdout() -> Self {
     Self(None, ShellPipeWriter::stdout())

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -4,11 +4,14 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsString;
+use std::io::Write;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 
 use console_static_text::ansi::strip_ansi_codes;
 use deno_config::workspace::FolderConfigs;
@@ -25,6 +28,7 @@ use deno_core::futures::FutureExt;
 use deno_core::futures::StreamExt;
 use deno_core::futures::future::LocalBoxFuture;
 use deno_core::futures::stream::futures_unordered;
+use deno_core::serde_json;
 use deno_core::serde_json::Value;
 use deno_core::url::Url;
 use deno_npm_installer::PackageCaching;
@@ -34,11 +38,13 @@ use deno_task_shell::ShellCommand;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use regex::Regex;
+use serde::Serialize;
 
 use crate::args::CliLockfile;
 use crate::args::CliOptions;
 use crate::args::Flags;
 use crate::args::TaskFlags;
+use crate::args::TaskReporter;
 use crate::colors;
 use crate::factory::CliFactory;
 use crate::node::CliNodeResolver;
@@ -349,6 +355,115 @@ fn colorize_task_prefix(label: &str, color_index: usize) -> String {
   }
 }
 
+/// A `deno task --reporter ndjson` lifecycle event, serialized as a single
+/// JSON object per line on stdout. The event/field set is intended to be
+/// stable; see `deno task --help` for documentation.
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum TaskEvent<'a> {
+  /// Emitted just before a task's command starts running.
+  #[serde(rename = "taskStart")]
+  Start {
+    package: Option<&'a str>,
+    task: &'a str,
+    command: &'a str,
+  },
+  /// A line of captured task output. One event is emitted per line written by
+  /// the task; `stream` is either `"stdout"` or `"stderr"`.
+  #[serde(rename = "taskOutput")]
+  Output {
+    package: Option<&'a str>,
+    task: &'a str,
+    stream: &'a str,
+    text: &'a str,
+  },
+  /// Emitted after a task's command finishes.
+  #[serde(rename = "taskEnd", rename_all = "camelCase")]
+  End {
+    package: Option<&'a str>,
+    task: &'a str,
+    code: i32,
+    duration_ms: u128,
+  },
+}
+
+/// Serialize an ndjson event and write it to stdout as a single line. The whole
+/// line (including the trailing newline) is written under one stdout lock so
+/// that output from concurrently-running tasks never interleaves mid-line.
+#[allow(
+  clippy::print_stdout,
+  reason = "the ndjson reporter writes its events to stdout"
+)]
+fn emit_ndjson_event(event: &TaskEvent) {
+  let Ok(mut line) = serde_json::to_vec(event) else {
+    return;
+  };
+  line.push(b'\n');
+  let stdout = std::io::stdout();
+  let mut lock = stdout.lock();
+  let _ = lock.write_all(&line);
+  let _ = lock.flush();
+}
+
+/// A writer that wraps each line of a task's captured output in a `taskOutput`
+/// ndjson event. Partial lines are buffered until a newline (or `flush`) so
+/// that every event corresponds to exactly one line of output.
+struct NdjsonOutputWriter {
+  package: Option<String>,
+  task: String,
+  stream: &'static str,
+  line_buf: Vec<u8>,
+}
+
+impl NdjsonOutputWriter {
+  fn new(package: Option<String>, task: String, stream: &'static str) -> Self {
+    Self {
+      package,
+      task,
+      stream,
+      line_buf: Vec::new(),
+    }
+  }
+
+  fn emit_line(&mut self) {
+    let text = String::from_utf8_lossy(&self.line_buf);
+    emit_ndjson_event(&TaskEvent::Output {
+      package: self.package.as_deref(),
+      task: &self.task,
+      stream: self.stream,
+      text: &text,
+    });
+    self.line_buf.clear();
+  }
+}
+
+impl std::io::Write for NdjsonOutputWriter {
+  fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+    let mut rest = buf;
+    while !rest.is_empty() {
+      match rest.iter().position(|&b| b == b'\n') {
+        Some(pos) => {
+          self.line_buf.extend_from_slice(&rest[..pos + 1]);
+          self.emit_line();
+          rest = &rest[pos + 1..];
+        }
+        None => {
+          self.line_buf.extend_from_slice(rest);
+          break;
+        }
+      }
+    }
+    Ok(buf.len())
+  }
+
+  fn flush(&mut self) -> std::io::Result<()> {
+    if !self.line_buf.is_empty() {
+      self.emit_line();
+    }
+    Ok(())
+  }
+}
+
 struct RunSingleOptions<'a> {
   task_name: &'a str,
   package_name: Option<&'a str>,
@@ -640,11 +755,17 @@ impl<'a> TaskRunner<'a> {
     parallel_info: Option<ParallelInfo>,
   ) -> Result<i32, deno_core::anyhow::Error> {
     let Some(command) = &definition.command else {
-      self.output_task(
-        task_name,
-        package_name,
-        &colors::gray("(no command)").to_string(),
-      );
+      match self.task_flags.reporter {
+        TaskReporter::Pretty => self.output_task(
+          task_name,
+          package_name,
+          &colors::gray("(no command)").to_string(),
+        ),
+        TaskReporter::Ndjson => {
+          self.report_task_start(task_name, package_name, "(no command)");
+          self.report_task_end(task_name, package_name, 0, Duration::ZERO);
+        }
+      }
       return Ok(0);
     };
 
@@ -791,31 +912,51 @@ impl<'a> TaskRunner<'a> {
       extra_env_vars,
     } = opts;
 
-    self.output_task(
-      task_name,
-      package_name,
-      &task_runner::get_script_with_args(script, argv),
-    );
+    let script_with_args = task_runner::get_script_with_args(script, argv);
+    self.report_task_start(task_name, package_name, &script_with_args);
 
-    let (stdio, prefix_handles) = if let Some(info) = parallel_info {
-      // Right-align the entire `[name]` block so brackets line up across rows,
-      // putting the leading padding spaces *outside* the brackets.
-      let inner: Cow<str> = if info.include_package
-        && let Some(pkg) = label_name
-      {
-        Cow::Owned(format!("{}#{}", pkg, task_name))
-      } else {
-        Cow::Borrowed(task_name)
-      };
-      let label = format!("[{}]", inner);
-      let padded_label =
-        format!("{:>width$}", label, width = info.label_pad_width + 2);
-      let prefix =
-        format!("{} ", colorize_task_prefix(&padded_label, info.color_index));
-      let (io, handles) = task_runner::make_prefixed_task_io(prefix);
-      (Some(io), handles)
-    } else {
-      (None, vec![])
+    let (stdio, output_handles) = match self.task_flags.reporter {
+      // Capture stdout/stderr and wrap each line in a `taskOutput` event so the
+      // stream on stdout stays valid NDJSON.
+      TaskReporter::Ndjson => {
+        let (io, handles) = task_runner::make_captured_task_io(
+          Box::new(NdjsonOutputWriter::new(
+            package_name.map(str::to_string),
+            task_name.to_string(),
+            "stdout",
+          )),
+          Box::new(NdjsonOutputWriter::new(
+            package_name.map(str::to_string),
+            task_name.to_string(),
+            "stderr",
+          )),
+        );
+        (Some(io), handles)
+      }
+      TaskReporter::Pretty => {
+        if let Some(info) = parallel_info {
+          // Right-align the entire `[name]` block so brackets line up across
+          // rows, putting the leading padding spaces *outside* the brackets.
+          let inner: Cow<str> = if info.include_package
+            && let Some(pkg) = label_name
+          {
+            Cow::Owned(format!("{}#{}", pkg, task_name))
+          } else {
+            Cow::Borrowed(task_name)
+          };
+          let label = format!("[{}]", inner);
+          let padded_label =
+            format!("{:>width$}", label, width = info.label_pad_width + 2);
+          let prefix = format!(
+            "{} ",
+            colorize_task_prefix(&padded_label, info.color_index)
+          );
+          let (io, handles) = task_runner::make_prefixed_task_io(prefix);
+          (Some(io), handles)
+        } else {
+          (None, vec![])
+        }
+      }
     };
 
     let env_vars = if extra_env_vars.is_empty() {
@@ -826,6 +967,7 @@ impl<'a> TaskRunner<'a> {
       env_vars
     };
 
+    let started_at = Instant::now();
     let exit_code = task_runner::run_task(task_runner::RunTaskOptions {
       task_name,
       script,
@@ -841,9 +983,17 @@ impl<'a> TaskRunner<'a> {
     .await?
     .exit_code;
 
-    for handle in prefix_handles {
+    // Wait for the output-forwarding tasks to drain before reporting the end so
+    // that all `taskOutput` events precede the `taskEnd` event.
+    for handle in output_handles {
       let _ = handle.await;
     }
+    self.report_task_end(
+      task_name,
+      package_name,
+      exit_code,
+      started_at.elapsed(),
+    );
 
     Ok(exit_code)
   }
@@ -860,6 +1010,45 @@ impl<'a> TaskRunner<'a> {
       }
     }
     Ok(())
+  }
+
+  /// Report that a task is about to start: either the human-readable `Task`
+  /// log line (pretty) or a `taskStart` ndjson event.
+  fn report_task_start(
+    &self,
+    task_name: &str,
+    package_name: Option<&str>,
+    command: &str,
+  ) {
+    match self.task_flags.reporter {
+      TaskReporter::Pretty => {
+        self.output_task(task_name, package_name, command)
+      }
+      TaskReporter::Ndjson => emit_ndjson_event(&TaskEvent::Start {
+        package: package_name,
+        task: task_name,
+        command,
+      }),
+    }
+  }
+
+  /// Report that a task finished. Only the ndjson reporter emits an end event;
+  /// the pretty reporter's output is unchanged.
+  fn report_task_end(
+    &self,
+    task_name: &str,
+    package_name: Option<&str>,
+    code: i32,
+    duration: Duration,
+  ) {
+    if let TaskReporter::Ndjson = self.task_flags.reporter {
+      emit_ndjson_event(&TaskEvent::End {
+        package: package_name,
+        task: task_name,
+        code,
+        duration_ms: duration.as_millis(),
+      });
+    }
   }
 
   fn output_task(

--- a/tests/specs/task/reporter_ndjson/__test__.jsonc
+++ b/tests/specs/task/reporter_ndjson/__test__.jsonc
@@ -1,0 +1,22 @@
+{
+  "tests": {
+    "single_task": {
+      "args": "task --reporter ndjson hello",
+      "output": "single.out"
+    },
+    "failing_task_preserves_exit_code": {
+      "args": "task --reporter ndjson fail",
+      "exitCode": 3,
+      "output": "fail.out"
+    },
+    "parallel_tasks": {
+      "args": "task --reporter ndjson main",
+      "output": "parallel.out"
+    },
+    "invalid_reporter": {
+      "args": "task --reporter bogus hello",
+      "exitCode": 1,
+      "output": "invalid.out"
+    }
+  }
+}

--- a/tests/specs/task/reporter_ndjson/deno.json
+++ b/tests/specs/task/reporter_ndjson/deno.json
@@ -1,0 +1,12 @@
+{
+  "tasks": {
+    "hello": "echo hi",
+    "fail": "echo before && exit 3",
+    "foo": "echo foo_output",
+    "bar": "echo bar_output",
+    "main": {
+      "command": "echo main_output",
+      "dependencies": ["foo", "bar"]
+    }
+  }
+}

--- a/tests/specs/task/reporter_ndjson/fail.out
+++ b/tests/specs/task/reporter_ndjson/fail.out
@@ -1,0 +1,3 @@
+{"type":"taskStart","package":null,"task":"fail","command":"echo before && exit 3"}
+{"type":"taskOutput","package":null,"task":"fail","stream":"stdout","text":"before\n"}
+{"type":"taskEnd","package":null,"task":"fail","code":3,"durationMs":[WILDLINE]

--- a/tests/specs/task/reporter_ndjson/invalid.out
+++ b/tests/specs/task/reporter_ndjson/invalid.out
@@ -1,0 +1,3 @@
+error: invalid value 'bogus' for '--reporter <reporter>'
+  [possible values: pretty, ndjson]
+[WILDCARD]

--- a/tests/specs/task/reporter_ndjson/parallel.out
+++ b/tests/specs/task/reporter_ndjson/parallel.out
@@ -1,0 +1,11 @@
+[UNORDERED_START]
+{"type":"taskStart","package":null,"task":"foo","command":"echo foo_output"}
+{"type":"taskOutput","package":null,"task":"foo","stream":"stdout","text":"foo_output\n"}
+{"type":"taskEnd","package":null,"task":"foo","code":0,"durationMs":[WILDLINE]
+{"type":"taskStart","package":null,"task":"bar","command":"echo bar_output"}
+{"type":"taskOutput","package":null,"task":"bar","stream":"stdout","text":"bar_output\n"}
+{"type":"taskEnd","package":null,"task":"bar","code":0,"durationMs":[WILDLINE]
+[UNORDERED_END]
+{"type":"taskStart","package":null,"task":"main","command":"echo main_output"}
+{"type":"taskOutput","package":null,"task":"main","stream":"stdout","text":"main_output\n"}
+{"type":"taskEnd","package":null,"task":"main","code":0,"durationMs":[WILDLINE]

--- a/tests/specs/task/reporter_ndjson/single.out
+++ b/tests/specs/task/reporter_ndjson/single.out
@@ -1,0 +1,3 @@
+{"type":"taskStart","package":null,"task":"hello","command":"echo hi"}
+{"type":"taskOutput","package":null,"task":"hello","stream":"stdout","text":"hi\n"}
+{"type":"taskEnd","package":null,"task":"hello","code":0,"durationMs":[WILDLINE]


### PR DESCRIPTION
## Summary

Adds `--reporter <pretty|ndjson>` to `deno task` (default `pretty`, which is byte-identical to today's behavior). Closes #35311.

In `ndjson` mode, `deno task` emits one JSON object per line to stdout describing task lifecycle events, so CI dashboards / tooling can consume task lifecycle and output as structured events:

```jsonc
{"type":"taskStart","package":"@scope/a","task":"build","command":"echo hi"}
{"type":"taskOutput","package":"@scope/a","task":"build","stream":"stdout","text":"hi\n"}
{"type":"taskEnd","package":"@scope/a","task":"build","code":0,"durationMs":12}
```

### Event schema

- `taskStart` — `{ type, package, task, command }`
- `taskOutput` — `{ type, package, task, stream, text }` where `stream` is `"stdout"` or `"stderr"`
- `taskEnd` — `{ type, package, task, code, durationMs }`

`package` is `null` for tasks that don't belong to a named workspace package.

### Behavior notes

- In `ndjson` mode, task stdout/stderr is captured and wrapped one event per line so the stream on stdout stays valid NDJSON; the human-readable `Task ...` header line is suppressed. Diagnostics still go to stderr.
- Output is written under a single stdout lock per line so concurrently-running tasks never interleave mid-line.
- Exit code semantics are unchanged — a non-zero task exit still fails the overall run with the same exit code.
- `--reporter pretty` (default) is unchanged.

### Out of scope (per the issue)

- A `--stream` line-interleaving mode for the pretty reporter.
- Persisting reports to a file (consumers can redirect stdout).

## Test plan

- New spec tests in `tests/specs/task/reporter_ndjson/`:
  - NDJSON validity + event coverage for a single task
  - non-zero task exit preserves exit code (and `code` field)
  - parallel tasks (dependencies run concurrently)
  - invalid `--reporter` value errors
- New flag-parsing unit test for `--reporter ndjson`.
- Existing `deno task` spec suite (122 tests) still passes, confirming pretty mode is unchanged.
- `deno task --help` documents the reporter values and event schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)