### PR TITLE
fix(ext/node): drain keep-alive connections on http server.close()

### DIFF
--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -1259,46 +1259,45 @@ function resOnFinish(req, res, socket, state, server) {
       socket.end();
     }
   } else if (state.outgoing.length === 0) {
-    // If the server is closing, destroy the socket instead of
-    // setting a keep-alive timeout (prevents timer leaks).
-    if (!server.listening) {
-      socket.destroy();
-    } else {
-      const keepAliveTimeout = NumberIsFinite(server.keepAliveTimeout) &&
-          server.keepAliveTimeout >= 0
-        ? server.keepAliveTimeout
-        : 0;
+    // Keep the connection alive so it can serve subsequent requests. This
+    // matches Node: server.close() stops accepting new connections but lets
+    // existing keep-alive connections drain, including requests that arrive
+    // after close() while the connection is still open. The keep-alive
+    // timeout (or a Connection: close request) eventually ends the socket.
+    const keepAliveTimeout = NumberIsFinite(server.keepAliveTimeout) &&
+        server.keepAliveTimeout >= 0
+      ? server.keepAliveTimeout
+      : 0;
 
-      if (keepAliveTimeout) {
-        const timeoutMsecs = keepAliveTimeout + 1000;
-        const suspendedTimeout = state.keepAliveTimeout;
-        if (
-          state.keepAliveTimeoutSuspended &&
-          socket.setTimeout === net.Socket.prototype.setTimeout &&
-          socket[kTimeout] === null &&
-          state.keepAliveTimeoutMsecs === timeoutMsecs
-        ) {
-          socket[kTimeout] = suspendedTimeout;
-          socket.timeout = timeoutMsecs;
-          suspendedTimeout.refresh();
-        } else {
-          if (state.keepAliveTimeoutSuspended) {
-            suspendedTimeout[kDestroy]();
-          }
-          socket.setTimeout(timeoutMsecs);
-          state.keepAliveTimeout = socket[kTimeout];
-          state.keepAliveTimeoutMsecs = timeoutMsecs;
-        }
-        state.keepAliveTimeoutSet = true;
-        state.keepAliveTimeoutSuspended = false;
-      } else if (
-        state.keepAliveTimeoutSuspended
+    if (keepAliveTimeout) {
+      const timeoutMsecs = keepAliveTimeout + 1000;
+      const suspendedTimeout = state.keepAliveTimeout;
+      if (
+        state.keepAliveTimeoutSuspended &&
+        socket.setTimeout === net.Socket.prototype.setTimeout &&
+        socket[kTimeout] === null &&
+        state.keepAliveTimeoutMsecs === timeoutMsecs
       ) {
-        state.keepAliveTimeout[kDestroy]();
-        state.keepAliveTimeout = null;
-        state.keepAliveTimeoutMsecs = 0;
-        state.keepAliveTimeoutSuspended = false;
+        socket[kTimeout] = suspendedTimeout;
+        socket.timeout = timeoutMsecs;
+        suspendedTimeout.refresh();
+      } else {
+        if (state.keepAliveTimeoutSuspended) {
+          suspendedTimeout[kDestroy]();
+        }
+        socket.setTimeout(timeoutMsecs);
+        state.keepAliveTimeout = socket[kTimeout];
+        state.keepAliveTimeoutMsecs = timeoutMsecs;
       }
+      state.keepAliveTimeoutSet = true;
+      state.keepAliveTimeoutSuspended = false;
+    } else if (
+      state.keepAliveTimeoutSuspended
+    ) {
+      state.keepAliveTimeout[kDestroy]();
+      state.keepAliveTimeout = null;
+      state.keepAliveTimeoutMsecs = 0;
+      state.keepAliveTimeoutSuspended = false;
     }
   } else {
     const m = ArrayPrototypeShift(state.outgoing);

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1597,6 +1597,61 @@ Deno.test("[node/http] server graceful close", async () => {
   await promise;
 });
 
+// Regression test for https://github.com/denoland/deno/issues/35609.
+// server.close() must stop accepting new connections but keep existing
+// keep-alive connections open so a follow-up request on the same socket is
+// still served (graceful drain). It previously tore the socket down as soon
+// as the in-flight response finished.
+Deno.test("[node/http] server.close() drains existing keep-alive connection", async () => {
+  let reqCount = 0;
+  let closeCallbackFired = false;
+  const server = http.createServer((_req, res) => {
+    reqCount++;
+    if (reqCount === 1) {
+      server.close(() => {
+        closeCallbackFired = true;
+      });
+    }
+    res.setHeader("Connection", "keep-alive");
+    res.end("reply-" + reqCount);
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  server.listen(0, "127.0.0.1", () => {
+    const port = (server.address() as AddressInfo).port;
+    const socket = net.connect(port, "127.0.0.1", () => {
+      socket.write(
+        "GET /first HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n",
+      );
+    });
+    let buf = "";
+    let sent2 = false;
+    socket.on("data", (d) => {
+      buf += d;
+      if (!sent2 && /reply-1/.test(buf)) {
+        sent2 = true;
+        // Second request arrives after close() on the still-open socket.
+        socket.write(
+          "GET /second HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+        );
+      }
+      if (/reply-2/.test(buf)) {
+        socket.destroy();
+        resolve();
+      }
+    });
+    socket.on("close", () => {
+      if (reqCount < 2) {
+        reject(new Error("connection dropped before 2nd request was served"));
+      }
+    });
+  });
+
+  await promise;
+  assert(closeCallbackFired);
+  assertEquals(reqCount, 2);
+});
+
 Deno.test("[node/http] server closeAllConnections shutdown", async () => {
   const server = http.createServer((_req, res) => {
     res.writeHead(200, { "Content-Type": "application/json" });


### PR DESCRIPTION
Deno's `node:http` `server.close()` diverged from Node. Per Node semantics,
`server.close()` stops accepting new connections but keeps existing keep-alive
connections open so in-flight and subsequent requests on them finish; the close
callback only fires once those connections end. Under Deno, `server.close()`
tore down the existing keep-alive connection as soon as the in-flight response
finished, so a follow-up request on the same socket was never served and the
close callback fired immediately.

The cause was a Deno-only branch in `resOnFinish` that destroyed the socket
when the server was no longer listening, instead of setting the keep-alive
timeout. This branch was introduced in the llhttp rewrite (#33208) with a note
about preventing timer leaks, but it breaks the graceful-drain behavior that
frameworks like fastify rely on for graceful shutdown (serving HTTP 503 to
in-flight connections while closing). Removing it makes the connection drain
like Node: the keep-alive timeout (or a `Connection: close` request) eventually
ends the socket.

Adds a regression test in `tests/unit_node/http_test.ts` that calls
`server.close()` during the first request and asserts a second request on the
same keep-alive socket is still served.

Closes #35609