### PR TITLE
fix(desktop): use native Wayland instead of XWayland on Wayland systems

### DIFF
--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -1359,10 +1359,7 @@ async fn package_linux_app_dir(
   std::fs::copy(dylib_path, &dest_dylib)?;
 
   // Create a shell launcher that invokes the backend with --runtime.
-  // --ozone-platform=x11 forces CEF to create X11 windows (via XWayland on
-  // Wayland sessions). The Linux LAUFEY mouse/focus/resize event monitor uses
-  // XI2 on X11 and does not support Wayland.
-  // GDK_BACKEND=x11 aligns GDK with Ozone so GDK_IS_X11_DISPLAY is true.
+  // laufey auto-detects Wayland vs X11 at runtime.
   //
   // Validate every name we interpolate: bash expands `$VAR`, backticks,
   // and `$(...)` even inside `"..."`.
@@ -1376,8 +1373,7 @@ async fn package_linux_app_dir(
     format!(
       "#!/bin/sh\n\
        DIR=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\n\
-       export GDK_BACKEND=x11\n\
-       exec \"$DIR/{laufey_binary}\" --ozone-platform=x11 --runtime \"$DIR/{dylib}\" \"$@\"\n",
+       exec \"$DIR/{laufey_binary}\" --runtime \"$DIR/{dylib}\" \"$@\"\n",
       laufey_binary = laufey_binary_name,
       dylib = dylib_filename_str,
     ),


### PR DESCRIPTION
(Fixed and wrote by DS flash4)
Fixes #35483

The Linux app launcher was hard-forcing `GDK_BACKEND=x11` and `--ozone-platform=x11`, which forced desktop apps through XWayland on Wayland systems even though laufey v0.4.0 supports native Wayland on all three backends:

- **webview (WebKitGTK)**: uses GDK signals (`on_button_event`, `on_motion_event`, etc.) - no XI2 code, works on both X11 and Wayland
- **CEF**: XI2 monitor is guarded by `GDK_IS_X11_DISPLAY` (skips on Wayland); `OnBeforeCommandLineProcessing` auto-selects Wayland when `WAYLAND_DISPLAY` is set
- **winit**: full native Wayland via winit

`--hmr` mode already launches the backend without these flags, proving auto-detection works. This brings normal mode in line with HMR mode.