### PR TITLE
fix: enable rusqlite "fallible_uint" feature in workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,7 +290,7 @@ reqwest = { version = "=0.12.5", default-features = false, features = ["rustls-t
 # already depends on `zstd`, and modern RPM tooling reads zstd payloads.
 rpm = { version = "0.25.1", default-features = false, features = ["payload", "zstd-compression"] }
 rstest = "0"
-rusqlite = { version = "0.40.0", features = ["unlock_notify", "bundled", "session", "modern_sqlite", "limits", "backup"] } # "modern_sqlite": need sqlite >= 3.49.0 for some db configs
+rusqlite = { version = "0.40.0", features = ["unlock_notify", "bundled", "session", "modern_sqlite", "limits", "backup", "fallible_uint"] } # "modern_sqlite": need sqlite >= 3.49.0 for some db configs; "fallible_uint": ToSql for u64/usize (needed when crates like deno_cache are published/built standalone, not just feature-unified via denokv_sqlite)
 rustls = { version = "=0.23.40", default-features = false, features = ["logging", "std", "tls12", "aws_lc_rs"] }
 rustls-pemfile = "2"
 rustls-tokio-stream = "=0.8.0"


### PR DESCRIPTION
The crate publish workflow fails during tarball verification of
`deno_cache` with:

    error[E0277]: the trait bound `u64: ToSql` is not satisfied
     --> sqlite.rs:408

`ext/cache/sqlite.rs` stores a UNIX timestamp using
`SystemTime::now().duration_since(UNIX_EPOCH)...as_secs()`, which is a
`u64`. As of rusqlite 0.40 the `ToSql` implementations for `u64` and
`usize` are gated behind the `fallible_uint` feature (the conversion to
sqlite`s `i64` can fail, hence "fallible").

In a normal workspace build this feature is enabled transitively by
`denokv_sqlite` (which declares `rusqlite = { features =
["fallible_uint"] }`) and Cargo unifies features across the whole
dependency graph, so `deno_cache` compiles fine. During `cargo publish`
each crate is verified from its own tarball in isolation, where
`denokv_sqlite` is not part of the graph, the feature is no longer
enabled, and the `u64: ToSql` impl disappears.

The fix enables `fallible_uint` directly on the workspace `rusqlite`
dependency so every `rusqlite.workspace = true` consumer (cache, kv,
node_sqlite, webstorage) gets it regardless of whether it is built as
part of the workspace or verified standalone.

Verified with `cargo publish --dry-run -p deno_cache`, which now passes
the verification step that previously failed.