### PR TITLE
fix(desktop): discover deno.json in the project dir for `deno desktop .`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -643,12 +643,23 @@ impl FlagsExt for Flags {
       | Compile(CompileFlags {
         source_file: script,
         ..
-      })
-      | Desktop(DesktopFlags {
-        source_file: script,
-        ..
       }) => resolve_single_folder_path(script, current_dir, |mut p| {
         if p.pop() { Some(p) } else { None }
+      })
+      .map(|p| vec![p]),
+      Desktop(DesktopFlags {
+        source_file: script,
+        ..
+      }) => resolve_single_folder_path(script, current_dir, |p| {
+        // The desktop entrypoint is commonly a directory (e.g. `deno desktop
+        // .` for framework detection), in which case the config lives in that
+        // directory itself — don't pop up to its parent. Only pop when the
+        // entrypoint is a file.
+        if p.is_dir() {
+          Some(p)
+        } else {
+          p.parent().map(|parent| parent.to_path_buf())
+        }
       })
       .map(|p| vec![p]),
       Task(TaskFlags {
@@ -14313,6 +14324,20 @@ mod tests {
         cwd.join("dir/b.js")
       ])
     );
+
+    // `deno desktop .` (and bare `deno desktop`) runs framework detection on
+    // the current directory, so config discovery must start in that directory
+    // rather than its parent. See issue #35653.
+    let flags = flags_from_vec(svec!["deno", "desktop", "."]).unwrap();
+    assert_eq!(flags.config_path_args(&cwd), Some(vec![cwd.clone()]));
+
+    let flags = flags_from_vec(svec!["deno", "desktop"]).unwrap();
+    assert_eq!(flags.config_path_args(&cwd), Some(vec![cwd.clone()]));
+
+    // An explicit file entrypoint resolves to its containing directory.
+    let flags =
+      flags_from_vec(svec!["deno", "desktop", "sub/main.ts"]).unwrap();
+    assert_eq!(flags.config_path_args(&cwd), Some(vec![cwd.join("sub")]));
   }
 
   #[test]


### PR DESCRIPTION
Fixes #35653.

## Problem

`deno desktop .` (and bare `deno desktop`) silently ignored the `desktop` config block in the project's `deno.json`: the build went to the default output directory instead of the configured `output`, the window kept the default title instead of `app.name`, etc.

## Root cause

The `desktop` subcommand shared its config-file discovery logic with `run`/`compile` in `Flags::config_path_args`. That code resolves the entrypoint and then pops the last path component to get the *containing directory* — correct when the entrypoint is a file like `main.ts`.

But `deno desktop .` uses `"."` as the entrypoint to trigger framework detection on the current directory. Resolving `"."` yields the **project directory**, and popping then moved up to its **parent** — so config discovery started one level above the project and never found its `deno.json`.

## Fix

Give the `desktop` subcommand its own discovery arm: when the resolved entrypoint is a directory (the `deno desktop .` / bare `deno desktop` case), use it directly as the config-discovery start dir; only pop to the parent when the entrypoint is an actual file. `run`/`compile` behavior is unchanged.

Added unit tests covering `deno desktop .`, bare `deno desktop`, and `deno desktop sub/main.ts`.
