### PR TITLE
fix(core): don't drain microtasks in mod_evaluate_sync mid-evaluation

### DIFF
--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -2030,7 +2030,19 @@ impl ModuleMap {
     // Under Explicit microtask policy, V8 won't drain microtasks after
     // module.evaluate(). We must do it ourselves so that the module
     // evaluation promise resolves for synchronous modules.
-    tc_scope.perform_microtask_checkpoint();
+    //
+    // However, skip the checkpoint when we are inside a top-level
+    // `module.evaluate()` call (i.e. `evaluating_top_level` is set), e.g.
+    // when a CJS `require()` of an ES module fires while V8 is evaluating
+    // an async module graph. Draining microtasks at that point can resume
+    // a suspended TLA dependency while its parent module is still in the
+    // Evaluating state on the stack; V8 then cannot propagate the
+    // completion to the parent and the graph's evaluation promise stays
+    // Pending forever. The module evaluated here has a synchronous graph
+    // (checked above), so its promise settles without a checkpoint.
+    if !self.evaluating_top_level.get() {
+      tc_scope.perform_microtask_checkpoint();
+    }
 
     if let Some(exception) = tc_scope.exception() {
       return Err(

--- a/tests/specs/run/import_defer_tla_require/__test__.jsonc
+++ b/tests/specs/run/import_defer_tla_require/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tests": {
+    // https://github.com/denoland/deno/issues/35697
+    "defer_tla_with_require_esm": {
+      "args": "run --allow-read main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/run/import_defer_tla_require/a.ts
+++ b/tests/specs/run/import_defer_tla_require/a.ts
@@ -1,0 +1,2 @@
+import "./tla.ts";
+export const a = 1;

--- a/tests/specs/run/import_defer_tla_require/b.cjs
+++ b/tests/specs/run/import_defer_tla_require/b.cjs
@@ -1,0 +1,1 @@
+require("./esm.mjs");

--- a/tests/specs/run/import_defer_tla_require/esm.mjs
+++ b/tests/specs/run/import_defer_tla_require/esm.mjs
@@ -1,0 +1,1 @@
+export const y = 1;

--- a/tests/specs/run/import_defer_tla_require/main.out
+++ b/tests/specs/run/import_defer_tla_require/main.out
@@ -1,0 +1,1 @@
+Hello World

--- a/tests/specs/run/import_defer_tla_require/main.ts
+++ b/tests/specs/run/import_defer_tla_require/main.ts
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/denoland/deno/issues/35697
+// The deferred subgraph contains an async (TLA) module whose resume
+// microtask is queued while the graph is still evaluating. The sibling
+// CJS module then require()s an ES module, which used to drain
+// microtasks mid-evaluation and permanently stall the graph's
+// evaluation promise.
+import defer * as a from "./a.ts";
+import "./b.cjs";
+console.log("Hello World");
+a;

--- a/tests/specs/run/import_defer_tla_require/tla.ts
+++ b/tests/specs/run/import_defer_tla_require/tla.ts
@@ -1,0 +1,2 @@
+await Promise.resolve();
+export const x = 1;


### PR DESCRIPTION
When a CJS `require()` of an ES module fired while V8 was still inside a
top-level `module.evaluate()` call on an async module graph,
`ModuleMap::mod_evaluate_sync` drained microtasks re-entrantly. That resumed
a suspended top-level-await dependency whose parent module was still in the
Evaluating state on the V8 stack; V8 cannot propagate the completion to such
a parent, so the parent's pending-async-dependency count never reached zero
and the graph's evaluation promise stayed pending forever, with no stalled
top-level await to report.

This surfaced with `import defer`, which eagerly evaluates the deferred
subgraph's async transitive dependencies inside the parent's evaluation:
a TLA module there (e.g. cliffy's `await import("node:fs")`) suspends with
its resume microtask queued, and a sibling npm CJS import then hits the
require-of-ESM path at the critical moment. The fix applies the same
`evaluating_top_level` guard that the lazy-load paths already use; the
checkpoint is safe to skip because `mod_evaluate_sync` only evaluates
synchronous graphs (async ones are rejected with ERR_REQUIRE_ASYNC_MODULE),
so their evaluation promise settles without it.

Fixes #35697