### PR TITLE
fix(permissions): split comma-separated paths in --ignore-read

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -8471,7 +8471,10 @@ fn permission_args_parse(
   }
 
   if let Some(read_wl) = matches.remove_many::<String>("ignore-read") {
-    flags.permissions.ignore_read = Some(read_wl.collect());
+    let read_wl = read_wl
+      .flat_map(flat_escape_split_commas)
+      .collect::<Result<Vec<_>, _>>()?;
+    flags.permissions.ignore_read = Some(read_wl);
     debug!("read ignorelist: {:#?}", &flags.permissions.ignore_read);
   }
 
@@ -11168,6 +11171,30 @@ mod tests {
       "run",
       "--ignore-read=something.txt",
       "--ignore-read=something2.txt",
+      "script.ts"
+    ]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Run(RunFlags::new_default(
+          "script.ts".to_string(),
+        )),
+        permissions: PermissionFlags {
+          ignore_read: Some(svec!["something.txt", "something2.txt"]),
+          ..Default::default()
+        },
+        code_cache_enabled: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn ignore_read_ignorelist_comma_separated() {
+    let r = flags_from_vec(svec![
+      "deno",
+      "run",
+      "--ignore-read=something.txt,something2.txt",
       "script.ts"
     ]);
     assert_eq!(


### PR DESCRIPTION
The help text for `--ignore-read` advertises comma-separated paths the same way `--allow-read`/`--deny-read` do (`--ignore-read="/etc,/var/log.txt"`), but the parse site just did a plain `.collect()` with no comma-splitting, so a comma-separated value got stored as one literal string that never matches a real path — the ignore rule silently does nothing. `--ignore-env` handles this correctly via `use_value_delimiter`, which is what made `--ignore-read` stand out as the inconsistent one rather than this being intentional.

Fixed it to go through `flat_escape_split_commas`, same as the adjacent `allow-read`/`deny-read` blocks. Added a test covering the comma-separated case.