### PR TITLE
fix(ext/node): report all active resources from process.getActiveResourcesInfo

### DIFF
--- a/ext/node/polyfills/internal/process/active_resources.ts
+++ b/ext/node/polyfills/internal/process/active_resources.ts
@@ -4,10 +4,22 @@
 
 (function () {
 const { primordials } = __bootstrap;
-const { ArrayPrototypePush, SafeSet, SafeSetIterator } = primordials;
+const {
+  ArrayPrototypePush,
+  SafeSet,
+  SafeSetIterator,
+  SafeWeakMap,
+  WeakMapPrototypeDelete,
+  WeakMapPrototypeGet,
+  WeakMapPrototypeSet,
+} = primordials;
 
 const activeRequests = new SafeSet();
 const activeHandles = new SafeSet();
+// Maps a tracked resource to the libuv-style wrap name Node reports from
+// `process.getActiveResourcesInfo()` (e.g. "TCPSocketWrap"). The role (server
+// vs. socket) isn't recoverable from the handle alone, so callers tag it here.
+const resourceNames = new SafeWeakMap();
 
 class FSReqCallback {}
 
@@ -19,40 +31,71 @@ function snapshot(set: Set<any>) {
   return resources;
 }
 
-function registerActiveRequest(request: any) {
+function resourceTypeName(resource: any) {
+  const name = WeakMapPrototypeGet(resourceNames, resource);
+  if (name !== undefined) {
+    return name;
+  }
+  const ctor = resource?.constructor;
+  return (ctor && ctor.name) || "Unknown";
+}
+
+function registerActiveRequest(request: any, name?: string) {
   activeRequests.add(request);
+  if (name !== undefined) {
+    WeakMapPrototypeSet(resourceNames, request, name);
+  }
   return request;
 }
 
 function unregisterActiveRequest(request: any) {
   activeRequests.delete(request);
+  WeakMapPrototypeDelete(resourceNames, request);
 }
 
 function createFSReqCallback() {
-  return registerActiveRequest(new FSReqCallback());
+  return registerActiveRequest(new FSReqCallback(), "FSReqCallback");
 }
 
 function getActiveRequests() {
   return snapshot(activeRequests);
 }
 
-function registerActiveHandle(handle: any) {
+function registerActiveHandle(handle: any, name?: string) {
   activeHandles.add(handle);
+  if (name !== undefined) {
+    WeakMapPrototypeSet(resourceNames, handle, name);
+  }
   return handle;
 }
 
 function unregisterActiveHandle(handle: any) {
   activeHandles.delete(handle);
+  WeakMapPrototypeDelete(resourceNames, handle);
 }
 
 function getActiveHandles() {
   return snapshot(activeHandles);
 }
 
+// The wrap names of every tracked handle and request, for
+// `process.getActiveResourcesInfo()`.
+function getActiveResourceNames() {
+  const names: string[] = [];
+  for (const handle of new SafeSetIterator(activeHandles)) {
+    ArrayPrototypePush(names, resourceTypeName(handle));
+  }
+  for (const request of new SafeSetIterator(activeRequests)) {
+    ArrayPrototypePush(names, resourceTypeName(request));
+  }
+  return names;
+}
+
 return {
   createFSReqCallback,
   getActiveHandles,
   getActiveRequests,
+  getActiveResourceNames,
   registerActiveHandle,
   registerActiveRequest,
   unregisterActiveHandle,

--- a/ext/node/polyfills/internal/timers.mjs
+++ b/ext/node/polyfills/internal/timers.mjs
@@ -86,6 +86,12 @@ function getActiveResourcesInfo() {
       ArrayPrototypePush(resources, "Timeout");
     }
   }
+  // Immediates aren't tracked in a JS-side collection: they're queued into and
+  // consumed by core, which keeps the count of refed (loop-alive) immediates.
+  const immediateCount = core.getActiveImmediateCount();
+  for (let i = 0; i < immediateCount; i++) {
+    ArrayPrototypePush(resources, "Immediate");
+  }
   return resources;
 }
 
@@ -178,9 +184,7 @@ Timeout.prototype[createTimer] = function () {
   let cb;
   function invokeCallback() {
     const wasRepeat = self._repeat;
-    if (!wasRepeat) {
-      MapPrototypeDelete(activeTimers, self[kTimerId]);
-    } else {
+    if (wasRepeat) {
       const currentCb = self._onTimeout;
       if (currentCb === null) {
         self[kDestroy]();
@@ -189,23 +193,30 @@ Timeout.prototype[createTimer] = function () {
     }
     const currentCb = wasRepeat ? self._onTimeout : callback;
     const args = self._timerArgs;
-    let ret;
-    if (args !== undefined && args.length > 0) {
-      ret = ReflectApply(currentCb, self, args);
-    } else {
-      ret = FunctionPrototypeCall(currentCb, self);
-    }
-    if (wasRepeat) {
-      if (self._idleTimeout < 0 || self._onTimeout === null) {
-        self[kDestroy]();
+    try {
+      if (args !== undefined && args.length > 0) {
+        return ReflectApply(currentCb, self, args);
+      } else {
+        return FunctionPrototypeCall(currentCb, self);
       }
-    } else if (self._repeat) {
-      // timeout was converted to interval inside callback
-      self[kTimerId] = self[createTimer]();
-    } else {
-      self._destroyed = true;
+    } finally {
+      // Cleanup runs after the callback (in a `finally` so it happens even if
+      // the callback throws). Node keeps a one-shot Timeout reported as an
+      // active resource during its own callback and only drops it afterwards,
+      // so `activeTimers` must retain it for the duration of the call.
+      if (wasRepeat) {
+        if (self._idleTimeout < 0 || self._onTimeout === null) {
+          self[kDestroy]();
+        }
+      } else if (self._repeat) {
+        // timeout was converted to interval inside callback
+        MapPrototypeDelete(activeTimers, self[kTimerId]);
+        self[kTimerId] = self[createTimer]();
+      } else {
+        MapPrototypeDelete(activeTimers, self[kTimerId]);
+        self._destroyed = true;
+      }
     }
-    return ret;
   }
   if (enabledHooksExist()) {
     cb = function () {

--- a/ext/node/polyfills/net.ts
+++ b/ext/node/polyfills/net.ts
@@ -2233,7 +2233,12 @@ ObjectDefineProperty(Socket.prototype, "_handle", {
     if (this[kHandle] && !v) {
       unregisterActiveHandle(this);
     } else if (!this[kHandle] && v) {
-      registerActiveHandle(this);
+      registerActiveHandle(
+        this,
+        ObjectPrototypeIsPrototypeOf(TCP.prototype, v)
+          ? "TCPSocketWrap"
+          : "PipeWrap",
+      );
     }
     this[kHandle] = v;
   },
@@ -2664,6 +2669,14 @@ function _onconnectionImpl(this: any, err: number, clientHandle?: Handle) {
   }
 }
 
+// The libuv-style wrap name Node reports for a server handle from
+// `process.getActiveResourcesInfo()`.
+function _serverWrapName(handle: Handle) {
+  return ObjectPrototypeIsPrototypeOf(TCP.prototype, handle)
+    ? "TCPServerWrap"
+    : "PipeWrap";
+}
+
 function _setupListenHandle(
   this: Server,
   address: string | null,
@@ -2679,7 +2692,7 @@ function _setupListenHandle(
   // In the case of a server sent via IPC, we don't need to do this.
   if (this._handle) {
     debug("setupListenHandle: have a handle already");
-    registerActiveHandle(this);
+    registerActiveHandle(this, _serverWrapName(this._handle));
   } else {
     debug("setupListenHandle: create a handle");
 
@@ -2730,7 +2743,7 @@ function _setupListenHandle(
     }
 
     this._handle = rval;
-    registerActiveHandle(this);
+    registerActiveHandle(this, _serverWrapName(this._handle));
   }
 
   this[asyncIdSymbol] = _getNewAsyncId(this._handle);

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -127,6 +127,7 @@ const { buildAllowedFlags } = core.loadExtScript(
 const {
   getActiveHandles,
   getActiveRequests,
+  getActiveResourceNames,
 } = core.loadExtScript("ext:deno_node/internal/process/active_resources.ts");
 const {
   getActiveResourcesInfo: getTimerActiveResourcesInfo,
@@ -149,6 +150,7 @@ const {
   ArrayIsArray,
   ArrayPrototypeConcat,
   ArrayPrototypeFind,
+  ArrayPrototypePush,
   BigInt,
   Error,
   ErrorCaptureStackTrace,
@@ -490,8 +492,37 @@ memoryUsage.rss = function (): number {
   return memoryUsage().rss;
 };
 
+// stdin/stdout/stderr are reported as "TTYWrap" when connected to a terminal,
+// matching Node, where the TTY handles keep the event loop alive. When they're
+// redirected to a pipe or file Node uses synchronous I/O without a libuv
+// handle, so nothing is reported.
+function getStdioActiveResources(): string[] {
+  const result: string[] = [];
+  const streams = [Deno.stdin, Deno.stdout, Deno.stderr];
+  for (const stream of new SafeArrayIterator(streams)) {
+    try {
+      if (stream && stream.isTerminal()) {
+        ArrayPrototypePush(result, "TTYWrap");
+      }
+    } catch {
+      // Stream may be closed or unavailable (e.g. in a worker); ignore.
+    }
+  }
+  return result;
+}
+
 export function getActiveResourcesInfo(): string[] {
-  return getTimerActiveResourcesInfo();
+  const result: string[] = [];
+  for (const name of new SafeArrayIterator(getStdioActiveResources())) {
+    ArrayPrototypePush(result, name);
+  }
+  for (const name of new SafeArrayIterator(getActiveResourceNames())) {
+    ArrayPrototypePush(result, name);
+  }
+  for (const name of new SafeArrayIterator(getTimerActiveResourcesInfo())) {
+    ArrayPrototypePush(result, name);
+  }
+  return result;
 }
 
 export function availableMemory(): number {

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -498,7 +498,7 @@ memoryUsage.rss = function (): number {
 // handle, so nothing is reported.
 function getStdioActiveResources(): string[] {
   const result: string[] = [];
-  const streams = [Deno.stdin, Deno.stdout, Deno.stderr];
+  const streams = [io.stdin, io.stdout, io.stderr];
   for (const stream of new SafeArrayIterator(streams)) {
     try {
       if (stream && stream.isTerminal()) {

--- a/libs/core/01_core.js
+++ b/libs/core/01_core.js
@@ -1093,6 +1093,9 @@
     clearImmediate,
     runImmediates,
     immediateQueue,
+    getActiveImmediateCount() {
+      return immediateInfo[kImmRefCount];
+    },
     kRefed,
     runMicrotasks: () => op_run_microtasks(),
     hasTickScheduled,

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -5208,7 +5208,11 @@
       "darwin": false,
       "reason": "process.execve is not a function"
     },
+    "parallel/test-process-getactiveresources-track-active-handles.js": {},
+    "parallel/test-process-getactiveresources-track-active-requests.js": {},
     "parallel/test-process-getactiveresources-track-interval-lifetime.js": {},
+    "parallel/test-process-getactiveresources-track-multiple-timers.js": {},
+    "parallel/test-process-getactiveresources-track-timer-lifetime.js": {},
     "parallel/test-process-initgroups.js": {
       "linux": false,
       "darwin": false,

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -941,6 +941,71 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "process.getActiveResourcesInfo reports net handles with Node wrap names",
+  async fn() {
+    const countOf = (type: string) =>
+      process.getActiveResourcesInfo().filter((t) => t === type).length;
+
+    const beforeServer = countOf("TCPServerWrap");
+    const beforeSocket = countOf("TCPSocketWrap");
+
+    let acceptedSocket: net.Socket | undefined;
+    const server = net.createServer((socket) => {
+      acceptedSocket = socket;
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    const serverConnection = once(server, "connection");
+    const clientSocket = net.connect(
+      (server.address() as net.AddressInfo).port,
+    );
+    try {
+      await Promise.all([once(clientSocket, "connect"), serverConnection]);
+
+      assertEquals(countOf("TCPServerWrap"), beforeServer + 1);
+      // The client socket plus the server-accepted socket.
+      assertEquals(countOf("TCPSocketWrap"), beforeSocket + 2);
+    } finally {
+      clientSocket.destroy();
+      acceptedSocket?.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  },
+});
+
+Deno.test({
+  name: "process.getActiveResourcesInfo reports fs requests as FSReqCallback",
+  async fn() {
+    const tempFile = Deno.makeTempFileSync();
+    const countOf = () =>
+      process.getActiveResourcesInfo().filter((t) => t === "FSReqCallback")
+        .length;
+    try {
+      const before = countOf();
+      const promises = Array.from(
+        { length: 5 },
+        () =>
+          new Promise<number>((resolve, reject) => {
+            fs.open(tempFile, "r", (err, fd) => {
+              if (err) reject(err);
+              else resolve(fd);
+            });
+          }),
+      );
+
+      assertEquals(countOf(), before + 5);
+
+      const fds = await Promise.all(promises);
+      for (const fd of fds) fs.closeSync(fd);
+      assertEquals(countOf(), before);
+    } finally {
+      Deno.removeSync(tempFile);
+    }
+  },
+});
+
+Deno.test({
   name: "process.hrtime",
   // TODO(kt3k): Enable this test
   ignore: true,


### PR DESCRIPTION
Closes #35071.

`process.getActiveResourcesInfo()` only returned timer entries. Active handles and requests are already tracked internally (`internal/process/active_resources.ts`) for `_getActiveHandles`/`_getActiveRequests`, but `getActiveResourcesInfo` ignored them, and stdio TTY handles were never reported at all.

So in a terminal Node returns:

```
Before: [ 'TTYWrap', 'TTYWrap', 'TTYWrap' ]
After:  [ 'TTYWrap', 'TTYWrap', 'TTYWrap', 'Timeout' ]
```

while Deno returned `[]` / `[ 'Timeout' ]`.

This aggregates the tracked handles/requests and stdio into the result, tagging each handle/request with the libuv-style wrap name Node uses:

- net sockets → `TCPSocketWrap` / `PipeWrap`
- net servers → `TCPServerWrap` / `PipeWrap`
- fs requests → `FSReqCallback`
- stdin/stdout/stderr → `TTYWrap` when connected to a terminal

stdio reports `TTYWrap` only for a TTY, matching Node: redirected/piped stdio uses synchronous I/O with no libuv handle, so nothing is reported there.

Verified against Node 24 for the timer, TCP server/socket and TTY cases, including under a real pty.