### PR TITLE
fix(npm): realpath npm bin main module

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -84,6 +84,7 @@ use node_resolver::InNpmPackageChecker;
 use node_resolver::NodeResolutionKind;
 use node_resolver::ResolutionMode;
 use node_resolver::errors::PackageJsonLoadError;
+use sys_traits::FsCanonicalize;
 use sys_traits::FsMetadata;
 use sys_traits::FsMetadataValue;
 use sys_traits::FsRead;
@@ -1147,15 +1148,20 @@ impl<TGraphContainer: ModuleGraphContainer>
     // `file:///<project>/` mapping whose prefix match rewrites any file URL
     // outside the project root (such as the npm cache) to live underneath the
     // project directory, breaking the load. Such a package-internal main
-    // module is not a user source file and must not be remapped, so load it
-    // verbatim. A user-provided path entry (e.g. `deno run ./thing.ts`) is
+    // module is not a user source file and must not be remapped, so bypass the
+    // import map. A user-provided path entry (e.g. `deno run ./thing.ts`) is
     // intentionally left to the import map.
     if matches!(kind, deno_core::ResolutionKind::MainModule)
       && let Ok(url) = ModuleSpecifier::parse(raw_specifier)
       && url.scheme() == "file"
       && self.shared.in_npm_pkg_checker.in_npm_package(&url)
     {
-      return Ok(url);
+      let canonicalized_url = deno_path_util::url_to_file_path(&url)
+        .ok()
+        .and_then(|path| self.shared.sys.fs_canonicalize(&path).ok())
+        .and_then(|path| deno_path_util::url_from_file_path(&path).ok())
+        .unwrap_or(url);
+      return Ok(canonicalized_url);
     }
 
     let referrer = self

--- a/tests/specs/npm/run_bin_symlink_realpath_package_json/__test__.jsonc
+++ b/tests/specs/npm/run_bin_symlink_realpath_package_json/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tempDir": true,
+  "if": "unix",
+  "steps": [
+    {
+      "args": "run -A setup.js",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "run -A --ext=js node_modules/.bin/cli",
+      "output": "loaded ok: OK\n"
+    }
+  ]
+}

--- a/tests/specs/npm/run_bin_symlink_realpath_package_json/setup.js
+++ b/tests/specs/npm/run_bin_symlink_realpath_package_json/setup.js
@@ -1,0 +1,18 @@
+Deno.mkdirSync("node_modules/.bin", { recursive: true });
+Deno.mkdirSync("node_modules/pkg/bin", { recursive: true });
+Deno.mkdirSync("node_modules/pkg/lib", { recursive: true });
+
+Deno.writeTextFileSync("package.json", "{}\n");
+Deno.writeTextFileSync(
+  "node_modules/pkg/package.json",
+  '{"name":"pkg","version":"1.0.0","type":"module"}\n',
+);
+Deno.writeTextFileSync(
+  "node_modules/pkg/bin/cli.js",
+  "import { x } from '../lib/x.js';\nconsole.log('loaded ok:', x);\n",
+);
+Deno.writeTextFileSync(
+  "node_modules/pkg/lib/x.js",
+  "export const x = 'OK';\n",
+);
+Deno.symlinkSync("../pkg/bin/cli.js", "node_modules/.bin/cli");


### PR DESCRIPTION
Closes #35551.

This fixes a 2.9.0 regression where a symlinked `node_modules/.bin` entry was kept as the main module URL when a project `package.json` caused the path to be treated as npm package space. Relative imports in the bin then resolved from `node_modules/.bin` instead of the real package target.

The npm main-module import-map bypass added for #23736 is still preserved, but file URLs in that path are canonicalized before being returned. That restores the realpath behavior for symlinked bin entries without applying the import map to package-internal main modules.

Validation:
- `cargo build --bin deno`
- `./x test-spec run_bin_symlink_realpath_package_json`
- `./x test-spec run_bin_with_root_import_map`
- `./tools/lint.js`
