### PR TITLE
docs(node_compat): typo compabitility -> compatibility

### DIFF
--- a/tests/node_compat/README.md
+++ b/tests/node_compat/README.md
@@ -69,7 +69,7 @@ Each test entry can include the following optional configuration properties:
 
 ## Add test case entry to CI check
 
-If you fixed some Node.js compabitility and some test cases started passing,
+If you fixed some Node.js compatibility and some test cases started passing,
 then add those cases to `config.jsonc`. The items listed in there are checked in
 CI check.
 


### PR DESCRIPTION
Fix typo in `tests/node_compat/README.md`: "compabitility" -> "compatibility".

Found via `typos` CLI in `tests/node_compat/README.md` line 72:

> If you fixed some Node.js compabitility and some test cases started passing,

Trivial prose-only change in markdown text (not in code block, not an identifier).
