### PR TITLE
fix(schema): correct property name for JSX new line configuration

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -855,7 +855,7 @@
           "default": "nextLine",
           "enum": ["maintain", "sameLine", "nextLine"]
         },
-        "jsx.forceNewLineSurroundingContent": {
+        "jsx.forceNewLinesSurroundingContent": {
           "description": "Forces newlines surrounding the content of JSX elements.",
           "default": false,
           "type": "boolean"


### PR DESCRIPTION
Fix typo in `cli/schemas/config-file.v1.json`. Property `jsx.forceNewLineSurroundingContent` should be `jsx.forceNewLinesSurroundingContent`, which the later one is used elsewhere.

> AI is used for commit summary/title and pull request title.
