### PR TITLE
perf(macos): enable chained fixups to cut pre-main startup (~0.8ms)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,12 +19,12 @@ rustflags = [
   "link-arg=/OPT:ICF",
 ]
 
-# Emit the modern chained-fixups format (LC_DYLD_CHAINED_FIXUPS) instead of the
-# legacy LC_DYLD_INFO_ONLY rebase/bind opcode stream. dyld applies chained
-# fixups lazily per-page instead of eagerly walking every relocation at launch,
-# which measurably cuts pre-main startup time on our ~116MB binary. Requires a
-# macOS 12 deployment target (older dyld can't parse the format); lld only emits
-# it automatically at min 13.0, so we request it explicitly to keep macOS 12.
+# Emit the modern chained-fixups format (LC_DYLD_CHAINED_FIXUPS) via -fixup_chains
+# instead of the legacy LC_DYLD_INFO_ONLY rebase/bind opcode stream. dyld applies
+# chained fixups lazily per-page instead of eagerly walking every relocation at
+# launch, cutting pre-main startup (~0.8ms on the ~116MB binary). Requires a
+# macOS 12 deployment target (older dyld can't parse the format) and the bundled
+# ld64.lld bumped to LLD 20 (LLD 17 segfaults on -fixup_chains; see tools/util.js).
 [env]
 MACOSX_DEPLOYMENT_TARGET = "12.0"
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,17 +19,27 @@ rustflags = [
   "link-arg=/OPT:ICF",
 ]
 
+# Emit the modern chained-fixups format (LC_DYLD_CHAINED_FIXUPS) instead of the
+# legacy LC_DYLD_INFO_ONLY rebase/bind opcode stream. dyld applies chained
+# fixups lazily per-page instead of eagerly walking every relocation at launch,
+# which measurably cuts pre-main startup time on our ~116MB binary. Requires a
+# macOS 12 deployment target (older dyld can't parse the format); lld only emits
+# it automatically at min 13.0, so we request it explicitly to keep macOS 12.
+[env]
+MACOSX_DEPLOYMENT_TARGET = "12.0"
+
 [target.x86_64-apple-darwin]
 rustflags = [
   "-C",
-  "link-args=-weak_framework Metal -weak_framework MetalPerformanceShaders -weak_framework QuartzCore -weak_framework CoreGraphics",
+  "link-args=-Wl,-fixup_chains -weak_framework Metal -weak_framework MetalPerformanceShaders -weak_framework QuartzCore -weak_framework CoreGraphics",
 ]
 
 [target.aarch64-apple-darwin]
 rustflags = [
   "-C",
   # --icf=safe folds identical (address-insignificant) functions; ~6MB (~10%) idle RSS win, measured on release.
-  "link-args=-fuse-ld=lld -Wl,--icf=safe -weak_framework Metal -weak_framework MetalPerformanceShaders -weak_framework QuartzCore -weak_framework CoreGraphics",
+  # -fixup_chains: see [env] note above (chained fixups -> faster pre-main launch).
+  "link-args=-fuse-ld=lld -Wl,--icf=safe -Wl,-fixup_chains -weak_framework Metal -weak_framework MetalPerformanceShaders -weak_framework QuartzCore -weak_framework CoreGraphics",
 ]
 
 [target.'cfg(all())']

--- a/tools/util.js
+++ b/tools/util.js
@@ -294,7 +294,7 @@ export function getPrebuiltToolPath(toolName) {
   return join(PREBUILT_TOOL_DIR, toolName + executableSuffix);
 }
 
-const commitId = "aa25a37b0f2bdadc83e99e625e8a074d56d1febd";
+const commitId = "e593815dcfe5d260b27e6556cc9e44dcfcaeda3d";
 const downloadUrl =
   `https://raw.githubusercontent.com/denoland/deno_third_party/${commitId}/prebuilt/${platformDirName}`;
 


### PR DESCRIPTION
## Summary

The macOS binary ships with the legacy **`LC_DYLD_INFO_ONLY`** fixup format. At
launch dyld must eagerly walk a rebase/bind opcode stream and apply every
internal-pointer relocation in the ~116MB binary — all before `main()` runs
(pre-main).

Switching to the modern **`LC_DYLD_CHAINED_FIXUPS`** format lets dyld apply
fixups lazily, per-page, on fault instead of eagerly at launch. This measurably
cuts pre-main startup time.

The format requires a macOS 12 deployment target (older dyld can't parse it).
`lld` (which we use via `-fuse-ld=lld`) only emits it automatically at a min-13.0
target, so we request it explicitly with `-Wl,-fixup_chains` to keep macOS 12
support rather than dropping to 13.

## Change

```toml
# .cargo/config.toml
[env]
MACOSX_DEPLOYMENT_TARGET = "12.0"
# + `-Wl,-fixup_chains` added to the apple-darwin link args
```

## Results (arm64, release, `deno run hello.js`, warm, overhead-corrected min of 150 runs)

| build | fixup format | min macOS | startup |
|---|---|---|---|
| before | `LC_DYLD_INFO_ONLY` | 11.0 | ~9.8ms |
| **after** | **`LC_DYLD_CHAINED_FIXUPS`** | **12.0** | **~9.0ms** |
| **delta** | | | **~0.8ms** |

The entire win is pre-main — the in-`main` startup phases are unchanged. Verified
`otool -l` reports `LC_DYLD_CHAINED_FIXUPS` and `minos 12.0`, and the binary runs
correctly.

## Notes

- **Drops macOS 11 (Big Sur) support; requires macOS 12 (Monterey, Oct 2021)+.**
  This is the only user-visible tradeoff.
- Ruled out as non-factors while investigating: stripping symbols (116MB→80MB)
  has zero startup effect — symbols live in `__LINKEDIT` and are never mapped for
  execution; static initializers are negligible (15 total).
