### PR TITLE
fix(ext/fetch): include path and reason when fetching a file:// URL fails

### DIFF
--- a/ext/fetch/fs_fetch_handler.rs
+++ b/ext/fetch/fs_fetch_handler.rs
@@ -47,11 +47,12 @@ impl FetchHandler for FsFetchHandler {
       .borrow::<PermissionsContainer>()
       .check_open(Cow::Owned(path), OpenAccessKind::Read, Some("fetch()"))
       .map(CheckedPath::into_owned);
+    let url_string = url.to_string();
     let response_fut = async move {
       let file = fs
         .open_async(path?, OpenOptions::read())
         .await
-        .map_err(|_| super::FetchError::NetworkError)?;
+        .map_err(|err| super::FetchError::FileFetch(url_string, err))?;
       let resource = Rc::new(FileResource::new(file, "".to_owned()));
       let body = BoxBody::new(ResourceToBodyAdapter::new(resource));
       let response = http::Response::new(body);

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -189,6 +189,9 @@ pub enum FetchError {
   #[error("NetworkError when attempting to fetch resource")]
   NetworkError,
   #[class(type)]
+  #[error("Error fetching file '{0}': {1}")]
+  FileFetch(String, deno_fs::FsError),
+  #[class(type)]
   #[error("Fetching files only supports the GET method: received {0}")]
   FsNotGet(Method),
   #[class(inherit)]

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -1792,11 +1792,13 @@ Deno.test(
 Deno.test(
   { permissions: { read: true } },
   async function fetchFileDoesNotExist() {
+    const url = import.meta.resolve("./bad.json");
     await assertRejects(
       async () => {
-        await fetch(import.meta.resolve("./bad.json"));
+        await fetch(url);
       },
       TypeError,
+      `Error fetching file '${url}'`,
     );
   },
 );


### PR DESCRIPTION
Fetching a `file://` URL that could not be opened always surfaced the
opaque `NetworkError when attempting to fetch resource`, discarding the
underlying filesystem error. The real reason (and which file) was lost
because `fs.open_async` errors were mapped with `map_err(|_| NetworkError)`.

This is especially confusing for compiled binaries and `deno desktop`
apps. There, `fetch(import.meta.resolve("./index.html"))` on an asset
that was not embedded with `--include` resolves to a path inside the
compile VFS and fails with no hint that the file is simply missing, as
reported in #35487.

This preserves the underlying error and the URL, so the message now
reads, for example:

```
Error fetching file 'file:///.../index.html': No such file or directory (os error 2)
```

The error remains a `TypeError` (file fetches are a Deno extension, and
keeping the class matches the previous behavior and fetch semantics for
network errors). The path under the compile temp directory now also
serves as a strong hint that `--include` is needed.

Fixes #35487.
