### PR TITLE
fix(ext/fs): no-follow metadata ops should not follow a terminal symlink

### DIFF
--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -511,31 +511,71 @@ fn mkdir(path: &Path, recursive: bool, mode: Option<u32>) -> FsResult<()> {
   builder.create(path).map_err(Into::into)
 }
 
-// Open the terminal path no-follow so a metadata operation cannot reach the
-// target of a terminal symlink. The permission check for these ops is performed
-// no-follow (against the named path, without canonicalization), so following a
-// terminal symlink here would let a writable symlink inside an allowed scope be
-// used to modify a file it points to outside that scope. O_NOFOLLOW makes the
-// open fail with ELOOP when the final component is a symlink; intermediate
-// symlinks are still resolved, matching the existing path model and the
-// truncate fix in #35239. O_NONBLOCK avoids blocking when the path is a FIFO or
-// other special file.
+// The permission check for the no-follow metadata ops (chmod, chown, utime) is
+// performed against the named path without canonicalization, so they must not
+// reach the target of a *terminal* symlink: a writable symlink inside an allowed
+// scope could otherwise be used to modify a file it points to outside that
+// scope. Intermediate symlinks are still resolved, matching the existing path
+// model and the truncate fix in #35239.
+//
+// A terminal symlink is rejected up-front with ELOOP (FilesystemLoop). The
+// mutation that follows is still performed no-follow (lchmod/lchown/lutimes, or
+// on Linux via a /proc/self/fd path pinned to a non-symlink inode), so that even
+// if the path is swapped for a symlink after the check, the symlink's own
+// metadata is changed rather than its target's. Unlike opening the path
+// O_NOFOLLOW, this only requires ownership of the file (as chmod(2)/chown(2)/
+// utimes do), not read access.
 #[cfg(unix)]
-fn open_no_follow_for_metadata(path: &Path) -> FsResult<fs::File> {
-  use std::os::unix::fs::OpenOptionsExt;
-  let mut open_options = fs::OpenOptions::new();
-  open_options.read(true);
-  open_options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
-  Ok(open_options.open(path)?)
+fn reject_terminal_symlink(path: &Path) -> FsResult<()> {
+  if fs::symlink_metadata(path)?.file_type().is_symlink() {
+    return Err(io::Error::from_raw_os_error(libc::ELOOP).into());
+  }
+  Ok(())
 }
 
-#[cfg(unix)]
+// On Linux, fchmodat(2) does not support AT_SYMLINK_NOFOLLOW, so open the file
+// with O_PATH|O_NOFOLLOW (no read access required, a terminal symlink is not
+// followed) and chmod it through /proc/self/fd/<n>, which resolves to the exact
+// inode the fd pins. This is the technique glibc uses to emulate a no-follow
+// chmod.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn chmod(path: &Path, mode: u32) -> FsResult<()> {
+  use std::os::unix::fs::OpenOptionsExt;
   use std::os::unix::fs::PermissionsExt;
-  let file = open_no_follow_for_metadata(path)?;
-  // Uses fchmod(2) on the opened fd rather than a path-based chmod(2), so a
-  // terminal symlink is refused (ELOOP) instead of having its target modified.
-  file.set_permissions(fs::Permissions::from_mode(mode))?;
+  use std::os::unix::io::AsRawFd;
+  let file = fs::OpenOptions::new()
+    .read(true) // access mode is ignored under O_PATH
+    .custom_flags(libc::O_PATH | libc::O_NOFOLLOW)
+    .open(path)?;
+  if file.metadata()?.file_type().is_symlink() {
+    return Err(io::Error::from_raw_os_error(libc::ELOOP).into());
+  }
+  let proc_path = format!("/proc/self/fd/{}", file.as_raw_fd());
+  fs::set_permissions(proc_path, fs::Permissions::from_mode(mode))?;
+  Ok(())
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+fn chmod(path: &Path, mode: u32) -> FsResult<()> {
+  use std::os::unix::ffi::OsStrExt;
+  reject_terminal_symlink(path)?;
+  let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())
+    .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+  // fchmodat with AT_SYMLINK_NOFOLLOW does not follow a terminal symlink, so a
+  // symlink swapped in after the check above has its own mode changed rather
+  // than its target's.
+  // SAFETY: `c_path` is a valid NUL-terminated C string that outlives the call.
+  let result = unsafe {
+    libc::fchmodat(
+      libc::AT_FDCWD,
+      c_path.as_ptr(),
+      mode as libc::mode_t,
+      libc::AT_SYMLINK_NOFOLLOW,
+    )
+  };
+  if result != 0 {
+    return Err(io::Error::last_os_error().into());
+  }
   Ok(())
 }
 
@@ -563,8 +603,10 @@ fn chmod(path: &Path, mode: i32) -> FsResult<()> {
 
 #[cfg(unix)]
 fn chown(path: &Path, uid: Option<u32>, gid: Option<u32>) -> FsResult<()> {
-  use std::os::unix::io::AsRawFd;
-  let file = open_no_follow_for_metadata(path)?;
+  use std::os::unix::ffi::OsStrExt;
+  reject_terminal_symlink(path)?;
+  let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())
+    .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
   // -1 = leave unchanged
   let uid = uid
     .map(|uid| uid as libc::uid_t)
@@ -572,10 +614,10 @@ fn chown(path: &Path, uid: Option<u32>, gid: Option<u32>) -> FsResult<()> {
   let gid = gid
     .map(|gid| gid as libc::gid_t)
     .unwrap_or(-1i32 as libc::gid_t);
-  // Uses fchown(2) on the opened fd rather than a path-based chown(2), so a
-  // terminal symlink is refused (ELOOP) instead of having its target modified.
-  // SAFETY: `file` owns a valid fd that lives throughout this call.
-  let result = unsafe { libc::fchown(file.as_raw_fd(), uid, gid) };
+  // lchown(2) does not follow a terminal symlink, so a symlink swapped in after
+  // the check above has its own ownership changed rather than its target's.
+  // SAFETY: `c_path` is a valid NUL-terminated C string that outlives the call.
+  let result = unsafe { libc::lchown(c_path.as_ptr(), uid, gid) };
   if result != 0 {
     return Err(io::Error::last_os_error().into());
   }
@@ -1298,11 +1340,12 @@ fn utime(
   atime: filetime::FileTime,
   mtime: filetime::FileTime,
 ) -> FsResult<()> {
-  // Open no-follow and update times on the fd so a terminal symlink is refused
-  // (ELOOP) rather than having its target's timestamps changed. The permission
-  // check is performed no-follow, mirroring the truncate fix in #35239.
-  let file = open_no_follow_for_metadata(path)?;
-  filetime::set_file_handle_times(&file, Some(atime), Some(mtime))?;
+  reject_terminal_symlink(path)?;
+  // set_symlink_file_times updates the times no-follow (lutimes / utimensat with
+  // AT_SYMLINK_NOFOLLOW), so a symlink swapped in after the check above has its
+  // own timestamps changed rather than its target's. On a regular file this is
+  // equivalent to a plain utimes.
+  filetime::set_symlink_file_times(path, atime, mtime)?;
   Ok(())
 }
 

--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -374,7 +374,7 @@ impl FileSystem for RealFs {
   ) -> FsResult<()> {
     let atime = filetime::FileTime::from_unix_time(atime_secs, atime_nanos);
     let mtime = filetime::FileTime::from_unix_time(mtime_secs, mtime_nanos);
-    filetime::set_file_times(path, atime, mtime).map_err(Into::into)
+    utime(path, atime, mtime)
   }
   async fn utime_async(
     &self,
@@ -386,10 +386,7 @@ impl FileSystem for RealFs {
   ) -> FsResult<()> {
     let atime = filetime::FileTime::from_unix_time(atime_secs, atime_nanos);
     let mtime = filetime::FileTime::from_unix_time(mtime_secs, mtime_nanos);
-    spawn_blocking(move || {
-      filetime::set_file_times(path, atime, mtime).map_err(Into::into)
-    })
-    .await?
+    spawn_blocking(move || utime(&path, atime, mtime)).await?
   }
 
   fn lutime_sync(
@@ -514,11 +511,31 @@ fn mkdir(path: &Path, recursive: bool, mode: Option<u32>) -> FsResult<()> {
   builder.create(path).map_err(Into::into)
 }
 
+// Open the terminal path no-follow so a metadata operation cannot reach the
+// target of a terminal symlink. The permission check for these ops is performed
+// no-follow (against the named path, without canonicalization), so following a
+// terminal symlink here would let a writable symlink inside an allowed scope be
+// used to modify a file it points to outside that scope. O_NOFOLLOW makes the
+// open fail with ELOOP when the final component is a symlink; intermediate
+// symlinks are still resolved, matching the existing path model and the
+// truncate fix in #35239. O_NONBLOCK avoids blocking when the path is a FIFO or
+// other special file.
+#[cfg(unix)]
+fn open_no_follow_for_metadata(path: &Path) -> FsResult<fs::File> {
+  use std::os::unix::fs::OpenOptionsExt;
+  let mut open_options = fs::OpenOptions::new();
+  open_options.read(true);
+  open_options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+  Ok(open_options.open(path)?)
+}
+
 #[cfg(unix)]
 fn chmod(path: &Path, mode: u32) -> FsResult<()> {
   use std::os::unix::fs::PermissionsExt;
-  let permissions = fs::Permissions::from_mode(mode);
-  fs::set_permissions(path, permissions)?;
+  let file = open_no_follow_for_metadata(path)?;
+  // Uses fchmod(2) on the opened fd rather than a path-based chmod(2), so a
+  // terminal symlink is refused (ELOOP) instead of having its target modified.
+  file.set_permissions(fs::Permissions::from_mode(mode))?;
   Ok(())
 }
 
@@ -546,14 +563,21 @@ fn chmod(path: &Path, mode: i32) -> FsResult<()> {
 
 #[cfg(unix)]
 fn chown(path: &Path, uid: Option<u32>, gid: Option<u32>) -> FsResult<()> {
-  use nix::unistd::Gid;
-  use nix::unistd::Uid;
-  use nix::unistd::chown;
-  let owner = uid.map(Uid::from_raw);
-  let group = gid.map(Gid::from_raw);
-  let res = chown(path, owner, group);
-  if let Err(err) = res {
-    return Err(io::Error::from_raw_os_error(err as i32).into());
+  use std::os::unix::io::AsRawFd;
+  let file = open_no_follow_for_metadata(path)?;
+  // -1 = leave unchanged
+  let uid = uid
+    .map(|uid| uid as libc::uid_t)
+    .unwrap_or(-1i32 as libc::uid_t);
+  let gid = gid
+    .map(|gid| gid as libc::gid_t)
+    .unwrap_or(-1i32 as libc::gid_t);
+  // Uses fchown(2) on the opened fd rather than a path-based chown(2), so a
+  // terminal symlink is refused (ELOOP) instead of having its target modified.
+  // SAFETY: `file` owns a valid fd that lives throughout this call.
+  let result = unsafe { libc::fchown(file.as_raw_fd(), uid, gid) };
+  if result != 0 {
+    return Err(io::Error::last_os_error().into());
   }
   Ok(())
 }
@@ -668,74 +692,84 @@ fn copy_file(from: &Path, to: &Path) -> FsResult<()> {
   #[cfg(target_os = "macos")]
   {
     use std::ffi::CString;
-    use std::os::unix::fs::OpenOptionsExt;
-    use std::os::unix::fs::PermissionsExt;
 
     use libc::clonefile;
     use libc::stat;
     use libc::unlink;
 
-    let from_str = CString::new(from.as_os_str().as_encoded_bytes())
-      .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
-    let to_str = CString::new(to.as_os_str().as_encoded_bytes())
-      .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    // Fast path: clonefile() large files. Skip it when the destination is a
+    // terminal symlink so we fall through to the no-follow copy below and
+    // refuse it (ELOOP) rather than unlinking the link and replacing it.
+    let dest_is_symlink = fs::symlink_metadata(to)
+      .map(|m| m.file_type().is_symlink())
+      .unwrap_or(false);
+    if !dest_is_symlink {
+      let from_str = CString::new(from.as_os_str().as_encoded_bytes())
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+      let to_str = CString::new(to.as_os_str().as_encoded_bytes())
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
 
-    // SAFETY: `from` and `to` are valid C strings.
-    // std::fs::copy does open() + fcopyfile() on macOS. We try to use
-    // clonefile() instead, which is more efficient.
-    unsafe {
-      let mut st = std::mem::zeroed();
-      let ret = stat(from_str.as_ptr(), &mut st);
-      if ret != 0 {
-        return Err(io::Error::last_os_error().into());
-      }
-
-      if st.st_size > 128 * 1024 {
-        // Try unlink. If it fails, we are going to try clonefile() anyway.
-        let _ = unlink(to_str.as_ptr());
-        // Matches rust stdlib behavior for io::copy.
-        // https://github.com/rust-lang/rust/blob/3fdd578d72a24d4efc2fe2ad18eec3b6ba72271e/library/std/src/sys/unix/fs.rs#L1613-L1616
-        if clonefile(from_str.as_ptr(), to_str.as_ptr(), 0) == 0 {
-          return Ok(());
+      // SAFETY: `from` and `to` are valid C strings.
+      // std::fs::copy does open() + fcopyfile() on macOS. We try to use
+      // clonefile() instead, which is more efficient.
+      unsafe {
+        let mut st = std::mem::zeroed();
+        let ret = stat(from_str.as_ptr(), &mut st);
+        if ret != 0 {
+          return Err(io::Error::last_os_error().into());
         }
-      } else {
-        // Do a regular copy. fcopyfile() is an overkill for < 128KB
-        // files.
-        let mut buf = [0u8; 128 * 1024];
-        let mut from_file = fs::File::open(from)?;
-        let perm = from_file.metadata()?.permissions();
 
-        let mut to_file = fs::OpenOptions::new()
-          // create the file with the correct mode right away
-          .mode(perm.mode())
-          .write(true)
-          .create(true)
-          .truncate(true)
-          .open(to)?;
-        let writer_metadata = to_file.metadata()?;
-        if writer_metadata.is_file() {
-          // Set the correct file permissions, in case the file already existed.
-          // Don't set the permissions on already existing non-files like
-          // pipes/FIFOs or device nodes.
-          to_file.set_permissions(perm)?;
-        }
-        loop {
-          let nread = from_file.read(&mut buf)?;
-          if nread == 0 {
-            break;
+        if st.st_size > 128 * 1024 {
+          // Try unlink. If it fails, we are going to try clonefile() anyway.
+          let _ = unlink(to_str.as_ptr());
+          // Matches rust stdlib behavior for io::copy.
+          // https://github.com/rust-lang/rust/blob/3fdd578d72a24d4efc2fe2ad18eec3b6ba72271e/library/std/src/sys/unix/fs.rs#L1613-L1616
+          if clonefile(from_str.as_ptr(), to_str.as_ptr(), 0) == 0 {
+            return Ok(());
           }
-          to_file.write_all(&buf[..nread])?;
         }
-        return Ok(());
       }
     }
 
-    // clonefile() failed, fall back to std::fs::copy().
+    // Small files, symlink destinations, and clonefile() failures fall through
+    // to the no-follow copy below.
   }
 
-  fs::copy(from, to)?;
+  // The permission check for the destination is performed no-follow, so on unix
+  // the destination is opened with O_NOFOLLOW: a terminal symlink is refused
+  // (ELOOP) instead of having its target overwritten, mirroring the truncate
+  // fix in #35239. Windows behavior is unchanged.
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::PermissionsExt;
 
-  Ok(())
+    let mut from_file = fs::File::open(from)?;
+    let perm = from_file.metadata()?.permissions();
+
+    let mut to_file = fs::OpenOptions::new()
+      // create the file with the correct mode right away
+      .mode(perm.mode())
+      .write(true)
+      .create(true)
+      .truncate(true)
+      .custom_flags(libc::O_NOFOLLOW)
+      .open(to)?;
+    let writer_metadata = to_file.metadata()?;
+    if writer_metadata.is_file() {
+      // Set the correct file permissions, in case the file already existed.
+      // Don't set the permissions on already existing non-files like
+      // pipes/FIFOs or device nodes.
+      to_file.set_permissions(perm)?;
+    }
+    io::copy(&mut from_file, &mut to_file)?;
+    Ok(())
+  }
+  #[cfg(not(unix))]
+  {
+    fs::copy(from, to)?;
+    Ok(())
+  }
 }
 
 fn cp(from: &Path, to: &Path) -> FsResult<()> {
@@ -1256,6 +1290,29 @@ fn symlink(
   };
 
   Ok(())
+}
+
+#[cfg(unix)]
+fn utime(
+  path: &Path,
+  atime: filetime::FileTime,
+  mtime: filetime::FileTime,
+) -> FsResult<()> {
+  // Open no-follow and update times on the fd so a terminal symlink is refused
+  // (ELOOP) rather than having its target's timestamps changed. The permission
+  // check is performed no-follow, mirroring the truncate fix in #35239.
+  let file = open_no_follow_for_metadata(path)?;
+  filetime::set_file_handle_times(&file, Some(atime), Some(mtime))?;
+  Ok(())
+}
+
+#[cfg(not(unix))]
+fn utime(
+  path: &Path,
+  atime: filetime::FileTime,
+  mtime: filetime::FileTime,
+) -> FsResult<()> {
+  filetime::set_file_times(path, atime, mtime).map_err(Into::into)
 }
 
 fn truncate(path: &Path, len: u64) -> FsResult<()> {

--- a/tests/unit/chmod_test.ts
+++ b/tests/unit/chmod_test.ts
@@ -57,38 +57,6 @@ Deno.test(
   },
 );
 
-// Check symlink when not on windows
-Deno.test(
-  {
-    permissions: { read: true, write: true },
-  },
-  function chmodSyncSymlinkSuccess() {
-    const enc = new TextEncoder();
-    const data = enc.encode("Hello");
-    const tempDir = Deno.makeTempDirSync();
-
-    const filename = tempDir + "/test.txt";
-    Deno.writeFileSync(filename, data, { mode: 0o666 });
-    const symlinkName = tempDir + "/test_symlink.txt";
-    Deno.symlinkSync(filename, symlinkName);
-
-    let symlinkInfo = Deno.lstatSync(symlinkName);
-    assert(symlinkInfo.mode);
-    const symlinkMode = symlinkInfo.mode & 0o777; // platform dependent
-
-    Deno.chmodSync(symlinkName, modeSync);
-
-    // Change actual file mode, not symlink
-    const fileInfo = Deno.statSync(filename);
-    assert(fileInfo.mode);
-    assertEquals(fileInfo.mode & 0o777, modeSync);
-
-    symlinkInfo = Deno.lstatSync(symlinkName);
-    assert(symlinkInfo.mode);
-    assertEquals(symlinkInfo.mode & 0o777, symlinkMode);
-  },
-);
-
 Deno.test({ permissions: { write: true } }, function chmodSyncFailure() {
   const filename = "/badfile.txt";
   assertThrows(
@@ -146,37 +114,6 @@ Deno.test(
   },
 );
 
-Deno.test(
-  {
-    permissions: { read: true, write: true },
-  },
-  async function chmodSymlinkSuccess() {
-    const enc = new TextEncoder();
-    const data = enc.encode("Hello");
-    const tempDir = Deno.makeTempDirSync();
-
-    const filename = tempDir + "/test.txt";
-    Deno.writeFileSync(filename, data, { mode: 0o666 });
-    const symlinkName = tempDir + "/test_symlink.txt";
-    Deno.symlinkSync(filename, symlinkName);
-
-    let symlinkInfo = Deno.lstatSync(symlinkName);
-    assert(symlinkInfo.mode);
-    const symlinkMode = symlinkInfo.mode & 0o777; // platform dependent
-
-    await Deno.chmod(symlinkName, modeAsync);
-
-    // Just change actual file mode, not symlink
-    const fileInfo = Deno.statSync(filename);
-    assert(fileInfo.mode);
-    assertEquals(fileInfo.mode & 0o777, modeAsync);
-
-    symlinkInfo = Deno.lstatSync(symlinkName);
-    assert(symlinkInfo.mode);
-    assertEquals(symlinkInfo.mode & 0o777, symlinkMode);
-  },
-);
-
 Deno.test({ permissions: { write: true } }, async function chmodFailure() {
   const filename = "/badfile.txt";
   await assertRejects(
@@ -193,3 +130,73 @@ Deno.test({ permissions: { write: false } }, async function chmodPerm() {
     await Deno.chmod("/somefile.txt", 0o777);
   }, Deno.errors.NotCapable);
 });
+
+// chmod does not follow a terminal symlink: the permission check is performed
+// no-follow, so a symlink at an allowed path must not be usable to change the
+// mode of a file it points to. The op opens the path with O_NOFOLLOW and fails
+// with FilesystemLoop (ELOOP) on a symlink target, leaving the target's mode
+// untouched.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function chmodSyncDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    Deno.writeFileSync(target, new Uint8Array([1, 2, 3]));
+    Deno.chmodSync(target, 0o600);
+    Deno.symlinkSync(target, link);
+
+    assertThrows(
+      () => Deno.chmodSync(link, 0o777),
+      Deno.errors.FilesystemLoop,
+    );
+    assertEquals(Deno.lstatSync(target).mode! & 0o777, 0o600);
+  },
+);
+
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  async function chmodDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    await Deno.writeFile(target, new Uint8Array([1, 2, 3]));
+    await Deno.chmod(target, 0o600);
+    await Deno.symlink(target, link);
+
+    await assertRejects(
+      () => Deno.chmod(link, 0o777),
+      Deno.errors.FilesystemLoop,
+    );
+    assertEquals(Deno.lstatSync(target).mode! & 0o777, 0o600);
+  },
+);
+
+// O_NOFOLLOW only protects the final path component. A symlink in an ancestor
+// directory is still resolved, so chmod-ing a regular file reached through a
+// symlinked directory continues to work.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function chmodSyncFollowsIntermediateSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const realDir = dir + "/real";
+    Deno.mkdirSync(realDir);
+    const file = realDir + "/data.txt";
+    Deno.writeFileSync(file, new Uint8Array([1, 2, 3]));
+    Deno.chmodSync(file, 0o600);
+    const linkDir = dir + "/linkdir";
+    Deno.symlinkSync(realDir, linkDir);
+
+    Deno.chmodSync(linkDir + "/data.txt", 0o755);
+    assertEquals(Deno.lstatSync(file).mode! & 0o777, 0o755);
+  },
+);

--- a/tests/unit/chown_test.ts
+++ b/tests/unit/chown_test.ts
@@ -188,3 +188,67 @@ Deno.test(
     Deno.removeSync(dirPath, { recursive: true });
   },
 );
+
+// chown does not follow a terminal symlink: the permission check is performed
+// no-follow, so a symlink at an allowed path must not be usable to change the
+// owner of a file it points to. The op opens the path with O_NOFOLLOW and fails
+// with FilesystemLoop (ELOOP) on a symlink target. Passing null/null leaves
+// owner and group unchanged, so this needs no elevated privileges.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function chownSyncDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    Deno.writeFileSync(target, new Uint8Array([1, 2, 3]));
+    Deno.symlinkSync(target, link);
+
+    assertThrows(
+      () => Deno.chownSync(link, null, null),
+      Deno.errors.FilesystemLoop,
+    );
+  },
+);
+
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  async function chownDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    await Deno.writeFile(target, new Uint8Array([1, 2, 3]));
+    await Deno.symlink(target, link);
+
+    await assertRejects(
+      () => Deno.chown(link, null, null),
+      Deno.errors.FilesystemLoop,
+    );
+  },
+);
+
+// O_NOFOLLOW only protects the final path component. A regular file reached
+// through a symlinked ancestor directory can still be chowned (null/null is a
+// no-op that just confirms the open succeeds).
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function chownSyncFollowsIntermediateSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const realDir = dir + "/real";
+    Deno.mkdirSync(realDir);
+    const file = realDir + "/data.txt";
+    Deno.writeFileSync(file, new Uint8Array([1, 2, 3]));
+    const linkDir = dir + "/linkdir";
+    Deno.symlinkSync(realDir, linkDir);
+
+    Deno.chownSync(linkDir + "/data.txt", null, null);
+  },
+);

--- a/tests/unit/copy_file_test.ts
+++ b/tests/unit/copy_file_test.ts
@@ -297,3 +297,97 @@ Deno.test(
     Deno.removeSync(tempDir, { recursive: true });
   },
 );
+
+// copyFile does not follow a terminal symlink at the destination: the
+// permission check for the destination is performed no-follow, so a symlink at
+// an allowed destination path must not be usable to overwrite the file it
+// points to. The destination is opened with O_NOFOLLOW and fails with
+// FilesystemLoop (ELOOP) on a symlink, leaving the symlink's target untouched.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function copyFileSyncDestDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const source = dir + "/source.txt";
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    writeFileString(source, "new contents");
+    writeFileString(target, "original contents");
+    Deno.symlinkSync(target, link);
+
+    assertThrows(
+      () => Deno.copyFileSync(source, link),
+      Deno.errors.FilesystemLoop,
+    );
+    assertEquals(readFileString(target), "original contents");
+  },
+);
+
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  async function copyFileDestDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const source = dir + "/source.txt";
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    writeFileString(source, "new contents");
+    writeFileString(target, "original contents");
+    Deno.symlinkSync(target, link);
+
+    await assertRejects(
+      () => Deno.copyFile(source, link),
+      Deno.errors.FilesystemLoop,
+    );
+    assertEquals(readFileString(target), "original contents");
+  },
+);
+
+// The same holds for large files (which take the clonefile() fast path on
+// macOS): a terminal symlink destination is refused, not replaced.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function copyFileSyncLargeDestDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const source = dir + "/source.txt";
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    Deno.writeFileSync(source, new Uint8Array(256 * 1024).fill(1));
+    writeFileString(target, "original contents");
+    Deno.symlinkSync(target, link);
+
+    assertThrows(
+      () => Deno.copyFileSync(source, link),
+      Deno.errors.FilesystemLoop,
+    );
+    assertEquals(readFileString(target), "original contents");
+  },
+);
+
+// O_NOFOLLOW only protects the final path component. A destination reached
+// through a symlinked ancestor directory is still resolved and written.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function copyFileSyncFollowsIntermediateSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const source = dir + "/source.txt";
+    writeFileString(source, "copied contents");
+    const realDir = dir + "/real";
+    Deno.mkdirSync(realDir);
+    const linkDir = dir + "/linkdir";
+    Deno.symlinkSync(realDir, linkDir);
+
+    Deno.copyFileSync(source, linkDir + "/dest.txt");
+    assertEquals(readFileString(realDir + "/dest.txt"), "copied contents");
+  },
+);

--- a/tests/unit/utime_test.ts
+++ b/tests/unit/utime_test.ts
@@ -338,3 +338,71 @@ Deno.test(
     }, Deno.errors.NotCapable);
   },
 );
+
+// utime does not follow a terminal symlink: the permission check is performed
+// no-follow, so a symlink at an allowed path must not be usable to change the
+// timestamps of a file it points to. The op opens the path with O_NOFOLLOW and
+// fails with FilesystemLoop (ELOOP) on a symlink target, leaving the target's
+// timestamps untouched.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function utimeSyncDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    Deno.writeFileSync(target, new Uint8Array([1, 2, 3]));
+    const before = Deno.lstatSync(target).mtime!;
+    Deno.symlinkSync(target, link);
+
+    assertThrows(
+      () => Deno.utimeSync(link, 1000, 1000),
+      Deno.errors.FilesystemLoop,
+    );
+    assertEquals(Deno.lstatSync(target).mtime!.getTime(), before.getTime());
+  },
+);
+
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  async function utimeDoesNotFollowSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const target = dir + "/target.txt";
+    const link = dir + "/link.txt";
+    await Deno.writeFile(target, new Uint8Array([1, 2, 3]));
+    const before = Deno.lstatSync(target).mtime!;
+    await Deno.symlink(target, link);
+
+    await assertRejects(
+      () => Deno.utime(link, 1000, 1000),
+      Deno.errors.FilesystemLoop,
+    );
+    assertEquals(Deno.lstatSync(target).mtime!.getTime(), before.getTime());
+  },
+);
+
+// O_NOFOLLOW only protects the final path component. A regular file reached
+// through a symlinked ancestor directory can still have its timestamps set.
+Deno.test(
+  {
+    permissions: { read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function utimeSyncFollowsIntermediateSymlink() {
+    const dir = Deno.makeTempDirSync();
+    const realDir = dir + "/real";
+    Deno.mkdirSync(realDir);
+    const file = realDir + "/data.txt";
+    Deno.writeFileSync(file, new Uint8Array([1, 2, 3]));
+    const linkDir = dir + "/linkdir";
+    Deno.symlinkSync(realDir, linkDir);
+
+    Deno.utimeSync(linkDir + "/data.txt", 1000, 1000);
+    assertEquals(Deno.statSync(file).mtime!.getTime(), 1000 * 1000);
+  },
+);


### PR DESCRIPTION
The permission check for `Deno.chmod`, `Deno.chown`, `Deno.utime`, and the
destination path of `Deno.copyFile` is performed no-follow: it is checked
against the path you name, without canonicalizing symlinks. The implementations,
however, used path-based syscalls (`chmod(2)`, `chown(2)`, the timestamp APIs,
and an `open` with truncation for the copy destination) that follow a terminal
symlink on Unix. A writable symlink sitting at a path inside an allowed scope
could therefore be used to modify a file it points to outside that scope, even
though the named path was the only thing that was permission-checked. This is
the same class of issue as #35239 (which addressed `truncate`).

Only the final path component is affected; intermediate symlinks are still
resolved, matching the existing path model. Windows behavior is unchanged.

## chmod / chown / utime

These ops require only *ownership* of the file, not read or write access, so the
target must be reached without an access-mode check. A terminal symlink is
rejected up-front with `ELOOP` (`FilesystemLoop`), and the mutation that follows
is itself performed no-follow so that even if the path is swapped for a symlink
after the check, the symlink's own metadata is changed rather than its target's:

- **chown**: `lchown(2)`.
- **utime**: `set_symlink_file_times` (`lutimes` / `utimensat` with
  `AT_SYMLINK_NOFOLLOW`).
- **chmod (macOS/BSD)**: `fchmodat` with `AT_SYMLINK_NOFOLLOW`.
- **chmod (Linux)**: `fchmodat` does not support `AT_SYMLINK_NOFOLLOW`, so the
  file is opened `O_PATH | O_NOFOLLOW` (no read access required, a terminal
  symlink is not followed) and chmod'd through `/proc/self/fd/<n>`, which
  resolves to the exact inode the fd pins. This is the technique glibc uses to
  emulate a no-follow chmod.

An earlier revision opened the target `O_RDONLY | O_NOFOLLOW` and operated on
the fd. That required the read bit, which regressed these ops on
owned-but-unreadable files (e.g. mode `0o200` → `PermissionDenied`); the
approach above avoids that.

## copyFile

The destination is opened with `O_NOFOLLOW` (it needs write access regardless),
so a terminal symlink is refused (`ELOOP`) instead of having its target
overwritten. The macOS `clonefile` fast path for large copies is skipped when
the destination is a terminal symlink, so it is refused rather than having the
link silently replaced.

## Tests

Unit tests cover the sync and async paths of each operation: a symlink whose
target holds data is operated on through the link, the operation now throws, and
the target is left untouched. Additional tests confirm that an intermediate
(ancestor directory) symlink is still resolved.
