### PR TITLE
chore: report server kind in control-sock Serving event

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -1192,10 +1192,16 @@ fn wait_for_start(
 
       #[derive(deno_core::serde::Serialize)]
       enum Event {
-        Serving,
+        Serving {
+          #[serde(skip_serializing_if = "Option::is_none")]
+          kind: Option<&'static str>,
+        },
       }
 
-      let mut buf = deno_core::serde_json::to_vec(&Event::Serving).unwrap();
+      let mut buf = deno_core::serde_json::to_vec(&Event::Serving {
+        kind: deno_runtime::deno_http::serving_server_kind(),
+      })
+      .unwrap();
       buf.push(b'\n');
       let _ = tx.write_all(&buf).await;
     });

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -1660,7 +1660,8 @@ function serveHttpOn(context, addr) {
     }
   })();
 
-  op_http_notify_serving();
+  // 1 = "deno-serve"; must match `serving_server_kind()` in lib.rs.
+  op_http_notify_serving(1);
 
   return {
     addr,

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -13,6 +13,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
@@ -1930,14 +1931,32 @@ fn parse_serve_address(input: &str) -> (u8, String, u32, bool) {
 
 pub static SERVE_NOTIFIER: Notify = Notify::const_new();
 
+/// Kind of server that fired the first "serving" notification, as reported
+/// by `op_http_notify_serving`. Zero until the notification fires.
+static SERVE_KIND: AtomicU32 = AtomicU32::new(0);
+
+/// Returns the kind of server that triggered [`SERVE_NOTIFIER`]:
+/// `"deno-serve"` for `Deno.serve`, `"node-http"` for a `node:http` or
+/// `node:https` server, `"node-http2"` for a `node:http2` server, or
+/// `None` when unknown.
+pub fn serving_server_kind() -> Option<&'static str> {
+  match SERVE_KIND.load(Ordering::Acquire) {
+    1 => Some("deno-serve"),
+    2 => Some("node-http"),
+    3 => Some("node-http2"),
+    _ => None,
+  }
+}
+
 #[op2(fast)]
-fn op_http_notify_serving() {
+fn op_http_notify_serving(#[smi] kind: u32) {
   static ONCE: AtomicBool = AtomicBool::new(false);
 
   if ONCE
     .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
     .is_ok()
   {
+    SERVE_KIND.store(kind, Ordering::Release);
     SERVE_NOTIFIER.notify_one();
   }
 }

--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -115,6 +115,7 @@ const { enqueueNodePerformanceEntry, hasNodeObserverForType } = core
 import {
   applyAddressOverride,
   notifyAddressOverrideServing,
+  SERVER_KIND_NODE_HTTP2,
   startOverrideListener,
 } from "ext:deno_node/internal/http/address_override.js";
 const {
@@ -1640,6 +1641,7 @@ export {
   kServerResponse,
   notifyAddressOverrideServing,
   Server,
+  SERVER_KIND_NODE_HTTP2,
   ServerResponse,
   setupConnectionsTracking,
   startOverrideListener,

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -74,6 +74,7 @@ const {
   kIncomingMessage,
   kServerResponse,
   notifyAddressOverrideServing,
+  SERVER_KIND_NODE_HTTP2,
   startOverrideListener,
   Server: HttpServer,
   setupConnectionsTracking,
@@ -5219,7 +5220,10 @@ Http2Server.prototype.listen = function listen(...args) {
       }
       const rewritten = [{ host: applied.host, port: applied.port }];
       if (cb) ArrayPrototypePush(rewritten, cb);
-      this.once("listening", notifyAddressOverrideServing);
+      this.once(
+        "listening",
+        () => notifyAddressOverrideServing(SERVER_KIND_NODE_HTTP2),
+      );
       return FunctionPrototypeApply(
         net.Server.prototype.listen,
         this,

--- a/ext/node/polyfills/internal/http/address_override.js
+++ b/ext/node/polyfills/internal/http/address_override.js
@@ -73,8 +73,13 @@ function consumeOverride() {
   addressOverrideConsumed = true;
 }
 
-function notifyAddressOverrideServing() {
-  op_http_notify_serving();
+// Server kind codes for op_http_notify_serving. Must match
+// `serving_server_kind()` in ext/http/lib.rs.
+const SERVER_KIND_NODE_HTTP = 2;
+const SERVER_KIND_NODE_HTTP2 = 3;
+
+function notifyAddressOverrideServing(kind = SERVER_KIND_NODE_HTTP) {
+  op_http_notify_serving(kind);
 }
 
 // Translate an override record into the argument for denoListen().
@@ -522,7 +527,9 @@ function startOverrideListener(
   }
 
   server[kOverrideListener] = denoListener;
-  notifyAddressOverrideServing();
+  notifyAddressOverrideServing(
+    alpnRouting ? SERVER_KIND_NODE_HTTP2 : SERVER_KIND_NODE_HTTP,
+  );
 
   (async () => {
     try {
@@ -623,5 +630,7 @@ function applyAddressOverride() {
 export {
   applyAddressOverride,
   notifyAddressOverrideServing,
+  SERVER_KIND_NODE_HTTP,
+  SERVER_KIND_NODE_HTTP2,
   startOverrideListener,
 };

--- a/tests/specs/run/unconfigured/main.out
+++ b/tests/specs/run/unconfigured/main.out
@@ -1,9 +1,13 @@
 true
 hello world
-EVENT: "Serving"
+EVENT: {"Serving":{"kind":"deno-serve"}}
 
 [Object: null prototype] { success: true, code: 0, signal: null }
 node listening
-NODE EVENT: "Serving"
+NODE EVENT: {"Serving":{"kind":"node-http"}}
+
+[Object: null prototype] { success: true, code: 0, signal: null }
+http2 listening
+HTTP2 EVENT: {"Serving":{"kind":"node-http2"}}
 
 [Object: null prototype] { success: true, code: 0, signal: null }

--- a/tests/specs/run/unconfigured/main.ts
+++ b/tests/specs/run/unconfigured/main.ts
@@ -119,3 +119,68 @@ console.log(
 );
 
 console.log(await nodeChild.status);
+
+const h2SockPath = `${tempDirPath}/h2-control.sock`;
+const h2OverrideSockPath = `${tempDirPath}/h2-override.sock`;
+const h2TestPath = `${tempDirPath}/h2_test.ts`;
+
+const h2Command = new Deno.Command(Deno.execPath(), {
+  env: {
+    DENO_UNSTABLE_CONTROL_SOCK: `unix:${h2SockPath}`,
+  },
+});
+
+const h2Child = h2Command.spawn();
+
+i = 0;
+while (true) {
+  try {
+    await Deno.lstat(h2SockPath);
+    break;
+  } catch {}
+
+  i += 1;
+  if (i > 100) {
+    throw new Error(`${h2SockPath} did not exist`);
+  }
+
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+const h2Sock = await Deno.connect({
+  transport: "unix",
+  path: h2SockPath,
+});
+
+Deno.writeTextFileSync(
+  h2TestPath,
+  `
+import http2 from "node:http2";
+const server = http2.createServer();
+server.listen(0, () => {
+  console.log("http2 listening");
+  server.close();
+});
+`,
+);
+
+const h2Data = JSON.stringify({
+  cwd: tempDirPath,
+  args: ["run", "-A", "h2_test.ts"],
+  env: [
+    ["DENO_AUTO_SERVE", "1"],
+    ["DENO_SERVE_ADDRESS", `duplicate,unix:${h2OverrideSockPath}`],
+  ],
+});
+
+await h2Sock.write(new TextEncoder().encode(h2Data + "\n"));
+
+const h2Buf = new Uint8Array(128);
+const h2N = await h2Sock.read(h2Buf);
+
+console.log(
+  "HTTP2 EVENT:",
+  new TextDecoder().decode(h2Buf.subarray(0, h2N)),
+);
+
+console.log(await h2Child.status);

--- a/tests/specs/run/unstable_cron_socket_serve_reject/test_runner.js
+++ b/tests/specs/run/unstable_cron_socket_serve_reject/test_runner.js
@@ -119,7 +119,10 @@ async function readControlMessages() {
       if (!line.trim()) continue;
 
       const msg = JSON.parse(line);
-      if (msg === "Serving") {
+      if (
+        msg === "Serving" ||
+        (typeof msg === "object" && msg !== null && "Serving" in msg)
+      ) {
         receivedServing = true;
         console.error("[CONTROL CLIENT] Received Serving signal from Deno");
 


### PR DESCRIPTION
The DENO_UNSTABLE_CONTROL_SOCK "Serving" notification did not say what
kind of server triggered it, so a supervising process could not tell a
Deno.serve server apart from a node:http or node:http2 server. That
distinction matters for proxying: node:http servers cannot handle HTTP/2,
because node's http2 compat API is incompatible with frameworks like
express that replace the req/res prototypes with http.IncomingMessage and
ServerResponse, so a proxy in front of them has to downgrade HTTP/2
requests to HTTP/1.1 while keeping HTTP/2 end-to-end for servers that do
support it.

This reports the kind in the event, as {"Serving":{"kind":"deno-serve"}}
for Deno.serve, "node-http" for node:http and node:https servers, and
"node-http2" for node:http2 servers. The op that fires the notification
now takes a numeric kind and the first notification wins; the node
override listener reports node-http2 when ALPN routing is configured and
node-http otherwise. The unconfigured spec test is extended with a
node:http2 server case.