### PR TITLE
feat(desktop): default UI backend to webview

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2509,7 +2509,7 @@ supported framework (Next.js, Astro, etc.) in the current directory.
           .long("backend")
           .help("Backend to use for the desktop app")
           .value_parser(["webview", "cef", "raw"])
-          .default_value("cef")
+          .default_value("webview")
           .help_heading(DESKTOP_HEADING),
       )
       .arg(
@@ -13837,6 +13837,29 @@ mod tests {
         ..Flags::default()
       }
     );
+  }
+
+  #[test]
+  fn desktop_backend_default() {
+    let r = flags_from_vec(svec!["deno", "desktop", "main.tsx"]);
+    let flags = r.unwrap();
+    let DenoSubcommand::Desktop(desktop) = flags.subcommand else {
+      panic!("expected desktop subcommand");
+    };
+    assert_eq!(desktop.source_file, "main.tsx");
+    // The UI backend defaults to webview.
+    assert_eq!(desktop.backend.as_deref(), Some("webview"));
+  }
+
+  #[test]
+  fn desktop_backend_explicit() {
+    let r =
+      flags_from_vec(svec!["deno", "desktop", "--backend", "cef", "main.tsx"]);
+    let flags = r.unwrap();
+    let DenoSubcommand::Desktop(desktop) = flags.subcommand else {
+      panic!("expected desktop subcommand");
+    };
+    assert_eq!(desktop.backend.as_deref(), Some("cef"));
   }
 
   #[test]

--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -1195,7 +1195,7 @@ async fn package_windows_app_dir(
   let app_name = parts.app_name;
   let app_dir = parts.parent.join(&app_name);
 
-  let backend = desktop_flags.backend.as_deref().unwrap_or("cef");
+  let backend = desktop_flags.backend.as_deref().unwrap_or("webview");
   let target = laufey_target_for(desktop_flags);
   let laufey_binary = laufey_resolver.find_binary(backend, target).await?;
   let laufey_dir = laufey_resolver.find_binary_dir(backend, target).await?;
@@ -1321,7 +1321,7 @@ async fn package_linux_app_dir(
     .unwrap_or(parts.app_name);
   let app_dir = parts.parent.join(&app_name);
 
-  let backend = desktop_flags.backend.as_deref().unwrap_or("cef");
+  let backend = desktop_flags.backend.as_deref().unwrap_or("webview");
   let target = laufey_target_for(desktop_flags);
   let laufey_binary = laufey_resolver.find_binary(backend, target).await?;
   let laufey_dir = laufey_resolver.find_binary_dir(backend, target).await?;
@@ -2612,7 +2612,7 @@ async fn package_macos_app_bundle(
   let app_bundle = parts.parent.join(format!("{}.app", app_name));
 
   // Find the LAUFEY backend .app and its main executable.
-  let backend = desktop_flags.backend.as_deref().unwrap_or("cef");
+  let backend = desktop_flags.backend.as_deref().unwrap_or("webview");
   let target = laufey_target_for(desktop_flags);
   let laufey_app = laufey_resolver.find_app_bundle(backend, target).await?;
   let laufey_executable_name = read_plist_string(


### PR DESCRIPTION
Changes the default UI backend for the `deno desktop` subcommand from
`cef` to `webview`. The CLI default value and the runtime fallbacks in
the macOS, Linux, and Windows packaging paths are all updated, matching
the backend already used by the HMR/inspector path.

The documentation at https://docs.deno.com/runtime/desktop/backends/
already states that webview is the default, but a bare `deno desktop`
invocation was pulling CEF from GitHub and building the app with CEF
instead. This aligns the implementation with the documented behaviour.

Added unit tests covering the new default and explicit `--backend`
selection.

Closes #35433