### PR TITLE
fix(install): don't write through hardlinks when copying package files

### DIFF
--- a/libs/npm_cache/fs_util.rs
+++ b/libs/npm_cache/fs_util.rs
@@ -95,11 +95,3 @@ pub fn hard_link_file<TSys: HardLinkFileSys>(
   }
   Ok(())
 }
-
-/// Returns true if the error is ETXTBSY ("text file busy"), which occurs
-/// on Linux when trying to write to or modify a file that is currently
-/// being executed.
-pub fn is_etxtbsy(err: &std::io::Error) -> bool {
-  // ETXTBSY is raw OS error 26 on Linux
-  cfg!(target_os = "linux") && err.raw_os_error() == Some(26)
-}

--- a/libs/npm_cache/lib.rs
+++ b/libs/npm_cache/lib.rs
@@ -40,7 +40,6 @@ mod tarball_extract;
 
 pub use fs_util::hard_link_dir_recursive;
 pub use fs_util::hard_link_file;
-pub use fs_util::is_etxtbsy;
 pub use registry_info::RegistryInfoProvider;
 pub use registry_info::SerializedCachedPackageInfo;
 pub use registry_info::get_package_url;

--- a/libs/npm_installer/fs.rs
+++ b/libs/npm_installer/fs.rs
@@ -91,18 +91,15 @@ pub fn copy_dir_recursive<TSys: CopyDirRecursiveSys>(
 
     if file_type.is_dir() {
       copy_dir_recursive(sys.as_ref(), &new_from, &new_to)?;
-    } else if file_type.is_file()
-      && let Err(err) = sys.fs_copy(&new_from, &new_to)
-    {
-      if deno_npm_cache::is_etxtbsy(&err) {
-        // The destination file is a hardlink to a currently-executing
-        // binary (ETXTBSY). Remove it first to break the hardlink,
-        // then retry the copy which will create a new inode.
-        let _ = sys.fs_remove_file(&new_to);
-        sys.fs_copy(&new_from, &new_to)?;
-      } else {
-        return Err(err);
-      }
+    } else if file_type.is_file() {
+      // Remove any existing file first so the copy writes a new inode.
+      // The destination may be a hardlink to another path (for example,
+      // esbuild's install script hardlinks its platform package's binary
+      // over its own JS shim) and copying in place would write through
+      // the link, corrupting the file at its other paths. Removing first
+      // also breaks hardlinks to currently-executing binaries (ETXTBSY).
+      let _ = sys.fs_remove_file(&new_to);
+      sys.fs_copy(&new_from, &new_to)?;
     }
   }
 
@@ -138,4 +135,43 @@ pub fn symlink_dir<TSys: sys_traits::BaseFsSymlinkDir>(
     }
     err_mapper(err, None)
   })
+}
+
+#[cfg(test)]
+mod test {
+  use sys_traits::FsCreateDirAll;
+  use sys_traits::FsHardLink;
+  use sys_traits::FsRead;
+  use sys_traits::FsWrite;
+  use test_util::TempDir;
+
+  use super::*;
+
+  #[test]
+  fn copy_dir_recursive_replaces_hardlinked_files() {
+    let temp_dir = TempDir::new();
+    let sys = sys_traits::impls::RealSys;
+    let root = temp_dir.path().to_path_buf();
+    let from = root.join("from");
+    let to = root.join("to");
+    sys.fs_create_dir_all(&from).unwrap();
+    sys.fs_create_dir_all(&to).unwrap();
+    sys.fs_write(from.join("file"), "from contents").unwrap();
+    // simulate what a lifecycle script like esbuild's install script does:
+    // hardlink another file (e.g. a platform package's binary) over a file
+    // that a future re-install will copy over again
+    let binary = root.join("binary");
+    sys.fs_write(&binary, "binary contents").unwrap();
+    sys.fs_hard_link(&binary, to.join("file")).unwrap();
+
+    copy_dir_recursive(&sys, &from, &to).unwrap();
+
+    // the destination now has the copied contents on a new inode
+    assert_eq!(
+      sys.fs_read_to_string(to.join("file")).unwrap(),
+      "from contents"
+    );
+    // and the other end of the hardlink was not written through
+    assert_eq!(sys.fs_read_to_string(&binary).unwrap(), "binary contents");
+  }
 }

--- a/libs/npm_installer/local.rs
+++ b/libs/npm_installer/local.rs
@@ -1321,20 +1321,12 @@ pub(crate) fn clone_dir_recursive_except_node_modules_child(
       )?;
     } else if file_type.is_file() {
       hard_link_file(sys.as_ref(), &new_from, &new_to).or_else(|_| {
-        sys
-          .fs_copy(&new_from, &new_to)
-          .or_else(|err| {
-            if deno_npm_cache::is_etxtbsy(&err) {
-              // The destination is a hardlink to a currently-executing
-              // binary (ETXTBSY). Remove it to break the hardlink, then
-              // retry the copy.
-              let _ = sys.fs_remove_file(&new_to);
-              sys.fs_copy(&new_from, &new_to)
-            } else {
-              Err(err)
-            }
-          })
-          .map(|_| ())
+        // Remove any existing file first so the copy writes a new inode
+        // rather than writing through a hardlinked destination, which
+        // would corrupt the file at its other paths. Removing first also
+        // breaks hardlinks to currently-executing binaries (ETXTBSY).
+        let _ = sys.fs_remove_file(&new_to);
+        sys.fs_copy(&new_from, &new_to).map(|_| ())
       })?;
     }
   }


### PR DESCRIPTION
Fixes #35734

`copy_dir_recursive` copied over existing destination files in place. If a lifecycle script had replaced such a file with a hardlink to another path — esbuild's install script hardlinks the platform package's native binary over its own JS shim — the copy wrote through the link and corrupted the file at its other paths, leaving `@esbuild/<platform>/bin/esbuild` containing the JS shim, which then spawns itself in an infinite loop (`EAGAIN`).

- remove the destination before `fs_copy` in `copy_dir_recursive` and in the `hard_link_file` fallback in `local.rs`, so copies always write a new inode instead of writing through a hardlinked destination
- this generalizes the previous Linux-only ETXTBSY handling, which relied on the copy failing and so never covered hardlinked files that weren't currently executing; that special case is now subsumed
- regression test: hardlink a file over the copy destination, run `copy_dir_recursive`, assert the other end of the link is untouched — fails before this change, passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)
