### PR TITLE
feat(release): publish npm:@deno/types on release

### DIFF
--- a/tools/deno.lock.json
+++ b/tools/deno.lock.json
@@ -2,11 +2,20 @@
   "version": "5",
   "specifiers": {
     "jsr:@b-fuze/deno-dom@0.1.56": "0.1.56",
+    "jsr:@david/code-block-writer@13": "13.0.3",
     "jsr:@david/console-static-text@0.3": "0.3.4",
+    "jsr:@david/dax@0.42": "0.42.0",
     "jsr:@david/dax@~0.43.2": "0.43.2",
     "jsr:@david/path@0.2": "0.2.0",
     "jsr:@david/which@~0.4.1": "0.4.2",
     "jsr:@deno/rust-automation@0.22.2": "0.22.2",
+    "jsr:@std/assert@0.221": "0.221.0",
+    "jsr:@std/bytes@0.221": "0.221.0",
+    "jsr:@std/io@0.221": "0.221.0",
+    "jsr:@std/streams@0.221": "0.221.0",
+    "jsr:@ts-morph/common@0.28": "0.28.1",
+    "jsr:@ts-morph/ts-morph@27.0.0": "27.0.0",
+    "npm:@types/decompress@4.2.7": "4.2.7",
     "npm:decompress@4.2.1": "4.2.1",
     "npm:octokit@^5.0.3": "5.0.5"
   },
@@ -14,8 +23,20 @@
     "@b-fuze/deno-dom@0.1.56": {
       "integrity": "8030e2dc1d8750f1682b53462ab893d9c3470f2287feecbe22f44a88c54ab148"
     },
+    "@david/code-block-writer@13.0.3": {
+      "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
+    },
     "@david/console-static-text@0.3.4": {
       "integrity": "1c596f500b075ff3c8bab1d328ca7148a88067fd9a506b16a73eeaf230c229fd"
+    },
+    "@david/dax@0.42.0": {
+      "integrity": "0c547c9a20577a6072b90def194c159c9ddab82280285ebfd8268a4ebefbd80b",
+      "dependencies": [
+        "jsr:@david/path",
+        "jsr:@david/which",
+        "jsr:@std/io",
+        "jsr:@std/streams"
+      ]
     },
     "@david/dax@0.43.2": {
       "integrity": "8c7df175465d994c0e3568e3eb91102768c2f1c86d2a513d7fc4cab13f9cb328",
@@ -34,8 +55,37 @@
     "@deno/rust-automation@0.22.2": {
       "integrity": "3ded7edc9bbc11078ba7688f4f48d5d1e78f3e5fdd935b62f7384516a4f5b10c",
       "dependencies": [
-        "jsr:@david/dax",
+        "jsr:@david/dax@~0.43.2",
         "npm:octokit"
+      ]
+    },
+    "@std/assert@0.221.0": {
+      "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
+    },
+    "@std/bytes@0.221.0": {
+      "integrity": "64a047011cf833890a4a2ab7293ac55a1b4f5a050624ebc6a0159c357de91966"
+    },
+    "@std/io@0.221.0": {
+      "integrity": "faf7f8700d46ab527fa05cc6167f4b97701a06c413024431c6b4d207caa010da",
+      "dependencies": [
+        "jsr:@std/assert",
+        "jsr:@std/bytes"
+      ]
+    },
+    "@std/streams@0.221.0": {
+      "integrity": "47f2f74634b47449277c0ee79fe878da4424b66bd8975c032e3afdca88986e61",
+      "dependencies": [
+        "jsr:@std/io"
+      ]
+    },
+    "@ts-morph/common@0.28.1": {
+      "integrity": "9d4a091c590221b21de811d8aa38f624a91706945d40e730de252c24051e4399"
+    },
+    "@ts-morph/ts-morph@27.0.0": {
+      "integrity": "03a93ea311d25a70642db60b376700560a942fc5bfab52718b5e448692d13ed7",
+      "dependencies": [
+        "jsr:@david/code-block-writer",
+        "jsr:@ts-morph/common"
       ]
     }
   },
@@ -235,6 +285,18 @@
     },
     "@types/aws-lambda@8.10.162": {
       "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw=="
+    },
+    "@types/decompress@4.2.7": {
+      "integrity": "sha512-9z+8yjKr5Wn73Pt17/ldnmQToaFHZxK0N1GHysuk/JIPT8RIdQeoInM01wWPgypRcvb6VH1drjuFpQ4zmY437g==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "@types/node@26.0.1": {
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "dependencies": [
+        "undici-types"
+      ]
     },
     "available-typed-arrays@1.0.7": {
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
@@ -654,6 +716,9 @@
         "buffer",
         "through"
       ]
+    },
+    "undici-types@8.3.0": {
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "universal-github-app-jwt@2.2.2": {
       "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="

--- a/tools/generate_types_deno.ts
+++ b/tools/generate_types_deno.ts
@@ -4,8 +4,8 @@
 // This script is used to generate the @types/deno package on DefinitelyTyped.
 
 import $ from "jsr:@david/dax@0.42.0";
-import { type NamedNode, Node, Project } from "jsr:@ts-morph/ts-morph@27.0.0";
 import * as semver from "jsr:@std/semver@1.0.3";
+import { generateDenoTypesDts } from "./release/types_dts.ts";
 
 const rootDir = $.path(import.meta.dirname!).parentOrThrow();
 const definitelyTypedDir = rootDir.join(
@@ -31,55 +31,9 @@ $.logStep("Formatting...");
 await $`pnpm dprint fmt`.cwd(definitelyTypedDir);
 
 async function createDenoDtsFile() {
-  function matchesAny(text: string | undefined, patterns: string[]): boolean {
-    if (text == null) {
-      return false;
-    }
-    for (const pattern of patterns) {
-      if (text.includes(pattern)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   const text = await $`${denoExec} types`.text();
-  const project = new Project();
-  const file = project.createSourceFile(
-    definitelyTypedDir.join("index.d.ts").toString(),
-    text,
-    {
-      overwrite: true,
-    },
-  );
-
-  for (const statement of file.getStatementsWithComments()) {
-    if (Node.isCommentNode(statement)) {
-      statement.remove();
-      continue;
-    }
-    const shouldKeepNode = (namedNode: NamedNode) => {
-      return matchesAny(namedNode.getName(), [
-        "Deno",
-      ]) || namedNode.getName()?.startsWith("GPU");
-    };
-    if (Node.isVariableStatement(statement)) {
-      for (const decl of statement.getDeclarations()) {
-        if (!shouldKeepNode(decl)) {
-          decl.remove();
-        }
-      }
-    } else if (!shouldKeepNode(statement)) {
-      statement.remove();
-    }
-  }
-
-  file.insertStatements(
-    0,
-    "// Copyright 2018-2026 the Deno authors. MIT license.\n\n",
-  );
-
-  file.saveSync();
+  const dts = generateDenoTypesDts(text);
+  definitelyTypedDir.join("index.d.ts").writeTextSync(dts);
 }
 
 async function updatePkgJson() {

--- a/tools/release/npm/build.ts
+++ b/tools/release/npm/build.ts
@@ -6,6 +6,7 @@ import $ from "jsr:@david/dax@^0.42.0";
 // @ts-types="npm:@types/decompress@4.2.7"
 import decompress from "npm:decompress@4.2.1";
 import { parseArgs } from "@std/cli/parse-args";
+import { generateDenoTypesDts } from "../types_dts.ts";
 
 interface Package {
   zipFileName: string;
@@ -151,6 +152,9 @@ if (!args["publish-only"]) {
         libc: pkg.libc == null ? undefined : [pkg.libc],
       });
     }
+
+    // setup the @deno/types package (types for the Deno namespace)
+    await setupTypesPackage();
   }
 }
 
@@ -171,6 +175,14 @@ if (args.publish || args["publish-only"]) {
     await $`cd ${pkgDir} && npm publish --provenance --access public`;
   }
 
+  $.logStep(`Publishing @deno/types...`);
+  if (await checkPackagePublished("@deno/types")) {
+    $.logLight("  Already published.");
+  } else {
+    const typesDir = scopeDir.join("types");
+    await $`cd ${typesDir} && npm publish --provenance --access public`;
+  }
+
   $.logStep(`Publishing deno...`);
   await $`cd ${denoDir} && npm publish --provenance --access public`;
 }
@@ -178,6 +190,85 @@ if (args.publish || args["publish-only"]) {
 function getPackageNameNoScope(name: Package) {
   const libc = name.libc == null ? "" : `-${name.libc}`;
   return `${name.os}-${name.cpu}${libc}`;
+}
+
+// Builds the `@deno/types` package: type definitions for the `Deno` namespace
+// extracted from `deno types`. See https://github.com/denoland/deno/issues/22192
+async function setupTypesPackage() {
+  $.logStep(`Setting up @deno/types...`);
+  const pkgDir = scopeDir.join("types");
+  await $`mkdir -p ${pkgDir}`;
+
+  // use the previously extracted binary matching the current platform to emit
+  // the declarations so they match the version being published
+  const platformPkg = getCurrentPlatformPackage();
+  const platformPkgDir = scopeDir.join(getPackageNameNoScope(platformPkg));
+  const denoExe = platformPkgDir.join(
+    platformPkg.os === "win32" ? "deno.exe" : "deno",
+  );
+  if (platformPkg.os !== "win32") {
+    await $`chmod +x ${denoExe}`;
+  }
+
+  const typesOutput = await $`${denoExe} types`.text();
+  const dtsPath = pkgDir.join("deno.d.ts");
+  dtsPath.writeTextSync(generateDenoTypesDts(typesOutput));
+
+  // guard against `deno types` output drift breaking the extraction
+  await $`${denoExe} check ${dtsPath}`;
+
+  pkgDir.join("README.md").writeTextSync(
+    `# @deno/types
+
+TypeScript type definitions for the [\`Deno\`](https://docs.deno.com/api/deno/)
+namespace, for use when writing Deno code that is type checked with \`tsc\`
+instead of \`deno check\`.
+
+Reference the types from a module with:
+
+\`\`\`ts
+/// <reference types="@deno/types" />
+
+const contents = await Deno.readTextFile("./mod.ts");
+\`\`\`
+
+The \`Deno\` namespace references DOM and Node.js types, so make sure \`"dom"\`
+is in the \`lib\` array and \`@types/node\` is installed (it is pulled in as a
+dependency of this package).
+`,
+  );
+  pkgDir.join("package.json").writeJsonPrettySync({
+    "name": "@deno/types",
+    "version": version,
+    "description": "TypeScript type definitions for the Deno namespace.",
+    "types": "deno.d.ts",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/denoland/deno.git",
+    },
+    "author": "the Deno authors",
+    "license": "MIT",
+    "bugs": {
+      "url": "https://github.com/denoland/deno/issues",
+    },
+    "homepage": "https://deno.com",
+    // the Deno namespace references `node:net` and `NodeJS.*` types
+    "dependencies": {
+      "@types/node": "*",
+    },
+  });
+}
+
+function getCurrentPlatformPackage() {
+  const os = Deno.build.os === "windows" ? "win32" : Deno.build.os;
+  const cpu = Deno.build.arch === "aarch64" ? "arm64" : "x64";
+  const pkg = packages.find((p) => p.os === os && p.cpu === cpu);
+  if (pkg == null) {
+    throw new Error(
+      `Could not find a package for the current platform: ${os} ${cpu}`,
+    );
+  }
+  return pkg;
 }
 
 function resolveVersion() {

--- a/tools/release/types_dts.ts
+++ b/tools/release/types_dts.ts
@@ -1,0 +1,53 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Shared logic for turning the output of `deno types` into a `.d.ts` file that
+// only declares the ambient `Deno` namespace (and the global `GPU*` WebGPU
+// types it references). The other web platform globals emitted by `deno types`
+// are stripped out because they would otherwise conflict with the standard
+// TypeScript libs when the declaration file is used in a project.
+//
+// This is used both to generate the `@types/deno` package on DefinitelyTyped
+// (see ../generate_types_deno.ts) and the `@deno/types` npm package (see
+// ./npm/build.ts).
+
+import { Node, Project } from "jsr:@ts-morph/ts-morph@27.0.0";
+
+/** Transforms the output of `deno types` into the declaration file shipped in
+ * the `@deno/types` and `@types/deno` packages. */
+export function generateDenoTypesDts(denoTypesOutput: string): string {
+  const project = new Project();
+  const file = project.createSourceFile("deno.d.ts", denoTypesOutput, {
+    overwrite: true,
+  });
+
+  function shouldKeepNode(node: Node): boolean {
+    if (!Node.hasName(node)) {
+      return false;
+    }
+    const name = node.getName();
+    return name === "Deno" || name.startsWith("GPU");
+  }
+
+  for (const statement of file.getStatementsWithComments()) {
+    if (Node.isCommentNode(statement)) {
+      statement.remove();
+      continue;
+    }
+    if (Node.isVariableStatement(statement)) {
+      for (const decl of statement.getDeclarations()) {
+        if (!shouldKeepNode(decl)) {
+          decl.remove();
+        }
+      }
+    } else if (!shouldKeepNode(statement)) {
+      statement.remove();
+    }
+  }
+
+  file.insertStatements(
+    0,
+    "// Copyright 2018-2026 the Deno authors. MIT license.\n\n",
+  );
+
+  return file.getFullText();
+}


### PR DESCRIPTION
Deno's type definitions for the `Deno` namespace are published to
DefinitelyTyped as `@types/deno`, but there is no first-party npm
package for them. This adds a `@deno/types` package that is built and
published on each release alongside the existing `deno` and
`@deno/<platform>` packages, so projects that type check Deno code with
`tsc` can depend on an official, versioned source of the types.

The declaration file is generated from the released binary's
`deno types` output, keeping only the `Deno` namespace and the global
`GPU` types it references and dropping the other web platform globals,
which would otherwise conflict with the standard TypeScript libs. This
is the same transform used to generate `@types/deno`, so the logic is
factored into a shared module to keep the two from drifting. The
generated file is type checked at build time to guard against future
`deno types` output changes breaking the extraction.

Closes #22192