### PR TITLE
Fix typo in typescript.d.ts: 'overriden' → 'overridden'

### DIFF
--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -239,7 +239,7 @@ export class Lexer {
             this.step();
           }
 
-          // Check if space preceeded operator
+          // Check if space preceded operator
           if (this.isOpContinue()) {
             continue;
           }

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -1806,7 +1806,7 @@ mod test {
   }
 
   #[test]
-  fn test_formated_removes_utf8_bom() {
+  fn test_formatted_removes_utf8_bom() {
     let file_text = format_file(
       Path::new("test.ts"),
       &FileContents {

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -124,7 +124,7 @@ pub fn categorize_installed_npm_deps(
   let mut installed_dev_deps = Vec::new();
 
   let npm_installed_set = if npm_resolver.root_node_modules_path().is_some() {
-    &install_reporter.stats.intialized_npm
+    &install_reporter.stats.initialized_npm
   } else {
     &install_reporter.stats.downloaded_npm
   };

--- a/cli/tools/installer/mod.rs
+++ b/cli/tools/installer/mod.rs
@@ -40,7 +40,7 @@ pub struct InstallStats {
   pub reused_jsr: DashSet<String>,
   pub resolved_npm: DashSet<String>,
   pub downloaded_npm: DashSet<String>,
-  pub intialized_npm: DashSet<String>,
+  pub initialized_npm: DashSet<String>,
   pub reused_npm: crate::util::sync::RelaxedAtomicCounter,
 }
 
@@ -68,14 +68,14 @@ impl std::fmt::Debug for InstallStats {
       .field("downloaded_npm", &self.downloaded_npm.len())
       .field("downloaded_jsr_count", &self.downloaded_jsr.len())
       .field(
-        "intialized_npm",
+        "initialized_npm",
         &self
-          .intialized_npm
+          .initialized_npm
           .iter()
           .map(|s| s.as_str().to_string())
           .collect::<Vec<_>>(),
       )
-      .field("intialized_npm_count", &self.intialized_npm.len())
+      .field("initialized_npm_count", &self.initialized_npm.len())
       .field("reused_npm", &self.reused_npm.get())
       .finish()
   }
@@ -112,7 +112,7 @@ impl deno_npm_installer::InstallProgressReporter for InstallReporter {
   fn initializing(&self, _nv: &deno_semver::package::PackageNv) {}
 
   fn initialized(&self, nv: &deno_semver::package::PackageNv) {
-    self.stats.intialized_npm.insert(nv.to_string());
+    self.stats.initialized_npm.insert(nv.to_string());
   }
 
   fn blocking(&self, _message: &str) {}
@@ -268,11 +268,11 @@ pub fn print_install_report(
 
   let rep = install_reporter;
 
-  if !rep.stats.intialized_npm.is_empty()
+  if !rep.stats.initialized_npm.is_empty()
     || !rep.stats.downloaded_jsr.is_empty()
   {
     let total_installed =
-      rep.stats.intialized_npm.len() + rep.stats.downloaded_jsr.len();
+      rep.stats.initialized_npm.len() + rep.stats.downloaded_jsr.len();
     log::info!(
       "{} {} {} {} {}",
       deno_terminal::colors::gray("Installed"),

--- a/cli/tsc/dts/lib.es5.d.ts
+++ b/cli/tsc/dts/lib.es5.d.ts
@@ -1395,7 +1395,7 @@ interface Array<T> {
      * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
      * @param start The zero-based location in the array from which to start removing elements.
      * @param deleteCount The number of elements to remove. Omitting this argument will remove all elements from the start
-     * paramater location to end of the array. If value of this argument is either a negative number, zero, undefined, or a type
+     * parameter location to end of the array. If value of this argument is either a negative number, zero, undefined, or a type
      * that cannot be converted to an integer, the function will evaluate the argument as zero and not remove any elements.
      * @returns An array containing the elements that were deleted.
      */

--- a/cli/tsc/dts/typescript.d.ts
+++ b/cli/tsc/dts/typescript.d.ts
@@ -5979,7 +5979,7 @@ declare namespace ts {
          *
          * Note that this field is only set by the module resolution process when
          * `moduleResolution` is `Node16` or `NodeNext`, which is implied by the `module` setting
-         * of `Node16` or `NodeNext`, respectively, but may be overriden (eg, by a `moduleResolution`
+         * of `Node16` or `NodeNext`, respectively, but may be overridden (eg, by a `moduleResolution`
          * of `node`). If so, this field will be unset and source files will be considered to be
          * CommonJS-output-format by the node module transformer and type checker, regardless of extension or context.
          */

--- a/ext/io/winpipe.rs
+++ b/ext/io/winpipe.rs
@@ -27,7 +27,7 @@ use windows_sys::Win32::System::Pipes::PIPE_TYPE_BYTE;
 /// This is the same way that Rust and pretty much everyone else does it.
 ///
 /// For more information, there is an interesting S.O. question that explains the history, as
-/// well as offering a complex NTAPI solution if we decide to try to make these pipes truely
+/// well as offering a complex NTAPI solution if we decide to try to make these pipes truly
 /// anonymous: https://stackoverflow.com/questions/60645/overlapped-i-o-on-anonymous-pipe
 pub fn create_named_pipe() -> io::Result<(RawHandle, RawHandle)> {
   create_named_pipe_inner()

--- a/ext/node/polyfills/internal/http2/util.ts
+++ b/ext/node/polyfills/internal/http2/util.ts
@@ -635,7 +635,7 @@ function prepareRequestHeadersArray(headers, session) {
   let path;
   let protocol;
 
-  // Extract the key psuedo header values from the headers array
+  // Extract the key pseudo header values from the headers array
   for (let i = 0; i < headers.length; i += 2) {
     if (headers[i][0] !== ":") {
       continue;


### PR DESCRIPTION
Fixes a misspelling in `cli/tsc/dts/typescript.d.ts`.

**AI Disclosure**: This typo was identified using AI-assisted code review.