### PR TITLE
fix(node): add worker_threads locks

### DIFF
--- a/cli/tsc/dts/node/worker_threads.d.cts
+++ b/cli/tsc/dts/node/worker_threads.d.cts
@@ -70,6 +70,39 @@ declare module "worker_threads" {
     const SHARE_ENV: unique symbol;
     const threadId: number;
     const workerData: any;
+    type LockMode = "exclusive" | "shared";
+    interface Lock {
+        readonly name: string;
+        readonly mode: LockMode;
+    }
+    interface LockOptions {
+        mode?: LockMode | undefined;
+        ifAvailable?: boolean | undefined;
+        steal?: boolean | undefined;
+        signal?: AbortSignal | undefined;
+    }
+    interface LockInfo {
+        name: string;
+        mode: LockMode;
+        clientId: string;
+    }
+    interface LockManagerSnapshot {
+        held: LockInfo[];
+        pending: LockInfo[];
+    }
+    interface LockManager {
+        request<T>(
+            name: string,
+            callback: (lock: Lock) => T | PromiseLike<T>,
+        ): Promise<T>;
+        request<T>(
+            name: string,
+            options: LockOptions,
+            callback: (lock: Lock | null) => T | PromiseLike<T>,
+        ): Promise<T>;
+        query(): Promise<LockManagerSnapshot>;
+    }
+    const locks: LockManager;
     /**
      * Instances of the `worker.MessageChannel` class represent an asynchronous,
      * two-way communications channel.

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -2234,6 +2234,8 @@ class BroadcastChannel extends WebBroadcastChannel {
   }
 }
 
+const { locks } = core.createLazyLoader("ext:deno_web/locks.js")();
+
 // Node's `worker_threads.MessagePort` is a function (not a class) that throws
 // `ERR_CONSTRUCT_CALL_INVALID` whether called as `MessagePort()` or
 // `new MessagePort()`. Mirror that here while keeping
@@ -2283,6 +2285,7 @@ ObjectAssign(exportsObj, {
   // Node's contract (an empty resourceLimits on the main thread).
   resourceLimits: {},
   threadName: "",
+  locks,
   markAsUncloneable,
   markAsUntransferable,
   isMarkedAsUntransferable,

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -65,7 +65,7 @@ pub use crate::timers::StartTime;
 use crate::timers::op_defer;
 use crate::timers::op_now;
 use crate::timers::op_time_origin;
-mod locks;
+pub mod locks;
 
 deno_core::extension!(deno_web,
   deps = [ deno_webidl ],

--- a/ext/web/locks.rs
+++ b/ext/web/locks.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::VecDeque;
+use std::fmt::Display;
 use std::rc::Rc;
 use std::sync::LazyLock;
 use std::sync::Mutex;
@@ -60,6 +61,14 @@ static LOCK_STATE: LazyLock<Mutex<LockState>> = LazyLock::new(|| {
 static CLIENT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 struct LockClientId(String);
+
+pub fn worker_lock_client_id(worker_id: impl Display) -> String {
+  format!("worker-{worker_id}")
+}
+
+pub fn set_lock_client_id(state: &mut OpState, client_id: String) {
+  state.put(LockClientId(client_id));
+}
 
 fn get_client_id(state: &mut OpState) -> String {
   if let Some(id) = state.try_borrow::<LockClientId>() {
@@ -118,6 +127,39 @@ fn cancel_request(state: &mut LockState, id: u64) {
       let _ = req.tx.send(false);
       return;
     }
+  }
+}
+
+pub fn cleanup_locks_for_client_id(client_id: &str) {
+  let mut state = LOCK_STATE.lock().unwrap();
+  let mut affected_names = Vec::new();
+
+  state.held.retain(|lock| {
+    if lock.client_id == client_id {
+      affected_names.push(lock.name.clone());
+      false
+    } else {
+      true
+    }
+  });
+
+  for (name, queue) in state.queues.iter_mut() {
+    let mut index = 0;
+    while index < queue.len() {
+      if queue[index].client_id == client_id {
+        let request = queue.remove(index).unwrap();
+        let _ = request.tx.send(false);
+        affected_names.push(name.clone());
+      } else {
+        index += 1;
+      }
+    }
+  }
+
+  affected_names.sort();
+  affected_names.dedup();
+  for name in affected_names {
+    process_queue(&mut state, &name);
   }
 }
 

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -97,6 +97,7 @@ pub struct WorkerThread {
   worker_type: WorkerThreadType,
   cancel_handle: Rc<CancelHandle>,
   cpu_thread_handle: Arc<AtomicU64>,
+  web_lock_client_id: Option<String>,
 
   // A WorkerThread that hasn't been explicitly terminated can only be removed
   // from the WorkersTable once close messages have been received for both the
@@ -121,6 +122,9 @@ impl WorkerThread {
 
 impl Drop for WorkerThread {
   fn drop(&mut self) {
+    if let Some(client_id) = &self.web_lock_client_id {
+      deno_web::locks::cleanup_locks_for_client_id(client_id);
+    }
     self.worker_handle.clone().terminate();
   }
 }
@@ -404,6 +408,8 @@ fn op_create_worker(
     worker_type: args.worker_type,
     cancel_handle: CancelHandle::new_rc(),
     cpu_thread_handle,
+    web_lock_client_id: matches!(args.worker_type, WorkerThreadType::Node)
+      .then(|| deno_web::locks::worker_lock_client_id(worker_id)),
     ctrl_closed: false,
     message_closed: false,
     termination_requested: false,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -708,6 +708,12 @@ impl WebWorker {
       );
       let op_state = js_runtime.op_state();
       let mut op_state = op_state.borrow_mut();
+      if options.worker_type == WorkerThreadType::Node {
+        deno_web::locks::set_lock_client_id(
+          &mut op_state,
+          deno_web::locks::worker_lock_client_id(options.worker_id),
+        );
+      }
       op_state.put(internal_handle.clone());
       op_state.put(crate::ops::web_worker::WaitForWorkerDebuggerOnMessage(
         options.wait_for_page_wait_for_debugger,

--- a/tests/unit_node/worker_threads_test.ts
+++ b/tests/unit_node/worker_threads_test.ts
@@ -4,6 +4,8 @@ import {
   assert,
   assertEquals,
   assertObjectMatch,
+  assertRejects,
+  assertStrictEquals,
   assertThrows,
   fail,
 } from "@std/assert";
@@ -55,6 +57,132 @@ Deno.test({
   name: "[node/worker_threads] resourceLimits",
   fn() {
     assertObjectMatch(workerThreads.resourceLimits, {});
+  },
+});
+
+Deno.test({
+  name: "[node/worker_threads] locks reuses Web Locks",
+  fn() {
+    const webLocks =
+      (navigator as typeof navigator & { locks: typeof workerThreads.locks })
+        .locks;
+    assertStrictEquals(workerThreads.locks, webLocks);
+  },
+});
+
+Deno.test({
+  name: "[node/worker_threads] locks request and query",
+  async fn() {
+    const lockName = "deno-worker-threads-locks-basic";
+    const result = await workerThreads.locks.request(
+      lockName,
+      async (lock) => {
+        assert(lock);
+        assertEquals(lock.name, lockName);
+        assertEquals(lock.mode, "exclusive");
+
+        const snapshot = await workerThreads.locks.query();
+        assert(snapshot.held.some((entry) => entry.name === lockName));
+        assertEquals(
+          snapshot.held.find((entry) => entry.name === lockName)?.mode,
+          "exclusive",
+        );
+        return 42;
+      },
+    );
+
+    assertEquals(result, 42);
+    const snapshot = await workerThreads.locks.query();
+    assertEquals(snapshot.held.some((entry) => entry.name === lockName), false);
+  },
+});
+
+Deno.test({
+  name: "[node/worker_threads] locks request can be aborted while pending",
+  async fn() {
+    const lockName = "deno-worker-threads-locks-abort";
+    await workerThreads.locks.request(lockName, async () => {
+      const ac = new AbortController();
+      const pending = workerThreads.locks.request(
+        lockName,
+        { signal: ac.signal },
+        () => fail("aborted lock request should not be granted"),
+      );
+
+      let sawPending = false;
+      for (let i = 0; i < 10; i++) {
+        const snapshot = await workerThreads.locks.query();
+        if (snapshot.pending.some((entry) => entry.name === lockName)) {
+          sawPending = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      assert(sawPending);
+
+      ac.abort();
+      const error = await assertRejects(() => pending);
+      assertEquals((error as Error).name, "AbortError");
+    });
+
+    const snapshot = await workerThreads.locks.query();
+    assertEquals(
+      snapshot.pending.some((entry) => entry.name === lockName),
+      false,
+    );
+  },
+});
+
+Deno.test({
+  name: "[node/worker_threads] locks ifAvailable and option validation",
+  async fn() {
+    const lockName = "deno-worker-threads-locks-if-available";
+    await workerThreads.locks.request(lockName, async () => {
+      const unavailable = await workerThreads.locks.request(
+        lockName,
+        { ifAvailable: true },
+        (lock) => lock === null,
+      );
+      assertEquals(unavailable, true);
+    });
+
+    const error = await assertRejects(() =>
+      workerThreads.locks.request(
+        lockName,
+        { ifAvailable: true, steal: true },
+        () => fail("invalid lock options should reject before callback"),
+      )
+    );
+    assertEquals((error as Error).name, "NotSupportedError");
+  },
+});
+
+Deno.test({
+  name: "[node/worker_threads] locks shared mode allows concurrent holders",
+  async fn() {
+    const lockName = "deno-worker-threads-locks-shared";
+    await workerThreads.locks.request(
+      lockName,
+      { mode: "shared" },
+      async (firstLock) => {
+        assert(firstLock !== null);
+        assertEquals(firstLock.mode, "shared");
+
+        const second = await workerThreads.locks.request(
+          lockName,
+          { mode: "shared" },
+          (secondLock) => secondLock?.mode,
+        );
+        assertEquals(second, "shared");
+
+        const exclusiveUnavailable = await workerThreads.locks.request(
+          lockName,
+          { ifAvailable: true },
+          (exclusiveLock) => exclusiveLock === null,
+        );
+        assertEquals(exclusiveUnavailable, true);
+      },
+    );
   },
 });
 
@@ -150,6 +278,158 @@ Deno.test({
     assertEquals((await once(worker, "message"))[0], "It works!");
     worker.terminate();
   },
+});
+
+Deno.test({
+  name: "[node/worker_threads] locks are shared with workers",
+  async fn() {
+    const lockName = "deno-worker-threads-locks-cross-worker";
+    const worker = new workerThreads.Worker(
+      `
+      const { parentPort, locks } = require("node:worker_threads");
+      parentPort.once("message", async (lockName) => {
+        try {
+          const unavailable = await locks.request(
+            lockName,
+            { ifAvailable: true },
+            (lock) => lock === null,
+          );
+          parentPort.postMessage(unavailable);
+        } catch (error) {
+          parentPort.postMessage({ error: error.message });
+        }
+      });
+      `,
+      { eval: true },
+    );
+
+    try {
+      await workerThreads.locks.request(lockName, async () => {
+        worker.postMessage(lockName);
+        const message = (await once(worker, "message"))[0];
+        assertEquals(message, true);
+      });
+    } finally {
+      await worker.terminate();
+    }
+  },
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "[node/worker_threads] locks are released when worker exits",
+  async fn() {
+    const lockName = "deno-worker-threads-locks-worker-exit";
+    const worker = new workerThreads.Worker(
+      `
+      const { parentPort, locks } = require("node:worker_threads");
+      locks.request(${JSON.stringify(lockName)}, async () => {
+        parentPort.postMessage("held");
+        await new Promise(() => {});
+      });
+      `,
+      { eval: true },
+    );
+
+    assertEquals((await once(worker, "message"))[0], "held");
+    await worker.terminate();
+
+    const available = await workerThreads.locks.request(
+      lockName,
+      { ifAvailable: true },
+      (lock) => lock !== null,
+    );
+    assertEquals(available, true);
+  },
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name:
+    "[node/worker_threads] pending worker locks are cleaned up on terminate",
+  async fn() {
+    const lockName = "deno-worker-threads-locks-pending-worker-exit";
+    const worker = new workerThreads.Worker(
+      `
+      const { parentPort, locks } = require("node:worker_threads");
+      parentPort.once("message", (lockName) => {
+        locks.request(lockName, async () => {
+          parentPort.postMessage("unexpected");
+        }).catch(() => {});
+        parentPort.postMessage("pending");
+      });
+      `,
+      { eval: true },
+    );
+
+    try {
+      await workerThreads.locks.request(lockName, async () => {
+        worker.postMessage(lockName);
+        assertEquals((await once(worker, "message"))[0], "pending");
+
+        let sawPending = false;
+        for (let i = 0; i < 10; i++) {
+          const snapshot = await workerThreads.locks.query();
+          if (snapshot.pending.some((entry) => entry.name === lockName)) {
+            sawPending = true;
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        assert(sawPending);
+
+        await worker.terminate();
+        const snapshot = await workerThreads.locks.query();
+        assertEquals(
+          snapshot.pending.some((entry) => entry.name === lockName),
+          false,
+        );
+      });
+    } finally {
+      await worker.terminate();
+    }
+  },
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "[node/worker_threads] exclusive locks are handed off to workers",
+  async fn() {
+    const lockName = "deno-worker-threads-locks-worker-handoff";
+    const worker = new workerThreads.Worker(
+      `
+      const { parentPort, locks } = require("node:worker_threads");
+      parentPort.once("message", async (lockName) => {
+        await locks.request(lockName, async (lock) => {
+          parentPort.postMessage(lock.name);
+        });
+      });
+      `,
+      { eval: true },
+    );
+
+    try {
+      const acquired = once(worker, "message");
+      await workerThreads.locks.request(lockName, async () => {
+        worker.postMessage(lockName);
+        let sawPending = false;
+        for (let i = 0; i < 10; i++) {
+          const snapshot = await workerThreads.locks.query();
+          if (snapshot.pending.some((entry) => entry.name === lockName)) {
+            sawPending = true;
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        assert(sawPending);
+      });
+
+      assertEquals((await acquired)[0], lockName);
+    } finally {
+      await worker.terminate();
+    }
+  },
+  sanitizeResources: false,
 });
 
 Deno.test({


### PR DESCRIPTION
Fixes #35370.

This adds the experimental `worker_threads.locks` export for Deno's Node compatibility layer.

- implements process-wide lock coordination for `LockManager.request()` and `query()`
- supports exclusive/shared locks, pending cancellation, `ifAvailable`, `steal`, and worker-exit cleanup
- adds TypeScript declarations for the new API
- adds unit coverage for query/release, aborting pending requests, option validation, shared locks, cross-worker contention, and worker-exit cleanup

Validation:
- `cargo check -p deno_runtime`
- `cargo build -p deno`
- `cargo test -p unit_node_tests --test unit_node -- worker_threads_test`
- `cargo fmt --package deno_runtime --check`
- `./target/debug/deno fmt --check tests/unit_node/worker_threads_test.ts`
- `git diff --check`