### PR TITLE
fix(core): don't cache WebIDL sequence keys in thread-local v8::Eternal

### DIFF
--- a/libs/core/runtime/jsrealm.rs
+++ b/libs/core/runtime/jsrealm.rs
@@ -144,6 +144,12 @@ pub struct ContextState {
     RefCell<std::collections::HashMap<usize, (bool, bool)>>,
   pub(crate) external_ops_tracker: ExternalOpsTracker,
   pub(crate) ext_import_meta_proto: RefCell<Option<v8::Global<v8::Object>>>,
+  /// Lazily-cached "next"/"done"/"value" iterator keys used by the WebIDL
+  /// sequence converter. Cached per-context (not in a `thread_local`) because
+  /// `v8::String` handles are isolate-bound. See
+  /// [`crate::webidl::WebIdlSequenceKeys`].
+  pub(crate) webidl_sequence_keys:
+    RefCell<Option<crate::webidl::WebIdlSequenceKeys>>,
   /// Phase-specific state for the libuv-style event loop.
   pub event_loop_phases: RefCell<EventLoopPhases>,
   /// Pointer to the `UvLoopInner` for the libuv compat layer.
@@ -213,6 +219,7 @@ impl ContextState {
       unrefed_ops,
       external_ops_tracker,
       ext_import_meta_proto: Default::default(),
+      webidl_sequence_keys: Default::default(),
       event_loop_phases: Default::default(),
       uv_loop_inner: Cell::new(None),
       uv_loop_ptr: Cell::new(None),

--- a/libs/core/webidl.rs
+++ b/libs/core/webidl.rs
@@ -298,12 +298,6 @@ crate::v8_static_strings! {
   VALUE = "value",
 }
 
-thread_local! {
-  static NEXT_ETERNAL: v8::Eternal<v8::String> = v8::Eternal::empty();
-  static DONE_ETERNAL: v8::Eternal<v8::String> = v8::Eternal::empty();
-  static VALUE_ETERNAL: v8::Eternal<v8::String> = v8::Eternal::empty();
-}
-
 // helper for iterating over a sequence
 fn for_each_in_sequence<'a, 'b, 'i>(
   scope: &mut v8::PinScope<'a, 'i>,
@@ -340,46 +334,28 @@ fn for_each_in_sequence<'a, 'b, 'i>(
     ));
   };
 
-  let next_key = NEXT_ETERNAL
-    .with(|eternal| {
-      if let Some(key) = eternal.get(scope) {
-        Ok(key)
-      } else {
-        let key = NEXT.v8_string(scope).map_err(|e| {
-          WebIdlError::other(prefix.clone(), context.borrowed(), e)
-        })?;
-        eternal.set(scope, key);
-        Ok(key)
-      }
-    })?
+  // These keys must be materialized fresh for the current isolate on every
+  // call. They were previously cached in a `thread_local` `v8::Eternal`, but an
+  // `Eternal` handle is scoped to the isolate that created it. In `deno test`
+  // each test file runs in its own isolate, and those isolates are created on
+  // reused tokio blocking-pool threads, so a cached handle would dangle into a
+  // disposed isolate once a thread was reused. That manifested as spurious
+  // "can not be converted to a sequence" errors (and occasionally SIGSEGV)
+  // starting from the third test file. Re-creating the strings here is cheap:
+  // they are built once per sequence conversion, not once per element.
+  let next_key = NEXT
+    .v8_string(scope)
+    .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))?
     .into();
 
-  let done_key = DONE_ETERNAL
-    .with(|eternal| {
-      if let Some(key) = eternal.get(scope) {
-        Ok(key)
-      } else {
-        let key = DONE.v8_string(scope).map_err(|e| {
-          WebIdlError::other(prefix.clone(), context.borrowed(), e)
-        })?;
-        eternal.set(scope, key);
-        Ok(key)
-      }
-    })?
+  let done_key = DONE
+    .v8_string(scope)
+    .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))?
     .into();
 
-  let value_key = VALUE_ETERNAL
-    .with(|eternal| {
-      if let Some(key) = eternal.get(scope) {
-        Ok(key)
-      } else {
-        let key = VALUE.v8_string(scope).map_err(|e| {
-          WebIdlError::other(prefix.clone(), context.borrowed(), e)
-        })?;
-        eternal.set(scope, key);
-        Ok(key)
-      }
-    })?
+  let value_key = VALUE
+    .v8_string(scope)
+    .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))?
     .into();
 
   let mut len = 0;

--- a/libs/core/webidl.rs
+++ b/libs/core/webidl.rs
@@ -10,6 +10,8 @@ use indexmap::IndexMap;
 use v8::Local;
 use v8::Value;
 
+use crate::FastStaticString;
+
 #[derive(Debug, JsError)]
 #[class(type)]
 pub struct WebIdlError {
@@ -298,6 +300,23 @@ crate::v8_static_strings! {
   VALUE = "value",
 }
 
+/// Per-context cache of the `"next"`, `"done"`, and `"value"` property-name
+/// strings used by the sequence iterator protocol.
+///
+/// These are cached per-context (in [`crate::runtime::ContextState`]) rather
+/// than in a `thread_local`, because `v8` string handles are bound to the
+/// isolate that created them. `deno test` runs each test file in its own
+/// isolate on reused thread-pool threads, so a thread-local handle would
+/// dangle into a disposed isolate once a thread was reused, producing spurious
+/// "can not be converted to a sequence" errors and intermittent SIGSEGV. This
+/// mirrors how Blink keeps these strings per-isolate. See
+/// <https://github.com/denoland/deno/issues/35460>.
+pub(crate) struct WebIdlSequenceKeys {
+  pub(crate) next: v8::Global<v8::String>,
+  pub(crate) done: v8::Global<v8::String>,
+  pub(crate) value: v8::Global<v8::String>,
+}
+
 // helper for iterating over a sequence
 fn for_each_in_sequence<'a, 'b, 'i>(
   scope: &mut v8::PinScope<'a, 'i>,
@@ -334,29 +353,31 @@ fn for_each_in_sequence<'a, 'b, 'i>(
     ));
   };
 
-  // These keys must be materialized fresh for the current isolate on every
-  // call. They were previously cached in a `thread_local` `v8::Eternal`, but an
-  // `Eternal` handle is scoped to the isolate that created it. In `deno test`
-  // each test file runs in its own isolate, and those isolates are created on
-  // reused tokio blocking-pool threads, so a cached handle would dangle into a
-  // disposed isolate once a thread was reused. That manifested as spurious
-  // "can not be converted to a sequence" errors (and occasionally SIGSEGV)
-  // starting from the third test file. Re-creating the strings here is cheap:
-  // they are built once per sequence conversion, not once per element.
-  let next_key = NEXT
-    .v8_string(scope)
-    .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))?
-    .into();
-
-  let done_key = DONE
-    .v8_string(scope)
-    .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))?
-    .into();
-
-  let value_key = VALUE
-    .v8_string(scope)
-    .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))?
-    .into();
+  // The "next"/"done"/"value" iterator keys are cached per-context. They must
+  // not be cached in a `thread_local`, because the `v8::String` handles are
+  // bound to the isolate that created them: `deno test` reuses thread-pool
+  // threads across per-file isolates, so a thread-local handle would dangle
+  // into a disposed isolate (see `WebIdlSequenceKeys`). Materialize them lazily
+  // on the first sequence conversion in this context and reuse them afterwards.
+  let context_state = crate::runtime::JsRealm::state_from_scope(scope);
+  if context_state.webidl_sequence_keys.borrow().is_none() {
+    let make = |scope: &mut v8::PinScope<'a, 'i>, s: &FastStaticString| {
+      s.v8_string(scope)
+        .map(|str| v8::Global::new(scope, str))
+        .map_err(|e| WebIdlError::other(prefix.clone(), context.borrowed(), e))
+    };
+    let keys = WebIdlSequenceKeys {
+      next: make(scope, &NEXT)?,
+      done: make(scope, &DONE)?,
+      value: make(scope, &VALUE)?,
+    };
+    *context_state.webidl_sequence_keys.borrow_mut() = Some(keys);
+  }
+  let keys = context_state.webidl_sequence_keys.borrow();
+  let keys = keys.as_ref().unwrap();
+  let next_key = v8::Local::new(scope, &keys.next).into();
+  let done_key = v8::Local::new(scope, &keys.done).into();
+  let value_key = v8::Local::new(scope, &keys.value).into();
 
   let mut len = 0;
 

--- a/tests/specs/test/crypto_webidl_sequence_cross_isolate/__test__.jsonc
+++ b/tests/specs/test/crypto_webidl_sequence_cross_isolate/__test__.jsonc
@@ -1,0 +1,31 @@
+{
+  // Regression test for https://github.com/denoland/deno/issues/35460.
+  //
+  // Running three or more test files that each perform a SubtleCrypto
+  // operation taking a WebIDL `sequence` argument (the `keyUsages` of
+  // `importKey`) under `--no-check` used to fail from the third file onward
+  // with "Argument 5 can not be converted to a sequence" (and occasionally
+  // SIGSEGV). The native sequence converter cached the "next"/"done"/"value"
+  // property-name strings in a thread-local `v8::Eternal`, whose handles are
+  // bound to the isolate that created them. Each test file runs in its own
+  // isolate on a reused thread-pool thread, so a later file read a handle that
+  // dangled into a disposed isolate.
+  //
+  // The bug only reproduces once module transpilation is cached: a cold
+  // DENO_DIR does enough extra per-file work that the blocking-pool threads
+  // are not reused in the offending pattern. The first step below warms the
+  // cache; the second step runs against the warm cache, which is where the
+  // dangling handle was read. Both steps must report all five files passing.
+  "steps": [
+    {
+      "args": "test --no-check a.ts b.ts c.ts d.ts e.ts",
+      "exitCode": 0,
+      "output": "main.out"
+    },
+    {
+      "args": "test --no-check a.ts b.ts c.ts d.ts e.ts",
+      "exitCode": 0,
+      "output": "main.out"
+    }
+  ]
+}

--- a/tests/specs/test/crypto_webidl_sequence_cross_isolate/a.ts
+++ b/tests/specs/test/crypto_webidl_sequence_cross_isolate/a.ts
@@ -1,0 +1,12 @@
+// Each file performs a SubtleCrypto operation that takes a WebIDL `sequence`
+// argument (`keyUsages`). See ../../../../tests/specs/test/
+// crypto_webidl_sequence_cross_isolate/__test__.jsonc for context.
+Deno.test("importKey with a keyUsages sequence", async () => {
+  await crypto.subtle.importKey(
+    "raw",
+    new Uint8Array(16),
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+});

--- a/tests/specs/test/crypto_webidl_sequence_cross_isolate/b.ts
+++ b/tests/specs/test/crypto_webidl_sequence_cross_isolate/b.ts
@@ -1,0 +1,12 @@
+// Each file performs a SubtleCrypto operation that takes a WebIDL `sequence`
+// argument (`keyUsages`). See ../../../../tests/specs/test/
+// crypto_webidl_sequence_cross_isolate/__test__.jsonc for context.
+Deno.test("importKey with a keyUsages sequence", async () => {
+  await crypto.subtle.importKey(
+    "raw",
+    new Uint8Array(16),
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+});

--- a/tests/specs/test/crypto_webidl_sequence_cross_isolate/c.ts
+++ b/tests/specs/test/crypto_webidl_sequence_cross_isolate/c.ts
@@ -1,0 +1,12 @@
+// Each file performs a SubtleCrypto operation that takes a WebIDL `sequence`
+// argument (`keyUsages`). See ../../../../tests/specs/test/
+// crypto_webidl_sequence_cross_isolate/__test__.jsonc for context.
+Deno.test("importKey with a keyUsages sequence", async () => {
+  await crypto.subtle.importKey(
+    "raw",
+    new Uint8Array(16),
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+});

--- a/tests/specs/test/crypto_webidl_sequence_cross_isolate/d.ts
+++ b/tests/specs/test/crypto_webidl_sequence_cross_isolate/d.ts
@@ -1,0 +1,12 @@
+// Each file performs a SubtleCrypto operation that takes a WebIDL `sequence`
+// argument (`keyUsages`). See ../../../../tests/specs/test/
+// crypto_webidl_sequence_cross_isolate/__test__.jsonc for context.
+Deno.test("importKey with a keyUsages sequence", async () => {
+  await crypto.subtle.importKey(
+    "raw",
+    new Uint8Array(16),
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+});

--- a/tests/specs/test/crypto_webidl_sequence_cross_isolate/e.ts
+++ b/tests/specs/test/crypto_webidl_sequence_cross_isolate/e.ts
@@ -1,0 +1,12 @@
+// Each file performs a SubtleCrypto operation that takes a WebIDL `sequence`
+// argument (`keyUsages`). See ../../../../tests/specs/test/
+// crypto_webidl_sequence_cross_isolate/__test__.jsonc for context.
+Deno.test("importKey with a keyUsages sequence", async () => {
+  await crypto.subtle.importKey(
+    "raw",
+    new Uint8Array(16),
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+});

--- a/tests/specs/test/crypto_webidl_sequence_cross_isolate/main.out
+++ b/tests/specs/test/crypto_webidl_sequence_cross_isolate/main.out
@@ -1,0 +1,3 @@
+[WILDCARD]
+ok | 5 passed | 0 failed ([WILDCARD])
+


### PR DESCRIPTION
The Rust WebIDL sequence converter cached the `"next"`, `"done"`, and
`"value"` property-name strings in a thread-local `v8::Eternal`. Those
handles are bound to the isolate that created them, but the thread-local
cache outlives any single isolate. `deno test` runs each test file in its
own isolate on reused tokio blocking-pool threads, and `--watch` recreates
the isolate on the same thread after a reload, so a later run would read a
handle that dangled into an already-disposed isolate. That surfaced as a
spurious `TypeError: ... can not be converted to a sequence` (and
intermittently a SIGSEGV), while the JS-visible iterator machinery in that
realm remained perfectly healthy.

The latent bug was exposed once WebIDL `sequence` arguments started flowing
through this native converter, e.g. `keyUsages` on `SubtleCrypto.importKey`
/ `generateKey`, and `requiredFeatures` on `GPUAdapter.requestDevice`, so
the regression showed up on canary under `deno test --no-check` and under
`--watch`.

Rather than dropping the cache, this keeps it but moves it from the
thread-local to a per-context cache in `ContextState`, mirroring how Blink
keeps these strings per-isolate. The keys are materialized lazily on the
first sequence conversion in a context and reused afterwards, so the
optimization is preserved while staying sound across per-file isolates that
share a reused thread.

The bug only reproduces once module transpilation is cached (a cold
DENO_DIR does enough extra per-file work that the offending thread reuse
does not happen), so the spec test runs five crypto test files twice over a
warm cache, which is the configuration that reliably reproduced the
dangling handle.

Fixes #35460
Fixes #32828