### PR TITLE
chore: require a distributed KV database via env var

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -802,6 +802,11 @@ static ENV_VARS: &[EnvVar] = &[
     example: None,
   },
   EnvVar {
+    name: "DENO_KV_REQUIRES_DISTRIBUTED_DATABASE",
+    description: "Require Deno.openKv() to resolve to a distributed (remote) database.\nWhen set to \"error\", Deno.openKv() is always exposed and rejects with a\nclear message unless the resolved path is remote. When set to \"warn\", a\nlocal/in-memory fallback is allowed but logs a warning. Used by Deno\nDeploy to surface a clear error when no KV database is attached.",
+    example: None,
+  },
+  EnvVar {
     name: "DENO_EMIT_CACHE_MODE",
     description: "Control if the transpiled sources should be cached.",
     example: None,

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1058,6 +1058,17 @@ impl CliFactory {
         }
       }
 
+      // Deno Deploy: when DENO_KV_REQUIRES_DISTRIBUTED_DATABASE=error, force the
+      // unstable KV feature on so `Deno.openKv()` is always exposed. The open
+      // path then rejects with a clear "no database attached" error instead of
+      // the runtime hiding the API and reporting "Deno.openKv is not a function".
+      if std::env::var("DENO_KV_REQUIRES_DISTRIBUTED_DATABASE").as_deref()
+        == Ok("error")
+        && !checker.check("kv")
+      {
+        checker.enable_feature("kv");
+      }
+
       Ok(Arc::new(checker))
     })
   }

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -1614,6 +1614,15 @@ pub async fn run_with_options(
       // can leak the string here.
       checker.enable_feature(feature.leak());
     }
+    // Mirror cli/factory.rs: force-enable the unstable KV feature when
+    // DENO_KV_REQUIRES_DISTRIBUTED_DATABASE=error so Deno.openKv() is exposed
+    // and surfaces a clear "no database attached" error.
+    if std::env::var("DENO_KV_REQUIRES_DISTRIBUTED_DATABASE").as_deref()
+      == Ok("error")
+      && !checker.check("kv")
+    {
+      checker.enable_feature("kv");
+    }
     checker
   });
   // Resolve a persistent, per-app data directory so origin-bound storage such

--- a/ext/kv/dynamic.rs
+++ b/ext/kv/dynamic.rs
@@ -72,6 +72,39 @@ impl DatabaseHandler for MultiBackendDbHandler {
       *path = format!("{}{}", prefix, path);
     }
 
+    // Deno Deploy: when an attached (distributed) KV database is required,
+    // do not silently fall back to a local/in-memory store. `error` rejects
+    // the open with a clear message; `warn` logs once and allows the fallback.
+    // A distributed database is one served over http(s) (see `remote_or_sqlite`).
+    if let Ok(mode) = std::env::var("DENO_KV_REQUIRES_DISTRIBUTED_DATABASE") {
+      let is_distributed = path
+        .as_deref()
+        .is_some_and(|p| p.starts_with("https://") || p.starts_with("http://"));
+      if !is_distributed {
+        match mode.as_str() {
+          "error" => {
+            return Err(JsErrorBox::type_error(
+              "Deno.openKv() failed: no KV database is attached to this app. \
+               Attach a KV database to your app in the Deno Deploy dashboard, \
+               then redeploy.",
+            ));
+          }
+          "warn" => {
+            static WARNED: std::sync::Once = std::sync::Once::new();
+            WARNED.call_once(|| {
+              log::warn!(
+                "Deno.openKv(): no KV database is attached to this app; using \
+                 a temporary in-memory store. Data will not persist and is not \
+                 shared between instances. Attach a KV database in the Deno \
+                 Deploy dashboard."
+              );
+            });
+          }
+          _ => {}
+        }
+      }
+    }
+
     for (prefixes, handler) in &self.backends {
       for &prefix in *prefixes {
         if prefix.is_empty() {

--- a/tests/specs/run/kv_requires_distributed_database/__test__.jsonc
+++ b/tests/specs/run/kv_requires_distributed_database/__test__.jsonc
@@ -1,0 +1,25 @@
+{
+  "tests": {
+    // No KV database attached + DENO_KV_REQUIRES_DISTRIBUTED_DATABASE=error:
+    // Deno.openKv() is force-exposed (even without --unstable-kv) and rejects
+    // with a clear message instead of "Deno.openKv is not a function".
+    "error_no_database": {
+      "args": "run -A main.ts",
+      "envs": { "DENO_KV_REQUIRES_DISTRIBUTED_DATABASE": "error" },
+      "output": "error.out"
+    },
+    // DENO_KV_REQUIRES_DISTRIBUTED_DATABASE=warn allows the local in-memory
+    // fallback but logs a warning. Requires KV to be enabled (--unstable-kv).
+    "warn_in_memory_fallback": {
+      "args": "run -A --unstable-kv main.ts",
+      "envs": { "DENO_KV_REQUIRES_DISTRIBUTED_DATABASE": "warn" },
+      "output": "warn.out"
+    },
+    // Without the env var, behavior is unchanged: no --unstable-kv means
+    // Deno.openKv is not exposed.
+    "unset_unchanged": {
+      "args": "run -A main.ts",
+      "output": "unset.out"
+    }
+  }
+}

--- a/tests/specs/run/kv_requires_distributed_database/error.out
+++ b/tests/specs/run/kv_requires_distributed_database/error.out
@@ -1,0 +1,2 @@
+typeof openKv: function
+caught: Deno.openKv() failed: no KV database is attached to this app. Attach a KV database to your app in the Deno Deploy dashboard, then redeploy.

--- a/tests/specs/run/kv_requires_distributed_database/main.ts
+++ b/tests/specs/run/kv_requires_distributed_database/main.ts
@@ -1,0 +1,9 @@
+// Probe Deno.openKv() under DENO_KV_REQUIRES_DISTRIBUTED_DATABASE.
+console.log("typeof openKv:", typeof Deno.openKv);
+try {
+  const kv = await Deno.openKv();
+  console.log("opened ok");
+  kv.close();
+} catch (e) {
+  console.log("caught:", (e as Error).message);
+}

--- a/tests/specs/run/kv_requires_distributed_database/unset.out
+++ b/tests/specs/run/kv_requires_distributed_database/unset.out
@@ -1,0 +1,2 @@
+typeof openKv: undefined
+caught: Deno.openKv is not a function

--- a/tests/specs/run/kv_requires_distributed_database/warn.out
+++ b/tests/specs/run/kv_requires_distributed_database/warn.out
@@ -1,0 +1,3 @@
+typeof openKv: function
+Deno.openKv(): no KV database is attached to this app; using a temporary in-memory store. Data will not persist and is not shared between instances. Attach a KV database in the Deno Deploy dashboard.
+opened ok


### PR DESCRIPTION
A platform that attaches Deno KV databases out-of-band (for example Deno
Deploy) has no way today to make a missing database obvious. When no
database is attached, `Deno.openKv()` either is not exposed at all, so
calling it reports the confusing "Deno.openKv is not a function", or it
silently falls back to a per-isolate in-memory store whose data never
persists and is not shared between instances.

This adds a `DENO_KV_REQUIRES_DISTRIBUTED_DATABASE` env var that controls
what happens when `Deno.openKv()` would resolve to a local or in-memory
store rather than a distributed (remote) database. Set to `error`, the
KV API is force-exposed even without `--unstable-kv` and the open rejects
with a clear "no KV database is attached" message. Set to `warn`, the
local fallback is still allowed but a warning is logged once. When the
var is unset, behavior is unchanged. A distributed database is one served
over http(s), matching the remote KV backend.