### PR TITLE
fix(compile): bump libsui to 0.16.1 to survive eu-strip in flatpak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6585,7 +6585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6640,9 +6640,9 @@ dependencies = [
 
 [[package]]
 name = "libsui"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0350f185d562954a521d1fcaffd621559ea0b707143ef53b599f1e665b97b5"
+checksum = "ac798c3b04091b5edeb15976e926c3f79e0c8b22faeea60478cf43a4d9ca67c7"
 dependencies = [
  "editpe",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ imara-diff = "=0.2.0"
 lax-css = "=0.2.4"
 lax-markup = "=0.2.5"
 lax-sql = "=0.2.1"
-libsui = "=0.16.0"
+libsui = "=0.16.1"
 malva = "=0.15.2"
 markup_fmt = "=0.27.3"
 object = { version = "0.36.3", default-features = false, features = ["read_core", "pe"] }

--- a/tests/specs/compile/eu_strip/__test__.jsonc
+++ b/tests/specs/compile/eu_strip/__test__.jsonc
@@ -1,0 +1,11 @@
+{
+  "tempDir": true,
+  "if": "linux",
+  "steps": [{
+    "args": "compile --output main main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "args": "run --allow-run=eu-strip,./main --allow-read run.ts",
+    "output": "OK[WILDLINE]\n"
+  }]
+}

--- a/tests/specs/compile/eu_strip/__test__.jsonc
+++ b/tests/specs/compile/eu_strip/__test__.jsonc
@@ -5,7 +5,7 @@
     "args": "compile --output main main.ts",
     "output": "[WILDCARD]"
   }, {
-    "args": "run --allow-run=eu-strip,./main --allow-read run.ts",
-    "output": "OK[WILDLINE]\n"
+    "args": "run --allow-run --allow-read run.ts",
+    "output": "[WILDCARD]OK[WILDLINE]\n"
   }]
 }

--- a/tests/specs/compile/eu_strip/main.ts
+++ b/tests/specs/compile/eu_strip/main.ts
@@ -1,0 +1,1 @@
+console.log("hello from compiled binary");

--- a/tests/specs/compile/eu_strip/run.ts
+++ b/tests/specs/compile/eu_strip/run.ts
@@ -41,7 +41,9 @@ if (!res.success) {
 
 const out = new TextDecoder().decode(res.stdout).trim();
 if (out !== "hello from compiled binary") {
-  console.error(`unexpected output from stripped binary: ${JSON.stringify(out)}`);
+  console.error(
+    `unexpected output from stripped binary: ${JSON.stringify(out)}`,
+  );
   Deno.exit(1);
 }
 

--- a/tests/specs/compile/eu_strip/run.ts
+++ b/tests/specs/compile/eu_strip/run.ts
@@ -1,0 +1,48 @@
+// Regression test for https://github.com/denoland/deno/issues/35633
+//
+// `flatpak-builder` runs `eu-strip` (elfutils) over compiled binaries. The
+// standalone binary embeds its payload via a note appended past the original
+// EOF, together with a relocated program header table. `eu-strip` lays the
+// stripped output out itself and zero-fills the file gap the program header
+// table lives in unless an allocated section covers it, producing an all-zero
+// program header table that segfaults on exec. This runs `eu-strip` over the
+// compiled binary and asserts it still executes.
+const bin = "./main";
+
+let strip;
+try {
+  strip = await new Deno.Command("eu-strip", {
+    args: [bin],
+    stdout: "null",
+    stderr: "piped",
+  }).output();
+} catch (err) {
+  if (err instanceof Deno.errors.NotFound) {
+    // elfutils isn't installed on this machine; nothing to exercise.
+    console.log("OK (eu-strip unavailable)");
+    Deno.exit(0);
+  }
+  throw err;
+}
+
+if (!strip.success) {
+  // eu-strip refused the file (e.g. already stripped); treat as a skip.
+  console.log("OK (eu-strip refused the file)");
+  Deno.exit(0);
+}
+
+const res = await new Deno.Command(bin, { stdout: "piped", stderr: "piped" })
+  .output();
+if (!res.success) {
+  console.error(new TextDecoder().decode(res.stderr));
+  console.error(`stripped binary exited with ${res.code}`);
+  Deno.exit(1);
+}
+
+const out = new TextDecoder().decode(res.stdout).trim();
+if (out !== "hello from compiled binary") {
+  console.error(`unexpected output from stripped binary: ${JSON.stringify(out)}`);
+  Deno.exit(1);
+}
+
+console.log("OK");


### PR DESCRIPTION
Fixes #35633

## Problem

Standalone binaries produced by `deno compile` segfault (exit 139) after `eu-strip` runs over them — which `flatpak-builder` does automatically during a flatpak build. Regression in Deno 2.9, bisected to the libsui 0.16.0 bump (#35467).

## Root cause

libsui's in-place `Elf::append` (new in 0.16.0) relocates the program header table past the original EOF, into the file gap just before the appended note. `eu-strip` (elfutils, as run by flatpak-builder) lays the stripped output out itself with `ELF_F_LAYOUT` and zero-fills every file gap that falls between two allocated sections. With only a note-sized `.note.sui` section past that gap, eu-strip treats the relocated program header table as dead space and zeroes it → all-NULL program headers → segfault on exec.

## Fix

libsui 0.16.1 (denoland/sui#75) covers the relocated program header table with a dedicated allocated `.sui.phdrs` section so section-based strip tools preserve it. This bumps the dependency and adds a spec test that `eu-strip`s a compiled binary and asserts it still runs (skips gracefully where `eu-strip` isn't installed).

## Verification

Reproduced and fixed against the exact flatpak toolchain (elfutils **0.193**, built from source) on Linux x86_64:

- real `deno 2.9.0` compiled binary + eu-strip 0.193 (flatpak flags) → **segfault 139**; with 0.16.1 → **runs**
- every binary shape (PIE+RELR, plain PIE, non-PIE, large `.bss`, section-header-stripped, fully stripped) × eu-strip 0.193 & 0.190 → runs, program headers intact
- payload sizes 1 B – 1 MB → payload still recoverable after strip
- real denort 2.9.0 base → program headers intact after strip
- binutils `strip` note-survival preserved (unchanged from 0.16.0)