### PR TITLE
fix(ext/webidl): accept iterable primitives in async iterable converter

### DIFF
--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -998,7 +998,13 @@ function createAsyncIterableConverter(converter) {
     context = undefined,
     opts = EMPTY_OPTS,
   ) {
-    if (type(V) !== "Object") {
+    // The spec obtains the iterator via GetIterator(), which performs the
+    // property lookups through ToObject() and therefore accepts iterable
+    // primitives such as strings (e.g. `ReadableStream.from("hi")`). Allow
+    // strings here; other primitives (and null/undefined) have no iterator
+    // method and fall through to the "is not iterable" error below.
+    const valueType = type(V);
+    if (valueType !== "Object" && valueType !== "String") {
       throw makeException(
         TypeError,
         "can not be converted to async iterable.",

--- a/tests/unit/streams_test.ts
+++ b/tests/unit/streams_test.ts
@@ -578,13 +578,26 @@ Deno.test(async function decompressionStreamInvalidGzipStillReported() {
   );
 });
 
-Deno.test(function readableStreamFromWithStringThrows() {
-  assertThrows(
-    // @ts-expect-error: primitives are not acceptable
-    () => ReadableStream.from("string"),
-    TypeError,
-    "Failed to execute 'ReadableStream.from': Argument 1 can not be converted to async iterable.",
-  );
+Deno.test(async function readableStreamFromString() {
+  // A string is a sync iterable; ReadableStream.from() should yield its
+  // characters one at a time (matches the WHATWG streams spec and Node).
+  // @ts-expect-error: TS lib types exclude primitives, but they work at runtime
+  const stream: ReadableStream<string> = ReadableStream.from("hi");
+  const reader = stream.getReader();
+  assertEquals(await reader.read(), { value: "h", done: false });
+  assertEquals(await reader.read(), { value: "i", done: false });
+  assertEquals(await reader.read(), { value: undefined, done: true });
+});
+
+Deno.test(function readableStreamFromNonIterableThrows() {
+  for (const value of [null, undefined, 42, true]) {
+    assertThrows(
+      // @ts-expect-error: non-iterable values are not acceptable
+      () => ReadableStream.from(value),
+      TypeError,
+      "Failed to execute 'ReadableStream.from': Argument 1 can not be converted to async iterable.",
+    );
+  }
 });
 
 Deno.test(async function readableStreamFromWithStringThrows() {


### PR DESCRIPTION
`ReadableStream.from()` rejected sync iterable primitives such as strings,
while Node and the WHATWG streams spec accept them:

```js
ReadableStream.from("hi")
// Node:  yields "h", "i"
// Deno:  TypeError: Failed to execute 'ReadableStream.from':
//        Argument 1 can not be converted to async iterable.
```

Per spec, `ReadableStream.from(asyncIterable)` takes `any` and obtains the
iterator via `GetIterator()`, which performs its property lookups through
`ToObject()` and therefore accepts iterable primitives. The webidl async
iterable converter rejected any non-Object value up front, so iterable objects
(arrays, Sets) worked but the string primitive did not.

This allows strings (the only iterable primitive) through. Other primitives and
`null`/`undefined` have no iterator method and still throw. The change is
confined to the async iterable converter; the other consumer of it (fetch
request body) only reaches the converter for values that are already objects,
so string bodies are still treated as text.

Surfaced in fastify's HEAD-route response-type test, which returns
`ReadableStream.from('...')`.

Closes #35611