### PR TITLE
fix(desktop): add Bluetooth usage descriptions to macOS Info.plist

### DIFF
--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -2752,6 +2752,10 @@ async fn package_macos_app_bundle(
     <key>NSAllowsLocalNetworking</key>
     <true/>
   </dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>{app_name} requires access to bluetooth</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>{app_name} requires access to bluetooth</string>
 </dict>
 </plist>
 "#,


### PR DESCRIPTION
Fixes issue: [35471](https://github.com/denoland/deno/issues/35471)

macOS kills `deno desktop` apps when the embedded CEF engine touches
Bluetooth without `NSBluetoothAlwaysUsageDescription` in the bundle
`Info.plist` (TCC crash: `__TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__`).

This can be reproduced when loading sites that trigger Bluetooth probing
during OAuth flows (e.g. Google sign-in on an external URL).

Add `NSBluetoothAlwaysUsageDescription` and
`NSBluetoothPeripheralUsageDescription` to the main app `Info.plist`
template generated in `assemble_macos_app_bundle`.

## AI disclosure
AI tools (Cursor) were used to help identify the crash cause, locate
the `Info.plist` generation site in `cli/tools/desktop.rs`.
The code change was reviewed manually.

## Test plan
- [ ] `./x fmt` passes
- [ ] `./x lint` passes
- [ ] Build a macOS desktop app (`deno desktop main.js`)
- [ ] Confirm `YourAppName.app/Contents/Info.plist` contains both Bluetooth keys
- [ ] Open an external HTTPS URL with Google sign-in; app no longer crashes
      after sign-in (manual test on macOS)