### PR TITLE
fix(node): handle empty typed arrays in IPC

### DIFF
--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -588,14 +588,21 @@ mod impl_ {
           };
 
           let array_buffer = v8::ArrayBuffer::new(scope, byte_length as usize);
-          // SAFETY: array_buffer is valid as v8 is keeping it alive, and is byte_length bytes
-          // buf is also byte_length bytes long
-          unsafe {
-            std::ptr::copy(
-              buf.as_ptr(),
-              array_buffer.data().unwrap().as_ptr().cast::<u8>(),
-              byte_length as usize,
-            );
+          if byte_length > 0 {
+            let Some(data) = array_buffer.data() else {
+              return throw_error(
+                "failed to allocate typed array backing store",
+              );
+            };
+            // SAFETY: array_buffer is valid as v8 is keeping it alive, and is byte_length bytes
+            // buf is also byte_length bytes long
+            unsafe {
+              std::ptr::copy(
+                buf.as_ptr(),
+                data.as_ptr().cast::<u8>(),
+                byte_length as usize,
+              );
+            }
           }
 
           let value = match index {

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1080,6 +1080,11 @@ Deno.test(async function ipcSerializationAdvanced() {
         true,
         null,
         new Uint8Array([1, 2, 3]),
+        new Uint8Array([]),
+        new Int32Array([]),
+        new Float64Array([]),
+        new DataView(new ArrayBuffer(0)),
+        Buffer.alloc(0),
         {
           foo: new Uint8Array([1, 2, 3]),
           bar: makeSab([4, 5, 6]),
@@ -1115,6 +1120,11 @@ Deno.test(async function ipcSerializationAdvanced() {
     true,
     null,
     new Uint8Array([1, 2, 3]),
+    new Uint8Array([]),
+    new Int32Array([]),
+    new Float64Array([]),
+    new DataView(new ArrayBuffer(0)),
+    Buffer.alloc(0),
     {
       foo: new Uint8Array([1, 2, 3]),
       bar: makeSab([4, 5, 6]),


### PR DESCRIPTION
Fixes #35339.

### What changed

- Avoid copying into a zero-length ArrayBuffer backing store when deserializing advanced IPC typed array views.
- Add regression coverage for empty typed arrays, DataView, and Buffer values sent over `child_process` advanced IPC.

### Testing

- `cargo check -p deno_node`
- `cargo build -p deno`
- `cargo test -p unit_node_tests --test unit_node -- child_process_test`
- Manual `CP.fork(..., { serialization: "advanced" })` repro with `process.send(new Uint8Array([]))`
