### PR TITLE
fix(ext/node): mock.reset() should also reset MockTimers

### DIFF
--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -3357,6 +3357,7 @@ const mock = {
   },
 
   reset: () => {
+    mockTimers.reset();
     ArrayPrototypeForEach(activeMocks, (ctx) => {
       ctx.resetCalls();
     });

--- a/tests/specs/node/node_test_mock_timers/test.js
+++ b/tests/specs/node/node_test_mock_timers/test.js
@@ -382,3 +382,15 @@ test("throws on invalid api name", () => {
     code: "ERR_INVALID_ARG_VALUE",
   });
 });
+
+test("mock.reset() resets timers - first call", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  mock.reset();
+});
+
+test("mock.reset() resets timers - second call", () => {
+  // This fails before the fix because the first test's mock.reset()
+  // left MockTimers in an enabled state.
+  mock.timers.enable({ apis: ["setTimeout"] });
+  mock.reset();
+});

--- a/tests/specs/node/node_test_mock_timers/test.out
+++ b/tests/specs/node/node_test_mock_timers/test.out
@@ -1,4 +1,4 @@
-running 32 tests from ./test.js
+running 34 tests from ./test.js
 reproducer from issue 32987 does not throw ... ok ([WILDLINE])
 setTimeout fires on tick ... ok ([WILDLINE])
 setInterval fires repeatedly on tick ... ok ([WILDLINE])
@@ -31,6 +31,8 @@ module setTimeout is untouched when its api is not enabled ... ok ([WILDLINE])
 throws ERR_INVALID_STATE when not enabled ... ok ([WILDLINE])
 throws ERR_INVALID_STATE when enabling twice ... ok ([WILDLINE])
 throws on invalid api name ... ok ([WILDLINE])
+mock.reset() resets timers - first call ... ok ([WILDLINE])
+mock.reset() resets timers - second call ... ok ([WILDLINE])
 
-ok | 32 passed | 0 failed ([WILDLINE])
+ok | 34 passed | 0 failed ([WILDLINE])
 


### PR DESCRIPTION
fix(ext/node): mock.reset() should also reset MockTimers

Fixes #35570

### Problem

`mock.reset()` iterates the internal `activeMocks` array calling
`resetCalls()` on each entry, but the `mockTimers` singleton (the
`MockTimers` instance behind `mock.timers`) is never pushed into
`activeMocks`. So `mock.reset()` walks right past it, leaving
`_enabled = true` — causing any subsequent `mock.timers.enable()` call
to throw `"MockTimers is already enabled"`.

This diverges from Node's `MockTracker.reset()`, which explicitly calls
`this.#timers.reset()`.

### Fix

One line added to `mock.reset()` in `ext/node/polyfills/testing.ts`:

```ts
reset: () => {
  mockTimers.reset(); // reset timers alongside function/module mocks
  ArrayPrototypeForEach(activeMocks, (ctx) => {
    ctx.resetCalls();
  });
},
```

`MockTimers.reset()` already guards with `if (!this._enabled) return`,
so calling it unconditionally is safe even when timers were never enabled.

### Tests

Regression tests added to
`tests/specs/node/node_test_mock_timers/test.js` and `test.out` updated
to reflect the new count.

### AI disclosure

I used Claude (Anthropic) to help investigate the root cause, locate the
relevant code in `testing.ts`, and draft parts of this PR description.
The fix and tests were validated manually.