### PR TITLE
fix(flake): rust-analyzer in nix develop shell and fix non-NixOS build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,8 @@
               export NIX_DYNAMIC_LINKER=$(patchelf --print-interpreter /usr/bin/env)
               export NIX_DONT_SET_RPATH=1
               export NIX_LDFLAGS="$@"
+              # Nix's libclang is incompatible with system glibc (non-NixOS Linux)
+              unset LIBCLANG_PATH
             fi
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           url = "https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_simdutf_release_${rustyV8Target}.a.gz";
           sha256 =
             {
-              "x86_64-linux" = "sha256-Uzfff0kIk7MAVpOZmFn7Pb24QPYsyTXJi/WcnL7kiVc=";
+              "x86_64-linux" = "sha256-qjDxmLbnviGI32SY+VBTxMBS8hIDegHywxQU16yoS1M";
               "aarch64-linux" = "sha256-eWUL59b9TQH111GE1ZaUS9SS7XD5ruBheojHT7klTiY=";
               "x86_64-darwin" = "sha256-1yHm1WslC1CbXIjSxNI1mEJqqq7SRAVByO8BkS1Tk5s=";
               "aarch64-darwin" = "sha256-W8fpKRWz6LgAB8Tu1501Ky8L2FOn4rGocDVHV3UN7Jk=";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.95.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]


### PR DESCRIPTION
## Changes

- [x]  add `rust-analyzer` and `rust-src` to `rust-toolchain.toml`. Needed to run `rust-analyzer` in editors (e.g. Zed) with same version of pinned toolchain in a `nix develop` shell.
- [x]  update hash of `x86_64-linux` to fix `nix build`

```sh
nix build
[...]
error: hash mismatch in fixed-output derivation '/nix/store/9w315n9dqbaffplb5kcl7y3y7zal75y0-librusty_v8_simdutf_release_x86_64-unknown-linux-gnu.a.gz.drv':
         specified: sha256-Uzfff0kIk7MAVpOZmFn7Pb24QPYsyTXJi/WcnL7kiVc=
            got:    sha256-qjDxmLbnviGI32SY+VBTxMBS8hIDegHywxQU16yoS1M
```
- [x]  unset `LIBCLANG_PATH` on non-NixOS Linux to fix `cargo build`

```sh
cargo build
[...]
Unable to find libclang: "the `libclang` shared library at /nix/store/y22y29qnqj6nsf347pr0srr6kf8kr8i0-clang-20.1.8-lib/lib/libclang.so.20.1.8 could not be opened: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_ABI_DT_X86_64_PLT' not found (required by /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libdl.so.2)"
[...]
```

## Tests (manually)

`cargo build` / `nix build` are running without issues now. 

All tested on:

```sh
nix-info -m
 - system: `"x86_64-linux"`
 - host os: `Linux 6.17.0-35-generic, Ubuntu, 24.04.4 LTS (Noble Numbat), nobuild`
[...]
 - version: `nix-env (Nix) 2.31.3`
 ```
