### PR TITLE
fix(test/node): mark test-worker-fshandles-open-close-on-termination as flaky

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -5514,7 +5514,9 @@
     "sequential/test-timers-set-interval-excludes-callback-duration.js": {},
     "sequential/test-tls-connect.js": {},
     "sequential/test-worker-fshandles-open-close-on-termination.js": {
-      "flaky": true
+      "flaky": true,
+      "windows": false,
+      "reason": "times out on Windows; flaky on other platforms"
     },
     "sequential/test-zlib-crc32-fast-api.js": {},
     "test-runner/test-output-default-output.mjs": {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4530,8 +4530,6 @@
     "test-runner/test-run-watch-no-emit-restarted-disabled.mjs": {},
     // TODO(bartlomieju): disabled during work on `node:inspector`, this test didn't actualy run before
     // "sequential/test-watch-mode-inspect.mjs": {},
-    // TODO(bartlomieju): this test is very flaky on CI, especially on Windows ARM
-    // "sequential/test-worker-fshandles-open-close-on-termination.js": {},
     "wasm-allocation/test-wasm-allocation.js": {
       "ignore": true,
       "reason": "Relies on an RLIMIT_AS virtual-memory ulimit (declared in the test header) to force WebAssembly.Memory allocation failures; Deno's node_compat runner does not apply that rlimit"
@@ -5515,7 +5513,9 @@
     "sequential/test-timers-block-eventloop.js": {},
     "sequential/test-timers-set-interval-excludes-callback-duration.js": {},
     "sequential/test-tls-connect.js": {},
-    "sequential/test-worker-fshandles-open-close-on-termination.js": {},
+    "sequential/test-worker-fshandles-open-close-on-termination.js": {
+      "flaky": true
+    },
     "sequential/test-zlib-crc32-fast-api.js": {},
     "test-runner/test-output-default-output.mjs": {
       "linux": false,


### PR DESCRIPTION
<!-- AI Disclosure: This PR was authored with the assistance of Claude (Anthropic). -->

## Summary

Mark `sequential/test-worker-fshandles-open-close-on-termination.js` as flaky
and skip it on Windows in the node_compat test configuration.

## Background

- This test was originally added as a commented-out (disabled) entry in
  d2a9b8c77a (#31908) with a note: "this test is very flaky on CI, especially
  on Windows ARM".
- It was later enabled without the `flaky` flag in 227008237f (#34184) as part
  of a batch enable of 397 passing-but-unenabled tests.
- Since then it has been observed to time out on Windows and fail intermittently
  on other platforms (e.g. #35215).
- Two attempts to skip it on Windows (24b9ffbb, 1b479bf8) were subsequently
  reverted in 077b6d61 as "unrelated ci workarounds", leaving the test without
  any flaky/skip configuration on main.

## Changes

- Add `"flaky": true` to retry on non-Windows platforms
- Add `"windows": false` to skip the test on Windows where it consistently
  times out
- Add `"reason"` explaining the configuration
- Remove the old commented-out duplicate entry

generated by Claude Code