### PR TITLE
fix(install): don't panic on jsr specifier with a tag like @latest

### DIFF
--- a/cli/jsr.rs
+++ b/cli/jsr.rs
@@ -57,6 +57,13 @@ impl JsrFetchResolver {
     &self,
     req: &PackageReq,
   ) -> Result<Option<PackageNv>, JsrPackageReqNotFoundError> {
+    // JSR has no dist-tags, so a tag can never resolve to a name and version.
+    // Bail out before reaching deno_graph's version resolver, which panics in
+    // VersionReq::matches when given a tag. Callers that want to support a
+    // convention like "@latest" resolve it separately via latest_version.
+    if req.version_req.tag().is_some() {
+      return Ok(None);
+    }
     if let Some(nv) = self.nv_by_req.get(req) {
       return Ok(nv.value().clone());
     }

--- a/cli/tools/pm/cache_deps.rs
+++ b/cli/tools/pm/cache_deps.rs
@@ -124,9 +124,9 @@ pub async fn cache_top_level_deps(
             // tagged reqs away from VersionReq::matches below, which
             // panics on tags.
             log::warn!(
-              "{} Ignoring \"{}\". Version tags are not supported in jsr specifiers.",
+              "{} Ignoring \"jsr:{}\". Version tags are not supported in jsr specifiers.",
               deno_terminal::colors::yellow("Warning"),
-              specifier_str,
+              req_ref.req(),
             );
             continue;
           }

--- a/cli/tools/pm/cache_deps.rs
+++ b/cli/tools/pm/cache_deps.rs
@@ -116,6 +116,20 @@ pub async fn cache_top_level_deps(
           if !seen_reqs.insert(req_ref.req().clone()) {
             continue;
           }
+          if req_ref.req().version_req.tag().is_some() {
+            // JSR has no dist-tags, so this dependency can never resolve.
+            // Warn instead of failing so the rest of the project still
+            // installs; the graph build reports a proper error when the
+            // specifier is actually imported. Skipping here also keeps
+            // tagged reqs away from VersionReq::matches below, which
+            // panics on tags.
+            log::warn!(
+              "{} Ignoring \"{}\". Version tags are not supported in jsr specifiers.",
+              deno_terminal::colors::yellow("Warning"),
+              specifier_str,
+            );
+            continue;
+          }
           let resolved_req = graph.packages.mappings().get(req_ref.req());
           let resolved_req = resolved_req.and_then(|nv| {
             // the version might end up being upgraded to a newer version that's already in

--- a/cli/tools/pm/deps.rs
+++ b/cli/tools/pm/deps.rs
@@ -762,6 +762,10 @@ impl DepManager {
             ModuleSpecifier::parse(&format!("npm:/{}/", dep.req)).unwrap(),
           ),
           DepKind::Jsr => {
+            // Note: a tagged req (e.g. `@latest`) never appears in the graph
+            // mappings because the graph build rejects jsr version tags, so
+            // the VersionReq::matches call below (which panics on tags)
+            // cannot be reached with one.
             let resolved_nv = graph.packages.mappings().get(&dep.req);
             let resolved_nv = resolved_nv
               .and_then(|nv| {

--- a/tests/specs/install/jsr_latest_tag_no_panic/__test__.jsonc
+++ b/tests/specs/install/jsr_latest_tag_no_panic/__test__.jsonc
@@ -1,13 +1,14 @@
 {
   // Regression test for https://github.com/denoland/deno/issues/35084
   // A jsr specifier pinned to a tag (e.g. `@latest`) used to panic in
-  // VersionReq::matches. JSR has no dist-tags, so the dep is treated as
-  // unresolvable (like any other unknown jsr dep) instead of crashing.
+  // VersionReq::matches. JSR has no dist-tags, so the dep is skipped with
+  // a warning (and otherwise treated as unresolvable, like any other
+  // unknown jsr dep) instead of crashing.
   "tempDir": true,
   "steps": [
     {
       "args": "install",
-      "output": "[WILDCARD]",
+      "output": "[WILDCARD]Warning Ignoring \"jsr:@denotest/add@latest\". Version tags are not supported in jsr specifiers.\n[WILDCARD]",
       "exitCode": 0
     }
   ]

--- a/tests/specs/install/jsr_latest_tag_no_panic/__test__.jsonc
+++ b/tests/specs/install/jsr_latest_tag_no_panic/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  // Regression test for https://github.com/denoland/deno/issues/35084
+  // A jsr specifier pinned to a tag (e.g. `@latest`) used to panic in
+  // VersionReq::matches. JSR has no dist-tags, so the dep is treated as
+  // unresolvable (like any other unknown jsr dep) instead of crashing.
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install",
+      "output": "[WILDCARD]",
+      "exitCode": 0
+    }
+  ]
+}

--- a/tests/specs/install/jsr_latest_tag_no_panic/deno.json
+++ b/tests/specs/install/jsr_latest_tag_no_panic/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@denotest/add": "jsr:@denotest/add@latest"
+  }
+}


### PR DESCRIPTION
Fixes #35084.

Running `deno install` in a project whose import map contains a JSR
specifier pinned to a tag, such as `jsr:@std/encoding@latest`, panicked
with `programming error: cannot use matches with a tag: latest`.

JSR has no dist-tags, so a tagged JSR specifier can never resolve to a
concrete name and version. The top-level install path
(`cache_top_level_deps`) and the dependency resolution path used by
`deno outdated`/`add`/`remove` both call `JsrFetchResolver::req_to_nv`
directly. That eventually reaches deno_graph's version resolver, which
calls `VersionReq::matches` on the requirement; that function panics by
design when the requirement is a tag rather than a semver range. The
graph build path already rejects these cleanly with "Version tag not
supported in jsr specifiers", but these package-management code paths
bypass it.

The fix short-circuits `req_to_nv` when the requirement is a tag and
returns `None`, the same "unresolvable" result already produced for an
unknown JSR package (for which `deno install` exits successfully without
caching anything). This keeps behavior consistent across all callers and
removes the panic. The existing `deno add jsr:...@latest` handling, which
intentionally treats `@latest` as "the newest version" and rejects other
tags, is unaffected: it resolves the tag via `latest_version` before
reaching `req_to_nv`.

Added a spec test covering `deno install` against a `jsr:...@latest`
dependency.

`deno install` additionally skips tagged jsr deps with a warning
("Ignoring \"jsr:@denotest/add@latest\". Version tags are not supported
in jsr specifiers.") so the problem is discoverable at install time
instead of only failing later at `deno run` with the graph error. The
spec test asserts the warning.
