### PR TITLE
perf(ext/webgpu): avoid heap allocation for the argument that requires a fixed length of sequence

### DIFF
--- a/ext/webgpu/webidl.rs
+++ b/ext/webgpu/webidl.rs
@@ -5,12 +5,52 @@ use std::borrow::Cow;
 use deno_core::WebIDL;
 use deno_core::cppgc::Ref;
 use deno_core::v8;
+use deno_core::webidl::ConstrainedSequence;
 use deno_core::webidl::ContextFn;
 use deno_core::webidl::IntOptions;
+use deno_core::webidl::SequenceLengthAtMost;
+use deno_core::webidl::SequenceLengthExact;
+use deno_core::webidl::SequenceLengthPolicy;
+use deno_core::webidl::SequenceLengthRange;
 use deno_core::webidl::WebIdlConverter;
 use deno_core::webidl::WebIdlError;
 use deno_core::webidl::WebIdlErrorKind;
 use deno_error::JsErrorBox;
+
+fn convert_webgpu_number_sequence<'a, 'b, 'i, T, P, const MAX: usize>(
+  scope: &mut v8::PinScope<'a, 'i>,
+  value: v8::Local<'a, v8::Value>,
+  prefix: Cow<'static, str>,
+  context: ContextFn<'b>,
+  options: &T::Options,
+  type_name: &'static str,
+) -> Result<ConstrainedSequence<T, P, MAX>, WebIdlError>
+where
+  T: WebIdlConverter<'a>,
+  P: SequenceLengthPolicy,
+{
+  match ConstrainedSequence::<T, P, MAX>::convert(
+    scope,
+    value,
+    prefix.clone(),
+    context.borrowed(),
+    options,
+  ) {
+    Ok(sequence) => Ok(sequence),
+    Err(WebIdlError {
+      kind: WebIdlErrorKind::InvalidSequenceLength { actual, .. },
+      ..
+    }) => Err(WebIdlError::other(
+      prefix,
+      context,
+      JsErrorBox::type_error(format!(
+        "A sequence of number used as a {type_name} must have {}, received {actual} elements",
+        P::expectation()
+      )),
+    )),
+    Err(err) => Err(err),
+  }
+}
 
 #[derive(WebIDL)]
 #[webidl(dictionary)]
@@ -54,32 +94,22 @@ impl<'a> WebIdlConverter<'a> for GPUExtent3D {
       if let Some(iter) = obj.get(scope, iter.into())
         && !iter.is_undefined()
       {
-        let conv = <Vec<u32>>::convert(
-          scope,
-          value,
-          prefix.clone(),
-          context.borrowed(),
-          &IntOptions {
-            clamp: false,
-            enforce_range: true,
-          },
-        )?;
-        if conv.is_empty() || conv.len() > 3 {
-          return Err(WebIdlError::other(
+        let conv =
+          convert_webgpu_number_sequence::<u32, SequenceLengthRange<1, 3>, 3>(
+            scope,
+            value,
             prefix,
             context,
-            JsErrorBox::type_error(format!(
-              "A sequence of number used as a GPUExtent3D must have between 1 and 3 elements, received {} elements",
-              conv.len()
-            )),
-          ));
-        }
-
-        let mut iter = conv.into_iter();
+            &IntOptions {
+              clamp: false,
+              enforce_range: true,
+            },
+            "GPUExtent3D",
+          )?;
         return Ok(GPUExtent3D::Sequence((
-          iter.next().unwrap(),
-          iter.next().unwrap_or(1),
-          iter.next().unwrap_or(1),
+          conv[0],
+          conv.get(1).copied().unwrap_or(1),
+          conv.get(2).copied().unwrap_or(1),
         )));
       }
 
@@ -164,32 +194,22 @@ impl<'a> WebIdlConverter<'a> for GPUOrigin3D {
       if let Some(iter) = obj.get(scope, iter.into())
         && !iter.is_undefined()
       {
-        let conv = <Vec<u32>>::convert(
-          scope,
-          value,
-          prefix.clone(),
-          context.borrowed(),
-          &IntOptions {
-            clamp: false,
-            enforce_range: true,
-          },
-        )?;
-        if conv.len() > 3 {
-          return Err(WebIdlError::other(
+        let conv =
+          convert_webgpu_number_sequence::<u32, SequenceLengthAtMost<3>, 3>(
+            scope,
+            value,
             prefix,
             context,
-            JsErrorBox::type_error(format!(
-              "A sequence of number used as a GPUOrigin3D must have at most 3 elements, received {} elements",
-              conv.len()
-            )),
-          ));
-        }
-
-        let mut iter = conv.into_iter();
+            &IntOptions {
+              clamp: false,
+              enforce_range: true,
+            },
+            "GPUOrigin3D",
+          )?;
         return Ok(GPUOrigin3D::Sequence((
-          iter.next().unwrap_or(0),
-          iter.next().unwrap_or(0),
-          iter.next().unwrap_or(0),
+          conv.get(0).copied().unwrap_or(0),
+          conv.get(1).copied().unwrap_or(0),
+          conv.get(2).copied().unwrap_or(0),
         )));
       }
 
@@ -259,31 +279,11 @@ impl<'a> WebIdlConverter<'a> for GPUColor {
       if let Some(iter) = obj.get(scope, iter.into())
         && !iter.is_undefined()
       {
-        let conv = <Vec<f64>>::convert(
-          scope,
-          value,
-          prefix.clone(),
-          context.borrowed(),
-          options,
-        )?;
-        if conv.len() != 4 {
-          return Err(WebIdlError::other(
-            prefix,
-            context,
-            JsErrorBox::type_error(format!(
-              "A sequence of number used as a GPUColor must have exactly 4 elements, received {} elements",
-              conv.len()
-            )),
-          ));
-        }
-
-        let mut iter = conv.into_iter();
-        return Ok(GPUColor::Sequence((
-          iter.next().unwrap(),
-          iter.next().unwrap(),
-          iter.next().unwrap(),
-          iter.next().unwrap(),
-        )));
+        let conv =
+          convert_webgpu_number_sequence::<f64, SequenceLengthExact<4>, 4>(
+            scope, value, prefix, context, options, "GPUColor",
+          )?;
+        return Ok(GPUColor::Sequence((conv[0], conv[1], conv[2], conv[3])));
       }
 
       return Ok(GPUColor::Dict(GPUColorDict::convert(

--- a/ext/webgpu/webidl.rs
+++ b/ext/webgpu/webidl.rs
@@ -207,7 +207,7 @@ impl<'a> WebIdlConverter<'a> for GPUOrigin3D {
             "GPUOrigin3D",
           )?;
         return Ok(GPUOrigin3D::Sequence((
-          conv.get(0).copied().unwrap_or(0),
+          conv.first().copied().unwrap_or(0),
           conv.get(1).copied().unwrap_or(0),
           conv.get(2).copied().unwrap_or(0),
         )));

--- a/libs/core/webidl.rs
+++ b/libs/core/webidl.rs
@@ -133,15 +133,29 @@ impl std::fmt::Display for WebIdlError {
 
 impl std::error::Error for WebIdlError {}
 
-#[derive(Debug)]
-pub struct SequenceLengthExpectation {
-  first: usize,
-  second: usize,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SequenceLengthExpectation {
+  Exact(usize),
+  AtMost(usize),
+  Range { min: usize, max: usize },
+  OneOf { first: usize, second: usize },
 }
 
 impl std::fmt::Display for SequenceLengthExpectation {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "exactly {} or {} elements", self.first, self.second)
+    match self {
+      Self::Exact(len) => write!(f, "exactly {len} elements"),
+      Self::AtMost(len) => write!(f, "at most {len} elements"),
+      Self::Range { min, max } if min == max => {
+        write!(f, "exactly {min} elements")
+      }
+      Self::Range { min, max } => {
+        write!(f, "between {min} and {max} elements")
+      }
+      Self::OneOf { first, second } => {
+        write!(f, "exactly {first} or {second} elements")
+      }
+    }
   }
 }
 
@@ -425,15 +439,48 @@ fn for_each_in_sequence<'a, 'b, 'i>(
   Ok(len)
 }
 
-// TODO: WebGPU API like `GPUExtent3D`, `GPUOrigin3D`
-// or `GPUColor` could be statically allocated sequence
-// due to its size being known at compile time.
-// Extend this helper with additional fixed-size/size-bounded policies
-// like `SequenceLengthExact<N>`, `SequenceLengthAtMost<N>`, or
-// `SequenceLengthRange<MIN, MAX>` when we need.
 pub trait SequenceLengthPolicy {
   fn accepts(len: usize) -> bool;
   fn expectation() -> SequenceLengthExpectation;
+}
+
+pub struct SequenceLengthExact<const N: usize>;
+
+impl<const N: usize> SequenceLengthPolicy for SequenceLengthExact<N> {
+  fn accepts(len: usize) -> bool {
+    len == N
+  }
+
+  fn expectation() -> SequenceLengthExpectation {
+    SequenceLengthExpectation::Exact(N)
+  }
+}
+
+pub struct SequenceLengthAtMost<const N: usize>;
+
+impl<const N: usize> SequenceLengthPolicy for SequenceLengthAtMost<N> {
+  fn accepts(len: usize) -> bool {
+    len <= N
+  }
+
+  fn expectation() -> SequenceLengthExpectation {
+    SequenceLengthExpectation::AtMost(N)
+  }
+}
+
+pub struct SequenceLengthRange<const MIN: usize, const MAX: usize>;
+
+impl<const MIN: usize, const MAX: usize> SequenceLengthPolicy
+  for SequenceLengthRange<MIN, MAX>
+{
+  fn accepts(len: usize) -> bool {
+    debug_assert!(MIN <= MAX);
+    (MIN..=MAX).contains(&len)
+  }
+
+  fn expectation() -> SequenceLengthExpectation {
+    SequenceLengthExpectation::Range { min: MIN, max: MAX }
+  }
 }
 
 pub struct SequenceLengthOneOf<const A: usize, const B: usize>;
@@ -446,7 +493,7 @@ impl<const A: usize, const B: usize> SequenceLengthPolicy
   }
 
   fn expectation() -> SequenceLengthExpectation {
-    SequenceLengthExpectation {
+    SequenceLengthExpectation::OneOf {
       first: A,
       second: B,
     }
@@ -1636,6 +1683,51 @@ mod tests {
         &Default::default(),
       );
     assert_eq!(&*converted.unwrap(), &[1, 2, 3, 4]);
+  }
+
+  #[test]
+  fn constrained_sequence_exact() {
+    let mut runtime = JsRuntime::new(Default::default());
+    deno_core::scope!(scope, runtime);
+
+    let values = [
+      v8::Number::new(scope, 1.0).into(),
+      v8::Number::new(scope, 2.0).into(),
+      v8::Number::new(scope, 3.0).into(),
+      v8::Number::new(scope, 4.0).into(),
+    ];
+    let val = v8::Array::new_with_elements(scope, &values);
+    let converted =
+      ConstrainedSequence::<u8, SequenceLengthExact<4>, 4>::convert(
+        scope,
+        val.into(),
+        "prefix".into(),
+        (|| "context".into()).into(),
+        &Default::default(),
+      );
+    assert_eq!(&*converted.unwrap(), &[1, 2, 3, 4]);
+  }
+
+  #[test]
+  fn constrained_sequence_at_most() {
+    let mut runtime = JsRuntime::new(Default::default());
+    deno_core::scope!(scope, runtime);
+
+    let values = [
+      v8::Number::new(scope, 1.0).into(),
+      v8::Number::new(scope, 2.0).into(),
+      v8::Number::new(scope, 3.0).into(),
+    ];
+    let val = v8::Array::new_with_elements(scope, &values);
+    let converted =
+      ConstrainedSequence::<u8, SequenceLengthAtMost<4>, 4>::convert(
+        scope,
+        val.into(),
+        "prefix".into(),
+        (|| "context".into()).into(),
+        &Default::default(),
+      );
+    assert_eq!(&*converted.unwrap(), &[1, 2, 3]);
   }
 
   #[test]


### PR DESCRIPTION
Follow-up from:
- https://github.com/denoland/deno/pull/33688

We can statically allocate stacks when the `GPUExtent3D`, `GPUOrigin3D` or `GPUColor` of the WebIDLs require a fixed length of sequence. I used `cargo bench` instead of `deno bench` since it was hard to directly compare the JS APIs.
The results show a speedup of approximately 5x times. In practice, the improvement rate will likely be roughly the same as that of the DOMMatrix PR.

```bash
% cargo bench -p deno_webgpu --bench webidl_convert

running 10 tests
test color_new     ... bench:      13,921 ns/iter (+/- 623)
test color_old     ... bench:     130,093 ns/iter (+/- 6,628)
test extent_2d_new ... bench:      31,502 ns/iter (+/- 2,012)
test extent_2d_old ... bench:     155,995 ns/iter (+/- 12,942)
test extent_3d_new ... bench:      34,251 ns/iter (+/- 1,917)
test extent_3d_old ... bench:     166,274 ns/iter (+/- 19,587)
test origin_2d_new ... bench:      31,690 ns/iter (+/- 1,774)
test origin_2d_old ... bench:     157,806 ns/iter (+/- 13,975)
test origin_3d_new ... bench:      34,435 ns/iter (+/- 1,375)
test origin_3d_old ... bench:     166,843 ns/iter (+/- 13,132)

test result: ok. 0 passed; 0 failed; 0 ignored; 10 measured
```

<details><summary>ext/webgpu/webidl.rs</summary>
<p>

```rust
// Copyright 2018-2026 the Deno authors. MIT license.

use std::hint::black_box;
use std::mem::MaybeUninit;

use bencher::Bencher;
use bencher::benchmark_group;
use bencher::benchmark_main;

const CONVERSIONS_PER_ITERATION: usize = 10_000;

fn convert_extent3d_old(values: &[u32]) -> (u32, u32, u32) {
  let conv = values.to_vec();
  assert!(!conv.is_empty() && conv.len() <= 3);

  let mut iter = conv.into_iter();
  (
    iter.next().unwrap(),
    iter.next().unwrap_or(1),
    iter.next().unwrap_or(1),
  )
}

fn convert_extent3d_new(values: &[u32]) -> (u32, u32, u32) {
  let conv = collect_constrained::<u32, 3>(values);
  assert!((1..=3).contains(&conv.len));

  (
    conv.get(0).copied().unwrap(),
    conv.get(1).copied().unwrap_or(1),
    conv.get(2).copied().unwrap_or(1),
  )
}

fn convert_origin3d_old(values: &[u32]) -> (u32, u32, u32) {
  let conv = values.to_vec();
  assert!(conv.len() <= 3);

  let mut iter = conv.into_iter();
  (
    iter.next().unwrap_or(0),
    iter.next().unwrap_or(0),
    iter.next().unwrap_or(0),
  )
}

fn convert_origin3d_new(values: &[u32]) -> (u32, u32, u32) {
  let conv = collect_constrained::<u32, 3>(values);
  assert!(conv.len <= 3);

  (
    conv.get(0).copied().unwrap_or(0),
    conv.get(1).copied().unwrap_or(0),
    conv.get(2).copied().unwrap_or(0),
  )
}

fn convert_color_old(values: &[f64]) -> (f64, f64, f64, f64) {
  let conv = values.to_vec();
  assert_eq!(conv.len(), 4);

  let mut iter = conv.into_iter();
  (
    iter.next().unwrap(),
    iter.next().unwrap(),
    iter.next().unwrap(),
    iter.next().unwrap(),
  )
}

fn convert_color_new(values: &[f64]) -> (f64, f64, f64, f64) {
  let conv = collect_constrained::<f64, 4>(values);
  assert_eq!(conv.len, 4);

  (
    conv.get(0).copied().unwrap(),
    conv.get(1).copied().unwrap(),
    conv.get(2).copied().unwrap(),
    conv.get(3).copied().unwrap(),
  )
}

struct ConstrainedBuffer<T, const MAX: usize> {
  len: usize,
  data: [MaybeUninit<T>; MAX],
}

impl<T, const MAX: usize> ConstrainedBuffer<T, MAX> {
  fn get(&self, index: usize) -> Option<&T> {
    if index >= self.len {
      return None;
    }

    // SAFETY: elements in `0..len` are initialized by `collect_constrained`.
    Some(unsafe { self.data[index].assume_init_ref() })
  }
}

fn collect_constrained<T: Copy, const MAX: usize>(
  values: &[T],
) -> ConstrainedBuffer<T, MAX> {
  assert!(values.len() <= MAX);

  let mut data = std::array::from_fn(|_| MaybeUninit::uninit());
  for (index, value) in values.iter().enumerate() {
    data[index].write(*value);
  }

  ConstrainedBuffer {
    len: values.len(),
    data,
  }
}

macro_rules! define_bench {
  ($name:ident, $values:expr, $func:path) => {
    fn $name(b: &mut Bencher) {
      let values = $values;
      b.iter(|| {
        let mut out = $func(values);
        for _ in 1..CONVERSIONS_PER_ITERATION {
          out = $func(values);
        }
        black_box(out);
      });
    }
  };
}

define_bench!(extent_2d_old, &[1_u32, 1_u32][..], convert_extent3d_old);
define_bench!(extent_2d_new, &[1_u32, 1_u32][..], convert_extent3d_new);
define_bench!(
  extent_3d_old,
  &[1_u32, 1_u32, 1_u32][..],
  convert_extent3d_old
);
define_bench!(
  extent_3d_new,
  &[1_u32, 1_u32, 1_u32][..],
  convert_extent3d_new
);

define_bench!(origin_2d_old, &[0_u32, 0_u32][..], convert_origin3d_old);
define_bench!(origin_2d_new, &[0_u32, 0_u32][..], convert_origin3d_new);
define_bench!(
  origin_3d_old,
  &[0_u32, 0_u32, 0_u32][..],
  convert_origin3d_old
);
define_bench!(
  origin_3d_new,
  &[0_u32, 0_u32, 0_u32][..],
  convert_origin3d_new
);

define_bench!(
  color_old,
  &[0.0_f64, 0.0_f64, 0.0_f64, 1.0_f64][..],
  convert_color_old
);
define_bench!(
  color_new,
  &[0.0_f64, 0.0_f64, 0.0_f64, 1.0_f64][..],
  convert_color_new
);

benchmark_main!(benches);
benchmark_group!(
  benches,
  extent_2d_old,
  extent_2d_new,
  extent_3d_old,
  extent_3d_new,
  origin_2d_old,
  origin_2d_new,
  origin_3d_old,
  origin_3d_new,
  color_old,
  color_new,
);
```

</p>
</details> 

AI assistance disclosure: This PR was prepared with help from OpenAI Codex.