### PR TITLE
fix(test): run Node-API finalizers at test worker shutdown

### DIFF
--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -1002,6 +1002,12 @@ async fn test_specifier_inner(
     .dispatch_unload_event()
     .map_err(|e| CoreErrorKind::Js(e).into_box())?;
 
+  // Run any pending Node-API finalizers before the worker is torn down. This
+  // matches the `deno run`/`deno bench` paths and Node.js, where finalizers
+  // registered via `napi_wrap`/`napi_add_finalizer` are invoked at teardown
+  // even if the wrapped value was never garbage collected during the run.
+  worker.run_napi_ref_finalizers();
+
   // Ensure all output has been flushed
   _ = worker
     .js_runtime

--- a/tests/integration/napi_tests.rs
+++ b/tests/integration/napi_tests.rs
@@ -141,6 +141,43 @@ fn napi_wrap_leak_pointers_finalizer_on_shutdown() {
   );
 }
 
+/// Test that NAPI wrap finalizers are also called at shutdown when the
+/// wrapping happens inside a `Deno.test`. Regression test for #35692, where
+/// the `deno test` worker was torn down without draining the NAPI finalizer
+/// queue (unlike the `deno run` path).
+#[test_util::test]
+fn napi_wrap_leak_finalizer_on_test_shutdown() {
+  napi_build();
+
+  let output = deno_cmd()
+    .current_dir(napi_tests_path())
+    .arg("test")
+    .arg("--allow-read")
+    .arg("--allow-env")
+    .arg("--allow-ffi")
+    .arg("--config")
+    .arg(deno_config_path())
+    .arg("--no-lock")
+    .arg("wrap_leak_test.js")
+    .envs(env_vars_for_npm_tests())
+    .output()
+    .unwrap();
+  let stdout = std::str::from_utf8(&output.stdout).unwrap();
+  let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+  if !output.status.success() {
+    eprintln!("exit code {:?}", output.status.code());
+    println!("stdout {}", stdout);
+    println!("stderr {}", stderr);
+  }
+  assert!(output.status.success());
+  assert!(
+    stdout.contains("pointers released on shutdown"),
+    "Expected wrap finalizer to run at test shutdown, got stdout: {}",
+    stdout
+  );
+}
+
 /// Test napi_fatal_error: calling it should abort the process and log the
 /// error message to stderr.
 #[test_util::test]

--- a/tests/napi/wrap_leak_test.js
+++ b/tests/napi/wrap_leak_test.js
@@ -1,0 +1,19 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Test that napi_wrap finalizers run at shutdown even when the wrapped JS
+// object is still reachable and the wrapping happens inside a `Deno.test`.
+// This mirrors `wrap_leak.js` (which uses `deno run`) and guards against the
+// regression where `deno test` tore down the worker without draining the
+// NAPI finalizer queue (see #35692).
+
+import { loadTestLibrary } from "./common.js";
+
+const lib = loadTestLibrary();
+
+Deno.test("napi wrap finalizer runs at test worker shutdown", () => {
+  // Create an object and wrap it with a native finalizer. Keep the reference
+  // alive (in global scope) so GC won't collect it during the test run. The
+  // wrap finalizer should still be called when the test worker shuts down,
+  // printing the message.
+  globalThis._leaked = lib.test_wrap_leak({});
+});


### PR DESCRIPTION
Native addons register finalizers via `napi_wrap` / `napi_add_finalizer`
that are meant to run at environment teardown, even when the wrapped value
was never garbage collected during the run. This is how Node behaves: at
process exit `napi_env__::DeleteMe()` calls `RefTracker::FinalizeAll()` over
every remaining reference, unconditionally, without forcing a GC between or
after test cases.

Deno already has the equivalent drain, `MainWorker::run_napi_ref_finalizers()`,
and calls it on the `deno run` and `deno bench` paths. The `deno test` path
tore down the worker without calling it, so any addon that relied on a
shutdown finalizer (for example cleanup like WAL checkpointing) never ran it
when its code was wrapped in a test. This calls the drain after the unload
event in the test path so it matches the run/bench paths and Node.

Adds a regression test that wraps an object inside a `Deno.test`, keeps it
reachable so GC never collects it, and asserts the finalizer still runs at
test worker shutdown. It mirrors the existing `deno run` variant.

Fixes #35692