### PR TITLE
feat(jupyter): scope notebook cells with permissions.jupyter from deno.json

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1233,6 +1233,28 @@ impl CliOptions {
     Ok(permissions_options)
   }
 
+  /// Resolves the permission set the Jupyter kernel should run notebook cells
+  /// with: the `jupyter` set if present, otherwise the `default` set. Returns
+  /// `None` when neither is defined, so the kernel can fall back to allow-all
+  /// and preserve backwards compatibility with notebooks that predate
+  /// config-file permissions.
+  pub fn jupyter_permissions_options(
+    &self,
+  ) -> Result<Option<PermissionsOptions>, AnyError> {
+    let config = self.start_dir.to_permissions_config()?;
+    let Some(set) = config
+      .sets
+      .get("jupyter")
+      .or_else(|| config.sets.get("default"))
+    else {
+      return Ok(None);
+    };
+    let mut options =
+      flags_to_permissions_options(&self.flags.permissions, Some(set))?;
+    self.augment_import_permissions(&mut options);
+    Ok(Some(options))
+  }
+
   fn resolve_config_permissions_for_dir<'a>(
     &self,
     dir: &'a WorkspaceDirectory,

--- a/cli/ops/jupyter.rs
+++ b/cli/ops/jupyter.rs
@@ -393,19 +393,21 @@ pub enum JupyterBroadcastError {
 /// the stdin ZMQ channel) and blocks until a reply arrives. Returns `None`
 /// when stdin is disabled, the channel has been closed, or the frontend
 /// declines to answer.
-#[op2]
-#[string]
-pub fn op_jupyter_input(
-  state: &mut OpState,
-  #[string] prompt: String,
-  is_password: bool,
+/// Sends an `input_request` to the frontend (via the kernel thread) and blocks
+/// the calling thread until the `input_reply` value arrives. Returns `None`
+/// when stdin is disabled, the channel has been closed, or the frontend
+/// declines to answer. Shared by `prompt()`/`confirm()` and the permission
+/// prompter, both of which run synchronously on the REPL thread.
+pub fn request_input_blocking(
+  sender: &mpsc::UnboundedSender<PendingInputRequest>,
+  prompt: String,
+  password: bool,
 ) -> Option<String> {
-  let sender = state.borrow::<ReplInputSender>().tx.clone();
   let (resp_tx, resp_rx) = oneshot::channel();
   if sender
     .send(PendingInputRequest {
       prompt,
-      password: is_password,
+      password,
       resp_tx,
     })
     .is_err()
@@ -418,6 +420,17 @@ pub fn op_jupyter_input(
     .join()
     .ok()
     .flatten()
+}
+
+#[op2]
+#[string]
+pub fn op_jupyter_input(
+  state: &mut OpState,
+  #[string] prompt: String,
+  is_password: bool,
+) -> Option<String> {
+  let sender = state.borrow::<ReplInputSender>().tx.clone();
+  request_input_blocking(&sender, prompt, is_password)
 }
 
 #[op2]

--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -38,6 +38,7 @@ use crate::tools::test::TestEventWorkerSender;
 use crate::tools::test::create_single_test_event_channel;
 
 mod install;
+mod prompter;
 
 pub async fn kernel(
   flags: Arc<Flags>,
@@ -133,6 +134,7 @@ pub async fn kernel(
   .unwrap();
   let repl_main_module2 = repl_main_module.clone();
   let repl_iopub_tx = iopub_tx.clone();
+  let prompter_input_tx = input_tx.clone();
   let repl_input_tx = input_tx;
 
   let repl_thread = std::thread::spawn(move || {
@@ -170,6 +172,14 @@ pub async fn kernel(
         "Deno[Deno.internal].enableJupyter();",
       )?;
       let worker = worker.into_main_worker();
+
+      // Route permission prompts to the notebook frontend over the stdin
+      // channel. A kernel has no controlling terminal, so without this any
+      // denied access under a `permissions.jupyter` set would fail outright
+      // with no way to grant it interactively.
+      deno_runtime::deno_permissions::prompter::set_prompter(Box::new(
+        prompter::JupyterPrompter::new(prompter_input_tx),
+      ));
 
       let mut repl_session = repl::ReplSession::initialize(
         &cli_options_arc,

--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -14,6 +14,7 @@ use deno_path_util::resolve_url_or_path;
 use deno_runtime::WorkerExecutionMode;
 use deno_runtime::deno_io::Stdio;
 use deno_runtime::deno_io::StdioPipe;
+use deno_runtime::deno_permissions::Permissions;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_terminal::colors;
 use tokio::sync::mpsc;
@@ -78,8 +79,28 @@ pub async fn kernel(
 
   let factory = CliFactory::from_flags(flags);
   let cli_options = factory.cli_options()?;
-  let permissions =
-    PermissionsContainer::allow_all(factory.permission_desc_parser()?.clone());
+  let desc_parser = factory.permission_desc_parser()?.clone();
+  // The ZMQ kernel worker only binds the kernel's loopback sockets and drives
+  // the protocol; it never runs user code, so it always runs with full
+  // permissions.
+  let permissions = PermissionsContainer::allow_all(desc_parser.clone());
+  // Notebook cells run in the REPL worker. They use the project's
+  // `permissions.jupyter` set (falling back to `default`) from `deno.json` when
+  // one is defined; otherwise the kernel keeps the historical allow-all
+  // behavior so existing notebooks don't suddenly lose access.
+  let repl_permissions = match cli_options.jupyter_permissions_options()? {
+    Some(options) => {
+      log::info!(
+        "{} Applying \"permissions\" from the config file to the Jupyter kernel is experimental and may change in the future.",
+        colors::yellow("Warning"),
+      );
+      PermissionsContainer::new(
+        desc_parser.clone(),
+        Permissions::from_options(desc_parser.as_ref(), &options)?,
+      )
+    }
+    None => permissions.clone(),
+  };
   let npm_installer = factory.npm_installer_if_managed().await?.cloned();
   let compiler_options_resolver_arc =
     factory.compiler_options_resolver()?.clone();
@@ -111,7 +132,6 @@ pub async fn kernel(
   )
   .unwrap();
   let repl_main_module2 = repl_main_module.clone();
-  let repl_permissions = permissions.clone();
   let repl_iopub_tx = iopub_tx.clone();
   let repl_input_tx = input_tx;
 

--- a/cli/tools/jupyter/prompter.rs
+++ b/cli/tools/jupyter/prompter.rs
@@ -1,0 +1,55 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+use deno_runtime::deno_permissions::prompter::GetFormattedStackFn;
+use deno_runtime::deno_permissions::prompter::PermissionPrompter;
+use deno_runtime::deno_permissions::prompter::PromptResponse;
+use tokio::sync::mpsc;
+
+use crate::ops::jupyter::PendingInputRequest;
+use crate::ops::jupyter::request_input_blocking;
+
+/// Routes Deno permission prompts to the notebook frontend over Jupyter's
+/// `stdin` channel instead of the controlling terminal (which a kernel does not
+/// have). Without this, a notebook running under a restrictive
+/// `permissions.jupyter` set would have every denied access fail immediately,
+/// with no way for the user to grant it interactively.
+pub struct JupyterPrompter {
+  input_tx: mpsc::UnboundedSender<PendingInputRequest>,
+}
+
+impl JupyterPrompter {
+  pub fn new(input_tx: mpsc::UnboundedSender<PendingInputRequest>) -> Self {
+    Self { input_tx }
+  }
+}
+
+impl PermissionPrompter for JupyterPrompter {
+  fn prompt(
+    &mut self,
+    message: &str,
+    name: &str,
+    _api_name: Option<&str>,
+    is_unary: bool,
+    _get_stack: Option<GetFormattedStackFn>,
+  ) -> PromptResponse {
+    let options = if is_unary {
+      format!("[y = allow once, A = allow all {name} access, n = deny]")
+    } else {
+      "[y = allow, n = deny]".to_string()
+    };
+    let prompt = format!("Deno requests {message}.\nAllow? {options}");
+
+    // The frontend renders this on the stdin channel and returns the typed
+    // answer. `None` means stdin is unavailable (the frontend doesn't support
+    // it) or the user dismissed the prompt; both are treated as a denial, which
+    // matches the terminal prompter's behavior when it can't prompt.
+    match request_input_blocking(&self.input_tx, prompt, false)
+      .as_deref()
+      .map(str::trim)
+    {
+      Some("y") | Some("Y") => PromptResponse::Allow,
+      Some("A") if is_unary => PromptResponse::AllowAll,
+      _ => PromptResponse::Deny,
+    }
+  }
+}

--- a/tests/integration/jupyter_tests.rs
+++ b/tests/integration/jupyter_tests.rs
@@ -595,6 +595,127 @@ async fn jupyter_permissions_default_allow_all() -> Result<()> {
   Ok(())
 }
 
+// Sends a cell, answers the single permission/input prompt it raises on the
+// stdin channel with `answer`, and returns (execute_reply status, prompt text,
+// concatenated stream text).
+async fn run_cell_answering_prompt(
+  client: &JupyterClient,
+  code: &str,
+  answer: &str,
+) -> Result<(String, String, String)> {
+  client
+    .send(
+      Shell,
+      "execute_request",
+      json!({
+        "silent": false,
+        "store_history": true,
+        "user_expressions": {},
+        "allow_stdin": true,
+        "stop_on_error": false,
+        "code": code,
+      }),
+    )
+    .await?;
+
+  let req = client.recv(Stdin).await?;
+  assert_eq!(req.header.msg_type, "input_request");
+  let prompt = req
+    .content
+    .get("prompt")
+    .and_then(|p| p.as_str())
+    .unwrap_or_default()
+    .to_string();
+  client
+    .send(
+      Stdin,
+      "input_reply",
+      json!({ "value": answer, "status": "ok" }),
+    )
+    .await?;
+
+  let reply = client.recv(Shell).await?;
+  assert_eq!(reply.header.msg_type, "execute_reply");
+  let status = reply
+    .content
+    .get("status")
+    .and_then(|s| s.as_str())
+    .unwrap_or_default()
+    .to_string();
+
+  let mut text = String::new();
+  for _ in 0..8 {
+    match client.recv(IoPub).await {
+      Ok(msg) => {
+        if msg.header.msg_type == "stream"
+          && let Some(t) = msg.content.get("text").and_then(|t| t.as_str())
+        {
+          text.push_str(t);
+        }
+        if msg
+          .content
+          .get("execution_state")
+          .map(|s| s == "idle")
+          .unwrap_or(false)
+        {
+          break;
+        }
+      }
+      Err(e) => {
+        if e.downcast_ref::<tokio::time::error::Elapsed>().is_some() {
+          break;
+        }
+        return Err(e);
+      }
+    }
+  }
+  Ok((status, prompt, text))
+}
+
+const PROMPT_PROBE: &str = r#"
+let r;
+try { r = "value:" + Deno.env.get("DENIED_VAR"); }
+catch (e) { r = "denied:" + e.name; }
+console.log(r);
+"#;
+
+// When a cell accesses something outside its `permissions.jupyter` set, the
+// kernel asks the frontend over the stdin channel; answering "y" grants it.
+#[test]
+async fn jupyter_permission_prompt_allow() -> Result<()> {
+  let (_ctx, client, _process) = setup_with_deno_json(
+    r#"{ "permissions": { "jupyter": { "env": ["ALLOWED_VAR"] } } }"#,
+  )
+  .await;
+  let (status, prompt, text) =
+    run_cell_answering_prompt(&client, PROMPT_PROBE, "y").await?;
+  assert!(
+    prompt.contains("Deno requests env access"),
+    "prompt: {prompt:?}"
+  );
+  assert_eq!(status, "ok");
+  assert!(text.contains("value:"), "got: {text:?}");
+  Ok(())
+}
+
+// Answering "n" to the prompt denies the access, surfacing a NotCapable error.
+#[test]
+async fn jupyter_permission_prompt_deny() -> Result<()> {
+  let (_ctx, client, _process) = setup_with_deno_json(
+    r#"{ "permissions": { "jupyter": { "env": ["ALLOWED_VAR"] } } }"#,
+  )
+  .await;
+  let (status, prompt, text) =
+    run_cell_answering_prompt(&client, PROMPT_PROBE, "n").await?;
+  assert!(
+    prompt.contains("Deno requests env access"),
+    "prompt: {prompt:?}"
+  );
+  assert_eq!(status, "ok");
+  assert!(text.contains("denied:NotCapable"), "got: {text:?}");
+  Ok(())
+}
+
 #[test]
 async fn jupyter_heartbeat_echoes() -> Result<()> {
   let (_ctx, client, _process) = setup().await;

--- a/tests/integration/jupyter_tests.rs
+++ b/tests/integration/jupyter_tests.rs
@@ -428,7 +428,19 @@ async fn setup_server() -> (TestContext, ConnectionSpec, JupyterServerProcess) {
 async fn setup_server_with_key(
   key: &str,
 ) -> (TestContext, ConnectionSpec, JupyterServerProcess) {
+  setup_server_with_key_and_config(key, None).await
+}
+
+async fn setup_server_with_key_and_config(
+  key: &str,
+  deno_json: Option<&str>,
+) -> (TestContext, ConnectionSpec, JupyterServerProcess) {
   let context = TestContextBuilder::new().use_temp_cwd().build();
+  // The kernel is launched with the temp dir as its cwd, so a `deno.json`
+  // written here is discovered the same way it would be next to a notebook.
+  if let Some(deno_json) = deno_json {
+    context.temp_dir().path().join("deno.json").write(deno_json);
+  }
   let (mut conn, mut listeners) = ConnectionSpec::new();
   conn.key = key.into();
   let conn_file = context.temp_dir().path().join("connection.json");
@@ -485,6 +497,102 @@ async fn setup() -> (TestContext, JupyterClient, JupyterServerProcess) {
   let _ = client.recv_heartbeat().await.unwrap();
 
   (context, client, process)
+}
+
+async fn setup_with_deno_json(
+  deno_json: &str,
+) -> (TestContext, JupyterClient, JupyterServerProcess) {
+  let (context, conn, process) =
+    setup_server_with_key_and_config("", Some(deno_json)).await;
+  let client = JupyterClient::new(&conn).await;
+  client.io_subscribe("").await.unwrap();
+  client.send_heartbeat(b"ping").await.unwrap();
+  let _ = client.recv_heartbeat().await.unwrap();
+  (context, client, process)
+}
+
+// Runs a cell and returns the concatenated text of its `stream` (stdout/stderr)
+// iopub messages once the `execute_reply` arrives.
+async fn run_cell_collect_stream(
+  client: &JupyterClient,
+  code: &str,
+) -> Result<String> {
+  client
+    .send(
+      Shell,
+      "execute_request",
+      json!({
+        "silent": false,
+        "store_history": true,
+        "user_expressions": {},
+        "allow_stdin": false,
+        "stop_on_error": false,
+        "code": code,
+      }),
+    )
+    .await?;
+  let reply = client.recv(Shell).await?;
+  assert_eq!(reply.header.msg_type, "execute_reply");
+  let mut text = String::new();
+  for _ in 0..8 {
+    match client.recv(IoPub).await {
+      Ok(msg) => {
+        if msg.header.msg_type == "stream"
+          && let Some(t) = msg.content.get("text").and_then(|t| t.as_str())
+        {
+          text.push_str(t);
+        }
+        if msg
+          .content
+          .get("execution_state")
+          .map(|s| s == "idle")
+          .unwrap_or(false)
+        {
+          break;
+        }
+      }
+      Err(e) => {
+        if e.downcast_ref::<tokio::time::error::Elapsed>().is_some() {
+          break;
+        }
+        return Err(e);
+      }
+    }
+  }
+  Ok(text)
+}
+
+const PERMS_PROBE: &str = r#"
+const out = [];
+try { Deno.env.get("ALLOWED_VAR"); out.push("env_allowed:ok"); }
+catch (e) { out.push("env_allowed:" + e.name); }
+try { Deno.env.get("DENIED_VAR"); out.push("env_denied:ok"); }
+catch (e) { out.push("env_denied:" + e.name); }
+console.log(out.join(" "));
+"#;
+
+// A `permissions.jupyter` set in deno.json scopes what notebook cells may do.
+#[test]
+async fn jupyter_permissions_jupyter_set() -> Result<()> {
+  let (_ctx, client, _process) = setup_with_deno_json(
+    r#"{ "permissions": { "jupyter": { "env": ["ALLOWED_VAR"] } } }"#,
+  )
+  .await;
+  let out = run_cell_collect_stream(&client, PERMS_PROBE).await?;
+  assert!(out.contains("env_allowed:ok"), "got: {out:?}");
+  assert!(out.contains("env_denied:NotCapable"), "got: {out:?}");
+  Ok(())
+}
+
+// With no `permissions` key the kernel keeps the historical allow-all behavior.
+#[test]
+async fn jupyter_permissions_default_allow_all() -> Result<()> {
+  let (_ctx, client, _process) =
+    setup_with_deno_json(r#"{ "unstable": [] }"#).await;
+  let out = run_cell_collect_stream(&client, PERMS_PROBE).await?;
+  assert!(out.contains("env_allowed:ok"), "got: {out:?}");
+  assert!(out.contains("env_denied:ok"), "got: {out:?}");
+  Ok(())
 }
 
 #[test]


### PR DESCRIPTION
The Jupyter kernel ran every notebook cell with all permissions granted, so
there was no way to limit what a notebook could read, write, or reach over the
network. This lets a project declare a `permissions.jupyter` set in its
`deno.json` (falling back to the `default` set) and have the kernel run
notebook cells under it. The config is discovered from the kernel's working
directory exactly like every other subcommand, so a `deno.json` next to the
notebook just works. When no permission set is defined the kernel keeps its
previous allow-all behavior, so existing notebooks are unaffected.

Only the worker that evaluates cells is scoped. The kernel's own ZMQ worker
keeps full permissions because it just binds the kernel's loopback sockets and
runs no user code.

So that a scoped notebook stays usable, the kernel also routes permission
prompts to the notebook frontend over Jupyter's stdin channel (the same
channel `prompt()`/`confirm()` use). When a cell accesses something outside
its set, the user is asked in the notebook and can allow it once, allow all of
that permission, or deny — instead of the access just failing. If the frontend
doesn't support stdin the access is denied, matching the terminal prompter.

Config-file permissions are still experimental, so applying a set emits the
same experimental notice used elsewhere. This is part of making
`foo.ipynb` + `deno.json` the canonical way to configure a Deno notebook;
`unstable` features already resolve from `deno.json` this way today.