### PR TITLE
docs: improve JSDoc for Deno namespace types from docs feedback

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -1466,6 +1466,14 @@ declare namespace Deno {
    * Register a benchmark test which will be run when `deno bench` is used on
    * the command line and the containing module looks like a bench module.
    *
+   * A module "looks like a bench module" when `deno bench` selects it for
+   * execution. When you pass explicit file paths to `deno bench`, those files
+   * are always run. When you run `deno bench` without paths, it walks the
+   * directory looking for files whose name (ignoring the extension) ends with
+   * `_bench` or `.bench`, or is exactly `bench`. Examples are `foo_bench.ts`,
+   * `foo.bench.js`, or `bench.ts`. Supported extensions are the same as for
+   * tests (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.mts`, `.cjs`, `.cts`).
+   *
    * If the test function (`fn`) returns a promise or is async, the test runner
    * will await resolution to consider the test complete.
    *
@@ -3118,12 +3126,18 @@ declare namespace Deno {
   ): Promise<void>;
 
   /** Asynchronously reads and returns the entire contents of a file as an UTF-8
-   *  decoded string. Reading a directory throws an error.
+   *  decoded string.
    *
    * ```ts
    * const data = await Deno.readTextFile("hello.txt");
    * console.log(data);
    * ```
+   *
+   * The returned promise rejects if the operation fails, for example with
+   * {@linkcode Deno.errors.NotFound} if the file does not exist,
+   * {@linkcode Deno.errors.IsADirectory} if `path` refers to a directory, or
+   * {@linkcode Deno.errors.PermissionDenied} if the required permission has not
+   * been granted.
    *
    * Requires `allow-read` permission.
    *
@@ -3136,12 +3150,18 @@ declare namespace Deno {
   ): Promise<string>;
 
   /** Synchronously reads and returns the entire contents of a file as an UTF-8
-   *  decoded string. Reading a directory throws an error.
+   *  decoded string.
    *
    * ```ts
    * const data = Deno.readTextFileSync("hello.txt");
    * console.log(data);
    * ```
+   *
+   * Throws if the operation fails, for example with
+   * {@linkcode Deno.errors.NotFound} if the file does not exist,
+   * {@linkcode Deno.errors.IsADirectory} if `path` refers to a directory, or
+   * {@linkcode Deno.errors.PermissionDenied} if the required permission has not
+   * been granted.
    *
    * Requires `allow-read` permission.
    *
@@ -3593,6 +3613,13 @@ declare namespace Deno {
    * await Deno.writeTextFile("hello1.txt", "Hello world\n");  // overwrite "hello1.txt" or create it
    * ```
    *
+   * The data is written to the file and the file is closed, but this does not
+   * guarantee that the contents have been flushed from the operating system's
+   * buffers to the physical storage device. If you need such a durability
+   * guarantee (for example before signalling that a write has been committed),
+   * open the file with {@linkcode Deno.open} and call
+   * {@linkcode Deno.FsFile.sync} before closing it.
+   *
    * Requires `allow-write` permission, and `allow-read` if `options.create` is
    * `false`.
    *
@@ -3611,6 +3638,12 @@ declare namespace Deno {
    * ```ts
    * Deno.writeTextFileSync("hello1.txt", "Hello world\n");  // overwrite "hello1.txt" or create it
    * ```
+   *
+   * As with {@linkcode Deno.writeTextFile}, the data is written and the file is
+   * closed, but this does not guarantee the contents have been flushed from the
+   * operating system's buffers to the physical storage device. If you need such
+   * a durability guarantee, open the file with {@linkcode Deno.openSync} and
+   * call {@linkcode Deno.FsFile.syncSync} before closing it.
    *
    * Requires `allow-write` permission, and `allow-read` if `options.create` is
    * `false`.
@@ -3971,7 +4004,11 @@ declare namespace Deno {
     get stdout(): SubprocessReadableStream;
     get stderr(): SubprocessReadableStream;
     readonly pid: number;
-    /** Get the status of the child. */
+    /** A promise that resolves once the child process has exited, with its
+     * exit code and terminating signal (if any). The promise never rejects; if
+     * the process is still running the promise is pending. Accessing this
+     * property does not, on its own, prevent the Deno process from exiting -
+     * see {@linkcode ChildProcess.ref}. */
     readonly status: Promise<CommandStatus>;
 
     /** Waits for the child to exit completely, returning all its output and
@@ -5258,12 +5295,17 @@ declare namespace Deno {
    *   beyond the range of 16-bit unsigned integer.
    * - the request timed out.
    *
+   * The `"A"`, `"AAAA"`, `"ANAME"`, `"CNAME"`, `"NS"` and `"PTR"` record types
+   * resolve to an array of strings.
+   *
    * ```ts
    * const a = await Deno.resolveDns("example.com", "A");
+   * // ["93.184.215.14"]
    *
    * const aaaa = await Deno.resolveDns("example.com", "AAAA", {
    *   nameServer: { ipAddr: "8.8.8.8", port: 53 },
    * });
+   * // ["2606:2800:21f:cb07:6820:80da:af6b:8b2c"]
    * ```
    *
    * Requires `allow-net` permission.
@@ -5288,12 +5330,12 @@ declare namespace Deno {
    *   beyond the range of 16-bit unsigned integer.
    * - the request timed out.
    *
-   * ```ts
-   * const a = await Deno.resolveDns("example.com", "A");
+   * The `"CAA"` record type resolves to an array of
+   * {@linkcode Deno.CaaRecord} objects.
    *
-   * const aaaa = await Deno.resolveDns("example.com", "AAAA", {
-   *   nameServer: { ipAddr: "8.8.8.8", port: 53 },
-   * });
+   * ```ts
+   * const caa = await Deno.resolveDns("example.com", "CAA");
+   * // [{ critical: false, tag: "issue", value: "letsencrypt.org" }]
    * ```
    *
    * Requires `allow-net` permission.
@@ -5318,12 +5360,12 @@ declare namespace Deno {
    *   beyond the range of 16-bit unsigned integer.
    * - the request timed out.
    *
-   * ```ts
-   * const a = await Deno.resolveDns("example.com", "A");
+   * The `"MX"` record type resolves to an array of
+   * {@linkcode Deno.MxRecord} objects.
    *
-   * const aaaa = await Deno.resolveDns("example.com", "AAAA", {
-   *   nameServer: { ipAddr: "8.8.8.8", port: 53 },
-   * });
+   * ```ts
+   * const mx = await Deno.resolveDns("example.com", "MX");
+   * // [{ preference: 10, exchange: "mail.example.com" }]
    * ```
    *
    * Requires `allow-net` permission.
@@ -5348,12 +5390,19 @@ declare namespace Deno {
    *   beyond the range of 16-bit unsigned integer.
    * - the request timed out.
    *
-   * ```ts
-   * const a = await Deno.resolveDns("example.com", "A");
+   * The `"NAPTR"` record type resolves to an array of
+   * {@linkcode Deno.NaptrRecord} objects.
    *
-   * const aaaa = await Deno.resolveDns("example.com", "AAAA", {
-   *   nameServer: { ipAddr: "8.8.8.8", port: 53 },
-   * });
+   * ```ts
+   * const naptr = await Deno.resolveDns("example.com", "NAPTR");
+   * // [{
+   * //   order: 100,
+   * //   preference: 10,
+   * //   flags: "S",
+   * //   services: "SIP+D2U",
+   * //   regexp: "",
+   * //   replacement: "_sip._udp.example.com",
+   * // }]
    * ```
    *
    * Requires `allow-net` permission.
@@ -5378,12 +5427,20 @@ declare namespace Deno {
    *   beyond the range of 16-bit unsigned integer.
    * - the request timed out.
    *
-   * ```ts
-   * const a = await Deno.resolveDns("example.com", "A");
+   * The `"SOA"` record type resolves to an array of
+   * {@linkcode Deno.SoaRecord} objects.
    *
-   * const aaaa = await Deno.resolveDns("example.com", "AAAA", {
-   *   nameServer: { ipAddr: "8.8.8.8", port: 53 },
-   * });
+   * ```ts
+   * const soa = await Deno.resolveDns("example.com", "SOA");
+   * // [{
+   * //   mname: "ns.example.com",
+   * //   rname: "hostmaster.example.com",
+   * //   serial: 2024010101,
+   * //   refresh: 7200,
+   * //   retry: 3600,
+   * //   expire: 1209600,
+   * //   minimum: 3600,
+   * // }]
    * ```
    *
    * Requires `allow-net` permission.
@@ -5408,12 +5465,12 @@ declare namespace Deno {
    *   beyond the range of 16-bit unsigned integer.
    * - the request timed out.
    *
-   * ```ts
-   * const a = await Deno.resolveDns("example.com", "A");
+   * The `"SRV"` record type resolves to an array of
+   * {@linkcode Deno.SrvRecord} objects.
    *
-   * const aaaa = await Deno.resolveDns("example.com", "AAAA", {
-   *   nameServer: { ipAddr: "8.8.8.8", port: 53 },
-   * });
+   * ```ts
+   * const srv = await Deno.resolveDns("_sip._tcp.example.com", "SRV");
+   * // [{ priority: 10, weight: 5, port: 5060, target: "sip.example.com" }]
    * ```
    *
    * Requires `allow-net` permission.
@@ -5438,12 +5495,12 @@ declare namespace Deno {
    *   beyond the range of 16-bit unsigned integer.
    * - the request timed out.
    *
-   * ```ts
-   * const a = await Deno.resolveDns("example.com", "A");
+   * The `"TXT"` record type resolves to an array of string arrays, since a
+   * single TXT record can be split into multiple character strings.
    *
-   * const aaaa = await Deno.resolveDns("example.com", "AAAA", {
-   *   nameServer: { ipAddr: "8.8.8.8", port: 53 },
-   * });
+   * ```ts
+   * const txt = await Deno.resolveDns("example.com", "TXT");
+   * // [["v=spf1 include:_spf.example.com ~all"]]
    * ```
    *
    * Requires `allow-net` permission.
@@ -5468,10 +5525,14 @@ declare namespace Deno {
    *   beyond the range of 16-bit unsigned integer.
    * - the request timed out.
    *
-   * ```ts
-   * const a = await Deno.resolveDns("example.com", "A");
+   * This overload is selected when the record type is only known at runtime. The
+   * shape of each resolved record depends on the {@linkcode Deno.RecordType}
+   * that was requested - see the more specific overloads above for the exact
+   * return type of each record type.
    *
-   * const aaaa = await Deno.resolveDns("example.com", "AAAA", {
+   * ```ts
+   * const recordType: Deno.RecordType = "A";
+   * const records = await Deno.resolveDns("example.com", recordType, {
    *   nameServer: { ipAddr: "8.8.8.8", port: 53 },
    * });
    * ```
@@ -5549,6 +5610,12 @@ declare namespace Deno {
   }
 
   /** A handler for HTTP requests. Consumes a request and returns a response.
+   *
+   * The `request` argument is a standard Web platform {@linkcode Request}, and
+   * the handler must return a standard Web platform {@linkcode Response} (or a
+   * promise resolving to one). These are the same `Request` and `Response`
+   * classes available as globals in Deno and in browsers, so the body, headers,
+   * URL, and method can all be read from the incoming `Request`.
    *
    * If a handler throws, the server calling the handler will assume the impact
    * of the error is isolated to the individual request. It will catch the error

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -171,7 +171,26 @@ declare namespace Deno {
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
-   * Bundle Typescript/Javascript code
+   * Bundle Typescript/Javascript code into a single file.
+   *
+   * This is an unstable API and requires the `--unstable-bundle` flag to be
+   * passed when running Deno:
+   *
+   * ```sh
+   * deno run --unstable-bundle main.ts
+   * ```
+   *
+   * ```ts
+   * const result = await Deno.bundle({
+   *   entrypoints: ["./main.ts"],
+   *   minify: true,
+   * });
+   *
+   * for (const file of result.outputFiles ?? []) {
+   *   console.log(file.text());
+   * }
+   * ```
+   *
    * @category Bundle
    * @experimental
    */
@@ -398,14 +417,36 @@ declare namespace Deno {
    *
    * Open a new {@linkcode Deno.Kv} connection to persist data.
    *
-   * When a path is provided, the database will be persisted to disk at that
-   * path. Read and write access to the file is required.
+   * This is an unstable API and requires the `--unstable-kv` flag to be passed
+   * when running Deno.
+   *
+   * The `path` argument accepts several forms:
+   *
+   * - A path to a local SQLite database **file** (not a directory). The file,
+   *   and any missing parent directories, are created if they don't exist. For
+   *   example `Deno.openKv("./my_database.sqlite")`. Read and write access to
+   *   the file is required.
+   * - The special value `":memory:"` to open an in-memory database that is
+   *   discarded when the process exits.
+   * - An `http://` or `https://` URL pointing at a remote KV database, such as
+   *   one hosted on Deno Deploy.
    *
    * When no path is provided, the database will be opened in a default path for
    * the current script. This location is persistent across script runs and is
    * keyed on the origin storage key (the same key that is used to determine
    * `localStorage` persistence). More information about the origin storage key
    * can be found in the Deno Manual.
+   *
+   * ```ts
+   * // Open (or create) a database backed by a local file.
+   * const kv = await Deno.openKv("./my_database.sqlite");
+   *
+   * await kv.set(["users", "alice"], { name: "Alice" });
+   * const entry = await kv.get(["users", "alice"]);
+   * console.log(entry.value); // { name: "Alice" }
+   *
+   * kv.close();
+   * ```
    *
    * @tags allow-read, allow-write
    * @category Cloud
@@ -446,6 +487,9 @@ declare namespace Deno {
    * Create a cron job that will periodically execute the provided handler
    * callback based on the specified schedule.
    *
+   * This is an unstable API and requires the `--unstable-cron` flag to be
+   * passed when running Deno.
+   *
    * ```ts
    * Deno.cron("sample cron", "20 * * * *", () => {
    *   console.log("cron job executed");
@@ -461,6 +505,13 @@ declare namespace Deno {
    * `schedule` can be a string in the Unix cron format or in JSON format
    * as specified by interface {@linkcode CronSchedule}, where time is specified
    * using UTC time zone.
+   *
+   * Calling `Deno.cron` registers the job and immediately returns. The returned
+   * promise should not be awaited to wait for the job to run, it is provided
+   * only to surface registration errors. The job keeps running in the
+   * background for the lifetime of the process. To be able to stop a cron job
+   * (for example during a graceful shutdown), use the overload that accepts an
+   * `options` object with an {@linkcode AbortSignal}.
    *
    * @category Cloud
    * @experimental
@@ -494,6 +545,21 @@ declare namespace Deno {
    * means that a failed execution will be retried at most 3 times, with 1
    * second, 5 seconds, and 10 seconds delay between each retry. There is a
    * limit of 5 retries and a maximum interval of 1 hour (3600000 milliseconds).
+   *
+   * `signal` option can be used to stop the cron job by passing an
+   * {@linkcode AbortSignal} and aborting it. This is useful for implementing a
+   * graceful shutdown, since aborting the signal unregisters the job:
+   *
+   * ```ts
+   * const ac = new AbortController();
+   *
+   * Deno.cron("sample cron", "20 * * * *", { signal: ac.signal }, () => {
+   *   console.log("cron job executed");
+   * });
+   *
+   * // Later, stop the cron job from running again.
+   * ac.abort();
+   * ```
    *
    * @category Cloud
    * @experimental

--- a/cli/tsc/dts/lib.deno_net.d.ts
+++ b/cli/tsc/dts/lib.deno_net.d.ts
@@ -448,12 +448,26 @@ declare namespace Deno {
    * @category Network */
   export interface TcpConn extends Conn<NetAddr> {
     /**
-     * Enable/disable the use of Nagle's algorithm.
+     * Sets the `TCP_NODELAY` option on this connection, which controls whether
+     * Nagle's algorithm is used.
+     *
+     * Note that the boolean is `noDelay`, not "enable Nagle", so the sense is
+     * the opposite of enabling the algorithm:
+     *
+     * - `setNoDelay(true)` (the default) sets `TCP_NODELAY`, which **disables**
+     *   Nagle's algorithm. Small writes are sent immediately with lower latency,
+     *   at the cost of potentially more, smaller packets.
+     * - `setNoDelay(false)` clears `TCP_NODELAY`, which **enables** Nagle's
+     *   algorithm. Small writes may be buffered and coalesced to reduce the
+     *   number of packets sent.
      *
      * @param [noDelay=true]
      */
     setNoDelay(noDelay?: boolean): void;
-    /** Enable/disable keep-alive functionality. */
+    /**
+     * Enable or disable TCP keep-alive probes on this connection. Pass `true`
+     * to enable keep-alive and `false` to disable it.
+     */
     setKeepAlive(keepAlive?: boolean): void;
   }
 

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -13359,7 +13359,7 @@ fn lsp_jupyter_completions() {
       },
       "documentation": {
         "kind": "markdown",
-        "value": "Asynchronously reads and returns the entire contents of a file as an UTF-8\ndecoded string. Reading a directory throws an error.\n\n```ts\nconst data = await Deno.readTextFile(\"hello.txt\");\nconsole.log(data);\n```\n\nRequires `allow-read` permission.\n\n*@tags* — allow-read\n\n\n*@category* — File System\n",
+        "value": "Asynchronously reads and returns the entire contents of a file as an UTF-8\ndecoded string.\n\n```ts\nconst data = await Deno.readTextFile(\"hello.txt\");\nconsole.log(data);\n```\n\nThe returned promise rejects if the operation fails, for example with\n[`Deno.errors.NotFound`](deno:/asset/lib.deno.ns.d.ts#174,5-174,43) if the file does not exist,\n[`Deno.errors.IsADirectory`](deno:/asset/lib.deno.ns.d.ts#307,5-307,47) if `path` refers to a directory, or\n[`Deno.errors.PermissionDenied`](deno:/asset/lib.deno.ns.d.ts#185,5-185,51) if the required permission has not\nbeen granted.\n\nRequires `allow-read` permission.\n\n*@tags* — allow-read\n\n\n*@category* — File System\n",
       },
       "sortText": "11",
     }),


### PR DESCRIPTION
This improves the JSDoc on several `Deno` namespace type definitions so that
the generated API reference at <https://docs.deno.com/api/deno> answers the
questions that users have raised through the docs feedback widget. Each of
these came in as an `upstream` issue on `denoland/docs` because the source of
truth is the type declarations here, not the docs site.

The changes are documentation only (comments and examples); no type signatures
or runtime behavior change.

What is clarified:

- `Deno.openKv`: the `path` argument is a SQLite database **file**, not a
  directory, which was a direct point of confusion. The `:memory:` and
  `http(s)://` forms are now documented, along with the `--unstable-kv` flag
  and a short usage example. (denoland/docs#3131, denoland/docs#2720)
- `Deno.cron`: explains that the call registers the job and returns
  immediately, that the returned promise is not something you await to wait
  for executions, and that a job can be stopped for graceful shutdown by
  passing an `AbortSignal` via the options overload (with an example). Also
  notes the `--unstable-cron` flag. (denoland/docs#2792)
- `Deno.bench`: explains what makes a module "look like a bench module",
  i.e. the file-name patterns (`*_bench`, `*.bench`, `bench`) and the
  supported extensions that `deno bench` uses for discovery.
  (denoland/docs#2758)
- `Deno.writeTextFile` / `Deno.writeTextFileSync`: note that the data is not
  fsynced and explain how to obtain a durability guarantee with
  `FsFile.sync`/`syncSync`. (denoland/docs#2608)
- `Deno.readTextFile` / `Deno.readTextFileSync`: document the errors that can
  be thrown (`NotFound`, `IsADirectory`, `PermissionDenied`).
  (denoland/docs#2600)
- `Deno.resolveDns`: each record-type overload now has an example tailored to
  that record type and shows the resolved shape, instead of every overload
  repeating the same `A`/`AAAA` example. (denoland/docs#2597)
- `Deno.bundle`: notes the `--unstable-bundle` flag required to access the API
  and adds an example. (denoland/docs#2579)
- `Deno.ServeHandler`: clarifies that the request and response are the standard
  Web platform `Request` and `Response`. (denoland/docs#2543)
- `Deno.ChildProcess.prototype.status`: documents that the promise resolves
  once the process exits and never rejects. (denoland/docs#2816)
- `Deno.TcpConn.setNoDelay`: clarifies the inverted sense, i.e. that
  `setNoDelay(true)` disables Nagle's algorithm. (denoland/docs#1053)

All facts above were verified against the implementation in `cli/`, `ext/kv`,
`ext/fs`, `ext/cron`, and `ext/process`. `deno fmt` passes on the changed
files.