### PR TITLE
fix(ext/node): don't panic when main module path has invalid percent-encoding

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -1783,7 +1783,6 @@ function mainModuleArgv(
   }
   return join(Deno.cwd(), "$deno$node.mjs");
 }
-internals.mainModuleArgv = mainModuleArgv;
 
 // Should be called only once, in `runtime/js/99_main.js` when the runtime is
 // bootstrapped.

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -1763,6 +1763,28 @@ function synchronizeListeners() {
 internals.dispatchProcessBeforeExitEvent = dispatchProcessBeforeExitEvent;
 internals.dispatchProcessExitEvent = dispatchProcessExitEvent;
 
+// Resolves the value for `process.argv[1]` from `Deno.mainModule`. Converting a
+// `file:` URL to a path can throw (e.g. `URIError: URI malformed` when the path
+// contains invalid percent-encoding), and this runs during bootstrap where an
+// uncaught throw aborts the runtime with a panic. Fall back to the raw
+// specifier so a non-decodable main module can't crash the process.
+function mainModuleArgv(
+  mainModule: string | undefined = Deno.mainModule,
+): string {
+  if (Deno.build.standalone) {
+    return Deno.execPath();
+  }
+  if (mainModule?.startsWith("file:")) {
+    try {
+      return pathFromURL(new URL(mainModule));
+    } catch {
+      return mainModule;
+    }
+  }
+  return join(Deno.cwd(), "$deno$node.mjs");
+}
+internals.mainModuleArgv = mainModuleArgv;
+
 // Should be called only once, in `runtime/js/99_main.js` when the runtime is
 // bootstrapped.
 internals.__bootstrapNodeProcess = function (
@@ -1794,11 +1816,7 @@ internals.__bootstrapNodeProcess = function (
     op_stream_base_register_state(streamBaseState);
     argv0 = argv0Val || "";
     argv[0] = Deno.execPath();
-    argv[1] = Deno.build.standalone
-      ? Deno.execPath()
-      : Deno.mainModule?.startsWith("file:")
-      ? pathFromURL(new URL(Deno.mainModule))
-      : join(Deno.cwd(), "$deno$node.mjs");
+    argv[1] = mainModuleArgv();
     // Manually concatenate these arrays to avoid triggering the getter
     for (let i = 0; i < args.length; i++) {
       argv[i + 2] = args[i];

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -184,25 +184,6 @@ Deno.test({
 });
 
 Deno.test({
-  // Regression test for https://github.com/denoland/deno/issues/34178: a main
-  // module whose path contains invalid percent-encoding made `process.argv[1]`
-  // resolution throw `URIError: URI malformed` during bootstrap, panicking the
-  // runtime. It must fall back to the raw specifier instead of throwing.
-  name: "process.argv[1] resolution survives a malformed main module URL",
-  fn() {
-    // @ts-ignore: Deno[Deno.internal] allowed
-    const mainModuleArgv = Deno[Deno.internal].mainModuleArgv;
-    assertEquals(typeof mainModuleArgv, "function");
-    // Invalid percent-encoding (a non-UTF-8 byte) must not throw.
-    assertEquals(mainModuleArgv("file:///%C0"), "file:///%C0");
-    // Valid file URLs still decode to a path.
-    if (Deno.build.os !== "windows") {
-      assertEquals(mainModuleArgv("file:///tmp/a%20b.mjs"), "/tmp/a b.mjs");
-    }
-  },
-});
-
-Deno.test({
   name: "process.ppid",
   fn() {
     assertEquals(typeof process.ppid, "number");

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -184,6 +184,25 @@ Deno.test({
 });
 
 Deno.test({
+  // Regression test for https://github.com/denoland/deno/issues/34178: a main
+  // module whose path contains invalid percent-encoding made `process.argv[1]`
+  // resolution throw `URIError: URI malformed` during bootstrap, panicking the
+  // runtime. It must fall back to the raw specifier instead of throwing.
+  name: "process.argv[1] resolution survives a malformed main module URL",
+  fn() {
+    // @ts-ignore: Deno[Deno.internal] allowed
+    const mainModuleArgv = Deno[Deno.internal].mainModuleArgv;
+    assertEquals(typeof mainModuleArgv, "function");
+    // Invalid percent-encoding (a non-UTF-8 byte) must not throw.
+    assertEquals(mainModuleArgv("file:///%C0"), "file:///%C0");
+    // Valid file URLs still decode to a path.
+    if (Deno.build.os !== "windows") {
+      assertEquals(mainModuleArgv("file:///tmp/a%20b.mjs"), "/tmp/a b.mjs");
+    }
+  },
+});
+
+Deno.test({
   name: "process.ppid",
   fn() {
     assertEquals(typeof process.ppid, "number");

--- a/tools/lint_plugins/no_deno_api_in_polyfills.ts
+++ b/tools/lint_plugins/no_deno_api_in_polyfills.ts
@@ -14,7 +14,7 @@
 // Paths are relative to the repo root.
 export const EXPECTED_VIOLATIONS: Record<string, number> = {
   "ext/node/polyfills/fs.ts": 53,
-  "ext/node/polyfills/process.ts": 32,
+  "ext/node/polyfills/process.ts": 31,
   "ext/node/polyfills/os.ts": 22,
   "ext/node/polyfills/internal/child_process.ts": 23,
   "ext/node/polyfills/_fs/_fs_copy.ts": 8,


### PR DESCRIPTION
Closes #34178.

When the node process polyfill bootstraps, it sets `process.argv[1]` from `Deno.mainModule` by converting the `file:` URL to a path. That conversion ends in `decodeURIComponent`, which throws `URIError: URI malformed` if the path contains invalid percent-encoding (e.g. a non-UTF-8 byte). Since this happens during bootstrap, the uncaught throw aborts the runtime with a panic:

```
thread 'main' panicked at runtime/worker.rs:745:
Bootstrap exception: URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at pathFromURLPosix (ext:deno_web/00_infra.js)
```

This was hit in the wild via yt-dlp's `deno` provider (#34178).

The decode itself is not wrong — Node throws the same `URIError` from `fileURLToPath` for these paths — so this only fixes the crash: the conversion is guarded and falls back to the raw specifier when it can't be decoded, so a non-decodable main module no longer takes down the process.

Reproducing the exact filesystem state is awkward on macOS (the path needs a non-UTF-8 byte), so the regression test exercises the extracted helper directly with a malformed URL.