### PR TITLE
fix(compile): bump libsui to 0.16.3 to fix segfault under gVisor/Cloud Run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6599,9 +6599,9 @@ dependencies = [
 
 [[package]]
 name = "libsui"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac798c3b04091b5edeb15976e926c3f79e0c8b22faeea60478cf43a4d9ca67c7"
+checksum = "ca68ddfd95a7422fda71830518f057cb14aa784a0feed007bc5ef9dff04818b1"
 dependencies = [
  "editpe",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ imara-diff = "=0.2.0"
 lax-css = "=0.2.4"
 lax-markup = "=0.2.5"
 lax-sql = "=0.2.1"
-libsui = "=0.16.1"
+libsui = "=0.16.3"
 malva = "=0.15.2"
 markup_fmt = "=0.27.3"
 object = { version = "0.36.3", default-features = false, features = ["read_core", "pe"] }


### PR DESCRIPTION
Fixes #35700.

## Problem

A `deno compile` binary with a native npm addon crashes at startup on Google Cloud Run (`debian:bookworm-slim`, run directly as PID 1):

```
Inconsistency detected by ld.so: rtld.c: rtld_setup_main_map:
  Assertion `GL(dl_rtld_map).l_libname' failed!
```

(a plain `Uncaught signal: 11` for the reduced repro). Invoking through the loader explicitly — `CMD ["/lib64/ld-linux-x86-64.so.2", "/app/main"]` — works.

## Root cause

Cloud Run runs under **gVisor**. libsui's in-place `Elf::append` relocates the program header table into a new `PT_LOAD` past EOF, packed just above the highest existing vaddr — giving that segment a different file-offset→vaddr bias than the first `PT_LOAD` (~23 MB for the deno base). gVisor computes `AT_PHDR = load_bias + (first_load.p_vaddr - first_load.p_offset) + e_phoff`, so it lands tens of MB off the real table, reads garbage program headers, and dies before `main`. The Linux kernel recomputes `AT_PHDR` from the segment table, so it only breaks in the sandbox. The native addon is incidental — a trivial `console.log` binary reproduces it.

## Fix

libsui 0.16.3 (denoland/sui#78) pins the relocated segment's vaddr to `new_phoff + first_load_bias`, preserving the first load's bias so the naive `AT_PHDR` computation is correct.

## Verification

Reproduced under gVisor (`runsc`) on Linux x86_64:

- the compiled `@node-rs/bcrypt` repro built with the current libsui crashes with the exact assertion; built with 0.16.3 it runs (`gVisor exit=0`).
- also verified for PIE (+RELR), non-PIE, large `.bss`, and section-header-stripped inputs, and that it composes with the eu-strip fix (an eu-stripped binary also runs under gVisor).

The fix carries an `AT_PHDR`-invariant regression test in libsui.