### PR TITLE
chore: track deno_lint main branch via git patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,8 +2800,7 @@ dependencies = [
 [[package]]
 name = "deno_lint"
 version = "0.84.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f077fbc572115bf86a5e6ed8314aa7b5ad18266e03df3db5c32004a6b1cd1df"
+source = "git+https://github.com/denoland/deno_lint.git?rev=d42bc4962b83ade9ec0035d490a39db68c3d7597#d42bc4962b83ade9ec0035d490a39db68c3d7597"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -472,6 +472,11 @@ win32job = "=2.0.3"
 windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Media", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_WindowsProgramming", "Wdk", "Wdk_System", "Wdk_System_SystemInformation", "Win32_Security", "Win32_System_Pipes", "Wdk_Storage_FileSystem", "Win32_System_Registry", "Win32_System_Kernel", "Win32_System_Threading", "Win32_UI", "Win32_UI_Shell"] }
 winres = "=0.1.12"
 
+[patch.crates-io]
+# Track the latest deno_lint main branch so we can build against in-flight
+# changes end-to-end before they are published to crates.io.
+deno_lint = { git = "https://github.com/denoland/deno_lint.git", rev = "d42bc4962b83ade9ec0035d490a39db68c3d7597" }
+
 # NB: the `bench` and `release` profiles must remain EXACTLY the same.
 [profile.release]
 codegen-units = 1

--- a/cli/ops/lint.rs
+++ b/cli/ops/lint.rs
@@ -160,6 +160,7 @@ impl LintPluginContainer {
     let lint_diagnostic = LintDiagnostic {
       specifier,
       range: Some(range),
+      severity: Default::default(),
       details: LintDiagnosticDetails {
         message,
         code: id,

--- a/cli/tools/lint/rules/no_slow_types.rs
+++ b/cli/tools/lint/rules/no_slow_types.rs
@@ -46,6 +46,7 @@ impl PackageLintRule for NoSlowTypesRule {
           range: range.range,
           description: d.range_description().map(|r| r.to_string()),
         }),
+        severity: Default::default(),
         details: LintDiagnosticDetails {
           message: d.message().to_string(),
           code: CODE.to_string(),


### PR DESCRIPTION
This points `deno_lint` at the latest `denoland/deno_lint` main commit
(`d42bc49`) through a `[patch.crates-io]` entry in the workspace
`Cargo.toml`. The goal is to start tracking in-flight changes in that
library and have them building end-to-end here before everything is
published to crates.io and merged.

The main branch introduces a required `severity` field on
`LintDiagnostic` (a new `LintDiagnosticSeverity` enum that defaults to
`Error`). Both places where we construct `LintDiagnostic` in the CLI,
the plugin op in `cli/ops/lint.rs` and the no-slow-types rule in
`cli/tools/lint/rules/no_slow_types.rs`, now set `severity` to its
default, which preserves the existing behavior of treating every
diagnostic as an error.

This is intentionally a tracking patch pinned to a specific revision
rather than a version bump; it should be replaced with a published
`deno_lint` release before the broader work lands.
