### PR TITLE
fix(ext/http): point legacy abort warning at docs.deno.com/go link

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -226,7 +226,7 @@ class InnerRequest {
         legacyAbortWarned = true;
         // deno-lint-ignore no-console
         console.warn(
-          "Deno.serve: request.signal aborts on successful responses (legacy behavior, see https://github.com/denoland/deno/issues/29111). Move cleanup to the handler's return path, or opt in to the new behavior with --unstable-no-legacy-abort. See https://docs.deno.com/runtime/reference/migrate-deprecations/",
+          "Deno.serve: request.signal aborts on successful responses (legacy behavior). To detect when a request has been fully delivered use the `completed` promise on the handler's info argument. Move cleanup to the handler's return path, or opt in to the new behavior with --unstable-no-legacy-abort. See https://docs.deno.com/go/unstable-no-legacy-abort",
         );
       }
       abortRequest(this.request);

--- a/tests/specs/serve/request_signal_streaming/main.out
+++ b/tests/specs/serve/request_signal_streaming/main.out
@@ -1,4 +1,4 @@
-Deno.serve: request.signal aborts on successful responses (legacy behavior, see https://github.com/denoland/deno/issues/29111). Move cleanup to the handler's return path, or opt in to the new behavior with --unstable-no-legacy-abort. See https://docs.deno.com/runtime/reference/migrate-deprecations/
+Deno.serve: request.signal aborts on successful responses (legacy behavior). To detect when a request has been fully delivered use the `completed` promise on the handler's info argument. Move cleanup to the handler's return path, or opt in to the new behavior with --unstable-no-legacy-abort. See https://docs.deno.com/go/unstable-no-legacy-abort
 body: chunk1;chunk2;chunk3;chunk4;chunk5;
 aborted during stream: false
 aborted after completion: true


### PR DESCRIPTION
The `Deno.serve` legacy request abort deprecation warning added in #34397
pointed users at https://docs.deno.com/runtime/reference/migrate-deprecations/,
a page that does not exist. This repoints it at the stable
`docs.deno.com/go/unstable-no-legacy-abort` short link.

That short link resolves to a new dedicated docs page (denoland/docs#3386)
that explains why the `request.signal` abort behavior is changing, what
`--unstable-no-legacy-abort` does, and how to detect when a request has
been fully delivered.

The warning now also names `info.completed` directly, since knowing when a
response has been fully sent is the most common reason people relied on the
legacy abort. That promise (on the handler's `ServeHandlerInfo` argument)
resolves once the response, including a streaming body, has been delivered
and rejects if delivery fails partway, which is the mode-independent
replacement for watching `request.signal`.

The existing warning tests still hold: the message continues to include
both `request.signal` and `--unstable-no-legacy-abort`.

Refs #28850, #29111, #34397.
