### PR TITLE
fix(fmt): stable formatting of multi-line html/svg tagged templates

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -633,20 +633,21 @@ fn format_embedded_html(
   // the result, so the text must be dedented first to make the round trip a
   // fixed point
   let dedented = dedent_embedded(text);
-  let Some(formatted) = lax_markup::format_text_with_external(
+  let formatted = match lax_markup::format_text_with_external(
     Path::new("embedded.html"),
     &dedented,
     &markup_config,
     &external,
-  )?
-  else {
-    return Ok(if dedented == text {
-      None
-    } else {
-      Some(dedented)
-    });
+  )? {
+    Some(formatted) => formatted,
+    None => dedented,
   };
-  let formatted = formatted.trim_end_matches('\n');
+  // the typescript formatter frames the contents on their own lines between the
+  // opening and closing backticks, so any leading or trailing blank line would
+  // be re-added on every pass and the format would never reach a fixed point.
+  // unlike lax-css, lax-markup keeps leading blank lines verbatim, so trim both
+  // ends here.
+  let formatted = formatted.trim_matches('\n');
   Ok(if formatted == text {
     None
   } else {

--- a/tests/specs/fmt/embedded_html_multiline_stable/__test__.jsonc
+++ b/tests/specs/fmt/embedded_html_multiline_stable/__test__.jsonc
@@ -1,0 +1,10 @@
+{
+  "tempDir": true,
+  "tests": {
+    "stdin": {
+      "args": "fmt -",
+      "input": "html`\n  ${\"Hello\"}\n`;\n",
+      "output": "html`\n  ${\"Hello\"}\n`;\n"
+    }
+  }
+}


### PR DESCRIPTION
Running `deno fmt` on a multi-line `html` (or `svg`) tagged template that
starts with a newline looped forever, repeatedly inserting a blank line
after the opening backtick until it gave up with "Formatting not stable.
Bailed after 5 tries". This regressed in 2.9.0 when embedded markup
formatting was added for these tags.

The embedded HTML formatter only trimmed the trailing newline of the
formatted contents. Unlike lax-css, lax-markup preserves a leading blank
line verbatim, and the TypeScript formatter then re-frames the contents
on their own lines between the backticks, prepending another newline. So
every pass added one more blank line and the output never reached a fixed
point. Trimming both ends makes the round trip stable.

Fixes #35528