### PR TITLE
fix(desktop): resolve launcher symlink so .deb/.rpm apps find the backend

### DIFF
--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -1652,8 +1652,13 @@ async fn package_linux_app_dir(
   std::fs::write(
     &launcher_path,
     format!(
+      // Resolve `$0` through symlinks before deriving DIR: `.deb`/`.rpm`
+      // install the real launcher under `/usr/lib/<pkg>/` and expose it via a
+      // `/usr/bin/<pkg>` symlink, so a bare `$0` would resolve DIR to
+      // `/usr/bin` and look for the backend binary there (issue #35623).
+      // `readlink -f` is fine here: this launcher only ships on Linux.
       "#!/bin/sh\n\
-       DIR=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\n\
+       DIR=\"$(cd \"$(dirname \"$(readlink -f \"$0\")\")\" && pwd)\"\n\
        export LAUFEY_RUNTIME_PATH=\"$DIR/{dylib}\"\n\
        exec \"$DIR/{laufey_binary}\" --runtime \"$DIR/{dylib}\" \"$@\"\n",
       laufey_binary = laufey_binary_name,


### PR DESCRIPTION
Fixes #35623.

## Problem

A `deno desktop` app packaged as `.rpm` (or `.deb`) fails to launch:

```
/usr/bin/app: line 3: /usr/bin/laufey_webview: No such file or directory
```

The Linux launcher script derives its own directory from `$0`:

```sh
DIR="$(cd "$(dirname "$0")" && pwd)"
exec "$DIR/laufey_webview" --runtime "$DIR/<dylib>" "$@"
```

But the packages install the real launcher under `/usr/lib/<pkg>/` and expose
it through a `/usr/bin/<pkg>` **symlink**. When the app is launched, `$0` is the
symlink path `/usr/bin/<pkg>`, so `dirname` yields `/usr/bin`, `DIR` resolves to
`/usr/bin`, and the script execs `/usr/bin/laufey_webview` — which doesn't
exist. The backend binary and dylib actually live next to the real launcher in
`/usr/lib/<pkg>/`.

## Fix

Resolve `$0` through symlinks with `readlink -f` before computing `DIR`:

```sh
DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
```

`DIR` now points at `/usr/lib/<pkg>/`, where the backend and dylib live.
`readlink -f` is safe here because this launcher is only generated for Linux
targets. AppImage's `AppRun` delegates to this same launcher in the same
directory, so it is unaffected.
