### PR TITLE
feat(cli): unstable relaxed default permission profile

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1219,11 +1219,16 @@ impl CliOptions {
     dir: &WorkspaceDirectory,
   ) -> Result<PermissionsOptions, AnyError> {
     let config_permissions = self.resolve_config_permissions_for_dir(dir)?;
+    let has_config_permissions = config_permissions.is_some();
     let mut permissions_options = flags_to_permissions_options(
       &self.flags.permissions,
       config_permissions,
     )?;
     self.augment_import_permissions(&mut permissions_options);
+    self.maybe_apply_relaxed_default_permissions(
+      &mut permissions_options,
+      has_config_permissions,
+    );
     if let DenoSubcommand::Serve(serve_flags) = &self.flags.subcommand {
       augment_permissions_with_serve_flags(
         &mut permissions_options,
@@ -1330,6 +1335,78 @@ impl CliOptions {
       }
       imports
     }
+  }
+
+  /// Applies the unstable relaxed default permission profile to the computed
+  /// permission options when the gate is on and the user provided no explicit
+  /// allow-side permission configuration.
+  ///
+  /// This is groundwork for the Deno 3 default-permissions change: instead of
+  /// denying every capability and prompting one by one, the profile grants a
+  /// pragmatic baseline that lets most CLI tools run without prompts while
+  /// still blocking exfiltration (net stays gated) and persistence outside the
+  /// project (write is confined to the cwd and the OS temp directory):
+  ///
+  /// - read: allowed everywhere on disk
+  /// - write: allowed only under the cwd (at process start) and the OS temp dir
+  /// - env: allowed
+  /// - net, run, ffi, sys: unchanged (still prompt in a TTY, deny
+  ///   non-interactively)
+  /// - import: unchanged (keeps its existing implicit trusted-host allowance)
+  ///
+  /// `--deny-*` flags do not disable the profile; they compose on top since
+  /// deny always wins.
+  fn maybe_apply_relaxed_default_permissions(
+    &self,
+    options: &mut PermissionsOptions,
+    has_config_permissions: bool,
+  ) {
+    // Only for subcommands that execute user code with the prompt-based
+    // defaults. `deno eval` and `deno x` already imply allow-all, and
+    // `deno compile` bakes permissions at compile time (out of scope).
+    if !matches!(
+      self.flags.subcommand,
+      DenoSubcommand::Run(_)
+        | DenoSubcommand::Serve(_)
+        | DenoSubcommand::Test(_)
+        | DenoSubcommand::Bench(_)
+        | DenoSubcommand::Task(_)
+        | DenoSubcommand::Repl(_)
+    ) {
+      return;
+    }
+
+    // Gated behind an unstable env var while we gather feedback.
+    if !relaxed_default_permissions_enabled() {
+      return;
+    }
+
+    // Any explicit allow-side configuration (--allow-*, -A, -P, or a
+    // permission set from the config file) opts out entirely, keeping
+    // behavior byte-for-byte identical to today. Note `--deny-*` flags are
+    // intentionally not consulted here so they compose on top of the profile.
+    if self.flags.permissions.has_allow_permission()
+      || self.flags.permission_set.is_some()
+      || has_config_permissions
+    {
+      return;
+    }
+
+    // TODO(deno3): consider also exposing this profile as a reserved built-in
+    // permission set name (e.g. `-P standard`) so it can be selected explicitly
+    // even with the gate off. Skipped here to keep the central default minimal.
+    log::debug!("Applying unstable relaxed default permission profile.");
+
+    // read: allowed everywhere (empty allow-list means "allow all").
+    options.allow_read = Some(Vec::new());
+    // env: allowed everywhere.
+    options.allow_env = Some(Vec::new());
+    // write: confined to the cwd (recorded at process start) and the OS temp
+    // directory.
+    options.allow_write = Some(relaxed_default_write_paths(self.initial_cwd()));
+    // net, run, ffi and sys are intentionally left untouched so they keep
+    // prompting in a TTY and denying non-interactively. import keeps its
+    // existing implicit trusted-host allowance from augment_import_permissions.
   }
 
   fn get_cli_arg_urls(&self) -> Vec<Cow<'_, Url>> {
@@ -1727,6 +1804,46 @@ fn allow_import_host_from_url(url: &Url) -> Option<String> {
       _ => None,
     }
   }
+}
+
+/// Env var gating the unstable relaxed default permission profile. Groundwork
+/// for the Deno 3 default-permissions change: the profile is on by default and
+/// setting the var to `0` opts back out to today's deny-by-default behavior.
+const RELAXED_PERMISSIONS_ENV_VAR: &str = "DENO_UNSTABLE_RELAXED_PERMISSIONS";
+
+fn relaxed_default_permissions_enabled() -> bool {
+  match std::env::var(RELAXED_PERMISSIONS_ENV_VAR) {
+    // On by default; only an explicit `0` disables it.
+    Ok(value) => value != "0",
+    Err(_) => true,
+  }
+}
+
+/// The write allow-list for the relaxed default profile: the process-start cwd
+/// and the OS temp directory. Both the raw and canonicalized forms of each path
+/// are included so that writes match regardless of symlinked prefixes (for
+/// example macOS's `/tmp` -> `/private/tmp` and `/var/folders` temp dirs, which
+/// are canonicalized at permission-check time). The OS temp directory honors
+/// the `TMPDIR` env var via `std::env::temp_dir`.
+fn relaxed_default_write_paths(initial_cwd: &Path) -> Vec<String> {
+  fn push_with_canonicalized(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.contains(&path) {
+      paths.push(path.clone());
+    }
+    if let Ok(canonical) = crate::util::fs::canonicalize_path(&path)
+      && !paths.contains(&canonical)
+    {
+      paths.push(canonical);
+    }
+  }
+
+  let mut paths: Vec<PathBuf> = Vec::with_capacity(4);
+  push_with_canonicalized(&mut paths, initial_cwd.to_path_buf());
+  push_with_canonicalized(&mut paths, std::env::temp_dir());
+  paths
+    .into_iter()
+    .map(|path| path.to_string_lossy().into_owned())
+    .collect()
 }
 
 // DO NOT make this public. People should use `cli_options.permissions_options/permissions_options_for_dir`

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -1045,6 +1045,22 @@ pub struct PermissionFlags {
 }
 
 impl PermissionFlags {
+  /// Whether any explicit allow-side permission was configured on the command
+  /// line. Unlike `has_permission`, this ignores `--deny-*`/`--ignore-*` flags
+  /// so that a deny flag on its own does not count as "the user configured
+  /// permissions". Used to decide whether an implicit default profile applies.
+  pub fn has_allow_permission(&self) -> bool {
+    self.allow_all
+      || self.allow_env.is_some()
+      || self.allow_ffi.is_some()
+      || self.allow_net.is_some()
+      || self.allow_read.is_some()
+      || self.allow_run.is_some()
+      || self.allow_sys.is_some()
+      || self.allow_write.is_some()
+      || self.allow_import.is_some()
+  }
+
   pub fn has_permission(&self) -> bool {
     self.allow_all
       || self.allow_env.is_some()

--- a/tests/specs/permission/relaxed_default/__test__.jsonc
+++ b/tests/specs/permission/relaxed_default/__test__.jsonc
@@ -1,0 +1,54 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_UNSTABLE_RELAXED_PERMISSIONS": "1",
+    "RELAXED_TEST_VAR": "hello"
+  },
+  "tests": {
+    "profile_default": {
+      // gate on, no flags: read anywhere, write under cwd and temp, env allowed,
+      // write outside both denied naming --allow-write
+      "args": "run --quiet profile.ts",
+      "output": "profile.out"
+    },
+    "net_denied": {
+      // net stays gated: fetch denied naming --allow-net
+      "args": "run --quiet net.ts",
+      "output": "net.out"
+    },
+    "explicit_flag_opts_out": {
+      // an explicit --allow-net flag disables the profile entirely, so a cwd
+      // write now fails
+      "args": "run --quiet --allow-net opt_out.ts",
+      "output": "opt_out.out"
+    },
+    "deny_write_composes": {
+      // --deny-* composes on top of the profile (deny wins)
+      "args": "run --quiet --deny-write=sub deny_write.ts",
+      "output": "deny_write.out"
+    },
+    "allow_all": {
+      // -A allows everything, unchanged
+      "args": "run --quiet -A allow_all.ts",
+      "output": "allow_all.out"
+    },
+    "gate_off": {
+      // gate off: byte-for-byte today's deny-by-default behavior
+      "args": "run --quiet gate_off.ts",
+      "envs": { "DENO_UNSTABLE_RELAXED_PERMISSIONS": "0" },
+      "output": "gate_off.out"
+    },
+    "worker_inherits": {
+      // a worker with default permissions inherits the profile: reads anywhere
+      // but cannot fetch
+      "args": "run --quiet worker_main.ts",
+      "output": "worker.out"
+    },
+    "chdir_does_not_widen": {
+      // the write grant is the cwd at process start; Deno.chdir does not widen it
+      "if": "unix",
+      "args": "run --quiet chdir.ts",
+      "output": "chdir.out"
+    }
+  }
+}

--- a/tests/specs/permission/relaxed_default/allow_all.out
+++ b/tests/specs/permission/relaxed_default/allow_all.out
@@ -1,0 +1,2 @@
+net: granted
+write: granted

--- a/tests/specs/permission/relaxed_default/allow_all.ts
+++ b/tests/specs/permission/relaxed_default/allow_all.ts
@@ -1,0 +1,5 @@
+// -A allows everything, unchanged by the profile.
+const net = await Deno.permissions.query({ name: "net" });
+const write = await Deno.permissions.query({ name: "write" });
+console.log(`net: ${net.state}`);
+console.log(`write: ${write.state}`);

--- a/tests/specs/permission/relaxed_default/chdir.out
+++ b/tests/specs/permission/relaxed_default/chdir.out
@@ -1,0 +1,2 @@
+write after chdir: NotCapable
+write original cwd: ok

--- a/tests/specs/permission/relaxed_default/chdir.ts
+++ b/tests/specs/permission/relaxed_default/chdir.ts
@@ -1,0 +1,13 @@
+// The write grant is the cwd recorded at process start; Deno.chdir does not
+// widen it. After chdir("/"), a relative write resolves outside the grant and
+// is denied, while writes back under the original cwd still succeed.
+const original = Deno.cwd();
+Deno.chdir("/");
+try {
+  Deno.writeTextFileSync("./relaxed_chdir.txt", "data");
+  console.log("write after chdir: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  console.log(`write after chdir: ${err.name}`);
+}
+Deno.writeTextFileSync(`${original}/still_ok.txt`, "data");
+console.log("write original cwd: ok");

--- a/tests/specs/permission/relaxed_default/deny_write.out
+++ b/tests/specs/permission/relaxed_default/deny_write.out
@@ -1,0 +1,2 @@
+write sub: NotCapable
+write cwd: ok

--- a/tests/specs/permission/relaxed_default/deny_write.ts
+++ b/tests/specs/permission/relaxed_default/deny_write.ts
@@ -1,0 +1,10 @@
+// --deny-write=sub composes on top of the profile: writes under the denied
+// subdir fail, while writes elsewhere in the cwd still succeed.
+try {
+  Deno.writeTextFileSync("./sub/denied.txt", "data");
+  console.log("write sub: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  console.log(`write sub: ${err.name}`);
+}
+Deno.writeTextFileSync("./allowed.txt", "data");
+console.log("write cwd: ok");

--- a/tests/specs/permission/relaxed_default/gate_off.out
+++ b/tests/specs/permission/relaxed_default/gate_off.out
@@ -1,0 +1,1 @@
+read: NotCapable --allow-read

--- a/tests/specs/permission/relaxed_default/gate_off.ts
+++ b/tests/specs/permission/relaxed_default/gate_off.ts
@@ -1,0 +1,13 @@
+// With the gate off (DENO_UNSTABLE_RELAXED_PERMISSIONS=0), behavior is
+// byte-for-byte today's deny-by-default: reading outside the cwd is denied
+// non-interactively naming --allow-read.
+const path = Deno.build.os === "windows"
+  ? "C:\\Windows\\win.ini"
+  : "/etc/hosts";
+try {
+  Deno.readFileSync(path);
+  console.log("read: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-read") ? "--allow-read" : "?";
+  console.log(`read: ${err.name} ${named}`);
+}

--- a/tests/specs/permission/relaxed_default/net.out
+++ b/tests/specs/permission/relaxed_default/net.out
@@ -1,0 +1,1 @@
+fetch: NotCapable --allow-net

--- a/tests/specs/permission/relaxed_default/net.ts
+++ b/tests/specs/permission/relaxed_default/net.ts
@@ -1,0 +1,9 @@
+// net stays gated under the relaxed profile: fetch is denied
+// non-interactively naming --allow-net.
+try {
+  await fetch("http://localhost/");
+  console.log("fetch: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-net") ? "--allow-net" : "?";
+  console.log(`fetch: ${err.name} ${named}`);
+}

--- a/tests/specs/permission/relaxed_default/opt_out.out
+++ b/tests/specs/permission/relaxed_default/opt_out.out
@@ -1,0 +1,1 @@
+write cwd: NotCapable --allow-write

--- a/tests/specs/permission/relaxed_default/opt_out.ts
+++ b/tests/specs/permission/relaxed_default/opt_out.ts
@@ -1,0 +1,10 @@
+// Providing any explicit allow-side flag (here --allow-net) disables the
+// relaxed profile entirely, so writing to the cwd now requires --allow-write
+// and is denied.
+try {
+  Deno.writeTextFileSync("./should_fail.txt", "data");
+  console.log("write cwd: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-write") ? "--allow-write" : "?";
+  console.log(`write cwd: ${err.name} ${named}`);
+}

--- a/tests/specs/permission/relaxed_default/profile.out
+++ b/tests/specs/permission/relaxed_default/profile.out
@@ -1,0 +1,5 @@
+read outside cwd: ok
+write cwd: ok
+write temp: ok
+write outside: NotCapable --allow-write
+env: hello

--- a/tests/specs/permission/relaxed_default/profile.ts
+++ b/tests/specs/permission/relaxed_default/profile.ts
@@ -1,0 +1,31 @@
+// Relaxed default permission profile (gate on, no flags): read is allowed
+// everywhere, write is allowed under the cwd and the OS temp directory, and
+// env is allowed. net stays gated (see net.ts).
+
+// read a file outside the cwd (the deno executable)
+Deno.readFileSync(Deno.execPath());
+console.log("read outside cwd: ok");
+
+// write inside the cwd
+Deno.writeTextFileSync("./in_cwd.txt", "data");
+console.log("write cwd: ok");
+
+// write inside the OS temp directory
+const tempFile = Deno.makeTempFileSync();
+Deno.writeTextFileSync(tempFile, "data");
+console.log("write temp: ok");
+
+// write outside both the cwd and the temp directory is denied
+const outside = Deno.build.os === "windows"
+  ? "C:\\relaxed_denied.txt"
+  : "/relaxed_denied.txt";
+try {
+  Deno.writeTextFileSync(outside, "data");
+  console.log("write outside: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-write") ? "--allow-write" : "?";
+  console.log(`write outside: ${err.name} ${named}`);
+}
+
+// env access is allowed
+console.log(`env: ${Deno.env.get("RELAXED_TEST_VAR")}`);

--- a/tests/specs/permission/relaxed_default/sub/keep.txt
+++ b/tests/specs/permission/relaxed_default/sub/keep.txt
@@ -1,0 +1,1 @@
+placeholder so the denied subdir exists in the test dir

--- a/tests/specs/permission/relaxed_default/worker.out
+++ b/tests/specs/permission/relaxed_default/worker.out
@@ -1,0 +1,1 @@
+worker read: ok, worker fetch: NotCapable

--- a/tests/specs/permission/relaxed_default/worker.ts
+++ b/tests/specs/permission/relaxed_default/worker.ts
@@ -1,0 +1,17 @@
+// Inherits the relaxed profile from the parent: read is allowed everywhere but
+// net stays gated.
+let read;
+try {
+  Deno.readFileSync(Deno.execPath());
+  read = "ok";
+} catch (err) {
+  read = err.name;
+}
+let net;
+try {
+  await fetch("http://localhost/");
+  net = "ok";
+} catch (err) {
+  net = err.name;
+}
+self.postMessage(`worker read: ${read}, worker fetch: ${net}`);

--- a/tests/specs/permission/relaxed_default/worker_main.ts
+++ b/tests/specs/permission/relaxed_default/worker_main.ts
@@ -1,0 +1,10 @@
+// A worker created with default permissions inherits the parent's relaxed
+// profile.
+const worker = new Worker(import.meta.resolve("./worker.ts"), {
+  type: "module",
+});
+const result = await new Promise((resolve) => {
+  worker.onmessage = (e) => resolve(e.data);
+});
+console.log(result);
+worker.terminate();

--- a/tests/util/lib/builders.rs
+++ b/tests/util/lib/builders.rs
@@ -969,6 +969,16 @@ impl TestCommandBuilder {
     if !envs.contains_key("DENO_NO_UPDATE_CHECK") {
       envs.insert("DENO_NO_UPDATE_CHECK".to_string(), "1".to_string());
     }
+    if !envs.contains_key("DENO_UNSTABLE_RELAXED_PERMISSIONS") {
+      // The unstable relaxed default permission profile is on by default in the
+      // real binary, but the existing test corpus asserts today's
+      // deny-by-default behavior. Disable it here so tests are deterministic;
+      // tests exercising the profile opt back in with `envs`.
+      envs.insert(
+        "DENO_UNSTABLE_RELAXED_PERMISSIONS".to_string(),
+        "0".to_string(),
+      );
+    }
     if !envs.contains_key("JSR_URL") {
       envs.insert("JSR_URL".to_string(), jsr_registry_unset_url());
     }


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/29784

This is groundwork for the Deno 3 default-permissions change. Today `deno
run` denies every capability by default and prompts one by one, which trains
users into reaching for `-A`. For example `deno run npm:cowsay hello` needs
two prompt rounds today, one of them just so the package can read its own
data file.

This adds a relaxed default permission profile that, when active, grants a
pragmatic baseline so most CLI tools run without prompts while still blocking
the two things that matter: exfiltration (net stays gated, so anything read
cannot leave the machine) and persistence outside the project (write is
confined to the working directory and the OS temp directory). Concretely the
profile grants:

- read: allowed everywhere on disk
- write: allowed only under the cwd (recorded at process start) and the OS
  temp directory
- env: allowed
- net, run, ffi, sys: unchanged, still prompt in a TTY and deny
  non-interactively
- import: unchanged, keeps its existing implicit trusted-host allowance

The profile is gated by the `DENO_UNSTABLE_RELAXED_PERMISSIONS` env var. It is
on by default and setting the var to `0` opts back out to today's
deny-by-default behavior. Gating it behind the unstable var lets us gather
feedback before committing to flipping the default.

The profile only applies when the user provided no explicit allow-side
permission configuration: no `--allow-*`, no `-A`, no `-P`/`--permission-set`,
and no permission set from the config file. Any of those means behavior is
byte-for-byte identical to today. `--deny-*` flags do not disable the profile;
they compose on top since deny always wins. The check reuses a new
`PermissionFlags::has_allow_permission()` helper that, unlike the existing
`has_permission()`, ignores deny/ignore flags.

The profile is applied centrally in `flags_to_permissions_options`'s caller so
it covers `deno run`, `serve`, `test`, `bench`, `task` and the repl uniformly.
It deliberately does not touch `deno eval` (already implicit allow-all), `deno
x` (has its own allow-all default), or `deno compile` (permissions are baked
at compile time; explicitly out of scope).

## Sharp edges handled

- Temp dir canonicalization: the write allow-list includes both the raw and
  canonicalized forms of the cwd and the OS temp dir, so a write to `/tmp/x`
  still matches when it is canonicalized to `/private/tmp/x` at check time
  (macOS symlinks `/tmp` and `/var/folders` under `/private`). `TMPDIR` is
  honored via `std::env::temp_dir`.
- cwd semantics: the grant is the path recorded at process start, so
  `Deno.chdir()` does not widen it. A spec test proves this.
- Worker inheritance: child workers derive from the parent's
  PermissionsContainer, so a default worker inherits the profile (reads
  anywhere but cannot fetch). A spec test covers it.

## Decisions

- env is included: node-compat code reads env pervasively (yargs reads `env._`
  before doing anything), and the exfil risk of readable env is mitigated by
  net remaining gated. Deno's env permission does not separate get from set;
  that is acceptable here.
- sys is not included in v1 (`os.cpus()`, `hostname`, etc. keep prompting). If
  testing shows this is the next biggest prompt-fatigue source for npm CLIs it
  is a follow-up candidate rather than scope creep here.
- Non-interactive behavior is unchanged: non-granted capabilities still
  auto-deny when there is no TTY.
- A reserved `-P standard` built-in set name that selects this profile even
  with the gate off was considered but deferred (left as a TODO) to keep the
  central default minimal.

## Tests

New spec tests under `tests/specs/permission/relaxed_default/` cover: read
anywhere, write under cwd and temp, env read, denied writes outside both,
gated net, explicit-flag opt-out (an `--allow-net` flag disables the profile
so a cwd write then fails), `--deny-write` composing on top, `-A` allowing
everything, a gate-off control, worker inheritance, and chdir not widening the
grant.

The existing test corpus asserts today's deny-by-default behavior, so the
shared test command builder defaults `DENO_UNSTABLE_RELAXED_PERMISSIONS=0`;
the new tests opt back in via `envs`. No existing `.out` expectations were
changed.

Real-world smoke test: with the gate on (including the default, env unset),
`deno run npm:cowsay@1.6.0 hello` completes with zero prompts and exit code 0.
