### PR TITLE
feat(check): add `--desktop` flag to type-check for deno desktop

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2273,6 +2273,13 @@ Unless --reload is specified, this command will not re-download already cached d
             .action(ArgAction::SetTrue)
         )
         .arg(
+          Arg::new("desktop")
+            .long("desktop")
+            .help("Type-check using the type definitions for `deno desktop`")
+            .action(ArgAction::SetTrue)
+            .help_heading(DESKTOP_HEADING)
+        )
+        .arg(
           Arg::new("file")
             .num_args(1..)
             .value_hint(ValueHint::FilePath),
@@ -6778,6 +6785,9 @@ fn check_parse(
   if matches.get_flag("all") || matches.get_flag("remote") {
     flags.type_check_mode = TypeCheckMode::All;
   }
+  if matches.get_flag("desktop") {
+    flags.internal.is_desktop = true;
+  }
   flags.subcommand = DenoSubcommand::Check(CheckFlags {
     files,
     doc: matches.get_flag("doc"),
@@ -10668,6 +10678,27 @@ mod tests {
         }),
         type_check_mode: TypeCheckMode::Local,
         code_cache_enabled: true,
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec!["deno", "check", "--desktop", "script.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Check(CheckFlags {
+          files: svec!["script.ts"],
+          doc: false,
+          doc_only: false,
+          check_js: false,
+          watch: None,
+        }),
+        type_check_mode: TypeCheckMode::Local,
+        code_cache_enabled: true,
+        internal: InternalFlags {
+          is_desktop: true,
+          ..Default::default()
+        },
         ..Flags::default()
       }
     );

--- a/tests/specs/check/desktop_flag/__test__.jsonc
+++ b/tests/specs/check/desktop_flag/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tests": {
+    "without_flag": {
+      "args": "check main.ts",
+      "output": "without_flag.out",
+      "exitCode": 1
+    },
+    "with_flag": {
+      "args": "check --desktop main.ts",
+      "output": "with_flag.out",
+      "exitCode": 0
+    }
+  }
+}

--- a/tests/specs/check/desktop_flag/main.ts
+++ b/tests/specs/check/desktop_flag/main.ts
@@ -1,0 +1,4 @@
+// `Notification` is only available in the `deno desktop` type libs, so this
+// fails to type-check without `--desktop` and succeeds with it.
+const n: Notification = new Notification("hi");
+console.log(n);

--- a/tests/specs/check/desktop_flag/with_flag.out
+++ b/tests/specs/check/desktop_flag/with_flag.out
@@ -1,0 +1,1 @@
+Check [WILDCARD]main.ts

--- a/tests/specs/check/desktop_flag/without_flag.out
+++ b/tests/specs/check/desktop_flag/without_flag.out
@@ -1,0 +1,4 @@
+Check [WILDCARD]main.ts
+TS2304 [ERROR]: Cannot find name 'Notification'.
+[WILDCARD]
+error: Type checking failed.


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/35499

## Summary

Adds a `--desktop` flag to `deno check` that type-checks against the `deno desktop` type definitions (`lib.deno.desktop.d.ts`) instead of the default `deno.window` libs. This lets users type-check code intended for `deno desktop` without going through a full compile.

The underlying plumbing already existed — `TsTypeLib::DenoDesktop`, `lib.deno.desktop.d.ts`, the lib-name mapping in `libs/resolver/deno_json.rs`, and the internal `is_desktop` flag that `CliOptions::ts_type_lib_window()` already honors. The `desktop` subcommand sets that internal flag during compile; this PR simply exposes it on `check`.

## Changes

- `cli/args/flags.rs`:
  - Add the `--desktop` arg to the `check` subcommand (under the existing "Desktop options" help heading).
  - Set `flags.internal.is_desktop = true` in `check_parse` when the flag is present. `check_specifiers` already reads the lib via `ts_type_lib_window()`, so this routes the check through the desktop libs.
  - Add a `--desktop` case to the `check()` flag-parsing unit test.
- `tests/specs/check/desktop_flag/`: new spec test using `Notification` (a desktop-only global) — fails to type-check without the flag and succeeds with `--desktop`.

## Verification

- `deno check main.ts` errors on a desktop-only global; `deno check --desktop main.ts` passes.
- Spec test `specs::check::desktop_flag` and unit test `args::flags::tests::check` pass.
- `cargo clippy` clean; formatted with `tools/format.js`.