### PR TITLE
fix(inspector): support Chrome worker debugging

### DIFF
--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -526,6 +526,7 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
           &shared.sys,
         ),
         wait_for_debugger_on_start: args.wait_for_debugger_on_start,
+        wait_for_page_wait_for_debugger: args.wait_for_page_wait_for_debugger,
       };
 
       let has_resource_limits = args.resource_limits.is_some();

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -525,6 +525,7 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
         enable_stack_trace_arg_in_ops: has_trace_permissions_enabled(
           &shared.sys,
         ),
+        wait_for_debugger_on_start: args.wait_for_debugger_on_start,
       };
 
       let has_resource_limits = args.resource_limits.is_some();

--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -453,6 +453,7 @@ struct JsRuntimeInspectorState {
   flags: Rc<RefCell<InspectorFlags>>,
   waker: Arc<InspectorWaker>,
   sessions: Rc<RefCell<SessionContainer>>,
+  active_session_count: Rc<Cell<usize>>,
   is_dispatching_message: Rc<RefCell<bool>>,
   pending_worker_messages: Arc<Mutex<Vec<(String, String)>>>,
   nodeworker_enabled: Rc<Cell<bool>>,
@@ -559,7 +560,7 @@ impl JsRuntimeInspectorState {
           // to yield back its ID).
           if fut.poll_unpin(cx).is_pending() {
             sessions.established.push(fut);
-            sessions.local.insert(id, session);
+            sessions.insert_local_session(id, session);
 
             // Track the first session as the main session for Target events
             if sessions.main_session_id.is_none() {
@@ -783,7 +784,7 @@ impl JsRuntimeInspectorState {
             // A session's pump future completed (WS disconnected).
             // Remove it from local so sessions_state() no longer
             // reports it as active.
-            sessions.local.remove(&completed_id);
+            sessions.remove_local_session(completed_id);
             // If this was the main session, promote another session
             // or clear, so new connections can become main and
             // Target/worker notifications continue to work.
@@ -884,14 +885,16 @@ impl JsRuntimeInspector {
       mpsc::unbounded::<InspectorSessionProxy>();
 
     let waker = InspectorWaker::new(scope.thread_safe_handle());
+    let active_session_count = Rc::new(Cell::new(0));
     let state = Rc::new(JsRuntimeInspectorState {
       waker,
       flags: Default::default(),
       isolate_ptr,
       context: v8::Global::new(scope, context),
-      sessions: Rc::new(
-        RefCell::new(SessionContainer::temporary_placeholder()),
-      ),
+      sessions: Rc::new(RefCell::new(SessionContainer::temporary_placeholder(
+        active_session_count.clone(),
+      ))),
+      active_session_count,
       is_dispatching_message: Default::default(),
       pending_worker_messages: Arc::new(Mutex::new(Vec::new())),
       nodeworker_enabled: Rc::new(Cell::new(false)),
@@ -908,8 +911,11 @@ impl JsRuntimeInspector {
       v8_inspector_client,
     ));
 
-    *state.sessions.borrow_mut() =
-      SessionContainer::new(v8_inspector.clone(), new_session_rx);
+    *state.sessions.borrow_mut() = SessionContainer::new(
+      v8_inspector.clone(),
+      new_session_rx,
+      state.active_session_count.clone(),
+    );
 
     // Tell the inspector about the main realm.
     let context_name_bytes = if is_main_runtime {
@@ -1193,7 +1199,7 @@ impl JsRuntimeInspector {
   }
 
   pub fn should_wait_for_page_wait_for_debugger_on_worker_start(&self) -> bool {
-    self.state.sessions.borrow().sessions_state().has_active
+    self.state.active_session_count.get() > 0
       && !self.should_wait_for_debugger_on_worker_start()
   }
 
@@ -1413,7 +1419,7 @@ impl JsRuntimeInspector {
         let mut s = sessions.borrow_mut();
         let id = s.next_local_id;
         s.next_local_id += 1;
-        assert!(s.local.insert(id, inspector_session).is_none());
+        assert!(s.insert_local_session(id, inspector_session).is_none());
         id
       };
 
@@ -1458,6 +1464,7 @@ pub struct SessionContainer {
   established: FuturesUnordered<InspectorSessionPumpMessages>,
   next_local_id: i32,
   local: HashMap<i32, Rc<InspectorSession>>,
+  active_session_count: Rc<Cell<usize>>,
 
   target_sessions: HashMap<String, Rc<TargetSession>>, // sessionId -> TargetSession
   main_session_id: Option<i32>, // The first session that should receive Target events
@@ -1519,6 +1526,7 @@ impl SessionContainer {
   fn new(
     v8_inspector: Rc<v8::inspector::V8Inspector>,
     new_session_rx: UnboundedReceiver<InspectorSessionProxy>,
+    active_session_count: Rc<Cell<usize>>,
   ) -> Self {
     Self {
       v8_inspector: Some(v8_inspector),
@@ -1527,6 +1535,7 @@ impl SessionContainer {
       established: FuturesUnordered::new(),
       next_local_id: 1,
       local: HashMap::new(),
+      active_session_count,
 
       target_sessions: HashMap::new(),
       main_session_id: None,
@@ -1543,6 +1552,31 @@ impl SessionContainer {
     self.handshake.take();
     self.established.clear();
     self.local.clear();
+    self.active_session_count.set(0);
+  }
+
+  fn insert_local_session(
+    &mut self,
+    id: i32,
+    session: Rc<InspectorSession>,
+  ) -> Option<Rc<InspectorSession>> {
+    let previous = self.local.insert(id, session);
+    if previous.is_none() {
+      self
+        .active_session_count
+        .set(self.active_session_count.get() + 1);
+    }
+    previous
+  }
+
+  fn remove_local_session(&mut self, id: i32) -> Option<Rc<InspectorSession>> {
+    let removed = self.local.remove(&id);
+    if removed.is_some() {
+      self
+        .active_session_count
+        .set(self.active_session_count.get().saturating_sub(1));
+    }
+    removed
   }
 
   fn sessions_state(&self) -> SessionsState {
@@ -1572,7 +1606,7 @@ impl SessionContainer {
   /// instance of V8Inspector is created. It's used in favor
   /// of `Default` implementation to signal that it's not meant
   /// for actual use.
-  fn temporary_placeholder() -> Self {
+  fn temporary_placeholder(active_session_count: Rc<Cell<usize>>) -> Self {
     let (_tx, rx) = mpsc::unbounded::<InspectorSessionProxy>();
     Self {
       v8_inspector: Default::default(),
@@ -1581,6 +1615,7 @@ impl SessionContainer {
       established: FuturesUnordered::new(),
       next_local_id: 1,
       local: HashMap::new(),
+      active_session_count,
 
       target_sessions: HashMap::new(),
       main_session_id: None,
@@ -2313,7 +2348,7 @@ impl LocalInspectorSession {
 impl Drop for LocalInspectorSession {
   fn drop(&mut self) {
     let mut sessions = self.sessions.borrow_mut();
-    sessions.local.remove(&self.session_id);
+    sessions.remove_local_session(self.session_id);
     if sessions.main_session_id == Some(self.session_id) {
       sessions.main_session_id = sessions.local.keys().next().copied();
     }

--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -1193,8 +1193,8 @@ impl JsRuntimeInspector {
   }
 
   pub fn should_wait_for_page_wait_for_debugger_on_worker_start(&self) -> bool {
-    self.state.auto_attach_enabled.get()
-      && !self.state.auto_attach_wait_for_debugger_on_start.get()
+    self.state.sessions.borrow().sessions_state().has_active
+      && !self.should_wait_for_debugger_on_worker_start()
   }
 
   /// Obtain a sender for proxy channels.

--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -1139,11 +1139,62 @@ impl JsRuntimeInspector {
     self.state.flags.borrow_mut().resumed_by_session_id = None;
   }
 
+  pub fn wait_for_page_wait_for_debugger(&self) {
+    const PAGE_WAIT_GRACE_PERIOD: std::time::Duration =
+      std::time::Duration::from_millis(500);
+
+    {
+      let mut flags = self.state.flags.borrow_mut();
+      flags.paused_on_start = true;
+      flags.waiting_for_session = false;
+      flags.page_wait_for_debugger_received = false;
+    }
+
+    let deadline = std::time::Instant::now() + PAGE_WAIT_GRACE_PERIOD;
+    loop {
+      {
+        let flags = self.state.flags.borrow();
+        if !flags.paused_on_start || flags.page_wait_for_debugger_received {
+          break;
+        }
+      }
+      if std::time::Instant::now() >= deadline {
+        let mut flags = self.state.flags.borrow_mut();
+        if !flags.page_wait_for_debugger_received {
+          flags.paused_on_start = false;
+          flags.waiting_for_session = false;
+          flags.resumed_by_session_id = None;
+          break;
+        }
+      }
+      let _ = self.state.poll_sessions(None).unwrap();
+      std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+
+    if self.state.flags.borrow().paused_on_start {
+      loop {
+        if !self.state.flags.borrow().paused_on_start {
+          break;
+        }
+        self.state.flags.borrow_mut().waiting_for_session = true;
+        let _ = self.state.poll_sessions(None).unwrap();
+      }
+      let mut flags = self.state.flags.borrow_mut();
+      flags.page_wait_for_debugger_received = false;
+      flags.resumed_by_session_id = None;
+    }
+  }
+
   pub fn should_wait_for_debugger_on_worker_start(&self) -> bool {
     self.state.auto_attach_enabled.get()
       && self.state.auto_attach_wait_for_debugger_on_start.get()
       || self.state.nodeworker_enabled.get()
         && self.state.nodeworker_wait_for_debugger_on_start.get()
+  }
+
+  pub fn should_wait_for_page_wait_for_debugger_on_worker_start(&self) -> bool {
+    self.state.auto_attach_enabled.get()
+      && !self.state.auto_attach_wait_for_debugger_on_start.get()
   }
 
   /// Obtain a sender for proxy channels.
@@ -1364,6 +1415,8 @@ struct InspectorFlags {
   /// Runtime.runIfWaitingForDebugger is received, allowing
   /// NodeRuntime.waitingForDebugger to be emitted.
   paused_on_start: bool,
+  /// Set when a frontend explicitly sends Page.waitForDebugger.
+  page_wait_for_debugger_received: bool,
   /// Tracks which session sent Runtime.runIfWaitingForDebugger,
   /// so schedule_pause_on_next_statement targets the correct session.
   resumed_by_session_id: Option<i32>,
@@ -1816,6 +1869,7 @@ impl InspectorSession {
     let mut flags = self.state.flags.borrow_mut();
     flags.paused_on_start = true;
     flags.waiting_for_session = true;
+    flags.page_wait_for_debugger_received = true;
   }
 
   /// Queue a message to be sent to a worker

--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -1197,6 +1197,24 @@ impl JsRuntimeInspector {
       && !self.should_wait_for_debugger_on_worker_start()
   }
 
+  pub fn wait_for_debugger_enabled_for_worker_message(&self) {
+    const WORKER_MESSAGE_DEBUGGER_GRACE_PERIOD: std::time::Duration =
+      std::time::Duration::from_millis(500);
+
+    let deadline =
+      std::time::Instant::now() + WORKER_MESSAGE_DEBUGGER_GRACE_PERIOD;
+    loop {
+      if self.state.flags.borrow().debugger_enabled_session_count > 0 {
+        break;
+      }
+      if std::time::Instant::now() >= deadline {
+        break;
+      }
+      let _ = self.state.poll_sessions(None).unwrap();
+      std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+  }
+
   /// Obtain a sender for proxy channels.
   pub fn get_session_sender(&self) -> UnboundedSender<InspectorSessionProxy> {
     self.new_session_tx.clone()
@@ -1420,6 +1438,7 @@ struct InspectorFlags {
   /// Tracks which session sent Runtime.runIfWaitingForDebugger,
   /// so schedule_pause_on_next_statement targets the correct session.
   resumed_by_session_id: Option<i32>,
+  debugger_enabled_session_count: usize,
 }
 
 #[derive(Debug)]
@@ -1582,6 +1601,12 @@ impl SessionContainer {
     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&message)
       && let Some(method) = parsed.get("method").and_then(|m| m.as_str())
     {
+      match method {
+        "Debugger.enable" => session.set_debugger_enabled(true),
+        "Debugger.disable" => session.set_debugger_enabled(false),
+        _ => {}
+      }
+
       if method == "Page.waitForDebugger" {
         session.wait_for_debugger();
         if let Some(id) = parsed.get("id") {
@@ -1794,6 +1819,7 @@ struct InspectorSessionState {
   // Runtime.executionContextDestroyed) to this session at exit, and waits for
   // the session to disconnect before terminating the process.
   notify_waiting_for_disconnect: Cell<bool>,
+  debugger_enabled: Cell<bool>,
   // Inspector flags (shared with JsRuntimeInspectorState) for checking waiting_for_session
   flags: Rc<RefCell<InspectorFlags>>,
   // Shared body buffer used by the Network.* command handlers.
@@ -1843,6 +1869,7 @@ impl InspectorSession {
       dom_storage_enabled: Cell::new(false),
       noderuntime_enabled: Cell::new(false),
       notify_waiting_for_disconnect: Cell::new(false),
+      debugger_enabled: Cell::new(false),
       flags,
       network_data,
     };
@@ -1870,6 +1897,19 @@ impl InspectorSession {
     flags.paused_on_start = true;
     flags.waiting_for_session = true;
     flags.page_wait_for_debugger_received = true;
+  }
+
+  fn set_debugger_enabled(&self, enabled: bool) {
+    if self.state.debugger_enabled.replace(enabled) == enabled {
+      return;
+    }
+    let mut flags = self.state.flags.borrow_mut();
+    if enabled {
+      flags.debugger_enabled_session_count += 1;
+    } else {
+      flags.debugger_enabled_session_count =
+        flags.debugger_enabled_session_count.saturating_sub(1);
+    }
   }
 
   /// Queue a message to be sent to a worker
@@ -2020,6 +2060,16 @@ async fn pump_inspector_session_messages(
     }
 
     match method {
+      "Debugger.enable" => {
+        session.set_debugger_enabled(true);
+        session.dispatch_message(msg);
+        continue;
+      }
+      "Debugger.disable" => {
+        session.set_debugger_enabled(false);
+        session.dispatch_message(msg);
+        continue;
+      }
       "NodeRuntime.enable" => {
         session.state.noderuntime_enabled.set(true);
         // If the runtime is paused on start (--inspect-brk), emit

--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -456,7 +456,9 @@ struct JsRuntimeInspectorState {
   is_dispatching_message: Rc<RefCell<bool>>,
   pending_worker_messages: Arc<Mutex<Vec<(String, String)>>>,
   nodeworker_enabled: Rc<Cell<bool>>,
+  nodeworker_wait_for_debugger_on_start: Rc<Cell<bool>>,
   auto_attach_enabled: Rc<Cell<bool>>,
+  auto_attach_wait_for_debugger_on_start: Rc<Cell<bool>>,
   discover_targets_enabled: Rc<Cell<bool>>,
   /// Shared buffer of captured Network.* request/response bodies, populated
   /// from `op_inspector_emit_protocol_event` and read by the dispatcher
@@ -616,26 +618,30 @@ impl JsRuntimeInspectorState {
 
                 if self.auto_attach_enabled.get() {
                   ts.attached.set(true);
+                  let waiting_for_debugger =
+                    self.auto_attach_wait_for_debugger_on_start.get();
                   (main_session.state.send)(InspectorMsg::notification(
                     json!({
                       "method": "Target.attachedToTarget",
                       "params": {
                         "sessionId": ts.session_id,
                         "targetInfo": ts.target_info(true),
-                        "waitingForDebugger": false
+                        "waitingForDebugger": waiting_for_debugger
                       }
                     }),
                   ));
                 }
 
                 if self.nodeworker_enabled.get() {
+                  let waiting_for_debugger =
+                    self.nodeworker_wait_for_debugger_on_start.get();
                   (main_session.state.send)(InspectorMsg::notification(
                     json!({
                       "method": "NodeWorker.attachedToWorker",
                       "params": {
                         "sessionId": ts.session_id,
                         "workerInfo": ts.worker_info(),
-                        "waitingForDebugger": false
+                        "waitingForDebugger": waiting_for_debugger
                       }
                     }),
                   ));
@@ -657,7 +663,9 @@ impl JsRuntimeInspectorState {
                 self.sessions.clone(),
                 self.pending_worker_messages.clone(),
                 self.nodeworker_enabled.clone(),
+                self.nodeworker_wait_for_debugger_on_start.clone(),
                 self.auto_attach_enabled.clone(),
+                self.auto_attach_wait_for_debugger_on_start.clone(),
                 self.discover_targets_enabled.clone(),
                 self.flags.clone(),
                 self.network_data.clone(),
@@ -887,7 +895,9 @@ impl JsRuntimeInspector {
       is_dispatching_message: Default::default(),
       pending_worker_messages: Arc::new(Mutex::new(Vec::new())),
       nodeworker_enabled: Rc::new(Cell::new(false)),
+      nodeworker_wait_for_debugger_on_start: Rc::new(Cell::new(false)),
       auto_attach_enabled: Rc::new(Cell::new(false)),
+      auto_attach_wait_for_debugger_on_start: Rc::new(Cell::new(false)),
       discover_targets_enabled: Rc::new(Cell::new(false)),
       network_data: Rc::new(RefCell::new(NetworkDataBuffer::default())),
     });
@@ -912,12 +922,15 @@ impl JsRuntimeInspector {
     // NOTE(bartlomieju): this is what Node.js does and it turns out some
     // debuggers (like VSCode) rely on this information to disconnect after
     // program completes.
-    // The auxData structure should match {isDefault: boolean, type: 'default'|'isolated'|'worker'}
-    // For Chrome DevTools to properly show workers in the execution context dropdown.
+    // The auxData structure should match
+    // {isDefault: boolean, type: 'default'|'isolated'|'worker'}.
+    // `isDefault` means this is the default context for its target, not
+    // whether the target is the main runtime. Chrome DevTools treats
+    // non-default contexts as content scripts and may blackbox them.
     let aux_data = if is_main_runtime {
       r#"{"isDefault": true, "type": "default"}"#
     } else {
-      r#"{"isDefault": false, "type": "worker"}"#
+      r#"{"isDefault": true, "type": "worker"}"#
     };
     let aux_data_view = v8::inspector::StringView::from(aux_data.as_bytes());
     v8_inspector.context_created(
@@ -1114,6 +1127,25 @@ impl JsRuntimeInspector {
     self.state.flags.borrow_mut().resumed_by_session_id = None;
   }
 
+  pub fn wait_for_runtime_run_if_waiting_for_debugger(&self) {
+    self.state.flags.borrow_mut().paused_on_start = true;
+    loop {
+      if !self.state.flags.borrow().paused_on_start {
+        break;
+      }
+      self.state.flags.borrow_mut().waiting_for_session = true;
+      let _ = self.state.poll_sessions(None).unwrap();
+    }
+    self.state.flags.borrow_mut().resumed_by_session_id = None;
+  }
+
+  pub fn should_wait_for_debugger_on_worker_start(&self) -> bool {
+    self.state.auto_attach_enabled.get()
+      && self.state.auto_attach_wait_for_debugger_on_start.get()
+      || self.state.nodeworker_enabled.get()
+        && self.state.nodeworker_wait_for_debugger_on_start.get()
+  }
+
   /// Obtain a sender for proxy channels.
   pub fn get_session_sender(&self) -> UnboundedSender<InspectorSessionProxy> {
     self.new_session_tx.clone()
@@ -1294,7 +1326,15 @@ impl JsRuntimeInspector {
         sessions.clone(),
         inspector.state.pending_worker_messages.clone(),
         inspector.state.nodeworker_enabled.clone(),
+        inspector
+          .state
+          .nodeworker_wait_for_debugger_on_start
+          .clone(),
         inspector.state.auto_attach_enabled.clone(),
+        inspector
+          .state
+          .auto_attach_wait_for_debugger_on_start
+          .clone(),
         inspector.state.discover_targets_enabled.clone(),
         inspector.state.flags.clone(),
         inspector.state.network_data.clone(),
@@ -1559,6 +1599,17 @@ impl SessionContainer {
     }
     false
   }
+
+  fn target_session_by_target_id(
+    &self,
+    target_id: &str,
+  ) -> Option<Rc<TargetSession>> {
+    self
+      .target_sessions
+      .values()
+      .find(|ts| ts.target_id == target_id)
+      .cloned()
+  }
 }
 
 struct InspectorWakerInner {
@@ -1656,8 +1707,10 @@ struct InspectorSessionState {
   pending_worker_messages: Arc<Mutex<Vec<(String, String)>>>,
   // Track whether NodeWorker.enable has been called (enables VSCode-style worker debugging)
   nodeworker_enabled: Rc<Cell<bool>>,
+  nodeworker_wait_for_debugger_on_start: Rc<Cell<bool>>,
   // Track whether Target.setAutoAttach has been called (enables worker auto-attach)
   auto_attach_enabled: Rc<Cell<bool>>,
+  auto_attach_wait_for_debugger_on_start: Rc<Cell<bool>>,
   // Track whether Target.setDiscoverTargets has been called (enables target discovery)
   discover_targets_enabled: Rc<Cell<bool>>,
   // Track whether Network.enable has been called (per-session, not shared)
@@ -1699,7 +1752,9 @@ impl InspectorSession {
     sessions: Rc<RefCell<SessionContainer>>,
     pending_worker_messages: Arc<Mutex<Vec<(String, String)>>>,
     nodeworker_enabled: Rc<Cell<bool>>,
+    nodeworker_wait_for_debugger_on_start: Rc<Cell<bool>>,
     auto_attach_enabled: Rc<Cell<bool>>,
+    auto_attach_wait_for_debugger_on_start: Rc<Cell<bool>>,
     discover_targets_enabled: Rc<Cell<bool>>,
     flags: Rc<RefCell<InspectorFlags>>,
     network_data: Rc<RefCell<NetworkDataBuffer>>,
@@ -1712,7 +1767,9 @@ impl InspectorSession {
       sessions,
       pending_worker_messages,
       nodeworker_enabled,
+      nodeworker_wait_for_debugger_on_start,
       auto_attach_enabled,
+      auto_attach_wait_for_debugger_on_start,
       discover_targets_enabled,
       network_enabled: Cell::new(false),
       dom_storage_enabled: Cell::new(false),
@@ -1926,13 +1983,19 @@ async fn pump_inspector_session_messages(
       }
       "NodeWorker.enable" => {
         session.state.nodeworker_enabled.set(true);
-        session.notify_workers(|ts, send| {
+        session
+          .state
+          .nodeworker_wait_for_debugger_on_start
+          .set(get_bool_param(&params, "waitForDebuggerOnStart"));
+        let waiting_for_debugger =
+          session.state.nodeworker_wait_for_debugger_on_start.get();
+        session.notify_workers(move |ts, send| {
           send(InspectorMsg::notification(json!({
             "method": "NodeWorker.attachedToWorker",
             "params": {
               "sessionId": ts.session_id,
               "workerInfo": ts.worker_info(),
-              "waitingForDebugger": false
+              "waitingForDebugger": waiting_for_debugger
             }
           })));
         });
@@ -1956,11 +2019,86 @@ async fn pump_inspector_session_messages(
           });
         }
       }
+      "Target.getTargets" => {
+        if let Some(id) = msg_id {
+          let call_id = id.as_i64().unwrap_or(0) as i32;
+          let send = session.state.send.clone();
+          let sessions = session.state.sessions.clone();
+          deno_core::unsync::spawn(async move {
+            let sessions = sessions.borrow();
+            let target_infos = sessions
+              .target_sessions
+              .values()
+              .map(|ts| ts.target_info(ts.attached.get()))
+              .collect::<Vec<_>>();
+            send(InspectorMsg {
+              kind: InspectorMsgKind::Message(call_id),
+              content: json!({
+                "id": id,
+                "result": {
+                  "targetInfos": target_infos
+                }
+              })
+              .to_string(),
+            });
+          });
+        }
+        continue;
+      }
+      "Target.attachToTarget" => {
+        let target_id = get_str_param(&params, "targetId");
+        if let Some(id) = msg_id {
+          let call_id = id.as_i64().unwrap_or(0) as i32;
+          let send = session.state.send.clone();
+          let sessions = session.state.sessions.clone();
+          deno_core::unsync::spawn(async move {
+            let target_session =
+              sessions.borrow().target_session_by_target_id(&target_id);
+            let content = if let Some(ts) = target_session {
+              ts.attached.set(true);
+              json!({
+                "id": id,
+                "result": {
+                  "sessionId": ts.session_id
+                }
+              })
+            } else {
+              json!({
+                "id": id,
+                "error": {
+                  "code": -32602,
+                  "message": "No target with given id found"
+                }
+              })
+            };
+            send(InspectorMsg {
+              kind: InspectorMsgKind::Message(call_id),
+              content: content.to_string(),
+            });
+          });
+        }
+        continue;
+      }
+      "Target.detachFromTarget" => {
+        let session_id = get_str_param(&params, "sessionId");
+        let sessions = session.state.sessions.clone();
+        deno_core::unsync::spawn(async move {
+          if let Some(ts) = sessions.borrow().target_sessions.get(&session_id) {
+            ts.attached.set(false);
+          }
+        });
+      }
       "Target.setAutoAttach" => {
         let auto_attach = get_bool_param(&params, "autoAttach");
+        let wait_for_debugger_on_start =
+          get_bool_param(&params, "waitForDebuggerOnStart");
         let send = session.state.send.clone();
         let sessions = session.state.sessions.clone();
         session.state.auto_attach_enabled.set(auto_attach);
+        session
+          .state
+          .auto_attach_wait_for_debugger_on_start
+          .set(wait_for_debugger_on_start);
         if auto_attach {
           deno_core::unsync::spawn(async move {
             let sessions = sessions.borrow();
@@ -1973,7 +2111,7 @@ async fn pump_inspector_session_messages(
                 "params": {
                   "sessionId": ts.session_id,
                   "targetInfo": ts.target_info(true),
-                  "waitingForDebugger": false
+                  "waitingForDebugger": wait_for_debugger_on_start
                 }
               })));
             }

--- a/libs/core/inspector.rs
+++ b/libs/core/inspector.rs
@@ -1528,21 +1528,36 @@ impl SessionContainer {
     // and skip V8 entirely.
     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&message)
       && let Some(method) = parsed.get("method").and_then(|m| m.as_str())
-      && let Some(outcome) = dispatch_custom_domain(method, &parsed, session)
     {
-      if let Some(id) = parsed.get("id") {
-        let call_id = id.as_i64().unwrap_or(0) as i32;
-        let content = match outcome {
-          CustomDomainOutcome::Empty => make_cdp_ok_response(id, json!({})),
-          CustomDomainOutcome::Result(v) => make_cdp_ok_response(id, v),
-          CustomDomainOutcome::Error(err) => make_cdp_error_response(id, &err),
-        };
-        (session.state.send)(InspectorMsg {
-          kind: InspectorMsgKind::Message(call_id),
-          content,
-        });
+      if method == "Page.waitForDebugger" {
+        session.wait_for_debugger();
+        if let Some(id) = parsed.get("id") {
+          let call_id = id.as_i64().unwrap_or(0) as i32;
+          (session.state.send)(InspectorMsg {
+            kind: InspectorMsgKind::Message(call_id),
+            content: make_cdp_ok_response(id, json!({})),
+          });
+        }
+        return;
       }
-      return;
+
+      if let Some(outcome) = dispatch_custom_domain(method, &parsed, session) {
+        if let Some(id) = parsed.get("id") {
+          let call_id = id.as_i64().unwrap_or(0) as i32;
+          let content = match outcome {
+            CustomDomainOutcome::Empty => make_cdp_ok_response(id, json!({})),
+            CustomDomainOutcome::Result(v) => make_cdp_ok_response(id, v),
+            CustomDomainOutcome::Error(err) => {
+              make_cdp_error_response(id, &err)
+            }
+          };
+          (session.state.send)(InspectorMsg {
+            kind: InspectorMsgKind::Message(call_id),
+            content,
+          });
+        }
+        return;
+      }
     }
 
     session.dispatch_message(message);
@@ -1797,6 +1812,12 @@ impl InspectorSession {
     *self.state.is_dispatching_message.borrow_mut() = false;
   }
 
+  fn wait_for_debugger(&self) {
+    let mut flags = self.state.flags.borrow_mut();
+    flags.paused_on_start = true;
+    flags.waiting_for_session = true;
+  }
+
   /// Queue a message to be sent to a worker
   fn queue_worker_message(&self, session_id: &str, message: String) {
     self
@@ -1980,6 +2001,9 @@ async fn pump_inspector_session_messages(
         // Forward to V8 for actual processing
         session.dispatch_message(msg);
         continue;
+      }
+      "Page.waitForDebugger" => {
+        session.wait_for_debugger();
       }
       "NodeWorker.enable" => {
         session.state.nodeworker_enabled.set(true);

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -24,6 +24,7 @@ import {
   op_snapshot_options,
   op_worker_close,
   op_worker_get_type,
+  op_worker_maybe_wait_for_debugger,
   op_worker_post_message,
   op_worker_post_message_raw,
   op_worker_recv_message,
@@ -342,6 +343,7 @@ async function pollForMessages() {
     }
     const data = await recvMessage;
     if (data === null) break;
+    op_worker_maybe_wait_for_debugger();
     dispatchWorkerMessage(data);
     // Drain messages already queued on the host side instead of taking the
     // async op + Promise path for each. The whole burst is processed within
@@ -359,6 +361,7 @@ async function pollForMessages() {
       // are already inside one.
       await new Promise((resolve) => queueMicrotask(() => resolve()));
       if (isClosing) break;
+      op_worker_maybe_wait_for_debugger();
       dispatchWorkerMessage(syncData);
     }
   }

--- a/runtime/ops/web_worker.rs
+++ b/runtime/ops/web_worker.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use deno_core::CancelFuture;
 use deno_core::DetachedBuffer;
 use deno_core::JsBuffer;
+use deno_core::JsRuntimeInspector;
 use deno_core::OpState;
 use deno_core::op2;
 use deno_web::JsMessageData;
@@ -26,12 +27,15 @@ deno_core::extension!(
     op_worker_post_message_raw,
     op_worker_recv_message,
     op_worker_recv_message_sync,
+    op_worker_maybe_wait_for_debugger,
     // Notify host that guest worker closes.
     op_worker_close,
     op_worker_get_type,
     op_worker_sync_fetch,
   ],
 );
+
+pub struct WaitForWorkerDebuggerOnMessage(pub bool);
 
 #[op2]
 fn op_worker_post_message(
@@ -78,6 +82,25 @@ fn op_worker_recv_message_sync(
 ) -> Result<Option<JsMessageData>, MessagePortError> {
   let handle = state.borrow::<WebWorkerInternalHandle>().clone();
   handle.port.try_recv_sync(state)
+}
+
+#[op2(fast)]
+fn op_worker_maybe_wait_for_debugger(state: &mut OpState) {
+  let should_wait = state
+    .try_borrow_mut::<WaitForWorkerDebuggerOnMessage>()
+    .map(|wait| {
+      let should_wait = wait.0;
+      wait.0 = false;
+      should_wait
+    })
+    .unwrap_or(false);
+  if !should_wait {
+    return;
+  }
+
+  if let Some(inspector) = state.try_borrow::<Rc<JsRuntimeInspector>>() {
+    inspector.wait_for_debugger_enabled_for_worker_message();
+  }
 }
 
 #[op2(fast)]

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -16,6 +16,7 @@ use deno_core::CancelHandle;
 use deno_core::DetachedBuffer;
 use deno_core::FromV8;
 use deno_core::JsBuffer;
+use deno_core::JsRuntimeInspector;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
 use deno_core::RcRef;
@@ -73,6 +74,7 @@ pub struct CreateWebWorkerArgs {
   /// normally by their own URLs.
   pub maybe_main_module_blob: Option<Arc<Blob>>,
   pub resource_limits: Option<ResourceLimits>,
+  pub wait_for_debugger_on_start: bool,
 }
 
 pub type CreateWebWorkerCb = dyn Fn(CreateWebWorkerArgs) -> (WebWorker, SendableWebWorkerHandle)
@@ -279,6 +281,10 @@ fn op_create_worker(
   let parent_permissions = parent_permissions.clone();
   let create_web_worker_cb = state.borrow::<CreateWebWorkerCbHolder>().clone();
   let format_js_error_fn = state.borrow::<FormatJsErrorFnHolder>().clone();
+  let wait_for_debugger_on_start = state
+    .try_borrow::<Rc<JsRuntimeInspector>>()
+    .map(|inspector| inspector.should_wait_for_debugger_on_worker_start())
+    .unwrap_or(false);
   let worker_id = WorkerId::new();
 
   let module_specifier = deno_core::resolve_url(&specifier)?;
@@ -342,6 +348,7 @@ fn op_create_worker(
           maybe_worker_metadata,
           maybe_main_module_blob,
           resource_limits: args.resource_limits,
+          wait_for_debugger_on_start,
         });
 
       // Send thread safe handle from newly created worker to host thread

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -75,6 +75,7 @@ pub struct CreateWebWorkerArgs {
   pub maybe_main_module_blob: Option<Arc<Blob>>,
   pub resource_limits: Option<ResourceLimits>,
   pub wait_for_debugger_on_start: bool,
+  pub wait_for_page_wait_for_debugger: bool,
 }
 
 pub type CreateWebWorkerCb = dyn Fn(CreateWebWorkerArgs) -> (WebWorker, SendableWebWorkerHandle)
@@ -285,6 +286,12 @@ fn op_create_worker(
     .try_borrow::<Rc<JsRuntimeInspector>>()
     .map(|inspector| inspector.should_wait_for_debugger_on_worker_start())
     .unwrap_or(false);
+  let wait_for_page_wait_for_debugger = state
+    .try_borrow::<Rc<JsRuntimeInspector>>()
+    .map(|inspector| {
+      inspector.should_wait_for_page_wait_for_debugger_on_worker_start()
+    })
+    .unwrap_or(false);
   let worker_id = WorkerId::new();
 
   let module_specifier = deno_core::resolve_url(&specifier)?;
@@ -349,6 +356,7 @@ fn op_create_worker(
           maybe_main_module_blob,
           resource_limits: args.resource_limits,
           wait_for_debugger_on_start,
+          wait_for_page_wait_for_debugger,
         });
 
       // Send thread safe handle from newly created worker to host thread

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -709,6 +709,9 @@ impl WebWorker {
       let op_state = js_runtime.op_state();
       let mut op_state = op_state.borrow_mut();
       op_state.put(internal_handle.clone());
+      op_state.put(crate::ops::web_worker::WaitForWorkerDebuggerOnMessage(
+        options.wait_for_page_wait_for_debugger,
+      ));
       (internal_handle, external_handle)
     };
 

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -405,6 +405,7 @@ pub struct WebWorkerOptions {
   pub maybe_cpu_prof_config: Option<CpuProfilerConfig>,
   pub enable_raw_imports: bool,
   pub enable_stack_trace_arg_in_ops: bool,
+  pub wait_for_debugger_on_start: bool,
 }
 
 /// This struct is an implementation of `Worker` Web API
@@ -431,6 +432,7 @@ pub struct WebWorker {
   /// Set to `true` by the near-heap-limit callback when resource limits
   /// are exceeded, so the error handler can emit `ERR_WORKER_OUT_OF_MEMORY`.
   pub oom_triggered: Arc<AtomicBool>,
+  wait_for_debugger_on_start: bool,
 }
 
 impl Drop for WebWorker {
@@ -748,6 +750,7 @@ impl WebWorker {
         maybe_cpu_prof_config: options.maybe_cpu_prof_config,
         bootstrap_error: None,
         oom_triggered: Arc::new(AtomicBool::new(false)),
+        wait_for_debugger_on_start: options.wait_for_debugger_on_start,
       },
       external_handle,
       options.bootstrap,
@@ -1120,6 +1123,13 @@ pub async fn run_web_worker(
       .post_event(WorkerControlEvent::TerminalError(error, 1))
       .expect("Failed to post message to host");
     return Ok(());
+  }
+
+  if worker.wait_for_debugger_on_start {
+    worker
+      .js_runtime
+      .inspector()
+      .wait_for_runtime_run_if_waiting_for_debugger();
   }
 
   // Execute provided source code immediately via V8 script evaluation

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -406,6 +406,7 @@ pub struct WebWorkerOptions {
   pub enable_raw_imports: bool,
   pub enable_stack_trace_arg_in_ops: bool,
   pub wait_for_debugger_on_start: bool,
+  pub wait_for_page_wait_for_debugger: bool,
 }
 
 /// This struct is an implementation of `Worker` Web API
@@ -433,6 +434,7 @@ pub struct WebWorker {
   /// are exceeded, so the error handler can emit `ERR_WORKER_OUT_OF_MEMORY`.
   pub oom_triggered: Arc<AtomicBool>,
   wait_for_debugger_on_start: bool,
+  wait_for_page_wait_for_debugger: bool,
 }
 
 impl Drop for WebWorker {
@@ -751,6 +753,8 @@ impl WebWorker {
         bootstrap_error: None,
         oom_triggered: Arc::new(AtomicBool::new(false)),
         wait_for_debugger_on_start: options.wait_for_debugger_on_start,
+        wait_for_page_wait_for_debugger: options
+          .wait_for_page_wait_for_debugger,
       },
       external_handle,
       options.bootstrap,
@@ -1130,6 +1134,11 @@ pub async fn run_web_worker(
       .js_runtime
       .inspector()
       .wait_for_runtime_run_if_waiting_for_debugger();
+  } else if worker.wait_for_page_wait_for_debugger {
+    worker
+      .js_runtime
+      .inspector()
+      .wait_for_page_wait_for_debugger();
   }
 
   // Execute provided source code immediately via V8 script evaluation

--- a/tests/unit/inspector_test.ts
+++ b/tests/unit/inspector_test.ts
@@ -1158,6 +1158,115 @@ setInterval(() => {}, 1000);
   }
 });
 
+Deno.test("inspector_worker_page_wait_for_debugger", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const mainScript = `${tempDir}/main.js`;
+  const workerScript = `${tempDir}/worker.js`;
+  await Deno.writeTextFile(
+    mainScript,
+    `
+new Worker(new URL("./worker.js", import.meta.url).href, {
+  type: "module",
+});
+setInterval(() => {}, 1000);
+`,
+  );
+  await Deno.writeTextFile(
+    workerScript,
+    `
+console.log("worker before debugger");
+debugger;
+console.log("worker after debugger");
+setInterval(() => {}, 1000);
+`,
+  );
+
+  const tester = await InspectorTester.create(
+    ["run", "-A", "--inspect-brk=0", mainScript],
+    { notificationFilter: ignoreScriptParsed },
+  );
+
+  try {
+    await tester.assertStderrForInspectBrk();
+
+    tester.sendMany([
+      { id: 1, method: "Runtime.enable" },
+      { id: 2, method: "Debugger.enable" },
+      {
+        id: 3,
+        method: "Target.setAutoAttach",
+        params: {
+          autoAttach: true,
+          waitForDebuggerOnStart: false,
+          flatten: true,
+        },
+      },
+      { id: 4, method: "Runtime.runIfWaitingForDebugger" },
+    ]);
+
+    await tester.expectResponse(1);
+    await tester.expectResponse(2);
+    await tester.expectResponse(3);
+    await tester.expectResponse(4);
+    await tester.expectNotification("Runtime.executionContextCreated");
+    await tester.expectNotification("Debugger.paused");
+
+    tester.send({ id: 5, method: "Debugger.resume" });
+    await tester.expectResponse(5);
+
+    const attached = await tester.expectNotification("Target.attachedToTarget");
+    const attachedParams = attached.params as Record<string, unknown>;
+    assertEquals(attachedParams.waitingForDebugger, false);
+    const sessionId = attachedParams.sessionId as string;
+    assert(sessionId, "attachedToTarget should include sessionId");
+
+    tester.sendMany([
+      { id: 6, sessionId, method: "Page.waitForDebugger" },
+      { id: 7, sessionId, method: "Runtime.enable" },
+      { id: 8, sessionId, method: "Debugger.enable" },
+    ]);
+    const waitResponse = await tester.expectResponse(6);
+    assertEquals(waitResponse.error, undefined);
+    await tester.expectResponse(7);
+    await tester.expectResponse(8);
+
+    const contextCreated = await tester.expectNotificationMatching(
+      (msg) =>
+        msg.sessionId === sessionId &&
+        msg.method === "Runtime.executionContextCreated",
+      "worker Runtime.executionContextCreated",
+    );
+    const context = (contextCreated.params as {
+      context: {
+        auxData: { isDefault: boolean; type: string };
+      };
+    }).context;
+    assertEquals(context.auxData, { isDefault: true, type: "worker" });
+
+    tester.send({
+      id: 9,
+      sessionId,
+      method: "Runtime.runIfWaitingForDebugger",
+    });
+    await tester.expectResponse(9);
+
+    assertEquals(await tester.nextStdoutLine(), "worker before debugger");
+    await tester.expectNotificationMatching(
+      (msg) => msg.sessionId === sessionId && msg.method === "Debugger.paused",
+      "worker Debugger.paused",
+    );
+
+    tester.send({ id: 10, sessionId, method: "Debugger.resume" });
+    await tester.expectResponse(10);
+    assertEquals(await tester.nextStdoutLine(), "worker after debugger");
+  } finally {
+    await tester.close();
+    tester.kill();
+    await tester.waitForExit();
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
 Deno.test("inspector_worker_wait_for_debugger_on_start", async () => {
   const tempDir = await Deno.makeTempDir();
   const mainScript = `${tempDir}/main.js`;

--- a/tests/unit/inspector_test.ts
+++ b/tests/unit/inspector_test.ts
@@ -10,6 +10,7 @@ const testdataPath = fromFileUrl(
 interface CDPMessage {
   id?: number;
   method?: string;
+  sessionId?: string;
   result?: unknown;
   params?: unknown;
   error?: { code: number; message: string };
@@ -303,6 +304,37 @@ class InspectorTester {
     }
 
     throw new Error(`Timeout waiting for notification method=${method}`);
+  }
+
+  async expectNotificationMatching(
+    predicate: (msg: CDPMessage) => boolean,
+    description: string,
+    options?: { timeout?: number },
+  ): Promise<CDPMessage> {
+    const timeoutMs = options?.timeout ?? this.timeout;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const idx = this.notificationBuffer.findIndex(predicate);
+      if (idx !== -1) {
+        const [msg] = this.notificationBuffer.splice(idx, 1);
+        return msg;
+      }
+
+      if (this.socketClosed) {
+        throw new Error(
+          `Socket closed while waiting for notification ${description}`,
+        );
+      }
+
+      try {
+        await this.waitForMessage(Math.min(1000, deadline - Date.now()));
+      } catch {
+        // continue
+      }
+    }
+
+    throw new Error(`Timeout waiting for notification ${description}`);
   }
 
   async nextStdoutLine(): Promise<string> {
@@ -922,6 +954,316 @@ Deno.test("inspector_worker_target_discovery", async () => {
     await tester.close();
     tester.kill();
     await tester.waitForExit();
+  }
+});
+
+Deno.test("inspector_worker_target_get_targets_and_attach", async () => {
+  const script = `${testdataPath}/worker_main.js`;
+  const tester = await InspectorTester.create(
+    ["run", "-A", "--inspect-brk=0", script],
+    { notificationFilter: ignoreScriptParsed },
+  );
+
+  try {
+    await tester.assertStderrForInspectBrk();
+
+    tester.sendMany([
+      { id: 1, method: "Runtime.enable" },
+      { id: 2, method: "Debugger.enable" },
+      {
+        id: 3,
+        method: "Target.setDiscoverTargets",
+        params: { discover: true },
+      },
+      { id: 4, method: "Runtime.runIfWaitingForDebugger" },
+    ]);
+
+    await tester.expectResponse(1);
+    await tester.expectResponse(2);
+    await tester.expectResponse(3);
+    await tester.expectResponse(4);
+    await tester.expectNotification("Runtime.executionContextCreated");
+    await tester.expectNotification("Debugger.paused");
+
+    tester.send({ id: 5, method: "Debugger.resume" });
+    await tester.expectResponse(5);
+
+    const targetCreated = await tester.expectNotification(
+      "Target.targetCreated",
+    );
+    const targetCreatedParams = targetCreated.params as Record<string, unknown>;
+    const targetInfo = targetCreatedParams.targetInfo as Record<
+      string,
+      unknown
+    >;
+    const targetId = targetInfo.targetId as string;
+    assert(targetId, "targetCreated should include targetId");
+
+    tester.send({ id: 6, method: "Target.getTargets" });
+    const targetsResponse = await tester.expectResponse(6);
+    const targetsResult = targetsResponse.result as {
+      targetInfos: Array<Record<string, unknown>>;
+    };
+    assert(
+      targetsResult.targetInfos.some((info) => info.targetId === targetId),
+      "getTargets should include discovered worker target",
+    );
+
+    tester.send({
+      id: 7,
+      method: "Target.attachToTarget",
+      params: { targetId, flatten: true },
+    });
+    const attachedResponse = await tester.expectResponse(7);
+    const attachedResult = attachedResponse.result as Record<string, unknown>;
+    const sessionId = attachedResult.sessionId as string;
+    assert(sessionId, "attachToTarget should return sessionId");
+
+    tester.send({ id: 8, sessionId, method: "Runtime.enable" });
+    await tester.expectResponse(8);
+    await tester.expectNotificationMatching(
+      (msg) =>
+        msg.sessionId === sessionId &&
+        msg.method === "Runtime.executionContextCreated",
+      "worker Runtime.executionContextCreated after attachToTarget",
+    );
+  } finally {
+    await tester.close();
+    tester.kill();
+    await tester.waitForExit();
+  }
+});
+
+Deno.test("inspector_worker_debugger_statement_not_blackboxed", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const mainScript = `${tempDir}/main.js`;
+  const workerScript = `${tempDir}/worker.js`;
+  await Deno.writeTextFile(
+    mainScript,
+    `
+globalThis.worker = new Worker(new URL("./worker.js", import.meta.url).href, {
+  type: "module",
+});
+globalThis.worker.onmessage = (e) => {
+  console.log("Main received:", e.data);
+};
+setInterval(() => {}, 1000);
+`,
+  );
+  await Deno.writeTextFile(
+    workerScript,
+    `
+self.onmessage = (e) => {
+  console.log("Worker received:", e.data);
+  debugger;
+  console.log("after debugger");
+};
+self.postMessage("ready");
+setInterval(() => {}, 1000);
+`,
+  );
+
+  const tester = await InspectorTester.create(
+    ["run", "-A", "--inspect-brk=0", mainScript],
+    { notificationFilter: ignoreScriptParsed },
+  );
+
+  try {
+    await tester.assertStderrForInspectBrk();
+
+    tester.sendMany([
+      { id: 1, method: "Runtime.enable" },
+      { id: 2, method: "Debugger.enable" },
+      {
+        id: 3,
+        method: "Target.setAutoAttach",
+        params: {
+          autoAttach: true,
+          waitForDebuggerOnStart: false,
+          flatten: true,
+        },
+      },
+      { id: 4, method: "Runtime.runIfWaitingForDebugger" },
+    ]);
+
+    await tester.expectResponse(1);
+    await tester.expectResponse(2);
+    await tester.expectResponse(3);
+    await tester.expectResponse(4);
+    await tester.expectNotification("Runtime.executionContextCreated");
+    await tester.expectNotification("Debugger.paused");
+
+    tester.send({ id: 5, method: "Debugger.resume" });
+    await tester.expectResponse(5);
+
+    const attached = await tester.expectNotification("Target.attachedToTarget");
+    const attachedParams = attached.params as Record<string, unknown>;
+    const sessionId = attachedParams.sessionId as string;
+    assert(sessionId, "attachedToTarget should include sessionId");
+
+    tester.sendMany([
+      { id: 6, sessionId, method: "Runtime.enable" },
+      { id: 7, sessionId, method: "Debugger.enable" },
+      {
+        id: 8,
+        sessionId,
+        method: "Debugger.setBlackboxPatterns",
+        params: { patterns: ["/node_modules/|^node:"], skipAnonymous: false },
+      },
+    ]);
+    await tester.expectResponse(6);
+    await tester.expectResponse(7);
+    await tester.expectResponse(8);
+
+    const contextCreated = await tester.expectNotificationMatching(
+      (msg) =>
+        msg.sessionId === sessionId &&
+        msg.method === "Runtime.executionContextCreated",
+      "worker Runtime.executionContextCreated",
+    );
+    const context = (contextCreated.params as {
+      context: {
+        name: string;
+        auxData: { isDefault: boolean; type: string };
+      };
+    }).context;
+    assertEquals(context.name, "worker [1]");
+    assertEquals(context.auxData, { isDefault: true, type: "worker" });
+
+    assertEquals(await tester.nextStdoutLine(), "Main received: ready");
+    tester.send({
+      id: 9,
+      method: "Runtime.evaluate",
+      params: {
+        expression: 'globalThis.worker.postMessage("go")',
+        returnByValue: true,
+      },
+    });
+    await tester.expectResponse(9);
+
+    assertEquals(await tester.nextStdoutLine(), "Worker received: go");
+    await tester.expectNotificationMatching(
+      (msg) => msg.sessionId === sessionId && msg.method === "Debugger.paused",
+      "worker Debugger.paused",
+    );
+
+    tester.send({ id: 10, sessionId, method: "Debugger.resume" });
+    await tester.expectResponse(10);
+    assertEquals(await tester.nextStdoutLine(), "after debugger");
+  } finally {
+    await tester.close();
+    tester.kill();
+    await tester.waitForExit();
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("inspector_worker_wait_for_debugger_on_start", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const mainScript = `${tempDir}/main.js`;
+  const workerScript = `${tempDir}/worker.js`;
+  await Deno.writeTextFile(
+    mainScript,
+    `
+const worker = new Worker(new URL("./worker.js", import.meta.url).href, {
+  type: "module",
+});
+worker.postMessage("start");
+setInterval(() => {}, 1000);
+`,
+  );
+  await Deno.writeTextFile(
+    workerScript,
+    `
+self.onmessage = (e) => {
+  console.log("Worker received:", e.data);
+  debugger;
+  console.log("after debugger");
+};
+setInterval(() => {}, 1000);
+`,
+  );
+
+  const tester = await InspectorTester.create(
+    ["run", "-A", "--inspect-brk=0", mainScript],
+    { notificationFilter: ignoreScriptParsed },
+  );
+
+  try {
+    await tester.assertStderrForInspectBrk();
+
+    tester.sendMany([
+      { id: 1, method: "Runtime.enable" },
+      { id: 2, method: "Debugger.enable" },
+      {
+        id: 3,
+        method: "Target.setAutoAttach",
+        params: {
+          autoAttach: true,
+          waitForDebuggerOnStart: true,
+          flatten: true,
+        },
+      },
+      { id: 4, method: "Runtime.runIfWaitingForDebugger" },
+    ]);
+
+    await tester.expectResponse(1);
+    await tester.expectResponse(2);
+    await tester.expectResponse(3);
+    await tester.expectResponse(4);
+    await tester.expectNotification("Runtime.executionContextCreated");
+    await tester.expectNotification("Debugger.paused");
+
+    tester.send({ id: 5, method: "Debugger.resume" });
+    await tester.expectResponse(5);
+
+    const attached = await tester.expectNotification("Target.attachedToTarget");
+    const attachedParams = attached.params as Record<string, unknown>;
+    assertEquals(attachedParams.waitingForDebugger, true);
+    const sessionId = attachedParams.sessionId as string;
+    assert(sessionId, "attachedToTarget should include sessionId");
+
+    tester.sendMany([
+      { id: 6, sessionId, method: "Runtime.enable" },
+      { id: 7, sessionId, method: "Debugger.enable" },
+      {
+        id: 8,
+        sessionId,
+        method: "Runtime.runIfWaitingForDebugger",
+      },
+    ]);
+    await tester.expectResponse(6);
+    await tester.expectResponse(7);
+    await tester.expectResponse(8);
+
+    const contextCreated = await tester.expectNotificationMatching(
+      (msg) =>
+        msg.sessionId === sessionId &&
+        msg.method === "Runtime.executionContextCreated",
+      "worker Runtime.executionContextCreated",
+    );
+    const context = (contextCreated.params as {
+      context: {
+        name: string;
+        auxData: { isDefault: boolean; type: string };
+      };
+    }).context;
+    assertEquals(context.auxData, { isDefault: true, type: "worker" });
+
+    assertEquals(await tester.nextStdoutLine(), "Worker received: start");
+    await tester.expectNotificationMatching(
+      (msg) => msg.sessionId === sessionId && msg.method === "Debugger.paused",
+      "worker Debugger.paused",
+    );
+
+    tester.send({ id: 9, sessionId, method: "Debugger.resume" });
+    await tester.expectResponse(9);
+    assertEquals(await tester.nextStdoutLine(), "after debugger");
+  } finally {
+    await tester.close();
+    tester.kill();
+    await tester.waitForExit();
+    await Deno.remove(tempDir, { recursive: true });
   }
 });
 

--- a/tests/unit/inspector_test.ts
+++ b/tests/unit/inspector_test.ts
@@ -1376,6 +1376,114 @@ setInterval(() => {}, 1000);
   }
 });
 
+Deno.test("inspector_worker_step_over_creation_waits_for_debugger", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const mainScript = `${tempDir}/main.js`;
+  const workerScript = `${tempDir}/worker.js`;
+  await Deno.writeTextFile(
+    mainScript,
+    `
+const worker = new Worker(new URL("./worker.js", import.meta.url).href, {
+  type: "module",
+});
+
+worker.postMessage("start");
+setInterval(() => {}, 1000);
+`,
+  );
+  await Deno.writeTextFile(
+    workerScript,
+    `
+self.onmessage = (e) => {
+  debugger;
+  console.log("Worker received:", e.data);
+  console.log("aa");
+};
+setInterval(() => {}, 1000);
+`,
+  );
+
+  const tester = await InspectorTester.create(
+    ["run", "-A", "--inspect-brk=0", mainScript],
+    { notificationFilter: ignoreScriptParsed, timeout: 5_000 },
+  );
+
+  try {
+    await tester.assertStderrForInspectBrk();
+
+    tester.sendMany([
+      { id: 1, method: "Runtime.enable" },
+      { id: 2, method: "Debugger.enable" },
+      {
+        id: 3,
+        method: "Target.setAutoAttach",
+        params: {
+          autoAttach: true,
+          waitForDebuggerOnStart: false,
+          flatten: true,
+        },
+      },
+      { id: 4, method: "Runtime.runIfWaitingForDebugger" },
+    ]);
+
+    await tester.expectResponse(1);
+    await tester.expectResponse(2);
+    await tester.expectResponse(3);
+    await tester.expectResponse(4);
+    await tester.expectNotification("Runtime.executionContextCreated");
+    await tester.expectNotification("Debugger.paused");
+
+    tester.send({ id: 5, method: "Debugger.stepOver" });
+    await tester.expectResponse(5);
+    await tester.expectNotification("Debugger.resumed");
+    await tester.expectNotification("Debugger.paused");
+
+    await new Promise((resolve) => setTimeout(resolve, 750));
+
+    tester.send({ id: 6, method: "Debugger.resume" });
+    await tester.expectResponse(6);
+    await tester.expectNotification("Debugger.resumed");
+
+    const attached = await tester.expectNotification("Target.attachedToTarget");
+    const attachedParams = attached.params as Record<string, unknown>;
+    assertEquals(attachedParams.waitingForDebugger, false);
+    const sessionId = attachedParams.sessionId as string;
+    assert(sessionId, "attachedToTarget should include sessionId");
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    tester.sendMany([
+      { id: 7, sessionId, method: "Page.waitForDebugger" },
+      { id: 8, sessionId, method: "Runtime.enable" },
+      { id: 9, sessionId, method: "Debugger.enable" },
+      {
+        id: 10,
+        sessionId,
+        method: "Runtime.runIfWaitingForDebugger",
+      },
+    ]);
+    await tester.expectResponse(7);
+    await tester.expectResponse(8);
+    await tester.expectResponse(9);
+    await tester.expectResponse(10);
+
+    await tester.expectNotificationMatching(
+      (msg) => msg.sessionId === sessionId && msg.method === "Debugger.paused",
+      "worker Debugger.paused",
+    );
+
+    tester.send({ id: 11, sessionId, method: "Debugger.resume" });
+    await tester.expectResponse(11);
+    assertEquals(await tester.nextStdoutLine(), "Worker received: start");
+    assertEquals(await tester.nextStdoutLine(), "aa");
+  } finally {
+    await tester.close();
+    tester.kill();
+    await tester.waitForExit();
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
 // Regression test for https://github.com/denoland/deno/issues/34291
 // vscode-js-debug calls NodeWorker.enable before the user script runs, so
 // any Worker constructor fires *after* NodeWorker.enable has been processed.


### PR DESCRIPTION
Related to #35624.

This updates worker inspector handling so Chrome dedicated Node DevTools can discover and attach to Deno workers, then route flattened worker-session protocol messages correctly.

The main changes are:
- expose worker targets through `Target.getTargets`;
- support explicit `Target.attachToTarget` / `Target.detachFromTarget`;
- preserve worker `sessionId` routing for Chrome flattened CDP sessions;
- keep worker wait-on-start behavior so `debugger;` in a worker can pause before subsequent code runs.

Validation:
- `cargo build -p deno`
- `target/debug/deno fmt --check tests/unit/inspector_test.ts`
- `target/debug/deno test --config tests/config/deno.json --no-check -A tests/unit/inspector_test.ts --filter inspector_worker_`
- `target/debug/deno test --config tests/config/deno.json --no-check -A tests/unit/inspector_test.ts --filter inspector_node_worker`
- Manual Chrome smoke test via `chrome://inspect`: resumed main script, DevTools showed `worker [1] paused` in Threads and stopped on the worker `debugger;` statement before `after debugger` printed.