### PR TITLE
fix(desktop): attribute bind calls to the registering window id

### DIFF
--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -735,7 +735,30 @@ pub const DESKTOP_JS: &str = r#"
           }
           case "bindCall": {
             const callbacks = windowBindCallbacks.get(ev.windowId);
-            const fn_ = callbacks?.get(ev.name);
+            let fn_ = callbacks?.get(ev.name);
+            // Fallback: the backend may report a window id for the calling
+            // renderer that doesn't line up with the id the binding was
+            // registered under (observed on the CEF/Windows backend when an
+            // entrypoint with extra modules — e.g. a `jsr:` import — delays
+            // startup; see denoland/deno#35647). The window->callback map and
+            // the native binding registry are both keyed by the same window
+            // id, so a miss here means the call arrived under a different id
+            // than `bind()` saw. When exactly one window has a callback for
+            // this name the target is unambiguous, so route to it rather than
+            // dropping the call. (Per-window same-named bindings keep strict
+            // matching: ambiguous names fall through to the rejection below.)
+            if (!fn_) {
+              let match = null;
+              let count = 0;
+              for (const map of windowBindCallbacks.values()) {
+                const candidate = map.get(ev.name);
+                if (candidate) {
+                  match = candidate;
+                  if (++count > 1) break;
+                }
+              }
+              if (count === 1) fn_ = match;
+            }
             if (!fn_) {
               op_desktop_reject_bind_call(ev.callId, "No callback bound for: " + ev.name);
               break;
@@ -1278,6 +1301,23 @@ mod tests {
     assert!(DESKTOP_JS.contains("navigator"));
     assert!(DESKTOP_JS.contains("permissions"));
     assert!(DESKTOP_JS.contains("PermissionStatus"));
+  }
+
+  #[test]
+  fn desktop_js_bind_call_falls_back_on_window_id_mismatch() {
+    // Regression guard for denoland/deno#35647: the CEF/Windows backend can
+    // deliver a `bindCall` whose window id doesn't match the id the binding
+    // was registered under. The dispatcher must not give up on the first
+    // window-scoped miss — it falls back to an unambiguous name match so the
+    // call still reaches its callback instead of erroring with
+    // "No callback bound for".
+    assert!(
+      DESKTOP_JS.contains("windowBindCallbacks.values()"),
+      "bindCall must scan all windows when the window-scoped lookup misses"
+    );
+    // The fallback only fires when exactly one window registered the name, so
+    // per-window same-named bindings keep strict routing.
+    assert!(DESKTOP_JS.contains("count === 1"));
   }
 
   #[test]

--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -14,8 +14,46 @@ pub use deno_runtime::ops::desktop::AutoUpdateState;
 pub use deno_runtime::ops::desktop::DesktopApi;
 pub use deno_runtime::ops::desktop::MenuItem;
 
+/// The `resolveBindCallback` routing helper, defined as a macro that expands
+/// to a string literal so it can be spliced into `DESKTOP_JS` via `concat!`
+/// while also being executed verbatim by `resolve_bind_callback_behaves`. The
+/// test therefore runs the exact bytes we ship — no source scraping.
+macro_rules! resolve_bind_callback_js {
+  () => {
+    r#"
+  // Resolve the callback for an incoming bindCall.
+  //
+  // The backend may report a window id for the calling renderer that doesn't
+  // line up with the id the binding was registered under (observed on the
+  // CEF/Windows backend when an entrypoint with extra modules — e.g. a `jsr:`
+  // import — delays startup; see denoland/deno#35647). A *known* window keeps
+  // strict per-window matching: per-window bindings are a security boundary,
+  // so a window must never reach a callback it did not itself register, even
+  // when the name is globally unique. Only an *unknown* window id — the drift
+  // case, where the call arrived under an id that registered nothing — falls
+  // back to a name match, and only when exactly one window registered that
+  // name. Ambiguous names return null so the caller still rejects.
+  function resolveBindCallback(registry, windowId, name) {
+    const callbacks = registry.get(windowId);
+    if (callbacks) return callbacks.get(name) ?? null;
+    let match = null;
+    let count = 0;
+    for (const map of registry.values()) {
+      const candidate = map.get(name);
+      if (candidate) {
+        match = candidate;
+        if (++count > 1) return null;
+      }
+    }
+    return count === 1 ? match : null;
+  }
+"#
+  };
+}
+
 /// JS code that exposes desktop APIs via `Deno.BrowserWindow` and `Deno.desktop`.
-pub const DESKTOP_JS: &str = r#"
+pub const DESKTOP_JS: &str = concat!(
+  r#"
 (() => {
   const internals = Deno[Deno.internal];
   const {
@@ -205,39 +243,9 @@ pub const DESKTOP_JS: &str = r#"
 
   // Per-window bind callback registry: windowId -> Map<name, fn>
   const windowBindCallbacks = new Map();
-
-  // Resolve the callback for an incoming bindCall. Kept as a standalone,
-  // closure-free function (the registry is passed in) so it can be executed
-  // directly in a unit test — see `resolve_bind_callback_*` in this file.
-  //
-  // The backend may report a window id for the calling renderer that doesn't
-  // line up with the id the binding was registered under (observed on the
-  // CEF/Windows backend when an entrypoint with extra modules — e.g. a `jsr:`
-  // import — delays startup; see denoland/deno#35647). `windowBindCallbacks`
-  // and the native binding registry are both keyed by the same window id, so a
-  // window-scoped miss means the call arrived under a different id than
-  // `bind()` saw. When exactly one window registered a callback for this name
-  // the target is unambiguous, so route to it rather than dropping the call.
-  // Per-window same-named bindings keep strict matching: ambiguous names
-  // return null so the caller still rejects.
-  // TEST-EXTRACT:resolveBindCallback:START
-  function resolveBindCallback(registry, windowId, name) {
-    const callbacks = registry.get(windowId);
-    const scoped = callbacks?.get(name);
-    if (scoped) return scoped;
-    let match = null;
-    let count = 0;
-    for (const map of registry.values()) {
-      const candidate = map.get(name);
-      if (candidate) {
-        match = candidate;
-        if (++count > 1) return null;
-      }
-    }
-    return count === 1 ? match : null;
-  }
-  // TEST-EXTRACT:resolveBindCallback:END
-
+"#,
+  resolve_bind_callback_js!(),
+  r#"
   // Binding-call correlation: when --inspect is active, both the Deno
   // and renderer consoles emit matching console.debug messages so the
   // developer can trace a binding call across isolates.
@@ -973,7 +981,8 @@ pub const DESKTOP_JS: &str = r#"
     }
   })();
 })();
-"#;
+"#
+);
 
 /// JS code that initializes auto-update APIs. Executed separately so
 /// version and rollback state can be baked in as literals.
@@ -1315,13 +1324,16 @@ mod tests {
     assert!(DESKTOP_JS.contains("PermissionStatus"));
   }
 
+  // The exact `resolveBindCallback` bytes baked into DESKTOP_JS, referenced
+  // directly by the regression test below — no source scraping.
+  const RESOLVE_BIND_CALLBACK_JS: &str = resolve_bind_callback_js!();
+
   #[test]
   fn resolve_bind_callback_behaves() {
     // Regression test for denoland/deno#35647. Runs the *actual*
-    // `resolveBindCallback` shipped in DESKTOP_JS (extracted between its
-    // TEST-EXTRACT markers) in a real V8 isolate and asserts its routing
-    // behaviour, rather than grepping the source for substrings.
-    let resolver = extract_marked(DESKTOP_JS, "resolveBindCallback");
+    // `resolveBindCallback` shipped in DESKTOP_JS in a real V8 isolate and
+    // asserts its routing behaviour, rather than grepping for substrings.
+    let resolver = RESOLVE_BIND_CALLBACK_JS;
     let harness = format!(
       r#"
 {resolver}
@@ -1360,6 +1372,12 @@ check(resolveBindCallback(reg2, 1, "ping")(), "a", "ambiguous exact w1");
 check(resolveBindCallback(reg2, 2, "ping")(), "b", "ambiguous exact w2");
 check(resolveBindCallback(reg2, 999, "ping"), null, "ambiguous fallback");
 
+// 5) Security boundary: a *known* window that never bound this name must not
+//    reach another window's uniquely-named callback via the fallback. Window
+//    3 exists (it bound "other") so asking it for "ping" resolves strictly and
+//    returns null, even though window 7's "ping" is globally unique.
+check(resolveBindCallback(reg, 3, "ping"), null, "known window no cross-reach");
+
 "ok"
 "#
     );
@@ -1369,17 +1387,6 @@ check(resolveBindCallback(reg2, 999, "ping"), null, "ambiguous fallback");
     runtime
       .execute_script("[resolve_bind_callback_test]", harness)
       .expect("resolveBindCallback assertions failed");
-  }
-
-  /// Pull the text between `// TEST-EXTRACT:<name>:START` and `:END` out of
-  /// `hay`. Lets a test run a self-contained slice of DESKTOP_JS (the real
-  /// shipped bytes) instead of asserting on substrings.
-  fn extract_marked(hay: &str, name: &str) -> String {
-    let start = format!("// TEST-EXTRACT:{name}:START");
-    let end = format!("// TEST-EXTRACT:{name}:END");
-    let from = hay.find(&start).expect("start marker present") + start.len();
-    let to = hay[from..].find(&end).expect("end marker present") + from;
-    hay[from..to].to_string()
   }
 
   #[test]

--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -206,6 +206,38 @@ pub const DESKTOP_JS: &str = r#"
   // Per-window bind callback registry: windowId -> Map<name, fn>
   const windowBindCallbacks = new Map();
 
+  // Resolve the callback for an incoming bindCall. Kept as a standalone,
+  // closure-free function (the registry is passed in) so it can be executed
+  // directly in a unit test — see `resolve_bind_callback_*` in this file.
+  //
+  // The backend may report a window id for the calling renderer that doesn't
+  // line up with the id the binding was registered under (observed on the
+  // CEF/Windows backend when an entrypoint with extra modules — e.g. a `jsr:`
+  // import — delays startup; see denoland/deno#35647). `windowBindCallbacks`
+  // and the native binding registry are both keyed by the same window id, so a
+  // window-scoped miss means the call arrived under a different id than
+  // `bind()` saw. When exactly one window registered a callback for this name
+  // the target is unambiguous, so route to it rather than dropping the call.
+  // Per-window same-named bindings keep strict matching: ambiguous names
+  // return null so the caller still rejects.
+  // TEST-EXTRACT:resolveBindCallback:START
+  function resolveBindCallback(registry, windowId, name) {
+    const callbacks = registry.get(windowId);
+    const scoped = callbacks?.get(name);
+    if (scoped) return scoped;
+    let match = null;
+    let count = 0;
+    for (const map of registry.values()) {
+      const candidate = map.get(name);
+      if (candidate) {
+        match = candidate;
+        if (++count > 1) return null;
+      }
+    }
+    return count === 1 ? match : null;
+  }
+  // TEST-EXTRACT:resolveBindCallback:END
+
   // Binding-call correlation: when --inspect is active, both the Deno
   // and renderer consoles emit matching console.debug messages so the
   // developer can trace a binding call across isolates.
@@ -734,31 +766,11 @@ pub const DESKTOP_JS: &str = r#"
             break;
           }
           case "bindCall": {
-            const callbacks = windowBindCallbacks.get(ev.windowId);
-            let fn_ = callbacks?.get(ev.name);
-            // Fallback: the backend may report a window id for the calling
-            // renderer that doesn't line up with the id the binding was
-            // registered under (observed on the CEF/Windows backend when an
-            // entrypoint with extra modules — e.g. a `jsr:` import — delays
-            // startup; see denoland/deno#35647). The window->callback map and
-            // the native binding registry are both keyed by the same window
-            // id, so a miss here means the call arrived under a different id
-            // than `bind()` saw. When exactly one window has a callback for
-            // this name the target is unambiguous, so route to it rather than
-            // dropping the call. (Per-window same-named bindings keep strict
-            // matching: ambiguous names fall through to the rejection below.)
-            if (!fn_) {
-              let match = null;
-              let count = 0;
-              for (const map of windowBindCallbacks.values()) {
-                const candidate = map.get(ev.name);
-                if (candidate) {
-                  match = candidate;
-                  if (++count > 1) break;
-                }
-              }
-              if (count === 1) fn_ = match;
-            }
+            const fn_ = resolveBindCallback(
+              windowBindCallbacks,
+              ev.windowId,
+              ev.name,
+            );
             if (!fn_) {
               op_desktop_reject_bind_call(ev.callId, "No callback bound for: " + ev.name);
               break;
@@ -1304,20 +1316,70 @@ mod tests {
   }
 
   #[test]
-  fn desktop_js_bind_call_falls_back_on_window_id_mismatch() {
-    // Regression guard for denoland/deno#35647: the CEF/Windows backend can
-    // deliver a `bindCall` whose window id doesn't match the id the binding
-    // was registered under. The dispatcher must not give up on the first
-    // window-scoped miss — it falls back to an unambiguous name match so the
-    // call still reaches its callback instead of erroring with
-    // "No callback bound for".
-    assert!(
-      DESKTOP_JS.contains("windowBindCallbacks.values()"),
-      "bindCall must scan all windows when the window-scoped lookup misses"
+  fn resolve_bind_callback_behaves() {
+    // Regression test for denoland/deno#35647. Runs the *actual*
+    // `resolveBindCallback` shipped in DESKTOP_JS (extracted between its
+    // TEST-EXTRACT markers) in a real V8 isolate and asserts its routing
+    // behaviour, rather than grepping the source for substrings.
+    let resolver = extract_marked(DESKTOP_JS, "resolveBindCallback");
+    let harness = format!(
+      r#"
+{resolver}
+
+// Tag each callback with the value it returns so we can assert identity.
+const tag = (v) => () => v;
+
+// Registry: window 7 bound "ping"; window 3 bound "other".
+const reg = new Map([
+  [7, new Map([["ping", tag("win7")]])],
+  [3, new Map([["other", tag("win3")]])],
+]);
+
+const check = (got, want, msg) => {{
+  if (got !== want) throw new Error(msg + ": got " + JSON.stringify(got));
+}};
+
+// 1) Exact window match resolves that window's callback.
+check(resolveBindCallback(reg, 7, "ping")(), "win7", "exact match");
+
+// 2) The #35647 case: the call arrives under a window id that never bound
+//    anything, but exactly one window bound "ping" -> route to it.
+check(resolveBindCallback(reg, 999, "ping")(), "win7", "unique fallback");
+
+// 3) Unknown binding name never resolves.
+check(resolveBindCallback(reg, 999, "missing"), null, "unknown name");
+check(resolveBindCallback(reg, 7, "missing"), null, "unknown name on real window");
+
+// 4) Ambiguous: two windows bound the same name. Exact id still matches its
+//    own callback, but a mismatched id must NOT guess between them.
+const reg2 = new Map([
+  [1, new Map([["ping", tag("a")]])],
+  [2, new Map([["ping", tag("b")]])],
+]);
+check(resolveBindCallback(reg2, 1, "ping")(), "a", "ambiguous exact w1");
+check(resolveBindCallback(reg2, 2, "ping")(), "b", "ambiguous exact w2");
+check(resolveBindCallback(reg2, 999, "ping"), null, "ambiguous fallback");
+
+"ok"
+"#
     );
-    // The fallback only fires when exactly one window registered the name, so
-    // per-window same-named bindings keep strict routing.
-    assert!(DESKTOP_JS.contains("count === 1"));
+
+    let mut runtime =
+      deno_core::JsRuntime::new(deno_core::RuntimeOptions::default());
+    runtime
+      .execute_script("[resolve_bind_callback_test]", harness)
+      .expect("resolveBindCallback assertions failed");
+  }
+
+  /// Pull the text between `// TEST-EXTRACT:<name>:START` and `:END` out of
+  /// `hay`. Lets a test run a self-contained slice of DESKTOP_JS (the real
+  /// shipped bytes) instead of asserting on substrings.
+  fn extract_marked(hay: &str, name: &str) -> String {
+    let start = format!("// TEST-EXTRACT:{name}:START");
+    let end = format!("// TEST-EXTRACT:{name}:END");
+    let from = hay.find(&start).expect("start marker present") + start.len();
+    let to = hay[from..].find(&end).expect("end marker present") + from;
+    hay[from..to].to_string()
   }
 
   #[test]

--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -14,46 +14,8 @@ pub use deno_runtime::ops::desktop::AutoUpdateState;
 pub use deno_runtime::ops::desktop::DesktopApi;
 pub use deno_runtime::ops::desktop::MenuItem;
 
-/// The `resolveBindCallback` routing helper, defined as a macro that expands
-/// to a string literal so it can be spliced into `DESKTOP_JS` via `concat!`
-/// while also being executed verbatim by `resolve_bind_callback_behaves`. The
-/// test therefore runs the exact bytes we ship — no source scraping.
-macro_rules! resolve_bind_callback_js {
-  () => {
-    r#"
-  // Resolve the callback for an incoming bindCall.
-  //
-  // The backend may report a window id for the calling renderer that doesn't
-  // line up with the id the binding was registered under (observed on the
-  // CEF/Windows backend when an entrypoint with extra modules — e.g. a `jsr:`
-  // import — delays startup; see denoland/deno#35647). A *known* window keeps
-  // strict per-window matching: per-window bindings are a security boundary,
-  // so a window must never reach a callback it did not itself register, even
-  // when the name is globally unique. Only an *unknown* window id — the drift
-  // case, where the call arrived under an id that registered nothing — falls
-  // back to a name match, and only when exactly one window registered that
-  // name. Ambiguous names return null so the caller still rejects.
-  function resolveBindCallback(registry, windowId, name) {
-    const callbacks = registry.get(windowId);
-    if (callbacks) return callbacks.get(name) ?? null;
-    let match = null;
-    let count = 0;
-    for (const map of registry.values()) {
-      const candidate = map.get(name);
-      if (candidate) {
-        match = candidate;
-        if (++count > 1) return null;
-      }
-    }
-    return count === 1 ? match : null;
-  }
-"#
-  };
-}
-
 /// JS code that exposes desktop APIs via `Deno.BrowserWindow` and `Deno.desktop`.
-pub const DESKTOP_JS: &str = concat!(
-  r#"
+pub const DESKTOP_JS: &str = r#"
 (() => {
   const internals = Deno[Deno.internal];
   const {
@@ -243,9 +205,7 @@ pub const DESKTOP_JS: &str = concat!(
 
   // Per-window bind callback registry: windowId -> Map<name, fn>
   const windowBindCallbacks = new Map();
-"#,
-  resolve_bind_callback_js!(),
-  r#"
+
   // Binding-call correlation: when --inspect is active, both the Deno
   // and renderer consoles emit matching console.debug messages so the
   // developer can trace a binding call across isolates.
@@ -774,11 +734,8 @@ pub const DESKTOP_JS: &str = concat!(
             break;
           }
           case "bindCall": {
-            const fn_ = resolveBindCallback(
-              windowBindCallbacks,
-              ev.windowId,
-              ev.name,
-            );
+            const callbacks = windowBindCallbacks.get(ev.windowId);
+            const fn_ = callbacks?.get(ev.name);
             if (!fn_) {
               op_desktop_reject_bind_call(ev.callId, "No callback bound for: " + ev.name);
               break;
@@ -981,8 +938,7 @@ pub const DESKTOP_JS: &str = concat!(
     }
   })();
 })();
-"#
-);
+"#;
 
 /// JS code that initializes auto-update APIs. Executed separately so
 /// version and rollback state can be baked in as literals.
@@ -1322,71 +1278,6 @@ mod tests {
     assert!(DESKTOP_JS.contains("navigator"));
     assert!(DESKTOP_JS.contains("permissions"));
     assert!(DESKTOP_JS.contains("PermissionStatus"));
-  }
-
-  // The exact `resolveBindCallback` bytes baked into DESKTOP_JS, referenced
-  // directly by the regression test below — no source scraping.
-  const RESOLVE_BIND_CALLBACK_JS: &str = resolve_bind_callback_js!();
-
-  #[test]
-  fn resolve_bind_callback_behaves() {
-    // Regression test for denoland/deno#35647. Runs the *actual*
-    // `resolveBindCallback` shipped in DESKTOP_JS in a real V8 isolate and
-    // asserts its routing behaviour, rather than grepping for substrings.
-    let resolver = RESOLVE_BIND_CALLBACK_JS;
-    let harness = format!(
-      r#"
-{resolver}
-
-// Tag each callback with the value it returns so we can assert identity.
-const tag = (v) => () => v;
-
-// Registry: window 7 bound "ping"; window 3 bound "other".
-const reg = new Map([
-  [7, new Map([["ping", tag("win7")]])],
-  [3, new Map([["other", tag("win3")]])],
-]);
-
-const check = (got, want, msg) => {{
-  if (got !== want) throw new Error(msg + ": got " + JSON.stringify(got));
-}};
-
-// 1) Exact window match resolves that window's callback.
-check(resolveBindCallback(reg, 7, "ping")(), "win7", "exact match");
-
-// 2) The #35647 case: the call arrives under a window id that never bound
-//    anything, but exactly one window bound "ping" -> route to it.
-check(resolveBindCallback(reg, 999, "ping")(), "win7", "unique fallback");
-
-// 3) Unknown binding name never resolves.
-check(resolveBindCallback(reg, 999, "missing"), null, "unknown name");
-check(resolveBindCallback(reg, 7, "missing"), null, "unknown name on real window");
-
-// 4) Ambiguous: two windows bound the same name. Exact id still matches its
-//    own callback, but a mismatched id must NOT guess between them.
-const reg2 = new Map([
-  [1, new Map([["ping", tag("a")]])],
-  [2, new Map([["ping", tag("b")]])],
-]);
-check(resolveBindCallback(reg2, 1, "ping")(), "a", "ambiguous exact w1");
-check(resolveBindCallback(reg2, 2, "ping")(), "b", "ambiguous exact w2");
-check(resolveBindCallback(reg2, 999, "ping"), null, "ambiguous fallback");
-
-// 5) Security boundary: a *known* window that never bound this name must not
-//    reach another window's uniquely-named callback via the fallback. Window
-//    3 exists (it bound "other") so asking it for "ping" resolves strictly and
-//    returns null, even though window 7's "ping" is globally unique.
-check(resolveBindCallback(reg, 3, "ping"), null, "known window no cross-reach");
-
-"ok"
-"#
-    );
-
-    let mut runtime =
-      deno_core::JsRuntime::new(deno_core::RuntimeOptions::default());
-    runtime
-      .execute_script("[resolve_bind_callback_test]", harness)
-      .expect("resolveBindCallback assertions failed");
   }
 
   #[test]

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -373,7 +373,14 @@ impl denort::desktop::DesktopApi for WefDesktopApi {
           let call_id =
             deno_runtime::ops::desktop::register_bind_call(&responses, resp_tx);
           let event = deno_runtime::ops::desktop::DesktopEvent::BindCall {
-            window_id: js_call.window_id,
+            // Attribute the call to the window the binding was registered on,
+            // not to `js_call.window_id`. The backend's per-call renderer id
+            // can drift from the id `bind()` recorded the callback under (seen
+            // on CEF/Windows when a larger module graph delays startup; see
+            // denoland/deno#35647), which would make the runtime-side lookup
+            // in `windowBindCallbacks` miss and reject an otherwise-registered
+            // call. The registration id always matches that map's key.
+            window_id,
             name,
             args: serde_json::Value::Array(args),
             call_id,


### PR DESCRIPTION
Fixes #35647.

## Problem

`deno desktop` bindings (`win.bind(name, fn)`) stop working when the entrypoint
has a `jsr:`/remote import that is actually used, e.g.:

```ts
import { extname } from "jsr:@std/path";
const win = new Deno.BrowserWindow({ title: "My App" });
win.bind("ping", async () => "pong");
async function unused() { return extname(); } // remove this call -> bindings work
Deno.serve((_) => new Response("hi", { headers: { "content-type": "text/html" } }));
```

Calling `bindings.ping()` in the renderer rejects with
`Uncaught (in promise) Error: No callback bound for: ping`, even though the
binding was registered.

## Root cause

The runtime keeps a per-window callback registry (`windowBindCallbacks` in
`DESKTOP_JS`) keyed by window id, and on a `bindCall` event looks the callback
up by `ev.windowId`. Every other window event (`keyboardEvent`, mouse events,
`focusChanged`, `windowResize`, `closeRequested`, menu clicks) sources its id
from laufey's per-window event struct (`ev.window_id`, wired up in
`setup_window_events`), so those ids always match the id `create_window`
returned.

`bindCall` was the one exception. `WefDesktopApi::bind` registers the native
binding on `Window::from_id(window_id)`, but the callback it installs emitted
`DesktopEvent::BindCall { window_id: js_call.window_id, .. }` — the backend's
*per-call renderer id*, not the id the binding was registered under. On the
CEF/Windows backend that per-call id can drift from the registration id (a
larger module graph from a used `jsr:` import delays startup and widens the
window), so the runtime-side lookup misses and the call is rejected.

This is why the error is the Deno-side `No callback bound for`, not the
backend's `No binding for`: the native binding *did* fire (its closure ran and
produced the event) — it just carried a window id the runtime never registered
a callback under.

## Fix

Emit the id the binding was registered on instead of `js_call.window_id`. The
bind closure already captures that `window_id` in scope, and it is exactly the
key `windowBindCallbacks` is keyed by, so the lookup can no longer miss. This
fixes the misrouting deterministically at the runtime↔backend boundary; the
runtime side needs no window-id heuristic and keeps its strict per-window
lookup, so multi-window apps retain per-window routing (a window can only reach
callbacks it itself registered).

The underlying defect — the backend reporting a per-call renderer window id
that is inconsistent with the id a window was created under — should still be
fixed upstream in laufey so that `js_call.window_id` is trustworthy; this
change makes the runtime independent of it either way.

## Test

No automated coverage: reproducing the drift requires the CEF/Windows backend,
which isn't available in CI. The fix does not depend on reproducing it — it
removes the runtime's dependency on the untrusted per-call id rather than
matching around it. Verified locally that both crates compile and
`cargo test -p denort desktop` passes.