### PR TITLE
fix(ext/web): make URL and URLSearchParams non-serializable

### DIFF
--- a/ext/web/00_url.js
+++ b/ext/web/00_url.js
@@ -42,6 +42,9 @@ const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
 const { createFilteredInspectProxy } = core.loadExtScript(
   "ext:deno_web/01_console.js",
 );
+const { markNotSerializable } = core.loadExtScript(
+  "ext:deno_web/13_message_port.js",
+);
 
 const _list = Symbol("list");
 const _urlObject = Symbol("url object");
@@ -454,6 +457,7 @@ webidl.mixinPairIterable("URLSearchParams", URLSearchParams, _list, 0, 1);
 
 webidl.configureInterface(URLSearchParams);
 const URLSearchParamsPrototype = URLSearchParams.prototype;
+markNotSerializable(URLSearchParamsPrototype);
 
 webidl.converters["URLSearchParams"] = webidl.createInterfaceConverter(
   "URLSearchParams",
@@ -1208,6 +1212,7 @@ class URL {
 
 webidl.configureInterface(URL);
 const URLPrototype = URL.prototype;
+markNotSerializable(URLPrototype);
 
 /**
  * This function implements application/x-www-form-urlencoded parsing.

--- a/tests/unit/structured_clone_test.ts
+++ b/tests/unit/structured_clone_test.ts
@@ -60,6 +60,21 @@ Deno.test("correct DataCloneError message", () => {
   structuredClone(ab2, { transfer: [ab2] });
 });
 
+Deno.test("structuredClone URL throws DataCloneError", () => {
+  // URL is not [Serializable] per the WHATWG/HTML spec, so cloning it must
+  // throw a DataCloneError rather than silently producing an empty object.
+  assertThrows(
+    () => structuredClone(new URL("https://example.com/")),
+    DOMException,
+    "Cannot clone object of unsupported type.",
+  );
+  assertThrows(
+    () => structuredClone(new URLSearchParams("a=1&b=2")),
+    DOMException,
+    "Cannot clone object of unsupported type.",
+  );
+});
+
 Deno.test("structuredClone CryptoKey", async () => {
   // AES key
   const aesKey = await crypto.subtle.generateKey(

--- a/tests/wpt/runner/expectations/url.json
+++ b/tests/wpt/runner/expectations/url.json
@@ -1,17 +1,10 @@
 {
   "historical.any.html": {
     "expectedFailures": [
-      "<a> and <area>.searchParams should be undefined",
-      "URL: no structured serialize/deserialize support",
-      "URLSearchParams: no structured serialize/deserialize support"
+      "<a> and <area>.searchParams should be undefined"
     ]
   },
-  "historical.any.worker.html": {
-    "expectedFailures": [
-      "URL: no structured serialize/deserialize support",
-      "URLSearchParams: no structured serialize/deserialize support"
-    ]
-  },
+  "historical.any.worker.html": true,
   "idlharness.any.html": true,
   "idlharness.any.worker.html": true,
   "toascii.window.html": {


### PR DESCRIPTION
Per the WHATWG/HTML spec, `URL` is not [Serializable], so cloning it via
`structuredClone()` or sending it through `postMessage()` must throw a
`DataCloneError`, which is what browsers and Node both do. Deno instead
silently produced an empty object (`instanceof URL` is false, stringifies
to `[object Object]`) because `URL` is a plain JS class whose state lives
in symbol-keyed slots that V8's `ValueSerializer` drops.

Deno already has the machinery for this: `markNotSerializable()` in
`13_message_port.js`, backed by a `kNotSerializable` symbol, with the
clone/`postMessage` paths checking it and throwing the expected
`DataCloneError`. The platform types that already behave correctly
(`Headers`, `Request`, `Response`, and the stream types) all call it on
their prototype; `URL` and `URLSearchParams` simply never registered.
This marks both prototypes so they take the same path.

This covers the top-level case. A non-serializable value nested inside
another object still serializes to `{}`, which is a pre-existing,
separately-documented limitation that needs a custom V8 serializer
delegate to fully resolve.