### PR TITLE
fix(check): load a single @types/node

### DIFF
--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -1153,6 +1153,42 @@ pub fn load_for_tsc<T: LoadContent, M: Mapper>(
   // handle the request for that module here.
   } else if load_specifier == MISSING_DEPENDENCY_SPECIFIER {
     None
+  } else if load_specifier == "asset:///lib.node.d.ts" {
+    // With a single global symbol table, loading both the built-in `@types/node`
+    // and a user-installed one duplicates every node declaration. If the user
+    // provides their own `@types/node`, reference that resolved file directly so
+    // exactly one copy is in the program; otherwise serve the built-in. We
+    // reference the resolved path rather than `types="npm:@types/node"` because
+    // the latter would be re-resolved relative to this asset file, which fails
+    // for cache-only / frozen installs.
+    let user_types_node = maybe_npm.and_then(|npm| {
+      let referrer =
+        deno_path_util::resolve_url_or_path("./", current_dir).ok()?;
+      let (spec, _) = resolve_non_graph_specifier_types(
+        "npm:@types/node",
+        &referrer,
+        ResolutionMode::Import,
+        Some(npm),
+      )
+      .ok()
+      .flatten()?;
+      spec
+        .to_file_path()
+        .ok()
+        .filter(|p| p.exists())
+        .map(|_| spec)
+    });
+    let source: Arc<str> = match user_types_node {
+      Some(spec) => format!(
+        "/// <reference no-default-lib=\"true\"/>\n/// <reference path=\"{}\" />\n",
+        spec.as_str(),
+      )
+      .into(),
+      None => get_lazily_loaded_asset("lib.node.d.ts").unwrap_or_default().into(),
+    };
+    hash = get_maybe_hash(Some(source.as_ref()), hash_data);
+    media_type = MediaType::Dts;
+    Some(T::from_arc_str(source))
   } else if let Some(name) = load_specifier.strip_prefix("asset:///") {
     let maybe_source = get_lazily_loaded_asset(name);
     hash = get_maybe_hash(maybe_source, hash_data);


### PR DESCRIPTION
When a project provides its own `@types/node`, the type-checker loaded it
**and** the built-in copy that backs `lib="node"`. With a single global symbol
table that means every node declaration (`process`, `Buffer`, `node:path`, the
`Server` / `Console` / etc. types) is declared twice. The current forked
compiler hides this with its dual node/deno global tables, but it's a latent
double-load and a blocker for moving to a single global table.

This resolves the user's `@types/node` once (from the project) and references
the resolved file directly from `lib.node.d.ts`, so exactly one copy ends up in
the program. When the project has no `@types/node`, the built-in copy is served
as before, so the default experience is unchanged.

The resolved path is referenced directly instead of re-emitting
`/// <reference types="npm:@types/node" />`, because the latter would be
re-resolved relative to the `asset:///lib.node.d.ts` file rather than the
project, which fails for cache-only / `--frozen` installs (the package is known
from the lockfile but not under `node_modules`).


---
Part of the broader effort to drop Deno's forked TypeScript; see #35621 for context and the overall plan.