### PR TITLE
feat(desktop): add `--check-only` flag to type-check with desktop lib

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2539,6 +2539,14 @@ supported framework (Next.js, Astro, etc.) in the current directory.
           .help_heading(DESKTOP_HEADING),
       )
       .arg(
+        Arg::new("check-only")
+          .long("check-only")
+          .help(cstr!("Type-check the app with the desktop type library and exit without building, packaging, or running it.
+  <p(245)>Use the desktop globals (e.g. Deno.BrowserWindow) when checking. Combine with --check=all to also type-check remote modules.</>"))
+          .action(ArgAction::SetTrue)
+          .help_heading(DESKTOP_HEADING),
+      )
+      .arg(
         Arg::new("compress")
           .long("compress")
           .help(
@@ -6904,6 +6912,7 @@ fn desktop_parse(
   let hmr = matches.get_flag("hmr");
   let backend = matches.remove_one::<String>("backend");
   let all_targets = matches.get_flag("all-targets");
+  let check_only = matches.get_flag("check-only");
   // Self-extracting packaging is opt-in via `--compress [<fmt>]`. Bare
   // `--compress` defaults to xz (decompressed by the system `tar` with no
   // external tool); zstd is smaller/faster but needs the `zstd` binary at
@@ -6939,6 +6948,7 @@ fn desktop_parse(
     codesign_identity: None,
     inspect_renderer,
     compress,
+    check_only,
   });
 
   Ok(())
@@ -14056,6 +14066,41 @@ mod tests {
       panic!("expected desktop subcommand");
     };
     assert_eq!(desktop.backend.as_deref(), Some("cef"));
+  }
+
+  #[test]
+  fn desktop_check_only() {
+    let r =
+      flags_from_vec(svec!["deno", "desktop", "--check-only", "main.tsx"]);
+    let flags = r.unwrap();
+    let DenoSubcommand::Desktop(desktop) = flags.subcommand else {
+      panic!("expected desktop subcommand");
+    };
+    assert!(desktop.check_only);
+    // `--check-only` alone keeps the default local check scope.
+    assert_eq!(flags.type_check_mode, TypeCheckMode::Local);
+
+    // `--check-only` defaults to off.
+    let r = flags_from_vec(svec!["deno", "desktop", "main.tsx"]);
+    let DenoSubcommand::Desktop(desktop) = r.unwrap().subcommand else {
+      panic!("expected desktop subcommand");
+    };
+    assert!(!desktop.check_only);
+
+    // `--check=all` composes to widen the check scope.
+    let r = flags_from_vec(svec![
+      "deno",
+      "desktop",
+      "--check-only",
+      "--check=all",
+      "main.tsx"
+    ]);
+    let flags = r.unwrap();
+    let DenoSubcommand::Desktop(desktop) = flags.subcommand else {
+      panic!("expected desktop subcommand");
+    };
+    assert!(desktop.check_only);
+    assert_eq!(flags.type_check_mode, TypeCheckMode::All);
   }
 
   #[test]

--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -375,6 +375,14 @@ async fn compile_desktop(
     None
   };
 
+  // `--check-only`: type-check the resolved entrypoint with the desktop type
+  // library (so `Deno.BrowserWindow` & co. resolve) and stop here — no
+  // building, packaging, or running. The temp framework entrypoint (if any)
+  // stays alive until it drops at the end of this scope.
+  if desktop_flags.check_only {
+    return check_desktop_entrypoint(flags, &desktop_flags.source_file).await;
+  }
+
   let self_extracting = desktop_entrypoint_file.is_some();
   // `desktop_entrypoint_file` (a NamedTempFile) keeps the file alive while
   // `compile_binary` reads it. It is explicitly closed right after compilation
@@ -592,6 +600,43 @@ async fn compile_desktop(
   }
 
   Ok(())
+}
+
+/// Type-check a desktop entrypoint without building it.
+///
+/// Backs `deno desktop --check-only`. The key difference from `deno check` is
+/// `internal.is_desktop = true`, which selects the desktop type library
+/// (`lib.deno.desktop.d.ts`) so the desktop globals (e.g. `Deno.BrowserWindow`)
+/// resolve. Check scope (local vs. remote) is carried on `flags.type_check_mode`
+/// from the existing `--check[=all]` flag; if checking was disabled (e.g. the
+/// Next.js auto-detect path, or `--no-check`), fall back to a local check so
+/// `--check-only` always actually checks something.
+async fn check_desktop_entrypoint(
+  mut flags: Flags,
+  source_file: &str,
+) -> Result<(), AnyError> {
+  flags.internal.is_desktop = true;
+  if matches!(flags.type_check_mode, TypeCheckMode::None) {
+    flags.type_check_mode = TypeCheckMode::Local;
+  }
+
+  let factory = CliFactory::from_flags(Arc::new(flags));
+  let main_graph_container = factory.main_module_graph_container().await?;
+  let specifiers = main_graph_container.collect_specifiers(
+    &[source_file.to_string()],
+    crate::graph_container::CollectSpecifiersOptions {
+      include_ignored_specified: false,
+    },
+  )?;
+  main_graph_container
+    .check_specifiers(
+      &specifiers,
+      crate::graph_container::CheckSpecifiersOptions {
+        allow_unknown_media_types: true,
+        ..Default::default()
+      },
+    )
+    .await
 }
 
 /// Convert a packaged app bundle into a self-extracting one: the heavy payload
@@ -6260,6 +6305,7 @@ def456  other.zip
       codesign_identity: None,
       inspect_renderer: None,
       compress: None,
+      check_only: false,
     }
   }
 

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -236,6 +236,11 @@ pub struct DesktopFlags {
   /// just a small download artifact. Value is the compressor: `"xz"` (LZMA)
   /// or `"zstd"`.
   pub compress: Option<String>,
+  /// When set, type-check the entrypoint with the desktop type library (so
+  /// `Deno.BrowserWindow` and friends resolve) and exit without building,
+  /// packaging, or running the app. Scope is controlled by the existing
+  /// `--check[=all]` flag.
+  pub check_only: bool,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

`deno check foo.ts` uses the `DenoWindow` TS lib, which doesn't include `Deno.BrowserWindow` (and the other desktop globals — those live in `lib.deno.desktop.d.ts`, only selected when `flags.internal.is_desktop` is set, i.e. during a `deno desktop` build/run). This left no way to type-check a desktop app with its globals resolved, which is what #35499 reports:

```
deno check m2.ts
TS2339 [ERROR]: Property 'BrowserWindow' does not exist on type 'typeof Deno'.
```

This PR adds a `--check-only` flag to `deno desktop` that type-checks the entrypoint with the desktop type library and exits — no building, packaging, or running. It composes with the existing `--check[=all]` scope flag.

```
deno desktop --check-only main.tsx             # local type-check + exit
deno desktop --check-only --check=all main.tsx # also check remote modules + exit
```

## Implementation

- `DesktopFlags` gets a `check_only: bool` field; `--check-only` is wired up in the desktop subcommand and parsed in `desktop_parse`.
- `compile_desktop` short-circuits to a new `check_desktop_entrypoint` helper once the entrypoint is resolved. The helper sets `internal.is_desktop = true` (so the desktop lib is selected), falls back to a local check if type checking was disabled (e.g. the Next.js auto-detect path or `--no-check`), and runs the graph check — reusing the same machinery as `deno check`.

## Testing

- `cargo test -p deno desktop_check_only` (new flag-parsing test) passes.
- Manual: `deno desktop --check-only` on a file using `new Deno.BrowserWindow(...)` exits 0 with the global resolved; a file with a type error exits 1; no artifacts are written.

No spec test is added because the repo currently has no `deno desktop` spec tests (experimental feature, excluded from the suite).

Closes #35499