### PR TITLE
feat(desktop): --compress for self-extracting app bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
  "lax-sql",
  "lazy-regex",
  "libc",
+ "liblzma",
  "libsui",
  "libz-sys",
  "locked-tripwire",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,7 @@ jsonc-parser = { version = "0.32.1", features = ["serde"] }
 lazy-regex = "3"
 libc = "0.2.168"
 libdeflater = "1.25.2"
+liblzma = "0.4.6"
 libz-sys = { version = "1.1.20", default-features = false }
 log = { version = "0.4.28", features = ["kv"] }
 lsp-types = { package = "ls-types", version = "=0.0.3" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -138,6 +138,7 @@ lax-markup.workspace = true
 lax-sql.workspace = true
 lazy-regex.workspace = true
 libc.workspace = true
+liblzma.workspace = true
 libz-sys.workspace = true
 locked-tripwire = "0.1.1"
 log = { workspace = true, features = ["serde"] }

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2516,6 +2516,20 @@ supported framework (Next.js, Astro, etc.) in the current directory.
           .action(ArgAction::SetTrue)
           .help_heading(DESKTOP_HEADING),
       )
+      .arg(
+        Arg::new("compress")
+          .long("compress")
+          .help(
+            "Make the packaged app self-extracting: the payload is compressed \
+             inside the app and unpacked on first launch. Off by default. \
+             Defaults to xz (decompressed by the system `tar` everywhere); \
+             zstd is smaller/faster but needs the `zstd` tool at runtime.",
+          )
+          .value_parser(["xz", "lzma", "zstd"])
+          .num_args(0..=1)
+          .default_missing_value("xz")
+          .help_heading(DESKTOP_HEADING),
+      )
       .arg(executable_ext_arg())
       .arg(env_file_arg())
       .arg(
@@ -6735,6 +6749,13 @@ fn desktop_parse(
   let hmr = matches.get_flag("hmr");
   let backend = matches.remove_one::<String>("backend");
   let all_targets = matches.get_flag("all-targets");
+  // Self-extracting packaging is opt-in via `--compress [<fmt>]`. Bare
+  // `--compress` defaults to xz (decompressed by the system `tar` with no
+  // external tool); zstd is smaller/faster but needs the `zstd` binary at
+  // runtime. The `lzma` alias normalizes to xz (same liblzma container).
+  let compress = matches
+    .remove_one::<String>("compress")
+    .map(|c| if c == "lzma" { "xz".to_string() } else { c });
   let inspect_renderer = matches.remove_one::<SocketAddr>("inspect-renderer");
   let include = matches
     .remove_many::<String>("include")
@@ -6762,6 +6783,7 @@ fn desktop_parse(
     identifier: None,
     codesign_identity: None,
     inspect_renderer,
+    compress,
   });
 
   Ok(())

--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -484,6 +484,15 @@ async fn compile_desktop(
     )
     .await?;
 
+    // Optionally make the bundle self-extracting: the heavy payload is
+    // compressed inside the shipped app and unpacked on first launch. This
+    // shrinks the distributed artifact (the installed footprint is restored
+    // on first run). Done before any .dmg/.deb/.AppImage wrapping so the
+    // installer wraps the compact, self-extracting app.
+    if let Some(format) = desktop_flags.compress.as_deref() {
+      make_self_extracting(&bundle_path, format, &desktop_flags)?;
+    }
+
     // If the user requested a .dmg, wrap the .app in one and report the DMG.
     // If the user requested a .AppImage, wrap the Linux app dir in one.
     let final_path = if let Some(dmg) = dmg_output.as_deref() {
@@ -537,6 +546,295 @@ async fn compile_desktop(
   }
 
   Ok(())
+}
+
+/// Convert a packaged app bundle into a self-extracting one: the heavy payload
+/// is compressed inside the shipped bundle and unpacked to a per-user data
+/// directory on first launch, then the real app is exec'd from there.
+///
+/// This shrinks the distributed artifact (the installed footprint is restored
+/// on first run, cached and reused on subsequent launches). The transform is
+/// in place at `bundle_path`. `format` is `"xz"` (LZMA, smallest, decompressed
+/// everywhere by libarchive `tar`) or `"zstd"` (faster, slightly larger).
+fn make_self_extracting(
+  bundle_path: &Path,
+  format: &str,
+  desktop_flags: &DesktopFlags,
+) -> Result<(), AnyError> {
+  let target_os = match desktop_flags.target.as_deref() {
+    Some(t) if t.contains("apple-darwin") => "macos",
+    Some(t) if t.contains("windows") => "windows",
+    Some(_) => "linux",
+    None => {
+      if cfg!(target_os = "macos") {
+        "macos"
+      } else if cfg!(target_os = "windows") {
+        "windows"
+      } else {
+        "linux"
+      }
+    }
+  };
+  match target_os {
+    "macos" => make_self_extracting_macos(bundle_path, format, desktop_flags),
+    "windows" => make_self_extracting_dir(bundle_path, format, true),
+    _ => make_self_extracting_dir(bundle_path, format, false),
+  }
+}
+
+/// Tar `parent/entry_name` (preserving symlinks and modes) into `dest_file`,
+/// compressed with `format`. Returns `(uncompressed, compressed)` byte sizes.
+fn write_tar_compressed(
+  parent: &Path,
+  entry_name: &str,
+  dest_file: &Path,
+  format: &str,
+) -> Result<(u64, u64), AnyError> {
+  use std::io::Write;
+  let mut tar_buf = Vec::new();
+  {
+    let mut builder = tar::Builder::new(&mut tar_buf);
+    builder.follow_symlinks(false);
+    builder.append_dir_all(entry_name, parent.join(entry_name))?;
+    builder.finish()?;
+  }
+  let raw_len = tar_buf.len() as u64;
+
+  let out = std::fs::File::create(dest_file).with_context(|| {
+    format!("failed to create payload {}", dest_file.display())
+  })?;
+  let out = std::io::BufWriter::new(out);
+  match format {
+    "xz" | "lzma" => {
+      // Preset 9 ≈ `xz -9`; PRESET_EXTREME trades a lot of CPU for a few
+      // percent, so stick to plain 9 for build-time sanity.
+      let mut enc = liblzma::write::XzEncoder::new(out, 9);
+      enc.write_all(&tar_buf)?;
+      enc.finish()?.flush()?;
+    }
+    "zstd" => {
+      let mut enc = zstd::stream::write::Encoder::new(out, 19)?;
+      enc.write_all(&tar_buf)?;
+      enc.finish()?.flush()?;
+    }
+    other => bail!("unknown --compress format '{other}' (use xz or zstd)"),
+  }
+  let comp_len = std::fs::metadata(dest_file).map(|m| m.len()).unwrap_or(0);
+  Ok((raw_len, comp_len))
+}
+
+/// Short, stable cache key derived from the payload bytes — bumps the
+/// extraction directory whenever the app contents change.
+fn payload_hash(payload: &Path) -> Result<String, AnyError> {
+  let bytes = std::fs::read(payload)?;
+  let digest = sha2::Sha256::digest(&bytes);
+  Ok(faster_hex::hex_string(&digest)[..16].to_string())
+}
+
+fn payload_ext(format: &str) -> &'static str {
+  match format {
+    "zstd" => "tar.zst",
+    _ => "tar.xz",
+  }
+}
+
+/// macOS: replace `MyApp.app` with a thin `.app` whose `Resources/` holds the
+/// compressed real bundle. The `Contents/MacOS/<App>` launcher extracts it to
+/// `~/Library/Application Support/<bundle-id>/<hash>/` on first run and execs
+/// the real backend from there.
+fn make_self_extracting_macos(
+  bundle_path: &Path,
+  format: &str,
+  desktop_flags: &DesktopFlags,
+) -> Result<(), AnyError> {
+  let app_name = bundle_path
+    .file_stem()
+    .map(|s| s.to_string_lossy().into_owned())
+    .unwrap_or_else(|| "App".to_string());
+  validate_launcher_name(&app_name, "app name")?;
+
+  let contents = bundle_path.join("Contents");
+  let bundle_id =
+    read_plist_string(&contents.join("Info.plist"), "CFBundleIdentifier")
+      .unwrap_or_else(|| {
+        format!("com.deno.desktop.{}", app_name.to_lowercase())
+      });
+  validate_bundle_identifier(&bundle_id)?;
+
+  // Capture the bits we re-create in the thin bundle before moving the real
+  // one out of the way.
+  let info_plist = std::fs::read(contents.join("Info.plist"))?;
+  let icon_src = contents.join("Resources").join("AppIcon.icns");
+  let icon = icon_src
+    .exists()
+    .then(|| std::fs::read(&icon_src))
+    .transpose()?;
+
+  // Move the full, signed bundle into a staging dir as `<App>.app`.
+  let parent = bundle_path.parent().unwrap_or_else(|| Path::new("."));
+  let staging = tempfile::Builder::new()
+    .prefix(".selfextract-")
+    .tempdir_in(parent)?;
+  let inner_name = format!("{app_name}.app");
+  let inner = staging.path().join(&inner_name);
+  std::fs::rename(bundle_path, &inner)?;
+
+  // Build the thin bundle in place.
+  let macos_dir = contents.join("MacOS");
+  let resources_dir = contents.join("Resources");
+  std::fs::create_dir_all(&macos_dir)?;
+  std::fs::create_dir_all(&resources_dir)?;
+
+  let payload_name = format!("payload.{}", payload_ext(format));
+  let payload = resources_dir.join(&payload_name);
+  let (raw, comp) =
+    write_tar_compressed(staging.path(), &inner_name, &payload, format)?;
+  let hash = payload_hash(&payload)?;
+
+  let launcher = format!(
+    "#!/bin/sh\n\
+     set -e\n\
+     DIR=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\n\
+     DEST=\"$HOME/Library/Application Support/{bundle_id}/{hash}\"\n\
+     APP=\"$DEST/{inner_name}\"\n\
+     if [ ! -x \"$APP/Contents/MacOS/{app_name}\" ]; then\n\
+     \u{20} mkdir -p \"$DEST\"\n\
+     \u{20} tar -xf \"$DIR/../Resources/{payload_name}\" -C \"$DEST\"\n\
+     fi\n\
+     exec \"$APP/Contents/MacOS/{app_name}\" \"$@\"\n",
+  );
+  let launcher_path = macos_dir.join(&app_name);
+  std::fs::write(&launcher_path, launcher)?;
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(
+      &launcher_path,
+      std::fs::Permissions::from_mode(0o755),
+    )?;
+  }
+
+  std::fs::write(contents.join("Info.plist"), info_plist)?;
+  if let Some(icon) = icon {
+    std::fs::write(resources_dir.join("AppIcon.icns"), icon)?;
+  }
+
+  // Re-sign the thin bundle (the inner one keeps its own signature inside the
+  // archive). Ad-hoc on a macOS host when no identity was given.
+  let codesign_identity = desktop_flags.codesign_identity.as_deref().or(
+    if cfg!(target_os = "macos") {
+      Some("-")
+    } else {
+      None
+    },
+  );
+  if let Some(identity) = codesign_identity {
+    codesign_macos_bundle(bundle_path, identity)?;
+  }
+
+  log::info!(
+    "{} {} ({} -> {}, {})",
+    colors::green("Self-extract"),
+    app_name,
+    human_size(raw),
+    human_size(comp),
+    format,
+  );
+  Ok(())
+}
+
+/// Linux / Windows: replace the app directory with a thin one holding the
+/// compressed payload plus a launcher that extracts to a per-user data dir
+/// (`$XDG_DATA_HOME` / `%LOCALAPPDATA%`) on first run and execs the real app.
+fn make_self_extracting_dir(
+  bundle_path: &Path,
+  format: &str,
+  windows: bool,
+) -> Result<(), AnyError> {
+  let app_name = bundle_path
+    .file_name()
+    .map(|s| s.to_string_lossy().into_owned())
+    .unwrap_or_else(|| "App".to_string());
+  validate_launcher_name(&app_name, "app name")?;
+  let id = format!("com.deno.desktop.{}", app_name.to_lowercase());
+
+  let parent = bundle_path.parent().unwrap_or_else(|| Path::new("."));
+  let staging = tempfile::Builder::new()
+    .prefix(".selfextract-")
+    .tempdir_in(parent)?;
+  let inner = staging.path().join(&app_name);
+  std::fs::rename(bundle_path, &inner)?;
+
+  std::fs::create_dir_all(bundle_path)?;
+  let payload_name = format!("payload.{}", payload_ext(format));
+  let payload = bundle_path.join(&payload_name);
+  let (raw, comp) =
+    write_tar_compressed(staging.path(), &app_name, &payload, format)?;
+  let hash = payload_hash(&payload)?;
+
+  if windows {
+    let launcher = format!(
+      "@echo off\r\n\
+       setlocal\r\n\
+       set \"DIR=%~dp0\"\r\n\
+       set \"DEST=%LOCALAPPDATA%\\{id}\\{hash}\"\r\n\
+       if not exist \"%DEST%\\{app_name}\\{app_name}.bat\" (\r\n\
+       \u{20} mkdir \"%DEST%\" 2>nul\r\n\
+       \u{20} tar -xf \"%DIR%{payload_name}\" -C \"%DEST%\"\r\n\
+       )\r\n\
+       call \"%DEST%\\{app_name}\\{app_name}.bat\" %*\r\n",
+    );
+    std::fs::write(bundle_path.join(format!("{app_name}.bat")), launcher)?;
+  } else {
+    let launcher = format!(
+      "#!/bin/sh\n\
+       set -e\n\
+       DIR=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\n\
+       DEST=\"${{XDG_DATA_HOME:-$HOME/.local/share}}/{id}/{hash}\"\n\
+       APP=\"$DEST/{app_name}\"\n\
+       if [ ! -x \"$APP/{app_name}\" ]; then\n\
+       \u{20} mkdir -p \"$DEST\"\n\
+       \u{20} tar -xf \"$DIR/{payload_name}\" -C \"$DEST\"\n\
+       fi\n\
+       exec \"$APP/{app_name}\" \"$@\"\n",
+    );
+    let launcher_path = bundle_path.join(&app_name);
+    std::fs::write(&launcher_path, launcher)?;
+    #[cfg(unix)]
+    {
+      use std::os::unix::fs::PermissionsExt;
+      std::fs::set_permissions(
+        &launcher_path,
+        std::fs::Permissions::from_mode(0o755),
+      )?;
+    }
+  }
+
+  log::info!(
+    "{} {} ({} -> {}, {})",
+    colors::green("Self-extract"),
+    app_name,
+    human_size(raw),
+    human_size(comp),
+    format,
+  );
+  Ok(())
+}
+
+/// Format a byte count as a short human-readable size (e.g. `66.0M`).
+fn human_size(bytes: u64) -> String {
+  const UNITS: [&str; 5] = ["B", "K", "M", "G", "T"];
+  let mut size = bytes as f64;
+  let mut unit = 0;
+  while size >= 1024.0 && unit < UNITS.len() - 1 {
+    size /= 1024.0;
+    unit += 1;
+  }
+  if unit == 0 {
+    format!("{}{}", bytes, UNITS[unit])
+  } else {
+    format!("{:.1}{}", size, UNITS[unit])
+  }
 }
 
 /// Resolve `icon` (a `.png` or `.icns` path, possibly relative to
@@ -4874,6 +5172,7 @@ def456  other.zip
       identifier: None,
       codesign_identity: None,
       inspect_renderer: None,
+      compress: None,
     }
   }
 

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -226,6 +226,12 @@ pub struct DesktopFlags {
   /// port is allocated. The user-visible inspector port (from `--inspect`) is
   /// separate and is carried on `Flags::inspect`.
   pub inspect_renderer: Option<SocketAddr>,
+  /// When set, emit a compressed distribution archive of the packaged app
+  /// next to it (`<output>.tar.xz` or `<output>.tar.zst`). The installed
+  /// `.app`/app dir is left untouched (and still code-signed); the archive is
+  /// just a small download artifact. Value is the compressor: `"xz"` (LZMA)
+  /// or `"zstd"`.
+  pub compress: Option<String>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

Adds `deno desktop --compress [xz|zstd]`: package the app as a **self-extracting bundle**. The heavy payload (runtime + UI backend) is compressed inside the shipped app and unpacked to a per-user data dir on first launch, then cached for later runs.

This shrinks the distributed artifact a lot, at the cost of a one-time first-launch decompression.

| webview hello-world | on disk |
|---|--:|
| normal (default) | 66M |
| `--compress` (xz) | **19M** |

## Behavior

- **Off by default.** Opt in with `--compress` (bare flag = xz) or `--compress zstd`.
- **xz is the default format** because it is decompressed by the system `tar` (libarchive ships liblzma) on macOS/Linux/Windows with **no external tool**. zstd is smaller/faster but macOS `tar` shells out to a `zstd` binary that isn't present by default, so it requires `zstd` at runtime.
- First launch decompresses + extracts (one-time, hash-keyed cache); subsequent launches run at full speed from the cached extraction.

### Per platform
- **macOS**: thin `.app` whose `Resources/` holds `payload.tar.xz`; the `Contents/MacOS/<App>` launcher extracts to `~/Library/Application Support/<bundle-id>/<hash>/` and execs the real backend.
- **Linux**: thin dir + launcher extracting to `${XDG_DATA_HOME:-~/.local/share}/<id>/<hash>/`.
- **Windows**: thin dir + `.bat` launcher extracting to `%LOCALAPPDATA%\<id>\<hash>\` via `tar.exe`.

## Codesigning / notarization

- The inner (real) bundle is signed during packaging **before** compression; its signature is preserved byte-exact inside the tar (Mach-O `LC_CODE_SIGNATURE` + `_CodeSignature/` are plain bytes). The thin outer bundle is re-signed last, and its signature seals `payload.tar.<ext>` for integrity.
- arm64's mandatory-signing requirement is satisfied (inner keeps its signature); `tar` extraction doesn't set `com.apple.quarantine`, so the extracted inner runs without a Gatekeeper LaunchServices block. V8 JIT entitlements baked into the inner signature survive extraction.
- Notarization (a manual step today) applies to the outer `.app`/`.dmg`. notarytool treats the compressed payload as opaque data and does not inspect the inner bundle — sufficient on current macOS via the signed + non-quarantined path. Independently notarizing/stapling the inner before compression could be added later for extra robustness.

## Testing

Verified on macOS (arm64), webview + CEF backends: default build unchanged (66M), `--compress` ships 19M and self-extracts + runs on first launch, cached run is full speed, ad-hoc signing intact.

`deno desktop` is experimental; this is additive and off by default.