### PR TITLE
fix(npm): show scoped-registry auth hint on tarball 404

### DIFF
--- a/libs/npm_cache/tarball.rs
+++ b/libs/npm_cache/tarball.rs
@@ -212,6 +212,17 @@ impl<THttpClient: NpmCacheHttpClient, TSys: NpmCacheSys>
       if let Some(reporter) = &reporter {
         reporter.downloaded(&package_nv);
       }
+      // The tarball URL had no matching auth, but the package's scoped registry
+      // does have credentials. Registries signal this either with a 401, or
+      // (notably GitLab instance-level npm registries) with a 404 to avoid
+      // disclosing whether a private package exists. In both cases, point the
+      // user at npm's "No auth for URI" guidance instead of an opaque error.
+      let scoped_registry_has_auth = maybe_registry_config.is_none()
+        && tarball_cache
+          .npmrc
+          .get_registry_config(&package_nv.name)
+          .auth_token
+          .is_some();
       let maybe_bytes = match result {
         Ok(response) => match response {
           NpmCacheHttpClientResponse::NotModified => unreachable!(), // no e-tag
@@ -219,20 +230,8 @@ impl<THttpClient: NpmCacheHttpClient, TSys: NpmCacheSys>
           NpmCacheHttpClientResponse::Bytes(r) => Some(r.bytes),
         },
         Err(err) => {
-          if err.status_code == Some(401)
-            && maybe_registry_config.is_none()
-            && tarball_cache.npmrc.get_registry_config(&package_nv.name).auth_token.is_some()
-          {
-            return Err(JsErrorBox::generic(format!(
-              concat!(
-                "No auth for tarball URI, but present for scoped registry.\n\n",
-                "Tarball URI: {}\n",
-                "Scope URI: {}\n\n",
-                "More info here: https://github.com/npm/cli/wiki/%22No-auth-for-URI,-but-auth-present-for-scoped-registry%22"
-              ),
-              dist.tarball,
-              registry_url,
-            )));
+          if err.status_code == Some(401) && scoped_registry_has_auth {
+            return Err(scoped_registry_auth_error(&dist.tarball, registry_url));
           }
           return Err(JsErrorBox::from_err(err))
         },
@@ -281,6 +280,11 @@ impl<THttpClient: NpmCacheHttpClient, TSys: NpmCacheSys>
           .map_err(JsErrorBox::from_err)
         }
         None => {
+          // A 404 lands here (mapped to `NotFound`), so the 401 check above is
+          // bypassed -- surface the auth hint here too when applicable.
+          if scoped_registry_has_auth {
+            return Err(scoped_registry_auth_error(&dist.tarball, registry_url));
+          }
           Err(JsErrorBox::generic(format!("Could not find npm package tarball at: {}", dist.tarball)))
         }
       }
@@ -288,4 +292,19 @@ impl<THttpClient: NpmCacheHttpClient, TSys: NpmCacheSys>
     .map(|r| r.map_err(Arc::new))
     .boxed_local()
   }
+}
+
+fn scoped_registry_auth_error(
+  tarball_uri: &str,
+  registry_url: &Url,
+) -> JsErrorBox {
+  JsErrorBox::generic(format!(
+    concat!(
+      "No auth for tarball URI, but present for scoped registry.\n\n",
+      "Tarball URI: {}\n",
+      "Scope URI: {}\n\n",
+      "More info here: https://github.com/npm/cli/wiki/%22No-auth-for-URI,-but-auth-present-for-scoped-registry%22"
+    ),
+    tarball_uri, registry_url,
+  ))
 }

--- a/tests/registry/npm-private/@denotest/tarballs-privateserver404/1.0.0/index.js
+++ b/tests/registry/npm-private/@denotest/tarballs-privateserver404/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = () => 'hi_private404';

--- a/tests/registry/npm-private/@denotest/tarballs-privateserver404/1.0.0/package.json
+++ b/tests/registry/npm-private/@denotest/tarballs-privateserver404/1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@denotest/tarballs-privateserver404",
+  "version": "1.0.0"
+}

--- a/tests/specs/npm/npmrc_tarball_other_server/__test__.jsonc
+++ b/tests/specs/npm/npmrc_tarball_other_server/__test__.jsonc
@@ -12,6 +12,12 @@
       "args": "run --node-modules-dir=auto -A main.js",
       "output": "fail/main.out",
       "exitCode": 1
+    },
+    "auth_fail_not_found": {
+      "cwd": "fail_not_found",
+      "args": "run --node-modules-dir=auto -A main.js",
+      "output": "fail_not_found/main.out",
+      "exitCode": 1
     }
   }
 }

--- a/tests/specs/npm/npmrc_tarball_other_server/fail_not_found/.npmrc
+++ b/tests/specs/npm/npmrc_tarball_other_server/fail_not_found/.npmrc
@@ -1,0 +1,2 @@
+@denotest:registry=http://localhost:4261/
+//localhost:4261/:_authToken=private-reg-token

--- a/tests/specs/npm/npmrc_tarball_other_server/fail_not_found/main.js
+++ b/tests/specs/npm/npmrc_tarball_other_server/fail_not_found/main.js
@@ -1,0 +1,3 @@
+import getValue from "@denotest/tarballs-privateserver404";
+
+console.log(getValue());

--- a/tests/specs/npm/npmrc_tarball_other_server/fail_not_found/main.out
+++ b/tests/specs/npm/npmrc_tarball_other_server/fail_not_found/main.out
@@ -1,0 +1,10 @@
+[WILDCARD]
+error: Failed caching npm package '@denotest/tarballs-privateserver404@1.0.0'
+
+Caused by:
+    No auth for tarball URI, but present for scoped registry.
+    
+    Tarball URI: http://localhost:4263/@denotest/tarballs-privateserver404/1.0.0.tgz
+    Scope URI: http://localhost:4261/
+    
+    More info here: https://github.com/npm/cli/wiki/%22No-auth-for-URI,-but-auth-present-for-scoped-registry%22

--- a/tests/specs/npm/npmrc_tarball_other_server/fail_not_found/package.json
+++ b/tests/specs/npm/npmrc_tarball_other_server/fail_not_found/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "npmrc_test",
+  "version": "0.0.1",
+  "dependencies": {
+    "@denotest/tarballs-privateserver404": "1.0.0"
+  }
+}

--- a/tests/util/server/npm.rs
+++ b/tests/util/server/npm.rs
@@ -495,6 +495,10 @@ fn get_npm_package(
   let registry_hostname = if package_name == "@denotest/tarballs-privateserver2"
   {
     "http://localhost:4262"
+  } else if package_name == "@denotest/tarballs-privateserver404" {
+    // Tarball served from a registry that 404s the unauthenticated request
+    // (and has no fixture there), to exercise the 404 auth-hint path.
+    "http://localhost:4263"
   } else {
     registry_hostname
   };


### PR DESCRIPTION
Fixes #34699.

The "No auth for tarball URI, but present for scoped registry" hint was gated on a **401** response. Some registries (notably GitLab instance-level npm registries) answer an unauthenticated tarball request with a **404** to avoid disclosing whether a private package exists. A 404 is mapped to `NotFound`, so it never reached the 401 check — the user instead saw the opaque:

```
Could not find npm package tarball at: https://.../@scope/pkg/-/...tgz
```

This surfaces the same guidance when a tarball 404s and there is no matching tarball auth but the package's scoped registry has credentials. The 401 and 404 paths now share a small helper.

Test: `tests/specs/npm/npmrc_tarball_other_server` gains a `fail_not_found` case — package metadata served by the authed scoped registry, tarball pointing at a registry that 404s — asserting the hint fires.