### PR TITLE
perf(ext/fetch): fast-path Response reconstruction

### DIFF
--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -219,6 +219,27 @@ function appendHeaderToList(list, name, value) {
 // Used by constructors to initialize a fresh list. This intentionally appends
 // directly to `list`; callers must not use it to mutate guarded Headers.
 function fillHeaderList(list, object, prefix, context, opts) {
+  // Fast path: initializing from an existing `Headers` object, e.g.
+  // `new Response(body, otherResponse)` / `new Request(input, { headers })` /
+  // `new Headers(headers)`. This is extremely common (frameworks reconstruct
+  // responses just to tweak a header). The source's entries are already
+  // validated byte strings, so copy them directly and skip the expensive
+  // webidl `sequence<sequence<ByteString>>` conversion plus per-entry
+  // revalidation. `_iterableHeaders` yields the same combined+sorted entries
+  // the slow path would produce, so the result is identical.
+  if (ObjectPrototypeIsPrototypeOf(HeadersPrototype, object)) {
+    // `_iterableHeaders` yields already-combined, sorted, lowercased and
+    // validated entries (one per name, except set-cookie), which is exactly the
+    // shape `fillHeaderList` builds for a fresh list -- so push them straight in
+    // and skip both the webidl conversion and `appendHeaderToList`'s per-entry
+    // revalidation and casing dedup.
+    const entries = object[_iterableHeaders];
+    for (let i = 0; i < entries.length; ++i) {
+      const entry = entries[i];
+      ArrayPrototypePush(list, [entry[0], entry[1]]);
+    }
+    return;
+  }
   if (ArrayIsArray(object)) {
     for (let i = 0; i < object.length; ++i) {
       const header = webidlConverterSequenceByteString(

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -45,6 +45,7 @@ const mimesniff = core.loadExtScript("ext:deno_web/01_mimesniff.js");
 const { BlobPrototype } = core.loadExtScript("ext:deno_web/09_file.js");
 const {
   createProxy,
+  createReadableStream,
   errorReadableStream,
   isReadableStreamDisturbed,
   readableStreamClose,
@@ -55,8 +56,18 @@ const {
   readableStreamThrowIfErrored,
 } = core.loadExtScript("ext:deno_web/06_streams.js");
 
+const noop = () => {};
+
 /** @type {WeakMap<ReadableStream<Uint8Array>, number>} */
 const staticBodyLength = new SafeWeakMap();
+
+// Maps a ReadableStream that was materialized from a static body (a string or
+// Uint8Array passed to `new Response(...)` / `new Request(...)`) back to that
+// original static body. This lets `extractBody` recover the static body when a
+// body stream is round-tripped through a new Response/Request without being
+// read, preserving the fast (Content-Length, single-write) response path.
+/** @type {WeakMap<ReadableStream<Uint8Array>, Uint8Array | string>} */
+const staticBodySource = new SafeWeakMap();
 
 /**
  * @param {Uint8Array | string} chunk
@@ -103,15 +114,27 @@ class InnerBody {
         readableStreamClose(this.streamOrStatic);
       } else {
         const length = this.length;
-        const stream = new ReadableStream({
-          start(controller) {
+        // Materialize the static body into a stream lazily. With a high water
+        // mark of 0 the body is only encoded/enqueued once the stream is
+        // actually read. The very common pattern of round-tripping a body
+        // through a new Response/Request just to mutate headers recovers the
+        // static body in `extractBody` (below) and never reads this stream, so
+        // the encode is skipped entirely. `createReadableStream` also avoids
+        // the webidl UnderlyingSource conversion `new ReadableStream({...})`
+        // performs.
+        const stream = createReadableStream(
+          noop,
+          (controller) => {
             controller.enqueue(chunkToU8(body));
             controller.close();
           },
-        });
+          noop,
+          0,
+        );
         if (length !== null) {
           WeakMapPrototypeSet(staticBodyLength, stream, length);
         }
+        WeakMapPrototypeSet(staticBodySource, stream, body);
         this.streamOrStatic = stream;
       }
     }
@@ -482,10 +505,22 @@ function extractBody(object) {
     source = object.toString();
     contentType = "application/x-www-form-urlencoded;charset=UTF-8";
   } else if (ObjectPrototypeIsPrototypeOf(ReadableStreamPrototype, object)) {
-    stream = object;
-    length = WeakMapPrototypeGet(staticBodyLength, object) ?? null;
     if (object.locked || isReadableStreamDisturbed(object)) {
       throw new TypeError("ReadableStream is locked or disturbed");
+    }
+    // Fast path: this stream was materialized from a static body and has not
+    // been read. A common framework pattern (e.g. Hono middleware) is to
+    // reconstruct a response via `new Response(oldResponse.body, oldResponse)`
+    // just to mutate headers. Without recovering the static body, the
+    // reconstructed body would be served through the streaming (chunked) path,
+    // losing Content-Length and the single-write fast response op. Recover the
+    // original static body so the fast path is preserved.
+    const recoveredSource = WeakMapPrototypeGet(staticBodySource, object);
+    if (recoveredSource !== undefined) {
+      source = recoveredSource;
+    } else {
+      stream = object;
+      length = WeakMapPrototypeGet(staticBodyLength, object) ?? null;
     }
   } else if (object[webidl.AsyncIterable] === webidl.AsyncIterable) {
     // If the underlying body is a Node `Readable` running in binary mode

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -18,6 +18,7 @@ const {
   ObjectDefineProperties,
   ObjectPrototypeIsPrototypeOf,
   PromisePrototypeCatch,
+  PromiseResolve,
   SafeWeakMap,
   TypedArrayPrototypeGetBuffer,
   TypedArrayPrototypeGetByteLength,
@@ -57,6 +58,7 @@ const {
 } = core.loadExtScript("ext:deno_web/06_streams.js");
 
 const noop = () => {};
+const noopAsync = async () => {};
 
 /** @type {WeakMap<ReadableStream<Uint8Array>, number>} */
 const staticBodyLength = new SafeWeakMap();
@@ -122,13 +124,17 @@ class InnerBody {
         // the encode is skipped entirely. `createReadableStream` also avoids
         // the webidl UnderlyingSource conversion `new ReadableStream({...})`
         // performs.
+        // The pull and cancel algorithms must return promises (see
+        // `createReadableStream`): `readableStreamCancel` and the controller's
+        // pull machinery call `.then` on the returned value directly.
         const stream = createReadableStream(
           noop,
           (controller) => {
             controller.enqueue(chunkToU8(body));
             controller.close();
+            return PromiseResolve(undefined);
           },
-          noop,
+          noopAsync,
           0,
         );
         if (length !== null) {

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -515,12 +515,24 @@ function extractBody(object) {
     // reconstructed body would be served through the streaming (chunked) path,
     // losing Content-Length and the single-write fast response op. Recover the
     // original static body so the fast path is preserved.
+    //
+    // Only recover when the resulting length matches the original body's
+    // known-length semantics: a string source's byte length is genuinely known
+    // (just deferred to avoid an eager encode), and a Uint8Array source is only
+    // known-length if `staticBodyLength` was recorded for it. Recovering a
+    // Uint8Array whose length was *unknown* (e.g. a chunked request body the
+    // server buffered) would wrongly synthesize a Content-Length when the body
+    // is later sent, so leave those as a stream.
     const recoveredSource = WeakMapPrototypeGet(staticBodySource, object);
-    if (recoveredSource !== undefined) {
+    const knownLength = WeakMapPrototypeGet(staticBodyLength, object);
+    if (
+      recoveredSource !== undefined &&
+      (typeof recoveredSource === "string" || knownLength !== undefined)
+    ) {
       source = recoveredSource;
     } else {
       stream = object;
-      length = WeakMapPrototypeGet(staticBodyLength, object) ?? null;
+      length = knownLength ?? null;
     }
   } else if (object[webidl.AsyncIterable] === webidl.AsyncIterable) {
     // If the underlying body is a Node `Readable` running in binary mode

--- a/tests/unit/http_test.ts
+++ b/tests/unit/http_test.ts
@@ -548,10 +548,19 @@ Deno.test(
   { permissions: { net: true } },
   // Issue: https://github.com/denoland/deno/issues/10870
   async function httpServerHang() {
-    // Quick and dirty way to make a readable stream from a string. Alternatively,
-    // `readableStreamFromReader(file)` could be used.
+    // A genuinely-opaque streaming body (unknown length -> chunked response),
+    // which is what this test exercises. Note: `new Response(s).body` can no
+    // longer be used here -- a body stream materialized from a static string is
+    // now recovered to a fixed-length body, so it would be sent with a
+    // Content-Length and skip the streaming path this test targets.
     function stream(s: string): ReadableStream<Uint8Array> {
-      return new Response(s).body!;
+      const bytes = new TextEncoder().encode(s);
+      return new ReadableStream({
+        pull(controller) {
+          controller.enqueue(bytes);
+          controller.close();
+        },
+      });
     }
 
     // deno-lint-ignore no-explicit-any

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -3054,10 +3054,21 @@ function createServerLengthTest(name: string, testCase: TestCase) {
   });
 }
 
-// Quick and dirty way to make a readable stream from a string. Alternatively,
-// `readableStreamFromReader(file)` could be used.
+// Make a genuinely-opaque readable stream from a string, i.e. one whose total
+// length is not known ahead of time. Note: `new Response(s).body` can no longer
+// be used here -- a body stream materialized from a static string is now
+// recovered and served with a Content-Length (see `recoveredStaticStreamBody`
+// below), so it would no longer exercise the chunked path these tests target.
 function stream(s: string): ReadableStream<Uint8Array> {
-  return new Response(s).body!;
+  const bytes = new TextEncoder().encode(s);
+  return new ReadableStream({
+    pull(controller) {
+      if (bytes.byteLength > 0) {
+        controller.enqueue(bytes);
+      }
+      controller.close();
+    },
+  });
 }
 
 createServerLengthTest("fixedResponseKnown", {
@@ -3124,6 +3135,16 @@ createServerLengthTest("autoResponseWithUnknownLengthEmpty", {
   body: stream(""),
   expectsChunked: true,
   expectsConnLen: false,
+});
+
+// A body stream that was materialized from a static string and not read (the
+// common `new Response(oldResponse.body, oldResponse)` framework pattern, e.g.
+// Hono header middleware) is recovered to its static body and served on the
+// fast path with a Content-Length, rather than being downgraded to chunked.
+createServerLengthTest("recoveredStaticStreamBody", {
+  body: new Response("foo bar baz").body!,
+  expectsChunked: false,
+  expectsConnLen: true,
 });
 
 Deno.test(


### PR DESCRIPTION
## Summary

A trivial [Hono](https://hono.dev) app served through `Deno.serve` left a lot of throughput on the table and emitted `transfer-encoding: chunked` where a fixed `Content-Length` was possible:

```ts
const app = new Hono();
app.use("*", async (c, next) => {
  await next();
  c.header("x-powered-by", "hono");
});
app.get("/", (c) => c.json({ hello: "world", framework: "hono" }));
Deno.serve({ port, hostname: "127.0.0.1" }, app.fetch);
```

Profiling (`samply` + `--v8-flags=--perf-basic-prof`) pinned the overhead to the middleware's `c.header()` call, which after `await next()` runs `new Response(oldResponse.body, oldResponse)` to tweak a header — a very common framework pattern. That exposed three avoidable costs, fixed here:

1. **Static body downgraded to a stream.** Reading `.body` turns the fast string body into a `ReadableStream`, so the response is served via the streaming/chunked path — 3 `__sendto` syscalls/req and no `Content-Length` (~30% of main-thread time). `extractBody` now recovers the original static body when a `Response`/`Request` is reconstructed from an **undisturbed, static-backed** stream, restoring the single-write fast static path. Genuine streams (and any read/locked stream) are untouched.

2. **Headers re-validated through webidl.** `fillHeaderList` sent the already-validated `Headers` init object through the full webidl `sequence<sequence<ByteString>>` converter, re-validating every entry (~22% of main-thread time after fix #1). It now copies a `Headers` instance's entries directly.

3. **Eager body-stream materialization.** The `.body` getter eagerly built and UTF-8-encoded a `ReadableStream` that recovery immediately discards. It's now materialized lazily (high-water-mark 0, via the internal `createReadableStream` that also skips the webidl `UnderlyingSource` conversion), so the encode only happens on an actual read.

## Result

`oha -n 1000000 -c 100 --disable-compression`, `--profile=release-lite`:

| | req/s | encoding |
|---|---|---|
| before | 54,899 | chunked |
| + static-body recovery | 79,207 | content-length |
| + Headers fast path | 91,807 | content-length |
| + lazy body stream | **98,637** | content-length |

**+80%** on the same app, with `Content-Length` restored. The remaining cost is dominated by raw socket I/O (`__sendto` + `__recvfrom` ≈ 42% of main-thread time) and the inherent cost of constructing `Response`/`Headers` objects in JS.

## Behavior change

Reconstructing a `Response`/`Request` from another body's stream (`new Response(other.body, other)`) and serving/consuming it now yields a `Content-Length` instead of chunked encoding when the source stream was static-backed and unread. As a side effect, consuming the reconstructed body no longer disturbs the original stream (the bytes are identical either way). Genuine `ReadableStream` bodies are unaffected.

## Tests

- `ext/fetch/22_body.js` / `ext/fetch/20_headers.js` changes.
- `tests/unit/serve_test.ts`: the `stream()` helper now builds a genuinely-opaque stream so the existing length/chunked tests still exercise the chunked path; added `recoveredStaticStreamBody` covering the new fast path.
- `unit::{streams,body,headers,response,request,fetch,serve}_test` all pass; `tools/format.js` + `tools/lint.js --js` clean.
