### PR TITLE
fix(npm): fall back for age-filtered npm dist-tags

### DIFF
--- a/libs/npm/resolution/common.rs
+++ b/libs/npm/resolution/common.rs
@@ -433,11 +433,14 @@ impl<'a> NpmPackageVersionResolver<'a> {
     let version_info = if let Some(tag) = version_req.tag() {
       match self.tag_to_version_info(tag) {
         Ok(version_info) => Ok(version_info),
-        Err(NpmPackageVersionResolutionError::DistTagVersionTooNew {
-          ..
-        }) => self.resolve_best_matching_dist_tag_fallback_version_info(
+        Err(
+          err @ NpmPackageVersionResolutionError::DistTagVersionTooNew {
+            ..
+          },
+        ) => self.resolve_best_matching_dist_tag_fallback_version_info(
           tag,
           version_req,
+          err,
         ),
         Err(err) => Err(err),
       }
@@ -470,6 +473,7 @@ impl<'a> NpmPackageVersionResolver<'a> {
     &self,
     tag: &str,
     error_version_req: &VersionReq,
+    too_new_error: NpmPackageVersionResolutionError,
   ) -> Result<&'a NpmPackageVersionInfo, NpmPackageVersionResolutionError> {
     let Some(tagged_version) = self.info.dist_tags.get(tag) else {
       // Unreachable in practice: this fn is only called after
@@ -494,7 +498,19 @@ impl<'a> NpmPackageVersionResolver<'a> {
         },
       ]))),
     );
-    self.resolve_best_matching_version_info(&fallback_req, error_version_req)
+    match self
+      .resolve_best_matching_version_info(&fallback_req, error_version_req)
+    {
+      Ok(version_info) => Ok(version_info),
+      // No version at or below the tagged version satisfies the minimum
+      // dependency age either. Surface the original error, which names the
+      // tag and the too-new version it maps to, rather than the generic
+      // "version req not matched" message for the synthesized `<=` range.
+      Err(NpmPackageVersionResolutionError::VersionReqNotMatched {
+        ..
+      }) => Err(too_new_error),
+      Err(err) => Err(err),
+    }
   }
 
   fn resolve_best_matching_version_info(
@@ -1133,6 +1149,62 @@ mod test {
     assert!(matches!(
       result,
       Err(NpmPackageVersionResolutionError::VersionReqNotMatched { .. })
+    ));
+  }
+
+  #[test]
+  fn test_tag_too_new_with_build_metadata_uses_lte_version() {
+    // The fallback range is built directly from the parsed tagged `Version`,
+    // so a tag pointing at a version carrying build metadata resolves without
+    // a format/reparse round-trip. Regression guard for that construction.
+    let package_req = PackageReq::from_str("test@latest").unwrap();
+    let package_info = NpmPackageInfo {
+      name: "test".into(),
+      versions: HashMap::from([
+        (version("1.9.0"), version_info("1.9.0")),
+        (version("2.0.0+build.5"), version_info("2.0.0+build.5")),
+      ]),
+      dist_tags: HashMap::from([("latest".into(), version("2.0.0+build.5"))]),
+      time: HashMap::from([
+        (version("1.9.0"), date("2025-05-15T00:00:00.000Z")),
+        (version("2.0.0+build.5"), date("2025-05-29T00:00:00.000Z")),
+      ]),
+    };
+    let resolver =
+      resolver_with_newest_dependency_date("2025-05-20T00:00:00.000Z");
+    let version_resolver = resolver.get_for_package(&package_info);
+    let result = version_resolver
+      .get_resolved_package_version_and_info(&package_req.version_req);
+    assert_eq!(result.unwrap().version.to_string(), "1.9.0");
+  }
+
+  #[test]
+  fn test_tag_too_new_with_no_allowed_lower_version_reports_tag_error() {
+    // When nothing at or below the tagged version satisfies the minimum
+    // dependency age, the error names the dist-tag and the version it maps to
+    // rather than the synthesized `<=` range.
+    let package_req = PackageReq::from_str("test@latest").unwrap();
+    let package_info = NpmPackageInfo {
+      name: "test".into(),
+      versions: HashMap::from([
+        (version("1.9.0"), version_info("1.9.0")),
+        (version("2.0.0"), version_info("2.0.0")),
+      ]),
+      dist_tags: HashMap::from([("latest".into(), version("2.0.0"))]),
+      time: HashMap::from([
+        (version("1.9.0"), date("2025-05-29T00:00:00.000Z")),
+        (version("2.0.0"), date("2025-05-30T00:00:00.000Z")),
+      ]),
+    };
+    let resolver =
+      resolver_with_newest_dependency_date("2025-05-20T00:00:00.000Z");
+    let version_resolver = resolver.get_for_package(&package_info);
+    let err = version_resolver
+      .get_resolved_package_version_and_info(&package_req.version_req)
+      .unwrap_err();
+    assert!(matches!(
+      err,
+      NpmPackageVersionResolutionError::DistTagVersionTooNew { .. }
     ));
   }
 

--- a/libs/npm/resolution/common.rs
+++ b/libs/npm/resolution/common.rs
@@ -4,9 +4,14 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use deno_semver::CowVec;
+use deno_semver::RangeBound;
 use deno_semver::RangeSetOrTag;
+use deno_semver::SmallStackString;
 use deno_semver::StackString;
 use deno_semver::Version;
+use deno_semver::VersionRange;
+use deno_semver::VersionRangeSet;
 use deno_semver::VersionReq;
 use deno_semver::WILDCARD_VERSION_REQ;
 use deno_semver::package::PackageName;
@@ -467,6 +472,9 @@ impl<'a> NpmPackageVersionResolver<'a> {
     error_version_req: &VersionReq,
   ) -> Result<&'a NpmPackageVersionInfo, NpmPackageVersionResolutionError> {
     let Some(tagged_version) = self.info.dist_tags.get(tag) else {
+      // Unreachable in practice: this fn is only called after
+      // `tag_to_version_info` returned `DistTagVersionTooNew`, which already
+      // found the tag in `dist_tags`. Kept as defensive code.
       return Err(NpmPackageVersionResolutionError::DistTagNotFound {
         package_name: self.info.name.clone(),
         dist_tag: tag.to_string(),
@@ -474,8 +482,18 @@ impl<'a> NpmPackageVersionResolver<'a> {
     };
     // Match npm-pick-manifest/pnpm: when a dist-tag points to a version newer
     // than the allowed publish date, retry as a semver `<= tagged_version`.
-    let fallback_req =
-      VersionReq::parse_from_npm(&format!("<={tagged_version}")).unwrap();
+    // Build the range directly from the parsed `Version` rather than
+    // formatting and reparsing, which avoids an `unwrap` and any round-trip
+    // edge cases (e.g. build metadata like `1.0.0+build`).
+    let fallback_req = VersionReq::from_raw_text_and_inner(
+      SmallStackString::from_string(format!("<={tagged_version}")),
+      RangeSetOrTag::RangeSet(VersionRangeSet(CowVec::from(vec![
+        VersionRange {
+          start: RangeBound::Unbounded,
+          end: RangeBound::inclusive(tagged_version.clone()),
+        },
+      ]))),
+    );
     self.resolve_best_matching_version_info(&fallback_req, error_version_req)
   }
 

--- a/libs/npm/resolution/common.rs
+++ b/libs/npm/resolution/common.rs
@@ -430,8 +430,8 @@ impl<'a> NpmPackageVersionResolver<'a> {
         Ok(version_info) => Ok(version_info),
         Err(NpmPackageVersionResolutionError::DistTagVersionTooNew {
           ..
-        }) if tag == "latest" => self.resolve_best_matching_version_info(
-          &WILDCARD_VERSION_REQ,
+        }) => self.resolve_best_matching_dist_tag_fallback_version_info(
+          tag,
           version_req,
         ),
         Err(err) => Err(err),
@@ -459,6 +459,24 @@ impl<'a> NpmPackageVersionResolver<'a> {
     // enforce the `no-downgrade` trust policy on the chosen registry version
     self.check_trust_policy(version_info)?;
     Ok(version_info)
+  }
+
+  fn resolve_best_matching_dist_tag_fallback_version_info(
+    &self,
+    tag: &str,
+    error_version_req: &VersionReq,
+  ) -> Result<&'a NpmPackageVersionInfo, NpmPackageVersionResolutionError> {
+    let Some(tagged_version) = self.info.dist_tags.get(tag) else {
+      return Err(NpmPackageVersionResolutionError::DistTagNotFound {
+        package_name: self.info.name.clone(),
+        dist_tag: tag.to_string(),
+      });
+    };
+    // Match npm-pick-manifest/pnpm: when a dist-tag points to a version newer
+    // than the allowed publish date, retry as a semver `<= tagged_version`.
+    let fallback_req =
+      VersionReq::parse_from_npm(&format!("<={tagged_version}")).unwrap();
+    self.resolve_best_matching_version_info(&fallback_req, error_version_req)
   }
 
   fn resolve_best_matching_version_info(
@@ -618,6 +636,32 @@ mod test {
   use deno_semver::package::PackageReq;
 
   use super::*;
+
+  fn version(text: &str) -> Version {
+    Version::parse_from_npm(text).unwrap()
+  }
+
+  fn version_info(text: &str) -> NpmPackageVersionInfo {
+    NpmPackageVersionInfo {
+      version: version(text),
+      ..Default::default()
+    }
+  }
+
+  fn date(text: &str) -> chrono::DateTime<chrono::Utc> {
+    text.parse().unwrap()
+  }
+
+  fn resolver_with_newest_dependency_date(text: &str) -> NpmVersionResolver {
+    NpmVersionResolver {
+      link_packages: Default::default(),
+      newest_dependency_date_options: NewestDependencyDateOptions::from_date(
+        date(text),
+      ),
+      overrides: Default::default(),
+      trust_policy: Default::default(),
+    }
+  }
 
   #[test]
   fn test_get_resolved_package_version_and_info() {
@@ -959,40 +1003,118 @@ mod test {
   }
 
   #[test]
-  fn test_non_latest_tag_too_new_errors() {
+  fn test_stable_tag_too_new_uses_newest_allowed_lte_version() {
+    let package_req = PackageReq::from_str("test@stable").unwrap();
+    let package_info = NpmPackageInfo {
+      name: "test".into(),
+      versions: HashMap::from([
+        (version("1.9.0"), version_info("1.9.0")),
+        (version("2.0.0-beta.1"), version_info("2.0.0-beta.1")),
+        (version("2.0.0"), version_info("2.0.0")),
+        (version("2.1.0"), version_info("2.1.0")),
+      ]),
+      dist_tags: HashMap::from([("stable".into(), version("2.0.0"))]),
+      time: HashMap::from([
+        (version("1.9.0"), date("2025-05-15T00:00:00.000Z")),
+        (version("2.0.0-beta.1"), date("2025-05-15T00:00:00.000Z")),
+        (version("2.0.0"), date("2025-05-29T00:00:00.000Z")),
+        (version("2.1.0"), date("2025-05-15T00:00:00.000Z")),
+      ]),
+    };
+    let resolver =
+      resolver_with_newest_dependency_date("2025-05-20T00:00:00.000Z");
+    let version_resolver = resolver.get_for_package(&package_info);
+    let result = version_resolver
+      .get_resolved_package_version_and_info(&package_req.version_req);
+    assert_eq!(result.unwrap().version.to_string(), "1.9.0");
+  }
+
+  #[test]
+  fn test_prerelease_tag_too_new_uses_semver_lte_version() {
     let package_req = PackageReq::from_str("test@next").unwrap();
     let package_info = NpmPackageInfo {
       name: "test".into(),
-      versions: HashMap::from([(
-        Version::parse_from_npm("1.1.0").unwrap(),
-        NpmPackageVersionInfo {
-          version: Version::parse_from_npm("1.1.0").unwrap(),
-          ..Default::default()
-        },
-      )]),
+      versions: HashMap::from([
+        (version("1.0.0-beta.9"), version_info("1.0.0-beta.9")),
+        (version("1.0.0-next.2"), version_info("1.0.0-next.2")),
+        (version("1.0.0"), version_info("1.0.0")),
+      ]),
+      dist_tags: HashMap::from([("next".into(), version("1.0.0-next.2"))]),
+      time: HashMap::from([
+        (version("1.0.0-beta.9"), date("2025-05-15T00:00:00.000Z")),
+        (version("1.0.0-next.2"), date("2025-05-29T00:00:00.000Z")),
+        (version("1.0.0"), date("2025-05-15T00:00:00.000Z")),
+      ]),
+    };
+    let resolver =
+      resolver_with_newest_dependency_date("2025-05-20T00:00:00.000Z");
+    let version_resolver = resolver.get_for_package(&package_info);
+    let result = version_resolver
+      .get_resolved_package_version_and_info(&package_req.version_req);
+    assert_eq!(result.unwrap().version.to_string(), "1.0.0-beta.9");
+  }
+
+  #[test]
+  fn test_latest_prerelease_tag_too_new_uses_newest_allowed_lte_version() {
+    let package_req = PackageReq::from_str("test@latest").unwrap();
+    let package_info = NpmPackageInfo {
+      name: "test".into(),
+      versions: HashMap::from([
+        (
+          version("7.0.0-dev.20260624.1"),
+          version_info("7.0.0-dev.20260624.1"),
+        ),
+        (
+          version("7.0.0-dev.20260626.1"),
+          version_info("7.0.0-dev.20260626.1"),
+        ),
+      ]),
       dist_tags: HashMap::from([(
-        "next".into(),
-        Version::parse_from_npm("1.1.0").unwrap(),
+        "latest".into(),
+        version("7.0.0-dev.20260626.1"),
       )]),
-      time: HashMap::from([(
-        Version::parse_from_npm("1.1.0").unwrap(),
-        "2025-05-29T00:00:00.000Z".parse().unwrap(),
-      )]),
+      time: HashMap::from([
+        (
+          version("7.0.0-dev.20260624.1"),
+          date("2025-05-15T00:00:00.000Z"),
+        ),
+        (
+          version("7.0.0-dev.20260626.1"),
+          date("2025-05-29T00:00:00.000Z"),
+        ),
+      ]),
     };
-    let resolver = NpmVersionResolver {
-      link_packages: Default::default(),
-      newest_dependency_date_options: NewestDependencyDateOptions::from_date(
-        "2025-05-20T00:00:00.000Z".parse().unwrap(),
-      ),
-      overrides: Default::default(),
-      trust_policy: Default::default(),
+    let resolver =
+      resolver_with_newest_dependency_date("2025-05-20T00:00:00.000Z");
+    let version_resolver = resolver.get_for_package(&package_info);
+    let result = version_resolver
+      .get_resolved_package_version_and_info(&package_req.version_req);
+    assert_eq!(result.unwrap().version.to_string(), "7.0.0-dev.20260624.1");
+  }
+
+  #[test]
+  fn test_exact_version_too_new_does_not_use_lte_fallback() {
+    let package_req = PackageReq::from_str("test@2.0.0").unwrap();
+    let package_info = NpmPackageInfo {
+      name: "test".into(),
+      versions: HashMap::from([
+        (version("1.9.0"), version_info("1.9.0")),
+        (version("2.0.0"), version_info("2.0.0")),
+      ]),
+      dist_tags: HashMap::from([("latest".into(), version("2.0.0"))]),
+      time: HashMap::from([
+        (version("1.9.0"), date("2025-05-15T00:00:00.000Z")),
+        (version("2.0.0"), date("2025-05-29T00:00:00.000Z")),
+      ]),
     };
+    let resolver =
+      resolver_with_newest_dependency_date("2025-05-20T00:00:00.000Z");
     let version_resolver = resolver.get_for_package(&package_info);
     let result = version_resolver
       .get_resolved_package_version_and_info(&package_req.version_req);
     assert!(matches!(
       result,
-      Err(NpmPackageVersionResolutionError::DistTagVersionTooNew { .. })
+      Err(NpmPackageVersionResolutionError::VersionReqNotMatched { .. })
     ));
   }
 

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -7495,7 +7495,7 @@ mod test {
       .await;
       assert_eq!(
         err.to_string(),
-        "Failed resolving tag 'a@tag' mapped to 'a@1.0.2' because the package version was published at 2022-11-07 00:00:00 UTC, but dependencies newer than 2010-11-07 00:00:00 UTC are not allowed because it is newer than the specified minimum dependency date."
+        "Could not find npm package 'a' matching 'tag'.\n\nA newer matching version was found, but it was not used because it was newer than the specified minimum dependency date of 2010-11-07 00:00:00 UTC."
       );
     }
   }

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -7495,7 +7495,7 @@ mod test {
       .await;
       assert_eq!(
         err.to_string(),
-        "Could not find npm package 'a' matching 'tag'.\n\nA newer matching version was found, but it was not used because it was newer than the specified minimum dependency date of 2010-11-07 00:00:00 UTC."
+        "Failed resolving tag 'a@tag' mapped to 'a@1.0.2' because the package version was published at 2022-11-07 00:00:00 UTC, but dependencies newer than 2010-11-07 00:00:00 UTC are not allowed because it is newer than the specified minimum dependency date."
       );
     }
   }

--- a/tests/registry/npm/@denotest/pre-release-latest-min-age/1.0.0-dev.1/index.js
+++ b/tests/registry/npm/@denotest/pre-release-latest-min-age/1.0.0-dev.1/index.js
@@ -1,0 +1,1 @@
+module.exports = { version: "1.0.0-dev.1" };

--- a/tests/registry/npm/@denotest/pre-release-latest-min-age/1.0.0-dev.1/package.json
+++ b/tests/registry/npm/@denotest/pre-release-latest-min-age/1.0.0-dev.1/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@denotest/pre-release-latest-min-age",
+  "version": "1.0.0-dev.1",
+  "main": "index.js",
+  "publishDate": "2000-01-01T00:00:00.000Z"
+}

--- a/tests/registry/npm/@denotest/pre-release-latest-min-age/1.0.0-dev.2/index.js
+++ b/tests/registry/npm/@denotest/pre-release-latest-min-age/1.0.0-dev.2/index.js
@@ -1,0 +1,1 @@
+module.exports = { version: "1.0.0-dev.2" };

--- a/tests/registry/npm/@denotest/pre-release-latest-min-age/1.0.0-dev.2/package.json
+++ b/tests/registry/npm/@denotest/pre-release-latest-min-age/1.0.0-dev.2/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@denotest/pre-release-latest-min-age",
+  "version": "1.0.0-dev.2",
+  "main": "index.js",
+  "publishDate": "9999-01-01T00:00:00.000Z",
+  "publishConfig": {
+    "tag": "latest"
+  }
+}

--- a/tests/specs/npm/min_dependency_age_prerelease_dist_tag/__test__.jsonc
+++ b/tests/specs/npm/min_dependency_age_prerelease_dist_tag/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "run --minimum-dependency-age=2025-01-01T00:00:00.000Z main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/npm/min_dependency_age_prerelease_dist_tag/main.out
+++ b/tests/specs/npm/min_dependency_age_prerelease_dist_tag/main.out
@@ -1,0 +1,1 @@
+[WILDCARD]resolved: 1.0.0-dev.1

--- a/tests/specs/npm/min_dependency_age_prerelease_dist_tag/main.ts
+++ b/tests/specs/npm/min_dependency_age_prerelease_dist_tag/main.ts
@@ -1,0 +1,7 @@
+// `latest` points at a prerelease (1.0.0-dev.2) that was published too recently
+// for the configured minimum dependency age. Resolution should fall back to the
+// newest allowed version at or below the tagged version (1.0.0-dev.1) instead of
+// failing the tag resolution outright.
+// Regression test for https://github.com/denoland/deno/issues/35552.
+import pkg from "npm:@denotest/pre-release-latest-min-age@latest";
+console.log("resolved:", pkg.version);


### PR DESCRIPTION
## Summary

Fixes #35552.

When an npm dist-tag points at a version newer than the configured minimum dependency age, retry resolution with a semver range of `<= tagged_version` instead of failing the tag resolution outright.

This applies to all dist-tags, not only `latest`, and matches the npm-pick-manifest/pnpm behavior we checked for tags like `latest`, `canary`, and `next`.

Exact versions stay exact: if `pkg@1.2.3` is too new, Deno still errors instead of falling back to an older version.

## Root Cause

The default minimum dependency age can reject a freshly-published dist-tag target before npm resolution gets a chance to select an older acceptable version. Deno only had a special fallback for `latest`, and that fallback was too broad for prerelease-only package streams.

For `@typescript/native-preview@latest`, this meant the fresh `latest` prerelease was rejected and resolution failed instead of selecting the newest mature version at or below the tagged version.

## Validation

- `cargo fmt --check`
- `cargo test -p deno_npm tag_too_new -- --nocapture`
- `cargo test -p deno_npm test_exact_version_too_new_does_not_use_lte_fallback -- --nocapture`
- `cargo test -p deno_npm`