### PR TITLE
fix(ext/http): apply automatic compression for zero-arg serve handlers

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -506,6 +506,37 @@ impl RawRequestHeaders {
     }
   }
 
+  /// Builds a minimal header set containing only the `accept-encoding`
+  /// header(s). Used by the zero-arg "no request" fast path, where the full
+  /// request is never exposed to JS but the response path still needs
+  /// `accept-encoding` to decide automatic compression.
+  fn from_h1_accept_encoding(headers: &[h1::Header<'_>]) -> Self {
+    let mut bytes = Vec::new();
+    let mut entries = Vec::new();
+    for header in headers {
+      if !header.name.eq_ignore_ascii_case(b"accept-encoding") {
+        continue;
+      }
+      let name_start = bytes.len();
+      bytes.extend_from_slice(header.name);
+      let value_start = bytes.len();
+      bytes.extend_from_slice(header.value);
+      entries.push(RawRequestHeader {
+        name_start,
+        name_len: header.name.len(),
+        value_start,
+        value_len: header.value.len(),
+      });
+    }
+    Self {
+      bytes,
+      entries,
+      host_index: None,
+      authorization_index: None,
+      authorization_multiple: false,
+    }
+  }
+
   fn len(&self) -> usize {
     self.entries.len()
   }
@@ -3294,9 +3325,14 @@ fn raw_request_target_to_string(target: &[u8]) -> String {
 fn raw_request_from_h1(
   request: h1::Request<'_>,
   store_request: bool,
+  automatic_compression: bool,
 ) -> RawParsedRequest {
   let headers = if store_request {
     RawRequestHeaders::from_h1(request.headers)
+  } else if automatic_compression {
+    // The full request isn't exposed to JS on the zero-arg fast path, but the
+    // response path still needs `accept-encoding` to decide compression.
+    RawRequestHeaders::from_h1_accept_encoding(request.headers)
   } else {
     RawRequestHeaders::empty()
   };
@@ -4268,7 +4304,7 @@ async fn serve_http11_raw(
   loop {
     let next_request = poll_fn(|cx| {
       conn.poll_next_request_with(cx, &mut scratch, |request| {
-        raw_request_from_h1(request, store_request)
+        raw_request_from_h1(request, store_request, automatic_compression)
       })
     })
     .or_cancel(cancel.clone())

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -3636,11 +3636,14 @@ for (const testCase of compressionTestCases) {
 
 Deno.test(
   { permissions: { net: true } },
-  async function httpServerAutomaticCompressionSkippedForNoRequestFastPath() {
+  async function httpServerAutomaticCompressionAppliesForNoRequestFastPath() {
     const body = "a".repeat(1000);
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
+    // A zero-argument handler takes the native "no request" fast path, where
+    // the request is never exposed to JS. Automatic compression must still
+    // apply: `accept-encoding` is retained so the response can be compressed.
     await using server = Deno.serve({
       handler: () => {
         return new Response(body, {
@@ -3659,8 +3662,8 @@ Deno.test(
         headers: { "accept-encoding": "gzip" },
       });
       assertEquals(await resp.text(), body);
-      assertEquals(resp.headers.get("content-encoding"), null);
-      assertEquals(resp.headers.get("vary"), null);
+      assertEquals(resp.headers.get("content-encoding"), "gzip");
+      assertEquals(resp.headers.get("vary"), "Accept-Encoding");
     } finally {
       ac.abort();
       await server.finished;


### PR DESCRIPTION
A `Deno.serve` handler that takes **zero arguments** uses the native "no
request" fast path, where the `Request` object is never materialized for JS.
On that path the HTTP/1.1 server discarded all request headers
(`RawRequestHeaders::empty()`), but automatic compression is decided by reading
`accept-encoding` from the stored request headers. With the headers gone,
`raw_request_compression` always returned `Compression::None`, so responses
from zero-arg handlers were never compressed — even when the client supported
gzip/brotli and the body was compressible.

This retains just the `accept-encoding` header on the fast path (when automatic
compression is enabled), so the compression decision works while still avoiding
the full request-header copy / `Request` materialization. When automatic
compression is disabled, the headers are still skipped entirely as before.

### Repro

```ts
// zero-arg handler -> native fast path
Deno.serve(() => new Response("compress me ".repeat(200)));
```

```
$ curl -s -H 'accept-encoding: gzip, br' -D - localhost:PORT -o /dev/null
# before: no content-encoding
# after:  content-encoding: br
```

### Tests

The existing `httpServerAutomaticCompressionSkippedForNoRequestFastPath` test
actually encoded the bug (it asserted compression was *skipped*). It's rewritten
as `httpServerAutomaticCompressionAppliesForNoRequestFastPath`, asserting
`content-encoding: gzip` and `vary: Accept-Encoding`. The `automaticCompression:
false` tests continue to assert no compression.
