### PR TITLE
fix(lint): don't error on non-analyzable package exports like CSS files

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use deno_ast::MediaType;
 use deno_config::deno_json;
 use deno_config::deno_json::CompilerOptionTypesDeserializeError;
 use deno_config::deno_json::NodeModulesDirMode;
@@ -418,6 +419,38 @@ pub struct CreatePublishGraphOptions<'a> {
   pub packages: &'a [JsrPackageConfig],
   pub build_fast_check_graph: bool,
   pub validate_graph: bool,
+  /// Whether to skip exports that can't be analyzed as modules
+  /// (ex. CSS files) instead of surfacing diagnostics for them.
+  /// This is used when linting because validating the exports is
+  /// the responsibility of `deno publish`.
+  /// See https://github.com/denoland/deno/issues/26308
+  pub skip_unanalyzable_exports: bool,
+}
+
+fn is_analyzable_export(url: &ModuleSpecifier) -> bool {
+  match MediaType::from_specifier(url) {
+    MediaType::JavaScript
+    | MediaType::Jsx
+    | MediaType::Mjs
+    | MediaType::Cjs
+    | MediaType::TypeScript
+    | MediaType::Mts
+    | MediaType::Cts
+    | MediaType::Dts
+    | MediaType::Dmts
+    | MediaType::Dcts
+    | MediaType::Tsx
+    | MediaType::Json
+    | MediaType::Wasm => true,
+    MediaType::Css
+    | MediaType::Jsonc
+    | MediaType::Json5
+    | MediaType::Html
+    | MediaType::Markdown
+    | MediaType::Sql
+    | MediaType::SourceMap
+    | MediaType::Unknown => false,
+  }
 }
 
 pub struct ModuleGraphCreator {
@@ -527,7 +560,13 @@ impl ModuleGraphCreator {
 
     let mut roots = Vec::new();
     for package_config in options.packages {
-      roots.extend(package_config.config_file.resolve_export_value_urls()?);
+      let export_urls =
+        package_config.config_file.resolve_export_value_urls()?;
+      if options.skip_unanalyzable_exports {
+        roots.extend(export_urls.into_iter().filter(is_analyzable_export));
+      } else {
+        roots.extend(export_urls);
+      }
     }
 
     let loader = self
@@ -578,11 +617,22 @@ impl ModuleGraphCreator {
     }
 
     if options.build_fast_check_graph {
-      let fast_check_workspace_members = options
+      let mut fast_check_workspace_members = options
         .packages
         .iter()
         .map(|p| config_to_deno_graph_workspace_member(&p.config_file))
         .collect::<Result<Vec<_>, _>>()?;
+      if options.skip_unanalyzable_exports {
+        for member in &mut fast_check_workspace_members {
+          let base = member.base.clone();
+          member.exports.retain(|_, value| {
+            base
+              .join(value)
+              .map(|url| is_analyzable_export(&url))
+              .unwrap_or(true)
+          });
+        }
+      }
       self.module_graph_builder.build_fast_check_graph(
         &mut graph,
         BuildFastCheckGraphOptions {

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -2051,6 +2051,7 @@ fn collect_scope_no_slow_types_diagnostics(
           packages: &packages,
           build_fast_check_graph: true,
           validate_graph: false,
+          skip_unanalyzable_exports: true,
         })
         .await?;
       let mut diagnostics_by_specifier: HashMap<

--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -444,6 +444,7 @@ impl WorkspaceLinter {
               packages: &packages,
               build_fast_check_graph: true,
               validate_graph: false,
+              skip_unanalyzable_exports: true,
             })
             .await
             .map(Rc::new)

--- a/cli/tools/pack/mod.rs
+++ b/cli/tools/pack/mod.rs
@@ -250,6 +250,7 @@ async fn create_graph(
       packages: std::slice::from_ref(package),
       build_fast_check_graph: !pack_flags.allow_slow_types,
       validate_graph: true,
+      skip_unanalyzable_exports: false,
     })
     .await?;
   warn_for_slow_type_diagnostics(&graph, package, pack_flags)?;

--- a/cli/tools/publish/mod.rs
+++ b/cli/tools/publish/mod.rs
@@ -377,6 +377,7 @@ impl PublishPreparer {
         packages: package_configs,
         build_fast_check_graph,
         validate_graph: true,
+        skip_unanalyzable_exports: false,
       })
       .await?;
 

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -15489,6 +15489,69 @@ fn lsp_no_slow_types_diagnostics() {
 }
 
 #[test(timeout = 300)]
+fn lsp_no_slow_types_unanalyzable_exports() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+
+  // a package with a non-JS export (like CSS) shouldn't surface an
+  // internal "export not found" diagnostic, but slow types in its
+  // analyzable exports should still be reported
+  // https://github.com/denoland/deno/issues/26308
+  temp_dir.write(
+    "deno.json",
+    r#"{
+  "name": "@foo/bar",
+  "version": "1.0.0",
+  "exports": {
+    "./mod.ts": "./mod.ts",
+    "./globals.css": "./globals.css"
+  }
+}
+"#,
+  );
+  temp_dir.write(
+    "mod.ts",
+    "export function add(a: number, b: number) {\n  return a + b;\n}\n",
+  );
+  temp_dir.write("globals.css", "body {\n  color: red;\n}\n");
+
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+
+  let diagnostics = client.did_open(json!({
+    "textDocument": {
+      "uri": url_to_uri(&temp_dir.url().join("mod.ts").unwrap()).unwrap(),
+      "languageId": "typescript",
+      "version": 1,
+      "text": temp_dir.read_to_string("mod.ts"),
+    }
+  }));
+  let no_slow_types_diagnostics = diagnostics
+    .all_messages()
+    .iter()
+    .flat_map(|m| m.diagnostics.iter())
+    .filter(|d| {
+      d.code == Some(lsp::NumberOrString::String("no-slow-types".to_string()))
+    })
+    .cloned()
+    .collect::<Vec<_>>();
+  assert!(
+    no_slow_types_diagnostics
+      .iter()
+      .any(|d| d.message.contains("missing explicit return type")),
+    "expected a no-slow-types diagnostic for the slow type, got: {no_slow_types_diagnostics:#?}"
+  );
+  assert!(
+    !no_slow_types_diagnostics
+      .iter()
+      .any(|d| d.message.contains("globals.css")),
+    "expected no no-slow-types diagnostics for the CSS export, got: {no_slow_types_diagnostics:#?}"
+  );
+
+  client.shutdown();
+}
+
+#[test(timeout = 300)]
 fn lsp_lint_with_config() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let temp_dir = context.temp_dir();

--- a/tests/specs/lint/package_unanalyzable_exports/__test__.jsonc
+++ b/tests/specs/lint/package_unanalyzable_exports/__test__.jsonc
@@ -1,0 +1,21 @@
+{
+  "tests": {
+    // https://github.com/denoland/deno/issues/26308
+    "css_export_ignored": {
+      "cwd": "ok",
+      "args": "lint",
+      "output": "Checked 1 file\n"
+    },
+    "css_export_ignored_entrypoint": {
+      "cwd": "ok",
+      "args": "lint main.ts",
+      "output": "Checked 1 file\n"
+    },
+    "no_slow_types_still_works": {
+      "cwd": "slow",
+      "args": "lint",
+      "output": "slow.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/lint/package_unanalyzable_exports/ok/deno.json
+++ b/tests/specs/lint/package_unanalyzable_exports/ok/deno.json
@@ -1,0 +1,8 @@
+{
+  "name": "@project/ui",
+  "version": "1.0.0",
+  "exports": {
+    "./main.ts": "./main.ts",
+    "./globals.css": "./globals.css"
+  }
+}

--- a/tests/specs/lint/package_unanalyzable_exports/ok/globals.css
+++ b/tests/specs/lint/package_unanalyzable_exports/ok/globals.css
@@ -1,0 +1,5 @@
+@layer base {
+  body {
+    color: red;
+  }
+}

--- a/tests/specs/lint/package_unanalyzable_exports/ok/main.ts
+++ b/tests/specs/lint/package_unanalyzable_exports/ok/main.ts
@@ -1,0 +1,1 @@
+export const a: string = "a";

--- a/tests/specs/lint/package_unanalyzable_exports/slow.out
+++ b/tests/specs/lint/package_unanalyzable_exports/slow.out
@@ -1,0 +1,14 @@
+error[no-slow-types]: missing explicit return type in the public API
+ --> [WILDCARD]main.ts:1:17
+  | 
+1 | export function add(a: number, b: number) {
+  |                 ^^^ this function is missing an explicit return type
+  | 
+  = hint: add an explicit return type to the function
+
+  info: all functions in the public API must have an explicit return type
+  docs: https://jsr.io/go/slow-type-missing-explicit-return-type
+
+
+Found 1 problem
+Checked 1 file

--- a/tests/specs/lint/package_unanalyzable_exports/slow/deno.json
+++ b/tests/specs/lint/package_unanalyzable_exports/slow/deno.json
@@ -1,0 +1,8 @@
+{
+  "name": "@project/slow",
+  "version": "1.0.0",
+  "exports": {
+    "./main.ts": "./main.ts",
+    "./globals.css": "./globals.css"
+  }
+}

--- a/tests/specs/lint/package_unanalyzable_exports/slow/globals.css
+++ b/tests/specs/lint/package_unanalyzable_exports/slow/globals.css
@@ -1,0 +1,5 @@
+@layer base {
+  body {
+    color: red;
+  }
+}

--- a/tests/specs/lint/package_unanalyzable_exports/slow/main.ts
+++ b/tests/specs/lint/package_unanalyzable_exports/slow/main.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number) {
+  return a + b;
+}


### PR DESCRIPTION
When a package's deno.json listed a non-JS export like a CSS file (a common
setup for npm workspace packages with tailwind/postcss), `deno lint` failed
on it. Originally this surfaced as a fatal parse error; since #30815 it
surfaces as an internal `no-slow-types` "export not found" diagnostic
telling the user to report a bug. Neither `lint.exclude` nor `--ignore`
could suppress it, because the package rules build their module graph
directly from the exports listed in the config file.

This adds a `skip_unanalyzable_exports` option to publish graph creation,
enabled for `deno lint` and the LSP's no-slow-types diagnostics, that
filters exports that can't be analyzed as modules (CSS, HTML, etc.) out of
the graph roots and the fast check workspace member exports. Validating
such exports stays the responsibility of `deno publish`, which still errors
on them with a proper message.

Fixes #26308