### PR TITLE
feat(http): disable Deno.serve automatic compression by default

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -824,7 +824,7 @@ static ENV_VARS: &[EnvVar] = &[
   },
   EnvVar {
     name: "DENO_SERVE_AUTOMATIC_COMPRESSION",
-    description: "Set to 0 or false to disable automatic response body compression in Deno.serve by default.",
+    description: "Set to 1 or true to enable automatic response body compression in Deno.serve by default.",
     example: None,
   },
   EnvVar {

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5749,7 +5749,7 @@ declare namespace Deno {
      * Whether to automatically compress response bodies when the client accepts
      * a supported encoding and the response is compressible.
      *
-     * @default {true}
+     * @default {false}
      */
     automaticCompression?: boolean;
   }

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -180,7 +180,7 @@ static OTEL_COLLECTORS: OnceCell<OtelCollectors> = OnceCell::new();
 
 const HTTP2_PREFIX: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Options {
   /// By passing a hook function, the caller can customize various configuration
   /// options for the HTTP/2 server.
@@ -196,16 +196,6 @@ pub struct Options {
 
   /// If `true`, responses may be compressed based on request and response headers.
   pub automatic_compression: bool,
-}
-
-impl Default for Options {
-  fn default() -> Self {
-    Self {
-      http2_builder_hook: None,
-      no_legacy_abort: false,
-      automatic_compression: true,
-    }
-  }
 }
 
 #[cfg(not(feature = "default_property_extractor"))]
@@ -1860,7 +1850,7 @@ pub fn op_http_serve_address_override() -> (u8, String, u32, bool) {
 pub fn op_http_serve_default_compression() -> bool {
   match std::env::var("DENO_SERVE_AUTOMATIC_COMPRESSION") {
     Ok(value) => !matches!(value.to_ascii_lowercase().as_str(), "0" | "false"),
-    Err(_) => true,
+    Err(_) => false,
   }
 }
 

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -3581,6 +3581,7 @@ for (const testCase of compressionTestCases) {
         const listeningDeferred = Promise.withResolvers<void>();
         const ac = new AbortController();
         await using server = Deno.serve({
+          automaticCompression: true,
           handler: async (_request) => {
             const f = await makeTempFile(testCase.length);
             deferred.resolve();
@@ -3642,6 +3643,7 @@ Deno.test(
     const ac = new AbortController();
 
     await using server = Deno.serve({
+      automaticCompression: true,
       handler: () => {
         return new Response(body, {
           headers: { "content-type": "text/plain" },
@@ -3670,14 +3672,13 @@ Deno.test(
 
 Deno.test(
   { permissions: { net: true } },
-  async function httpServerAutomaticCompressionCanBeDisabled() {
+  async function httpServerAutomaticCompressionOffByDefault() {
     const body = "a".repeat(1000);
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
     await using server = Deno.serve({
-      automaticCompression: false,
-      handler: () => {
+      handler: (_request) => {
         return new Response(body, {
           headers: { "content-type": "text/plain" },
         });
@@ -3746,6 +3747,7 @@ Deno.test(
     const ac = new AbortController();
 
     await using server = Deno.serve({
+      automaticCompression: true,
       handler: (_request) => {
         return new Response(body, {
           headers: { "content-type": "text/plain" },
@@ -3816,6 +3818,7 @@ Deno.test(
           }
 
           await check({});
+          await check({ automaticCompression: false });
           await check({ automaticCompression: true });
         `,
         ],
@@ -3828,11 +3831,23 @@ Deno.test(
       return new TextDecoder().decode(stdout).trim().split("\n");
     }
 
+    assertEquals(await run("1"), [
+      "gzip",
+      "none",
+      "gzip",
+    ]);
+    assertEquals(await run("true"), [
+      "gzip",
+      "none",
+      "gzip",
+    ]);
     assertEquals(await run("0"), [
+      "none",
       "none",
       "gzip",
     ]);
     assertEquals(await run("False"), [
+      "none",
       "none",
       "gzip",
     ]);
@@ -3847,6 +3862,7 @@ Deno.test(
     const ac = new AbortController();
 
     await using server = Deno.serve({
+      automaticCompression: true,
       handler: () => {
         return new Response(body, {
           headers: { "content-type": "text/plain" },


### PR DESCRIPTION
## Summary

This changes `Deno.serve` so automatic response compression is off by default.

- flips the runtime default for `automatic_compression` to `false`
- keeps explicit `automaticCompression: true` as the opt-in path
- updates `DENO_SERVE_AUTOMATIC_COMPRESSION` docs so `1`/`true` enable compression by default
- updates the `Deno.serve` type docs to show `automaticCompression` defaults to `false`
- adjusts serve tests so compression behavior coverage opts in explicitly, and adds/updates coverage for default-off and env-var behavior

## Validation

- `./tools/format.js cli/args/flags.rs ext/http/lib.rs tests/unit/serve_test.ts cli/tsc/dts/lib.deno.ns.d.ts`
- `cargo test -p deno_http compression_tests`
- `cargo test unit::serve_test -- httpServerAutomaticCompression --nocapture`