### PR TITLE
feat: update laufey to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,7 +4125,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.5",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -6219,7 +6219,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6411,9 +6411,9 @@ dependencies = [
 
 [[package]]
 name = "laufey"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7f33dc9932b2f679c9d5bd2858c986ec10b6014eaa17c83439db5aa4370ddf"
+checksum = "d0560b9568c4bba38e8a9432530917e724867ca873eaf0f263c3a49d39370777"
 dependencies = [
  "bindgen 0.72.1",
  "tokio",
@@ -8917,7 +8917,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9572,7 +9572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/cli/laufey_sums.lock
+++ b/cli/laufey_sums.lock
@@ -12,20 +12,20 @@
 # A `# version: vX.Y.Z` directive (optional) is matched against LAUFEY_VERSION
 # at build time to guard against forgetting to refresh this file.
 #
-# version: v0.4.1
+# version: v0.5.0
 
-07ca19d2aba3aa476f1f39bbc639f62c4b45ab28967ebd296d9782e142cb1411  laufey-cef-aarch64-apple-darwin.tar.gz
-1a4af1e55794c7dac07d72fd7d5e7ac51e2f7059272c56320aadec49f7b7143f  laufey-cef-aarch64-unknown-linux-gnu.tar.gz
-661d0527a6739a3a309e34388bb0f7c3fa622b1e16860c8b60848bdd1b537013  laufey-cef-x86_64-apple-darwin.tar.gz
-bdb383a71986cf6755c1725170a963da274518cbcf6b6c3290308901038ae71f  laufey-cef-x86_64-unknown-linux-gnu.tar.gz
-8e8d99a0c26706ab7b1f089052285c6d24dc6ca8c761786f4b2f3826e31a58ef  laufey-webview-aarch64-apple-darwin.tar.gz
-2e326688b6a1d38373b0843d956dbe7c5608ed2099ed9ce14fe97f6f2d41551b  laufey-webview-aarch64-unknown-linux-gnu.tar.gz
-343bc77076da47a6013c2b510ac8904b5488d31c826b2f98fe0c36f3766b0335  laufey-webview-x86_64-apple-darwin.tar.gz
-acd906560471b7e8deceb897f4c53eeda6392a6eb024f3fef651eabd6122b4c6  laufey-webview-x86_64-unknown-linux-gnu.tar.gz
-904096a7a552e8d04bec4b6b820c8839e42320b9c942269eeef12d92816d5cb7  laufey-winit-aarch64-apple-darwin.tar.gz
-c0400cd56e357626fc4ba35718a75d2dc163892c093e05688b4e3e6ba73276f4  laufey-winit-aarch64-unknown-linux-gnu.tar.gz
-fb08f1b2397f7525c8888a7c0fd6efc303d1291fd28211efbea439f85ab63d0b  laufey-winit-x86_64-apple-darwin.tar.gz
-1415ead0d20ad10a442621dd8550a41259fd0d30ff0c3e980eb6af16629e823e  laufey-winit-x86_64-unknown-linux-gnu.tar.gz
-3c671897594ff179d978f82676ab97a4158a5169adef2de56c4431b87ad48af4  laufey-cef-x86_64-pc-windows-msvc.zip
-f71ab10c4b56f48ca03bd302cda00994c2451dd9094435c6d10169502501bffe  laufey-webview-x86_64-pc-windows-msvc.zip
-2a77acace6c98acb7b2c5345ce02720d8017a344c7246172b8dc4bdcd97a4600  laufey-winit-x86_64-pc-windows-msvc.zip
+3915066260039225a1fbbd0434a1a9805735cc5f409d309a4514ec3cd5666732  laufey-cef-aarch64-apple-darwin.tar.gz
+1093b7be588ba65003c46fd53d716b98f9eec7fcdad729cf05cd92ab7e707559  laufey-cef-aarch64-unknown-linux-gnu.tar.gz
+e3a2f7fa4a37608d8eeb14d9d89a48c02d84524aa24699185dd40cb7fb51dd27  laufey-cef-x86_64-apple-darwin.tar.gz
+c75c9957d64dbffc8470706cc07f22969de716d66ef6cbe722ad87f3890f50cb  laufey-cef-x86_64-unknown-linux-gnu.tar.gz
+050c75c0f91e61fc9f3254f1e6ddc071312f24ee4827fe9a7d10d4c3213b231e  laufey-webview-aarch64-apple-darwin.tar.gz
+14ad8fabf71e991e0c7cb9c2980c86777847176ba184e789fb5d874c4e70150d  laufey-webview-aarch64-unknown-linux-gnu.tar.gz
+6c2b544d466df577fe8c20a66be91db3af224300fd4cd288980bf66d87e90797  laufey-webview-x86_64-apple-darwin.tar.gz
+79ea97868f7c95aa11a2cb617dffe64a337cacdc9b32a54a4ffd038e9a2409a4  laufey-webview-x86_64-unknown-linux-gnu.tar.gz
+e3c2d68c9912fdc54bb0113b72773335aef712b82172b5518e8a4c1ef3d026c2  laufey-winit-aarch64-apple-darwin.tar.gz
+2295085775e47d44aee9616f7027408f1426368bc84bb0cb0e51f1f5784f587c  laufey-winit-aarch64-unknown-linux-gnu.tar.gz
+33818792653bb58745fae440c63d08d160bef00e7dd2f2c01740cff8c8f3d06f  laufey-winit-x86_64-apple-darwin.tar.gz
+ec804f53a8d8fbf5ce0bc7e81dcc34a7c351b2b6d23ce94729645d9f659a11e1  laufey-winit-x86_64-unknown-linux-gnu.tar.gz
+554fda8db70f047ec4bb30dea9b5233f8c30531179fdded04ffe83b2f8814659  laufey-cef-x86_64-pc-windows-msvc.zip
+c0acd5167f56636f1360af27d021568c65d0cbf2c5526f0699a5a99a1cab52b1  laufey-webview-x86_64-pc-windows-msvc.zip
+4708237cf5fe2ae53cd25c8b30f04ba302cceabd15fe4f353bdecbd78cad297b  laufey-winit-x86_64-pc-windows-msvc.zip

--- a/cli/rt_desktop/Cargo.toml
+++ b/cli/rt_desktop/Cargo.toml
@@ -28,7 +28,7 @@ deno_runtime.workspace = true
 deno_snapshots.workspace = true
 deno_terminal.workspace = true
 denort = { path = "../rt" }
-laufey = "0.4.1"
+laufey = "0.5.0"
 libsui.workspace = true
 
 bytes.workspace = true

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -1961,6 +1961,7 @@ mod tests {
         id,
         accelerator,
         enabled,
+        ..
       } => {
         assert_eq!(label, "Save");
         assert_eq!(id.as_deref(), Some("file.save"));

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -47,7 +47,7 @@ use denort::run::RunOptions;
 /// makes the failure mode obvious instead of "the desktop app silently won't
 /// launch".
 const _: () = assert!(
-  laufey::LAUFEY_API_VERSION == 26,
+  laufey::LAUFEY_API_VERSION == 29,
   "LAUFEY_API_VERSION mismatch: update this assert and the prebuilt backend release pin in cli/tools/desktop.rs when laufey bumps its API version",
 );
 
@@ -227,6 +227,7 @@ impl denort::desktop::DesktopApi for WefDesktopApi {
         frameless,
         no_activate,
         transparent_titlebar,
+        ..Default::default()
       },
     );
     let window = self.setup_window_events(window);
@@ -811,6 +812,9 @@ fn desktop_menu_item_to_laufey_menu_item(
       id,
       accelerator,
       enabled,
+      checked: false,
+      icon: None,
+      tooltip: None,
     },
     denort::desktop::MenuItem::Submenu { label, items } => {
       laufey::MenuItem::Submenu {


### PR DESCRIPTION
Bumps the `laufey` capi crate from 0.4.1 to 0.5.0 and refreshes the pinned backend SHA-256 digests in `cli/laufey_sums.lock` from the upstream [v0.5.0 release](https://github.com/littledivy/laufey/releases/tag/v0.5.0).

laufey 0.5.0 bumps `LAUFEY_API_VERSION` to 29 and adds new fields, so `cli/rt_desktop/lib.rs` needed minimal updates to keep compiling:

- Bumped the `LAUFEY_API_VERSION` compile-time assert `26` → `29`.
- `WindowOptions` gained `hidden` and `transparent` — defaulted via `..Default::default()`.
- `MenuItem::Item` gained `checked`, `icon`, and `tooltip` — defaulted to `false`/`None`.

These new capabilities are defaulted for now to keep the update minimal; wiring them through the `denort` desktop ops can be a follow-up.

Beyond the new features, the 0.5.0 backends are built against an older Linux baseline (GLIBC_2.34 / GLIBCXX_3.4.30, down from GLIBC_2.38–2.39 in the previously reported build), so they now run on distributions like Debian 12 (GLIBC_2.36 / GLIBCXX_3.4.30). Together with #35267 (which fixed the `libdenort.so` unpack panic), this resolves the remaining backend-launch failure.

Closes #35271