### PR TITLE
perf(ext/http): coalesce chunked response writes into a single write

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -4143,6 +4143,10 @@ where
       }
       RawResponseBodyEvent::Frame(ResponseStreamResult::NoData) => continue,
       RawResponseBodyEvent::Frame(ResponseStreamResult::Error(error)) => {
+        // The head (and any chunks coalesced so far) may still be buffered;
+        // flush best-effort so the client receives the committed response
+        // before the connection is torn down, then surface the body error.
+        let _ = poll_fn(|cx| conn.poll_flush_write_buf(cx, scratch)).await;
         finish.finish(false);
         return Err(HttpNextError::Other(error));
       }
@@ -4319,6 +4323,17 @@ where
       }
       RawResponseBodyEvent::Frame(ResponseStreamResult::NoData) => continue,
       RawResponseBodyEvent::Frame(ResponseStreamResult::Error(error)) => {
+        // The head (and any chunks coalesced so far) may still be buffered;
+        // flush best-effort so the client receives the committed response
+        // before the connection is torn down, then surface the body error.
+        let _ = poll_fn(|cx| {
+          let mut conn = conn.borrow_mut();
+          let Some(conn) = conn.as_mut() else {
+            return Poll::Ready(Ok::<_, HttpNextError>(()));
+          };
+          conn.poll_flush(cx)
+        })
+        .await;
         finish.finish(false);
         return Err(HttpNextError::Other(error));
       }

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -1113,6 +1113,17 @@ where
       Poll::Pending => Poll::Pending,
     }
   }
+
+  fn poll_flush(
+    &mut self,
+    cx: &mut Context<'_>,
+  ) -> Poll<Result<(), HttpNextError>> {
+    match self.conn.poll_flush_write_buf(cx, &mut self.scratch) {
+      Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+      Poll::Ready(Err(error)) => Poll::Ready(Err(error.into())),
+      Poll::Pending => Poll::Pending,
+    }
+  }
 }
 
 type RawH1ConnectionCell<I> = Rc<RefCell<Option<RawH1ConnectionState<I>>>>;
@@ -4078,9 +4089,20 @@ where
         Poll::Ready(Ok(false)) | Poll::Pending => {}
         Poll::Ready(Err(error)) => return Poll::Ready(Err(error.into())),
       }
-      Poll::Ready(Ok::<_, HttpNextError>(RawResponseBodyEvent::Frame(ready!(
-        poll_raw_response_body_frame(&mut body, cx)
-      ))))
+      match poll_raw_response_body_frame(&mut body, cx) {
+        Poll::Ready(frame) => Poll::Ready(Ok::<_, HttpNextError>(
+          RawResponseBodyEvent::Frame(frame),
+        )),
+        Poll::Pending => {
+          // Body source has nothing ready; flush buffered response bytes so the
+          // client isn't kept waiting (keeps incremental/SSE streams
+          // responsive). Synchronous chunk+EOF still coalesce at finish.
+          match conn.poll_flush_write_buf(cx, scratch) {
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error.into())),
+            Poll::Ready(Ok(())) | Poll::Pending => Poll::Pending,
+          }
+        }
+      }
     })
     .await?;
     match event {
@@ -4217,9 +4239,24 @@ where
           Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
         }
       }
-      Poll::Ready(Ok::<_, HttpNextError>(RawResponseBodyEvent::Frame(ready!(
-        poll_raw_response_body_frame(&mut body, cx)
-      ))))
+      match poll_raw_response_body_frame(&mut body, cx) {
+        Poll::Ready(frame) => Poll::Ready(Ok::<_, HttpNextError>(
+          RawResponseBodyEvent::Frame(frame),
+        )),
+        Poll::Pending => {
+          // Body source has nothing ready; flush buffered response bytes so the
+          // client isn't kept waiting (keeps incremental/SSE streams
+          // responsive). Synchronous chunk+EOF still coalesce at finish.
+          let mut conn = conn.borrow_mut();
+          let Some(conn) = conn.as_mut() else {
+            return Poll::Ready(Err(raw_h1_connection_closed()));
+          };
+          match conn.poll_flush(cx) {
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Ready(Ok(())) | Poll::Pending => Poll::Pending,
+          }
+        }
+      }
     })
     .await?;
     match event {

--- a/libs/http_h1/conn.rs
+++ b/libs/http_h1/conn.rs
@@ -38,6 +38,13 @@ use crate::write_response_head;
 const DEFAULT_READ_CAPACITY: usize = 1024;
 const DEFAULT_WRITE_CAPACITY: usize = 512;
 const MAX_HEAD_BYTES: usize = 64 * 1024;
+// Chunked responses accumulate the head, body chunks and terminator into a
+// single per-connection buffer (`SharedScratch::write_buf`) so a small response
+// is emitted in one write instead of three. Flush once the buffer reaches this
+// size to bound memory for large/streaming bodies, and shrink the buffer back
+// to `DEFAULT_WRITE_CAPACITY` after each response so idle connections don't
+// retain a large allocation.
+const CHUNKED_FLUSH_THRESHOLD: usize = 64 * 1024;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -171,20 +178,20 @@ impl<'a> SharedFixedResponseHeadWriter<'a> {
 #[derive(Debug)]
 pub struct SharedResponseChunkWriter<'a> {
   chunk: &'a [u8],
-  prefix_written: usize,
+  // Used by the (non-buffered) Fixed / CloseDelimited body paths.
   body_written: usize,
-  suffix_written: usize,
-  coalesced_written: usize,
+  // For the buffered chunked path: whether this chunk's framing has already
+  // been appended to `write_buf` (so a re-poll after a partial flush does not
+  // append it again).
+  buffered: bool,
 }
 
 impl<'a> SharedResponseChunkWriter<'a> {
   pub fn new(chunk: &'a [u8]) -> Self {
     Self {
       chunk,
-      prefix_written: 0,
       body_written: 0,
-      suffix_written: 0,
-      coalesced_written: 0,
+      buffered: false,
     }
   }
 }
@@ -204,14 +211,16 @@ impl<'a> SharedResponseBodyWriter<'a> {
 #[derive(Debug)]
 pub struct SharedResponseEndWriter<'a> {
   trailers: &'a [Header<'a>],
-  written: usize,
+  // For the buffered chunked path: whether the terminating chunk has already
+  // been appended to `write_buf`.
+  buffered: bool,
 }
 
 impl<'a> SharedResponseEndWriter<'a> {
   pub fn new(trailers: &'a [Header<'a>]) -> Self {
     Self {
       trailers,
-      written: 0,
+      buffered: false,
     }
   }
 }
@@ -226,6 +235,10 @@ pub struct UpgradeParts<I> {
 pub struct SharedScratch {
   read_buf: Vec<u8>,
   write_buf: Vec<u8>,
+  // How many leading bytes of `write_buf` have already been flushed to the
+  // socket. Used to resume a partial flush of the buffered chunked response
+  // without re-sending bytes.
+  write_flushed: usize,
 }
 
 impl SharedScratch {
@@ -233,6 +246,7 @@ impl SharedScratch {
     Self {
       read_buf: vec![0; read_capacity],
       write_buf: Vec::with_capacity(write_capacity),
+      write_flushed: 0,
     }
   }
 
@@ -1132,18 +1146,39 @@ where
       return Poll::Ready(Err(Error::ResponseStreamActive));
     }
 
-    scratch.write_buf.clear();
-    write_chunked_response_head(
-      &mut scratch.write_buf,
-      ResponseHeader {
-        version: writer.response.version,
-        status: writer.response.status,
-        reason: writer.response.reason,
-        headers: writer.response.headers,
-        content_length: None,
-        keep_alive: writer.response.keep_alive,
-      },
-    );
+    if writer.written == 0 {
+      scratch.write_buf.clear();
+      scratch.write_flushed = 0;
+      write_chunked_response_head(
+        &mut scratch.write_buf,
+        ResponseHeader {
+          version: writer.response.version,
+          status: writer.response.status,
+          reason: writer.response.reason,
+          headers: writer.response.headers,
+          content_length: None,
+          keep_alive: writer.response.keep_alive,
+        },
+      );
+    }
+    let next_state = if status_allows_body(writer.response.status) {
+      if writer.response.version == Version::Http11 {
+        ResponseState::Chunked
+      } else {
+        ResponseState::CloseDelimited
+      }
+    } else {
+      ResponseState::NoBody
+    };
+    // For chunked (HTTP/1.1) responses, leave the head buffered in `write_buf`
+    // so it coalesces with the first body chunk and the terminator into a
+    // single write. CloseDelimited (HTTP/1.0) writes its body directly to the
+    // socket, and NoBody has no terminator to flush behind it, so both must
+    // flush the head now to preserve ordering.
+    if next_state == ResponseState::Chunked {
+      self.response_state = next_state;
+      return Poll::Ready(Ok(()));
+    }
     while writer.written < scratch.write_buf.len() {
       let written = ready!(
         Pin::new(&mut self.io)
@@ -1157,15 +1192,8 @@ where
       }
       writer.written += written;
     }
-    self.response_state = if status_allows_body(writer.response.status) {
-      if writer.response.version == Version::Http11 {
-        ResponseState::Chunked
-      } else {
-        ResponseState::CloseDelimited
-      }
-    } else {
-      ResponseState::NoBody
-    };
+    scratch.write_flushed = scratch.write_buf.len();
+    self.response_state = next_state;
     Poll::Ready(Ok(()))
   }
 
@@ -1296,74 +1324,47 @@ where
       return Poll::Ready(Ok(()));
     }
 
-    scratch.write_buf.clear();
-    append_chunk_prefix(&mut scratch.write_buf, writer.chunk.len());
-    let prefix_len = scratch.write_buf.len();
-    let coalesced_len = prefix_len + writer.chunk.len() + 2;
-    if writer.body_written == 0
-      && writer.suffix_written == 0
-      && coalesced_len <= scratch.write_buf.capacity()
-    {
+    // Append this chunk's framing (size prefix + data + CRLF) after the
+    // still-buffered head and any earlier chunks, so a small response coalesces
+    // into a single write. The buffer is flushed by `poll_finish_response_with`
+    // (terminator), by the driver when the body source would block, or here
+    // once it grows past the threshold.
+    if !writer.buffered {
+      append_chunk_prefix(&mut scratch.write_buf, writer.chunk.len());
       scratch.write_buf.extend_from_slice(writer.chunk);
       scratch.write_buf.extend_from_slice(b"\r\n");
-      while writer.coalesced_written < scratch.write_buf.len() {
-        let written = ready!(
-          Pin::new(&mut self.io)
-            .poll_write(cx, &scratch.write_buf[writer.coalesced_written..])
-        )?;
-        if written == 0 {
-          return Poll::Ready(Err(Error::Io(io::Error::new(
-            io::ErrorKind::WriteZero,
-            "failed to write response chunk",
-          ))));
-        }
-        writer.coalesced_written += written;
-      }
-      writer.prefix_written = prefix_len;
-      writer.body_written = writer.chunk.len();
-      writer.suffix_written = 2;
-      return Poll::Ready(Ok(()));
+      writer.buffered = true;
     }
+    if scratch.write_buf.len() >= CHUNKED_FLUSH_THRESHOLD {
+      return self.poll_flush_write_buf(cx, scratch);
+    }
+    Poll::Ready(Ok(()))
+  }
 
-    while writer.prefix_written < prefix_len {
+  /// Drains the buffered (but not yet sent) bytes of a chunked response in
+  /// `scratch.write_buf` to the socket, resuming from `scratch.write_flushed`
+  /// on a partial write. On completion the buffer is cleared so it can be
+  /// reused for the next chunk / response.
+  pub fn poll_flush_write_buf(
+    &mut self,
+    cx: &mut Context<'_>,
+    scratch: &mut SharedScratch,
+  ) -> Poll<Result<(), Error>> {
+    while scratch.write_flushed < scratch.write_buf.len() {
       let written = ready!(
         Pin::new(&mut self.io)
-          .poll_write(cx, &scratch.write_buf[writer.prefix_written..])
+          .poll_write(cx, &scratch.write_buf[scratch.write_flushed..])
       )?;
       if written == 0 {
         return Poll::Ready(Err(Error::Io(io::Error::new(
           io::ErrorKind::WriteZero,
-          "failed to write response chunk prefix",
+          "failed to write response chunk",
         ))));
       }
-      writer.prefix_written += written;
+      scratch.write_flushed += written;
     }
-    while writer.body_written < writer.chunk.len() {
-      let written = ready!(
-        Pin::new(&mut self.io)
-          .poll_write(cx, &writer.chunk[writer.body_written..])
-      )?;
-      if written == 0 {
-        return Poll::Ready(Err(Error::Io(io::Error::new(
-          io::ErrorKind::WriteZero,
-          "failed to write response chunk body",
-        ))));
-      }
-      writer.body_written += written;
-    }
-    while writer.suffix_written < 2 {
-      let written = ready!(
-        Pin::new(&mut self.io)
-          .poll_write(cx, &b"\r\n"[writer.suffix_written..])
-      )?;
-      if written == 0 {
-        return Poll::Ready(Err(Error::Io(io::Error::new(
-          io::ErrorKind::WriteZero,
-          "failed to write response chunk suffix",
-        ))));
-      }
-      writer.suffix_written += written;
-    }
+    scratch.write_buf.clear();
+    scratch.write_flushed = 0;
     Poll::Ready(Ok(()))
   }
 
@@ -1470,20 +1471,17 @@ where
       ResponseState::Chunked => {}
     }
 
-    scratch.write_buf.clear();
-    append_chunked_end(&mut scratch.write_buf, writer.trailers);
-    while writer.written < scratch.write_buf.len() {
-      let written = ready!(
-        Pin::new(&mut self.io)
-          .poll_write(cx, &scratch.write_buf[writer.written..])
-      )?;
-      if written == 0 {
-        return Poll::Ready(Err(Error::Io(io::Error::new(
-          io::ErrorKind::WriteZero,
-          "failed to finish response",
-        ))));
-      }
-      writer.written += written;
+    // Append the terminating chunk (and any trailers) after the still-buffered
+    // head and body chunks, then flush everything in one write.
+    if !writer.buffered {
+      append_chunked_end(&mut scratch.write_buf, writer.trailers);
+      writer.buffered = true;
+    }
+    ready!(self.poll_flush_write_buf(cx, scratch))?;
+    // Don't let a connection that served one large response retain an
+    // oversized buffer for the rest of its (idle) life.
+    if scratch.write_buf.capacity() > DEFAULT_WRITE_CAPACITY {
+      scratch.write_buf.shrink_to(DEFAULT_WRITE_CAPACITY);
     }
     self.response_state = ResponseState::Idle;
     Poll::Ready(Ok(()))

--- a/libs/http_h1/conn.rs
+++ b/libs/http_h1/conn.rs
@@ -1733,7 +1733,9 @@ mod tests {
       buf: &[u8],
     ) -> Poll<io::Result<usize>> {
       self.calls += 1;
-      if self.pending_every != 0 && self.calls % self.pending_every == 0 {
+      if self.pending_every != 0
+        && self.calls.is_multiple_of(self.pending_every)
+      {
         // Wake immediately so the executor re-polls: this is what forces the
         // flush to resume from `write_flushed` (and the chunk writer to be
         // re-polled with `buffered` already set) without re-sending bytes.

--- a/libs/http_h1/conn.rs
+++ b/libs/http_h1/conn.rs
@@ -1693,6 +1693,73 @@ mod tests {
     }
   }
 
+  // A write sink that accepts at most `max_write` bytes per `poll_write` and
+  // returns `Pending` on every `pending_every`-th call (0 = never). Used to
+  // drive the buffered chunked response path through partial writes and
+  // re-polls, which the duplex/`FragmentIo`-backed tests never do (they always
+  // accept the whole buffer in a single `poll_write`).
+  struct ShortWriteIo {
+    written: Vec<u8>,
+    max_write: usize,
+    pending_every: usize,
+    calls: usize,
+  }
+
+  impl ShortWriteIo {
+    fn new(max_write: usize, pending_every: usize) -> Self {
+      Self {
+        written: Vec::new(),
+        max_write: max_write.max(1),
+        pending_every,
+        calls: 0,
+      }
+    }
+  }
+
+  impl AsyncRead for ShortWriteIo {
+    fn poll_read(
+      self: Pin<&mut Self>,
+      _cx: &mut Context<'_>,
+      _buf: &mut TokioReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+      Poll::Ready(Ok(()))
+    }
+  }
+
+  impl AsyncWrite for ShortWriteIo {
+    fn poll_write(
+      mut self: Pin<&mut Self>,
+      cx: &mut Context<'_>,
+      buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+      self.calls += 1;
+      if self.pending_every != 0 && self.calls % self.pending_every == 0 {
+        // Wake immediately so the executor re-polls: this is what forces the
+        // flush to resume from `write_flushed` (and the chunk writer to be
+        // re-polled with `buffered` already set) without re-sending bytes.
+        cx.waker().wake_by_ref();
+        return Poll::Pending;
+      }
+      let n = buf.len().min(self.max_write);
+      self.written.extend_from_slice(&buf[..n]);
+      Poll::Ready(Ok(n))
+    }
+
+    fn poll_flush(
+      self: Pin<&mut Self>,
+      _cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+      Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+      self: Pin<&mut Self>,
+      _cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+      Poll::Ready(Ok(()))
+    }
+  }
+
   async fn read_shared_body_from_fragments(
     fragments: &[&[u8]],
   ) -> TestResult<Vec<u8>> {
@@ -2032,6 +2099,101 @@ mod tests {
       response?,
       b"HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n3\r\nabc\r\n3\r\ndef\r\n0\r\nx-trailer: ok\r\n\r\n"
     );
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn shared_conn_chunked_response_coalesces_across_short_writes()
+  -> TestResult<()> {
+    // Flush the entire buffered head + chunks + terminator one byte at a time,
+    // with periodic `Pending`, so the coalesced write is delivered across many
+    // partial `poll_write`s. Exercises `poll_flush_write_buf`'s resume from
+    // `write_flushed` and the `buffered` re-poll guards. The output must still
+    // be byte-identical to the single-write case.
+    let mut conn = SharedConn::new(ShortWriteIo::new(1, 4));
+    let mut scratch = SharedScratch::default();
+
+    let mut head = SharedChunkedResponseHeadWriter::new(ResponseHead {
+      version: Version::Http11,
+      status: 200,
+      reason: b"OK",
+      headers: &[],
+      keep_alive: false,
+    });
+    std::future::poll_fn(|cx| {
+      conn.poll_start_chunked_response_with(cx, &mut scratch, &mut head)
+    })
+    .await?;
+
+    for chunk in [b"abc".as_slice(), b"def".as_slice()] {
+      let mut writer = SharedResponseChunkWriter::new(chunk);
+      std::future::poll_fn(|cx| {
+        conn.poll_write_response_chunk_with(cx, &mut scratch, &mut writer)
+      })
+      .await?;
+    }
+
+    let trailers = [Header {
+      name: b"x-trailer",
+      value: b"ok",
+    }];
+    let mut end = SharedResponseEndWriter::new(&trailers);
+    std::future::poll_fn(|cx| {
+      conn.poll_finish_response_with(cx, &mut scratch, &mut end)
+    })
+    .await?;
+
+    assert_eq!(
+      conn.into_inner().written,
+      b"HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n3\r\nabc\r\n3\r\ndef\r\n0\r\nx-trailer: ok\r\n\r\n"
+    );
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn shared_conn_chunked_threshold_flush_survives_short_writes()
+  -> TestResult<()> {
+    // A chunk larger than `CHUNKED_FLUSH_THRESHOLD` makes
+    // `poll_write_response_chunk_with` flush mid-stream. Under short writes that
+    // flush returns `Pending` and the chunk writer is re-polled many times; the
+    // `buffered` guard must keep it from appending (and thus re-sending) the
+    // chunk on each re-poll.
+    let mut conn = SharedConn::new(ShortWriteIo::new(1000, 3));
+    let mut scratch = SharedScratch::default();
+
+    let mut head = SharedChunkedResponseHeadWriter::new(ResponseHead {
+      version: Version::Http11,
+      status: 200,
+      reason: b"OK",
+      headers: &[],
+      keep_alive: false,
+    });
+    std::future::poll_fn(|cx| {
+      conn.poll_start_chunked_response_with(cx, &mut scratch, &mut head)
+    })
+    .await?;
+
+    let big = vec![b'x'; CHUNKED_FLUSH_THRESHOLD + 1024];
+    let mut writer = SharedResponseChunkWriter::new(&big);
+    std::future::poll_fn(|cx| {
+      conn.poll_write_response_chunk_with(cx, &mut scratch, &mut writer)
+    })
+    .await?;
+
+    let mut end = SharedResponseEndWriter::new(&[]);
+    std::future::poll_fn(|cx| {
+      conn.poll_finish_response_with(cx, &mut scratch, &mut end)
+    })
+    .await?;
+
+    let mut expected = Vec::new();
+    expected.extend_from_slice(
+      b"HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n",
+    );
+    expected.extend_from_slice(format!("{:x}\r\n", big.len()).as_bytes());
+    expected.extend_from_slice(&big);
+    expected.extend_from_slice(b"\r\n0\r\n\r\n");
+    assert_eq!(conn.into_inner().written, expected);
     Ok(())
   }
 


### PR DESCRIPTION
## Summary

`Deno.serve` responses whose body is a `ReadableStream` (sent `Transfer-Encoding: chunked`) regressed in throughput when the HTTP/1 layer was rewritten: the chunked path emits the head, each body chunk, and the terminating `0\r\n\r\n` as **three separate `write` syscalls**, where it previously coalesced them into one. The fixed/`Content-Length` path was unaffected (it already coalesces head+body into a single write), so the regression is specific to streamed/chunked responses — which is what shows up as "streaming got slower" in the runtime benchmarks (a header-mutating Hono middleware re-emits the response as a `ReadableStream`, so it rides this path).

Measured with a `write`/`sendto` interposer, 30k requests, 100-byte body:

| path | before | after |
| --- | ---: | ---: |
| chunked (`ReadableStream`) | **3 sendto/req** | **1 sendto/req** |
| fixed (`Content-Length`) | 1 sendto/req | 1 sendto/req |

## Fix

Buffer a chunked response into the connection's existing per-request scratch buffer (`SharedScratch::write_buf`) and flush it once, instead of writing each piece straight to the socket:

- `poll_start_chunked_response_with` leaves the head in `write_buf` (deferred) for `Chunked` responses. `NoBody` / `CloseDelimited` (HTTP/1.0) still flush the head immediately, since they have no chunk framing to coalesce behind.
- `poll_write_response_chunk_with` appends each chunk's framing to `write_buf`, flushing only once it crosses `CHUNKED_FLUSH_THRESHOLD` (64 KiB) so memory stays bounded for large/long-lived bodies.
- `poll_finish_response_with` appends the terminator, flushes once, then shrinks `write_buf` back to its default capacity so a connection that served one large response doesn't retain an oversized buffer.
- The streaming drivers flush the buffer when the body source has nothing ready (`Poll::Pending`), so incremental/SSE responses are still delivered promptly; only chunks that are available synchronously coalesce.

No new per-connection allocation — it reuses the buffer that already exists for building response frames.

## Results

`oha -c 100 --disable-compression`, `--profile=release-lite`, same build for both columns:

| | before | after |
| --- | ---: | ---: |
| chunked stream rps | 75,643 | **102,024** (+35%) |
| fixed rps | ~145k | ~145k (unchanged) |
| stream RSS @ 400 rps | 60 MB | 60 MB (unchanged) |

## Tests

- `deno_http_h1` unit tests (which assert byte-exact chunked output, including partial/fragmented writes and trailers) pass.
- `unit::serve_test` and `unit::http_test` pass.
