### PR TITLE
fix(ext/node): forward permissions when spawning deno with subcommand args

### DIFF
--- a/libs/node_shim/lib.rs
+++ b/libs/node_shim/lib.rs
@@ -3260,6 +3260,68 @@ pub fn is_deno_subcommand(arg: &str) -> bool {
   DENO_SUBCOMMANDS.contains(&arg)
 }
 
+/// Subcommands that execute user code and accept permission flags. A spawned
+/// Node.js process has no permission model, so when one of these is produced by
+/// the node-compat translation without explicit permission flags, we grant `-A`
+/// to mirror Node.js behavior (and to match the non-pass-through script path).
+fn subcommand_runs_user_code(subcommand: &str) -> bool {
+  matches!(subcommand, "run" | "test" | "bench" | "serve")
+}
+
+/// Long-form permission flag names (without the leading `--`): allow/deny
+/// grants plus `--permission-set`. Mirrors the permission flags defined in the
+/// CLI parser (see `permission_args` in cli/args/flags.rs).
+const PERMISSION_LONG_FLAGS: &[&str] = &[
+  "allow-all",
+  "allow-read",
+  "allow-write",
+  "allow-net",
+  "allow-env",
+  "allow-run",
+  "allow-sys",
+  "allow-ffi",
+  "allow-import",
+  "deny-read",
+  "deny-write",
+  "deny-net",
+  "deny-env",
+  "deny-run",
+  "deny-sys",
+  "deny-ffi",
+  "deny-import",
+  "permission-set",
+];
+
+/// Short-form permission flag characters. Mirrors the `.short(...)` aliases in
+/// the CLI parser: -A/-R/-W/-N/-E/-S/-I plus -P for `--permission-set`.
+const PERMISSION_SHORT_FLAGS: &[char] =
+  &['A', 'R', 'W', 'N', 'E', 'S', 'I', 'P'];
+
+/// Whether `arg` is an explicit permission flag: long (`--allow-net`) or short
+/// (`-A`, `-RW`), with or without an `=value` (permission flags require `=` for
+/// values, so the value can be split off first).
+fn is_permission_flag(arg: &str) -> bool {
+  let flag = arg.split('=').next().unwrap_or(arg);
+  if let Some(long) = flag.strip_prefix("--") {
+    return PERMISSION_LONG_FLAGS.contains(&long);
+  }
+  if let Some(shorts) = flag.strip_prefix('-') {
+    // Short flags may be bundled (e.g. `-RW`); treat the arg as a permission
+    // flag if every character is an alphabetic short flag and at least one is a
+    // permission flag.
+    return !shorts.is_empty()
+      && shorts.chars().all(|c| c.is_ascii_alphabetic())
+      && shorts.chars().any(|c| PERMISSION_SHORT_FLAGS.contains(&c));
+  }
+  false
+}
+
+/// Whether the args already carry an explicit permission flag, in which case we
+/// must respect the caller's intent and not inject `-A`.
+fn has_permission_flag(args: &[String]) -> bool {
+  args.iter().any(|a| is_permission_flag(a))
+}
+
 /// Resolve a Node-style entrypoint to a specifier that Deno's `run` subcommand
 /// understands.
 ///
@@ -3366,12 +3428,23 @@ pub fn translate_to_deno_args(
   let node_options = &mut result.node_options;
 
   // Check if the args already look like Deno args (e.g., from vitest workers)
-  // If the first remaining arg is a Deno subcommand, pass through unchanged
+  // If the first remaining arg is a Deno subcommand, pass through unchanged.
   if let Some(first_arg) = parsed_args.remaining_args.first()
     && is_deno_subcommand(first_arg)
   {
-    // Already Deno-style args, return unchanged
-    result.deno_args = parsed_args.remaining_args;
+    let mut deno_args = parsed_args.remaining_args;
+    // A spawned Node.js process has no permission model. When a tool detects it
+    // is running under Deno and spawns an execution subcommand (e.g.
+    // `deno run <script>`) without any permission flags, grant `-A` so the
+    // child behaves like Node.js instead of tripping a permission prompt. Tools
+    // that pass explicit permission flags (e.g. vitest workers spawn
+    // `run -A ...`) are left untouched. See #35441.
+    if subcommand_runs_user_code(&deno_args[0])
+      && !has_permission_flag(&deno_args)
+    {
+      deno_args.insert(1, "-A".to_string());
+    }
+    result.deno_args = deno_args;
     return result;
   }
 
@@ -5223,4 +5296,74 @@ mod tests {
       "foo.js"
     ]
   );
+
+  /// Helper for the deno-subcommand pass-through path (used when a tool spawns
+  /// Deno with deno-style args). Translation is mode-independent here, so use
+  /// the child_process options.
+  fn translate_passthrough(input: Vec<String>) -> Vec<String> {
+    let parsed_args = parse_args(input).unwrap();
+    let options = TranslateOptions::for_child_process();
+    translate_to_deno_args(parsed_args, &options).deno_args
+  }
+
+  #[test]
+  fn passthrough_run_without_perms_gets_allow_all() {
+    // Regression test for #35441: `deno run <script>` spawned without any
+    // permission flags must receive `-A` so the Node-compat child has full
+    // access instead of prompting.
+    assert_eq!(
+      translate_passthrough(svec!["run", "child.mjs"]),
+      svec!["run", "-A", "child.mjs"]
+    );
+    assert_eq!(
+      translate_passthrough(svec!["run", "npm:storybook", "init"]),
+      svec!["run", "-A", "npm:storybook", "init"]
+    );
+  }
+
+  #[test]
+  fn passthrough_run_with_explicit_perms_is_unchanged() {
+    // vitest workers and similar pass `-A` already; respect explicit flags,
+    // including long, short, bundled and `=value` forms.
+    for flags in [
+      svec!["-A"],
+      svec!["--allow-all"],
+      svec!["--allow-read"],
+      svec!["--allow-read=/etc"],
+      svec!["-R"],
+      svec!["-R=/etc"],
+      svec!["-RW"],
+      svec!["-N=localhost"],
+      svec!["--deny-net"],
+      svec!["-P=prod"],
+    ] {
+      let mut input = svec!["run"];
+      input.extend(flags.iter().cloned());
+      input.push("worker.mjs".to_string());
+      assert_eq!(
+        translate_passthrough(input.clone()),
+        input,
+        "expected {input:?} to pass through unchanged"
+      );
+    }
+  }
+
+  #[test]
+  fn passthrough_run_with_non_permission_short_flag_gets_allow_all() {
+    // `-q` (quiet) is not a permission flag, so `-A` is still injected.
+    assert_eq!(
+      translate_passthrough(svec!["run", "-q", "worker.mjs"]),
+      svec!["run", "-A", "-q", "worker.mjs"]
+    );
+  }
+
+  #[test]
+  fn passthrough_non_execution_subcommand_is_unchanged() {
+    // Non-execution subcommands don't take `-A`; leave them alone.
+    assert_eq!(translate_passthrough(svec!["install"]), svec!["install"]);
+    assert_eq!(
+      translate_passthrough(svec!["add", "npm:foo"]),
+      svec!["add", "npm:foo"]
+    );
+  }
 }

--- a/tests/specs/node/child_process_node_cli_args/__test__.jsonc
+++ b/tests/specs/node/child_process_node_cli_args/__test__.jsonc
@@ -35,6 +35,10 @@
     "deno_subcommand_passthrough": {
       "args": "run -A --unstable-detect-cjs main.js deno_subcommand",
       "output": "deno_subcommand.out"
+    },
+    "permission_passthrough": {
+      "args": "run -A --unstable-detect-cjs main.js permission_passthrough",
+      "output": "permission_passthrough.out"
     }
   }
 }

--- a/tests/specs/node/child_process_node_cli_args/main.js
+++ b/tests/specs/node/child_process_node_cli_args/main.js
@@ -152,6 +152,22 @@ async function testDenoSubcommandPassthrough() {
   console.log("passthrough:", result.stdout);
 }
 
+async function testPermissionPassthrough() {
+  // Regression test for #35441: spawning `deno run <script>` (deno-style args)
+  // without permission flags must still grant the Node-compat child full
+  // permissions, instead of dropping to no permissions and prompting/erroring.
+  const path = require("path");
+  const script = path.join(__dirname, "perm_child.js");
+
+  // No permission flags -> child should be granted -A.
+  const result = await runChild(["run", script]);
+  console.log("run without perms:", result.stdout);
+
+  // Explicit permission flag -> respected, child still has env access.
+  const result2 = await runChild(["run", "--allow-env", script]);
+  console.log("run with --allow-env:", result2.stdout);
+}
+
 async function main() {
   switch (testName) {
     case "eval":
@@ -180,6 +196,9 @@ async function main() {
       break;
     case "deno_subcommand":
       await testDenoSubcommandPassthrough();
+      break;
+    case "permission_passthrough":
+      await testPermissionPassthrough();
       break;
     default:
       console.error("Unknown test:", testName);

--- a/tests/specs/node/child_process_node_cli_args/perm_child.js
+++ b/tests/specs/node/child_process_node_cli_args/perm_child.js
@@ -1,0 +1,12 @@
+// Child used by the #35441 regression test. Reading an env var requires
+// --allow-env; when spawned as `deno run <script>` (deno-style args) without
+// permission flags, the Node-compat translation must still grant full
+// permissions, so this should print "env-ok" instead of throwing.
+let result;
+try {
+  void process.env.PATH;
+  result = "env-ok";
+} catch (e) {
+  result = "env-denied: " + e.name;
+}
+console.log(result);

--- a/tests/specs/node/child_process_node_cli_args/permission_passthrough.out
+++ b/tests/specs/node/child_process_node_cli_args/permission_passthrough.out
@@ -1,0 +1,2 @@
+run without perms: env-ok
+run with --allow-env: env-ok


### PR DESCRIPTION
When an npm tool running under Deno spawns a child process that is itself
Deno, the node-compat layer translates the Node.js argv to Deno argv and
grants the child full permissions (-A) so it behaves like a permissionless
Node.js process. That injection was skipped whenever the spawned argv
already started with a Deno subcommand: a tool that detected it was running
under Deno and spawned something like "deno run <script>" had its args
passed through verbatim, dropping the implicit -A. The child then ran with
no permissions and tripped a permission prompt on the first env read (TERM),
which hung because the parent CLI holds stdin in raw mode and the prompt
could never be answered.

This restores Node.js semantics in that pass-through path: when the
subcommand executes user code (run/test/bench/serve) and no explicit
permission flag is present, -A is injected. Callers that pass their own
permission flags (for example vitest workers that spawn "run -A ...") are
left untouched, and detection covers long, short, bundled and =value forms
to mirror the CLI parser.

Fixes #35441