### PR TITLE
test(watcher): regression test for Deno.chdir() inside watched test

### DIFF
--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -1954,6 +1954,59 @@ console.log("done");
   check_alive_then_kill(child);
 }
 
+// Regression test for https://github.com/denoland/deno/issues/27383 —
+// `Deno.chdir()` inside a watched test must not break specifier
+// collection on restart. `deno test --watch test.ts` collects `test.ts`
+// relative to the original cwd; if the watcher doesn't restore cwd
+// before the second iteration, the specifier collection looks for
+// test.ts in the chdir'd directory and fails with "Module not found".
+#[test(flaky)]
+async fn test_watch_chdir() {
+  let t = TempDir::new();
+  let test_file = t.path().join("test.ts");
+  test_file.write(
+    r#"
+Deno.test("foo", () => {
+  Deno.chdir("temp");
+});
+"#,
+  );
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("test")
+    .arg("--watch")
+    .arg("--no-check")
+    .arg("-L")
+    .arg("debug")
+    .arg(&test_file)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_contains("foo ... ok", &mut stdout_lines).await;
+  wait_for_watcher("test.ts", &mut stderr_lines).await;
+
+  // Trigger a restart. The previous run did `Deno.chdir("temp")`
+  // inside the test; the watcher must restore cwd so the test file
+  // can be re-collected on the second iteration.
+  test_file.write(
+    r#"
+Deno.test("foo", () => {
+  Deno.chdir("temp");
+});
+Deno.test("bar", () => {});
+"#,
+  );
+
+  wait_contains("Restarting", &mut stderr_lines).await;
+  wait_contains("foo ... ok", &mut stdout_lines).await;
+  wait_contains("bar ... ok", &mut stdout_lines).await;
+  check_alive_then_kill(child);
+}
+
 #[cfg(unix)]
 #[test(flaky)]
 async fn test_watch_sigint() {


### PR DESCRIPTION
Adds a regression test for issue #27383 — Deno.chdir() inside a watched test must not break specifier collection on restart.

Companion to the existing run_watch_chdir test (tests/integration/watcher_tests.rs), which only covers deno run --watch. The test command path is different — specifier collection walks the workspace to find test files, and if cwd isn't restored between watcher iterations, the search misses the test file.

The test is marked #[test(flaky)] like its sibling. On the current main, the cwd restore in cli/util/file_watcher.rs should make it pass; if a future refactor breaks the restore, this test catches it.

Closes #27383.