### PR TITLE
feat(install): seed deno.lock from package-lock.json

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1500,6 +1500,12 @@ fn new_workspace_factory_options(
         DenoSubcommand::Install(InstallFlags::Global(..))
           | DenoSubcommand::Uninstall(_)
       ),
+    // Seed deno.lock from package-lock.json only when the user is explicitly
+    // setting up dependencies via `deno install` (local form).
+    import_npm_lockfile: matches!(
+      flags.subcommand,
+      DenoSubcommand::Install(InstallFlags::Local(..))
+    ),
     frozen_lockfile: flags.frozen_lockfile,
     lock_arg: flags.lock.as_ref().map(|l| initial_cwd.join(l)),
     lockfile_skip_write: flags.internal.lockfile_skip_write,

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1306,6 +1306,7 @@ impl WorkspaceConfigData {
         node_modules_linker: None,
         no_lock: false,
         no_npm: false,
+        import_npm_lockfile: false,
         npm_process_state: None,
         root_node_modules_dir_override: None,
         vendor: None,

--- a/libs/resolver/factory.rs
+++ b/libs/resolver/factory.rs
@@ -213,6 +213,9 @@ pub struct WorkspaceFactoryOptions {
   pub node_modules_linker: Option<NodeModulesLinkerMode>,
   pub no_lock: bool,
   pub no_npm: bool,
+  /// When no `deno.lock` exists, attempt to seed one by translating a
+  /// sibling `package-lock.json`. Currently set by `deno install`.
+  pub import_npm_lockfile: bool,
   /// The process state if using ext/node and the current process was "forked".
   /// This value is found at `deno_lib::args::NPM_PROCESS_STATE`
   /// but in most scenarios this can probably just be `None`.
@@ -547,6 +550,7 @@ impl<TSys: WorkspaceFactorySys> WorkspaceFactory<TSys> {
               ConfigDiscoveryOption::Disabled
             ),
             no_npm: self.options.no_npm,
+            import_npm_lockfile: self.options.import_npm_lockfile,
           },
           &workspace_directory.workspace,
           maybe_external_import_map.as_ref().map(|v| &v.value),

--- a/libs/resolver/lib.rs
+++ b/libs/resolver/lib.rs
@@ -58,6 +58,7 @@ pub mod import_map;
 pub mod loader;
 pub mod lockfile;
 pub mod npm;
+pub mod npm_lockfile_import;
 pub mod npmrc;
 #[cfg(feature = "sync")]
 mod rt;

--- a/libs/resolver/lockfile.rs
+++ b/libs/resolver/lockfile.rs
@@ -29,6 +29,7 @@ use node_resolver::PackageJson;
 use parking_lot::Mutex;
 use parking_lot::MutexGuard;
 
+use crate::npm_lockfile_import::package_lock_to_deno_lock_v5;
 use crate::workspace::WorkspaceNpmLinkPackagesRc;
 
 pub trait NpmRegistryApiEx: NpmRegistryApi + MaybeSend + MaybeSync {}
@@ -144,6 +145,9 @@ pub struct LockfileReadFromPathOptions {
   pub frozen: bool,
   /// Causes the lockfile to only be read from, but not written to.
   pub skip_write: bool,
+  /// If true and `file_path` does not exist, attempt to seed the lockfile by
+  /// translating a sibling `package-lock.json`.
+  pub import_npm_lockfile: bool,
 }
 
 #[sys_traits::auto_impl]
@@ -181,6 +185,10 @@ pub struct LockfileFlags {
   pub skip_write: bool,
   pub no_config: bool,
   pub no_npm: bool,
+  /// When no `deno.lock` exists in the workspace, attempt to seed one by
+  /// translating a sibling `package-lock.json`. Currently only set by
+  /// `deno install`.
+  pub import_npm_lockfile: bool,
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
@@ -349,6 +357,7 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
         file_path,
         frozen,
         skip_write: flags.skip_write,
+        import_npm_lockfile: flags.import_npm_lockfile,
       },
       api,
     )
@@ -513,7 +522,14 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
         .await?
       }
       Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-        Lockfile::new_empty(opts.file_path, false)
+        if opts.import_npm_lockfile
+          && let Some(seeded) =
+            try_import_npm_lockfile(&sys, &opts.file_path, api).await?
+        {
+          seeded
+        } else {
+          Lockfile::new_empty(opts.file_path, false)
+        }
       }
       Err(err) => {
         return Err(err).with_context(|| {
@@ -562,6 +578,55 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
       Ok(())
     }
   }
+}
+
+/// Attempt to translate a sibling `package-lock.json` into a seed `Lockfile`.
+/// Returns `Ok(None)` when no usable package-lock.json is present (so the
+/// caller falls back to creating an empty lockfile). The returned lockfile is
+/// flagged as changed so the next write persists it to disk.
+async fn try_import_npm_lockfile<TSys: LockfileSys>(
+  sys: &TSys,
+  deno_lock_path: &std::path::Path,
+  api: &dyn deno_lockfile::NpmPackageInfoProvider,
+) -> Result<Option<Lockfile>, AnyError> {
+  let Some(parent) = deno_lock_path.parent() else {
+    return Ok(None);
+  };
+  let pkg_lock_path = parent.join("package-lock.json");
+  let pkg_lock_text = match sys.fs_read_to_string(&pkg_lock_path) {
+    Ok(text) => text,
+    Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+    Err(err) => {
+      return Err(err).with_context(|| {
+        format!("Failed reading '{}'", pkg_lock_path.display())
+      });
+    }
+  };
+  let deno_lock_text = match package_lock_to_deno_lock_v5(&pkg_lock_text) {
+    Ok(text) => text,
+    Err(err) => {
+      log::warn!(
+        "Failed to import npm lockfile at {}: {}. Falling back to an empty deno.lock.",
+        pkg_lock_path.display(),
+        err
+      );
+      return Ok(None);
+    }
+  };
+  log::info!("Seeded deno.lock from {}", pkg_lock_path.display());
+  let mut lockfile = Lockfile::new(
+    deno_lockfile::NewLockfileOptions {
+      file_path: deno_lock_path.to_path_buf(),
+      content: &deno_lock_text,
+      overwrite: false,
+    },
+    api,
+  )
+  .await?;
+  // Force write on first save so the imported state is persisted even if no
+  // subsequent resolution mutates the lockfile.
+  lockfile.has_content_changed = true;
+  Ok(Some(lockfile))
 }
 
 /// An adapter to use the lockfile with `deno_graph`.

--- a/libs/resolver/npm_lockfile_import.rs
+++ b/libs/resolver/npm_lockfile_import.rs
@@ -65,7 +65,7 @@ pub fn package_lock_to_deno_lock_v5(
   let lockfile: NpmLockfile =
     serde_json::from_str(json_text).map_err(NpmLockfileImportError::Parse)?;
 
-  if lockfile.lockfile_version < 2 {
+  if !(2..=3).contains(&lockfile.lockfile_version) {
     return Err(NpmLockfileImportError::UnsupportedVersion(
       lockfile.lockfile_version,
     ));
@@ -419,5 +419,12 @@ mod tests {
     let input = r#"{ "lockfileVersion": 1, "packages": {} }"#;
     let err = package_lock_to_deno_lock_v5(input).unwrap_err();
     assert!(matches!(err, NpmLockfileImportError::UnsupportedVersion(1)));
+  }
+
+  #[test]
+  fn rejects_unknown_future_lockfile() {
+    let input = r#"{ "lockfileVersion": 4, "packages": {} }"#;
+    let err = package_lock_to_deno_lock_v5(input).unwrap_err();
+    assert!(matches!(err, NpmLockfileImportError::UnsupportedVersion(4)));
   }
 }

--- a/libs/resolver/npm_lockfile_import.rs
+++ b/libs/resolver/npm_lockfile_import.rs
@@ -1,0 +1,423 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Translation from npm's `package-lock.json` to a deno.lock v5 JSON string.
+//!
+//! Only npm packages are translated. The produced lockfile contains the
+//! `specifiers` and `npm` sections derived from the package-lock; everything
+//! else (workspace, jsr, redirects, remote) is left empty for later
+//! population by Deno during resolution.
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, thiserror::Error)]
+pub enum NpmLockfileImportError {
+  #[error("Failed to parse package-lock.json")]
+  Parse(#[source] serde_json::Error),
+  #[error(
+    "Unsupported package-lock.json `lockfileVersion`: {0}. Only versions 2 and 3 are supported."
+  )]
+  UnsupportedVersion(u32),
+}
+
+#[derive(Debug, Deserialize)]
+struct NpmLockfile {
+  #[serde(rename = "lockfileVersion")]
+  lockfile_version: u32,
+  #[serde(default)]
+  packages: BTreeMap<String, NpmLockPackage>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NpmLockPackage {
+  #[serde(default)]
+  name: Option<String>,
+  #[serde(default)]
+  version: Option<String>,
+  #[serde(default)]
+  integrity: Option<String>,
+  #[serde(default)]
+  link: bool,
+  #[serde(default)]
+  dependencies: BTreeMap<String, String>,
+  #[serde(default, rename = "devDependencies")]
+  dev_dependencies: BTreeMap<String, String>,
+  #[serde(default, rename = "optionalDependencies")]
+  optional_dependencies: BTreeMap<String, String>,
+  #[serde(default, rename = "peerDependencies")]
+  peer_dependencies: BTreeMap<String, String>,
+  #[serde(default, rename = "peerDependenciesMeta")]
+  peer_dependencies_meta: BTreeMap<String, Value>,
+  #[serde(default)]
+  os: Vec<String>,
+  #[serde(default)]
+  cpu: Vec<String>,
+}
+
+/// Convert a `package-lock.json` (lockfileVersion 2 or 3) JSON string into a
+/// deno.lock v5 JSON string. Only the npm subset is populated.
+pub fn package_lock_to_deno_lock_v5(
+  json_text: &str,
+) -> Result<String, NpmLockfileImportError> {
+  let lockfile: NpmLockfile =
+    serde_json::from_str(json_text).map_err(NpmLockfileImportError::Parse)?;
+
+  if lockfile.lockfile_version < 2 {
+    return Err(NpmLockfileImportError::UnsupportedVersion(
+      lockfile.lockfile_version,
+    ));
+  }
+
+  // Build path -> (name, version) for every non-link, non-root entry that
+  // has a version. The name is taken from the explicit `name` field when
+  // present, falling back to the trailing path segment (which is what
+  // npm produces).
+  let mut resolved: HashMap<&str, (String, String)> = HashMap::new();
+  for (path, pkg) in lockfile.packages.iter() {
+    if path.is_empty() || pkg.link {
+      continue;
+    }
+    let Some(version) = pkg.version.as_deref() else {
+      continue;
+    };
+    let name = match pkg.name.as_deref() {
+      Some(n) => n.to_string(),
+      None => match package_name_from_path(path) {
+        Some(n) => n.to_string(),
+        None => continue,
+      },
+    };
+    resolved.insert(path.as_str(), (name, version.to_string()));
+  }
+
+  let resolve_dep =
+    |from_path: &str, dep_name: &str| -> Option<&(String, String)> {
+      if from_path.is_empty() {
+        let candidate = format!("node_modules/{}", dep_name);
+        return resolved.get(candidate.as_str());
+      }
+      let mut prefix = from_path.to_string();
+      loop {
+        let candidate = format!("{}/node_modules/{}", prefix, dep_name);
+        if let Some(entry) = resolved.get(candidate.as_str()) {
+          return Some(entry);
+        }
+        match prefix.rfind("/node_modules/") {
+          Some(idx) => prefix.truncate(idx),
+          None => break,
+        }
+      }
+      let candidate = format!("node_modules/{}", dep_name);
+      resolved.get(candidate.as_str())
+    };
+
+  // Build npm section.
+  let mut npm = BTreeMap::<String, Value>::new();
+  for (path, pkg) in lockfile.packages.iter() {
+    if path.is_empty() || pkg.link {
+      continue;
+    }
+    let Some((name, version)) = resolved.get(path.as_str()) else {
+      continue;
+    };
+    let Some(integrity) = pkg.integrity.as_deref() else {
+      // Skip packages without integrity (bundled, git, file, workspace).
+      continue;
+    };
+
+    let (regular_deps, optional_peers_from_peers) = {
+      // Combine `dependencies` and (non-optional) `peerDependencies` into the
+      // single deno.lock `dependencies` list. Optional peers go in their own
+      // bucket.
+      let mut regular: Vec<String> = Vec::new();
+      let mut opt_peers: Vec<String> = Vec::new();
+      for dep_name in pkg.dependencies.keys() {
+        if let Some((n, v)) = resolve_dep(path, dep_name) {
+          regular.push(format_dep_entry(dep_name, n, v));
+        }
+      }
+      for dep_name in pkg.peer_dependencies.keys() {
+        let is_optional = pkg
+          .peer_dependencies_meta
+          .get(dep_name)
+          .and_then(|v| v.get("optional"))
+          .and_then(|v| v.as_bool())
+          .unwrap_or(false);
+        if let Some((n, v)) = resolve_dep(path, dep_name) {
+          let entry = format_dep_entry(dep_name, n, v);
+          if is_optional {
+            opt_peers.push(entry);
+          } else {
+            regular.push(entry);
+          }
+        }
+      }
+      regular.sort();
+      regular.dedup();
+      opt_peers.sort();
+      opt_peers.dedup();
+      (regular, opt_peers)
+    };
+
+    let optional_deps: Vec<String> = {
+      let mut v: Vec<String> = pkg
+        .optional_dependencies
+        .keys()
+        .filter_map(|dep_name| {
+          resolve_dep(path, dep_name)
+            .map(|(n, ver)| format_dep_entry(dep_name, n, ver))
+        })
+        .collect();
+      v.sort();
+      v.dedup();
+      v
+    };
+
+    let mut entry = serde_json::Map::new();
+    entry.insert(
+      "integrity".to_string(),
+      Value::String(integrity.to_string()),
+    );
+    if !regular_deps.is_empty() {
+      entry.insert(
+        "dependencies".to_string(),
+        Value::Array(regular_deps.into_iter().map(Value::String).collect()),
+      );
+    }
+    if !optional_deps.is_empty() {
+      entry.insert(
+        "optionalDependencies".to_string(),
+        Value::Array(optional_deps.into_iter().map(Value::String).collect()),
+      );
+    }
+    if !optional_peers_from_peers.is_empty() {
+      entry.insert(
+        "optionalPeers".to_string(),
+        Value::Array(
+          optional_peers_from_peers
+            .into_iter()
+            .map(Value::String)
+            .collect(),
+        ),
+      );
+    }
+    if !pkg.os.is_empty() {
+      entry.insert(
+        "os".to_string(),
+        Value::Array(pkg.os.iter().cloned().map(Value::String).collect()),
+      );
+    }
+    if !pkg.cpu.is_empty() {
+      entry.insert(
+        "cpu".to_string(),
+        Value::Array(pkg.cpu.iter().cloned().map(Value::String).collect()),
+      );
+    }
+
+    let key = format!("{}@{}", name, version);
+    npm.insert(key, Value::Object(entry));
+  }
+
+  // Build specifiers from the root package's dependencies. Each (name, req)
+  // pair maps to the resolved version found at `node_modules/<name>`.
+  let mut specifiers = BTreeMap::<String, String>::new();
+  if let Some(root) = lockfile.packages.get("") {
+    let root_dep_iters = [
+      &root.dependencies,
+      &root.dev_dependencies,
+      &root.optional_dependencies,
+      &root.peer_dependencies,
+    ];
+    for deps in root_dep_iters {
+      for (dep_name, req) in deps.iter() {
+        if !is_supported_root_req(req) {
+          continue;
+        }
+        let Some((_n, version)) = resolve_dep("", dep_name) else {
+          continue;
+        };
+        let key = format!("npm:{}@{}", dep_name, req);
+        specifiers.entry(key).or_insert_with(|| version.clone());
+      }
+    }
+  }
+
+  let mut output = serde_json::Map::new();
+  output.insert("version".to_string(), Value::String("5".to_string()));
+  if !specifiers.is_empty() {
+    output.insert(
+      "specifiers".to_string(),
+      Value::Object(
+        specifiers
+          .into_iter()
+          .map(|(k, v)| (k, Value::String(v)))
+          .collect(),
+      ),
+    );
+  }
+  if !npm.is_empty() {
+    output.insert("npm".to_string(), Value::Object(npm.into_iter().collect()));
+  }
+
+  Ok(serde_json::to_string(&Value::Object(output)).unwrap())
+}
+
+fn format_dep_entry(alias: &str, name: &str, version: &str) -> String {
+  if alias == name {
+    format!("{}@{}", name, version)
+  } else {
+    // npm aliasing: `alias@npm:name@version`
+    format!("{}@npm:{}@{}", alias, name, version)
+  }
+}
+
+fn package_name_from_path(path: &str) -> Option<&str> {
+  if let Some(idx) = path.rfind("/node_modules/") {
+    Some(&path[idx + "/node_modules/".len()..])
+  } else {
+    path.strip_prefix("node_modules/")
+  }
+}
+
+fn is_supported_root_req(req: &str) -> bool {
+  // Skip file:, link:, workspace:, git:, https:// tarballs, etc. These
+  // cannot be represented as plain npm specifiers in deno.lock.
+  !req.starts_with("file:")
+    && !req.starts_with("link:")
+    && !req.starts_with("workspace:")
+    && !req.starts_with("git+")
+    && !req.starts_with("git:")
+    && !req.starts_with("github:")
+    && !req.starts_with("http:")
+    && !req.starts_with("https:")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn translates_simple_package_lock() {
+    let input = r#"{
+      "name": "myapp",
+      "version": "1.0.0",
+      "lockfileVersion": 3,
+      "requires": true,
+      "packages": {
+        "": {
+          "name": "myapp",
+          "version": "1.0.0",
+          "dependencies": {
+            "lodash": "^4.17.0"
+          }
+        },
+        "node_modules/lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    }"#;
+    let out = package_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["version"], "5");
+    assert_eq!(v["specifiers"]["npm:lodash@^4.17.0"], "4.17.21");
+    let lodash = &v["npm"]["lodash@4.17.21"];
+    assert!(lodash["integrity"].as_str().unwrap().starts_with("sha512-"));
+  }
+
+  #[test]
+  fn nested_dependency_resolution() {
+    let input = r#"{
+      "name": "myapp",
+      "version": "1.0.0",
+      "lockfileVersion": 3,
+      "packages": {
+        "": {
+          "dependencies": { "a": "^1" }
+        },
+        "node_modules/a": {
+          "version": "1.0.0",
+          "integrity": "sha512-AAAAA",
+          "dependencies": { "b": "^2" }
+        },
+        "node_modules/a/node_modules/b": {
+          "version": "2.0.0",
+          "integrity": "sha512-BBBBB"
+        },
+        "node_modules/b": {
+          "version": "1.0.0",
+          "integrity": "sha512-BBB1"
+        }
+      }
+    }"#;
+    let out = package_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    // a's dependency on b should resolve to its nested copy (2.0.0)
+    let a_deps = v["npm"]["a@1.0.0"]["dependencies"].as_array().unwrap();
+    assert_eq!(a_deps[0], "b@2.0.0");
+    // both versions of b should be present
+    assert!(v["npm"].as_object().unwrap().contains_key("b@1.0.0"));
+    assert!(v["npm"].as_object().unwrap().contains_key("b@2.0.0"));
+  }
+
+  #[test]
+  fn scoped_packages() {
+    let input = r#"{
+      "lockfileVersion": 3,
+      "packages": {
+        "": {
+          "dependencies": { "@scope/pkg": "^1" }
+        },
+        "node_modules/@scope/pkg": {
+          "version": "1.2.3",
+          "integrity": "sha512-XXXX"
+        }
+      }
+    }"#;
+    let out = package_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["specifiers"]["npm:@scope/pkg@^1"], "1.2.3");
+    assert!(
+      v["npm"]
+        .as_object()
+        .unwrap()
+        .contains_key("@scope/pkg@1.2.3")
+    );
+  }
+
+  #[test]
+  fn skips_workspace_links() {
+    let input = r#"{
+      "lockfileVersion": 3,
+      "packages": {
+        "": {
+          "dependencies": { "ws-pkg": "*", "lodash": "^4" }
+        },
+        "node_modules/ws-pkg": {
+          "resolved": "../ws-pkg",
+          "link": true
+        },
+        "node_modules/lodash": {
+          "version": "4.17.21",
+          "integrity": "sha512-AAA"
+        }
+      }
+    }"#;
+    let out = package_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert!(v["specifiers"].get("npm:ws-pkg@*").is_none());
+    assert!(v["npm"].as_object().unwrap().get("ws-pkg").is_none());
+    assert_eq!(v["specifiers"]["npm:lodash@^4"], "4.17.21");
+  }
+
+  #[test]
+  fn rejects_v1_lockfile() {
+    let input = r#"{ "lockfileVersion": 1, "packages": {} }"#;
+    let err = package_lock_to_deno_lock_v5(input).unwrap_err();
+    assert!(matches!(err, NpmLockfileImportError::UnsupportedVersion(1)));
+  }
+}

--- a/tests/specs/install/import_from_package_lock_json/__test__.jsonc
+++ b/tests/specs/install/import_from_package_lock_json/__test__.jsonc
@@ -1,0 +1,24 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      // No deno.lock exists, so `deno install` should seed one from
+      // package-lock.json.
+      "args": "install",
+      "output": "install.out"
+    },
+    {
+      "args": [
+        "eval",
+        "console.log(Deno.readTextFileSync('deno.lock').trim())"
+      ],
+      "output": "deno.lock.out"
+    },
+    {
+      // Sanity check that the package resolved by the seeded lockfile is
+      // usable.
+      "args": "run --cached-only main.js",
+      "output": "3\n"
+    }
+  ]
+}

--- a/tests/specs/install/import_from_package_lock_json/deno.lock.out
+++ b/tests/specs/install/import_from_package_lock_json/deno.lock.out
@@ -1,0 +1,19 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@denotest/add@1": "1.0.0"
+  },
+  "npm": {
+    "@denotest/add@1.0.0": {
+      "integrity": "[WILDCARD]",
+      "tarball": "http://localhost:4260/@denotest/add/1.0.0.tgz"
+    }
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@denotest/add@1"
+      ]
+    }
+  }
+}

--- a/tests/specs/install/import_from_package_lock_json/install.out
+++ b/tests/specs/install/import_from_package_lock_json/install.out
@@ -1,0 +1,1 @@
+[WILDCARD]Seeded deno.lock from [WILDCARD]package-lock.json[WILDCARD]

--- a/tests/specs/install/import_from_package_lock_json/main.js
+++ b/tests/specs/install/import_from_package_lock_json/main.js
@@ -1,0 +1,2 @@
+import { add } from "@denotest/add";
+console.log(add(1, 2));

--- a/tests/specs/install/import_from_package_lock_json/package-lock.json
+++ b/tests/specs/install/import_from_package_lock_json/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test",
+      "version": "1.0.0",
+      "dependencies": {
+        "@denotest/add": "1"
+      }
+    },
+    "node_modules/@denotest/add": {
+      "version": "1.0.0",
+      "resolved": "http://localhost:4260/@denotest/add/-/add-1.0.0.tgz",
+      "integrity": "sha512-uvNpnVPU/CC2Do/LNF3TkhoLGLLKC6jFDPiSnojuZCEwmoXJjS2+Sn+LYk7eUix4vsMKA9ctxaMhcfb6pdHQTQ=="
+    }
+  }
+}

--- a/tests/specs/install/import_from_package_lock_json/package.json
+++ b/tests/specs/install/import_from_package_lock_json/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "dependencies": {
+    "@denotest/add": "1"
+  }
+}


### PR DESCRIPTION
When `deno install` runs in a project that has a `package-lock.json` but
no `deno.lock`, translate the npm lockfile into deno.lock v5 format and
use it to seed resolution. Projects migrating from npm don't lose their
pinned versions and integrity hashes on the first `deno install`.

The seeding only kicks in for the local `deno install` subcommand and
only when no `deno.lock` already exists; other commands keep their
current behavior of starting from an empty lockfile. The translator
handles scoped packages, nested node_modules resolution, optional/peer
dependencies, and OS/CPU constraints. Workspace links, file/git/http
deps, and packages without integrity are skipped.

This is the first piece split out of #34296, which additionally seeds
from `pnpm-lock.yaml` and `yarn.lock`. Those formats (and the `saphyr`
YAML dependency they require) will follow in separate PRs on top of this
one so each importer can be reviewed independently.

Towards #25815
Towards #26521