### PR TITLE
fix(desktop): default window title to app name instead of laufey_webview

### DIFF
--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -1665,6 +1665,10 @@ async fn run_desktop(
   let auto_update_rolled_back =
     auto_update_state.as_ref().is_some_and(|s| s.rolled_back);
 
+  // App name (deno.json `desktop.app.name`, baked in at compile time) used as
+  // the default window title. Moved into the op_state_init closure below.
+  let app_name = data.metadata.app_name.clone();
+
   let run_opts = RunOptions {
     auto_serve: true,
     serve_port: Some(desktop_serve_port),
@@ -1707,6 +1711,15 @@ async fn run_desktop(
       let window_id = api.create_window(800, 600, false, false, false);
       initial_window_id.store(window_id, Ordering::Release);
 
+      // Title the initial window with the app name up front, so an app that
+      // never constructs its own `BrowserWindow` still shows "MyApp" rather
+      // than the backend's internal default (`laufey_webview`). The
+      // `BrowserWindow` constructor applies the same default to any further
+      // untitled windows via `DesktopAppName` in op state.
+      if let Some(name) = app_name.as_deref().filter(|n| !n.is_empty()) {
+        api.set_title(window_id, name);
+      }
+
       denort::desktop::init_desktop_state(
         state,
         Box::new(api),
@@ -1718,6 +1731,9 @@ async fn run_desktop(
       state.put(denort::desktop::InitialWindowId(std::sync::Mutex::new(
         Some(window_id),
       )));
+      if let Some(name) = app_name {
+        state.put(deno_runtime::ops::desktop::DesktopAppName(name));
+      }
     })),
     override_main_module: None,
     auto_update_version,

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -1731,7 +1731,7 @@ async fn run_desktop(
       state.put(denort::desktop::InitialWindowId(std::sync::Mutex::new(
         Some(window_id),
       )));
-      if let Some(name) = app_name {
+      if let Some(name) = app_name.filter(|n| !n.is_empty()) {
         state.put(deno_runtime::ops::desktop::DesktopAppName(name));
       }
     })),

--- a/runtime/ops/desktop.rs
+++ b/runtime/ops/desktop.rs
@@ -488,6 +488,12 @@ pub enum PermissionState {
 /// window; subsequent constructors create new windows.
 pub struct InitialWindowId(pub std::sync::Mutex<Option<u32>>);
 
+/// The compiled app's name (from deno.json `desktop.app.name`, falling back to
+/// the output file name). Used as the default window title so a window the app
+/// doesn't explicitly title shows the app name instead of the backend's
+/// internal default (`laufey_webview`).
+pub struct DesktopAppName(pub String);
+
 struct BrowserWindow {
   api: Arc<dyn DesktopApi>,
   window_id: u32,
@@ -560,6 +566,17 @@ impl BrowserWindow {
           transparent_titlebar,
         )
       });
+
+    // Default the window title to the app name when the app doesn't set one,
+    // so the window shows e.g. "MyApp" instead of the backend's internal
+    // default (`laufey_webview`). An explicit `title` option below overrides
+    // this, and a page that sets `document.title` overrides it at the OS level.
+    if options.as_ref().and_then(|o| o.title.as_ref()).is_none()
+      && let Some(name) = state.try_borrow::<DesktopAppName>()
+      && !name.0.is_empty()
+    {
+      api.set_title(window_id, &name.0);
+    }
 
     if let Some(options) = &options {
       if let Some(title) = &options.title {


### PR DESCRIPTION
Fixes #35501.

A desktop app window that the app doesn't explicitly title showed the
backend's internal default, `laufey_webview`, rather than the configured
`desktop.app.name` from `deno.json`. This was visible on the docs "Hello
desktop" example, where the window title bar read `laufey_webview`.

The app name is already baked into the compiled binary at compile time
(from `desktop.app.name`, falling back to the output file name). This
change uses it as the default window title: the initial window is titled
at creation, and the `BrowserWindow` constructor applies the same default
to any further untitled windows via a new `DesktopAppName` value in op
state.

An explicit `title` option on `new BrowserWindow({ title })` still takes
precedence, and a page that sets `document.title` still overrides the
title at the OS level, so this only changes the previously-empty default.

No automated test is included: desktop window titles are GUI/laufey-bound
and not exercisable in CI. Verified manually against the docs "Hello
desktop" example.
