### PR TITLE
feat(ext/http): stop aborting request signal on successful responses

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -504,10 +504,11 @@ impl FlagsExt for Flags {
   }
 
   fn no_legacy_abort(&self) -> bool {
-    self
-      .unstable_config
-      .features
-      .contains(&String::from("no-legacy-abort"))
+    // The legacy behavior (aborting `request.signal` on successfully
+    // completed requests) is no longer available;
+    // `--unstable-no-legacy-abort` is kept as a no-op for backwards
+    // compatibility.
+    true
   }
 
   fn otel_config(&self) -> OtelConfig {

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -1687,7 +1687,7 @@ pub async fn run_with_options(
     serve_port: options.serve_port,
     serve_host: options.serve_host,
     otel_config: metadata.otel_config,
-    no_legacy_abort: false,
+    no_legacy_abort: true,
     startup_snapshot: deno_snapshots::CLI_SNAPSHOT,
     residual_lazy_js_sources: deno_snapshots::RESIDUAL_LAZY_JS,
     residual_lazy_esm_sources: deno_snapshots::RESIDUAL_LAZY_ESM,

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -132,8 +132,6 @@ const {
 
 const _upgraded = Symbol("_upgraded");
 
-let legacyAbortWarned = false;
-
 function internalServerError() {
   // "Internal Server Error"
   return new Response(
@@ -192,7 +190,6 @@ class InnerRequest {
   #upgraded;
   #urlValue;
   #completed;
-  #signalAccessed;
   request;
 
   constructor(external, context) {
@@ -200,7 +197,6 @@ class InnerRequest {
     this.#context = context;
     this.#upgraded = false;
     this.#completed = undefined;
-    this.#signalAccessed = false;
   }
 
   close(success = true) {
@@ -222,13 +218,6 @@ class InnerRequest {
       }
     }
     if (this.#context.legacyAbort) {
-      if (success && this.#signalAccessed && !legacyAbortWarned) {
-        legacyAbortWarned = true;
-        // deno-lint-ignore no-console
-        console.warn(
-          "Deno.serve: request.signal aborts on successful responses (legacy behavior). To detect when a request has been fully delivered use the `completed` promise on the handler's info argument. Move cleanup to the handler's return path, or opt in to the new behavior with --unstable-no-legacy-abort. See https://docs.deno.com/go/unstable-no-legacy-abort",
-        );
-      }
       abortRequest(this.request);
     }
     this.#external = null;
@@ -448,7 +437,6 @@ class InnerRequest {
   }
 
   onCancel(callback) {
-    this.#signalAccessed = true;
     if (this.#external === null) {
       if (this.#context.legacyAbort) callback();
       return;
@@ -1670,9 +1658,6 @@ internals.addTrailers = addTrailers;
 internals.upgradeHttpRaw = upgradeHttpRaw;
 internals.serveHttpOnListener = serveHttpOnListener;
 internals.serveHttpOnConnection = serveHttpOnConnection;
-internals.resetLegacyAbortWarning = () => {
-  legacyAbortWarned = false;
-};
 
 function registerDeclarativeServer(exports) {
   if (!ObjectHasOwn(exports, "fetch")) return;

--- a/runtime/features/data.rs
+++ b/runtime/features/data.rs
@@ -102,9 +102,12 @@ pub static FEATURE_DESCRIPTIONS: &[UnstableFeatureDescription] = &[
     env_var: None,
   },
   UnstableFeatureDescription {
+    // Deprecated: `request.signal` in Deno.serve no longer aborts on
+    // successfully completed requests by default, so this flag is a no-op
+    // kept only for backwards compatibility.
     name: "no-legacy-abort",
-    help_text: "Enable abort signal in Deno.serve without legacy behavior. This will not abort the server when the request is handled successfully.",
-    show_in_help: true,
+    help_text: "Deprecated. `request.signal` in Deno.serve no longer aborts on successfully completed requests, so this flag has no effect.",
+    show_in_help: false,
     kind: UnstableFeatureKind::Runtime,
     env_var: None,
   },

--- a/runtime/features/gen.rs
+++ b/runtime/features/gen.rs
@@ -114,8 +114,8 @@ pub static UNSTABLE_FEATURES: &[UnstableFeatureDefinition] = &[
   UnstableFeatureDefinition {
     name: "no-legacy-abort",
     flag_name: "unstable-no-legacy-abort",
-    help_text: "Enable abort signal in Deno.serve without legacy behavior. This will not abort the server when the request is handled successfully.",
-    show_in_help: true,
+    help_text: "Deprecated. `request.signal` in Deno.serve no longer aborts on successfully completed requests, so this flag has no effect.",
+    show_in_help: false,
     id: 13,
     kind: UnstableFeatureKind::Runtime,
   },

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -156,7 +156,7 @@ impl Default for BootstrapOptions {
       node_cluster_sched_policy: None,
       node_ipc_init: None,
       mode: WorkerExecutionMode::None,
-      no_legacy_abort: false,
+      no_legacy_abort: true,
       serve_port: Default::default(),
       serve_host: Default::default(),
       otel_config: Default::default(),

--- a/tests/specs/serve/request_signal_streaming/main.out
+++ b/tests/specs/serve/request_signal_streaming/main.out
@@ -1,4 +1,3 @@
-Deno.serve: request.signal aborts on successful responses (legacy behavior). To detect when a request has been fully delivered use the `completed` promise on the handler's info argument. Move cleanup to the handler's return path, or opt in to the new behavior with --unstable-no-legacy-abort. See https://docs.deno.com/go/unstable-no-legacy-abort
 body: chunk1;chunk2;chunk3;chunk4;chunk5;
 aborted during stream: false
-aborted after completion: true
+aborted after completion: false

--- a/tests/specs/serve/request_signal_streaming/main.ts
+++ b/tests/specs/serve/request_signal_streaming/main.ts
@@ -1,7 +1,5 @@
-// Request.signal must not abort while the response body is still streaming.
-// (In legacy-abort mode the signal aborts when the request completes; that
-// must happen only after the response body has been fully written, otherwise
-// proxied bodies tied to the signal get torn down mid-stream.)
+// Request.signal must not abort while the response body is still streaming,
+// nor after the request completes successfully.
 let abortedDuringStream = false;
 const abortedAfterCompletion = Promise.withResolvers<void>();
 
@@ -35,7 +33,7 @@ const text = await res.text();
 console.log("body:", text);
 console.log("aborted during stream:", abortedDuringStream);
 
-// Legacy-abort mode still aborts the signal, but only after completion.
+// The signal must not abort on a successfully completed request.
 let timer: number;
 const result = await Promise.race([
   abortedAfterCompletion.promise.then(() => true),

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -31,7 +31,6 @@ const {
   serveHttpOnListener,
   serveHttpOnConnection,
   getCachedAbortSignal,
-  resetLegacyAbortWarning,
   // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
 } = Deno[Deno.internal];
 
@@ -4111,10 +4110,8 @@ for (const delay of ["delay", "nodelay"]) {
   }
 }
 
-// NOTE: This test will start failing when we disable "deno_http/legacy_abort" feature.
-//
 // Test for the internal implementation detail of cached request signals. Ensure that the request's
-// signal is aborted if we try to access it after the request has been completed.
+// signal is NOT aborted if we access it after the request has completed successfully.
 Deno.test(
   { permissions: { net: true } },
   async function httpServerSignalCancelled() {
@@ -4129,10 +4126,10 @@ Deno.test(
     abort();
     await finished;
 
-    // `false` is a semaphore for a signal that should be aborted on creation
-    assertEquals(getCachedAbortSignal(stashedRequest!), false);
-    // Requesting the signal causes it to be materialized
-    assert(stashedRequest!.signal.aborted);
+    // The request completed successfully, so no abort semaphore was recorded
+    assertEquals(getCachedAbortSignal(stashedRequest!), undefined);
+    // Requesting the signal causes it to be materialized, unaborted
+    assert(!stashedRequest!.signal.aborted);
     // The cached signal is now a full `AbortSignal`
     assertEquals(
       getCachedAbortSignal(stashedRequest!).constructor,
@@ -5992,103 +5989,35 @@ Deno.test(
   },
 );
 
-async function captureLegacyAbortWarnings(
-  fn: () => Promise<void>,
-): Promise<string[]> {
-  resetLegacyAbortWarning();
-  const warnings: string[] = [];
-  const originalWarn = console.warn;
-  console.warn = (...args: unknown[]) => {
-    if (typeof args[0] === "string" && args[0].includes("request.signal")) {
-      warnings.push(args[0]);
-      return;
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerSignalNotAbortedOnSuccessfulRequest() {
+    let aborted = false;
+    const { finished, shutdown } = await makeServer((req) => {
+      req.signal.addEventListener("abort", () => {
+        aborted = true;
+      });
+      return new Response("ok");
+    });
+    for (let i = 0; i < 3; i++) {
+      await (await fetch(`http://localhost:${servePort}`)).text();
     }
-    originalWarn(...args);
-  };
-  try {
-    await fn();
-  } finally {
-    console.warn = originalWarn;
-    resetLegacyAbortWarning();
-  }
-  return warnings;
-}
-
-Deno.test(
-  { permissions: { net: true } },
-  async function httpServerLegacyAbortWarningFiresOnce() {
-    const warnings = await captureLegacyAbortWarnings(async () => {
-      const { finished, shutdown } = await makeServer((req) => {
-        req.signal.addEventListener("abort", () => {});
-        return new Response("ok");
-      });
-      for (let i = 0; i < 3; i++) {
-        await (await fetch(`http://localhost:${servePort}`)).text();
-      }
-      await shutdown();
-      await finished;
-    });
-    assertEquals(warnings.length, 1);
-    assertStringIncludes(warnings[0], "request.signal");
-    assertStringIncludes(warnings[0], "--unstable-no-legacy-abort");
+    await shutdown();
+    await finished;
+    assertEquals(aborted, false);
   },
 );
 
 Deno.test(
-  { permissions: { net: true } },
-  async function httpServerLegacyAbortWarningSkipsWhenSignalUntouched() {
-    const warnings = await captureLegacyAbortWarnings(async () => {
-      const { finished, shutdown } = await makeServer(() => {
-        return new Response("ok");
-      });
-      for (let i = 0; i < 3; i++) {
-        await (await fetch(`http://localhost:${servePort}`)).text();
-      }
-      await shutdown();
-      await finished;
-    });
-    assertEquals(warnings.length, 0);
-  },
-);
-
-Deno.test(
-  { permissions: { net: true, run: true, read: true } },
-  async function httpServerLegacyAbortWarningSilentUnderUnstableFlag() {
-    const subprocessPort = servePort + 1;
-    const code = `
-      const originalWarn = console.warn;
-      let warned = false;
-      console.warn = (...args) => {
-        if (typeof args[0] === "string" && args[0].includes("request.signal")) {
-          warned = true;
-        }
-        originalWarn(...args);
-      };
-      const { promise, resolve } = Promise.withResolvers();
-      const server = Deno.serve({
-        port: ${subprocessPort},
-        handler: (req) => {
-          req.signal.addEventListener("abort", () => {});
-          return new Response("ok");
-        },
-        onListen: resolve,
-      });
-      await promise;
-      for (let i = 0; i < 3; i++) {
-        await (await fetch("http://localhost:${subprocessPort}")).text();
-      }
-      console.log(warned ? "WARNED" : "QUIET");
-      await server.shutdown();
-    `;
+  { permissions: { run: true, read: true } },
+  async function unstableNoLegacyAbortFlagIsNoop() {
     const command = new Deno.Command(Deno.execPath(), {
-      args: ["eval", "--unstable-no-legacy-abort", code],
+      args: ["eval", "--unstable-no-legacy-abort", "console.log('ok')"],
       stdout: "piped",
       stderr: "piped",
     });
     const { code: exitCode, stdout } = await command.output();
-    const output = new TextDecoder().decode(stdout);
     assertEquals(exitCode, 0);
-    assertStringIncludes(output, "QUIET");
-    assert(!output.includes("WARNED"));
+    assertStringIncludes(new TextDecoder().decode(stdout), "ok");
   },
 );


### PR DESCRIPTION
Deno.serve fired abort on request.signal even when the handler returned a
successful response. This legacy behavior broke common Node proxy setups
(Vite's http-proxy, http-proxy-middleware), which treat the upstream abort
as a real failure and spam "ws proxy error: AbortError" on every proxied
request. The opt-in fix landed as --unstable-no-legacy-abort in #28371 and
a deprecation warning shipped in #34397; this flips the default.

Code that relied on the old abort to detect request completion should use
`Deno.ServeHandlerInfo.completed` instead, a promise on the handler's
second argument that resolves once the response has been fully delivered:

```ts
Deno.serve((req, info) => {
  info.completed.then(() => {
    console.log("request done");
  });
  return new Response("ok");
});
```

The flag is now a hidden no-op, following the unstable-node-globals
precedent, and the deprecation warning is removed along with its test
plumbing. The legacyAbort mechanism in ext/http is kept so deno_runtime
embedders can still opt into the old behavior if they need it.

Closes #28850