### PR TITLE
feat(node): implement getTestContext() in node:test

### DIFF
--- a/cli/tsc/dts/node/test.d.cts
+++ b/cli/tsc/dts/node/test.d.cts
@@ -1444,6 +1444,27 @@ declare module "node:test" {
          */
         function afterEach(fn?: HookFn, options?: HookOptions): void;
         /**
+         * This function returns the {@link TestContext} of the test that is currently
+         * executing, or `undefined` if there is no test running in the current
+         * asynchronous context. It can be used to access the current test context from
+         * helper functions without having to explicitly pass the context around.
+         *
+         * ```js
+         * import { test, getTestContext } from 'node:test';
+         *
+         * function assertContextName(expected) {
+         *   const ctx = getTestContext();
+         *   assert.strictEqual(ctx.name, expected);
+         * }
+         *
+         * test('example test', () => {
+         *   assertContextName('example test');
+         * });
+         * ```
+         * @since v26.1.0
+         */
+        function getTestContext(): TestContext | undefined;
+        /**
          * The hook function. The first argument is the context in which the hook is called.
          * If the hook uses callbacks, the callback function is passed as the second argument.
          */

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -1460,7 +1460,12 @@ class NodeTestContext {
                 parentContext.#beforeEachHooks,
               )
             ) {
-              await hook();
+              // `t.beforeEach()` hooks run in the parent test's context, so
+              // `getTestContext()` inside them observes the parent (Node).
+              await runInTestContext(
+                parentContext,
+                () => hook(newNodeTextContext),
+              );
             }
             await runPossiblyExpectingFailure(
               prepared.fn,
@@ -1487,7 +1492,11 @@ class NodeTestContext {
                 parentContext.#afterEachHooks,
               )
             ) {
-              await hook();
+              // `t.afterEach()` hooks likewise run in the parent's context.
+              await runInTestContext(
+                parentContext,
+                () => hook(newNodeTextContext),
+              );
             }
           }
         },
@@ -1566,8 +1575,10 @@ class NodeTestContext {
   async _runBeforeHooksOnce() {
     if (this.#beforeHooksRun) return;
     this.#beforeHooksRun = true;
+    // deno-lint-ignore no-this-alias
+    const ctx = this;
     for (const hook of new SafeArrayIterator(this.#beforeHooks)) {
-      await hook();
+      await runInTestContext(ctx, () => hook(ctx));
     }
   }
 
@@ -1577,8 +1588,10 @@ class NodeTestContext {
   async _runAfterHooksOnce() {
     if (this.#afterHooksRun) return;
     this.#afterHooksRun = true;
+    // deno-lint-ignore no-this-alias
+    const ctx = this;
     for (const hook of new SafeArrayIterator(this.#afterHooks)) {
-      await hook();
+      await runInTestContext(ctx, () => hook(ctx));
     }
   }
 }
@@ -1611,6 +1624,24 @@ function getTestContextALS() {
 function getCurrentTestContext() {
   if (testContextALS === null) return null;
   return testContextALS.getStore() ?? null;
+}
+
+// node:test `getTestContext()` (Node v26.1.0+). Returns the TestContext /
+// SuiteContext of the test, subtest, or hook currently executing, or
+// `undefined` when called outside of any test. It reads the same
+// AsyncLocalStorage that routes nested `test()` calls (see getTestContextALS):
+// every test/it body runs within it, and each hook is executed inside the ALS
+// scope of the context it was registered on (see runInTestContext) so a hook
+// observes its owning test/suite context rather than the subtest it runs for.
+function getTestContext() {
+  return getCurrentTestContext() ?? undefined;
+}
+
+// Runs `fn` with `ctx` installed as the current test context for the duration
+// of the call, including across its `await` points, so that `getTestContext()`
+// (and nested `test()` routing) observe `ctx` while a hook runs.
+function runInTestContext(ctx, fn) {
+  return getTestContextALS().run(ctx, fn);
 }
 
 const rootBeforeHooks = [];
@@ -1689,13 +1720,19 @@ class TestSuite {
         }
         try {
           for (const hook of new SafeArrayIterator(rootBeforeEachHooks)) {
-            await hook(newNodeTextContext);
+            await runInTestContext(
+              newNodeTextContext,
+              () => hook(newNodeTextContext),
+            );
           }
           for (let i = suiteChain.length - 1; i >= 0; i--) {
+            // A suite's beforeEach() runs in that suite's context, so
+            // `getTestContext()` observes the suite, not the subtest (Node).
+            const suiteCtx = suiteChain[i].nodeTestContext;
             for (
               const hook of new SafeArrayIterator(suiteChain[i].beforeEachHooks)
             ) {
-              await hook(newNodeTextContext);
+              await runInTestContext(suiteCtx, () => hook(newNodeTextContext));
             }
           }
           return await runPossiblyExpectingFailure(
@@ -1711,17 +1748,24 @@ class TestSuite {
           }
         } finally {
           for (let i = 0; i < suiteChain.length; i++) {
+            const suiteCtx = suiteChain[i].nodeTestContext;
             for (
               const hook of new SafeArrayIterator(suiteChain[i].afterEachHooks)
             ) {
               try {
-                await hook(newNodeTextContext);
+                await runInTestContext(
+                  suiteCtx,
+                  () => hook(newNodeTextContext),
+                );
               } catch { /* ignore */ }
             }
           }
           for (const hook of new SafeArrayIterator(rootAfterEachHooks)) {
             try {
-              await hook(newNodeTextContext);
+              await runInTestContext(
+                newNodeTextContext,
+                () => hook(newNodeTextContext),
+              );
             } catch { /* ignore */ }
           }
         }
@@ -1798,7 +1842,7 @@ function wrapTestFn(fn, resolve, name, options) {
     try {
       await runRootBeforeOnce();
       for (const hook of new SafeArrayIterator(rootBeforeEachHooks)) {
-        await hook(nodeTestContext);
+        await runInTestContext(nodeTestContext, () => hook(nodeTestContext));
       }
       beforeEachOk = true;
       await runPossiblyExpectingFailure(fn, nodeTestContext, options);
@@ -1816,7 +1860,10 @@ function wrapTestFn(fn, resolve, name, options) {
       if (beforeEachOk) {
         for (const hook of new SafeArrayIterator(rootAfterEachHooks)) {
           try {
-            await hook(nodeTestContext);
+            await runInTestContext(
+              nodeTestContext,
+              () => hook(nodeTestContext),
+            );
           } catch { /* swallow to match node behavior on hook error */ }
         }
       }
@@ -1865,19 +1912,26 @@ function wrapSuiteFn(fn, resolve, name, parentNodeContext, parentSuite) {
       parentSuite,
     );
     try {
-      fn(suiteNodeContext);
+      // Run the suite body in the suite's context so `getTestContext()` inside
+      // it (and any synchronously-registered hook bodies) observes the suite.
+      runInTestContext(suiteNodeContext, () => fn(suiteNodeContext));
     } finally {
       currentSuite = prevSuite;
     }
     try {
+      // Suite-level before()/after() hooks run in the suite's context and
+      // receive it as their argument, matching Node.
       for (const hook of new SafeArrayIterator(suite.beforeAllHooks)) {
-        await hook();
+        await runInTestContext(suiteNodeContext, () => hook(suiteNodeContext));
       }
       await suite.execute();
     } finally {
       try {
         for (const hook of new SafeArrayIterator(suite.afterAllHooks)) {
-          await hook();
+          await runInTestContext(
+            suiteNodeContext,
+            () => hook(suiteNodeContext),
+          );
         }
       } finally {
         if (isTopLevel) {
@@ -2046,6 +2100,7 @@ test.before = before;
 test.after = after;
 test.beforeEach = beforeEach;
 test.afterEach = afterEach;
+test.getTestContext = getTestContext;
 
 const activeMocks = [];
 
@@ -3412,6 +3467,7 @@ return {
   beforeEach,
   afterEach,
   mock,
+  getTestContext,
   default: test,
 };
 })();

--- a/ext/node/polyfills/testing_esm.ts
+++ b/ext/node/polyfills/testing_esm.ts
@@ -13,6 +13,7 @@ export const {
   beforeEach,
   afterEach,
   mock,
+  getTestContext,
 } = mod;
 
 export default mod.default;

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -5244,6 +5244,7 @@
       "darwin": false,
       "reason": "error: Uncaught AssertionError: ifError got unwanted exception: ifError got unwa"
     },
+    "parallel/test-runner-get-test-context.js": {},
     "parallel/test-runner-global-setup-watch-mode.mjs": {
       "linux": false,
       "darwin": false,


### PR DESCRIPTION
## Summary

Implements `getTestContext()` for `node:test`, closing #35659. The method was added in Node v26.1.0 and returns the `TestContext` of the currently running test/subtest/hook, letting helper functions access the current context without it being passed explicitly. Before this change it existed neither as a runtime export nor as a type, so the issue's repro failed with both a `TS2724 ... has no exported member named 'getTestContext'` type error and a runtime `SyntaxError: ... does not provide an export named 'getTestContext'`.

## Changes

- **`ext/node/polyfills/testing.ts`** — implement `getTestContext()`, backed by the existing `AsyncLocalStorage` that already routes nested `test()` calls. Returns the current context, or `undefined` when called outside any test. To make it return the correct context inside hooks, each hook is now run within the ALS scope of the context it was registered on (new `runInTestContext` helper):
  - `test`/`it` bodies → their own context (already handled)
  - describe-level `before`/`after`/`beforeEach`/`afterEach` → the suite context (`before`/`after` now also receive the suite context as their argument, matching Node)
  - `t.beforeEach`/`t.afterEach` → the owning parent test's context
- **`ext/node/polyfills/testing_esm.ts`** — re-export `getTestContext` for ESM imports.
- **`cli/tsc/dts/node/test.d.cts`** — add the `getTestContext(): TestContext | undefined` type declaration.
- **`tests/node_compat/config.jsonc`** — register `parallel/test-runner-get-test-context.js` (already present in the Node suite) so it runs in CI.

## Testing

- The node_compat test `test-runner-get-test-context.js` passes (all 7 tests: top-level test, nested subtest, describe/it, suite context, describe-level hooks, test-level hooks, and async-continuation cases).
- The issue's repro now type-checks and runs, printing `Running test: example test`. The only remaining TS diagnostic is the correct "`ctx` is possibly undefined", matching Node's own `TestContext | undefined` typing.
- Existing `node:test` hook tests continue to pass; `tools/format.js` and `tools/lint.js --js` are clean.

Closes #35659