### PR TITLE
fix(task): run node eval scripts with deno

### DIFF
--- a/cli/task_runner.rs
+++ b/cli/task_runner.rs
@@ -18,6 +18,8 @@ use deno_task_shell::ShellCommand;
 use deno_task_shell::ShellCommandContext;
 use deno_task_shell::ShellPipeReader;
 use deno_task_shell::ShellPipeWriter;
+use percent_encoding::NON_ALPHANUMERIC;
+use percent_encoding::utf8_percent_encode;
 use tokio::task::JoinHandle;
 use tokio::task::LocalSet;
 use tokio_util::sync::CancellationToken;
@@ -377,11 +379,73 @@ impl ShellCommand for DenoCommand {
 
 pub struct NodeCommand;
 
+fn node_eval_arg(args: &[OsString]) -> Option<(String, usize)> {
+  let first_arg = args.first()?.to_string_lossy();
+  if first_arg == "-e" || first_arg == "--eval" {
+    let code = args.get(1)?.to_string_lossy().into_owned();
+    Some((code, 2))
+  } else if let Some(code) = first_arg.strip_prefix("--eval=") {
+    Some((code.to_string(), 1))
+  } else {
+    None
+  }
+}
+
+fn wrap_node_eval_script(code: &str) -> String {
+  format!(
+    r#"import {{ createRequire }} from "node:module";
+import process from "node:process";
+const require = createRequire(`${{Deno.cwd()}}/[eval]`);
+const module = {{ exports: {{}} }};
+const exports = module.exports;
+const __filename = "[eval]";
+// Node reports "." for __dirname in -e/--eval scripts.
+const __dirname = ".";
+process.argv.splice(1, 1);
+{code}"#
+  )
+}
+
+fn node_eval_data_url(code: &str) -> OsString {
+  format!(
+    "data:application/javascript,{}",
+    utf8_percent_encode(code, NON_ALPHANUMERIC)
+  )
+  .into()
+}
+
 impl ShellCommand for NodeCommand {
   fn execute(
     &self,
     context: ShellCommandContext,
   ) -> LocalBoxFuture<'static, ExecuteResult> {
+    if let Some((code, consumed_args)) = node_eval_arg(&context.args) {
+      let mut args: Vec<OsString> = Vec::with_capacity(
+        3 + context.args.len().saturating_sub(consumed_args),
+      );
+      args.push("run".into());
+      args.push("-A".into());
+      args.push(node_eval_data_url(&wrap_node_eval_script(&code)));
+      args.extend(context.args.into_iter().skip(consumed_args));
+
+      let mut state = context.state;
+      state.apply_env_var(
+        OsStr::new(USE_PKG_JSON_HIDDEN_ENV_VAR_NAME),
+        OsStr::new("1"),
+      );
+      return ExecutableCommand::new(
+        "deno".to_string(),
+        std::env::current_exe()
+          .and_then(|p| canonicalize_path(&p))
+          .unwrap(),
+      )
+      .execute(ShellCommandContext {
+        args,
+        state,
+        ..context
+      });
+    }
+
     // continue to use Node if the first argument is a flag
     // or there are no arguments provided for some reason
     if context.args.is_empty()

--- a/tests/registry/npm/@denotest/node-eval-lifecycle/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/node-eval-lifecycle/1.0.0/index.js
@@ -1,0 +1,1 @@
+export const value = "node-eval-lifecycle";

--- a/tests/registry/npm/@denotest/node-eval-lifecycle/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/node-eval-lifecycle/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@denotest/node-eval-lifecycle",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node -e \"require('./postinstall.js')\" && node --eval=\"const fs=require('fs');const path=require('path');fs.appendFileSync(path.join(process.env.INIT_CWD,'node-eval-lifecycle.txt'),'\\nargv:'+process.argv.slice(1).join(',')+'\\nfilename:'+__filename+'\\ndirname:'+__dirname)\" extra"
+  },
+  "exports": "./index.js"
+}

--- a/tests/registry/npm/@denotest/node-eval-lifecycle/1.0.0/postinstall.js
+++ b/tests/registry/npm/@denotest/node-eval-lifecycle/1.0.0/postinstall.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+const path = require("path");
+const pkg = require("./package.json");
+
+fs.writeFileSync(
+  path.join(process.env.INIT_CWD, "node-eval-lifecycle.txt"),
+  `installed ${pkg.name}`,
+);

--- a/tests/specs/npm/lifecycle_scripts/argument/__test__.jsonc
+++ b/tests/specs/npm/lifecycle_scripts/argument/__test__.jsonc
@@ -51,6 +51,24 @@
         }
       ]
     },
+    "node_eval_lifecycle_script_without_node_on_path": {
+      "steps": [
+        {
+          "envs": {
+            "PATH": ""
+          },
+          "args": "cache --allow-scripts node_eval.js",
+          "output": "node_eval.out"
+        },
+        {
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('node-eval-lifecycle.txt'))"
+          ],
+          "output": "node_eval_file.out"
+        }
+      ]
+    },
     "deno_run_lifecycle_scripts": {
       "steps": [
         {

--- a/tests/specs/npm/lifecycle_scripts/argument/node_eval.js
+++ b/tests/specs/npm/lifecycle_scripts/argument/node_eval.js
@@ -1,0 +1,5 @@
+import { value } from "npm:@denotest/node-eval-lifecycle";
+
+if (value !== "node-eval-lifecycle") {
+  throw new Error("unexpected package value");
+}

--- a/tests/specs/npm/lifecycle_scripts/argument/node_eval.out
+++ b/tests/specs/npm/lifecycle_scripts/argument/node_eval.out
@@ -1,0 +1,13 @@
+Download http://localhost:4260/@denotest%2fnode-eval-lifecycle
+Download http://localhost:4260/@denotest/node-eval-lifecycle/1.0.0.tgz
+Initialize @denotest/node-eval-lifecycle@1.0.0
+Initialize @denotest/node-eval-lifecycle@1.0.0: running 'postinstall' script
+Installed 1 package in [WILDCARD]
+Reused 0 packages from cache
+Downloaded 0 packages from JSR
+Downloaded 1 package from npm
++
+
+Dependencies:
++ npm:@denotest/node-eval-lifecycle 1.0.0
+

--- a/tests/specs/npm/lifecycle_scripts/argument/node_eval_file.out
+++ b/tests/specs/npm/lifecycle_scripts/argument/node_eval_file.out
@@ -1,0 +1,4 @@
+installed @denotest/node-eval-lifecycle
+argv:extra
+filename:[eval]
+dirname:.


### PR DESCRIPTION
Fixes #24916.

This keeps `node -e` / `node --eval` lifecycle scripts on Deno's existing task-runner path instead of falling back to a real `node` binary when the first argument is an eval flag.

- detects `-e`, `--eval`, and `--eval=...` in the task runner
- wraps eval code with a small CommonJS-style shim so relative `require()` resolves from the package script cwd
- preserves eval script args and Node-style `__filename` / `__dirname` values
- adds a registry fixture that runs `node -e` and `node --eval=...` with `PATH` empty

Validation:
- `cargo build -p deno`
- `cargo test -p specs_tests --test specs -- npm::lifecycle_scripts::argument::node_eval_lifecycle_script_without_node_on_path --no-capture`
- `cargo test -p specs_tests --test specs -- npm::lifecycle_scripts::argument::lifecycle_scripts --no-capture`
- `cargo test -p specs_tests --test specs -- npm::lifecycle_scripts::argument::deno_run_lifecycle_scripts --no-capture`
- `cargo fmt --package deno --check`
- `git diff --check`