### PR TITLE
fix(ext/node): pass Deno subcommands through child_process spawn

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -16090,6 +16090,36 @@ mod tests {
   }
 
   #[test]
+  fn subcommands_recognized_by_node_shim() {
+    // When `deno <subcommand>` is spawned via `node:child_process`, the args
+    // are passed through unchanged only if node_shim recognizes the
+    // subcommand. Otherwise it is misinterpreted as a script for `deno run`
+    // (see #35591). This test fails if a subcommand is added to the CLI
+    // without also adding it to `DENO_SUBCOMMANDS` in `libs/node_shim/lib.rs`.
+    //
+    // Most subcommands are registered lazily via clap's `.defer(...)`, so the
+    // command must be built before they show up in `get_subcommands()`.
+    let mut root = clap_root();
+    root.build();
+    for command in root.get_subcommands() {
+      let name = command.get_name();
+      assert!(
+        node_shim::is_deno_subcommand(name),
+        "subcommand `{name}` is missing from node_shim's DENO_SUBCOMMANDS list; \
+         add it to `libs/node_shim/lib.rs` so it is passed through when spawned \
+         via node:child_process",
+      );
+      for alias in command.get_visible_aliases() {
+        assert!(
+          node_shim::is_deno_subcommand(alias),
+          "visible alias `{alias}` of subcommand `{name}` is missing from \
+           node_shim's DENO_SUBCOMMANDS list; add it to `libs/node_shim/lib.rs`",
+        );
+      }
+    }
+  }
+
+  #[test]
   fn equal_help_output() {
     for command in clap_root().get_subcommands() {
       if command.get_name() == "help" {

--- a/ext/node/ops/node_cli_parser.rs
+++ b/ext/node/ops/node_cli_parser.rs
@@ -389,6 +389,20 @@ mod tests {
   }
 
   #[test]
+  fn test_translate_subcommand_passthrough() {
+    // Deno subcommands spawned via node:child_process should be passed through
+    // unchanged rather than being treated as a script for `deno run`. See
+    // #35591.
+    for subcommand in ["bundle", "serve", "fmt", "compile", "lint"] {
+      let parsed =
+        parse_args(svec![subcommand, "jsr:@std/http/file-server"]).unwrap();
+      let result = translate_to_deno_args(parsed, false, true);
+      assert_eq!(result.deno_args[0], subcommand);
+      assert!(!result.deno_args.contains(&"run".to_string()));
+    }
+  }
+
+  #[test]
   fn test_wrap_eval_code() {
     let wrapped = wrap_eval_code("console.log(42)");
     assert!(

--- a/libs/node_shim/lib.rs
+++ b/libs/node_shim/lib.rs
@@ -3225,34 +3225,64 @@ pub fn wrap_eval_code(source_code: &str) -> String {
   )
 }
 
-/// Deno subcommands - if the first arg is one of these, pass through unchanged
+/// Deno subcommands - if the first arg is one of these, pass through unchanged.
+/// This must be kept in sync with the subcommands registered in
+/// `cli/args/flags.rs` so that spawning e.g. `deno bundle ...` via
+/// `node:child_process` is passed through instead of being treated as a script
+/// to `deno run`. The `subcommands_recognized_by_node_shim` test in
+/// `cli/args/flags.rs` enforces this. See #35591.
 const DENO_SUBCOMMANDS: &[&str] = &[
   "add",
+  "approve-scripts",
+  "audit",
   "bench",
+  "bump-version",
+  "bundle",
   "cache",
   "check",
+  "ci",
+  "clean",
   "compile",
   "completions",
   "coverage",
+  "create",
+  "deploy",
+  "desktop",
   "doc",
   "eval",
   "fmt",
   "help",
+  "i",
   "info",
   "init",
   "install",
+  "json_reference",
+  "jupyter",
+  "link",
   "lint",
+  "list",
   "lsp",
+  "outdated",
+  "pack",
   "publish",
+  "remove",
   "repl",
   "run",
+  "sandbox",
+  "serve",
   "task",
   "tasks",
   "test",
+  "transpile",
   "types",
   "uninstall",
+  "unlink",
+  "update",
   "upgrade",
   "vendor",
+  "watch",
+  "why",
+  "x",
 ];
 
 /// Check if a string is a Deno subcommand


### PR DESCRIPTION
Spawning the Deno executable with a subcommand like `bundle` via
`node:child_process` failed with `Module not found ".../bundle"`. When
child_process spawns Deno, the args are translated by node_shim, which
passes them through unchanged only when the first arg is a recognized Deno
subcommand; otherwise it treats the first arg as a script and wraps it as
`deno run -A ... <arg>`. The list of recognized subcommands had drifted out
of sync with the CLI and was missing `bundle`, `serve`, and roughly twenty
others, so those were misread as scripts.

This syncs the pass-through list with the subcommands registered in
`cli/args/flags.rs` and adds a test that builds the clap command and asserts
every subcommand (and visible alias) is recognized by node_shim, so the list
can no longer silently drift when a new subcommand is added.

Fixes #35591