### PR TITLE
fix(cache): skip checksums for cached 404 entries

### DIFF
--- a/libs/cache_dir/file_fetcher/mod.rs
+++ b/libs/cache_dir/file_fetcher/mod.rs
@@ -719,30 +719,34 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
           url: url.clone(),
           source,
         })?;
-    match self.http_cache.get(&cache_key, None) {
+    let maybe_headers =
+      self.http_cache.read_headers(&cache_key).map_err(|source| {
+        CacheReadError {
+          url: url.clone(),
+          source,
+        }
+      })?;
+    if let Some(headers) = &maybe_headers
+      && headers.contains_key(NOT_FOUND_CACHE_HEADER)
+    {
+      let download_time = self
+        .http_cache
+        .read_download_time(&cache_key)
+        .map_err(|source| CacheReadError {
+          url: url.clone(),
+          source,
+        })?;
+      return if self.is_not_found_entry_fresh(download_time) {
+        Err(FetchCachedNoFollowErrorKind::NotFound(url.clone()).into_box())
+      } else {
+        // expired, treat as a cache miss so the URL is re-requested
+        Ok(None)
+      };
+    }
+
+    match self.http_cache.get(&cache_key, maybe_checksum) {
       Ok(Some(entry)) => {
-        if entry.metadata.headers.contains_key(NOT_FOUND_CACHE_HEADER) {
-          let download_time = entry
-            .metadata
-            .time
-            .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs(secs));
-          return if self.is_not_found_entry_fresh(download_time) {
-            Err(FetchCachedNoFollowErrorKind::NotFound(url.clone()).into_box())
-          } else {
-            // expired, treat as a cache miss so the URL is re-requested
-            Ok(None)
-          };
-        }
-        let file_or_redirect =
-          FileOrRedirect::from_deno_cache_entry(url, entry)?;
-        if let Some(checksum) = maybe_checksum
-          && let FileOrRedirect::File(file) = &file_or_redirect
-        {
-          checksum.check(url, &file.source).map_err(|err| {
-            FetchCachedNoFollowErrorKind::ChecksumIntegrity(*err)
-          })?;
-        }
-        Ok(Some(file_or_redirect))
+        Ok(Some(FileOrRedirect::from_deno_cache_entry(url, entry)?))
       }
       Ok(None) => Ok(None),
       Err(CacheReadFileError::Io(source)) => Err(

--- a/libs/cache_dir/file_fetcher/mod.rs
+++ b/libs/cache_dir/file_fetcher/mod.rs
@@ -719,7 +719,7 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
           url: url.clone(),
           source,
         })?;
-    match self.http_cache.get(&cache_key, maybe_checksum) {
+    match self.http_cache.get(&cache_key, None) {
       Ok(Some(entry)) => {
         if entry.metadata.headers.contains_key(NOT_FOUND_CACHE_HEADER) {
           let download_time = entry
@@ -733,7 +733,16 @@ impl<TBlobStore: BlobStore, TSys: FileFetcherSys, THttpClient: HttpClient>
             Ok(None)
           };
         }
-        Ok(Some(FileOrRedirect::from_deno_cache_entry(url, entry)?))
+        let file_or_redirect =
+          FileOrRedirect::from_deno_cache_entry(url, entry)?;
+        if let Some(checksum) = maybe_checksum
+          && let FileOrRedirect::File(file) = &file_or_redirect
+        {
+          checksum.check(url, &file.source).map_err(|err| {
+            FetchCachedNoFollowErrorKind::ChecksumIntegrity(*err)
+          })?;
+        }
+        Ok(Some(file_or_redirect))
       }
       Ok(None) => Ok(None),
       Err(CacheReadFileError::Io(source)) => Err(

--- a/libs/cache_dir/tests/file_fetcher_test.rs
+++ b/libs/cache_dir/tests/file_fetcher_test.rs
@@ -4,6 +4,7 @@
 
 use std::time::SystemTime;
 
+use deno_cache_dir::Checksum;
 use deno_cache_dir::file_fetcher::AuthTokens;
 use deno_cache_dir::file_fetcher::CacheSetting;
 use deno_cache_dir::file_fetcher::CachedOrRedirect;
@@ -397,6 +398,17 @@ async fn test_fetch_not_found_is_negatively_cached() {
   assert_not_found(
     file_fetcher
       .fetch_no_follow(&url, FetchNoFollowOptions::default())
+      .await,
+  );
+  assert_not_found(
+    file_fetcher
+      .fetch_no_follow(
+        &url,
+        FetchNoFollowOptions {
+          maybe_checksum: Some(Checksum::new("not matching")),
+          ..Default::default()
+        },
+      )
       .await,
   );
   match file_fetcher


### PR DESCRIPTION
Closes #35525.

## What changed

Cached 404 entries are now recognized before applying a content checksum in the file fetcher cache path. The checksum is still applied to real cached file bodies, but synthetic not-found metadata entries report `NotFound` instead of trying to validate an empty body against a JSR package manifest checksum.

## Why

JSR packages can contain dependency probes for extensionless Node built-ins such as `crypto`, `fs`, or `path`. Those URLs are cached as 404 metadata entries. On a later run, the module graph can provide a package-manifest checksum for the missing JSR subpath, which previously caused the cached 404's empty body to fail integrity validation with `Expected: package-manifest-missing-checksum`.

## Validation

- `cargo fmt -p deno_cache_dir`
- `cargo test -p deno_cache_dir test_fetch_not_found_is_negatively_cached`
- `cargo test -p deno_cache_dir`
- `./tools/lint.js`
- End-to-end: first and second `cargo run --quiet --bin deno -- cache jsr:@ts-morph/ts-morph@28.0.0` with the same temporary `DENO_DIR` both exited 0
