### PR TITLE
chore(release): update versions.json in bucket on release

### DIFF
--- a/.github/workflows/post_publish.generated.yml
+++ b/.github/workflows/post_publish.generated.yml
@@ -35,6 +35,8 @@ jobs:
           AWS_DEFAULT_REGION: '${{vars.S3_REGION }}'
         run: |-
           VERSION=${GITHUB_REF#refs/*/}
+          VERSIONS_FILE=$(deno run --allow-net --allow-write tools/release/update_versions_json.ts "$VERSION")
+          aws s3 cp "$VERSIONS_FILE" "s3://dl-deno-land/$VERSIONS_FILE" --content-type application/json
           LATEST_FILE=$(deno run --allow-net --allow-write tools/release/upload_version_file.ts "$VERSION" || exit 0)
           [ -z "$LATEST_FILE" ] && exit 0
           aws s3 cp "$LATEST_FILE" "s3://dl-deno-land/$LATEST_FILE"

--- a/.github/workflows/post_publish.generated.yml
+++ b/.github/workflows/post_publish.generated.yml
@@ -35,8 +35,8 @@ jobs:
           AWS_DEFAULT_REGION: '${{vars.S3_REGION }}'
         run: |-
           VERSION=${GITHUB_REF#refs/*/}
-          VERSIONS_FILE=$(deno run --allow-net --allow-write tools/release/update_versions_json.ts "$VERSION")
-          aws s3 cp "$VERSIONS_FILE" "s3://dl-deno-land/$VERSIONS_FILE" --content-type application/json
+          deno run --allow-net --allow-write tools/release/update_versions_json.ts "$VERSION"
+          aws s3 cp versions.json s3://dl-deno-land/versions.json --content-type application/json
           LATEST_FILE=$(deno run --allow-net --allow-write tools/release/upload_version_file.ts "$VERSION" || exit 0)
           [ -z "$LATEST_FILE" ] && exit 0
           aws s3 cp "$LATEST_FILE" "s3://dl-deno-land/$LATEST_FILE"

--- a/.github/workflows/post_publish.ts
+++ b/.github/workflows/post_publish.ts
@@ -48,8 +48,8 @@ const workflow = createWorkflow({
         },
         run: [
           "VERSION=${GITHUB_REF#refs/*/}",
-          'VERSIONS_FILE=$(deno run --allow-net --allow-write tools/release/update_versions_json.ts "$VERSION")',
-          'aws s3 cp "$VERSIONS_FILE" "s3://dl-deno-land/$VERSIONS_FILE" --content-type application/json',
+          'deno run --allow-net --allow-write tools/release/update_versions_json.ts "$VERSION"',
+          "aws s3 cp versions.json s3://dl-deno-land/versions.json --content-type application/json",
           'LATEST_FILE=$(deno run --allow-net --allow-write tools/release/upload_version_file.ts "$VERSION" || exit 0)',
           '[ -z "$LATEST_FILE" ] && exit 0',
           'aws s3 cp "$LATEST_FILE" "s3://dl-deno-land/$LATEST_FILE"',

--- a/.github/workflows/post_publish.ts
+++ b/.github/workflows/post_publish.ts
@@ -48,6 +48,8 @@ const workflow = createWorkflow({
         },
         run: [
           "VERSION=${GITHUB_REF#refs/*/}",
+          'VERSIONS_FILE=$(deno run --allow-net --allow-write tools/release/update_versions_json.ts "$VERSION")',
+          'aws s3 cp "$VERSIONS_FILE" "s3://dl-deno-land/$VERSIONS_FILE" --content-type application/json',
           'LATEST_FILE=$(deno run --allow-net --allow-write tools/release/upload_version_file.ts "$VERSION" || exit 0)',
           '[ -z "$LATEST_FILE" ] && exit 0',
           'aws s3 cp "$LATEST_FILE" "s3://dl-deno-land/$LATEST_FILE"',

--- a/tools/release/update_versions_json.ts
+++ b/tools/release/update_versions_json.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env -S deno run -A --lock=tools/deno.lock.json
+// Copyright 2018-2026 the Deno authors. MIT license.
+// deno-lint-ignore-file no-console
+
+// Fetches the current versions.json from the bucket, prepends the given
+// release version to the "cli" list (if not already present), writes the
+// result to versions.json and prints the file name to stdout.
+
+const version = Deno.args[0];
+if (!version) {
+  console.error("Usage: update_versions_json.ts <version-tag>");
+  Deno.exit(1);
+}
+
+const outFile = "versions.json";
+
+interface Versions {
+  cli: string[];
+}
+
+let versions: Versions = { cli: [] };
+const response = await fetch("https://dl.deno.land/versions.json");
+if (response.ok) {
+  versions = await response.json();
+  if (!Array.isArray(versions.cli)) {
+    versions.cli = [];
+  }
+} else if (response.status !== 404) {
+  throw new Error(`Failed to fetch versions.json: ${response.statusText}`);
+} else {
+  // Ensure the body is consumed so the connection can be reused/closed.
+  await response.body?.cancel();
+}
+
+// The freshly published release is always the newest, so prepend it.
+if (!versions.cli.includes(version)) {
+  versions.cli.unshift(version);
+}
+
+console.error("Adding version:", version);
+console.error("Total versions:", versions.cli.length);
+
+Deno.writeTextFileSync(outFile, JSON.stringify(versions) + "\n");
+
+// Print the file name so the caller knows what to upload.
+console.log(outFile);

--- a/tools/release/update_versions_json.ts
+++ b/tools/release/update_versions_json.ts
@@ -3,16 +3,14 @@
 // deno-lint-ignore-file no-console
 
 // Fetches the current versions.json from the bucket, prepends the given
-// release version to the "cli" list (if not already present), writes the
-// result to versions.json and prints the file name to stdout.
+// release version to the "cli" list (if not already present), and writes the
+// result to versions.json.
 
 const version = Deno.args[0];
 if (!version) {
   console.error("Usage: update_versions_json.ts <version-tag>");
   Deno.exit(1);
 }
-
-const outFile = "versions.json";
 
 interface Versions {
   cli: string[];
@@ -40,7 +38,4 @@ if (!versions.cli.includes(version)) {
 console.error("Adding version:", version);
 console.error("Total versions:", versions.cli.length);
 
-Deno.writeTextFileSync(outFile, JSON.stringify(versions) + "\n");
-
-// Print the file name so the caller knows what to upload.
-console.log(outFile);
+Deno.writeTextFileSync("versions.json", JSON.stringify(versions) + "\n");


### PR DESCRIPTION
## Summary

Extends the `post_publish` workflow (triggered on GitHub release published) to also maintain a `versions.json` file in the `dl-deno-land` bucket, alongside the existing `release-*-latest.txt` files.

Format:

```json
{ "cli": ["v2.0.0", "v1.0.1", "v1.0.0"] }
```

## Changes

- **`tools/release/update_versions_json.ts`** (new): fetches the current `https://dl.deno.land/versions.json`, prepends the released tag to the `cli` list if not already present, and writes `versions.json`. The freshly published release is always the newest, so it's simply prepended — mirroring the equivalent logic in `dotcom`'s `update_version.ts`.
- **`.github/workflows/post_publish.ts`** / **`.generated.yml`**: runs the new script and uploads `versions.json` to `s3://dl-deno-land/versions.json` with `content-type: application/json`, before the existing latest-txt handling.

## Notes

- All release channels (stable + alpha/beta prereleases) are recorded.
- The existing `versions.json` in the bucket (full history) is preserved; the new tag is prepended.