### PR TITLE
docs: consolidate Deno.bundle reference category

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -191,7 +191,7 @@ declare namespace Deno {
    * }
    * ```
    *
-   * @category Bundle
+   * @category Bundler
    * @experimental
    */
   export function bundle(


### PR DESCRIPTION
The bundling API in `lib.deno.unstable.d.ts` was split across two doc
categories: `Deno.bundle()` carried `@category Bundle` while the
`Deno.bundle` namespace and all of its types carried `@category
Bundler`. On the API reference page that renders as two separate cards
for what is really one API, and neither card had a description.

This retags the `Deno.bundle()` function as `@category Bundler` so the
function, namespace, and types all group under a single category. The
matching category description is added separately in the docs repo
(`reference_gen/deno-categories.json`), since that file is where the
reference generator reads category text from.