### PR TITLE
fix(core): always register isolate to prevent silent foreground task drop

### DIFF
--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -967,15 +967,12 @@ impl JsRuntime {
     // threads can queue foreground tasks. The task queue Arc is already shared
     // with JsRuntimeState (created above) so the event loop can drain it
     // without touching the global map.
-    // Not all contexts have a tokio runtime (e.g. snapshot creation, unit tests).
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-      setup::register_isolate(
-        setup::isolate_ptr_to_key(isolate_ptr),
-        waker.clone(),
-        handle,
-        state_rc.foreground_tasks.clone(),
-      );
-    }
+    setup::register_isolate(
+      setup::isolate_ptr_to_key(isolate_ptr),
+      waker.clone(),
+      tokio::runtime::Handle::try_current().ok(),
+      state_rc.foreground_tasks.clone(),
+    );
 
     // ...isolate is fully set up, we can forward its pointer to the ops to finish
     // their' setup...

--- a/libs/core/runtime/setup.rs
+++ b/libs/core/runtime/setup.rs
@@ -43,7 +43,7 @@ pub type ForegroundTaskQueue = std::sync::Arc<Mutex<Vec<v8::Task>>>;
 /// push tasks and wake the event loop.
 struct IsolateEntry {
   waker: std::sync::Arc<AtomicWaker>,
-  handle: tokio::runtime::Handle,
+  handle: Option<tokio::runtime::Handle>,
   tasks: ForegroundTaskQueue,
 }
 
@@ -57,7 +57,7 @@ static ISOLATE_ENTRIES: std::sync::LazyLock<
 pub fn register_isolate(
   isolate_ptr: usize,
   waker: std::sync::Arc<AtomicWaker>,
-  handle: tokio::runtime::Handle,
+  handle: Option<tokio::runtime::Handle>,
   tasks: ForegroundTaskQueue,
 ) {
   let mut map = ISOLATE_ENTRIES.lock().unwrap();
@@ -87,18 +87,23 @@ fn queue_task(key: usize, task: v8::Task) {
 
 /// Spawn a delayed V8 foreground task on the isolate's tokio runtime.
 /// After the delay, the task is queued for synchronous draining (not
-/// run directly on the tokio worker thread).
+/// run directly on the tokio worker thread). Falls back to immediate
+/// queuing when no tokio handle is available.
 fn spawn_delayed_task(key: usize, task: v8::Task, delay_in_seconds: f64) {
   let map = ISOLATE_ENTRIES.lock().unwrap();
-  if let Some(entry) = map.get(&key) {
-    let tasks = entry.tasks.clone();
-    let waker = entry.waker.clone();
-    entry.handle.spawn(async move {
-      tokio::time::sleep(Duration::from_secs_f64(delay_in_seconds)).await;
-      tasks.lock().unwrap().push(task);
-      waker.wake();
-    });
-  }
+  let Some(entry) = map.get(&key) else { return };
+  let Some(handle) = entry.handle.as_ref() else {
+    entry.tasks.lock().unwrap().push(task);
+    entry.waker.wake();
+    return;
+  };
+  let tasks = entry.tasks.clone();
+  let waker = entry.waker.clone();
+  handle.spawn(async move {
+    tokio::time::sleep(Duration::from_secs_f64(delay_in_seconds)).await;
+    tasks.lock().unwrap().push(task);
+    waker.wake();
+  });
 }
 
 /// Custom V8 platform implementation that queues immediate foreground

--- a/libs/core/runtime/tests/misc.rs
+++ b/libs/core/runtime/tests/misc.rs
@@ -1892,6 +1892,8 @@ fn foreground_tasks_delivered_without_tokio_handle() {
     .build()
     .unwrap();
 
+  // Created outside `block_on` so there is no tokio runtime context and
+  // the isolate is registered with `handle: None`.
   let mut runtime = JsRuntime::new(Default::default());
 
   tokio_runtime.block_on(async {

--- a/libs/core/runtime/tests/misc.rs
+++ b/libs/core/runtime/tests/misc.rs
@@ -1882,3 +1882,37 @@ async fn test_nexttick_before_queue_microtask() {
     .unwrap();
   runtime.run_event_loop(Default::default()).await.unwrap();
 }
+
+// Test that foreground tasks are delivered even when the isolate is
+// registered without a tokio handle.
+#[test]
+fn foreground_tasks_delivered_without_tokio_handle() {
+  let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .unwrap();
+
+  let mut runtime = JsRuntime::new(Default::default());
+
+  tokio_runtime.block_on(async {
+    let promise = runtime
+      .execute_script(
+        "foreground_task_test.js",
+        r#"
+      (async () => {
+        const wasmCode = new Uint8Array([
+          0,   97,  115, 109, 1,   0,   0,   0,   1,  4,   1,
+          96,  0,   0,   3,   2,   1,   0,   7,   17, 1,   13,
+          105, 110, 102, 105, 110, 105, 116, 101, 95, 108, 111,
+          111, 112, 0,   0,   10,  9,   1,   7,   0,  3,   64,
+          12,  0,   11,  11,
+        ]);
+        await WebAssembly.compile(wasmCode);
+      })()
+    "#,
+      )
+      .unwrap();
+    #[allow(deprecated, reason = "test code")]
+    runtime.resolve_value(promise).await.unwrap();
+  });
+}


### PR DESCRIPTION
Fixes #35345

Registration in `ISOLATE_ENTRIES` was conditional on `Handle::try_current()`, so it could be skipped. When skipped, `queue_task` and `spawn_delayed_task` silently dropped foreground tasks, causing the event loop to hang.

This change makes registration unconditional by making `Handle` optional. `queue_task` does not use the handle, so it works regardless. `spawn_delayed_task` falls back to immediate queuing when no handle is available, consistent with the `PlatformImpl` defaults.

A missing entry now unambiguously means the isolate was already unregistered during shutdown, so dropping is safe.

This PR was prepared with assistance from Claude Code. All changes were directed and reviewed by the author.