### PR TITLE
feat(task): add --if-present flag to deno task

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -668,6 +668,8 @@ pub struct TaskFlags {
   pub filter: Option<String>,
   pub eval: bool,
   pub no_prefix: bool,
+  /// Exit with code 0 instead of an error when the named task is not found.
+  pub if_present: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5039,6 +5041,14 @@ Evaluate a task from string:
           )
           .action(ArgAction::SetTrue),
       )
+      .arg(
+        Arg::new("if-present")
+          .long("if-present")
+          .help(
+            "Exit with code 0 instead of an error when the task is not found",
+          )
+          .action(ArgAction::SetTrue),
+      )
       .arg(env_file_arg())
       .arg(node_modules_dir_arg())
       .arg(node_modules_linker_arg())
@@ -8603,6 +8613,7 @@ fn task_parse(
     filter,
     eval: matches.get_flag("eval"),
     no_prefix: matches.get_flag("no-prefix"),
+    if_present: matches.get_flag("if-present"),
   };
 
   match matches.remove_subcommand() {
@@ -14784,6 +14795,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         argv: svec!["hello", "world"],
         ..Flags::default()
@@ -14802,6 +14814,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         ..Flags::default()
       }
@@ -14819,6 +14832,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         ..Flags::default()
       }
@@ -14836,6 +14850,7 @@ mod tests {
           filter: Some("*".to_string()),
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         ..Flags::default()
       }
@@ -14853,6 +14868,7 @@ mod tests {
           filter: Some("*".to_string()),
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         ..Flags::default()
       }
@@ -14870,6 +14886,7 @@ mod tests {
           filter: Some("*".to_string()),
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         ..Flags::default()
       }
@@ -14887,6 +14904,7 @@ mod tests {
           filter: None,
           eval: true,
           no_prefix: false,
+          if_present: false,
         }),
         ..Flags::default()
       }
@@ -14919,6 +14937,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         argv: svec!["--", "hello", "world"],
         config_flag: ConfigFlag::Path("deno.json".to_owned()),
@@ -14940,6 +14959,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         argv: svec!["--", "hello", "world"],
         ..Flags::default()
@@ -14962,6 +14982,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         argv: svec!["--"],
         ..Flags::default()
@@ -14983,6 +15004,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         argv: svec!["-1", "--test"],
         ..Flags::default()
@@ -15004,6 +15026,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         argv: svec!["--test"],
         ..Flags::default()
@@ -15026,6 +15049,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         log_level: Some(log::Level::Error),
         ..Flags::default()
@@ -15047,6 +15071,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         ..Flags::default()
       }
@@ -15067,6 +15092,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         config_flag: ConfigFlag::Path("deno.jsonc".to_string()),
         ..Flags::default()
@@ -15088,6 +15114,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         config_flag: ConfigFlag::Path("deno.jsonc".to_string()),
         ..Flags::default()
@@ -15118,6 +15145,7 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         env_file: Some(vec![".env".to_owned()]),
         ..Flags::default()
@@ -15142,8 +15170,30 @@ mod tests {
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         }),
         env_file: Some(vec![".env.dev".to_owned(), ".env.local".to_owned()]),
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn task_subcommand_if_present() {
+    let r = flags_from_vec(svec!["deno", "task", "--if-present", "build"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Task(TaskFlags {
+          cwd: None,
+          task: Some("build".to_string()),
+          is_run: false,
+          recursive: false,
+          filter: None,
+          eval: false,
+          no_prefix: false,
+          if_present: true,
+        }),
         ..Flags::default()
       }
     );

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -291,6 +291,7 @@ async fn run_subcommand(
           filter: None,
           eval: false,
           no_prefix: false,
+          if_present: false,
         };
         let mut flags = flags;
         flags.subcommand = DenoSubcommand::Task(task_flags.clone());
@@ -403,6 +404,7 @@ async fn run_subcommand(
                   filter: None,
                   eval: false,
                   no_prefix: false,
+                  if_present: false,
                 };
                 new_flags.subcommand = DenoSubcommand::Task(task_flags.clone());
                 let result = tools::task::execute_script(

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -418,6 +418,11 @@ impl<'a> TaskRunner<'a> {
       if self.task_flags.is_run {
         return Err(anyhow!("Task not found: {}", task_name));
       }
+      // `--if-present` mirrors npm's flag: exit cleanly and quietly when the
+      // requested task does not exist, without listing available tasks.
+      if self.task_flags.if_present {
+        return Ok(0);
+      }
       log::error!("Task not found: {}", task_name);
       if log::log_enabled!(log::Level::Error)
         && let Some(pkg) = packages.first()

--- a/tests/specs/task/if_present/__test__.jsonc
+++ b/tests/specs/task/if_present/__test__.jsonc
@@ -1,0 +1,17 @@
+{
+  "tests": {
+    // A missing task with --if-present exits 0 and prints nothing, mirroring
+    // npm's --if-present flag.
+    "missing_task": {
+      "args": "task --config deno.json --if-present non_existent",
+      "output": "",
+      "exitCode": 0
+    },
+    // An existing task still runs normally with --if-present.
+    "existing_task": {
+      "args": "task --config deno.json --if-present echo",
+      "output": "existing.out",
+      "exitCode": 0
+    }
+  }
+}

--- a/tests/specs/task/if_present/deno.json
+++ b/tests/specs/task/if_present/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "echo": "echo hello"
+  }
+}

--- a/tests/specs/task/if_present/existing.out
+++ b/tests/specs/task/if_present/existing.out
@@ -1,0 +1,2 @@
+Task echo echo hello
+hello


### PR DESCRIPTION
`deno task <name>` exits with code 1 when the named task does not exist,
which makes it awkward to invoke optional tasks from generated CI
workflows where a task may not be defined yet. This adds an
`--if-present` flag, mirroring npm's flag of the same name, that makes
`deno task` exit 0 and print nothing when the requested task is not
found.

The flag only suppresses the not-found case for an explicitly named
task; listing tasks (bare `deno task`), running an existing task, and
genuine errors such as a missing task dependency are unaffected.

Closes #20130