### PR TITLE
fix(ext/web): throw DataCloneError when posting non-serializable values

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -25,6 +25,7 @@ const {
 } = core.ops;
 const {
   deserializeJsMessageData,
+  isUncloneable,
   markAsUncloneable: webMarkAsUncloneable,
   MessageChannel,
   MessagePort,
@@ -781,6 +782,15 @@ class NodeWorker extends EventEmitter {
       transferOrOptions === null ||
       (arguments.length <= 1)
     ) {
+      // Reject non-serializable values (e.g. URL) and per-instance
+      // markAsUncloneable values before V8's serializer silently turns them
+      // into `{}`, matching the web MessagePort path and Node's behavior.
+      if (isUncloneable(message)) {
+        throw new DOMException(
+          "Cannot clone object of unsupported type.",
+          "DataCloneError",
+        );
+      }
       op_host_post_message_raw(
         this.#id,
         core.serialize(message),

--- a/ext/web/13_message_port.js
+++ b/ext/web/13_message_port.js
@@ -795,6 +795,13 @@ function markAsUncloneable(target) {
   });
 }
 
+// Returns true when `value` must raise a `DataCloneError` if it appears at the
+// top level of a `postMessage()` or `structuredClone()` call. This covers both
+// non-serializable Web API platform types (marked on their prototype via
+// `markNotSerializable`, e.g. URL / Headers / Request) and values flagged
+// per-instance by `worker_threads.markAsUncloneable`. Both must be rejected
+// before V8's ValueSerializer runs, since it can't see these JS-only symbols
+// and would otherwise silently round-trip them as `{}`.
 function isUncloneable(value) {
   if (value === null) return false;
   const t = typeof value;
@@ -807,6 +814,12 @@ function isUncloneable(value) {
   // approximate the brand check by treating `value.constructor.prototype
   // === value` as "this is a prototype object, allow cloning unless the
   // marker is set on the value itself".
+  if (
+    value[kNotSerializable] === true &&
+    !isOwnPrototypeObject(value, kNotSerializable)
+  ) {
+    return true;
+  }
   if (
     value[kUncloneable] === true &&
     !isOwnPrototypeObject(value, kUncloneable)
@@ -864,20 +877,13 @@ function structuredClone(value, options) {
   // transferring is not the same as serializing.
   if (
     value !== null && typeof value === "object" &&
-    !ArrayPrototypeIncludes(options.transfer, value)
+    !ArrayPrototypeIncludes(options.transfer, value) &&
+    isUncloneable(value)
   ) {
-    // Same prototype-object exemption as in isUncloneable: a marker on a
-    // class's prototype means "instances are uncloneable", not "the
-    // prototype object itself is".
-    const blocked = (value[kNotSerializable] === true &&
-      !isOwnPrototypeObject(value, kNotSerializable)) ||
-      isUncloneable(value);
-    if (blocked) {
-      throw new DOMException(
-        "Cannot clone object of unsupported type.",
-        "DataCloneError",
-      );
-    }
+    throw new DOMException(
+      "Cannot clone object of unsupported type.",
+      "DataCloneError",
+    );
   }
 
   // Fast-path, avoiding round-trip serialization and deserialization
@@ -898,6 +904,7 @@ function structuredClone(value, options) {
 
 return {
   deserializeJsMessageData,
+  isUncloneable,
   markAsUncloneable,
   markNotSerializable,
   MessageChannel,

--- a/tests/unit/structured_clone_test.ts
+++ b/tests/unit/structured_clone_test.ts
@@ -75,6 +75,27 @@ Deno.test("structuredClone URL throws DataCloneError", () => {
   );
 });
 
+Deno.test("postMessage URL throws DataCloneError", () => {
+  // Posting a non-serializable value must take the same path as
+  // structuredClone and throw, instead of silently delivering `{}`.
+  const { port1, port2 } = new MessageChannel();
+  try {
+    assertThrows(
+      () => port2.postMessage(new URL("https://example.org/")),
+      DOMException,
+      "Cannot clone object of unsupported type.",
+    );
+    assertThrows(
+      () => port2.postMessage(new URLSearchParams("a=1")),
+      DOMException,
+      "Cannot clone object of unsupported type.",
+    );
+  } finally {
+    port1.close();
+    port2.close();
+  }
+});
+
 Deno.test("structuredClone CryptoKey", async () => {
   // AES key
   const aesKey = await crypto.subtle.generateKey(

--- a/tests/unit_node/worker_threads_test.ts
+++ b/tests/unit_node/worker_threads_test.ts
@@ -1126,3 +1126,36 @@ Deno.test({
     );
   },
 });
+
+// Placed last: creating a Worker bumps the process-global threadId counter,
+// which the "Worker threadId" test above asserts absolute values for.
+Deno.test("[node/worker_threads] postMessage of non-serializable value throws", async () => {
+  // URL is not [Serializable] per the WHATWG/HTML spec; posting it must throw
+  // a DataCloneError instead of silently delivering `{}`. Regression test for
+  // denoland/deno#35401.
+  const { port1, port2 } = new workerThreads.MessageChannel();
+  try {
+    assertThrows(
+      () => port2.postMessage(new URL("https://example.org/")),
+      DOMException,
+      "Cannot clone object of unsupported type.",
+    );
+  } finally {
+    port1.close();
+    port2.close();
+  }
+
+  // Same must hold for the Worker.postMessage (main thread -> worker) path.
+  const worker = new workerThreads.Worker(
+    new URL("./testdata/worker_threads.mjs", import.meta.url),
+  );
+  try {
+    assertThrows(
+      () => worker.postMessage(new URL("https://example.org/")),
+      DOMException,
+      "Cannot clone object of unsupported type.",
+    );
+  } finally {
+    await worker.terminate();
+  }
+});


### PR DESCRIPTION
Per the WHATWG/HTML spec, types like `URL` and `URLSearchParams` are not
[Serializable], so sending them through `postMessage()` must throw a
`DataCloneError`, which is what browsers and Node both do. #35423 already
made `structuredClone()` reject them, but `postMessage()` still silently
serialized them to an empty object, both through a web `MessageChannel`
(including the `node:worker_threads` `MessageChannel`) and through
`Worker.postMessage()`.

The non-serializable marker that #35423 added on the prototypes was only
consulted inside `structuredClone()`. The `postMessage` paths gate on a
separate per-instance "uncloneable" check, so they never saw it. This folds
the prototype marker into that shared check so the MessagePort fast path,
`serializeJsMessageData()`, and `structuredClone()` all reject these types
consistently, and additionally guards the node `Worker.postMessage()` fast
path, which previously serialized directly with no check at all.

Fixes #35401