### PR TITLE
perf(core/webidl): check `next` method outside of iterator loop

### DIFF
--- a/libs/core/webidl.rs
+++ b/libs/core/webidl.rs
@@ -1681,7 +1681,11 @@ mod tests {
       &Default::default(),
     )
     .unwrap_err();
-    assert!(err.to_string().contains("Expected next() function on iterator."));
+    assert!(
+      err
+        .to_string()
+        .contains("Expected next() function on iterator.")
+    );
   }
 
   #[test]

--- a/libs/core/webidl.rs
+++ b/libs/core/webidl.rs
@@ -6,11 +6,13 @@ use std::mem::MaybeUninit;
 use std::ops::Deref;
 
 use deno_error::JsError;
+use deno_error::JsErrorBox;
 use indexmap::IndexMap;
 use v8::Local;
 use v8::Value;
 
 use crate::FastStaticString;
+use crate::error::exception_to_err;
 
 #[derive(Debug, JsError)]
 #[class(type)]
@@ -379,13 +381,54 @@ fn for_each_in_sequence<'a, 'b, 'i>(
   let done_key = v8::Local::new(scope, &keys.done).into();
   let value_key = v8::Local::new(scope, &keys.value).into();
 
+  // Match GetIteratorFromMethod's Iterator Record by reading `next` once and
+  // reusing that nextMethod for the rest of the iteration.
+  // https://tc39.es/ecma262/#sec-getiteratorfrommethod
+  let next_method = {
+    // Read `iterator.next` under `TryCatch` so an exception thrown by a getter
+    // is preserved and converted into the original JS error.
+    v8::tc_scope!(let tc_scope, scope);
+    match iter.get(tc_scope, next_key) {
+      Some(next_method) => Ok(v8::Global::new(tc_scope, next_method)),
+      None => {
+        if tc_scope.has_caught() {
+          let exception = tc_scope.exception().unwrap();
+          Err(WebIdlError::other(
+            prefix.clone(),
+            context.borrowed(),
+            exception_to_err(tc_scope, exception, false, false),
+          ))
+        } else {
+          // This fallback is only kept for the unlikely case where V8 returns
+          // an empty `MaybeLocal` without surfacing an exception.
+          Err(WebIdlError::other(
+            prefix.clone(),
+            context.borrowed(),
+            JsErrorBox::type_error("Failed to read iterator.next."),
+          ))
+        }
+      }
+    }
+  }?;
+  // The `TryCatch` scope above cannot outlive this block, so keep the value in
+  // a `Global` and reopen it in the outer scope before validating/calling it.
+  let next_method = v8::Local::new(scope, next_method);
+  // TODO: Keep this as a `v8::Value` like an ECMAScript
+  // Iterator Record's [[NextMethod]], and defer the callable check to the call
+  // site so `for_each_in_sequence()` can mirror IteratorNext more closely.
+  let next_method = next_method.try_cast::<v8::Function>().map_err(|_| {
+    WebIdlError::other(
+      prefix.clone(),
+      context.borrowed(),
+      JsErrorBox::type_error("Expected next() function on iterator."),
+    )
+  })?;
+
   let mut len = 0;
 
   loop {
-    let Some(res) = iter
-      .get(scope, next_key)
-      .and_then(|next| next.try_cast::<v8::Function>().ok())
-      .and_then(|next| next.call(scope, iter.cast(), &[]))
+    let Some(res) = next_method
+      .call(scope, iter.cast(), &[])
       .and_then(|res| res.to_object(scope))
     else {
       return Err(WebIdlError::new(
@@ -1610,6 +1653,70 @@ mod tests {
       &Default::default(),
     );
     assert_eq!(converted.unwrap(), vec![1, 2]);
+  }
+
+  #[test]
+  fn sequence_next_method_must_be_callable() {
+    let mut runtime = JsRuntime::new(Default::default());
+    let val = runtime
+      .execute_script(
+        "",
+        r#"
+        ({
+          [Symbol.iterator]() {
+            return { next: 1 };
+          },
+        })
+        "#,
+      )
+      .unwrap();
+
+    deno_core::scope!(scope, runtime);
+    let val = Local::new(scope, val);
+    let err = Vec::<u8>::convert(
+      scope,
+      val,
+      "prefix".into(),
+      (|| "context".into()).into(),
+      &Default::default(),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("Expected next() function on iterator."));
+  }
+
+  #[test]
+  fn sequence_propagates_next_getter_exception() {
+    let mut runtime = JsRuntime::new(Default::default());
+    let val = runtime
+      .execute_script(
+        "",
+        r#"
+        ({
+          [Symbol.iterator]() {
+            return {
+              get next() {
+                throw new TypeError("boom");
+              },
+            };
+          },
+        })
+        "#,
+      )
+      .unwrap();
+
+    let err = {
+      deno_core::scope!(scope, runtime);
+      let val = Local::new(scope, val);
+      Vec::<u8>::convert(
+        scope,
+        val,
+        "prefix".into(),
+        (|| "context".into()).into(),
+        &Default::default(),
+      )
+      .unwrap_err()
+    };
+    assert!(err.to_string().contains("boom"));
   }
 
   #[test]

--- a/libs/core/webidl.rs
+++ b/libs/core/webidl.rs
@@ -1724,6 +1724,62 @@ mod tests {
   }
 
   #[test]
+  fn sequence_caches_next_method() {
+    let mut runtime = JsRuntime::new(Default::default());
+    let val = runtime
+      .execute_script(
+        "",
+        r#"
+        globalThis.nextReads = 0;
+        ({
+          [Symbol.iterator]() {
+            let index = 0;
+            return {
+              get next() {
+                // Regression guard: old behavior re-read `next` on each loop.
+                if (++globalThis.nextReads > 1) {
+                  throw new Error("next getter called twice");
+                }
+                return () => {
+                  index++;
+                  if (index === 1) {
+                    return { done: false, value: 1 };
+                  }
+                  if (index === 2) {
+                    return { done: false, value: 2 };
+                  }
+                  return { done: true, value: undefined };
+                };
+              },
+            };
+          },
+        })
+        "#,
+      )
+      .unwrap();
+
+    let converted = {
+      deno_core::scope!(scope, runtime);
+      let val = Local::new(scope, val);
+      Vec::<u8>::convert(
+        scope,
+        val,
+        "prefix".into(),
+        (|| "context".into()).into(),
+        &Default::default(),
+      )
+      .unwrap()
+    };
+    assert_eq!(converted, vec![1, 2]);
+
+    let next_reads =
+      runtime.execute_script("", "globalThis.nextReads").unwrap();
+    deno_core::scope!(scope, runtime);
+    let next_reads = Local::new(scope, next_reads);
+    assert_eq!(next_reads.uint32_value(scope).unwrap(), 1);
+  }
+
+  #[test]
   fn constrained_sequence_one_of() {
     let mut runtime = JsRuntime::new(Default::default());
     deno_core::scope!(scope, runtime);

--- a/libs/core/webidl.rs
+++ b/libs/core/webidl.rs
@@ -1724,7 +1724,7 @@ mod tests {
   }
 
   #[test]
-  fn sequence_caches_next_method() {
+  fn sequence_check_next_method_once() {
     let mut runtime = JsRuntime::new(Default::default());
     let val = runtime
       .execute_script(


### PR DESCRIPTION
According to the ECMAScript spec, the iterator's `next` method should be looked up once and then reused for the rest of the iteration. This change makes some API faster which required a WebIDL sequence.

| benchmark | avg (main -> PR) | avg Δ | avg speedup | p75 (main -> PR) | p75 Δ | p75 speedup | p99 (main -> PR) | p99 Δ | p99 speedup |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 2d-sequence | 789.3 ns -> 670.8 ns | -15.0% | 1.18x | 790.0 ns -> 672.3 ns | -14.9% | 1.18x | 920.0 ns -> 783.5 ns | -14.8% | 1.17x |
| 2d-sequence-readonly | 784.8 ns -> 666.2 ns | -15.1% | 1.18x | 786.1 ns -> 668.1 ns | -15.0% | 1.18x | 861.9 ns -> 750.8 ns | -12.9% | 1.15x |
| 3d-sequence | 1.71 µs -> 1.36 µs | -20.6% | 1.26x | 1.72 µs -> 1.37 µs | -20.6% | 1.26x | 1.74 µs -> 1.38 µs | -20.9% | 1.26x |
| 3d-sequence-readonly | 1.70 µs -> 1.35 µs | -20.7% | 1.26x | 1.71 µs -> 1.35 µs | -20.8% | 1.26x | 1.73 µs -> 1.37 µs | -20.7% | 1.26x |

<details><summary>matrix.ts</summary>
<p>

```ts
// deno-fmt-ignore
const seq2d = [1, 0, 0, 1, 10, 20];

Deno.bench("2d-sequence", () => {
  new DOMMatrix(seq2d);
});

Deno.bench("2d-sequence-readonly", () => {
  new DOMMatrixReadOnly(seq2d);
});

// deno-fmt-ignore
const seq3d = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1];

Deno.bench("3d-sequence", () => {
  new DOMMatrix(seq3d);
});

Deno.bench("3d-sequence-readonly", () => {
  new DOMMatrixReadOnly(seq3d);
});
```

</p>
</details> 

AI assistance disclosure: This PR was prepared with help from OpenAI Codex.