### PR TITLE
fix(desktop): restart on HMR top-level change; watch static assets

### DIFF
--- a/cli/rt/hmr.rs
+++ b/cli/rt/hmr.rs
@@ -140,6 +140,38 @@ fn should_retry(status: &cdp::Status) -> bool {
   )
 }
 
+/// Source files that are part of the V8 module graph and can be hot-replaced
+/// via `Debugger.setScriptSource` (after transpiling, if needed).
+fn is_script_ext(ext: &str) -> bool {
+  matches!(ext, "js" | "ts" | "jsx" | "tsx" | "mjs" | "cjs")
+}
+
+/// Static assets served to the webview. They aren't in the module graph, so a
+/// change can't be hot-replaced — the webview just needs to re-fetch them with
+/// a page reload.
+fn is_asset_ext(ext: &str) -> bool {
+  matches!(
+    ext,
+    "html"
+      | "htm"
+      | "css"
+      | "json"
+      | "svg"
+      | "png"
+      | "jpg"
+      | "jpeg"
+      | "gif"
+      | "webp"
+      | "avif"
+      | "ico"
+      | "wasm"
+      | "woff"
+      | "woff2"
+      | "ttf"
+      | "otf"
+  )
+}
+
 /// Transpile a TypeScript/TSX/JSX source file to JavaScript for HMR.
 fn transpile_for_hmr(
   specifier: &Url,
@@ -279,15 +311,32 @@ impl HmrState {
   }
 }
 
-/// Callback invoked after a module is successfully hot-replaced.
-pub type HmrReloadCallback = Box<dyn Fn() + Send + Sync>;
+/// How the host should react to a change that couldn't be (or didn't need to
+/// be) hot-replaced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReloadKind {
+  /// Refresh the webview content (e.g. `location.reload()`). Enough when only
+  /// served assets or already-hot-replaced handler code changed.
+  Soft,
+  /// The V8 module graph itself must be re-evaluated from scratch (a top-level
+  /// module change V8 can't patch in place). A soft reload can't reset the
+  /// runtime's module state, so the whole app has to be restarted.
+  Restart,
+}
+
+/// Callback invoked when the host should reload or restart the app.
+pub type HmrReloadCallback = Box<dyn Fn(ReloadKind) + Send + Sync>;
 
 /// Result of attempting to apply a single change.
 enum ChangeOutcome {
   /// `setScriptSource` succeeded — the URL was hot-replaced.
   Replaced(String),
-  /// V8 can't apply the change in place; ask the host to reload.
-  NeedsReload(String),
+  /// The change can't be hot-replaced but a webview refresh picks it up
+  /// (static assets, or a removed module the page just needs to re-fetch).
+  SoftReload(String),
+  /// V8 rejected the change as a top-level module edit; the runtime must be
+  /// fully restarted to re-evaluate the module graph.
+  Restart(String),
   /// Nothing to do (untracked file, transient I/O error, etc.).
   Skipped,
 }
@@ -348,7 +397,7 @@ impl DesktopHmrRunner {
         };
         for path in event.paths {
           if let Some(ext) = path.extension().and_then(|e| e.to_str())
-            && matches!(ext, "js" | "ts" | "jsx" | "tsx" | "mjs" | "cjs")
+            && (is_script_ext(ext) || is_asset_ext(ext))
           {
             let _ = changed_tx.send((path, change));
           }
@@ -436,16 +485,21 @@ impl DesktopHmrRunner {
             }
           }
 
-          let mut needs_reload = false;
+          let mut needs_soft_reload = false;
+          let mut needs_restart = false;
           let mut handled: HashSet<String> = HashSet::new();
           for (path, change) in pending {
             match self.handle_change(&path, change).await {
               ChangeOutcome::Replaced(url) => {
                 handled.insert(url);
               }
-              ChangeOutcome::NeedsReload(reason) => {
-                log::info!("HMR: {} — falling back to page reload", reason);
-                needs_reload = true;
+              ChangeOutcome::SoftReload(reason) => {
+                log::info!("HMR: {} — reloading page", reason);
+                needs_soft_reload = true;
+              }
+              ChangeOutcome::Restart(reason) => {
+                log::info!("HMR: {} — restarting app", reason);
+                needs_restart = true;
               }
               ChangeOutcome::Skipped => {}
             }
@@ -456,10 +510,15 @@ impl DesktopHmrRunner {
             log::info!("HMR: replaced {}", url);
           }
 
-          if (needs_reload || !handled.is_empty())
-            && let Some(on_reload) = &self.on_reload
-          {
-            on_reload();
+          // A restart re-evaluates the whole module graph, so it subsumes any
+          // soft reload queued in the same batch. Otherwise refresh the webview
+          // if anything was hot-replaced or an asset changed.
+          if let Some(on_reload) = &self.on_reload {
+            if needs_restart {
+              on_reload(ReloadKind::Restart);
+            } else if needs_soft_reload || !handled.is_empty() {
+              on_reload(ReloadKind::Soft);
+            }
           }
         }
       }
@@ -473,6 +532,14 @@ impl DesktopHmrRunner {
     path: &Path,
     change: FileChange,
   ) -> ChangeOutcome {
+    // Static assets aren't in the V8 module graph and can't be hot-replaced.
+    // Any change to one means the webview is showing stale content, so ask the
+    // host for a soft page reload to re-fetch it.
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    if !is_script_ext(ext) {
+      return ChangeOutcome::SoftReload(format!("{} changed", path.display()));
+    }
+
     #[allow(
       clippy::disallowed_methods,
       reason = "denort has no canonicalize helper; non-canonicalizable paths are handled below"
@@ -519,7 +586,7 @@ impl DesktopHmrRunner {
       // that V8 had loaded. Either way, setScriptSource isn't applicable —
       // ask the host to reload so it picks up the new state.
       return if script_id.is_some() {
-        ChangeOutcome::NeedsReload(format!("{} removed", module_url))
+        ChangeOutcome::SoftReload(format!("{} removed", module_url))
       } else {
         ChangeOutcome::Skipped
       };
@@ -574,11 +641,14 @@ impl DesktopHmrRunner {
       log::error!("HMR: failed to reload {}: {}", module_url, explain(&result));
 
       // V8 can't replace modules whose top-level surface (imports, exported
-      // bindings, top-level let/const) changed. The classic run-mode HMR
-      // restarts the worker; here we tell the host to reload the page so the
-      // user's edit isn't silently dropped.
+      // bindings, top-level let/const) changed. A page reload won't help: it
+      // refreshes the webview but leaves the runtime's module graph untouched,
+      // so the edit is silently dropped and — because the unapplied top-level
+      // diff is re-sent with every later edit — all subsequent HMR for this
+      // module stays blocked too. The classic run-mode HMR restarts the worker;
+      // do the equivalent here by asking the host to restart the app.
       if matches!(result.status, cdp::Status::BlockedByTopLevelEsModuleChange) {
-        return ChangeOutcome::NeedsReload(format!(
+        return ChangeOutcome::Restart(format!(
           "{} requires a top-level module reload",
           module_url
         ));
@@ -684,4 +754,29 @@ pub fn setup_desktop_hmr(
 
   runner.start();
   Ok(runner)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn script_vs_asset_classification() {
+    // Module-graph sources are hot-replaced; nothing else is.
+    for ext in ["js", "ts", "jsx", "tsx", "mjs", "cjs"] {
+      assert!(is_script_ext(ext), "{ext} should be a script");
+      assert!(!is_asset_ext(ext), "{ext} should not be an asset");
+    }
+    // Static assets (the #35496 sibling fix) trigger a page reload, not a
+    // setScriptSource — they must be watched but never treated as scripts.
+    for ext in ["html", "css", "json", "svg", "png", "wasm", "woff2"] {
+      assert!(is_asset_ext(ext), "{ext} should be an asset");
+      assert!(!is_script_ext(ext), "{ext} should not be a script");
+    }
+    // Editor noise (swap/backup/temp) stays out of both sets so it never
+    // triggers a reload.
+    for ext in ["swp", "tmp", "orig", "bak"] {
+      assert!(!is_script_ext(ext) && !is_asset_ext(ext));
+    }
+  }
 }

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -1521,6 +1521,24 @@ fn find_section_in_dylib() -> Result<&'static [u8], AnyError> {
   }
 }
 
+/// Exit code the runtime uses to ask the `deno desktop --hmr` supervisor to
+/// relaunch the app. Kept in sync with `HMR_RESTART_EXIT_CODE` in
+/// `cli/tools/desktop.rs`, which owns the child process and re-spawns it (so the
+/// process group, Ctrl-C handling and temp-entrypoint cleanup stay intact —
+/// re-execing from here would orphan the new process from the supervisor).
+const HMR_RESTART_EXIT_CODE: i32 = 75;
+
+/// Ask the supervisor to fully restart the app.
+///
+/// Used by HMR when a top-level module change can't be hot-patched: the module
+/// graph has to be re-evaluated from scratch, which only a fresh process
+/// achieves. We exit with a sentinel code rather than re-spawning ourselves so
+/// the `deno desktop` parent stays in charge of the relaunch.
+fn restart_desktop_app() {
+  log::info!("HMR: restarting desktop app");
+  std::process::exit(HMR_RESTART_EXIT_CODE);
+}
+
 async fn run_desktop(
   update_rolled_back: bool,
   desktop_serve_port: u16,
@@ -1623,20 +1641,29 @@ async fn run_desktop(
 
   let hmr_on_reload: Option<denort::hmr::HmrReloadCallback> =
     if hmr_watch_dir.is_some() && !is_framework_dev {
-      Some(Box::new(move || {
-        let ids: Vec<u32> = open_windows_for_hmr
-          .lock()
-          .unwrap()
-          .iter()
-          .copied()
-          .collect();
-        for id in ids {
-          laufey::Window::from_id(id)
-            .execute_js::<fn(Result<laufey::Value, laufey::Value>)>(
-              "location.reload()",
-              None,
-            );
+      Some(Box::new(move |kind| match kind {
+        // Hot-replaced handler code or a changed static asset: refreshing the
+        // webview re-fetches the served content from the still-running runtime.
+        denort::hmr::ReloadKind::Soft => {
+          let ids: Vec<u32> = open_windows_for_hmr
+            .lock()
+            .unwrap()
+            .iter()
+            .copied()
+            .collect();
+          for id in ids {
+            laufey::Window::from_id(id)
+              .execute_js::<fn(Result<laufey::Value, laufey::Value>)>(
+                "location.reload()",
+                None,
+              );
+          }
         }
+        // A top-level module change V8 can't patch: the runtime's module graph
+        // has to be re-evaluated from scratch, which only a full process
+        // restart achieves. `location.reload()` would leave the stale runtime
+        // running and wedge all subsequent HMR.
+        denort::hmr::ReloadKind::Restart => restart_desktop_app(),
       }))
     } else {
       None

--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -987,26 +987,10 @@ async fn run_desktop_hmr(
     log::info!("{} desktop app under inspector", colors::green("Running"),);
   }
 
-  let mut cmd = std::process::Command::new(&laufey_backend);
-  cmd
-    .arg("--runtime")
-    .arg(&dylib_abs)
-    .env("LAUFEY_RUNTIME_PATH", &dylib_abs)
-    .current_dir(&source_abs);
-  #[cfg(target_os = "macos")]
-  if let Some(icon_path) = laufey_app_icon.as_ref() {
-    cmd.env("LAUFEY_APP_ICON", icon_path);
-  }
-  if let Some(name) = app_name.as_ref() {
-    cmd.env("LAUFEY_APP_NAME", name);
-  }
-  // Only enable the file watcher + setScriptSource pipeline when the user
-  // actually asked for HMR. `deno desktop --inspect` alone used to spin up
-  // both, surprising users (and burning the inspector channel on hot
-  // reloads they didn't request).
-  if desktop_flags.hmr {
-    cmd.env("DENO_DESKTOP_HMR", &source_abs);
-  }
+  // Extra environment collected for the child below. Kept separate from the
+  // command itself because the child may be relaunched (HMR top-level restart),
+  // so the command is rebuilt fresh on each spawn via `make_cmd`.
+  let mut extra_env: Vec<(&'static str, String)> = Vec::new();
 
   // Wire up the unified DevTools multiplexer when --inspect is set.
   // The mux runs in this (parent) process and fronts both the Deno runtime
@@ -1055,36 +1039,71 @@ async fn run_desktop_hmr(
       cef_internal,
     );
 
-    cmd
-      .env(
-        "DENO_DESKTOP_INSPECT_INTERNAL_PORT",
-        deno_internal.to_string(),
-      )
-      // Exposed so rt_desktop's `openDevtools()` can launch a browser
-      // pointed at the unified DevTools frontend instead of CEF's
-      // renderer-only native window.
-      .env("DENO_DESKTOP_MUX_WS", handle.listen.to_string())
-      .env(
-        "LAUFEY_REMOTE_DEBUGGING_PORT",
-        cef_internal.port().to_string(),
-      );
+    extra_env.push((
+      "DENO_DESKTOP_INSPECT_INTERNAL_PORT",
+      deno_internal.to_string(),
+    ));
+    // Exposed so rt_desktop's `openDevtools()` can launch a browser
+    // pointed at the unified DevTools frontend instead of CEF's
+    // renderer-only native window.
+    extra_env.push(("DENO_DESKTOP_MUX_WS", handle.listen.to_string()));
+    extra_env.push((
+      "LAUFEY_REMOTE_DEBUGGING_PORT",
+      cef_internal.port().to_string(),
+    ));
     if flags.inspect_brk.is_some() {
-      cmd.env("DENO_DESKTOP_INSPECT_BRK", "1");
+      extra_env.push(("DENO_DESKTOP_INSPECT_BRK", "1".to_string()));
     }
     if flags.inspect_wait.is_some() {
-      cmd.env("DENO_DESKTOP_INSPECT_WAIT", "1");
+      extra_env.push(("DENO_DESKTOP_INSPECT_WAIT", "1".to_string()));
     }
     Some(handle)
   } else {
     None
   };
 
-  // `kill_on_drop` is a safety net: if the parent panics or exits via any
-  // path that doesn't reach the explicit `wait` below, the LAUFEY backend
-  // (and its CEF renderer subprocesses) get SIGKILLed on `Child` drop
-  // rather than being orphaned. Normal Ctrl-C delivers SIGINT to the
-  // whole process group so this rarely matters in practice; it covers
-  // the abnormal-exit cases.
+  // Builds a fresh launch command. Called once per spawn so the child can be
+  // relaunched (HMR top-level restart) without reusing a consumed `Command`.
+  let make_cmd = || {
+    let mut cmd = std::process::Command::new(&laufey_backend);
+    cmd
+      .arg("--runtime")
+      .arg(&dylib_abs)
+      .env("LAUFEY_RUNTIME_PATH", &dylib_abs)
+      .current_dir(&source_abs);
+    #[cfg(target_os = "macos")]
+    if let Some(icon_path) = laufey_app_icon.as_ref() {
+      cmd.env("LAUFEY_APP_ICON", icon_path);
+    }
+    if let Some(name) = app_name.as_ref() {
+      cmd.env("LAUFEY_APP_NAME", name);
+    }
+    // Only enable the file watcher + setScriptSource pipeline when the user
+    // actually asked for HMR. `deno desktop --inspect` alone used to spin up
+    // both, surprising users (and burning the inspector channel on hot
+    // reloads they didn't request).
+    if desktop_flags.hmr {
+      cmd.env("DENO_DESKTOP_HMR", &source_abs);
+    }
+    for (key, value) in &extra_env {
+      cmd.env(key, value);
+    }
+    cmd
+  };
+
+  // The runtime exits with this code to request a full relaunch (e.g. an HMR
+  // top-level module change that can't be hot-patched). Kept in sync with
+  // `HMR_RESTART_EXIT_CODE` in `cli/rt_desktop/lib.rs`. The supervisor owns the
+  // relaunch — re-execing from inside the runtime would orphan the new process
+  // from the process group, Ctrl-C handling and temp-entrypoint cleanup.
+  const HMR_RESTART_EXIT_CODE: i32 = 75;
+
+  // Spawn, wait, and relaunch on the restart sentinel. `kill_on_drop` is a
+  // safety net: if the parent panics or exits via any path that doesn't reach
+  // the explicit `wait` below, the LAUFEY backend (and its CEF renderer
+  // subprocesses) get SIGKILLed on `Child` drop rather than being orphaned.
+  // Normal Ctrl-C delivers SIGINT to the whole process group so this rarely
+  // matters in practice; it covers the abnormal-exit cases.
   //
   // On macOS we go through posix_spawn with TCC responsibility disclaimed
   // (see `disclaim_spawn`) so the laufey child is its own permission principal.
@@ -1092,34 +1111,46 @@ async fn run_desktop_hmr(
   // to whatever started deno (typically the terminal), which has no bundle
   // id and causes `UNUserNotificationCenter.requestAuthorization` to fail
   // with UNErrorCodeNotificationsNotAllowed before any user prompt.
-  #[cfg(target_os = "macos")]
-  let status = {
-    let mut child = disclaim_spawn::spawn(&cmd).with_context(|| {
-      format!(
-        "Failed to launch LAUFEY backend: {}",
-        laufey_backend.display()
-      )
-    })?;
-    child
-      .wait()
-      .await
-      .context("Failed waiting for LAUFEY backend")?
-  };
-  #[cfg(not(target_os = "macos"))]
-  let status = {
-    let mut child = tokio::process::Command::from(cmd)
-      .kill_on_drop(true)
-      .spawn()
-      .with_context(|| {
+  let status = loop {
+    let cmd = make_cmd();
+    #[cfg(target_os = "macos")]
+    let status = {
+      let mut child = disclaim_spawn::spawn(&cmd).with_context(|| {
         format!(
           "Failed to launch LAUFEY backend: {}",
           laufey_backend.display()
         )
       })?;
-    child
-      .wait()
-      .await
-      .context("Failed waiting for LAUFEY backend")?
+      child
+        .wait()
+        .await
+        .context("Failed waiting for LAUFEY backend")?
+    };
+    #[cfg(not(target_os = "macos"))]
+    let status = {
+      let mut child = tokio::process::Command::from(cmd)
+        .kill_on_drop(true)
+        .spawn()
+        .with_context(|| {
+          format!(
+            "Failed to launch LAUFEY backend: {}",
+            laufey_backend.display()
+          )
+        })?;
+      child
+        .wait()
+        .await
+        .context("Failed waiting for LAUFEY backend")?
+    };
+
+    if status.code() == Some(HMR_RESTART_EXIT_CODE) {
+      log::info!(
+        "{} desktop app (HMR top-level change)",
+        colors::green("Restarting"),
+      );
+      continue;
+    }
+    break status;
   };
 
   // Keep the mux alive until the subprocess exits, then drop it.


### PR DESCRIPTION
## Summary

Fixes two `deno desktop --hmr` bugs, both rooted in `location.reload()` only refreshing the webview while never re-evaluating the Deno runtime's module graph.

### 1. Top-level module changes break all subsequent HMR (#35496)

When V8 rejects a `setScriptSource` with `BlockedByTopLevelEsModuleChange` (e.g. editing module-scope code), the old code fell back to a page reload. That:
- did nothing useful — the runtime module state was never reset, so the edit was silently dropped, and
- wedged HMR entirely: the unapplied top-level diff is re-sent on every later edit, so even previously-working function-body hot-replaces stay blocked.

Now a top-level change requests a **full app restart**. The runtime exits with a sentinel code (`75`); the `deno desktop --hmr` supervisor relaunches the child. The relaunch lives in the supervisor (which owns the process group, Ctrl-C handling and temp-entrypoint cleanup) — re-execing from inside the runtime would orphan the new process. A new `ReloadKind { Soft, Restart }` distinguishes a webview refresh from a full restart.

### 2. Static asset changes (HTML/CSS/...) are not detected

The file watcher only forwarded `js/ts/jsx/tsx/mjs/cjs`, so editing HTML/CSS/images was ignored. The watcher now also forwards common web assets, and `handle_change` routes any non-script file to a soft page reload (the webview re-fetches the served content) instead of attempting a hot-replace. Editor noise (`.swp`/`.tmp`/`.bak`) is still ignored.

## Changes
- `cli/rt/hmr.rs` — `ReloadKind` enum; `is_script_ext`/`is_asset_ext`; top-level change → `Restart`; non-script change → `SoftReload`; unit test for the classification.
- `cli/rt_desktop/lib.rs` — `restart_desktop_app()` exits with `HMR_RESTART_EXIT_CODE` (75); reload callback dispatches on `ReloadKind`.
- `cli/tools/desktop.rs` — supervisor loops and relaunches the child on code 75; command build factored into a `make_cmd` closure.

## Testing
- `cargo check` clean across `deno`, `denort`, `denort_desktop`.
- New unit test `hmr::tests::script_vs_asset_classification` passes.
- Note: desktop HMR is GUI/laufey-driven and has no spec-harness coverage, so end-to-end restart/asset-reload behavior was not exercised in CI here.

Closes #35496
