### PR TITLE
fix(jupyter): report cell errors instead of failing silently

### DIFF
--- a/cli/js/jupyter_kernel.js
+++ b/cli/js/jupyter_kernel.js
@@ -733,7 +733,7 @@ async function startJupyterKernel() {
 
     if (evalResult !== null && evalResult !== undefined) {
       // Check for exception
-      const exDetails = evalResult?.value?.exceptionDetails;
+      const exDetails = evalResult?.exceptionDetails;
       if (exDetails) {
         // Exception during execution
         const exception = exDetails.exception;
@@ -795,7 +795,7 @@ async function startJupyterKernel() {
         await socket.send(peerId, replyFrames);
       } else {
         // Success: publish the result
-        const result = evalResult?.value?.result;
+        const result = evalResult?.result;
         if (result && !silent) {
           const arg0 = { value: executionCount };
           const arg1 = result.objectId
@@ -1077,7 +1077,7 @@ async function startJupyterKernel() {
       const resp = await op_jupyter_repl_evaluate(
         `(${expr})`, // wrap to handle expressions like "globalThis"
       );
-      return resp?.value?.result?.objectId || null;
+      return resp?.result?.objectId || null;
     } catch {
       return null;
     }

--- a/tests/integration/jupyter_tests.rs
+++ b/tests/integration/jupyter_tests.rs
@@ -598,6 +598,79 @@ async fn jupyter_execute_request() -> Result<()> {
   Ok(())
 }
 
+// Regression test for denoland/deno#35290: a cell that throws must report the
+// error. The JS-kernel rewrite (#34083) read the evaluate result under a bogus
+// `.value` wrapper that the Rust op never sends, so `exceptionDetails` was
+// always `undefined`: errors silently became `status: "ok"` with no broadcast.
+#[test]
+async fn jupyter_execute_error_reports_traceback() -> Result<()> {
+  let (_ctx, client, _process) = setup().await;
+  let request = client
+    .send(
+      Shell,
+      "execute_request",
+      json!({
+        "silent": false,
+        "store_history": true,
+        "user_expressions": {},
+        "allow_stdin": true,
+        "stop_on_error": false,
+        "code": "throw new Error(\"boom\")"
+      }),
+    )
+    .await?;
+  let reply = client.recv(Shell).await?;
+  assert_eq!(reply.header.msg_type, "execute_reply");
+  assert_json_subset(
+    reply.content.clone(),
+    json!({
+      "status": "error",
+      "execution_count": 1,
+      "ename": "Error",
+      "evalue": "boom",
+    }),
+  );
+  let traceback = reply
+    .content
+    .get("traceback")
+    .and_then(|t| t.as_array())
+    .expect("traceback array");
+  assert!(
+    traceback
+      .iter()
+      .any(|line| line.as_str().map(|s| s.contains("boom")).unwrap_or(false)),
+    "traceback should mention the error: {traceback:?}",
+  );
+
+  let mut msgs = Vec::new();
+  for _ in 0..4 {
+    match client.recv(IoPub).await {
+      Ok(msg) => msgs.push(msg),
+      Err(e) => {
+        if e.downcast_ref::<tokio::time::error::Elapsed>().is_some() {
+          eprintln!("Timed out waiting for messages");
+        }
+        panic!("Error: {:#?}", e);
+      }
+    }
+  }
+
+  let error_msg = msgs
+    .iter()
+    .find(|msg| msg.header.msg_type == "error")
+    .expect("error message not broadcast on iopub");
+  assert_eq!(error_msg.parent_header, request.header.to_json());
+  assert_json_subset(
+    error_msg.content.clone(),
+    json!({
+      "ename": "Error",
+      "evalue": "boom",
+    }),
+  );
+
+  Ok(())
+}
+
 // Regression test for denoland/deno#22771: a `complete_request` whose code
 // contains multi-byte (e.g. Korean) characters must not crash the kernel. The
 // old Rust kernel sliced the cell text using the codepoint-based `cursor_pos`


### PR DESCRIPTION
`deno jupyter` stopped surfacing cell errors in 2.8.2: a cell that throws
just produced an empty `status: "ok"` reply with no stack trace, where
2.8.1 showed the error. The regression came in with the JS-kernel rewrite
in #34083.

The cause is a data-shape mismatch between the kernel JS and the Rust op
it calls. `op_jupyter_repl_evaluate` returns a `cdp::EvaluateResponse`
directly, which serializes to `{ result, exceptionDetails }` at the top
level. The JS kernel, however, read it through a `.value` wrapper that the
Rust side never sends, so `evalResult?.value?.exceptionDetails` was always
`undefined`. The error branch never fired and the throwing cell silently
reported success with no `error` broadcast. The same wrong indirection
also broke the last-expression display value and the completion objectId
lookup.

This drops the bogus `.value` in the three affected reads so the kernel
reads `exceptionDetails`, `result`, and `result.objectId` off the response
where they actually live.

Adds a regression test that evaluates a throwing cell and asserts the
`execute_reply` comes back with `status: "error"` plus a populated
traceback, and that an `error` message is broadcast on iopub.

Fixes #35290