### PR TITLE
feat(task): set npm_execpath, npm_node_execpath and npm_command for package.json scripts

### DIFF
--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -723,10 +723,11 @@ impl<'a> TaskRunner<'a> {
       &node_modules_bin_dirs,
     )?;
 
-    // npm sets a number of `npm_package_*` lifecycle env vars when running a
-    // package.json script. Build them from the script's package.json so that
-    // `deno task` matches npm's behavior (see #35251).
-    let base_npm_env_vars = self
+    // npm sets a number of `npm_*` env vars when running a package.json script.
+    // Build the `npm_package_*` vars from the script's package.json plus the
+    // process-level vars (`npm_execpath`, `npm_node_execpath`, `npm_command`)
+    // so that `deno task` matches npm's behavior (see #35251, #35306).
+    let mut base_npm_env_vars = self
       .cli_options
       .workspace()
       .config_folders()
@@ -734,6 +735,7 @@ impl<'a> TaskRunner<'a> {
       .and_then(|folder| folder.pkg_json.as_ref())
       .map(|pkg_json| npm_package_env_vars(pkg_json))
       .unwrap_or_default();
+    base_npm_env_vars.extend(npm_process_env_vars());
 
     for task_name in &task_names {
       if let Some(script) = scripts.get(task_name) {
@@ -1044,6 +1046,27 @@ fn npm_package_env_vars(
       );
     }
   }
+  env_vars
+}
+
+/// Build the process-level npm env vars that npm sets for every package.json
+/// script, independent of which package it belongs to:
+///
+/// - `npm_execpath`: the package manager executable. npm points this at
+///   `npm-cli.js`; like pnpm/yarn point it at their own binary, we point it at
+///   the running `deno` executable.
+/// - `npm_node_execpath`: the JS runtime executing the script. npm sets this to
+///   the `node` binary; under `deno task` the runtime is `deno` itself.
+/// - `npm_command`: the npm command being run. `deno task <name>` runs a script
+///   the same way `npm run <name>` does, which npm reports as `run-script`.
+fn npm_process_env_vars() -> HashMap<OsString, OsString> {
+  let mut env_vars = HashMap::new();
+  if let Ok(exe) = std::env::current_exe() {
+    env_vars
+      .insert(OsString::from("npm_execpath"), exe.clone().into_os_string());
+    env_vars.insert(OsString::from("npm_node_execpath"), exe.into_os_string());
+  }
+  env_vars.insert(OsString::from("npm_command"), OsString::from("run-script"));
   env_vars
 }
 

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -365,8 +365,11 @@ struct RunSingleOptions<'a> {
   parallel_info: Option<ParallelInfo>,
   /// Extra environment variables to overlay on the runner's base env vars for
   /// this script (the npm `npm_package_*`/`npm_lifecycle_*`/process vars when
-  /// running package.json scripts). Borrowed so the shared map can be reused
-  /// across a package's pre/run/post scripts without re-cloning it.
+  /// running package.json scripts). Borrowed because the caller builds this map
+  /// once per package and overwrites the per-script `npm_lifecycle_*` entries
+  /// in place, rather than rebuilding the whole map for each pre/run/post
+  /// script. The entries are still cloned onto the base env when the script
+  /// actually runs.
   extra_env_vars: &'a HashMap<OsString, OsString>,
 }
 

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -363,10 +363,11 @@ struct RunSingleOptions<'a> {
   kill_signal: KillSignal,
   argv: &'a [String],
   parallel_info: Option<ParallelInfo>,
-  /// Extra environment variables to set for this script in addition to the
-  /// runner's base env vars. Used for the npm lifecycle vars (`npm_package_*`,
-  /// `npm_lifecycle_*`) when running package.json scripts.
-  extra_env_vars: HashMap<OsString, OsString>,
+  /// Extra environment variables to overlay on the runner's base env vars for
+  /// this script (the npm `npm_package_*`/`npm_lifecycle_*`/process vars when
+  /// running package.json scripts). Borrowed so the shared map can be reused
+  /// across a package's pre/run/post scripts without re-cloning it.
+  extra_env_vars: &'a HashMap<OsString, OsString>,
 }
 
 struct TaskRunner<'a> {
@@ -679,7 +680,7 @@ impl<'a> TaskRunner<'a> {
         argv,
         parallel_info,
         // npm lifecycle env vars are only set for package.json scripts.
-        extra_env_vars: HashMap::new(),
+        extra_env_vars: &HashMap::new(),
       })
       .await
   }
@@ -724,30 +725,29 @@ impl<'a> TaskRunner<'a> {
     )?;
 
     // npm sets a number of `npm_*` env vars when running a package.json script.
-    // Build the `npm_package_*` vars from the script's package.json plus the
-    // process-level vars (`npm_execpath`, `npm_node_execpath`, `npm_command`)
-    // so that `deno task` matches npm's behavior (see #35251, #35306).
-    let mut base_npm_env_vars = self
+    // Build them once (the `npm_package_*` vars from the script's package.json
+    // plus the process-level `npm_execpath`/`npm_node_execpath`/`npm_command`)
+    // so that `deno task` matches npm's behavior (see #35251, #35306). The
+    // per-script `npm_lifecycle_*` vars are overwritten in place each iteration,
+    // so this single map is reused across the package's pre/run/post scripts.
+    let pkg_json = self
       .cli_options
       .workspace()
       .config_folders()
       .get(dir_url)
-      .and_then(|folder| folder.pkg_json.as_ref())
-      .map(|pkg_json| npm_package_env_vars(pkg_json))
-      .unwrap_or_default();
-    base_npm_env_vars.extend(npm_process_env_vars());
+      .and_then(|folder| folder.pkg_json.as_deref());
+    let mut npm_env_vars = npm_script_env_vars(pkg_json);
 
     for task_name in &task_names {
       if let Some(script) = scripts.get(task_name) {
-        let mut extra_env_vars = base_npm_env_vars.clone();
         // `npm_lifecycle_event` is the name of the script currently running
         // (the pre/post-prefixed name), and `npm_lifecycle_script` is its
         // command.
-        extra_env_vars.insert(
+        npm_env_vars.insert(
           OsString::from("npm_lifecycle_event"),
           OsString::from(task_name),
         );
-        extra_env_vars.insert(
+        npm_env_vars.insert(
           OsString::from("npm_lifecycle_script"),
           OsString::from(script),
         );
@@ -763,7 +763,7 @@ impl<'a> TaskRunner<'a> {
             kill_signal: kill_signal.clone(),
             argv,
             parallel_info,
-            extra_env_vars,
+            extra_env_vars: &npm_env_vars,
           })
           .await?;
         if exit_code > 0 {
@@ -824,7 +824,8 @@ impl<'a> TaskRunner<'a> {
       self.env_vars.clone()
     } else {
       let mut env_vars = self.env_vars.clone();
-      env_vars.extend(extra_env_vars);
+      env_vars
+        .extend(extra_env_vars.iter().map(|(k, v)| (k.clone(), v.clone())));
       env_vars
     };
 
@@ -1016,42 +1017,14 @@ fn matches_package(
   false
 }
 
-/// Build the `npm_package_*` env vars that npm sets when running a
-/// package.json script (`npm_package_name`, `npm_package_version`,
-/// `npm_package_json`, and flattened `npm_package_config_*`). The
-/// `npm_lifecycle_*` vars are set per-script by the caller.
-fn npm_package_env_vars(
-  pkg_json: &deno_package_json::PackageJson,
-) -> HashMap<OsString, OsString> {
-  let mut env_vars = HashMap::new();
-  if let Some(name) = &pkg_json.name {
-    env_vars.insert(OsString::from("npm_package_name"), OsString::from(name));
-  }
-  if let Some(version) = &pkg_json.version {
-    env_vars.insert(
-      OsString::from("npm_package_version"),
-      OsString::from(version),
-    );
-  }
-  env_vars.insert(
-    OsString::from("npm_package_json"),
-    pkg_json.path.clone().into_os_string(),
-  );
-  if let Some(config) = &pkg_json.config {
-    for (key, value) in config {
-      flatten_config_env_var(
-        &mut env_vars,
-        &format!("npm_package_config_{key}"),
-        value,
-      );
-    }
-  }
-  env_vars
-}
-
-/// Build the process-level npm env vars that npm sets for every package.json
-/// script, independent of which package it belongs to:
+/// Build the base `npm_*` env vars that npm sets when running a package.json
+/// script, in a single map. These are shared by every script in a run; the
+/// per-script `npm_lifecycle_*` vars are added by the caller.
 ///
+/// Package vars (from `pkg_json`): `npm_package_name`, `npm_package_version`,
+/// `npm_package_json`, and flattened `npm_package_config_*`.
+///
+/// Process vars (independent of the package):
 /// - `npm_execpath`: the package manager executable. npm points this at
 ///   `npm-cli.js`; like pnpm/yarn point it at their own binary, we point it at
 ///   the running `deno` executable.
@@ -1059,12 +1032,42 @@ fn npm_package_env_vars(
 ///   the `node` binary; under `deno task` the runtime is `deno` itself.
 /// - `npm_command`: the npm command being run. `deno task <name>` runs a script
 ///   the same way `npm run <name>` does, which npm reports as `run-script`.
-fn npm_process_env_vars() -> HashMap<OsString, OsString> {
+fn npm_script_env_vars(
+  pkg_json: Option<&deno_package_json::PackageJson>,
+) -> HashMap<OsString, OsString> {
   let mut env_vars = HashMap::new();
+  if let Some(pkg_json) = pkg_json {
+    if let Some(name) = &pkg_json.name {
+      env_vars.insert(OsString::from("npm_package_name"), OsString::from(name));
+    }
+    if let Some(version) = &pkg_json.version {
+      env_vars.insert(
+        OsString::from("npm_package_version"),
+        OsString::from(version),
+      );
+    }
+    env_vars.insert(
+      OsString::from("npm_package_json"),
+      pkg_json.path.clone().into_os_string(),
+    );
+    if let Some(config) = &pkg_json.config {
+      for (key, value) in config {
+        flatten_config_env_var(
+          &mut env_vars,
+          &format!("npm_package_config_{key}"),
+          value,
+        );
+      }
+    }
+  }
   if let Ok(exe) = std::env::current_exe() {
-    env_vars
-      .insert(OsString::from("npm_execpath"), exe.clone().into_os_string());
-    env_vars.insert(OsString::from("npm_node_execpath"), exe.into_os_string());
+    // Normalize so `npm_execpath`/`npm_node_execpath` match `Deno.execPath()`
+    // exactly (it normalizes `current_exe()` too).
+    let exe = normalize_path(Cow::Owned(exe))
+      .into_owned()
+      .into_os_string();
+    env_vars.insert(OsString::from("npm_execpath"), exe.clone());
+    env_vars.insert(OsString::from("npm_node_execpath"), exe);
   }
   env_vars.insert(OsString::from("npm_command"), OsString::from("run-script"));
   env_vars

--- a/tests/specs/task/npm_process_env_vars/__test__.jsonc
+++ b/tests/specs/task/npm_process_env_vars/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "task env",
+  "output": "env.out",
+  "exitCode": 0
+}

--- a/tests/specs/task/npm_process_env_vars/env.out
+++ b/tests/specs/task/npm_process_env_vars/env.out
@@ -1,0 +1,4 @@
+Task env [WILDLINE]
+command:run-script
+execpath_is_deno:true
+node_execpath_is_deno:true

--- a/tests/specs/task/npm_process_env_vars/env.out
+++ b/tests/specs/task/npm_process_env_vars/env.out
@@ -2,3 +2,4 @@ Task env [WILDLINE]
 command:run-script
 execpath_is_deno:true
 node_execpath_is_deno:true
+execpath_eq_node:true

--- a/tests/specs/task/npm_process_env_vars/package.json
+++ b/tests/specs/task/npm_process_env_vars/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "my-package",
+  "version": "1.0.0",
+  "scripts": {
+    "env": "echo command:$npm_command && deno eval \"console.log('execpath_is_deno:' + (Deno.env.get('npm_execpath') === Deno.execPath())); console.log('node_execpath_is_deno:' + (Deno.env.get('npm_node_execpath') === Deno.execPath()))\""
+  }
+}

--- a/tests/specs/task/npm_process_env_vars/package.json
+++ b/tests/specs/task/npm_process_env_vars/package.json
@@ -2,6 +2,6 @@
   "name": "my-package",
   "version": "1.0.0",
   "scripts": {
-    "env": "echo command:$npm_command && deno eval \"console.log('execpath_is_deno:' + (Deno.env.get('npm_execpath') === Deno.execPath())); console.log('node_execpath_is_deno:' + (Deno.env.get('npm_node_execpath') === Deno.execPath()))\""
+    "env": "echo command:$npm_command && deno eval \"console.log('execpath_is_deno:' + (Deno.env.get('npm_execpath') === Deno.execPath())); console.log('node_execpath_is_deno:' + (Deno.env.get('npm_node_execpath') === Deno.execPath())); console.log('execpath_eq_node:' + (Deno.env.get('npm_execpath') === Deno.env.get('npm_node_execpath')))\""
   }
 }

--- a/tests/specs/task/npm_process_env_vars_deno_task/__test__.jsonc
+++ b/tests/specs/task/npm_process_env_vars_deno_task/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "task env",
+  "output": "env.out",
+  "exitCode": 0
+}

--- a/tests/specs/task/npm_process_env_vars_deno_task/deno.json
+++ b/tests/specs/task/npm_process_env_vars_deno_task/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "env": "deno eval \"console.log('command:' + Deno.env.get('npm_command')); console.log('execpath:' + Deno.env.get('npm_execpath')); console.log('node_execpath:' + Deno.env.get('npm_node_execpath'))\""
+  }
+}

--- a/tests/specs/task/npm_process_env_vars_deno_task/env.out
+++ b/tests/specs/task/npm_process_env_vars_deno_task/env.out
@@ -1,0 +1,4 @@
+Task env [WILDLINE]
+command:undefined
+execpath:undefined
+node_execpath:undefined


### PR DESCRIPTION
## Summary

Audits the `npm_*` environment variables `deno task` exposes when running `package.json` scripts (follow-up to #35251) and adds the process-level vars that were still missing, requested in #35306.

The new vars are set **only for package.json scripts** — native `deno.json` tasks continue to exclude npm semantics, matching the issue's scope note.

## `npm_*` comparison: present today vs. added

| Variable | Before | After | Value under `deno task` |
|---|:---:|:---:|---|
| `npm_config_user_agent` | ✅ | ✅ | `deno/<v> npm/? deno/<v> <os> <arch>` |
| `npm_lifecycle_event` | ✅ | ✅ | script name (incl. `pre`/`post` prefix) |
| `npm_lifecycle_script` | ✅ | ✅ | the script's command string |
| `npm_package_name` | ✅ | ✅ | `package.json` `name` |
| `npm_package_version` | ✅ | ✅ | `package.json` `version` |
| `npm_package_json` | ✅ | ✅ | path to `package.json` |
| `npm_package_config_*` | ✅ | ✅ | flattened `package.json` `config` |
| **`npm_execpath`** | ❌ | ✅ | path to the running `deno` executable |
| **`npm_node_execpath`** | ❌ | ✅ | path to the running `deno` executable |
| **`npm_command`** | ❌ | ✅ | `run-script` |

### Rationale for the added values
- **`npm_execpath`** — npm points this at `npm-cli.js`; pnpm/yarn point it at their own binary. `deno` is the package manager invoking the script, so we point it at the running `deno` executable (`std::env::current_exe()`).
- **`npm_node_execpath`** — npm sets this to the `node` binary running the script. Under `deno task` the JS runtime is `deno` itself.
- **`npm_command`** — `deno task <name>` runs a script the same way `npm run <name>` does, which npm reports as `run-script`.

### Intentionally deferred
`npm_config_*` config mirrors beyond the user-agent (e.g. `npm_config_registry`) are **not** included here — they depend on resolving `.npmrc`/registry configuration and are rarely required by scripts. They can follow in a separate change if a concrete need arises.

## Implementation
`cli/tools/task.rs`: new `npm_process_env_vars()` helper, merged into the per-script env in `run_npm_script` alongside the existing `npm_package_*` vars.

## Tests
New spec test `tests/specs/task/npm_process_env_vars/` asserting `npm_command == run-script` and that `npm_execpath`/`npm_node_execpath` equal `Deno.execPath()`. Verified existing `package_json_env_vars`, `pre_post`, `pre_only`, `post_only`, and `deno_no_pre_post` tests still pass (the latter confirms deno.json tasks don't receive these vars).

Closes #35306

🤖 Generated with [Claude Code](https://claude.com/claude-code)