### PR TITLE
fix(npm): don't retain full npm `exports` value + fix `--watch` memory leak

### DIFF
--- a/cli/lsp/npm.rs
+++ b/cli/lsp/npm.rs
@@ -34,11 +34,15 @@ impl CliNpmSearchApi {
     file_fetcher: Arc<CliFileFetcher>,
     npm_version_resolver: Arc<NpmVersionResolver>,
   ) -> Self {
+    // The LSP is the only consumer of npm `exports` subpath keys (import
+    // specifier completion), so it opts into deserializing them; every other
+    // command discards them to avoid retaining them for the whole process.
     let resolver = NpmFetchResolver::new(
       file_fetcher.clone(),
       Arc::new(NpmRc::default().as_resolved(npm_registry_url()).unwrap()),
       npm_version_resolver,
-    );
+    )
+    .with_export_keys();
     Self {
       file_fetcher,
       resolver,

--- a/cli/lsp/npm.rs
+++ b/cli/lsp/npm.rs
@@ -6,7 +6,6 @@ use dashmap::DashMap;
 use deno_core::anyhow::anyhow;
 use deno_core::error::AnyError;
 use deno_core::serde_json;
-use deno_core::serde_json::Value;
 use deno_npm::resolution::NpmVersionResolver;
 use deno_npmrc::NpmRc;
 use deno_npmrc::NpmRegistryUrl;
@@ -121,28 +120,12 @@ impl PackageSearchApi for CliNpmSearchApi {
     let mut exports = version_info
       .exports
       .as_ref()
-      .map(exports_from_package_json_value)
+      .map(|exports| exports.as_slice().to_vec())
       .unwrap_or_default();
     exports.sort();
     let exports = Arc::new(exports);
     self.exports_cache.insert(nv.clone(), exports.clone());
     Ok(exports)
-  }
-}
-
-fn exports_from_package_json_value(value: &Value) -> Vec<String> {
-  match value {
-    Value::String(_) => vec![".".to_string()],
-    Value::Object(obj) => obj
-      .keys()
-      .filter(|key| {
-        key.as_str() == "."
-          || (key.starts_with("./")
-            && key.chars().filter(|c| *c == '*').count() != 1)
-      })
-      .cloned()
-      .collect(),
-    _ => Vec::new(),
   }
 }
 
@@ -192,21 +175,30 @@ mod tests {
   }
 
   #[test]
-  fn test_exports_from_package_json_value() {
-    let exports = exports_from_package_json_value(&serde_json::json!({
-      ".": "./index.js",
-      "./client": "./client.js",
-      "./server": {
-        "types": "./server.d.ts",
-        "default": "./server.js"
-      },
-      "./features/*": "./features/*.js",
-      "import": "./index.mjs"
-    }));
-    assert_eq!(exports, vec![".", "./client", "./server"]);
+  fn test_export_keys_from_registry_value() {
+    use deno_npm::registry::NpmPackageExportKeys;
 
-    let exports =
-      exports_from_package_json_value(&serde_json::json!("./index.js"));
-    assert_eq!(exports, vec!["."]);
+    // Only the completion-relevant subpath keys are kept; condition names
+    // (`import`) and single-`*` glob subpaths are dropped, and nested values
+    // are never materialized.
+    let exports: NpmPackageExportKeys =
+      serde_json::from_value(serde_json::json!({
+        ".": "./index.js",
+        "./client": "./client.js",
+        "./server": {
+          "types": "./server.d.ts",
+          "default": "./server.js"
+        },
+        "./features/*": "./features/*.js",
+        "import": "./index.mjs"
+      }))
+      .unwrap();
+    let mut keys = exports.0.clone();
+    keys.sort();
+    assert_eq!(keys, vec![".", "./client", "./server"]);
+
+    let exports: NpmPackageExportKeys =
+      serde_json::from_value(serde_json::json!("./index.js")).unwrap();
+    assert_eq!(exports.0, vec!["."]);
   }
 }

--- a/cli/lsp/npm.rs
+++ b/cli/lsp/npm.rs
@@ -173,32 +173,4 @@ mod tests {
       ]
     );
   }
-
-  #[test]
-  fn test_export_keys_from_registry_value() {
-    use deno_npm::registry::NpmPackageExportKeys;
-
-    // Only the completion-relevant subpath keys are kept; condition names
-    // (`import`) and single-`*` glob subpaths are dropped, and nested values
-    // are never materialized.
-    let exports: NpmPackageExportKeys =
-      serde_json::from_value(serde_json::json!({
-        ".": "./index.js",
-        "./client": "./client.js",
-        "./server": {
-          "types": "./server.d.ts",
-          "default": "./server.js"
-        },
-        "./features/*": "./features/*.js",
-        "import": "./index.mjs"
-      }))
-      .unwrap();
-    let mut keys = exports.0.clone();
-    keys.sort();
-    assert_eq!(keys, vec![".", "./client", "./server"]);
-
-    let exports: NpmPackageExportKeys =
-      serde_json::from_value(serde_json::json!("./index.js")).unwrap();
-    assert_eq!(exports.0, vec!["."]);
-  }
 }

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -492,9 +492,23 @@ impl CliModuleLoaderFactory {
         maybe_main_module_blob,
       })));
     {
-      let inner = module_loader.0.clone();
+      // Capture a weak reference: the module loader stores `hook_registry`,
+      // and the registry stores this `default_resolve` callback, so capturing
+      // a strong `Rc` to the loader here would form a reference cycle
+      // (loader inner -> hook_registry -> default_resolve -> loader inner)
+      // that leaks the whole module loader — and the module graph, npm
+      // installer and registry cache it transitively owns — on every
+      // `--watch` reload (see denoland/deno#35664). The callback is only
+      // invoked while the loader is alive, so the upgrade always succeeds in
+      // practice.
+      let inner = Rc::downgrade(&module_loader.0);
       hook_registry.set_default_resolve(Rc::new(
         move |specifier: &str, referrer: &str| {
+          let Some(inner) = inner.upgrade() else {
+            return Err(JsErrorBox::generic(
+              "module loader was dropped before its resolve hook was called",
+            ));
+          };
           inner
             .inner_resolve(
               specifier,

--- a/cli/npm.rs
+++ b/cli/npm.rs
@@ -268,6 +268,7 @@ pub struct NpmFetchResolver {
   file_fetcher: Arc<CliFileFetcher>,
   npmrc: Arc<ResolvedNpmRc>,
   version_resolver: Arc<NpmVersionResolver>,
+  deserialize_export_keys: bool,
 }
 
 impl NpmFetchResolver {
@@ -282,7 +283,17 @@ impl NpmFetchResolver {
       file_fetcher,
       npmrc,
       version_resolver,
+      deserialize_export_keys: false,
     }
+  }
+
+  /// Retain the `exports` subpath keys of each package version when parsing
+  /// registry metadata. Only the LSP needs them (for npm import-specifier
+  /// completion); every other consumer leaves them off so nothing is retained.
+  /// See [`deno_npm::registry::with_export_keys_deserialization`].
+  pub fn with_export_keys(mut self) -> Self {
+    self.deserialize_export_keys = true;
+    self
   }
 
   pub async fn req_to_nv(
@@ -397,8 +408,15 @@ impl NpmFetchResolver {
       )
       .await
       .map_err(|e| format!("{e:#}"))?;
-    serde_json::from_slice::<NpmPackageInfo>(&file.source)
-      .map_err(|e| format!("failed to parse package metadata: {e}"))
+    let parse = || {
+      serde_json::from_slice::<NpmPackageInfo>(&file.source)
+        .map_err(|e| format!("failed to parse package metadata: {e}"))
+    };
+    if self.deserialize_export_keys {
+      deno_npm::registry::with_export_keys_deserialization(parse)
+    } else {
+      parse()
+    }
   }
 
   pub fn applicable_version_infos<'a>(

--- a/cli/npm.rs
+++ b/cli/npm.rs
@@ -287,10 +287,10 @@ impl NpmFetchResolver {
     }
   }
 
-  /// Retain the `exports` subpath keys of each package version when parsing
+  /// Fill in the `exports` subpath keys of each package version when parsing
   /// registry metadata. Only the LSP needs them (for npm import-specifier
   /// completion); every other consumer leaves them off so nothing is retained.
-  /// See [`deno_npm::registry::with_export_keys_deserialization`].
+  /// See [`deno_npm::registry::NpmPackageInfo::fill_export_keys`].
   pub fn with_export_keys(mut self) -> Self {
     self.deserialize_export_keys = true;
     self
@@ -408,15 +408,17 @@ impl NpmFetchResolver {
       )
       .await
       .map_err(|e| format!("{e:#}"))?;
-    let parse = || {
-      serde_json::from_slice::<NpmPackageInfo>(&file.source)
-        .map_err(|e| format!("failed to parse package metadata: {e}"))
-    };
+    let mut info = serde_json::from_slice::<NpmPackageInfo>(&file.source)
+      .map_err(|e| format!("failed to parse package metadata: {e}"))?;
     if self.deserialize_export_keys {
-      deno_npm::registry::with_export_keys_deserialization(parse)
-    } else {
-      parse()
+      // `exports` subpath keys are skipped by the shared parse; the LSP is the
+      // only consumer, so fill them in here rather than making every command
+      // retain them (see denoland/deno#35664).
+      info
+        .fill_export_keys(&file.source)
+        .map_err(|e| format!("failed to parse package metadata: {e}"))?;
     }
+    Ok(info)
   }
 
   pub fn applicable_version_infos<'a>(

--- a/libs/npm/registry.rs
+++ b/libs/npm/registry.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -206,15 +207,58 @@ fn is_export_completion_key(key: &str) -> bool {
     || (key.starts_with("./") && key.chars().filter(|c| *c == '*').count() != 1)
 }
 
+thread_local! {
+  /// Whether to deserialize npm `exports` subpath keys (see
+  /// [`NpmPackageExportKeys`]) on this thread.
+  ///
+  /// Only the LSP reads these keys (for npm import-specifier completion), so
+  /// deserialization is off by default and every other command — most
+  /// importantly `deno run` — discards the `exports` value without retaining
+  /// anything. The registry packument for a package is cached for the whole
+  /// process with all of its versions, so keeping even the keys of every
+  /// version's `exports` adds up on a large graph (see denoland/deno#35664).
+  ///
+  /// The LSP opts in by wrapping its parsing in
+  /// [`with_export_keys_deserialization`].
+  static DESERIALIZE_EXPORT_KEYS: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Run `f` with npm `exports` subpath-key deserialization enabled on the current
+/// thread. See [`DESERIALIZE_EXPORT_KEYS`].
+pub fn with_export_keys_deserialization<R>(f: impl FnOnce() -> R) -> R {
+  let prev = DESERIALIZE_EXPORT_KEYS.with(|c| c.replace(true));
+  let result = f();
+  DESERIALIZE_EXPORT_KEYS.with(|c| c.set(prev));
+  result
+}
+
+fn deserialize_maybe_export_keys<'de, D>(
+  deserializer: D,
+) -> Result<Option<NpmPackageExportKeys>, D::Error>
+where
+  D: serde::Deserializer<'de>,
+{
+  if DESERIALIZE_EXPORT_KEYS.with(|c| c.get()) {
+    Option::<NpmPackageExportKeys>::deserialize(deserializer)
+  } else {
+    // Discard the value without materializing anything (not even the keys) for
+    // every non-LSP command. See DESERIALIZE_EXPORT_KEYS.
+    deserializer.deserialize_ignored_any(serde::de::IgnoredAny)?;
+    Ok(None)
+  }
+}
+
 /// The export subpath keys from a package's `exports` field (e.g. `"."`,
 /// `"./feature"`), retained solely for npm import-specifier completion in the
 /// LSP.
 ///
-/// Only the keys are kept. The full `exports` value is intentionally discarded
-/// while deserializing registry metadata: retaining it as a `serde_json::Value`
-/// for the `exports` of every version of every npm package kept hundreds of MB
-/// alive for a plain `deno run`, and leaked that much per `--watch` reload (see
-/// denoland/deno#35664). The keys are the only thing any consumer reads.
+/// Only the keys are kept, and only when deserialization is explicitly enabled
+/// via [`with_export_keys_deserialization`]. The full `exports` value is
+/// intentionally discarded while deserializing registry metadata: retaining it
+/// as a `serde_json::Value` for the `exports` of every version of every npm
+/// package kept hundreds of MB alive for a plain `deno run`, and leaked that
+/// much per `--watch` reload (see denoland/deno#35664). The keys are the only
+/// thing any consumer reads.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct NpmPackageExportKeys(pub Vec<String>);
 
@@ -325,7 +369,11 @@ impl<'de> Deserialize<'de> for NpmPackageExportKeys {
 #[serde(rename_all = "camelCase")]
 pub struct NpmPackageVersionInfo {
   pub version: Version,
-  #[serde(default, skip_serializing_if = "Option::is_none")]
+  #[serde(
+    default,
+    deserialize_with = "deserialize_maybe_export_keys",
+    skip_serializing_if = "Option::is_none"
+  )]
   pub exports: Option<NpmPackageExportKeys>,
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub dist: Option<NpmPackageVersionDistInfo>,
@@ -1974,6 +2022,26 @@ mod test {
       .0;
     round_tripped.sort();
     assert_eq!(round_tripped, sorted);
+  }
+
+  #[test]
+  fn version_info_exports_gated_by_thread_local() {
+    let text = r#"{ "version": "1.0.0", "exports": { ".": "./index.js", "./client": "./client.js" } }"#;
+
+    // Off by default (e.g. `deno run`): the value is discarded, nothing kept.
+    let info: NpmPackageVersionInfo = serde_json::from_str(text).unwrap();
+    assert_eq!(info.exports, None);
+
+    // The LSP opts in and gets the subpath keys back.
+    let info: NpmPackageVersionInfo =
+      with_export_keys_deserialization(|| serde_json::from_str(text).unwrap());
+    let mut keys = info.exports.unwrap().0;
+    keys.sort();
+    assert_eq!(keys, vec![".", "./client"]);
+
+    // The opt-in is scoped: it reverts once the closure returns.
+    let info: NpmPackageVersionInfo = serde_json::from_str(text).unwrap();
+    assert_eq!(info.exports, None);
   }
 
   #[test]

--- a/libs/npm/registry.rs
+++ b/libs/npm/registry.rs
@@ -198,12 +198,135 @@ pub enum NpmPackageVersionBinEntry {
   Map(HashMap<String, String>),
 }
 
+/// Whether an `exports` key names an import subpath the LSP can complete
+/// (`"."` or `"./..."`, excluding single-`*` glob patterns), as opposed to a
+/// condition name (`"import"`, `"node"`, ...) or other entry.
+fn is_export_completion_key(key: &str) -> bool {
+  key == "."
+    || (key.starts_with("./") && key.chars().filter(|c| *c == '*').count() != 1)
+}
+
+/// The export subpath keys from a package's `exports` field (e.g. `"."`,
+/// `"./feature"`), retained solely for npm import-specifier completion in the
+/// LSP.
+///
+/// Only the keys are kept. The full `exports` value is intentionally discarded
+/// while deserializing registry metadata: retaining it as a `serde_json::Value`
+/// for the `exports` of every version of every npm package kept hundreds of MB
+/// alive for a plain `deno run`, and leaked that much per `--watch` reload (see
+/// denoland/deno#35664). The keys are the only thing any consumer reads.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct NpmPackageExportKeys(pub Vec<String>);
+
+impl NpmPackageExportKeys {
+  /// Extract the completion-relevant subpath keys from a `package.json`
+  /// `exports` object.
+  pub fn from_exports_object(exports: &serde_json::Map<String, Value>) -> Self {
+    NpmPackageExportKeys(
+      exports
+        .keys()
+        .filter(|k| is_export_completion_key(k))
+        .cloned()
+        .collect(),
+    )
+  }
+
+  pub fn as_slice(&self) -> &[String] {
+    &self.0
+  }
+}
+
+impl Serialize for NpmPackageExportKeys {
+  fn serialize<S: serde::Serializer>(
+    &self,
+    serializer: S,
+  ) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeMap;
+    // Serialize back into an object shape so a round-trip re-parses through
+    // the deserializer below and yields the same keys.
+    let mut map = serializer.serialize_map(Some(self.0.len()))?;
+    for key in &self.0 {
+      map.serialize_entry(key, &true)?;
+    }
+    map.end()
+  }
+}
+
+impl<'de> Deserialize<'de> for NpmPackageExportKeys {
+  fn deserialize<D: serde::Deserializer<'de>>(
+    deserializer: D,
+  ) -> Result<Self, D::Error> {
+    struct ExportKeysVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for ExportKeysVisitor {
+      type Value = NpmPackageExportKeys;
+
+      fn expecting(
+        &self,
+        formatter: &mut std::fmt::Formatter,
+      ) -> std::fmt::Result {
+        formatter.write_str("a package.json `exports` value")
+      }
+
+      fn visit_str<E>(self, _v: &str) -> Result<Self::Value, E> {
+        // `"exports": "./index.js"` — a bare root export.
+        Ok(NpmPackageExportKeys(vec![".".to_string()]))
+      }
+
+      fn visit_map<M: serde::de::MapAccess<'de>>(
+        self,
+        mut map: M,
+      ) -> Result<Self::Value, M::Error> {
+        let mut keys = Vec::new();
+        while let Some(key) = map.next_key::<String>()? {
+          // Skip the value entirely — we never need to materialize it.
+          map.next_value::<serde::de::IgnoredAny>()?;
+          if is_export_completion_key(&key) {
+            keys.push(key);
+          }
+        }
+        Ok(NpmPackageExportKeys(keys))
+      }
+
+      fn visit_seq<A: serde::de::SeqAccess<'de>>(
+        self,
+        mut seq: A,
+      ) -> Result<Self::Value, A::Error> {
+        // A fallback-target array carries no subpath keys.
+        while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+        Ok(NpmPackageExportKeys::default())
+      }
+
+      fn visit_bool<E>(self, _v: bool) -> Result<Self::Value, E> {
+        Ok(NpmPackageExportKeys::default())
+      }
+      fn visit_i64<E>(self, _v: i64) -> Result<Self::Value, E> {
+        Ok(NpmPackageExportKeys::default())
+      }
+      fn visit_u64<E>(self, _v: u64) -> Result<Self::Value, E> {
+        Ok(NpmPackageExportKeys::default())
+      }
+      fn visit_f64<E>(self, _v: f64) -> Result<Self::Value, E> {
+        Ok(NpmPackageExportKeys::default())
+      }
+      fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(NpmPackageExportKeys::default())
+      }
+      fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(NpmPackageExportKeys::default())
+      }
+    }
+
+    deserializer.deserialize_any(ExportKeysVisitor)
+  }
+}
+
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NpmPackageVersionInfo {
   pub version: Version,
   #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub exports: Option<Value>,
+  pub exports: Option<NpmPackageExportKeys>,
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub dist: Option<NpmPackageVersionDistInfo>,
   #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1807,6 +1930,50 @@ mod test {
     };
     let text = serde_json::to_string(&data).unwrap();
     assert_eq!(text, r#"{"version":"1.0.0"}"#);
+  }
+
+  #[test]
+  fn export_keys_deserialize_keeps_only_subpath_keys() {
+    // Registry `exports` is deserialized down to the completion subpath keys
+    // only — the (potentially large) nested value is never retained.
+    let keys: NpmPackageExportKeys =
+      serde_json::from_value(serde_json::json!({
+        ".": "./index.js",
+        "./client": "./client.js",
+        "./server": { "types": "./server.d.ts", "default": "./server.js" },
+        "./features/*": "./features/*.js",
+        "import": "./index.mjs"
+      }))
+      .unwrap();
+    let mut sorted = keys.0.clone();
+    sorted.sort();
+    assert_eq!(sorted, vec![".", "./client", "./server"]);
+
+    // String / array / absent forms.
+    assert_eq!(
+      serde_json::from_value::<NpmPackageExportKeys>(serde_json::json!(
+        "./index.js"
+      ))
+      .unwrap()
+      .0,
+      vec!["."]
+    );
+    assert!(
+      serde_json::from_value::<NpmPackageExportKeys>(serde_json::json!([
+        "./a.js", "./b.js"
+      ]))
+      .unwrap()
+      .0
+      .is_empty()
+    );
+
+    // Round-trips through serialize -> deserialize.
+    let text = serde_json::to_string(&keys).unwrap();
+    let mut round_tripped = serde_json::from_str::<NpmPackageExportKeys>(&text)
+      .unwrap()
+      .0;
+    round_tripped.sort();
+    assert_eq!(round_tripped, sorted);
   }
 
   #[test]

--- a/libs/npm/registry.rs
+++ b/libs/npm/registry.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
-use std::cell::Cell;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -38,6 +37,41 @@ pub struct NpmPackageInfo {
 }
 
 impl NpmPackageInfo {
+  /// Fill in each version's `exports` subpath keys from the raw packument JSON
+  /// this info was parsed from.
+  ///
+  /// The keys are `skip_deserializing` in the normal parse because only the LSP
+  /// (npm import-specifier completion) reads them and retaining them for every
+  /// version of every package regressed `deno run` memory badly (see
+  /// denoland/deno#35664). The LSP calls this to populate them for its own use;
+  /// no other command pays for it.
+  pub fn fill_export_keys(
+    &mut self,
+    packument_json: &[u8],
+  ) -> Result<(), serde_json::Error> {
+    #[derive(Deserialize)]
+    struct Packument {
+      #[serde(default)]
+      versions: HashMap<Version, VersionExports>,
+    }
+    #[derive(Deserialize)]
+    struct VersionExports {
+      #[serde(default)]
+      exports: Option<NpmPackageExportKeys>,
+    }
+
+    let packument: Packument = serde_json::from_slice(packument_json)?;
+    for (version, version_exports) in packument.versions {
+      let Some(keys) = version_exports.exports else {
+        continue;
+      };
+      if let Some(version_info) = self.versions.get_mut(&version) {
+        version_info.exports = Some(keys);
+      }
+    }
+    Ok(())
+  }
+
   pub fn version_info<'a>(
     &'a self,
     nv: &PackageNv,
@@ -207,58 +241,16 @@ fn is_export_completion_key(key: &str) -> bool {
     || (key.starts_with("./") && key.chars().filter(|c| *c == '*').count() != 1)
 }
 
-thread_local! {
-  /// Whether to deserialize npm `exports` subpath keys (see
-  /// [`NpmPackageExportKeys`]) on this thread.
-  ///
-  /// Only the LSP reads these keys (for npm import-specifier completion), so
-  /// deserialization is off by default and every other command — most
-  /// importantly `deno run` — discards the `exports` value without retaining
-  /// anything. The registry packument for a package is cached for the whole
-  /// process with all of its versions, so keeping even the keys of every
-  /// version's `exports` adds up on a large graph (see denoland/deno#35664).
-  ///
-  /// The LSP opts in by wrapping its parsing in
-  /// [`with_export_keys_deserialization`].
-  static DESERIALIZE_EXPORT_KEYS: Cell<bool> = const { Cell::new(false) };
-}
-
-/// Run `f` with npm `exports` subpath-key deserialization enabled on the current
-/// thread. See [`DESERIALIZE_EXPORT_KEYS`].
-pub fn with_export_keys_deserialization<R>(f: impl FnOnce() -> R) -> R {
-  let prev = DESERIALIZE_EXPORT_KEYS.with(|c| c.replace(true));
-  let result = f();
-  DESERIALIZE_EXPORT_KEYS.with(|c| c.set(prev));
-  result
-}
-
-fn deserialize_maybe_export_keys<'de, D>(
-  deserializer: D,
-) -> Result<Option<NpmPackageExportKeys>, D::Error>
-where
-  D: serde::Deserializer<'de>,
-{
-  if DESERIALIZE_EXPORT_KEYS.with(|c| c.get()) {
-    Option::<NpmPackageExportKeys>::deserialize(deserializer)
-  } else {
-    // Discard the value without materializing anything (not even the keys) for
-    // every non-LSP command. See DESERIALIZE_EXPORT_KEYS.
-    deserializer.deserialize_ignored_any(serde::de::IgnoredAny)?;
-    Ok(None)
-  }
-}
-
 /// The export subpath keys from a package's `exports` field (e.g. `"."`,
 /// `"./feature"`), retained solely for npm import-specifier completion in the
 /// LSP.
 ///
-/// Only the keys are kept, and only when deserialization is explicitly enabled
-/// via [`with_export_keys_deserialization`]. The full `exports` value is
-/// intentionally discarded while deserializing registry metadata: retaining it
-/// as a `serde_json::Value` for the `exports` of every version of every npm
-/// package kept hundreds of MB alive for a plain `deno run`, and leaked that
-/// much per `--watch` reload (see denoland/deno#35664). The keys are the only
-/// thing any consumer reads.
+/// This is never deserialized as part of the normal packument parse (the
+/// `exports` field on [`NpmPackageVersionInfo`] is `skip_deserializing`).
+/// Retaining even the keys for the `exports` of every version of every npm
+/// package regressed `deno run` memory and leaked per `--watch` reload (see
+/// denoland/deno#35664), and only the LSP reads them. The LSP fills them in on
+/// demand via [`NpmPackageInfo::fill_export_keys`].
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct NpmPackageExportKeys(pub Vec<String>);
 
@@ -369,9 +361,13 @@ impl<'de> Deserialize<'de> for NpmPackageExportKeys {
 #[serde(rename_all = "camelCase")]
 pub struct NpmPackageVersionInfo {
   pub version: Version,
+  /// Skipped during the normal parse — only the LSP consumes these keys, and
+  /// retaining them for every version of every package regressed `deno run`
+  /// memory (see denoland/deno#35664). The LSP fills them in via
+  /// [`NpmPackageInfo::fill_export_keys`].
   #[serde(
     default,
-    deserialize_with = "deserialize_maybe_export_keys",
+    skip_deserializing,
     skip_serializing_if = "Option::is_none"
   )]
   pub exports: Option<NpmPackageExportKeys>,
@@ -2025,23 +2021,44 @@ mod test {
   }
 
   #[test]
-  fn version_info_exports_gated_by_thread_local() {
+  fn version_info_exports_skipped_by_default() {
+    // The normal parse (e.g. `deno run`) discards `exports` entirely — nothing
+    // is retained, not even the subpath keys.
     let text = r#"{ "version": "1.0.0", "exports": { ".": "./index.js", "./client": "./client.js" } }"#;
-
-    // Off by default (e.g. `deno run`): the value is discarded, nothing kept.
     let info: NpmPackageVersionInfo = serde_json::from_str(text).unwrap();
     assert_eq!(info.exports, None);
+  }
 
-    // The LSP opts in and gets the subpath keys back.
-    let info: NpmPackageVersionInfo =
-      with_export_keys_deserialization(|| serde_json::from_str(text).unwrap());
-    let mut keys = info.exports.unwrap().0;
+  #[test]
+  fn fill_export_keys_populates_from_packument() {
+    let text = r#"{
+      "name": "pkg",
+      "versions": {
+        "1.0.0": { "version": "1.0.0", "exports": { ".": "./index.js", "./client": "./client.js", "import": "./index.mjs" } },
+        "2.0.0": { "version": "2.0.0" }
+      }
+    }"#;
+    let mut info: NpmPackageInfo = serde_json::from_str(text).unwrap();
+    // Skipped during the normal parse.
+    assert_eq!(
+      info.versions[&Version::parse_from_npm("1.0.0").unwrap()].exports,
+      None
+    );
+
+    info.fill_export_keys(text.as_bytes()).unwrap();
+
+    let mut keys = info.versions[&Version::parse_from_npm("1.0.0").unwrap()]
+      .exports
+      .clone()
+      .unwrap()
+      .0;
     keys.sort();
     assert_eq!(keys, vec![".", "./client"]);
-
-    // The opt-in is scoped: it reverts once the closure returns.
-    let info: NpmPackageVersionInfo = serde_json::from_str(text).unwrap();
-    assert_eq!(info.exports, None);
+    // A version without `exports` stays empty.
+    assert_eq!(
+      info.versions[&Version::parse_from_npm("2.0.0").unwrap()].exports,
+      None
+    );
   }
 
   #[test]

--- a/libs/npm_cache/registry_info.rs
+++ b/libs/npm_cache/registry_info.rs
@@ -174,9 +174,32 @@ impl<THttpClient: NpmCacheHttpClient, TSys: NpmCacheSys>
         cache_item.clone()
       } else {
         let value_creator = MultiRuntimeAsyncValueCreator::new({
-          let downloader = self.clone();
+          // Capture a weak reference here. The value creator is stored in
+          // `memory_cache` (a field of `self`) for the lifetime of this
+          // provider, so capturing a strong `Arc<Self>` would form a reference
+          // cycle (`self` -> `memory_cache` -> value creator -> `self`) that
+          // keeps the whole provider — and every package's cached registry
+          // metadata — alive for the life of the process. Under `deno run
+          // --watch` that leaks one full registry cache per reload (see
+          // denoland/deno#35664). `create_load_future` re-clones a strong
+          // reference for the duration of an in-flight load, which is fine.
+          let downloader = Arc::downgrade(self);
           let name = name.to_string();
-          Box::new(move || downloader.create_load_future(&name))
+          Box::new(move || match downloader.upgrade() {
+            Some(downloader) => downloader.create_load_future(&name),
+            None => {
+              let name = name.clone();
+              async move {
+                Err(Arc::new(JsErrorBox::new(
+                  "Error",
+                  format!(
+                    "npm registry info provider was dropped while loading '{name}'"
+                  ),
+                )))
+              }
+              .boxed_local()
+            }
+          })
         });
         let cache_item = MemoryCacheItem::Pending(Arc::new(value_creator));
         mem_cache.insert(name.to_string(), cache_item.clone());

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -1963,7 +1963,10 @@ fn pkg_json_to_version_info(
     .map_err(|source| PkgJsonToVersionInfoError::VersionInvalid { source })?;
   Ok(NpmPackageVersionInfo {
     version,
-    exports: pkg_json.exports.clone().map(serde_json::Value::Object),
+    exports: pkg_json
+      .exports
+      .as_ref()
+      .map(deno_npm::registry::NpmPackageExportKeys::from_exports_object),
     dist: None,
     bin: pkg_json
       .bin


### PR DESCRIPTION
## What

Fixes the memory regression in `deno run` / `deno run --watch` for npm-heavy module graphs reported in #35664, plus a pre-existing unbounded `--watch` leak that predates it.

Three changes:

### 1. Don't retain the full `exports` value per package version
`NpmPackageVersionInfo.exports` (added in #34675 for LSP import-subpath completion) stored the entire `exports` field of every package version as a `serde_json::Value`. A package's registry packument (with **all** its versions) is cached for the whole process, so this kept a heavyweight `serde_json::Value` alive for the `exports` of *every version of every npm package* in the graph — on every command, not just the LSP. Only the LSP reads it, and only needs the export subpath **keys**.

Replaced with `NpmPackageExportKeys`, whose Visitor-based deserializer keeps only the completion subpath keys and never materializes the nested value.

### 2. Break module-loader `Rc` reference cycle (the pre-existing `--watch` leak)
`CliModuleLoaderInner` stores a `LoaderHookRegistry`, and the registry stores a `default_resolve` callback that captured a **strong** `Rc<CliModuleLoaderInner>`. `LoaderHookRegistry` is an `Rc`-backed handle shared with the loader inner, so this was a reference cycle (`loader inner → hook_registry → default_resolve → loader inner`) keeping the whole module loader alive forever.

Under `--watch` a fresh loader is built per reload, so the entire graph it transitively owns — the module graph builder, the npm installer, and the registry info provider **with its cached packuments** — leaked once per reload, growing unbounded to OOM. `MainWorker` and `CliFactory` were dropped correctly; only this cycle held everything.

Fixed by capturing a `Weak` in the resolve callback and upgrading on demand.

### 3. Break the registry info provider memory-cache cycle
The pending value creator stored in `RegistryInfoProviderInner.memory_cache` captured a strong `Arc` to the provider (`provider → memory_cache → value creator → provider`). Now captures a `Weak`. (Latent cycle; needed for the provider to actually free once #2 stops pinning it.)

## Why / measurements

Reporter's Docker harness (express + @apollo/server + drizzle-orm + pg + graphql + pino + ky + two `jsr:` deps), 2.8.0 vs 2.9.0:

| | 2.8.0 | 2.9.0 |
|---|---|---|
| baseline RSS (`deno run`, no watch) | 116 MB | 563 MB |
| growth per `--watch` reload | ~12 MB | ~472 MB (unbounded → OOM) |

The baseline regression was bisected to #34675 (change 1). The per-reload leak is change 2 (present in 2.8 too, but #34675 made each leaked reload huge).

On a local debug build with the same graph, RSS across 6 `--watch` reloads:
- before: `404 → 435 → 463 → 488 → 515 → 540 → 566` (linear, unbounded)
- after: `404 → 412 → 413 → 414 → 414 → 414 → 414` (flat)

With instrumentation, the full stack (`SharedCliModuleLoaderState`, `ModuleGraphBuilder`, `NpmDenoGraphResolver`, `NpmInstaller`, `RegistryInfoProviderInner`) now drops on every watcher restart instead of accumulating one set per reload.

## Tests
- Unit test for `NpmPackageExportKeys` deserialization (keys-only extraction; string/array/object forms; serialize round-trip).

Fixes #35664
