### PR TITLE
fix(libs/http): add missing `write_flushed` in `poll_start_fixed_response_with`

### DIFF
--- a/libs/http_h1/conn.rs
+++ b/libs/http_h1/conn.rs
@@ -2225,6 +2225,48 @@ mod tests {
   }
 
   #[tokio::test]
+  async fn shared_conn_fixed_response_flush_after_head_does_not_resend_head()
+  -> TestResult<()> {
+    // Regression for #35648. The serve loop flushes buffered bytes whenever a
+    // streaming body source yields `Pending`. For a fixed-length response the
+    // head is written directly to the socket in
+    // `poll_start_fixed_response_with`, so that flush must be a no-op and must
+    // NOT re-send the still-buffered head as body. Without
+    // `write_flushed = write_buf.len()` it re-sent the head into the body.
+    let io = FragmentIo::new(&[]);
+    let mut conn = SharedConn::new(io);
+    let mut scratch = SharedScratch::default();
+
+    let mut head = SharedFixedResponseHeadWriter::new(
+      ResponseHead {
+        version: Version::Http11,
+        status: 200,
+        reason: b"OK",
+        headers: &[],
+        keep_alive: true,
+      },
+      3,
+    );
+    std::future::poll_fn(|cx| {
+      conn.poll_start_fixed_response_with(cx, &mut scratch, &mut head)
+    })
+    .await?;
+
+    // Body source has nothing ready yet: the driver flushes buffered bytes.
+    std::future::poll_fn(|cx| conn.poll_flush_write_buf(cx, &mut scratch))
+      .await?;
+
+    conn.write_response_body_with_scratch(b"abc").await?;
+    conn.finish_response_with_scratch(&mut scratch, &[]).await?;
+
+    assert_eq!(
+      conn.into_inner().written,
+      b"HTTP/1.1 200 OK\r\ncontent-length: 3\r\n\r\nabc"
+    );
+    Ok(())
+  }
+
+  #[tokio::test]
   async fn shared_conn_fixed_streaming_response_rejects_overflow()
   -> TestResult<()> {
     let io = FragmentIo::new(&[]);

--- a/libs/http_h1/conn.rs
+++ b/libs/http_h1/conn.rs
@@ -1246,6 +1246,7 @@ where
       }
       writer.written += written;
     }
+    scratch.write_flushed = scratch.write_buf.len();
     self.response_state = if status_allows_body(writer.response.status) {
       ResponseState::Fixed {
         remaining: writer.content_length,


### PR DESCRIPTION
## Issue details

See #35648

## Fix

Add missing `scratch.write_flushed = scratch.write_buf.len();` in `poll_start_fixed_response_with`. 

_Without it_, `poll_flush_write_buf` re-sends the response head as the body when the `ReadableStream` source yields `Poll::Pending`.  It mirrors what `poll_start_chunked_response_with` _already_ does (introduced in #35523)

## Verify

- Create `example.ts` (change path to your PNG file as needed) 
```ts
Deno.serve({ port: 9999 }, async (request) => {
  await request.body?.cancel();
  const path = "your-image.png";
  const { size } = await Deno.stat(path);
  const file = await Deno.open(path, { read: true });
  return new Response(file.readable, {
    headers: {
      "content-type": "image/png",
      "content-length": String(size),
    },
  });
});
```

- Run the example

```sh
deno run -A ./example.ts
Listening on http://0.0.0.0:9999/ (http://localhost:9999/)
```

- Check the output

**Before:**

```sh
curl -s http://localhost:9999 | head -c 8
HTTP/1.1
```

**Now:**

```sh
curl -s http://localhost:9999 | head -c 8
PNG
```


Fixes #35648