### PR TITLE
fix(node/test): route nested top-level test() to a subtest

### DIFF
--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -1086,13 +1086,14 @@ async function runPossiblyExpectingFailure(fn, nodeTestContext, options) {
   };
   // Install this context as the current one for the duration of the body so a
   // top-level `test()` called inside it is routed here as a subtest (see the
-  // dispatcher in `test()`). Saved/restored synchronously around the body:
-  // Deno runs test bodies sequentially, so a plain variable suffices, and
-  // unlike wrapping the body in an extra call it adds no stack frames - extra
-  // frames can push `ext:cli/40_test.js` out of a failure's captured stack and
-  // break the source location reported for failed tests.
-  const prevContext = currentTestContext;
-  currentTestContext = nodeTestContext;
+  // dispatcher in `test()`). `enterWith` is a synchronous setter that binds the
+  // context for the current async root and its descendants without adding a
+  // stack frame - extra frames can push `ext:cli/40_test.js` out of a failure's
+  // captured stack and break the source location reported for failed tests. No
+  // save/restore is needed: each body runs in its own async root, so concurrent
+  // subtest bodies each keep their own context even when they interleave across
+  // `await`.
+  getTestContextALS().enterWith(nodeTestContext);
   if (
     !options.expectFailure ||
     options.skip ||
@@ -1106,7 +1107,6 @@ async function runPossiblyExpectingFailure(fn, nodeTestContext, options) {
       nodeTestContext._checkPlan();
       return result;
     } finally {
-      currentTestContext = prevContext;
       // Drain even on failure so subtests registered before the error finish
       // their Deno test steps before this test settles.
       await nodeTestContext._drainSubtests();
@@ -1124,7 +1124,6 @@ async function runPossiblyExpectingFailure(fn, nodeTestContext, options) {
     failed = true;
     assertExpectedFailure(err, options.expectFailure);
   } finally {
-    currentTestContext = prevContext;
     await nodeTestContext._drainSubtests();
   }
 
@@ -1414,18 +1413,32 @@ class NodeTestContext {
 
 let currentSuite = null;
 
-// The NodeTestContext whose body is currently executing, or null when no test
-// body is on the stack. Set by `runPossiblyExpectingFailure` for the duration
-// of each body so that a top-level `test()` / `it()` call made from inside
-// another test's body is registered as a subtest of that test (via
-// `t.step()`), matching Node, rather than hitting Deno's "Nested Deno.test()
-// calls are not supported" error. Deno runs test bodies sequentially, so a
-// single variable with save/restore tracks the active body across its `await`
-// boundaries and through nested subtests. See
+// AsyncLocalStorage holding the NodeTestContext whose body is currently
+// executing, or null when no test body is on the stack. Set by
+// `runPossiblyExpectingFailure` for the duration of each body so that a
+// top-level `test()` / `it()` call made from inside another test's body is
+// registered as a subtest of that test (via `t.step()`), matching Node, rather
+// than hitting Deno's "Nested Deno.test() calls are not supported" error.
+//
+// This must be an ALS, not a single module global with synchronous
+// save/restore: the unawaited routed-subtest path this enables makes execution
+// non-LIFO. With concurrent subtest bodies suspended across `await`, a plain
+// variable can point at a sibling when a parent resumes and silently mis-nest
+// the next routed `test()`. Each Deno test/step fn is its own async root, so
+// the store stays scoped to that body's subtree and survives `await`
+// boundaries, giving every interleaved body its own context. See
 // https://github.com/denoland/deno/issues/35391.
-let currentTestContext = null;
+let testContextALS = null;
+function getTestContextALS() {
+  if (testContextALS !== null) return testContextALS;
+  const mod = core.loadExtScript("ext:deno_node/async_hooks.ts");
+  const ALS = mod.AsyncLocalStorage;
+  testContextALS = new ALS();
+  return testContextALS;
+}
 function getCurrentTestContext() {
-  return currentTestContext;
+  if (testContextALS === null) return null;
+  return testContextALS.getStore() ?? null;
 }
 
 const rootBeforeHooks = [];

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -1078,6 +1078,21 @@ async function runNodeTestFunction(fn, nodeTestContext) {
   return await ReflectApply(fn, nodeTestContext, [nodeTestContext]);
 }
 
+// Runs a node test body with `nodeTestContext` installed as the current test
+// context (via AsyncLocalStorage) so that any top-level `test()` call made
+// inside the body is routed to it as a subtest. Returns the body's result.
+function runBodyInContext(fn, nodeTestContext, guards) {
+  const als = getTestContextALS();
+  return als.run(
+    nodeTestContext,
+    () =>
+      runWithTestGuards(
+        () => runNodeTestFunction(fn, nodeTestContext),
+        guards,
+      ),
+  );
+}
+
 async function runPossiblyExpectingFailure(fn, nodeTestContext, options) {
   const guards = {
     timeout: options.timeout,
@@ -1089,24 +1104,26 @@ async function runPossiblyExpectingFailure(fn, nodeTestContext, options) {
     options.skip ||
     options.todo
   ) {
-    const result = await runWithTestGuards(
-      () => runNodeTestFunction(fn, nodeTestContext),
-      guards,
-    );
-    nodeTestContext._checkPlan();
-    return result;
+    try {
+      const result = await runBodyInContext(fn, nodeTestContext, guards);
+      nodeTestContext._checkPlan();
+      return result;
+    } finally {
+      // Drain even on failure so subtests registered before the error finish
+      // their Deno test steps before this test settles.
+      await nodeTestContext._drainSubtests();
+    }
   }
 
   let failed = false;
   try {
-    await runWithTestGuards(
-      () => runNodeTestFunction(fn, nodeTestContext),
-      guards,
-    );
+    await runBodyInContext(fn, nodeTestContext, guards);
     nodeTestContext._checkPlan();
   } catch (err) {
     failed = true;
     assertExpectedFailure(err, options.expectFailure);
+  } finally {
+    await nodeTestContext._drainSubtests();
   }
 
   if (!failed) {
@@ -1155,6 +1172,11 @@ class NodeTestContext {
   // When set via `runOnly(true)`, only direct subtests registered with the
   // `only: true` option are executed; all other subtests are skipped.
   #runOnly = false;
+  // Promises for top-level `test()` calls routed here from inside this
+  // context's body (see `_trackSubtest`). The body awaits these before settling
+  // so such subtests still complete (Node semantics) and their Deno test steps
+  // finish before the parent step returns.
+  #subtestPromises = [];
 
   constructor(t, parent, name) {
     this.#denoContext = t;
@@ -1242,12 +1264,12 @@ class NodeTestContext {
     return null;
   }
 
-  test(name, options, fn) {
-    const prepared = prepareOptions(name, options, fn, {});
+  test(name, options, fn, overrides) {
+    const prepared = prepareOptions(name, options, fn, overrides);
     if (this.#plan) this.#plan.increment();
     // deno-lint-ignore no-this-alias
     const parentContext = this;
-    return PromisePrototypeThen(
+    const stepPromise = PromisePrototypeThen(
       this.#denoContext.step({
         name: prepared.name,
         fn: async (denoTestContext) => {
@@ -1303,7 +1325,39 @@ class NodeTestContext {
         sanitizeResources: false,
       }),
       () => undefined,
+      // A failed step settles `false` rather than rejecting, but guard against
+      // rejection so the returned promise never surfaces as unhandled.
+      () => undefined,
     );
+    return stepPromise;
+  }
+
+  // Records a subtest promise so the body runner can await it before this test
+  // settles. Used only for top-level `test()` calls routed here from inside the
+  // body (see the dispatcher in `test()`); a user awaiting `t.test()` directly
+  // sequences it themselves, and an unawaited `t.test()` keeps its existing
+  // (Node-divergent) "INCOMPLETE" behavior so unref'd-timer subtests are not
+  // forced to resolve.
+  _trackSubtest(promise) {
+    ArrayPrototypePush(this.#subtestPromises, promise);
+  }
+
+  // Awaits subtests registered via a routed top-level `test()` call. Called by
+  // the body runner after the test function returns so that such subtests,
+  // which are commonly not awaited (e.g. fastify's suites), still run to
+  // completion before the parent test settles.
+  async _drainSubtests() {
+    if (this.#subtestPromises.length === 0) return;
+    const promises = ArrayPrototypeSplice(
+      this.#subtestPromises,
+      0,
+      this.#subtestPromises.length,
+    );
+    for (const p of new SafeArrayIterator(promises)) {
+      try {
+        await p;
+      } catch { /* failures already reported through the subtest's own step */ }
+    }
   }
 
   before(fn, _options) {
@@ -1357,6 +1411,27 @@ class NodeTestContext {
 }
 
 let currentSuite = null;
+
+// Tracks the NodeTestContext whose body is currently executing so that a
+// top-level `test()` / `it()` call made from inside another test's body is
+// registered as a subtest of that test (via `t.step()`), matching Node, rather
+// than hitting Deno's "Nested Deno.test() calls are not supported" error. We
+// use AsyncLocalStorage so the association survives `await` boundaries within
+// the body. See https://github.com/denoland/deno/issues/35391.
+let testContextALS = null;
+function getTestContextALS() {
+  if (testContextALS === null) {
+    const { AsyncLocalStorage } = core.loadExtScript(
+      "ext:deno_node/async_hooks.ts",
+    );
+    testContextALS = new AsyncLocalStorage();
+  }
+  return testContextALS;
+}
+function getCurrentTestContext() {
+  if (testContextALS === null) return null;
+  return testContextALS.getStore() ?? null;
+}
 
 const rootBeforeHooks = [];
 const rootAfterHooks = [];
@@ -1663,6 +1738,17 @@ function test(name, options, fn, overrides) {
   }
   if (currentSuite) {
     return currentSuite.addTest(name, options, fn, overrides);
+  }
+  // A top-level `test()` called from inside another test's body becomes a
+  // subtest of that test, matching Node. Without this it would fall through to
+  // `Deno.test()`, which rejects nested registration.
+  const currentContext = getCurrentTestContext();
+  if (currentContext !== null) {
+    const promise = currentContext.test(name, options, fn, overrides);
+    // The body that issued this call may not await it; have the running test
+    // wait for it before settling so the subtest still completes (Node).
+    currentContext._trackSubtest(promise);
+    return promise;
   }
   return prepareDenoTest(name, options, fn, overrides);
 }

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -1078,37 +1078,35 @@ async function runNodeTestFunction(fn, nodeTestContext) {
   return await ReflectApply(fn, nodeTestContext, [nodeTestContext]);
 }
 
-// Runs a node test body with `nodeTestContext` installed as the current test
-// context (via AsyncLocalStorage) so that any top-level `test()` call made
-// inside the body is routed to it as a subtest. Returns the body's result.
-function runBodyInContext(fn, nodeTestContext, guards) {
-  const als = getTestContextALS();
-  return als.run(
-    nodeTestContext,
-    () =>
-      runWithTestGuards(
-        () => runNodeTestFunction(fn, nodeTestContext),
-        guards,
-      ),
-  );
-}
-
 async function runPossiblyExpectingFailure(fn, nodeTestContext, options) {
   const guards = {
     timeout: options.timeout,
     signal: options.signal,
     abort: (reason) => nodeTestContext._abort(reason),
   };
+  // Install this context as the current one for the duration of the body so a
+  // top-level `test()` called inside it is routed here as a subtest (see the
+  // dispatcher in `test()`). Saved/restored synchronously around the body:
+  // Deno runs test bodies sequentially, so a plain variable suffices, and
+  // unlike wrapping the body in an extra call it adds no stack frames - extra
+  // frames can push `ext:cli/40_test.js` out of a failure's captured stack and
+  // break the source location reported for failed tests.
+  const prevContext = currentTestContext;
+  currentTestContext = nodeTestContext;
   if (
     !options.expectFailure ||
     options.skip ||
     options.todo
   ) {
     try {
-      const result = await runBodyInContext(fn, nodeTestContext, guards);
+      const result = await runWithTestGuards(
+        () => runNodeTestFunction(fn, nodeTestContext),
+        guards,
+      );
       nodeTestContext._checkPlan();
       return result;
     } finally {
+      currentTestContext = prevContext;
       // Drain even on failure so subtests registered before the error finish
       // their Deno test steps before this test settles.
       await nodeTestContext._drainSubtests();
@@ -1117,12 +1115,16 @@ async function runPossiblyExpectingFailure(fn, nodeTestContext, options) {
 
   let failed = false;
   try {
-    await runBodyInContext(fn, nodeTestContext, guards);
+    await runWithTestGuards(
+      () => runNodeTestFunction(fn, nodeTestContext),
+      guards,
+    );
     nodeTestContext._checkPlan();
   } catch (err) {
     failed = true;
     assertExpectedFailure(err, options.expectFailure);
   } finally {
+    currentTestContext = prevContext;
     await nodeTestContext._drainSubtests();
   }
 
@@ -1412,25 +1414,18 @@ class NodeTestContext {
 
 let currentSuite = null;
 
-// Tracks the NodeTestContext whose body is currently executing so that a
-// top-level `test()` / `it()` call made from inside another test's body is
-// registered as a subtest of that test (via `t.step()`), matching Node, rather
-// than hitting Deno's "Nested Deno.test() calls are not supported" error. We
-// use AsyncLocalStorage so the association survives `await` boundaries within
-// the body. See https://github.com/denoland/deno/issues/35391.
-let testContextALS = null;
-function getTestContextALS() {
-  if (testContextALS === null) {
-    const { AsyncLocalStorage } = core.loadExtScript(
-      "ext:deno_node/async_hooks.ts",
-    );
-    testContextALS = new AsyncLocalStorage();
-  }
-  return testContextALS;
-}
+// The NodeTestContext whose body is currently executing, or null when no test
+// body is on the stack. Set by `runPossiblyExpectingFailure` for the duration
+// of each body so that a top-level `test()` / `it()` call made from inside
+// another test's body is registered as a subtest of that test (via
+// `t.step()`), matching Node, rather than hitting Deno's "Nested Deno.test()
+// calls are not supported" error. Deno runs test bodies sequentially, so a
+// single variable with save/restore tracks the active body across its `await`
+// boundaries and through nested subtests. See
+// https://github.com/denoland/deno/issues/35391.
+let currentTestContext = null;
 function getCurrentTestContext() {
-  if (testContextALS === null) return null;
-  return testContextALS.getStore() ?? null;
+  return currentTestContext;
 }
 
 const rootBeforeHooks = [];

--- a/tests/specs/node/node_test_module/test.out
+++ b/tests/specs/node/node_test_module/test.out
@@ -80,8 +80,13 @@ DIAGNOSTIC: this subtest should make its parent test fail
 subtest sync throw fail ... FAILED (due to 1 failed step) ([WILDLINE])
 sync throw non-error fail ... FAILED ([WILDLINE])
 level 0a ...
-  level 1a ... INCOMPLETE
-level 0a ... FAILED ([WILDLINE])
+[UNORDERED_START]
+  level 1a ... ok ([WILDLINE])
+  level 1b ... ok ([WILDLINE])
+  level 1c ... ok ([WILDLINE])
+  level 1d ... ok ([WILDLINE])
+[UNORDERED_END]
+level 0a ... ok ([WILDLINE])
 top level ...
   +long running ... INCOMPLETE
   +short running ...
@@ -147,6 +152,6 @@ rejected thenable => ./test.js:455:1
 unfinished test with uncaughtException => ./test.js:466:1
 unfinished test with unhandledRejection => ./test.js:474:1
 
-FAILED | 40 passed (23 steps) | 22 failed (12 steps) | 7 ignored ([WILDLINE])
+FAILED | 41 passed (27 steps) | 21 failed (11 steps) | 7 ignored ([WILDLINE])
 
 error: Test failed

--- a/tests/specs/node/node_test_nested_top_level/__test__.jsonc
+++ b/tests/specs/node/node_test_nested_top_level/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test test.js",
+  "output": "test.out",
+  "exitCode": 1
+}

--- a/tests/specs/node/node_test_nested_top_level/test.js
+++ b/tests/specs/node/node_test_nested_top_level/test.js
@@ -1,0 +1,37 @@
+// deno-lint-ignore-file
+
+// Calling the top-level `test()` from inside another test's body should
+// register a subtest of the running test, matching Node.js, instead of
+// throwing "Nested Deno.test() calls are not supported".
+// https://github.com/denoland/deno/issues/35391
+
+import assert from "node:assert";
+import { test } from "node:test";
+
+test("outer", async (t) => {
+  // Not awaited, just like real-world suites (e.g. fastify) do it.
+  test("inner declared with top-level test()", () => {
+    assert.strictEqual(1 + 1, 2);
+  });
+});
+
+test("outer with mixed nesting", async (t) => {
+  let ran = false;
+  // `t.test()` keeps working alongside the routed top-level `test()`.
+  await t.test("via t.test()", () => {
+    ran = true;
+  });
+  assert.ok(ran);
+
+  test("via top-level test()", (t2) => {
+    test("nested two levels deep", () => {
+      assert.strictEqual(t2.name, "via top-level test()");
+    });
+  });
+});
+
+test("failing nested test fails its parent", () => {
+  test("nested failure", () => {
+    throw new Error("boom");
+  });
+});

--- a/tests/specs/node/node_test_nested_top_level/test.out
+++ b/tests/specs/node/node_test_nested_top_level/test.out
@@ -1,0 +1,17 @@
+running 3 tests from ./test.js
+outer ...
+  inner declared with top-level test() ... ok ([WILDLINE])
+outer ... ok ([WILDLINE])
+outer with mixed nesting ...
+  via t.test() ... ok ([WILDLINE])
+  via top-level test() ...
+    nested two levels deep ... ok ([WILDLINE])
+  via top-level test() ... ok ([WILDLINE])
+outer with mixed nesting ... ok ([WILDLINE])
+failing nested test fails its parent ...
+  nested failure ... FAILED ([WILDLINE])
+failing nested test fails its parent ... FAILED (due to 1 failed step) ([WILDLINE])
+[WILDCARD] ERRORS [WILDCARD] FAILURES [WILDCARD]
+FAILED | 2 passed (4 steps) | 1 failed (1 step) ([WILDLINE])
+
+error: Test failed


### PR DESCRIPTION
Calling the top-level `test()` (or `it()`) from `node:test` inside another
test's body threw "Nested Deno.test() calls are not supported. Use t.step()
for nested tests." In Node this pattern registers a subtest of the running
test, and real-world suites rely on it; the incompatibility was found while
trying to run fastify's test suite.

This tracks the test whose body is currently executing (via an
AsyncLocalStorage so the association survives await boundaries) and routes a
nested top-level `test()` to it as a subtest through `t.step()`, instead of
falling through to `Deno.test()`. Such subtests are commonly not awaited by
the body, so the running test now waits for them to finish before it settles,
matching Node. Only these routed calls are drained; an unawaited `t.test()`
keeps its existing behavior so subtests holding the loop open with unref'd
timers are not forced to resolve.

Closes #35391