### PR TITLE
fix(lsp): use UTF-16 columns for JSON parse error diagnostics in import maps

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -66,6 +66,7 @@ use crate::lsp::documents::OpenDocument;
 use crate::lsp::language_server::OnceCellMap;
 use crate::lsp::lint::LspLinter;
 use crate::lsp::logging::lsp_warn;
+use crate::lsp::text::LineIndex;
 use crate::lsp::urls::uri_to_url;
 use crate::sys::CliSys;
 use crate::tools::lint::collect_no_slow_type_diagnostics;
@@ -1573,12 +1574,24 @@ fn import_map_diagnostic_range(
   lsp::Range::default()
 }
 
-fn json_error_range(err: &serde_json::Error) -> lsp::Range {
+fn json_error_range(
+  line_index: &LineIndex,
+  err: &serde_json::Error,
+) -> lsp::Range {
   let line = err.line().saturating_sub(1) as u32;
-  let character = err.column().saturating_sub(1) as u32;
+  // `serde_json::Error::column()` is a UTF-8 byte offset within the line,
+  // not a UTF-16 code unit offset, so it needs to be converted before it
+  // can be used as an LSP `character` position.
+  let byte_col = err.column().saturating_sub(1) as u32;
+  let position = line_index
+    .position_utf16_from_utf8_line_col(line, byte_col)
+    .unwrap_or(lsp::Position {
+      line,
+      character: byte_col,
+    });
   lsp::Range {
-    start: lsp::Position { line, character },
-    end: lsp::Position { line, character },
+    start: position,
+    end: position,
   }
 }
 
@@ -1690,7 +1703,7 @@ pub(crate) fn generate_import_map_diagnostics(
         DenoDiagnostic::ImportMapDiagnostic(format!(
           "Unable to parse import map JSON: {err}"
         ))
-        .to_lsp_diagnostic(&json_error_range(err)),
+        .to_lsp_diagnostic(&json_error_range(&document.line_index, err)),
       ],
       _ => vec![
         DenoDiagnostic::ImportMapDiagnostic(err.to_string())
@@ -2367,6 +2380,52 @@ mod tests {
               "code": "import-map-diagnostic",
               "source": "deno",
               "message": "Unable to parse import map JSON: EOF while parsing a value at line 1 column 13",
+            },
+          ],
+        ],
+      ]),
+    );
+  }
+
+  #[tokio::test]
+  async fn test_import_map_document_json_parse_diagnostic_non_ascii() {
+    // `serde_json::Error::column()` reports a UTF-8 *byte* offset within the
+    // line, not a UTF-16 code unit offset. With a 4-byte emoji (2 UTF-16
+    // units) before the syntax error, naively using `column - 1` as the LSP
+    // `character` overshoots by 2: byte column 24 (1-indexed) naively
+    // becomes character 23, but the emoji only accounts for 2 UTF-16 units
+    // instead of 4 bytes, so the correct character is 21.
+    let (temp_dir, snapshot) = setup(
+      &[(
+        "import-map.json",
+        "{ \"imports\": { \"\u{1F995}\": invalid } }",
+        1,
+        LanguageId::Json,
+      )],
+      Some((
+        "deno.json",
+        r#"{
+        "importMap": "./import-map.json"
+      }"#,
+      )),
+    )
+    .await;
+    let actual = generate_all_import_map_diagnostics(&snapshot);
+    assert_eq!(
+      json!(actual),
+      json!([
+        [
+          url_to_uri(&temp_dir.url().join("import-map.json").unwrap()).unwrap(),
+          [
+            {
+              "range": {
+                "start": { "line": 0, "character": 21 },
+                "end": { "line": 0, "character": 21 },
+              },
+              "severity": 1,
+              "code": "import-map-diagnostic",
+              "source": "deno",
+              "message": "Unable to parse import map JSON: expected value at line 1 column 24",
             },
           ],
         ],

--- a/cli/lsp/text.rs
+++ b/cli/lsp/text.rs
@@ -59,6 +59,24 @@ impl LineIndex {
     }
   }
 
+  /// Given a 0-indexed line and a UTF-8 byte column within that line,
+  /// returns the corresponding LSP position (UTF-16 code units). Useful for
+  /// translating positions from APIs like `serde_json::Error`, which report
+  /// columns as UTF-8 byte offsets rather than UTF-16 code units.
+  pub fn position_utf16_from_utf8_line_col(
+    &self,
+    line: u32,
+    utf8_col: u32,
+  ) -> Option<lsp::Position> {
+    let lc = self
+      .inner
+      .utf16_position_from_utf8_line_col(line, utf8_col)?;
+    Some(lsp::Position {
+      line: lc.line_index as u32,
+      character: lc.column_index as u32,
+    })
+  }
+
   pub fn line_length_utf16(&self, line: u32) -> TextSize {
     self.inner.line_length_utf16(line)
   }

--- a/cli/util/text_encoding.rs
+++ b/cli/util/text_encoding.rs
@@ -261,6 +261,22 @@ impl Utf16Map {
     Some(self.utf16_offsets[line] + TextSize::from(col_utf16))
   }
 
+  /// Given a line index and a UTF-8 byte column *within that line* (both
+  /// 0-indexed), returns the UTF-16 line/column position. This is the
+  /// counterpart to `utf8_to_utf16_offset` for callers (like JSON parse
+  /// error reporting) that only have a per-line byte column rather than an
+  /// absolute document-wide byte offset.
+  pub fn utf16_position_from_utf8_line_col(
+    &self,
+    line: u32,
+    utf8_col: u32,
+  ) -> Option<LineAndColumnIndex> {
+    let line_start_utf8 = *self.utf8_offsets.get(line as usize)?;
+    let utf8_offset = line_start_utf8 + TextSize::from(utf8_col);
+    let utf16_offset = self.utf8_to_utf16_offset(utf8_offset)?;
+    Some(self.position_utf16(utf16_offset))
+  }
+
   fn utf8_to_utf16_col(&self, line: u32, col: TextSize) -> u32 {
     let mut utf16_col = u32::from(col);
 


### PR DESCRIPTION
`json_error_range` in `cli/lsp/diagnostics.rs` takes `serde_json::Error::column()` and treats it as an LSP UTF-16 character offset, but it's actually a UTF-8 byte offset. Doesn't matter for ASCII, but drop an emoji into an `import-map.json` before a syntax error (say 🦕 — 4 bytes, 2 UTF-16 units) and the reported column ends up two characters too far right, so editors squiggle the wrong spot.

Fixed by routing it through the same `LineIndex`/`Utf16Map` conversion the rest of this file already uses for import map diagnostics, and added a test with a non-ASCII key before the broken JSON.
