### PR TITLE
fix(check): don't interleave errors with "Check" lines in a workspace

### DIFF
--- a/cli/type_checker.rs
+++ b/cli/type_checker.rs
@@ -245,7 +245,7 @@ impl TypeChecker {
     // diagnostics. Otherwise, in a workspace with multiple folders, errors
     // from one folder would be printed in the middle of the "Check ..." lines
     // of the following folders.
-    let mut all_diagnostics = Vec::new();
+    let mut all_diagnostics = Vec::with_capacity(diagnostics_iter.remaining());
     for result in diagnostics_iter.by_ref() {
       all_diagnostics.push(result?);
     }
@@ -447,6 +447,17 @@ pub struct DiagnosticsByFolderIterator<'a>(
 );
 
 impl DiagnosticsByFolderIterator<'_> {
+  /// Number of folders remaining to be checked, i.e. the exact number of items
+  /// this iterator will still yield.
+  pub fn remaining(&self) -> usize {
+    match &self.0 {
+      DiagnosticsByFolderIteratorInner::Empty(_) => 0,
+      DiagnosticsByFolderIteratorInner::Real(r) => {
+        r.groups.len().saturating_sub(r.current_group_index)
+      }
+    }
+  }
+
   pub fn into_graph(self) -> Arc<ModuleGraph> {
     match self.0 {
       DiagnosticsByFolderIteratorInner::Empty(module_graph) => module_graph,

--- a/cli/type_checker.rs
+++ b/cli/type_checker.rs
@@ -239,10 +239,18 @@ impl TypeChecker {
     graph: ModuleGraph,
     options: CheckOptions,
   ) -> Result<Arc<ModuleGraph>, CheckError> {
-    let mut diagnostics = self.check_diagnostics(graph, options)?;
+    let mut diagnostics_iter = self.check_diagnostics(graph, options)?;
+    // Drain the iterator first so that all the "Check ..." lines (which are
+    // printed while type checking each folder) are emitted before any
+    // diagnostics. Otherwise, in a workspace with multiple folders, errors
+    // from one folder would be printed in the middle of the "Check ..." lines
+    // of the following folders.
+    let mut all_diagnostics = Vec::new();
+    for result in diagnostics_iter.by_ref() {
+      all_diagnostics.push(result?);
+    }
     let mut failed = false;
-    for result in diagnostics.by_ref() {
-      let mut diagnostics = result?;
+    for mut diagnostics in all_diagnostics {
       diagnostics.emit_warnings();
       if diagnostics.has_diagnostic() {
         failed = true;
@@ -260,7 +268,7 @@ impl TypeChecker {
         .into(),
       )
     } else {
-      Ok(diagnostics.into_graph())
+      Ok(diagnostics_iter.into_graph())
     }
   }
 

--- a/tests/specs/check/check_workspace/check_config_flag.out
+++ b/tests/specs/check/check_workspace/check_config_flag.out
@@ -1,4 +1,5 @@
 Check [WILDCARD]main.ts
+Check [WILDCARD]mod.ts
 TS2304 [ERROR]: Cannot find name 'onmessage'.
 onmessage;
 ~~~~~~~~~
@@ -11,7 +12,6 @@ onmessage;
 
 Found 2 errors.
 
-Check [WILDCARD]mod.ts
 TS2304 [ERROR]: Cannot find name 'localStorage'.
 localStorage;
 ~~~~~~~~~~~~

--- a/tests/specs/check/check_workspace/check_discover.out
+++ b/tests/specs/check/check_workspace/check_discover.out
@@ -1,4 +1,5 @@
 Check [WILDCARD]main.ts
+Check [WILDCARD]mod.ts
 TS2304 [ERROR]: Cannot find name 'onmessage'.
 onmessage;
 ~~~~~~~~~
@@ -11,7 +12,6 @@ onmessage;
 
 Found 2 errors.
 
-Check [WILDCARD]mod.ts
 TS2304 [ERROR]: Cannot find name 'localStorage'.
 localStorage;
 ~~~~~~~~~~~~

--- a/tests/specs/check/workspace/root.out
+++ b/tests/specs/check/workspace/root.out
@@ -1,12 +1,12 @@
 Check [WILDCARD]mod.ts
 Check [WILDCARD]mod.ts
 Check [WILDCARD]mod.ts
+Check [WILDCARD]mod.ts
 TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
 const test: string = add(1, 2);
       ~~~~
     at file:///[WILDLINE]/package-b/mod.ts:3:7
 
-Check [WILDCARD]mod.ts
 TS2554 [ERROR]: Expected 2 arguments, but got 1.
 console.log(Math.pow(""));
                  ~~~

--- a/tests/specs/check/workspace_compiler_option_types/root.out
+++ b/tests/specs/check/workspace_compiler_option_types/root.out
@@ -1,5 +1,6 @@
 Check package-a[WILDCHAR]mod.ts
 Check package-c[WILDCHAR]mod.ts
+Check package-b[WILDCHAR]mod.ts
 TS2552 [ERROR]: Cannot find name 'myPackageBGlobal'. Did you mean 'myPackageAGlobal'?
 console.log(myPackageBGlobal);
             ~~~~~~~~~~~~~~~~
@@ -10,7 +11,6 @@ console.log(myPackageBGlobal);
                 ~~~~~~~~~~~~~~~~
         at file:///[WILDLINE]/package-a/globals.d.ts:1:13
 
-Check package-b[WILDCHAR]mod.ts
 TS2552 [ERROR]: Cannot find name 'myPackageAGlobal'. Did you mean 'myPackageBGlobal'?
 console.log(myPackageAGlobal);
             ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #30322.

When type checking a workspace with multiple folders, `deno check` could
print type errors in the middle of the `Check ...` output lines:

```
Check ...
Check ...
Error ...
Check ...
Check ...
```

## Root cause

`TypeChecker::check()` consumes a lazy, per-folder diagnostics iterator.
Each call to the iterator's `next()` prints that folder's `Check ...` line
and runs `tsc`, while the caller emitted that folder's errors immediately
after each iteration step. In a multi-folder workspace this meant errors
from one folder were printed in the middle of the `Check ...` lines of the
following folders.

## Fix

Drain the diagnostics iterator first (which prints all the `Check ...`
lines and runs `tsc` for every folder), then emit warnings and errors, so
all the `Check ...` lines appear before any diagnostics:

```
Check ...
Check ...
Check ...
Error ...
```

## Tests

Three existing spec tests encoded the old interleaved order; their `.out`
files are updated to the correct grouped order:

- `check/check_workspace`
- `check/workspace`
- `check/workspace_compiler_option_types`