### PR TITLE
fix(jupyter): register stdin peer only after ZMTP handshake completes

### DIFF
--- a/cli/js/jupyter_kernel.js
+++ b/cli/js/jupyter_kernel.js
@@ -410,10 +410,21 @@ class RouterSocket {
   _handlePeer(conn) {
     const peerId = crypto.getRandomValues(new Uint8Array(5));
     const peerKey = Array.from(peerId).join(",");
-    this.peers.set(peerKey, conn);
     (async () => {
       try {
+        // Only expose the peer for sending *after* its ZMTP handshake has
+        // completed. The stdin channel sends proactively (`input_request` for
+        // `prompt()`/`confirm()`), unlike shell/control which only ever reply
+        // to a message they already received. If we registered the peer before
+        // the handshake, a prompt firing during the connection's setup window
+        // (e.g. a frontend that runs the first cell as soon as it connects)
+        // would write message frames into the middle of the greeting exchange,
+        // corrupting the stream so the frontend drops the kernel ("kernel
+        // died" / "Socket is closed"). Registering post-handshake makes
+        // `requestInput`'s `peers.size === 0` wait until stdin is actually
+        // ready.
         await zmtpHandshake(conn, "ROUTER");
+        this.peers.set(peerKey, conn);
         while (true) {
           const frames = await recvMultipart(conn);
           this.incoming.push({ peerId, peerKey, frames });

--- a/tests/integration/jupyter_tests.rs
+++ b/tests/integration/jupyter_tests.rs
@@ -671,6 +671,172 @@ async fn jupyter_execute_error_reports_traceback() -> Result<()> {
   Ok(())
 }
 
+// Reproduction for the VS Code "kernel died" hang when a cell calls `prompt()`:
+// the kernel must send an `input_request` on the stdin channel, accept the
+// `input_reply`, and complete the cell.
+#[test]
+async fn jupyter_execute_prompt_stdin() -> Result<()> {
+  let (_ctx, client, _process) = setup().await;
+  let request = client
+    .send(
+      Shell,
+      "execute_request",
+      json!({
+        "silent": false,
+        "store_history": true,
+        "user_expressions": {},
+        "allow_stdin": true,
+        "stop_on_error": false,
+        "code": "const name = prompt(\"Name?\"); console.log(`Hello, ${name}!`)"
+      }),
+    )
+    .await?;
+
+  // The kernel should ask the frontend for input on the stdin channel.
+  let input_req = client.recv(Stdin).await?;
+  assert_eq!(input_req.header.msg_type, "input_request");
+  assert_json_subset(
+    input_req.content.clone(),
+    json!({ "prompt": "Name?", "password": false }),
+  );
+  assert_eq!(input_req.parent_header, request.header.to_json());
+
+  // Reply with a value.
+  client
+    .send(
+      Stdin,
+      "input_reply",
+      json!({ "value": "World", "status": "ok" }),
+    )
+    .await?;
+
+  // The cell should now finish successfully.
+  let reply = client.recv(Shell).await?;
+  assert_eq!(reply.header.msg_type, "execute_reply");
+  assert_json_subset(
+    reply.content,
+    json!({ "status": "ok", "execution_count": 1 }),
+  );
+
+  // And it should have printed the answer.
+  let mut printed = None;
+  for _ in 0..6 {
+    let msg = client.recv(IoPub).await?;
+    if msg.header.msg_type == "stream" {
+      printed = msg
+        .content
+        .get("text")
+        .and_then(|t| t.as_str().map(String::from));
+      if printed.is_some() {
+        break;
+      }
+    }
+  }
+  assert_eq!(printed.as_deref(), Some("Hello, World!\n"));
+
+  Ok(())
+}
+
+// While a `prompt()` is waiting for an `input_reply`, the kernel must stay
+// responsive: the heartbeat must keep echoing (otherwise a frontend like VS Code
+// declares the kernel dead and tears down the sockets, which is the "kernel
+// died" + "Socket is closed EBADF" symptom).
+#[test]
+async fn jupyter_prompt_does_not_block_heartbeat() -> Result<()> {
+  let (_ctx, client, _process) = setup().await;
+  client
+    .send(
+      Shell,
+      "execute_request",
+      json!({
+        "silent": false,
+        "store_history": true,
+        "user_expressions": {},
+        "allow_stdin": true,
+        "stop_on_error": false,
+        "code": "const name = prompt(\"Name?\"); name"
+      }),
+    )
+    .await?;
+
+  // Kernel asks for input.
+  let input_req = client.recv(Stdin).await?;
+  assert_eq!(input_req.header.msg_type, "input_request");
+
+  // Now simulate a user who takes a while to type: the kernel must keep
+  // answering heartbeats during this window.
+  for i in 0..5 {
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    client.send_heartbeat(format!("ping{i}").as_bytes()).await?;
+    let pong = client.recv_heartbeat().await?;
+    assert_eq!(
+      pong,
+      Bytes::from(format!("ping{i}")),
+      "heartbeat stalled while a prompt was open (iteration {i})",
+    );
+  }
+
+  // Finally answer and let the cell finish.
+  client
+    .send(
+      Stdin,
+      "input_reply",
+      json!({ "value": "World", "status": "ok" }),
+    )
+    .await?;
+  let reply = client.recv(Shell).await?;
+  assert_eq!(reply.header.msg_type, "execute_reply");
+  assert_json_subset(reply.content, json!({ "status": "ok" }));
+
+  Ok(())
+}
+
+// The real reproduction of the VS Code "kernel died" hang: with a connection
+// KEY configured (every frontend does this), a `prompt()` must complete. If the
+// kernel can't verify the HMAC of the `input_reply`, `requestInput` loops
+// forever and the cell never finishes.
+#[test]
+async fn jupyter_prompt_hmac_signed() -> Result<()> {
+  const KEY: &str = "super-secret-connection-key";
+  let (_ctx, conn, _process) = setup_server_with_key(KEY).await;
+  let client = JupyterClient::new(&conn).await;
+  client.io_subscribe("").await?;
+  client.send_heartbeat(b"ping").await?;
+  let _ = client.recv_heartbeat().await?;
+
+  let mut req = JupyterMsg::new(
+    client.session,
+    "execute_request",
+    json!({
+      "silent": false,
+      "store_history": true,
+      "user_expressions": {},
+      "allow_stdin": true,
+      "stop_on_error": false,
+      "code": "const name = prompt(\"Name?\"); name"
+    }),
+  );
+  req.sign(KEY);
+  client.send_msg(Shell, &req).await?;
+
+  let input_req = client.recv(Stdin).await?;
+  assert_eq!(input_req.header.msg_type, "input_request");
+
+  let mut input_reply = JupyterMsg::new(
+    client.session,
+    "input_reply",
+    json!({ "value": "World", "status": "ok" }),
+  );
+  input_reply.sign(KEY);
+  client.send_msg(Stdin, &input_reply).await?;
+
+  let reply = client.recv(Shell).await?;
+  assert_eq!(reply.header.msg_type, "execute_reply");
+  assert_json_subset(reply.content, json!({ "status": "ok" }));
+
+  Ok(())
+}
+
 // Regression test for denoland/deno#22771: a `complete_request` whose code
 // contains multi-byte (e.g. Korean) characters must not crash the kernel. The
 // old Rust kernel sliced the cell text using the codepoint-based `cursor_pos`


### PR DESCRIPTION
Running a notebook cell that calls `prompt()` or `confirm()` could kill the
Deno kernel. In VS Code this showed up as "The kernel 'Deno' died" together
with a "Socket is closed (EBADF)" error on the stdin channel, right after the
cell started.

The cause is in the hand-rolled ZMTP kernel: the stdin ROUTER socket
registered each incoming peer connection before that connection's ZMTP
handshake had finished. The stdin channel is the only one that sends
proactively (it pushes an `input_request` when user code calls
`prompt()`/`confirm()`); shell and control only ever reply to a message they
have already received, so they never write before a handshake. When a prompt
fired during the brief window while a peer was still being set up, the kernel
wrote message frames into the middle of the greeting exchange, corrupting the
stream so the frontend dropped the kernel. Clients that perform a full
`kernel_info` handshake before running a cell (JupyterLab, jupyter_client)
close the window first and never hit it, which is why it reproduced in VS
Code but not elsewhere.

Registering the peer only after its handshake completes makes the readiness
check in `requestInput` wait until stdin is actually usable instead of
writing into a half-open connection. This also adds the first integration
test coverage for the stdin/`prompt()` round-trip: a plain prompt, a prompt
that stays open while heartbeats continue, and an HMAC-signed prompt.