### PR TITLE
fix: add PerformanceObserver and PerformanceObserverEntryList types

### DIFF
--- a/cli/tsc/dts/lib.deno.shared_globals.d.ts
+++ b/cli/tsc/dts/lib.deno.shared_globals.d.ts
@@ -985,6 +985,71 @@ declare var PerformanceMeasure: {
   new (): never;
 };
 
+/** A list of {@linkcode PerformanceEntry} objects passed to a
+ * {@linkcode PerformanceObserver} callback via its `observe()` method.
+ *
+ * @category Performance
+ */
+interface PerformanceObserverEntryList {
+  /** Returns all explicitly observed performance entries. */
+  getEntries(): PerformanceEntry[];
+  /** Returns the observed performance entries with the given name. */
+  getEntriesByName(name: string, type?: string): PerformanceEntry[];
+  /** Returns the observed performance entries with the given entry type. */
+  getEntriesByType(type: string): PerformanceEntry[];
+}
+
+/** A list of {@linkcode PerformanceEntry} objects passed to a
+ * {@linkcode PerformanceObserver} callback via its `observe()` method.
+ *
+ * @category Performance
+ */
+declare var PerformanceObserverEntryList: {
+  readonly prototype: PerformanceObserverEntryList;
+  new (): never;
+};
+
+/** The callback invoked when the observed set of performance entries grows.
+ *
+ * @category Performance
+ */
+interface PerformanceObserverCallback {
+  (list: PerformanceObserverEntryList, observer: PerformanceObserver): void;
+}
+
+/** Observes performance measurement events and is notified of new
+ * {@linkcode PerformanceEntry} objects as they are recorded in the performance
+ * timeline.
+ *
+ * @category Performance
+ */
+interface PerformanceObserver {
+  /** Stops the observer from receiving any further performance entries. */
+  disconnect(): void;
+  /** Specifies the set of performance entry types to observe. */
+  observe(
+    options?: {
+      entryTypes?: string[];
+      type?: string;
+      buffered?: boolean;
+    },
+  ): void;
+  /** Returns the current list of buffered performance entries, emptying it. */
+  takeRecords(): PerformanceEntry[];
+}
+
+/** Observes performance measurement events and is notified of new
+ * {@linkcode PerformanceEntry} objects as they are recorded in the performance
+ * timeline.
+ *
+ * @category Performance
+ */
+declare var PerformanceObserver: {
+  readonly prototype: PerformanceObserver;
+  readonly supportedEntryTypes: readonly string[];
+  new (callback: PerformanceObserverCallback): PerformanceObserver;
+};
+
 /** @category Events */
 interface CustomEventInit<T = any> extends EventInit {
   detail?: T;


### PR DESCRIPTION
`PerformanceObserver` and `PerformanceObserverEntryList` exist at runtime in
Deno but were never declared in the default libs — only `lib.webworker.d.ts`
declares them, and the `deno.window` lib doesn't load it. As a result:

```ts
const obs = new PerformanceObserver(
  (list: PerformanceObserverEntryList) => { // TS2749 before this change
    for (const e of list.getEntries()) console.log(e.name);
  },
);
obs.observe({ entryTypes: ["measure"] });
```

`PerformanceObserverEntryList` used as a type errored with `TS2749`
("'PerformanceObserverEntryList' refers to a value, but is being used as a type
here"), even though the value exists at runtime.

This adds the `PerformanceObserver`, `PerformanceObserverEntryList`, and
`PerformanceObserverCallback` declarations to `lib.deno.shared_globals.d.ts`
next to the existing `Performance` / `PerformanceEntry` / `PerformanceMark` /
`PerformanceMeasure` ones, so both are usable as values and types in Deno code.


---
Part of the broader effort to drop Deno's forked TypeScript; see #35621 for context and the overall plan.