### PR TITLE
fix(tests): skip npm/playwright_compat on windows-aarch64

### DIFF
--- a/tests/specs/npm/playwright_compat/__test__.jsonc
+++ b/tests/specs/npm/playwright_compat/__test__.jsonc
@@ -1,4 +1,5 @@
 {
+  "if": "notWindowsArm",
   "envs": {
     "PLAYWRIGHT_BROWSERS_PATH": "../../../../.ms-playwright"
   },


### PR DESCRIPTION
The npm/playwright_compat spec test hangs on the windows-aarch64 CI
runners: instead of completing or failing it stalls indefinitely, which
holds the whole spec shard open until the 30-minute job timeout fires.
This has been keeping main's CI red on that platform.

The test launches a real chromium browser via `chromium.launch()`, so the
likely cause is chromium not starting reliably on windows-aarch64, but
that has not been confirmed. For now skip the test there with the existing
`notWindowsArm` condition, the same way the `upgrade/*` and
`cert/deno_land_unsafe_ssl` tests are already excluded on that platform.
Coverage is unchanged everywhere the test runs today (windows-x86_64,
linux, macos).