### PR TITLE
feat(inspector): start inspector server on SIGUSR1

### DIFF
--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -183,9 +183,7 @@ impl CliMainWorker {
   /// cost of installing a process-wide signal handler.
   #[cfg(unix)]
   fn spawn_sigusr1_inspector_listener(&mut self) {
-    use deno_runtime::deno_inspector_server::InspectPublishUid;
-    use deno_runtime::deno_inspector_server::create_inspector_server;
-    use deno_runtime::deno_inspector_server::get_inspector_server;
+    use deno_runtime::deno_inspector_server::activate_default_inspector_server;
 
     const GRACE_PERIOD: std::time::Duration =
       std::time::Duration::from_millis(500);
@@ -208,26 +206,13 @@ impl CliMainWorker {
         let Some(inspector) = inspector.upgrade() else {
           return;
         };
-        // No-op when the inspector server is already running (an
-        // `--inspect*` flag, `node:inspector`'s `open()`, or a previous
-        // SIGUSR1).
-        if get_inspector_server().is_some() {
-          continue;
-        }
-        let host = std::net::SocketAddr::from(([127, 0, 0, 1], 9229));
-        match create_inspector_server(
-          host,
+        if let Some(url) = activate_default_inspector_server(
           deno_lib::version::DENO_VERSION_INFO.user_agent,
-          InspectPublishUid::default(),
+          main_module.clone(),
+          inspector,
+          false,
         ) {
-          Ok(server) => {
-            let url =
-              server.register_inspector(main_module.clone(), inspector, false);
-            op_state.borrow_mut().put(url);
-          }
-          Err(err) => {
-            log::error!("Failed to start inspector server: {}", err);
-          }
+          op_state.borrow_mut().put(url);
         }
       }
     });

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -196,9 +196,7 @@ impl CliMainWorker {
 
     deno_core::unsync::spawn(async move {
       tokio::time::sleep(GRACE_PERIOD).await;
-      let Ok(mut sigusr1) = tokio::signal::unix::signal(
-        tokio::signal::unix::SignalKind::user_defined1(),
-      ) else {
+      let Ok(mut sigusr1) = deno_signals::signal_stream(libc::SIGUSR1) else {
         return;
       };
       while sigusr1.recv().await.is_some() {

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -145,6 +145,11 @@ impl CliMainWorker {
       self.install_watcher_exit_handle();
     }
 
+    // Like Node.js, allow activating the inspector on an already running
+    // process by sending it SIGUSR1.
+    #[cfg(unix)]
+    self.spawn_sigusr1_inspector_listener();
+
     let mut result = self
       .run_to_completion(&mut maybe_hmr_runner, has_coverage)
       .await;
@@ -170,6 +175,59 @@ impl CliMainWorker {
 
     result?;
     Ok(self.worker.exit_code())
+  }
+
+  /// Starts listening for SIGUSR1 and activates the inspector server when
+  /// the signal is received, mirroring Node.js behavior. Listening starts
+  /// after a short grace period so that short-lived programs don't pay the
+  /// cost of installing a process-wide signal handler.
+  #[cfg(unix)]
+  fn spawn_sigusr1_inspector_listener(&mut self) {
+    use deno_runtime::deno_inspector_server::InspectPublishUid;
+    use deno_runtime::deno_inspector_server::create_inspector_server;
+    use deno_runtime::deno_inspector_server::get_inspector_server;
+
+    const GRACE_PERIOD: std::time::Duration =
+      std::time::Duration::from_millis(500);
+
+    let inspector = self.worker.js_runtime().inspector();
+    let op_state = self.worker.js_runtime().op_state();
+    let main_module = self.worker.main_module().to_string();
+
+    deno_core::unsync::spawn(async move {
+      tokio::time::sleep(GRACE_PERIOD).await;
+      let Ok(mut sigusr1) = tokio::signal::unix::signal(
+        tokio::signal::unix::SignalKind::user_defined1(),
+      ) else {
+        return;
+      };
+      while sigusr1.recv().await.is_some() {
+        // No-op when the inspector server is already running (an
+        // `--inspect*` flag, `node:inspector`'s `open()`, or a previous
+        // SIGUSR1).
+        if get_inspector_server().is_some() {
+          continue;
+        }
+        let host = std::net::SocketAddr::from(([127, 0, 0, 1], 9229));
+        match create_inspector_server(
+          host,
+          deno_lib::version::DENO_VERSION_INFO.user_agent,
+          InspectPublishUid::default(),
+        ) {
+          Ok(server) => {
+            let url = server.register_inspector(
+              main_module.clone(),
+              inspector.clone(),
+              false,
+            );
+            op_state.borrow_mut().put(url);
+          }
+          Err(err) => {
+            log::error!("Failed to start inspector server: {}", err);
+          }
+        }
+      }
+    });
   }
 
   /// Runs the main module to completion: preload + main module, lifecycle

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -190,7 +190,11 @@ impl CliMainWorker {
     const GRACE_PERIOD: std::time::Duration =
       std::time::Duration::from_millis(500);
 
-    let inspector = self.worker.js_runtime().inspector();
+    // Hold only a `Weak` reference to the inspector: the runtime asserts on
+    // teardown that it is the sole owner, so this long-lived task must not keep
+    // it alive. We upgrade to a strong reference only while handling a signal.
+    let inspector =
+      std::rc::Rc::downgrade(&self.worker.js_runtime().inspector());
     let op_state = self.worker.js_runtime().op_state();
     let main_module = self.worker.main_module().to_string();
 
@@ -200,6 +204,10 @@ impl CliMainWorker {
         return;
       };
       while sigusr1.recv().await.is_some() {
+        // The runtime is gone (the program finished); stop listening.
+        let Some(inspector) = inspector.upgrade() else {
+          return;
+        };
         // No-op when the inspector server is already running (an
         // `--inspect*` flag, `node:inspector`'s `open()`, or a previous
         // SIGUSR1).
@@ -213,11 +221,8 @@ impl CliMainWorker {
           InspectPublishUid::default(),
         ) {
           Ok(server) => {
-            let url = server.register_inspector(
-              main_module.clone(),
-              inspector.clone(),
-              false,
-            );
+            let url =
+              server.register_inspector(main_module.clone(), inspector, false);
             op_state.borrow_mut().put(url);
           }
           Err(err) => {

--- a/libs/inspector_server/lib.rs
+++ b/libs/inspector_server/lib.rs
@@ -117,6 +117,43 @@ pub fn create_inspector_server(
   Ok(server)
 }
 
+/// The default address the inspector server listens on, matching Node.js.
+pub fn default_inspector_host() -> SocketAddr {
+  SocketAddr::from(([127, 0, 0, 1], 9229))
+}
+
+/// Activates the global inspector server on the [`default_inspector_host`] and
+/// registers `inspector`, mirroring Node.js' behavior when a process is sent
+/// SIGUSR1.
+///
+/// This is a no-op returning `None` when a server is already running (an
+/// `--inspect*` flag, `node:inspector`'s `open()`, or a previous activation).
+/// On success the inspector's WebSocket URL is returned; if the server fails to
+/// bind, the error is logged and `None` is returned.
+pub fn activate_default_inspector_server(
+  name: &'static str,
+  module_url: String,
+  inspector: Rc<JsRuntimeInspector>,
+  wait_for_session: bool,
+) -> Option<InspectorServerUrl> {
+  if get_inspector_server().is_some() {
+    return None;
+  }
+  match create_inspector_server(
+    default_inspector_host(),
+    name,
+    InspectPublishUid::default(),
+  ) {
+    Ok(server) => {
+      Some(server.register_inspector(module_url, inspector, wait_for_session))
+    }
+    Err(err) => {
+      log::error!("Failed to start inspector server: {}", err);
+      None
+    }
+  }
+}
+
 static RESTART_NOTIFIER: OnceLock<broadcast::Sender<()>> = OnceLock::new();
 
 fn get_restart_notifier() -> broadcast::Sender<()> {

--- a/tests/testdata/inspector/sigusr1.js
+++ b/tests/testdata/inspector/sigusr1.js
@@ -1,0 +1,5 @@
+// Keep the event loop alive so the inspector can be activated via SIGUSR1.
+setInterval(() => {}, 1000);
+// The SIGUSR1 listener is only installed after a 500ms grace period; print
+// the marker well after that so the test knows it is safe to send the signal.
+setTimeout(() => console.log("ready"), 1000);

--- a/tests/unit/inspector_test.ts
+++ b/tests/unit/inspector_test.ts
@@ -2361,3 +2361,52 @@ Deno.test("inspector_no_pause_on_handled_stream_rejection", async () => {
     await tester.waitForExit();
   }
 });
+
+Deno.test({
+  name: "inspector_starts_on_sigusr1",
+  ignore: Deno.build.os === "windows",
+  permissions: { run: true, read: true, net: true },
+  async fn() {
+    const script = testdataPath + "sigusr1.js";
+    const child = new Deno.Command(Deno.execPath(), {
+      args: ["run", script],
+      stdout: "piped",
+      stderr: "piped",
+    }).spawn();
+    const stdoutReader = child.stdout
+      .pipeThrough(new TextDecoderStream())
+      .getReader();
+    const stderrReader = child.stderr
+      .pipeThrough(new TextDecoderStream())
+      .getReader();
+    try {
+      // Wait until the SIGUSR1 listener's grace period has passed.
+      let stdoutBuffer = "";
+      while (!stdoutBuffer.includes("ready")) {
+        const { value, done } = await stdoutReader.read();
+        if (done) throw new Error("child exited before printing ready");
+        stdoutBuffer += value;
+      }
+
+      child.kill("SIGUSR1");
+      const wsUrl = await extractWsUrl(stderrReader);
+      assertStringIncludes(wsUrl, "ws://127.0.0.1:9229/");
+
+      // The /json endpoint should list the main module as a target.
+      const response = await fetch("http://127.0.0.1:9229/json");
+      const targets = await response.json();
+      assertEquals(targets.length, 1);
+      assertStringIncludes(targets[0].url, "sigusr1.js");
+
+      // A second SIGUSR1 must be a no-op, not crash the process.
+      child.kill("SIGUSR1");
+      const secondResponse = await fetch("http://127.0.0.1:9229/json");
+      assertEquals((await secondResponse.json()).length, 1);
+    } finally {
+      child.kill("SIGKILL");
+      await child.status;
+      await stdoutReader.cancel().catch(() => {});
+      await stderrReader.cancel().catch(() => {});
+    }
+  },
+});


### PR DESCRIPTION
In Node.js you can start the inspector on an already running process by
sending it SIGUSR1, which is useful for debugging long-running tasks that
cannot easily be restarted with --inspect. This adds the same capability
to deno: on Unix, sending SIGUSR1 starts the inspector server on the
default 127.0.0.1:9229 without pausing execution, and prints the usual
"Debugger listening on ws://..." banner.

The listener is installed after a 500ms grace period so short-lived
programs don't pay the cost of a process-wide signal handler (a trivial
`deno eval` still exits in ~30ms). If the inspector server is already
running (an --inspect* flag, node:inspector's open(), or a previous
SIGUSR1), the signal is a no-op. The activation reuses the runtime
registration path that already backs node:inspector's open(). JS
listeners added with Deno.addSignalListener("SIGUSR1") keep working
alongside it.

Closes #9312