### PR TITLE
fix(check): error on unresolvable compilerOptions.types entry

### DIFF
--- a/cli/type_checker.rs
+++ b/cli/type_checker.rs
@@ -572,6 +572,13 @@ impl DiagnosticsByFolderRealIterator<'_> {
       graph_walker.add_config_import(import, &check_group.referrer);
     }
 
+    if let Some(root) = check_group.roots.first() {
+      let compiler_options_data =
+        self.compiler_options_resolver.for_specifier(root);
+      graph_walker
+        .add_compiler_options_types_import_diagnostics(compiler_options_data);
+    }
+
     for root in &check_group.roots {
       graph_walker.add_root(root);
     }
@@ -945,6 +952,40 @@ impl<'a> GraphWalker<'a> {
             is_root: false,
           });
           self.resolve_pending();
+        }
+      }
+    }
+  }
+
+  /// Surface `compilerOptions.types` entries that could not be resolved as
+  /// `TS2307`, matching `tsc` which reports a missing type definition file.
+  ///
+  /// A resolved but missing entry (e.g. `"./nonexistent.d.ts"`) is already
+  /// reported when it is walked as a config import, but an entry that fails to
+  /// resolve at all (e.g. a bare `"asdfasdf"`) is recorded by deno_graph as a
+  /// `Resolution::Err` on the config import and is otherwise dropped without a
+  /// diagnostic.
+  pub fn add_compiler_options_types_import_diagnostics(
+    &mut self,
+    compiler_options_data: &CompilerOptionsData,
+  ) {
+    for (referrer, types) in
+      compiler_options_data.compiler_options_types().iter()
+    {
+      let Some(graph_import) = self.graph.imports.get(referrer) else {
+        continue;
+      };
+      for type_import in types {
+        let Some(dep) = graph_import.dependencies.get(type_import) else {
+          continue;
+        };
+        if let deno_graph::Resolution::Err(resolution_error) = &dep.maybe_type
+          && let Some(diagnostic) = tsc::Diagnostic::maybe_from_resolution_error(
+            resolution_error,
+            self.bare_importable_pkg_names,
+          )
+        {
+          self.missing_diagnostics.push(diagnostic);
         }
       }
     }

--- a/tests/specs/check/compiler_options_types_not_found/__test__.jsonc
+++ b/tests/specs/check/compiler_options_types_not_found/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tests": {
+    "not_found": {
+      "args": "check ./main.ts",
+      "output": "check.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/check/compiler_options_types_not_found/check.out
+++ b/tests/specs/check/compiler_options_types_not_found/check.out
@@ -1,0 +1,6 @@
+Check [WILDCARD]main.ts
+TS2307 [ERROR]: Import "asdfasdf" not a dependency
+  hint: If you want to use the npm package, try running `deno add npm:asdfasdf`
+    at [WILDCARD]deno.json:1:1
+
+error: Type checking failed.

--- a/tests/specs/check/compiler_options_types_not_found/deno.json
+++ b/tests/specs/check/compiler_options_types_not_found/deno.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["asdfasdf"]
+  }
+}

--- a/tests/specs/check/compiler_options_types_not_found/main.ts
+++ b/tests/specs/check/compiler_options_types_not_found/main.ts
@@ -1,0 +1,1 @@
+console.log("hello");


### PR DESCRIPTION
`deno check` silently passed when a `compilerOptions.types` entry could not
be resolved at all, even though `tsc` reports a missing type definition
file for the same config.

A `compilerOptions.types` entry is turned into a config import and resolved
by deno_graph. A resolved-but-missing entry such as `"./nonexistent.d.ts"`
already surfaced as `TS2307`, but a bare specifier that fails to resolve
entirely, such as `"asdfasdf"`, was recorded by deno_graph as a
`Resolution::Err` on the config import and then silently dropped, so the
check reported no error.

This surfaces those unresolved `compilerOptions.types` entries as `TS2307`
using the same path as ordinary unresolved imports, so the behavior now
matches the resolved-but-missing case.

Closes #32764
