### PR TITLE
fix(resolver): better hint when importing a linked package by the wrong name

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -90,6 +90,9 @@ pub struct GraphValidOptions<'a> {
   pub exit_integrity_errors: bool,
   pub allow_unknown_media_types: bool,
   pub allow_unknown_jsr_exports: bool,
+  /// Names of packages importable by bare specifier (workspace members and
+  /// packages linked via the "links" field), used to enhance import errors.
+  pub bare_importable_pkg_names: &'a [String],
 }
 
 /// Check if `roots` and their deps are available. Returns `Ok(())` if
@@ -119,6 +122,7 @@ pub fn graph_valid(
       will_type_check: options.will_type_check,
       allow_unknown_media_types: options.allow_unknown_media_types,
       allow_unknown_jsr_exports: options.allow_unknown_jsr_exports,
+      bare_importable_pkg_names: options.bare_importable_pkg_names,
     },
   );
   match errors.next() {
@@ -143,6 +147,9 @@ pub struct GraphWalkErrorsOptions<'a> {
   pub will_type_check: bool,
   pub allow_unknown_media_types: bool,
   pub allow_unknown_jsr_exports: bool,
+  /// Names of packages importable by bare specifier (workspace members and
+  /// packages linked via the "links" field), used to enhance import errors.
+  pub bare_importable_pkg_names: &'a [String],
 }
 
 /// Walks the errors found in the module graph that should be surfaced to users
@@ -221,6 +228,7 @@ pub fn graph_walk_errors<'a>(
         } else {
           EnhanceGraphErrorMode::ShowRange
         },
+        options.bare_importable_pkg_names,
       );
 
       Some(enhanced)
@@ -1152,6 +1160,12 @@ impl ModuleGraphBuilder {
     allow_unknown_jsr_exports: bool,
   ) -> Result<(), JsErrorBox> {
     let will_type_check = self.cli_options.type_check_mode().is_true();
+    let bare_importable_pkg_names = self
+      .cli_options
+      .workspace()
+      .resolver_jsr_pkgs()
+      .map(|pkg| pkg.name)
+      .collect::<Vec<_>>();
     graph_valid(
       graph,
       &self.sys,
@@ -1169,6 +1183,7 @@ impl ModuleGraphBuilder {
         exit_integrity_errors: true,
         allow_unknown_media_types,
         allow_unknown_jsr_exports,
+        bare_importable_pkg_names: &bare_importable_pkg_names,
       },
     )
   }

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -90,9 +90,11 @@ pub struct GraphValidOptions<'a> {
   pub exit_integrity_errors: bool,
   pub allow_unknown_media_types: bool,
   pub allow_unknown_jsr_exports: bool,
-  /// Names of packages importable by bare specifier (workspace members and
-  /// packages linked via the "links" field), used to enhance import errors.
-  pub bare_importable_pkg_names: &'a [String],
+  /// Lazily collects the names of packages importable by bare specifier
+  /// (workspace members and packages linked via the "links" field), used to
+  /// enhance import errors. Only called when a resolution error is actually
+  /// encountered, so the happy path pays nothing.
+  pub collect_bare_importable_pkg_names: &'a dyn Fn() -> Vec<String>,
 }
 
 /// Check if `roots` and their deps are available. Returns `Ok(())` if
@@ -122,7 +124,8 @@ pub fn graph_valid(
       will_type_check: options.will_type_check,
       allow_unknown_media_types: options.allow_unknown_media_types,
       allow_unknown_jsr_exports: options.allow_unknown_jsr_exports,
-      bare_importable_pkg_names: options.bare_importable_pkg_names,
+      collect_bare_importable_pkg_names: options
+        .collect_bare_importable_pkg_names,
     },
   );
   match errors.next() {
@@ -147,9 +150,11 @@ pub struct GraphWalkErrorsOptions<'a> {
   pub will_type_check: bool,
   pub allow_unknown_media_types: bool,
   pub allow_unknown_jsr_exports: bool,
-  /// Names of packages importable by bare specifier (workspace members and
-  /// packages linked via the "links" field), used to enhance import errors.
-  pub bare_importable_pkg_names: &'a [String],
+  /// Lazily collects the names of packages importable by bare specifier
+  /// (workspace members and packages linked via the "links" field), used to
+  /// enhance import errors. Only called when a resolution error is actually
+  /// encountered, so the happy path pays nothing.
+  pub collect_bare_importable_pkg_names: &'a dyn Fn() -> Vec<String>,
 }
 
 /// Walks the errors found in the module graph that should be surfaced to users
@@ -178,6 +183,12 @@ pub fn graph_walk_errors<'a>(
     // surface these as typescript diagnostics instead
     will_type_check && has_module_graph_error_for_tsc_diagnostic(sys, error)
   }
+
+  let collect_bare_importable_pkg_names =
+    options.collect_bare_importable_pkg_names;
+  // Built lazily on the first error that needs enhancing, then reused for the
+  // rest of the walk.
+  let mut bare_importable_pkg_names: Option<Vec<String>> = None;
 
   graph
     .walk(
@@ -228,7 +239,8 @@ pub fn graph_walk_errors<'a>(
         } else {
           EnhanceGraphErrorMode::ShowRange
         },
-        options.bare_importable_pkg_names,
+        bare_importable_pkg_names
+          .get_or_insert_with(&collect_bare_importable_pkg_names),
       );
 
       Some(enhanced)
@@ -1160,12 +1172,14 @@ impl ModuleGraphBuilder {
     allow_unknown_jsr_exports: bool,
   ) -> Result<(), JsErrorBox> {
     let will_type_check = self.cli_options.type_check_mode().is_true();
-    let bare_importable_pkg_names = self
-      .cli_options
-      .workspace()
-      .resolver_jsr_pkgs()
-      .map(|pkg| pkg.name)
-      .collect::<Vec<_>>();
+    let collect_bare_importable_pkg_names = || {
+      self
+        .cli_options
+        .workspace()
+        .resolver_jsr_pkgs()
+        .map(|pkg| pkg.name)
+        .collect::<Vec<_>>()
+    };
     graph_valid(
       graph,
       &self.sys,
@@ -1183,7 +1197,7 @@ impl ModuleGraphBuilder {
         exit_integrity_errors: true,
         allow_unknown_media_types,
         allow_unknown_jsr_exports,
-        bare_importable_pkg_names: &bare_importable_pkg_names,
+        collect_bare_importable_pkg_names: &collect_bare_importable_pkg_names,
       },
     )
   }

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -743,8 +743,11 @@ pub enum DenoDiagnostic {
   NoExportNpm(NpmPackageReqReference),
   /// A local module was not found on the local file system.
   NoLocal(ModuleSpecifier),
-  /// An error occurred when resolving the specifier string.
-  ResolutionError(deno_graph::ResolutionError),
+  /// An error occurred when resolving the specifier string. The second field
+  /// holds the names of packages importable by bare specifier (workspace
+  /// members and packages linked via the "links" field), used to enhance the
+  /// error with a better hint.
+  ResolutionError(deno_graph::ResolutionError, Vec<String>),
   /// Unknown `node:` specifier.
   UnknownNodeSpecifier(ModuleSpecifier),
   /// Bare specifier is used for `node:` specifier
@@ -764,7 +767,7 @@ impl DenoDiagnostic {
       Self::NotInstalledNpm(_, _) => "not-installed-npm",
       Self::NoExportNpm(_) => "no-export-npm",
       Self::NoLocal(_) => "no-local",
-      Self::ResolutionError(err) => {
+      Self::ResolutionError(err, _) => {
         if deno_resolver::graph::get_resolution_error_bare_node_specifier(err)
           .is_some()
         {
@@ -1020,8 +1023,8 @@ impl DenoDiagnostic {
         });
         (lsp::DiagnosticSeverity::ERROR, no_local_message(specifier, sloppy_resolution.as_ref().map(|(resolved, sloppy_reason)| sloppy_reason.suggestion_message_for_specifier(resolved))), data)
       },
-      Self::ResolutionError(err) => {
-        let message = strip_ansi_codes(&enhanced_resolution_error_message(err, &[])).into_owned();
+      Self::ResolutionError(err, bare_importable_pkg_names) => {
+        let message = strip_ansi_codes(&enhanced_resolution_error_message(err, bare_importable_pkg_names)).into_owned();
         (
         lsp::DiagnosticSeverity::ERROR,
         message,
@@ -1096,7 +1099,7 @@ fn maybe_ambient_import_specifier(
     DenoDiagnostic::NoCache(url) | DenoDiagnostic::NoLocal(url) => {
       Some(url.to_string())
     }
-    DenoDiagnostic::ResolutionError(err) => {
+    DenoDiagnostic::ResolutionError(err, _) => {
       maybe_ambient_specifier_resolution_err(err)
     }
     _ => None,
@@ -1283,11 +1286,31 @@ fn diagnose_resolution(
     // The specifier resolution resulted in an error, so we want to issue a
     // diagnostic for that.
     Resolution::Err(err) => {
+      // Names of packages importable by bare specifier (workspace members and
+      // packages linked via the "links" field) in the referrer's scope, used
+      // to enhance the error with a better hint.
+      let bare_importable_pkg_names = snapshot
+        .config
+        .tree
+        .data_for_specifier(&referrer_module.specifier)
+        .map(|d| {
+          d.member_dir
+            .workspace
+            .resolver_jsr_pkgs()
+            .map(|pkg| pkg.name)
+            .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
       if maybe_ambient_specifier_resolution_err(err).is_none() {
-        diagnostics.push(DenoDiagnostic::ResolutionError(*err.clone()))
+        diagnostics.push(DenoDiagnostic::ResolutionError(
+          *err.clone(),
+          bare_importable_pkg_names,
+        ))
       } else {
-        deferred_diagnostics
-          .push(DenoDiagnostic::ResolutionError(*err.clone()));
+        deferred_diagnostics.push(DenoDiagnostic::ResolutionError(
+          *err.clone(),
+          bare_importable_pkg_names,
+        ));
       }
     }
     _ => (),

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1021,7 +1021,7 @@ impl DenoDiagnostic {
         (lsp::DiagnosticSeverity::ERROR, no_local_message(specifier, sloppy_resolution.as_ref().map(|(resolved, sloppy_reason)| sloppy_reason.suggestion_message_for_specifier(resolved))), data)
       },
       Self::ResolutionError(err) => {
-        let message = strip_ansi_codes(&enhanced_resolution_error_message(err)).into_owned();
+        let message = strip_ansi_codes(&enhanced_resolution_error_message(err, &[])).into_owned();
         (
         lsp::DiagnosticSeverity::ERROR,
         message,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -435,6 +435,7 @@ impl LanguageServer {
           exit_integrity_errors: false,
           allow_unknown_media_types: true,
           allow_unknown_jsr_exports: false,
+          bare_importable_pkg_names: &[],
         },
       )?;
       Ok(())

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -424,12 +424,14 @@ impl LanguageServer {
           NpmCachingStrategy::Eager,
         )
         .await?;
-      let bare_importable_pkg_names = factory
-        .cli_options()?
-        .workspace()
-        .resolver_jsr_pkgs()
-        .map(|pkg| pkg.name)
-        .collect::<Vec<_>>();
+      let cli_options = factory.cli_options()?;
+      let collect_bare_importable_pkg_names = || {
+        cli_options
+          .workspace()
+          .resolver_jsr_pkgs()
+          .map(|pkg| pkg.name)
+          .collect::<Vec<_>>()
+      };
       graph_util::graph_valid(
         &graph,
         &CliSys::default(),
@@ -441,7 +443,7 @@ impl LanguageServer {
           exit_integrity_errors: false,
           allow_unknown_media_types: true,
           allow_unknown_jsr_exports: false,
-          bare_importable_pkg_names: &bare_importable_pkg_names,
+          collect_bare_importable_pkg_names: &collect_bare_importable_pkg_names,
         },
       )?;
       Ok(())

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -424,6 +424,12 @@ impl LanguageServer {
           NpmCachingStrategy::Eager,
         )
         .await?;
+      let bare_importable_pkg_names = factory
+        .cli_options()?
+        .workspace()
+        .resolver_jsr_pkgs()
+        .map(|pkg| pkg.name)
+        .collect::<Vec<_>>();
       graph_util::graph_valid(
         &graph,
         &CliSys::default(),
@@ -435,7 +441,7 @@ impl LanguageServer {
           exit_integrity_errors: false,
           allow_unknown_media_types: true,
           allow_unknown_jsr_exports: false,
-          bare_importable_pkg_names: &[],
+          bare_importable_pkg_names: &bare_importable_pkg_names,
         },
       )?;
       Ok(())

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -265,6 +265,7 @@ pub async fn doc(
         graph.roots.iter().cloned().collect::<Vec<_>>();
 
       graph_exit_integrity_errors(&graph);
+      let collect_bare_importable_pkg_names = Vec::<String>::new;
       let errors = graph_walk_errors(
         &graph,
         &sys,
@@ -275,7 +276,7 @@ pub async fn doc(
           will_type_check: false,
           allow_unknown_media_types: false,
           allow_unknown_jsr_exports: false,
-          bare_importable_pkg_names: &[],
+          collect_bare_importable_pkg_names: &collect_bare_importable_pkg_names,
         },
       );
       let mut markdown_urls = IndexSet::new();

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -275,6 +275,7 @@ pub async fn doc(
           will_type_check: false,
           allow_unknown_media_types: false,
           allow_unknown_jsr_exports: false,
+          bare_importable_pkg_names: &[],
         },
       );
       let mut markdown_urls = IndexSet::new();

--- a/cli/tsc/diagnostics.rs
+++ b/cli/tsc/diagnostics.rs
@@ -202,7 +202,10 @@ impl Diagnostic {
     }
   }
 
-  pub fn maybe_from_resolution_error(error: &ResolutionError) -> Option<Self> {
+  pub fn maybe_from_resolution_error(
+    error: &ResolutionError,
+    bare_importable_pkg_names: &[String],
+  ) -> Option<Self> {
     /// Some node resolution errors say "imported from '...'", but it's not
     /// very useful in a tsc diagnostic because it already has the referrer
     /// context, so remove that text
@@ -224,7 +227,8 @@ impl Diagnostic {
         None,
       ))
     } else {
-      let mut message = enhanced_resolution_error_message(error, &[]);
+      let mut message =
+        enhanced_resolution_error_message(error, bare_importable_pkg_names);
       // the diagnostic already shows the location, so this is redundant
       remove_imported_from(&mut message);
       Some(Self::from_missing_error_with_message(

--- a/cli/tsc/diagnostics.rs
+++ b/cli/tsc/diagnostics.rs
@@ -224,7 +224,7 @@ impl Diagnostic {
         None,
       ))
     } else {
-      let mut message = enhanced_resolution_error_message(error);
+      let mut message = enhanced_resolution_error_message(error, &[]);
       // the diagnostic already shows the location, so this is redundant
       remove_imported_from(&mut message);
       Some(Self::from_missing_error_with_message(

--- a/cli/type_checker.rs
+++ b/cli/type_checker.rs
@@ -350,6 +350,12 @@ impl TypeChecker {
           self.cli_options.initial_cwd(),
         )
         .map_err(|e| CheckErrorKind::Other(JsErrorBox::from_err(e)))?,
+        bare_importable_pkg_names: self
+          .cli_options
+          .workspace()
+          .resolver_jsr_pkgs()
+          .map(|pkg| pkg.name)
+          .collect(),
       }),
     ))
   }
@@ -480,6 +486,9 @@ struct DiagnosticsByFolderRealIterator<'a> {
   code_cache: Option<Arc<crate::cache::CodeCache>>,
   initial_cwd: PathBuf,
   current_dir: Url,
+  /// Names of packages importable by bare specifier (workspace members and
+  /// packages linked via the "links" field), used to enhance import errors.
+  bare_importable_pkg_names: Vec<String>,
 }
 
 impl Iterator for DiagnosticsByFolderRealIterator<'_> {
@@ -554,6 +563,7 @@ impl DiagnosticsByFolderRealIterator<'_> {
       self.node_resolver,
       self.npm_resolver,
       self.compiler_options_resolver,
+      &self.bare_importable_pkg_names,
       self.npm_check_state_hash,
       check_group.compiler_options,
       self.options.type_check_mode,
@@ -847,6 +857,9 @@ struct GraphWalker<'a> {
   node_resolver: &'a CliNodeResolver,
   npm_resolver: &'a CliNpmResolver,
   compiler_options_resolver: &'a CompilerOptionsResolver,
+  /// Names of packages importable by bare specifier (workspace members and
+  /// packages linked via the "links" field), used to enhance import errors.
+  bare_importable_pkg_names: &'a [String],
   maybe_hasher: Option<FastInsecureHasher>,
   seen: HashSet<&'a Url>,
   pending: VecDeque<PendingGraphWalkSpecifier<'a>>,
@@ -870,6 +883,7 @@ impl<'a> GraphWalker<'a> {
     node_resolver: &'a CliNodeResolver,
     npm_resolver: &'a CliNpmResolver,
     compiler_options_resolver: &'a CompilerOptionsResolver,
+    bare_importable_pkg_names: &'a [String],
     npm_cache_state_hash: Option<u64>,
     compiler_options: &CompilerOptions,
     type_check_mode: TypeCheckMode,
@@ -892,6 +906,7 @@ impl<'a> GraphWalker<'a> {
       node_resolver,
       npm_resolver,
       compiler_options_resolver,
+      bare_importable_pkg_names,
       maybe_hasher,
       seen: HashSet::with_capacity(
         graph.imports.len() + graph.specifiers_count(),
@@ -1137,7 +1152,10 @@ impl<'a> GraphWalker<'a> {
                 )
               }))
             && let Some(diagnostic) =
-              tsc::Diagnostic::maybe_from_resolution_error(resolution_error)
+              tsc::Diagnostic::maybe_from_resolution_error(
+                resolution_error,
+                self.bare_importable_pkg_names,
+              )
           {
             self.push_missing_diagnostic(
               diagnostic,
@@ -1325,7 +1343,10 @@ impl<'a> GraphWalker<'a> {
             let resolution_error =
               ResolutionError::InvalidSpecifier { error, range };
             if let Some(diagnostic) =
-              tsc::Diagnostic::maybe_from_resolution_error(&resolution_error)
+              tsc::Diagnostic::maybe_from_resolution_error(
+                &resolution_error,
+                self.bare_importable_pkg_names,
+              )
             {
               self.missing_diagnostics.push(diagnostic);
             }

--- a/libs/resolver/graph.rs
+++ b/libs/resolver/graph.rs
@@ -700,15 +700,25 @@ pub fn enhance_graph_error(
   sys: &(impl sys_traits::FsMetadata + Clone),
   error: ModuleGraphError,
   mode: EnhanceGraphErrorMode,
+  // Names of packages importable by bare specifier (workspace members and
+  // packages linked via the "links" field). Used to produce a better hint
+  // when a bare import almost matches one of them.
+  bare_importable_pkg_names: &[String],
 ) -> EnhancedGraphError {
   let mut message = match &error {
     ModuleGraphError::ResolutionError(resolution_error) => {
-      enhanced_resolution_error_message(resolution_error)
+      enhanced_resolution_error_message(
+        resolution_error,
+        bare_importable_pkg_names,
+      )
     }
     ModuleGraphError::TypesResolutionError(resolution_error) => {
       format!(
         "Failed resolving types. {}",
-        enhanced_resolution_error_message(resolution_error)
+        enhanced_resolution_error_message(
+          resolution_error,
+          bare_importable_pkg_names,
+        )
       )
     }
     ModuleGraphError::ModuleError(error) => {
@@ -756,7 +766,10 @@ fn maybe_docs_url_for_graph_error(
 }
 
 /// Adds more explanatory information to a resolution error.
-pub fn enhanced_resolution_error_message(error: &ResolutionError) -> String {
+pub fn enhanced_resolution_error_message(
+  error: &ResolutionError,
+  bare_importable_pkg_names: &[String],
+) -> String {
   let mut message = format_deno_graph_error(error);
 
   let maybe_hint = if let Some(specifier) =
@@ -767,7 +780,16 @@ pub fn enhanced_resolution_error_message(error: &ResolutionError) -> String {
     ))
   } else {
     get_import_prefix_missing_error(error).map(|specifier| {
-      if specifier.starts_with("@std/") {
+      // If the specifier looks like a workspace member or linked package whose
+      // declared name is scoped (e.g. importing "foo" when "@scope/foo" is
+      // linked), point at the real name instead of suggesting `deno add`.
+      if let Some(name) =
+        maybe_matching_bare_pkg_name(specifier, bare_importable_pkg_names)
+      {
+        format!(
+          "\"{name}\" is available in this workspace (via a workspace member or the \"links\" field). Import it by its full name: \"{name}\".",
+        )
+      } else if specifier.starts_with("@std/") {
         format!(
           "If you want to use the JSR package, try running `deno add jsr:{}`",
           specifier
@@ -942,6 +964,34 @@ fn get_resolution_error_bare_specifier(
   }
 }
 
+/// If `specifier` (a bare import that failed to resolve) matches the unscoped
+/// name of a known bare-importable package, returns that package's full name.
+///
+/// This catches the common mistake of importing a scoped package by its
+/// unscoped tail, e.g. importing `"my-pkg"` when `"@scope/my-pkg"` is linked.
+fn maybe_matching_bare_pkg_name<'a>(
+  specifier: &str,
+  bare_importable_pkg_names: &'a [String],
+) -> Option<&'a str> {
+  // Compare only the package portion, ignoring any imported subpath.
+  let specifier_head = specifier.split('/').next().unwrap_or(specifier);
+  bare_importable_pkg_names
+    .iter()
+    .map(|name| name.as_str())
+    .find(|name| {
+      // The unscoped tail of `@scope/foo` is `foo`; an unscoped name is its
+      // own tail.
+      let unscoped = name
+        .strip_prefix('@')
+        .and_then(|rest| rest.split_once('/'))
+        .map(|(_scope, tail)| tail)
+        .unwrap_or(name);
+      // Only suggest when the user didn't already type the full name (that
+      // would have resolved), but the unscoped tail matches.
+      *name != specifier_head && unscoped == specifier_head
+    })
+}
+
 fn get_import_prefix_missing_error(error: &ResolutionError) -> Option<&str> {
   // not exact, but ok because this is just a hint
   let media_type =
@@ -1106,5 +1156,32 @@ mod test {
       };
       assert_eq!(get_resolution_error_bare_node_specifier(&err), output,);
     }
+  }
+
+  #[test]
+  fn matching_bare_pkg_name() {
+    let names = [
+      "@scope/my-pkg".to_string(),
+      "plain-pkg".to_string(),
+      "@org/utils".to_string(),
+    ];
+    // Unscoped tail of a scoped package matches.
+    assert_eq!(
+      maybe_matching_bare_pkg_name("my-pkg", &names),
+      Some("@scope/my-pkg")
+    );
+    // Importing a subpath still matches on the package head.
+    assert_eq!(
+      maybe_matching_bare_pkg_name("utils/helpers", &names),
+      Some("@org/utils")
+    );
+    // The full scoped name resolves on its own, so no suggestion.
+    assert_eq!(maybe_matching_bare_pkg_name("@scope/my-pkg", &names), None);
+    // An unscoped name that already matches exactly would have resolved.
+    assert_eq!(maybe_matching_bare_pkg_name("plain-pkg", &names), None);
+    // No relation at all.
+    assert_eq!(maybe_matching_bare_pkg_name("unrelated", &names), None);
+    // Nothing linked.
+    assert_eq!(maybe_matching_bare_pkg_name("my-pkg", &[]), None);
   }
 }

--- a/libs/resolver/graph.rs
+++ b/libs/resolver/graph.rs
@@ -787,7 +787,7 @@ pub fn enhanced_resolution_error_message(
         maybe_matching_bare_pkg_name(specifier, bare_importable_pkg_names)
       {
         format!(
-          "\"{name}\" is available in this workspace (via a workspace member or the \"links\" field). Import it by its full name: \"{name}\".",
+          "\"{name}\" is available in this workspace (via a workspace member or the \"links\" field). Import it by its full name.",
         )
       } else if specifier.starts_with("@std/") {
         format!(
@@ -969,6 +969,9 @@ fn get_resolution_error_bare_specifier(
 ///
 /// This catches the common mistake of importing a scoped package by its
 /// unscoped tail, e.g. importing `"my-pkg"` when `"@scope/my-pkg"` is linked.
+///
+/// If two packages share an unscoped tail (e.g. `@a/foo` and `@b/foo`), the
+/// first match wins; that's acceptable since this only produces a hint.
 fn maybe_matching_bare_pkg_name<'a>(
   specifier: &str,
   bare_importable_pkg_names: &'a [String],

--- a/libs/resolver/loader/module_loader.rs
+++ b/libs/resolver/loader/module_loader.rs
@@ -412,6 +412,9 @@ impl<TSys: ModuleLoaderSys> PreparedModuleLoader<TSys> {
         &self.sys,
         deno_graph::ModuleGraphError::ModuleError(err.clone()),
         EnhanceGraphErrorMode::ShowRange,
+        // This is the post-build module-load path; bare-specifier resolution
+        // hints don't apply here.
+        &[],
       )
     })?;
 

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -6891,7 +6891,7 @@ fn lsp_diagnostics_linked_pkg_wrong_name_hint() {
   let message = messages.diagnostics[0].message.as_str();
   assert!(
     message.contains(
-      "\"@org/package\" is available in this workspace (via a workspace member or the \"links\" field). Import it by its full name: \"@org/package\".",
+      "\"@org/package\" is available in this workspace (via a workspace member or the \"links\" field). Import it by its full name.",
     ),
     "unexpected diagnostic message: {message}",
   );

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -6861,6 +6861,44 @@ fn lsp_jsr_auto_import_completion_patch() {
 }
 
 #[test(timeout = 300)]
+fn lsp_diagnostics_linked_pkg_wrong_name_hint() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write(
+    "deno.json",
+    json!({
+      "links": ["package"],
+    })
+    .to_string(),
+  );
+  temp_dir.write(
+    "package/deno.json",
+    json!({
+      "name": "@org/package",
+      "exports": "./mod.ts",
+    })
+    .to_string(),
+  );
+  temp_dir.write("package/mod.ts", "export const someValue = 1;\n");
+  // Import the linked package by its unscoped tail ("package") instead of its
+  // declared name ("@org/package"). The diagnostic should hint at the full
+  // name rather than suggesting `deno add npm:`.
+  let file = temp_dir.source_file("file.ts", "import \"package\";\n");
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  let diagnostics = client.did_open_file(&file);
+  let messages = diagnostics.messages_with_source("deno");
+  let message = messages.diagnostics[0].message.as_str();
+  assert!(
+    message.contains(
+      "\"@org/package\" is available in this workspace (via a workspace member or the \"links\" field). Import it by its full name: \"@org/package\".",
+    ),
+    "unexpected diagnostic message: {message}",
+  );
+  client.shutdown();
+}
+
+#[test(timeout = 300)]
 fn lsp_jsr_code_action_missing_declaration() {
   let context = TestContextBuilder::new()
     .use_http_server()

--- a/tests/specs/run/link_bare_specifier/__test__.jsonc
+++ b/tests/specs/run/link_bare_specifier/__test__.jsonc
@@ -12,6 +12,11 @@
     "import_map_entry_resolves": {
       "args": "run --config=with_import_map.json import_map.ts",
       "output": "import_map.out"
+    },
+    "wrong_name_hints_full_name": {
+      "args": "run wrong_name.ts",
+      "output": "wrong_name.out",
+      "exitCode": 1
     }
   }
 }

--- a/tests/specs/run/link_bare_specifier/__test__.jsonc
+++ b/tests/specs/run/link_bare_specifier/__test__.jsonc
@@ -17,6 +17,11 @@
       "args": "run wrong_name.ts",
       "output": "wrong_name.out",
       "exitCode": 1
+    },
+    "wrong_name_hints_full_name_check": {
+      "args": "check wrong_name.ts",
+      "output": "wrong_name_check.out",
+      "exitCode": 1
     }
   }
 }

--- a/tests/specs/run/link_bare_specifier/wrong_name.out
+++ b/tests/specs/run/link_bare_specifier/wrong_name.out
@@ -1,3 +1,3 @@
 error: Import "foo" not a dependency and not in import map from "[WILDCARD]wrong_name.ts"
-  hint: "@org/foo" is available in this workspace (via a workspace member or the "links" field). Import it by its full name: "@org/foo".
+  hint: "@org/foo" is available in this workspace (via a workspace member or the "links" field). Import it by its full name.
 [WILDCARD]

--- a/tests/specs/run/link_bare_specifier/wrong_name.out
+++ b/tests/specs/run/link_bare_specifier/wrong_name.out
@@ -1,0 +1,3 @@
+error: Import "foo" not a dependency and not in import map from "[WILDCARD]wrong_name.ts"
+  hint: "@org/foo" is available in this workspace (via a workspace member or the "links" field). Import it by its full name: "@org/foo".
+[WILDCARD]

--- a/tests/specs/run/link_bare_specifier/wrong_name.ts
+++ b/tests/specs/run/link_bare_specifier/wrong_name.ts
@@ -1,0 +1,1 @@
+import "foo";

--- a/tests/specs/run/link_bare_specifier/wrong_name_check.out
+++ b/tests/specs/run/link_bare_specifier/wrong_name_check.out
@@ -1,0 +1,6 @@
+Check [WILDCARD]wrong_name.ts
+TS2307 [ERROR]: Import "foo" not a dependency and not in import map from "[WILDCARD]wrong_name.ts"
+  hint: "@org/foo" is available in this workspace (via a workspace member or the "links" field). Import it by its full name: "@org/foo".
+    at [WILDCARD]wrong_name.ts:1:8
+
+error: Type checking failed.

--- a/tests/specs/run/link_bare_specifier/wrong_name_check.out
+++ b/tests/specs/run/link_bare_specifier/wrong_name_check.out
@@ -1,6 +1,6 @@
 Check [WILDCARD]wrong_name.ts
 TS2307 [ERROR]: Import "foo" not a dependency and not in import map from "[WILDCARD]wrong_name.ts"
-  hint: "@org/foo" is available in this workspace (via a workspace member or the "links" field). Import it by its full name: "@org/foo".
+  hint: "@org/foo" is available in this workspace (via a workspace member or the "links" field). Import it by its full name.
     at [WILDCARD]wrong_name.ts:1:8
 
 error: Type checking failed.


### PR DESCRIPTION
When a bare import fails to resolve, Deno appends a hint suggesting
`deno add npm:<name>`. That hint sends people the wrong way when the
project actually has a matching workspace member or a package linked via
the `links` field: the package is importable, just by its declared
`name`. The common case, seen in #35300, is a local package that
declares `"name": "@scope/my-pkg"` but is imported as `"my-pkg"`, which
fails with "not a dependency and not in import map" plus the npm hint.

This threads the set of bare-importable package names (workspace members
and linked packages) into the resolution-error enhancement. When the
failing specifier matches the unscoped tail of a known package name, the
hint now points at the full name to import instead of suggesting an npm
install. The hint is wired through all the paths that surface resolution
errors: the primary `deno run` / `deno check` path, the LSP diagnostics,
and the tsc diagnostics.

The package-name collection is lazy on the `deno run` / `deno check`
path, so it is only built when a resolution error is actually
encountered and the happy path pays nothing.

Towards #35300