### PR TITLE
perf(snapshot): guard against lazy modules leaking into eager snapshot

### DIFF
--- a/cli/snapshot/build.rs
+++ b/cli/snapshot/build.rs
@@ -49,6 +49,8 @@ fn create_cli_snapshot(
     .map(String::as_str)
     .collect();
 
+  assert_consumed_set_unchanged(&consumed);
+
   let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
   let residual_sources_dir = out_dir.join("residual_sources");
   std::fs::create_dir_all(&residual_sources_dir).unwrap();
@@ -106,6 +108,116 @@ fn create_cli_snapshot(
   // concat! literal rather than a source-tree path.
   write_residual_table(&mut f, &out_dir, "RESIDUAL_LAZY_JS", &residual_js);
   write_residual_table(&mut f, &out_dir, "RESIDUAL_LAZY_ESM", &residual_esm);
+}
+
+/// The exact set of `lazy_loaded_*` specifiers that are legitimately pulled
+/// into the eager snapshot, i.e. statically reachable from an eager `esm`
+/// module. Captured at the time PR #34450 landed. The heavy node-polyfill
+/// closure (process / stream / net / tty / require / the ~118 polyfill modules)
+/// is deliberately *absent* — it is `lazy_loaded_esm`, deserialized only on
+/// first `node:*` use, so non-node `deno run` / `eval` never pay for it.
+///
+/// Anything reaching the eager graph that is NOT in this list regresses
+/// empty/ESM startup (each leaked module adds snapshot deserialization the
+/// common path can't avoid). `assert_consumed_set_unchanged` enforces it.
+///
+/// To update: run a build, take the `consumed_lazy_specifiers` reported by
+/// `create_runtime_snapshot`, and reconcile here — but first confirm the new
+/// entry is *meant* to be eager. A node-closure module showing up almost
+/// always means an eager `esm` entry (or a static import from one) is dragging
+/// the polyfill closure into startup; fix that in `ext/node/lib.rs` rather than
+/// widening this list. See PR #34450.
+#[cfg(not(feature = "disable"))]
+const EXPECTED_CONSUMED: &[&str] = &[
+  "ext:deno_crypto/00_crypto.js",
+  "ext:deno_fetch/22_http_client.js",
+  "ext:deno_ffi/00_ffi.js",
+  "ext:deno_fs/30_fs.js",
+  "ext:deno_io/12_io.js",
+  "ext:deno_net/01_net.js",
+  "ext:deno_net/02_tls.js",
+  "ext:deno_node/02_register_cloneable.js",
+  "ext:deno_node/_util/os.ts",
+  "ext:deno_node/internal/async_hooks.ts",
+  "ext:deno_node/internal/buffer.mjs",
+  "ext:deno_node/internal/crypto/_keys.ts",
+  "ext:deno_node/internal/crypto/constants.ts",
+  "ext:deno_node/internal/error_codes.ts",
+  "ext:deno_node/internal/errors.ts",
+  "ext:deno_node/internal/hide_stack_frames.ts",
+  "ext:deno_node/internal/normalize_encoding.ts",
+  "ext:deno_node/internal/options.ts",
+  "ext:deno_node/internal/primordials.mjs",
+  "ext:deno_node/internal/timers.mjs",
+  "ext:deno_node/internal/util.mjs",
+  "ext:deno_node/internal/util/colorize.mjs",
+  "ext:deno_node/internal/util/inspect.mjs",
+  "ext:deno_node/internal/util/types.ts",
+  "ext:deno_node/internal/validators.mjs",
+  "ext:deno_node/internal_binding/_libuv_winerror.ts",
+  "ext:deno_node/internal_binding/_node.ts",
+  "ext:deno_node/internal_binding/_utils.ts",
+  "ext:deno_node/internal_binding/async_wrap.ts",
+  "ext:deno_node/internal_binding/buffer.ts",
+  "ext:deno_node/internal_binding/constants.ts",
+  "ext:deno_node/internal_binding/node_options.ts",
+  "ext:deno_node/internal_binding/string_decoder.ts",
+  "ext:deno_node/internal_binding/symbols.ts",
+  "ext:deno_node/internal_binding/types.ts",
+  "ext:deno_node/internal_binding/util.ts",
+  "ext:deno_node/internal_binding/uv.ts",
+  "ext:deno_node/timers.ts",
+  "ext:deno_os/30_os.js",
+  "ext:deno_os/40_signals.js",
+  "ext:deno_web/00_infra.js",
+  "ext:deno_web/00_url.js",
+  "ext:deno_web/01_console.js",
+  "ext:deno_web/01_dom_exception.js",
+  "ext:deno_web/02_event.js",
+  "ext:deno_web/02_timers.js",
+  "ext:deno_web/03_abort_signal.js",
+  "ext:deno_web/04_global_interfaces.js",
+  "ext:deno_web/05_base64.js",
+  "ext:deno_web/08_text_encoding.js",
+  "ext:deno_web/09_file.js",
+  "ext:deno_web/12_location.js",
+  "ext:deno_web/13_message_port.js",
+  "ext:deno_web/15_performance.js",
+  "ext:deno_webgpu/00_init.js",
+  "ext:deno_webidl/00_webidl.js",
+  "ext:runtime/01_errors.js",
+  "ext:runtime/01_version.ts",
+  "ext:runtime/06_util.js",
+  "ext:runtime/10_permissions.js",
+  "ext:runtime/11_workers.js",
+  "ext:runtime/40_fs_events.js",
+  "ext:runtime/40_tty.js",
+  "node:buffer",
+  "node:timers",
+];
+
+/// Startup guardrail (see PR #34450). Asserts the set of `lazy_loaded_*`
+/// modules consumed into the eager snapshot is exactly `EXPECTED_CONSUMED`.
+/// Catches a single lazy module silently leaking into the eager graph — the
+/// failure mode that regresses empty/ESM startup at fine granularity, well
+/// before a coarse count threshold would notice. Removals (a module becoming
+/// lazy — an improvement) are allowed; additions fail the build.
+#[cfg(not(feature = "disable"))]
+fn assert_consumed_set_unchanged(consumed: &std::collections::HashSet<&str>) {
+  let expected: std::collections::HashSet<&str> =
+    EXPECTED_CONSUMED.iter().copied().collect();
+  let mut leaked: Vec<&str> = consumed.difference(&expected).copied().collect();
+  leaked.sort_unstable();
+  assert!(
+    leaked.is_empty(),
+    "lazy module(s) newly pulled into the eager snapshot: {leaked:?}.\nEach \
+     adds snapshot deserialization to the common `deno run` / `eval` startup \
+     path. If a `node:*` / `ext:deno_node/*` module leaked, an eager `esm` \
+     entry or a static import from an eager module is dragging the node \
+     polyfill closure into startup — fix it in ext/node/lib.rs. If the entry \
+     is genuinely meant to be eager, add it to EXPECTED_CONSUMED. See \
+     PR #34450."
+  );
 }
 
 #[cfg(not(feature = "disable"))]


### PR DESCRIPTION
## Why

#34450 moved the node-polyfill closure (`process` / `stream` / `net` / `tty` / `require` / the ~118 polyfill modules) out of the eager snapshot into `lazy_loaded_esm`, so non-node `deno run` / `eval` no longer deserialize it at startup (~28–31% faster on the common paths).

Nothing guards that win. The closure stays lazy only as long as no eager `esm` entry — and nothing statically imported from one — references it. A single such import silently pulls a closure module back into the eager graph and regresses empty/ESM startup, with **no test going red**. It's a quiet, easy-to-reintroduce regression.

## What

Pin the exact set of `lazy_loaded_*` specifiers that are legitimately consumed into the eager snapshot. The snapshot builder already reports them as `consumed_lazy_specifiers`; this asserts, at build time, that the consumed set is a subset of `EXPECTED_CONSUMED`.

- Any lazy module **newly** reaching the eager graph fails the build, naming the offender at single-module granularity (well before a coarse size/count threshold would notice a partial leak).
- Removals — a module *becoming* lazy, i.e. an improvement — are allowed.
- The error message points at `ext/node/lib.rs` (the usual cause) and explains how to update the list for an intentional eager addition.

Build-time only, zero runtime cost.

## Test

- Builds clean on `main` (consumed set == `EXPECTED_CONSUMED`).
- Negative test: removing an entry from the allowlist (simulating a leak) fails the build with `lazy module(s) newly pulled into the eager snapshot: ["…"]`.