### PR TITLE
feat(install): seed deno.lock from pnpm-lock.yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3283,6 +3289,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "phf 0.11.2",
+ "saphyr",
  "serde",
  "serde_json",
  "sys_traits",
@@ -7444,6 +7451,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8895,6 +8911,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "saphyr"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3767dfe8889ebb55a21409df2b6f36e66abfbe1eb92d64ff76ae799d3f91016"
+dependencies = [
+ "arraydeque",
+ "hashlink 0.10.0",
+ "ordered-float 5.3.0",
+ "saphyr-parser",
+]
+
+[[package]]
+name = "saphyr-parser"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
+dependencies = [
+ "arraydeque",
+ "hashlink 0.10.0",
 ]
 
 [[package]]
@@ -11452,7 +11490,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "once_cell",
- "ordered-float",
+ "ordered-float 4.6.0",
  "parking_lot",
  "profiling",
  "range-alloc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,12 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arraydeque"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,7 +3283,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "phf 0.11.2",
- "saphyr",
  "serde",
  "serde_json",
  "sys_traits",
@@ -3297,6 +3290,7 @@ dependencies = [
  "thiserror 2.0.12",
  "twox-hash 2.1.2",
  "url",
+ "yaml_parser",
 ]
 
 [[package]]
@@ -7451,15 +7445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "os_pipe"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8911,28 +8896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "saphyr"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3767dfe8889ebb55a21409df2b6f36e66abfbe1eb92d64ff76ae799d3f91016"
-dependencies = [
- "arraydeque",
- "hashlink 0.10.0",
- "ordered-float 5.3.0",
- "saphyr-parser",
-]
-
-[[package]]
-name = "saphyr-parser"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
-dependencies = [
- "arraydeque",
- "hashlink 0.10.0",
 ]
 
 [[package]]
@@ -11490,7 +11453,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "once_cell",
- "ordered-float 4.6.0",
+ "ordered-float",
  "parking_lot",
  "profiling",
  "range-alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,7 +290,6 @@ rustls-webpki = "0.103"
 rustyline = { version = "=17.0.0", features = ["custom-bindings"] }
 rustyline-derive = "=0.11.1"
 same-file = "1.0.6"
-saphyr = { version = "=0.0.6", default-features = false }
 scopeguard = "1.2.0"
 semver = "=1.0.25"
 serde = { version = "1.0.149", features = ["derive"] }
@@ -381,6 +380,7 @@ text-size = "=1.1.1"
 text_lines = "=0.6.0"
 unicode-normalization = "0.1"
 unicode-width = "0.1.3"
+yaml_parser = "=0.2.1"
 zstd = "=0.13.2"
 
 # crypto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,6 +290,7 @@ rustls-webpki = "0.103"
 rustyline = { version = "=17.0.0", features = ["custom-bindings"] }
 rustyline-derive = "=0.11.1"
 same-file = "1.0.6"
+saphyr = { version = "=0.0.6", default-features = false }
 scopeguard = "1.2.0"
 semver = "=1.0.25"
 serde = { version = "1.0.149", features = ["derive"] }

--- a/libs/resolver/Cargo.toml
+++ b/libs/resolver/Cargo.toml
@@ -60,6 +60,7 @@ node_resolver.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 phf = { workspace = true, features = ["macros"] }
+saphyr.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sys_traits.workspace = true

--- a/libs/resolver/Cargo.toml
+++ b/libs/resolver/Cargo.toml
@@ -60,13 +60,13 @@ node_resolver.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 phf = { workspace = true, features = ["macros"] }
-saphyr.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sys_traits.workspace = true
 thiserror.workspace = true
 twox-hash.workspace = true
 url.workspace = true
+yaml_parser.workspace = true
 
 [dev-dependencies]
 node_resolver.workspace = true

--- a/libs/resolver/lib.rs
+++ b/libs/resolver/lib.rs
@@ -60,6 +60,7 @@ pub mod lockfile;
 pub mod npm;
 pub mod npm_lockfile_import;
 pub mod npmrc;
+pub mod pnpm_lockfile_import;
 #[cfg(feature = "sync")]
 mod rt;
 pub mod workspace;

--- a/libs/resolver/lockfile.rs
+++ b/libs/resolver/lockfile.rs
@@ -30,6 +30,7 @@ use parking_lot::Mutex;
 use parking_lot::MutexGuard;
 
 use crate::npm_lockfile_import::package_lock_to_deno_lock_v5;
+use crate::pnpm_lockfile_import::pnpm_lock_to_deno_lock_v5;
 use crate::workspace::WorkspaceNpmLinkPackagesRc;
 
 pub trait NpmRegistryApiEx: NpmRegistryApi + MaybeSend + MaybeSync {}
@@ -580,10 +581,13 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
   }
 }
 
-/// Attempt to translate a sibling `package-lock.json` into a seed `Lockfile`.
-/// Returns `Ok(None)` when no usable package-lock.json is present (so the
-/// caller falls back to creating an empty lockfile). The returned lockfile is
-/// flagged as changed so the next write persists it to disk.
+/// Attempt to translate a sibling `package-lock.json` or `pnpm-lock.yaml`
+/// into a seed `Lockfile`. Returns `Ok(None)` when no usable lockfile is
+/// present (so the caller falls back to creating an empty lockfile). The
+/// returned lockfile is flagged as changed so the next write persists it to
+/// disk.
+///
+/// When both are present, `package-lock.json` wins.
 async fn try_import_npm_lockfile<TSys: LockfileSys>(
   sys: &TSys,
   deno_lock_path: &std::path::Path,
@@ -592,41 +596,56 @@ async fn try_import_npm_lockfile<TSys: LockfileSys>(
   let Some(parent) = deno_lock_path.parent() else {
     return Ok(None);
   };
-  let pkg_lock_path = parent.join("package-lock.json");
-  let pkg_lock_text = match sys.fs_read_to_string(&pkg_lock_path) {
-    Ok(text) => text,
-    Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-    Err(err) => {
-      return Err(err).with_context(|| {
-        format!("Failed reading '{}'", pkg_lock_path.display())
-      });
-    }
-  };
-  let deno_lock_text = match package_lock_to_deno_lock_v5(&pkg_lock_text) {
-    Ok(text) => text,
-    Err(err) => {
-      log::warn!(
-        "Failed to import npm lockfile at {}: {}. Falling back to an empty deno.lock.",
-        pkg_lock_path.display(),
-        err
-      );
-      return Ok(None);
-    }
-  };
-  log::info!("Seeded deno.lock from {}", pkg_lock_path.display());
-  let mut lockfile = Lockfile::new(
-    deno_lockfile::NewLockfileOptions {
-      file_path: deno_lock_path.to_path_buf(),
-      content: &deno_lock_text,
-      overwrite: false,
-    },
-    api,
-  )
-  .await?;
-  // Force write on first save so the imported state is persisted even if no
-  // subsequent resolution mutates the lockfile.
-  lockfile.has_content_changed = true;
-  Ok(Some(lockfile))
+
+  type Translator = fn(&str) -> Result<String, String>;
+  let candidates: [(&str, Translator); 2] = [
+    ("package-lock.json", |s| {
+      package_lock_to_deno_lock_v5(s).map_err(|e| e.to_string())
+    }),
+    ("pnpm-lock.yaml", |s| {
+      pnpm_lock_to_deno_lock_v5(s).map_err(|e| e.to_string())
+    }),
+  ];
+
+  for (file_name, translate) in candidates {
+    let path = parent.join(file_name);
+    let text = match sys.fs_read_to_string(&path) {
+      Ok(text) => text,
+      Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+      Err(err) => {
+        return Err(err)
+          .with_context(|| format!("Failed reading '{}'", path.display()));
+      }
+    };
+    let deno_lock_text = match translate(&text) {
+      Ok(text) => text,
+      Err(err) => {
+        log::warn!(
+          "Failed to import {} at {}: {}. Trying the next candidate.",
+          file_name,
+          path.display(),
+          err
+        );
+        continue;
+      }
+    };
+    log::info!("Seeded deno.lock from {}", path.display());
+    let mut lockfile = Lockfile::new(
+      deno_lockfile::NewLockfileOptions {
+        file_path: deno_lock_path.to_path_buf(),
+        content: &deno_lock_text,
+        overwrite: false,
+      },
+      api,
+    )
+    .await?;
+    // Force write on first save so the imported state is persisted even if
+    // no subsequent resolution mutates the lockfile.
+    lockfile.has_content_changed = true;
+    return Ok(Some(lockfile));
+  }
+
+  Ok(None)
 }
 
 /// An adapter to use the lockfile with `deno_graph`.

--- a/libs/resolver/lockfile.rs
+++ b/libs/resolver/lockfile.rs
@@ -523,9 +523,13 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
         .await?
       }
       Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+        // Box the seeding future so its (multi-candidate) size stays off the
+        // stack of every caller that awaits a lockfile read, which would
+        // otherwise trip clippy's `large_futures` lint.
         if opts.import_npm_lockfile
           && let Some(seeded) =
-            try_import_npm_lockfile(&sys, &opts.file_path, api).await?
+            Box::pin(try_import_npm_lockfile(&sys, &opts.file_path, api))
+              .await?
         {
           seeded
         } else {

--- a/libs/resolver/pnpm_lockfile_import.rs
+++ b/libs/resolver/pnpm_lockfile_import.rs
@@ -1,0 +1,470 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Translation from pnpm's `pnpm-lock.yaml` to a deno.lock v5 JSON string.
+//!
+//! Only the npm subset is translated. Targets pnpm lockfileVersion 6.x and
+//! 9.x (the formats produced by pnpm v8 and pnpm v9+ respectively).
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+
+use saphyr::LoadableYamlNode;
+use saphyr::Yaml;
+use serde_json::Value;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PnpmLockfileImportError {
+  #[error("Failed to parse pnpm-lock.yaml")]
+  Parse(#[source] saphyr::ScanError),
+  #[error("pnpm-lock.yaml is empty or not a mapping")]
+  EmptyOrInvalid,
+  #[error(
+    "Unsupported pnpm-lock.yaml `lockfileVersion`: {0}. Supported versions are 6.x and 9.x."
+  )]
+  UnsupportedVersion(String),
+}
+
+/// Convert a `pnpm-lock.yaml` (lockfileVersion 6 or 9) string into a
+/// deno.lock v5 JSON string. Only the npm subset is populated.
+pub fn pnpm_lock_to_deno_lock_v5(
+  yaml_text: &str,
+) -> Result<String, PnpmLockfileImportError> {
+  let mut docs =
+    Yaml::load_from_str(yaml_text).map_err(PnpmLockfileImportError::Parse)?;
+  let doc = docs
+    .pop()
+    .filter(|d| d.is_mapping())
+    .ok_or(PnpmLockfileImportError::EmptyOrInvalid)?;
+
+  let version = doc
+    .as_mapping_get("lockfileVersion")
+    .and_then(yaml_to_string)
+    .ok_or_else(
+      || PnpmLockfileImportError::UnsupportedVersion(String::new()),
+    )?;
+  let major = version
+    .split('.')
+    .next()
+    .and_then(|s| s.parse::<u32>().ok())
+    .ok_or_else(|| {
+      PnpmLockfileImportError::UnsupportedVersion(version.clone())
+    })?;
+  if !matches!(major, 6 | 9) {
+    return Err(PnpmLockfileImportError::UnsupportedVersion(version));
+  }
+
+  // Build integrity map: `name@version` -> integrity. pnpm v6 keys may be
+  // prefixed with `/` (e.g. `/lodash@4.17.21`); v9 keys are bare.
+  let mut integrity: HashMap<String, String> = HashMap::new();
+  if let Some(packages) = doc.as_mapping_get("packages")
+    && let Some(map) = packages.as_mapping()
+  {
+    for (k, v) in map {
+      let Some(key) = yaml_to_string(k) else {
+        continue;
+      };
+      let key = normalize_package_key(&key);
+      let base = strip_peer_suffix(&key).to_string();
+      if let Some(integ) = v
+        .as_mapping_get("resolution")
+        .and_then(|r| r.as_mapping_get("integrity"))
+        .and_then(yaml_to_string)
+      {
+        integrity.entry(base).or_insert(integ);
+      }
+    }
+  }
+
+  // Snapshots define the resolved dependency tree. In v6 the `packages`
+  // section itself carries `dependencies`; in v9 they live under `snapshots`.
+  // We accept whichever is present (or both, with snapshots taking
+  // precedence).
+  let mut npm: BTreeMap<String, Value> = BTreeMap::new();
+  // In v9 dependencies live under `snapshots`; in v6 they live inline under
+  // `packages`. Walk snapshots first so the dep-bearing entries win when
+  // both sections exist (the `packages` pass for v9 only carries metadata
+  // we've already captured in `integrity`).
+  let snapshot_sources: [&str; 2] = ["snapshots", "packages"];
+  for section in snapshot_sources {
+    let Some(snaps) = doc.as_mapping_get(section).and_then(|s| s.as_mapping())
+    else {
+      continue;
+    };
+    for (k, v) in snaps {
+      let Some(raw_key) = yaml_to_string(k) else {
+        continue;
+      };
+      let normalized = normalize_package_key(&raw_key);
+      let base = strip_peer_suffix(&normalized).to_string();
+      // Snapshot keys may include peer-suffix parens; for our purposes,
+      // collapse to the base `name@version`. First entry wins.
+      if npm.contains_key(&base) {
+        continue;
+      }
+      let Some(integ) = integrity.get(&base) else {
+        // No integrity for this package — skip.
+        continue;
+      };
+
+      let deps = collect_deps(v.as_mapping_get("dependencies"));
+      let optional_deps =
+        collect_deps(v.as_mapping_get("optionalDependencies"));
+
+      let mut entry = serde_json::Map::new();
+      entry.insert("integrity".to_string(), Value::String(integ.clone()));
+      if !deps.is_empty() {
+        entry.insert(
+          "dependencies".to_string(),
+          Value::Array(deps.into_iter().map(Value::String).collect()),
+        );
+      }
+      if !optional_deps.is_empty() {
+        entry.insert(
+          "optionalDependencies".to_string(),
+          Value::Array(optional_deps.into_iter().map(Value::String).collect()),
+        );
+      }
+      npm.insert(base, Value::Object(entry));
+    }
+  }
+
+  // Ensure every package with integrity ends up in the npm section even if
+  // it has no snapshot entry of its own.
+  for (base, integ) in &integrity {
+    npm.entry(base.clone()).or_insert_with(|| {
+      let mut entry = serde_json::Map::new();
+      entry.insert("integrity".to_string(), Value::String(integ.clone()));
+      Value::Object(entry)
+    });
+  }
+
+  // Build specifiers from the root importer (key `.`).
+  let mut specifiers: BTreeMap<String, String> = BTreeMap::new();
+  if let Some(importers) = doc.as_mapping_get("importers")
+    && let Some(root) = importers.as_mapping_get(".")
+  {
+    for section in ["dependencies", "devDependencies", "optionalDependencies"] {
+      let Some(deps) =
+        root.as_mapping_get(section).and_then(|s| s.as_mapping())
+      else {
+        continue;
+      };
+      for (name_node, info) in deps {
+        let Some(name) = yaml_to_string(name_node) else {
+          continue;
+        };
+        let Some(spec) =
+          info.as_mapping_get("specifier").and_then(yaml_to_string)
+        else {
+          continue;
+        };
+        let Some(ver) = info.as_mapping_get("version").and_then(yaml_to_string)
+        else {
+          continue;
+        };
+        if !is_supported_spec(&spec) {
+          continue;
+        }
+        let resolved = strip_peer_suffix(&ver).to_string();
+        let key = format!("npm:{}@{}", name, spec);
+        specifiers.entry(key).or_insert(resolved);
+      }
+    }
+  }
+  // pnpm v6 places top-level deps directly on the document root.
+  if major == 6 {
+    let specifiers_section = doc
+      .as_mapping_get("specifiers")
+      .and_then(|s| s.as_mapping());
+    for section in ["dependencies", "devDependencies", "optionalDependencies"] {
+      let Some(deps) = doc.as_mapping_get(section).and_then(|s| s.as_mapping())
+      else {
+        continue;
+      };
+      for (name_node, ver_node) in deps {
+        let Some(name) = yaml_to_string(name_node) else {
+          continue;
+        };
+        let Some(ver) = yaml_to_string(ver_node) else {
+          continue;
+        };
+        let spec = specifiers_section
+          .and_then(|s| {
+            s.iter().find(|(k, _)| {
+              yaml_to_string(k).as_deref() == Some(name.as_str())
+            })
+          })
+          .and_then(|(_, v)| yaml_to_string(v))
+          .unwrap_or_else(|| ver.clone());
+        if !is_supported_spec(&spec) {
+          continue;
+        }
+        let resolved = strip_peer_suffix(&ver).to_string();
+        let key = format!("npm:{}@{}", name, spec);
+        specifiers.entry(key).or_insert(resolved);
+      }
+    }
+  }
+
+  let mut output = serde_json::Map::new();
+  output.insert("version".to_string(), Value::String("5".to_string()));
+  if !specifiers.is_empty() {
+    output.insert(
+      "specifiers".to_string(),
+      Value::Object(
+        specifiers
+          .into_iter()
+          .map(|(k, v)| (k, Value::String(v)))
+          .collect(),
+      ),
+    );
+  }
+  if !npm.is_empty() {
+    output.insert("npm".to_string(), Value::Object(npm.into_iter().collect()));
+  }
+
+  Ok(serde_json::to_string(&Value::Object(output)).unwrap())
+}
+
+fn yaml_to_string(node: &Yaml) -> Option<String> {
+  // Saphyr lazy-parses plain scalars and leaves them in the `Representation`
+  // variant when they don't resolve to a typed value (e.g. multi-dot
+  // version strings like `4.3.0`). Pull the raw text out for those before
+  // falling back to the typed accessors.
+  if let Yaml::Representation(raw, _, _) = node {
+    return Some(raw.to_string());
+  }
+  if let Some(s) = node.as_str() {
+    return Some(s.to_string());
+  }
+  if let Some(b) = node.as_bool() {
+    return Some(b.to_string());
+  }
+  if let Some(i) = node.as_integer() {
+    return Some(i.to_string());
+  }
+  node.as_floating_point().map(|f| f.to_string())
+}
+
+/// Build a sorted list of `dep@version` strings from a pnpm dependency
+/// mapping (e.g. `{ ansi-styles: 4.3.0, color-convert: 2.0.1 }`).
+fn collect_deps(node: Option<&Yaml>) -> Vec<String> {
+  let Some(map) = node.and_then(|n| n.as_mapping()) else {
+    return Vec::new();
+  };
+  let mut out: Vec<String> = map
+    .iter()
+    .filter_map(|(k, v)| {
+      let name = yaml_to_string(k)?;
+      let ver = yaml_to_string(v)?;
+      let ver = strip_peer_suffix(&ver);
+      Some(format!("{}@{}", name, ver))
+    })
+    .collect();
+  out.sort();
+  out.dedup();
+  out
+}
+
+/// In pnpm v6 the keys in `packages` and reference paths are prefixed with
+/// `/`, e.g. `/lodash@4.17.21` or `/@babel/core@7.0.0`. Strip it.
+fn normalize_package_key(key: &str) -> String {
+  let stripped = key.strip_prefix('/').unwrap_or(key);
+  // pnpm v6 sometimes used `/name/version` instead of `/name@version`. We
+  // detect the `/version` form by checking whether the last `/` is followed
+  // by what looks like a semver number.
+  if !stripped.contains('@') || stripped.starts_with('@') {
+    // For scoped packages, the only `@` may be at the start. Check the
+    // `name/version` form by splitting on the last `/`.
+    if let Some(idx) = stripped.rfind('/') {
+      let (name, ver) = stripped.split_at(idx);
+      let ver = &ver[1..];
+      if ver.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return format!("{}@{}", name, ver);
+      }
+    }
+  }
+  stripped.to_string()
+}
+
+/// Strip pnpm's peer-dependency suffix from a package id. E.g.
+/// `chalk@5.0.0(react@18.0.0)` -> `chalk@5.0.0`.
+fn strip_peer_suffix(key: &str) -> &str {
+  match key.find('(') {
+    Some(idx) => &key[..idx],
+    None => key,
+  }
+}
+
+fn is_supported_spec(req: &str) -> bool {
+  !req.starts_with("file:")
+    && !req.starts_with("link:")
+    && !req.starts_with("workspace:")
+    && !req.starts_with("git+")
+    && !req.starts_with("git:")
+    && !req.starts_with("github:")
+    && !req.starts_with("http:")
+    && !req.starts_with("https:")
+    && !req.starts_with("catalog:")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn translates_simple_v9() {
+    let input = r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+  lodash@4.17.21:
+    resolution: {integrity: sha512-AAA}
+
+snapshots:
+  lodash@4.17.21: {}
+"#;
+    let out = pnpm_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["version"], "5");
+    assert_eq!(v["specifiers"]["npm:lodash@^4.17.21"], "4.17.21");
+    assert_eq!(v["npm"]["lodash@4.17.21"]["integrity"], "sha512-AAA");
+  }
+
+  #[test]
+  fn translates_v9_with_nested_deps() {
+    let input = r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      chalk:
+        specifier: ^4.0.0
+        version: 4.1.2
+
+packages:
+  chalk@4.1.2:
+    resolution: {integrity: sha512-CHALK}
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-ANSI}
+
+snapshots:
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+  ansi-styles@4.3.0: {}
+"#;
+    let out = pnpm_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["npm"]["chalk@4.1.2"]["integrity"], "sha512-CHALK");
+    let chalk_deps =
+      v["npm"]["chalk@4.1.2"]["dependencies"].as_array().unwrap();
+    assert_eq!(chalk_deps[0], "ansi-styles@4.3.0");
+    assert_eq!(v["npm"]["ansi-styles@4.3.0"]["integrity"], "sha512-ANSI");
+  }
+
+  #[test]
+  fn strips_peer_suffix() {
+    let input = r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      some-plugin:
+        specifier: ^1.0.0
+        version: 1.0.0(react@18.3.1)
+
+packages:
+  some-plugin@1.0.0:
+    resolution: {integrity: sha512-PLUGIN}
+  react@18.3.1:
+    resolution: {integrity: sha512-REACT}
+
+snapshots:
+  some-plugin@1.0.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+  react@18.3.1: {}
+"#;
+    let out = pnpm_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["specifiers"]["npm:some-plugin@^1.0.0"], "1.0.0");
+    let plugin_deps = v["npm"]["some-plugin@1.0.0"]["dependencies"]
+      .as_array()
+      .unwrap();
+    assert_eq!(plugin_deps[0], "react@18.3.1");
+  }
+
+  #[test]
+  fn scoped_packages_v9() {
+    let input = r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      '@scope/pkg':
+        specifier: ^1.0.0
+        version: 1.2.3
+
+packages:
+  '@scope/pkg@1.2.3':
+    resolution: {integrity: sha512-XXX}
+
+snapshots:
+  '@scope/pkg@1.2.3': {}
+"#;
+    let out = pnpm_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["specifiers"]["npm:@scope/pkg@^1.0.0"], "1.2.3");
+    assert!(
+      v["npm"]
+        .as_object()
+        .unwrap()
+        .contains_key("@scope/pkg@1.2.3")
+    );
+  }
+
+  #[test]
+  fn translates_v6() {
+    let input = r#"
+lockfileVersion: '6.0'
+
+specifiers:
+  lodash: ^4.17.21
+
+dependencies:
+  lodash: 4.17.21
+
+packages:
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-LODASH}
+    dev: false
+"#;
+    let out = pnpm_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["specifiers"]["npm:lodash@^4.17.21"], "4.17.21");
+    assert_eq!(v["npm"]["lodash@4.17.21"]["integrity"], "sha512-LODASH");
+  }
+
+  #[test]
+  fn rejects_unsupported_version() {
+    let input = r#"lockfileVersion: '4.0'
+packages: {}
+"#;
+    let err = pnpm_lock_to_deno_lock_v5(input).unwrap_err();
+    assert!(matches!(
+      err,
+      PnpmLockfileImportError::UnsupportedVersion(_)
+    ));
+  }
+}

--- a/libs/resolver/pnpm_lockfile_import.rs
+++ b/libs/resolver/pnpm_lockfile_import.rs
@@ -436,6 +436,9 @@ fn strip_peer_suffix(key: &str) -> &str {
 }
 
 fn is_supported_spec(req: &str) -> bool {
+  // `npm:` reqs are aliased dependencies (e.g. `foo: npm:bar@^1`). Building a
+  // specifier from those would produce `npm:foo@npm:bar@^1`, which isn't a
+  // valid deno.lock specifier, so skip them and let resolution handle aliases.
   !req.starts_with("file:")
     && !req.starts_with("link:")
     && !req.starts_with("workspace:")
@@ -444,6 +447,7 @@ fn is_supported_spec(req: &str) -> bool {
     && !req.starts_with("github:")
     && !req.starts_with("http:")
     && !req.starts_with("https:")
+    && !req.starts_with("npm:")
     && !req.starts_with("catalog:")
 }
 
@@ -593,6 +597,67 @@ packages:
     let v: Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["specifiers"]["npm:lodash@^4.17.21"], "4.17.21");
     assert_eq!(v["npm"]["lodash@4.17.21"]["integrity"], "sha512-LODASH");
+  }
+
+  #[test]
+  fn skips_aliased_specifier() {
+    // An aliased dependency (`my-lodash: npm:lodash@^4`) must not produce a
+    // malformed `npm:my-lodash@npm:lodash@^4` specifier.
+    let input = r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      my-lodash:
+        specifier: npm:lodash@^4.17.21
+        version: lodash@4.17.21
+
+packages:
+  lodash@4.17.21:
+    resolution: {integrity: sha512-AAA}
+
+snapshots:
+  lodash@4.17.21: {}
+"#;
+    let out = pnpm_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    // No specifier is emitted for the aliased dep.
+    assert!(v.get("specifiers").is_none());
+    // The resolved package itself is still captured in the npm section.
+    assert_eq!(v["npm"]["lodash@4.17.21"]["integrity"], "sha512-AAA");
+  }
+
+  #[test]
+  fn captures_optional_dependencies() {
+    let input = r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      pkg:
+        specifier: ^1.0.0
+        version: 1.0.0
+
+packages:
+  pkg@1.0.0:
+    resolution: {integrity: sha512-PKG}
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-FS}
+
+snapshots:
+  pkg@1.0.0:
+    optionalDependencies:
+      fsevents: 2.3.3
+  fsevents@2.3.3: {}
+"#;
+    let out = pnpm_lock_to_deno_lock_v5(input).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    let opt = v["npm"]["pkg@1.0.0"]["optionalDependencies"]
+      .as_array()
+      .unwrap();
+    assert_eq!(opt[0], "fsevents@2.3.3");
   }
 
   #[test]

--- a/libs/resolver/pnpm_lockfile_import.rs
+++ b/libs/resolver/pnpm_lockfile_import.rs
@@ -4,18 +4,30 @@
 //!
 //! Only the npm subset is translated. Targets pnpm lockfileVersion 6.x and
 //! 9.x (the formats produced by pnpm v8 and pnpm v9+ respectively).
+//!
+//! YAML is parsed with `yaml_parser` (the same parser `deno fmt` already
+//! depends on) to avoid pulling a new YAML crate into the dependency tree.
+//! `yaml_parser` is a lossless CST parser, so the helpers below adapt its
+//! syntax tree into a small `Node`/`MapNode` value model that is convenient
+//! for the lookups this translation needs.
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
-use saphyr::LoadableYamlNode;
-use saphyr::Yaml;
 use serde_json::Value;
+use yaml_parser::SyntaxError;
+use yaml_parser::ast::AstNode;
+use yaml_parser::ast::BlockMap;
+use yaml_parser::ast::BlockMapKey;
+use yaml_parser::ast::BlockMapValue;
+use yaml_parser::ast::Flow;
+use yaml_parser::ast::FlowMap;
+use yaml_parser::ast::Root;
 
 #[derive(Debug, thiserror::Error)]
 pub enum PnpmLockfileImportError {
   #[error("Failed to parse pnpm-lock.yaml")]
-  Parse(#[source] saphyr::ScanError),
+  Parse(#[source] SyntaxError),
   #[error("pnpm-lock.yaml is empty or not a mapping")]
   EmptyOrInvalid,
   #[error(
@@ -29,16 +41,18 @@ pub enum PnpmLockfileImportError {
 pub fn pnpm_lock_to_deno_lock_v5(
   yaml_text: &str,
 ) -> Result<String, PnpmLockfileImportError> {
-  let mut docs =
-    Yaml::load_from_str(yaml_text).map_err(PnpmLockfileImportError::Parse)?;
-  let doc = docs
-    .pop()
-    .filter(|d| d.is_mapping())
+  let syntax =
+    yaml_parser::parse(yaml_text).map_err(PnpmLockfileImportError::Parse)?;
+  let root_map = Root::cast(syntax)
+    .and_then(|root| root.documents().next())
+    .and_then(|doc| doc.block())
+    .and_then(|block| block.block_map())
+    .map(MapNode::Block)
     .ok_or(PnpmLockfileImportError::EmptyOrInvalid)?;
 
-  let version = doc
-    .as_mapping_get("lockfileVersion")
-    .and_then(yaml_to_string)
+  let version = root_map
+    .get("lockfileVersion")
+    .and_then(Node::into_string)
     .ok_or_else(
       || PnpmLockfileImportError::UnsupportedVersion(String::new()),
     )?;
@@ -56,19 +70,16 @@ pub fn pnpm_lock_to_deno_lock_v5(
   // Build integrity map: `name@version` -> integrity. pnpm v6 keys may be
   // prefixed with `/` (e.g. `/lodash@4.17.21`); v9 keys are bare.
   let mut integrity: HashMap<String, String> = HashMap::new();
-  if let Some(packages) = doc.as_mapping_get("packages")
-    && let Some(map) = packages.as_mapping()
-  {
-    for (k, v) in map {
-      let Some(key) = yaml_to_string(k) else {
-        continue;
-      };
+  if let Some(packages) = root_map.get("packages").and_then(Node::into_map) {
+    for (key, value) in packages.entries() {
       let key = normalize_package_key(&key);
       let base = strip_peer_suffix(&key).to_string();
-      if let Some(integ) = v
-        .as_mapping_get("resolution")
-        .and_then(|r| r.as_mapping_get("integrity"))
-        .and_then(yaml_to_string)
+      if let Some(integ) = value
+        .into_map()
+        .and_then(|m| m.get("resolution"))
+        .and_then(Node::into_map)
+        .and_then(|m| m.get("integrity"))
+        .and_then(Node::into_string)
       {
         integrity.entry(base).or_insert(integ);
       }
@@ -77,23 +88,15 @@ pub fn pnpm_lock_to_deno_lock_v5(
 
   // Snapshots define the resolved dependency tree. In v6 the `packages`
   // section itself carries `dependencies`; in v9 they live under `snapshots`.
-  // We accept whichever is present (or both, with snapshots taking
-  // precedence).
+  // Walk snapshots first so the dep-bearing entries win when both sections
+  // exist (the `packages` pass for v9 only carries metadata we've already
+  // captured in `integrity`).
   let mut npm: BTreeMap<String, Value> = BTreeMap::new();
-  // In v9 dependencies live under `snapshots`; in v6 they live inline under
-  // `packages`. Walk snapshots first so the dep-bearing entries win when
-  // both sections exist (the `packages` pass for v9 only carries metadata
-  // we've already captured in `integrity`).
-  let snapshot_sources: [&str; 2] = ["snapshots", "packages"];
-  for section in snapshot_sources {
-    let Some(snaps) = doc.as_mapping_get(section).and_then(|s| s.as_mapping())
-    else {
+  for section in ["snapshots", "packages"] {
+    let Some(snaps) = root_map.get(section).and_then(Node::into_map) else {
       continue;
     };
-    for (k, v) in snaps {
-      let Some(raw_key) = yaml_to_string(k) else {
-        continue;
-      };
+    for (raw_key, value) in snaps.entries() {
       let normalized = normalize_package_key(&raw_key);
       let base = strip_peer_suffix(&normalized).to_string();
       // Snapshot keys may include peer-suffix parens; for our purposes,
@@ -106,9 +109,19 @@ pub fn pnpm_lock_to_deno_lock_v5(
         continue;
       };
 
-      let deps = collect_deps(v.as_mapping_get("dependencies"));
-      let optional_deps =
-        collect_deps(v.as_mapping_get("optionalDependencies"));
+      let value_map = value.into_map();
+      let deps = collect_deps(
+        value_map
+          .as_ref()
+          .and_then(|m| m.get("dependencies"))
+          .and_then(Node::into_map),
+      );
+      let optional_deps = collect_deps(
+        value_map
+          .as_ref()
+          .and_then(|m| m.get("optionalDependencies"))
+          .and_then(Node::into_map),
+      );
 
       let mut entry = serde_json::Map::new();
       entry.insert("integrity".to_string(), Value::String(integ.clone()));
@@ -140,26 +153,26 @@ pub fn pnpm_lock_to_deno_lock_v5(
 
   // Build specifiers from the root importer (key `.`).
   let mut specifiers: BTreeMap<String, String> = BTreeMap::new();
-  if let Some(importers) = doc.as_mapping_get("importers")
-    && let Some(root) = importers.as_mapping_get(".")
+  if let Some(root_importer) = root_map
+    .get("importers")
+    .and_then(Node::into_map)
+    .and_then(|m| m.get("."))
+    .and_then(Node::into_map)
   {
     for section in ["dependencies", "devDependencies", "optionalDependencies"] {
-      let Some(deps) =
-        root.as_mapping_get(section).and_then(|s| s.as_mapping())
+      let Some(deps) = root_importer.get(section).and_then(Node::into_map)
       else {
         continue;
       };
-      for (name_node, info) in deps {
-        let Some(name) = yaml_to_string(name_node) else {
+      for (name, info) in deps.entries() {
+        let Some(info) = info.into_map() else {
           continue;
         };
-        let Some(spec) =
-          info.as_mapping_get("specifier").and_then(yaml_to_string)
+        let Some(spec) = info.get("specifier").and_then(Node::into_string)
         else {
           continue;
         };
-        let Some(ver) = info.as_mapping_get("version").and_then(yaml_to_string)
-        else {
+        let Some(ver) = info.get("version").and_then(Node::into_string) else {
           continue;
         };
         if !is_supported_spec(&spec) {
@@ -173,28 +186,20 @@ pub fn pnpm_lock_to_deno_lock_v5(
   }
   // pnpm v6 places top-level deps directly on the document root.
   if major == 6 {
-    let specifiers_section = doc
-      .as_mapping_get("specifiers")
-      .and_then(|s| s.as_mapping());
+    let specifiers_section =
+      root_map.get("specifiers").and_then(Node::into_map);
     for section in ["dependencies", "devDependencies", "optionalDependencies"] {
-      let Some(deps) = doc.as_mapping_get(section).and_then(|s| s.as_mapping())
-      else {
+      let Some(deps) = root_map.get(section).and_then(Node::into_map) else {
         continue;
       };
-      for (name_node, ver_node) in deps {
-        let Some(name) = yaml_to_string(name_node) else {
-          continue;
-        };
-        let Some(ver) = yaml_to_string(ver_node) else {
+      for (name, ver_node) in deps.entries() {
+        let Some(ver) = ver_node.into_string() else {
           continue;
         };
         let spec = specifiers_section
-          .and_then(|s| {
-            s.iter().find(|(k, _)| {
-              yaml_to_string(k).as_deref() == Some(name.as_str())
-            })
-          })
-          .and_then(|(_, v)| yaml_to_string(v))
+          .as_ref()
+          .and_then(|s| s.get(&name))
+          .and_then(Node::into_string)
           .unwrap_or_else(|| ver.clone());
         if !is_supported_spec(&spec) {
           continue;
@@ -223,40 +228,174 @@ pub fn pnpm_lock_to_deno_lock_v5(
     output.insert("npm".to_string(), Value::Object(npm.into_iter().collect()));
   }
 
-  Ok(serde_json::to_string(&Value::Object(output)).unwrap())
+  Ok(
+    serde_json::to_string(&Value::Object(output))
+      .expect("serializing deno.lock v5"),
+  )
 }
 
-fn yaml_to_string(node: &Yaml) -> Option<String> {
-  // Saphyr lazy-parses plain scalars and leaves them in the `Representation`
-  // variant when they don't resolve to a typed value (e.g. multi-dot
-  // version strings like `4.3.0`). Pull the raw text out for those before
-  // falling back to the typed accessors.
-  if let Yaml::Representation(raw, _, _) = node {
-    return Some(raw.to_string());
+/// A minimal value model over `yaml_parser`'s CST, covering the node shapes
+/// `pnpm-lock.yaml` uses: scalars and mappings (block or flow style).
+enum Node {
+  Scalar(String),
+  Map(MapNode),
+  Other,
+}
+
+impl Node {
+  fn into_string(self) -> Option<String> {
+    match self {
+      Node::Scalar(s) => Some(s),
+      _ => None,
+    }
   }
-  if let Some(s) = node.as_str() {
-    return Some(s.to_string());
+
+  fn into_map(self) -> Option<MapNode> {
+    match self {
+      Node::Map(m) => Some(m),
+      _ => None,
+    }
   }
-  if let Some(b) = node.as_bool() {
-    return Some(b.to_string());
+}
+
+enum MapNode {
+  Block(BlockMap),
+  Flow(FlowMap),
+}
+
+impl MapNode {
+  /// Materialize the mapping's entries as `(key, value)` pairs. Entries whose
+  /// key is not a scalar are skipped.
+  fn entries(&self) -> Vec<(String, Node)> {
+    match self {
+      MapNode::Block(block_map) => block_map
+        .entries()
+        .filter_map(|entry| {
+          let key = entry.key().and_then(|k| block_key_text(&k))?;
+          let value = entry
+            .value()
+            .map(|v| block_value_to_node(&v))
+            .unwrap_or(Node::Other);
+          Some((key, value))
+        })
+        .collect(),
+      MapNode::Flow(flow_map) => {
+        let Some(entries) = flow_map.entries() else {
+          return Vec::new();
+        };
+        entries
+          .entries()
+          .filter_map(|entry| {
+            let key = entry
+              .key()
+              .and_then(|k| k.flow())
+              .and_then(|f| flow_text(&f))?;
+            let value = entry
+              .value()
+              .and_then(|v| v.flow())
+              .map(|f| flow_to_node(&f))
+              .unwrap_or(Node::Other);
+            Some((key, value))
+          })
+          .collect()
+      }
+    }
   }
-  if let Some(i) = node.as_integer() {
-    return Some(i.to_string());
+
+  fn get(&self, key: &str) -> Option<Node> {
+    self
+      .entries()
+      .into_iter()
+      .find(|(k, _)| k == key)
+      .map(|(_, v)| v)
   }
-  node.as_floating_point().map(|f| f.to_string())
+}
+
+fn block_key_text(key: &BlockMapKey) -> Option<String> {
+  key.flow().and_then(|f| flow_text(&f))
+}
+
+fn block_value_to_node(value: &BlockMapValue) -> Node {
+  if let Some(block_map) = value.block().and_then(|b| b.block_map()) {
+    return Node::Map(MapNode::Block(block_map));
+  }
+  if let Some(flow) = value.flow() {
+    return flow_to_node(&flow);
+  }
+  Node::Other
+}
+
+fn flow_to_node(flow: &Flow) -> Node {
+  if let Some(text) = flow_text(flow) {
+    return Node::Scalar(text);
+  }
+  if let Some(flow_map) = flow.flow_map() {
+    return Node::Map(MapNode::Flow(flow_map));
+  }
+  Node::Other
+}
+
+/// Extract the string content of a scalar `Flow`, unquoting single/double
+/// quoted forms. Returns `None` for non-scalar flows (maps, sequences).
+fn flow_text(flow: &Flow) -> Option<String> {
+  if let Some(token) = flow.plain_scalar() {
+    return Some(token.text().trim().to_string());
+  }
+  if let Some(token) = flow.single_quoted_scalar() {
+    return Some(unquote_single(token.text()));
+  }
+  if let Some(token) = flow.double_qouted_scalar() {
+    return Some(unquote_double(token.text()));
+  }
+  None
+}
+
+fn unquote_single(raw: &str) -> String {
+  let inner = raw
+    .strip_prefix('\'')
+    .and_then(|s| s.strip_suffix('\''))
+    .unwrap_or(raw);
+  // In single-quoted YAML scalars the only escape is a doubled quote.
+  inner.replace("''", "'")
+}
+
+fn unquote_double(raw: &str) -> String {
+  let inner = raw
+    .strip_prefix('"')
+    .and_then(|s| s.strip_suffix('"'))
+    .unwrap_or(raw);
+  let mut out = String::with_capacity(inner.len());
+  let mut chars = inner.chars();
+  while let Some(c) = chars.next() {
+    if c != '\\' {
+      out.push(c);
+      continue;
+    }
+    match chars.next() {
+      Some('n') => out.push('\n'),
+      Some('t') => out.push('\t'),
+      Some('r') => out.push('\r'),
+      Some('"') => out.push('"'),
+      Some('\\') => out.push('\\'),
+      Some('0') => out.push('\0'),
+      Some(other) => out.push(other),
+      None => {}
+    }
+  }
+  out
 }
 
 /// Build a sorted list of `dep@version` strings from a pnpm dependency
 /// mapping (e.g. `{ ansi-styles: 4.3.0, color-convert: 2.0.1 }`).
-fn collect_deps(node: Option<&Yaml>) -> Vec<String> {
-  let Some(map) = node.and_then(|n| n.as_mapping()) else {
+fn collect_deps(node: Option<MapNode>) -> Vec<String> {
+  let Some(map) = node else {
     return Vec::new();
   };
   let mut out: Vec<String> = map
-    .iter()
-    .filter_map(|(k, v)| {
-      let name = yaml_to_string(k)?;
-      let ver = yaml_to_string(v)?;
+    .entries()
+    .into_iter()
+    .filter_map(|(name, value)| {
+      let ver = value.into_string()?;
       let ver = strip_peer_suffix(&ver);
       Some(format!("{}@{}", name, ver))
     })

--- a/tests/specs/install/import_from_pnpm_lock_yaml/__test__.jsonc
+++ b/tests/specs/install/import_from_pnpm_lock_yaml/__test__.jsonc
@@ -1,0 +1,22 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      // No deno.lock or package-lock.json — `deno install` should seed
+      // deno.lock from pnpm-lock.yaml instead.
+      "args": "install",
+      "output": "install.out"
+    },
+    {
+      "args": [
+        "eval",
+        "console.log(Deno.readTextFileSync('deno.lock').trim())"
+      ],
+      "output": "deno.lock.out"
+    },
+    {
+      "args": "run --cached-only main.js",
+      "output": "3\n"
+    }
+  ]
+}

--- a/tests/specs/install/import_from_pnpm_lock_yaml/deno.lock.out
+++ b/tests/specs/install/import_from_pnpm_lock_yaml/deno.lock.out
@@ -1,0 +1,19 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@denotest/add@1": "1.0.0"
+  },
+  "npm": {
+    "@denotest/add@1.0.0": {
+      "integrity": "[WILDCARD]",
+      "tarball": "http://localhost:4260/@denotest/add/1.0.0.tgz"
+    }
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@denotest/add@1"
+      ]
+    }
+  }
+}

--- a/tests/specs/install/import_from_pnpm_lock_yaml/install.out
+++ b/tests/specs/install/import_from_pnpm_lock_yaml/install.out
@@ -1,0 +1,1 @@
+[WILDCARD]Seeded deno.lock from [WILDCARD]pnpm-lock.yaml[WILDCARD]

--- a/tests/specs/install/import_from_pnpm_lock_yaml/main.js
+++ b/tests/specs/install/import_from_pnpm_lock_yaml/main.js
@@ -1,0 +1,2 @@
+import { add } from "@denotest/add";
+console.log(add(1, 2));

--- a/tests/specs/install/import_from_pnpm_lock_yaml/package.json
+++ b/tests/specs/install/import_from_pnpm_lock_yaml/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "dependencies": {
+    "@denotest/add": "1"
+  }
+}

--- a/tests/specs/install/import_from_pnpm_lock_yaml/pnpm-lock.yaml
+++ b/tests/specs/install/import_from_pnpm_lock_yaml/pnpm-lock.yaml
@@ -1,0 +1,21 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      '@denotest/add':
+        specifier: '1'
+        version: 1.0.0
+
+packages:
+  '@denotest/add@1.0.0':
+    resolution: {
+      integrity: sha512-uvNpnVPU/CC2Do/LNF3TkhoLGLLKC6jFDPiSnojuZCEwmoXJjS2+Sn+LYk7eUix4vsMKA9ctxaMhcfb6pdHQTQ==,
+    }
+
+snapshots:
+  '@denotest/add@1.0.0': {}


### PR DESCRIPTION
Follow-up to #35330, which seeded `deno.lock` from a sibling
`package-lock.json` on the first local `deno install`. This extends that
seeding to `pnpm-lock.yaml`, so projects migrating from pnpm don't lose
their pinned versions and integrity hashes on the first `deno install`.

As before, the seeding only kicks in for the local `deno install`
subcommand and only when no `deno.lock` already exists; other commands
keep their current behavior of starting from an empty lockfile. The new
importer lives in `libs/resolver/pnpm_lockfile_import.rs`, parses to the
same deno.lock v5 JSON intermediate the npm importer produces, and is
wired into `try_import_npm_lockfile` in `libs/resolver/lockfile.rs`. When
both a `package-lock.json` and a `pnpm-lock.yaml` are present,
`package-lock.json` wins.

pnpm's lockfile is YAML. Rather than add a new YAML crate, the importer
parses with `yaml_parser`, which is already in the tree as a dependency of
`pretty_yaml` (used by `deno fmt`), so this adds no new crates and no new
transitive dependencies. `yaml_parser` is a lossless CST parser, so a
small value model adapts its syntax tree into the mapping/scalar lookups
the translation needs.

The translator targets pnpm `lockfileVersion` 6.x and 9.x (the formats
produced by pnpm v8 and v9+). It reads integrity from the `packages`
section, the resolved dependency tree from `snapshots` (v9) or inline
`packages` entries (v6), strips pnpm's peer-dependency suffixes (e.g.
`chalk@5.0.0(react@18.0.0)`), and builds specifiers from the root
importer. Workspace, file, git, http, and `catalog:` deps are skipped, and
unsupported lockfile versions are rejected with a clear error.

The next piece, seeding from `yarn.lock`, will follow in a separate PR on
top of this one.

Towards #25815
Towards #26521
