### PR TITLE
fix(ext/node): remove Readable.resume/pause destroyed early-returns

### DIFF
--- a/ext/node/polyfills/internal/streams/readable.js
+++ b/ext/node/polyfills/internal/streams/readable.js
@@ -1321,9 +1321,6 @@ function nReadingNextTick(self) {
 // If the user uses them, then switch into old mode.
 Readable.prototype.resume = function () {
   const state = this._readableState;
-  if ((state[kState] & kDestroyed) !== 0) {
-    return this;
-  }
   if ((state[kState] & kFlowing) === 0) {
     debug("resume");
     // We flow only if there is no one listening
@@ -1365,9 +1362,6 @@ function resume_(stream, state) {
 
 Readable.prototype.pause = function () {
   const state = this._readableState;
-  if ((state[kState] & kDestroyed) !== 0) {
-    return this;
-  }
   debug("call pause");
   if ((state[kState] & (kHasFlowing | kFlowing)) !== kHasFlowing) {
     debug("pause");


### PR DESCRIPTION
The Node.js 26.3 bump (#34746) added `if (state.destroyed) return this;`
early-returns to `Readable.prototype.resume` and `Readable.prototype.pause`
in `ext/node/polyfills/internal/streams/readable.js`. These deadlock piped
Readables.

When a piped destination drains, `pipeOnDrain` calls `src.resume()` to
restart the flow. The destroyed early-return makes that `resume()` a no-op in
a state where the source still needs to be resumed, so the source stops being
read and the destination never receives `end()`. The pipe wedges with no
pending op and an empty buffer.

In the wild this manifests as a hang while `npm:playwright`'s installer
extracts a downloaded browser archive: yauzl streams thousands of small zip
entries through `readStream.pipe(writeStream)`, and one entry deadlocks. That
is what hangs `specs::npm::playwright_compat` indefinitely in CI (it holds the
spec shard open until the 30-minute job timeout, across multiple arches and
OSes; it is not specific to windows-aarch64, which was separately skipped in
\#35358).

A `git bisect` pins the regression to #34746, and the `resume()` early-return
is the specific culprit (removing `howMuchToRead`'s fast path or the `pause`
guard alone does not fix it; removing the `resume` guard does). Upstream
Node's `resume`/`pause` do not bail out entirely on a destroyed stream, so
this restores the prior, correct behavior. Both guards are removed since they
were added together.

Verification:
- `specs::npm::playwright_compat` passes (~26s) instead of hanging.
- A deterministic local repro (yauzl `extract()` of a chromium archive, fresh
  `DENO_DIR`) completes fully (306/306 files) instead of stalling, across
  repeated runs.
- The resume/pause/pipe/destroy node compat stream tests still pass
  (`test-stream-pipe-deadlock`, `test-stream-pipe-cleanup-pause`,
  `test-stream-end-paused`, `test-stream-ispaused`, `test-stream-auto-destroy`,
  `test-stream-pipe-await-drain*`, `test-stream-destroy`, and others).

Supersedes the need for the mitigation in #35396 (which made the test
fail-fast rather than hang) and resolves #35395.
