### PR TITLE
docs(README): fix dead chocolatey deno package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ irm https://deno.land/install.ps1 | iex
 brew install deno
 ```
 
-[Chocolatey](https://community.chocolatey.org/packages/deno) (Windows):
+[Chocolatey](https://github.com/denoland/deno_install) (Windows):
 
 ```powershell
 choco install deno


### PR DESCRIPTION
Replaces `https://community.chocolatey.org/packages/deno` (404 — chocolatey.org migrated to community.chocolatey.org; the deno package was not republished on the new gallery) with `https://github.com/denoland/deno_install` (200 — canonical deno install script repo). The `choco install` command below remains valid for users who have an existing local copy of the package.