### PR TITLE
fix(core): apply deferred fast-call op upgrade to the captured bootstrap clone

### DIFF
--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -3307,6 +3307,13 @@ impl ModuleMap {
   pub(crate) fn set_captured_bootstrap(&self, value: v8::Global<v8::Value>) {
     *self.data.borrow().captured_bootstrap.borrow_mut() = Some(value);
   }
+
+  /// The snapshot-time `__bootstrap` view stashed by `set_captured_bootstrap`,
+  /// if any. Used by the deferred fast-call upgrade to also update the cloned
+  /// `core.ops` that residual ext modules read through.
+  pub(crate) fn captured_bootstrap(&self) -> Option<v8::Global<v8::Value>> {
+    self.data.borrow().captured_bootstrap.borrow().clone()
+  }
 }
 
 /// Skip past a lazy-loaded script's leading prologue (line/block comments and

--- a/libs/core/runtime/bindings.rs
+++ b/libs/core/runtime/bindings.rs
@@ -611,6 +611,13 @@ pub(crate) fn upgrade_snapshotted_ops_with_fast_calls<'s, 'i>(
   // deferred caller can no longer read them from the global (see
   // `snapshotted_fast_op_refs` / `ensure_fast_ops_upgraded`).
   deno_core_ops_obj: v8::Local<'s, v8::Object>,
+  // The captured-bootstrap clone of `Deno.core.ops` (`capturedCore.ops` in
+  // 01_core.js) that residual ext modules read ops through. The flat-op `.set`s
+  // below replace slots on the ops object, which the shallow clone doesn't see;
+  // mirror them here so residual ext modules get the fast functions too.
+  // (Method/static-method upgrades mutate the shared class objects that the
+  // clone already references, so they need no mirroring.)
+  clone_ops_obj: Option<v8::Local<'s, v8::Object>>,
   set_up_async_stub_fn: v8::Local<'s, v8::Function>,
   op_ctxs: &[OpCtx],
   op_method_decls: &[OpMethodDecl],
@@ -697,6 +704,9 @@ pub(crate) fn upgrade_snapshotted_ops_with_fast_calls<'s, 'i>(
     }
 
     deno_core_ops_obj.set(scope, key.into(), op_fn.into());
+    if let Some(clone_ops_obj) = clone_ops_obj {
+      clone_ops_obj.set(scope, key.into(), op_fn.into());
+    }
   }
 }
 
@@ -742,9 +752,27 @@ pub(crate) fn ensure_fast_ops_upgraded(scope: &mut v8::PinScope) {
   };
   let deno_core_ops_obj = v8::Local::new(scope, &ops_global);
   let set_up_async_stub_fn = v8::Local::new(scope, &stub_global);
+
+  // Residual ext modules read ops through the captured-bootstrap clone of
+  // `core.ops` (`capturedCore.ops` in 01_core.js), a shallow copy that the
+  // flat-op `.set`s below otherwise wouldn't reach. Resolve `<captured>.core
+  // .ops` so the upgrade can mirror the fast functions onto it.
+  let module_map = JsRealm::module_map_from(scope);
+  let clone_ops_obj = module_map.captured_bootstrap().and_then(|g| {
+    let captured = v8::Local::new(scope, &g);
+    let captured = v8::Local::<v8::Object>::try_from(captured).ok()?;
+    let core_key = CORE.v8_string(scope).unwrap();
+    let core = captured.get(scope, core_key.into())?;
+    let core = v8::Local::<v8::Object>::try_from(core).ok()?;
+    let ops_key = OPS.v8_string(scope).unwrap();
+    let ops = core.get(scope, ops_key.into())?;
+    v8::Local::<v8::Object>::try_from(ops).ok()
+  });
+
   upgrade_snapshotted_ops_with_fast_calls(
     scope,
     deno_core_ops_obj,
+    clone_ops_obj,
     set_up_async_stub_fn,
     &context_state.op_ctxs,
     &context_state.op_method_decls,


### PR DESCRIPTION
## Problem

The V8 14.9 deferred fast-call op upgrade (`upgrade_snapshotted_ops_with_fast_calls`) re-attaches fast-call overloads to ops at runtime, because the snapshot serializer rejects the `Managed<CFunctionWithSignature>` resources fast-call setup creates — so the snapshot bakes the *slow* version of every op function.

That pass overwrites the flat op entries on `Deno.core.ops`. But residual ext modules don't read ops through `Deno.core.ops`: after bootstrap scrubs `Deno.core`, `load_ext_script` hands them the **captured-bootstrap clone** (`capturedCore.ops`, a shallow copy built at the end of `01_core.js`). The upgrade never touched that clone, so every op called from a residual ext module — the node-compat polyfills (`node:buffer`, `node:crypto`, …) and any ext JS loaded as a residual module — kept running the slow `CallApiCallback` path instead of taking its V8 fast call.

## Fix

Mirror the flat-op upgrades onto the clone's `core.ops` too. (Method and static-method upgrades already reach the clone, since it shares the same op-class objects; only the flat-op `.set`s — which replace slots on the ops object itself — were missed.)

## Impact

A trivial primitive fast op (`(u32, u32) -> u32`) called from a residual ext module, measured in a tiered-up function (release-lite, M-series):

| | ns/op |
|---|---|
| before | ~10.7 |
| after | ~1.1 |

This applies to every op called from a residual ext module across the runtime.

## Testing

- `node:crypto` / `node:buffer` unit tests pass; behavior unchanged.
- Confirmed via microbenchmark + flamegraph that the op flips from the slow `CallApiCallbackOptimized` path to its V8 fast call.