### PR TITLE
chore: bump libsui to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6640,9 +6640,9 @@ dependencies = [
 
 [[package]]
 name = "libsui"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af25036f57ea101cca401af0769d705cb5380181f9b1fe674c0e890a194eb03"
+checksum = "3a0350f185d562954a521d1fcaffd621559ea0b707143ef53b599f1e665b97b5"
 dependencies = [
  "editpe",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ imara-diff = "=0.2.0"
 lax-css = "=0.2.4"
 lax-markup = "=0.2.5"
 lax-sql = "=0.2.1"
-libsui = "=0.15.0"
+libsui = "=0.16.0"
 malva = "=0.15.2"
 markup_fmt = "=0.27.3"
 object = { version = "0.36.3", default-features = false, features = ["read_core", "pe"] }


### PR DESCRIPTION
Bumps `libsui` 0.15.0 → 0.16.0.

## Why

Fixes the `deno desktop` "no window" hang on Linux (#35381).

`deno desktop` embeds the app's metadata into the compiled runtime `.so` via `libsui::Elf::append`. In 0.15.0 `append` placed the `.note.sui` section at a virtual address derived from its **file** offset, ignoring that a trailing `.bss` (`SHT_NOBITS`) makes the carrier `PT_LOAD`'s **memory** image larger than its file image. On a binary whose `.bss` is large enough to cross the placement boundary — e.g. the CI-built `libdenort.so` (glibc-2.27 sysroot) — the note's mapped range landed **inside** `.bss`. At startup the zero-initialized globals aliased the embedded metadata:

- `find_section` read corrupted bytes → `control character (\^@-\^_) found while parsing a string`, or
- a futex deadlock during `dlopen` static init → hang, no window, before `Deno.serve` ran.

Small binaries (a local debug `libdenort.so`) have a different `.bss` layout that doesn't cross the boundary, which is why the `DENORT_DESKTOP_BIN=…/libdenort.so` workaround in the issue worked.

## Fix (in libsui 0.16.0)

- Place the appended note past the carrier segment's **whole memory image** (`p_offset + p_memsz`), so its derived vaddr always clears `.bss` (denoland/sui#70).
- Rewrite `append` to add the note **in-place** so RELR relative relocations are preserved (denoland/sui#72).

Regression test in libsui inflates a fixture's `.bss` and asserts the note's mapped range overlaps no allocated section (fails on 0.15.0, passes on 0.16.0).

No deno code changes — the `libsui` API is unchanged.

Note: the earlier `libc++abi: __cxa_guard_acquire` crash from the same issue was already fixed in #35424.

Closes #35381