### PR TITLE
feat(check): print 'Checked N files' summary like fmt and lint

### DIFF
--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -89,5 +89,12 @@ async fn check_with_factory(
         ..Default::default()
       },
     )
-    .await
+    .await?;
+
+  match specifiers_for_typecheck.len() {
+    1 => log::info!("Checked 1 file"),
+    n => log::info!("Checked {} files", n),
+  }
+
+  Ok(())
 }

--- a/tests/integration/check_tests.rs
+++ b/tests/integration/check_tests.rs
@@ -39,7 +39,7 @@ fn cache_switching_config_then_no_config() {
     output.assert_exit_code(0);
 
     let stderr = output.stderr();
-    stderr.contains("Check")
+    stderr.lines().any(|line| line.starts_with("Check "))
   }
 }
 
@@ -67,7 +67,7 @@ fn reload_flag() {
     output.assert_exit_code(0);
 
     let stderr = output.stderr();
-    stderr.contains("Check")
+    stderr.lines().any(|line| line.starts_with("Check "))
   }
 }
 
@@ -154,7 +154,7 @@ fn check_error_in_dep_then_fix() {
 
   temp_dir.write("greet.ts", correct_code);
   let output = check_command.run();
-  output.assert_matches_text("Check [WILDCARD]main.ts\n");
+  output.assert_matches_text("Check [WILDCARD]main.ts\nChecked 1 file\n");
 
   temp_dir.write("greet.ts", incorrect_code);
   let output = check_command.run();

--- a/tests/integration/npm_tests.rs
+++ b/tests/integration/npm_tests.rs
@@ -1453,7 +1453,7 @@ console.log(getValue());
   let output = test_context.new_command().args("run main.ts").run();
   output.assert_matches_text("5\n");
   let output = test_context.new_command().args("check main.ts").run();
-  output.assert_matches_text("Check main.ts\n");
+  output.assert_matches_text("Check main.ts\nChecked 1 file\n");
 }
 
 #[test]
@@ -1577,7 +1577,7 @@ console.log(add(1, 2));
     .new_command()
     .args("check ./project-b/main.ts")
     .run();
-  output.assert_matches_text("Check project-b/main.ts\n");
+  output.assert_matches_text("Check project-b/main.ts\nChecked 1 file\n");
 
   // Now a file in the main directory should just be able to
   // import it via node resolution even though a package.json
@@ -1594,7 +1594,7 @@ console.log(getValue());
   let output = test_context.new_command().args("run main.ts").run();
   output.assert_matches_text("7\n");
   let output = test_context.new_command().args("check main.ts").run();
-  output.assert_matches_text("Check main.ts\n");
+  output.assert_matches_text("Check main.ts\nChecked 1 file\n");
 }
 
 #[test]
@@ -1676,7 +1676,7 @@ console.log(add(1, 2));
     .new_command()
     .args("check ./project-b/main.ts")
     .run();
-  output.assert_matches_text("Check project-b/main.ts\n");
+  output.assert_matches_text("Check project-b/main.ts\nChecked 1 file\n");
 
   // Now a file in the main directory should just be able to
   // import it via node resolution even though a package.json
@@ -1693,7 +1693,7 @@ console.log(getValue());
   let output = test_context.new_command().args("run main.ts").run();
   output.assert_matches_text("7\n");
   let output = test_context.new_command().args("check main.ts").run();
-  output.assert_matches_text("Check main.ts\n");
+  output.assert_matches_text("Check main.ts\nChecked 1 file\n");
 }
 
 #[test]
@@ -1708,7 +1708,7 @@ fn check_css_package_json_exports() {
     .new_command()
     .args("check main.ts")
     .run()
-    .assert_matches_text("Download [WILDCARD]css-export\nDownload [WILDCARD]css-export/1.0.0.tgz\nCheck main.ts\n")
+    .assert_matches_text("Download [WILDCARD]css-export\nDownload [WILDCARD]css-export/1.0.0.tgz\nCheck main.ts\nChecked 1 file\n")
     .assert_exit_code(0);
 }
 

--- a/tests/specs/check/ambient_modules/foo.out
+++ b/tests/specs/check/ambient_modules/foo.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]foo.ts
+Checked 1 file

--- a/tests/specs/check/byonm_import_missing_types/check.out
+++ b/tests/specs/check/byonm_import_missing_types/check.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/check/check_js_flag/without_flag.out
+++ b/tests/specs/check/check_js_flag/without_flag.out
@@ -1,0 +1,1 @@
+Checked 1 file

--- a/tests/specs/check/check_types_dts/main.out
+++ b/tests/specs/check/check_types_dts/main.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/check/check_with_excluded_file_specified/check.out
+++ b/tests/specs/check/check_with_excluded_file_specified/check.out
@@ -1,1 +1,2 @@
 Warning No matching files found.
+Checked 0 files

--- a/tests/specs/check/compiler_options_types/__test__.jsonc
+++ b/tests/specs/check/compiler_options_types/__test__.jsonc
@@ -13,7 +13,7 @@
         },
         {
           "args": "check ./main.ts",
-          "output": "Check [WILDCARD]main.ts\n"
+          "output": "Check [WILDCARD]main.ts\nChecked 1 file\n"
         }
       ]
     },
@@ -29,7 +29,7 @@
         },
         {
           "args": "check ./main.ts",
-          "output": "Check [WILDCARD]main.ts\n"
+          "output": "Check [WILDCARD]main.ts\nChecked 1 file\n"
         }
       ]
     },
@@ -45,7 +45,7 @@
         },
         {
           "args": "check ./main.ts",
-          "output": "Check [WILDCARD]main.ts\n"
+          "output": "Check [WILDCARD]main.ts\nChecked 1 file\n"
         }
       ]
     }

--- a/tests/specs/check/css_import/__test__.jsonc
+++ b/tests/specs/check/css_import/__test__.jsonc
@@ -25,7 +25,7 @@
     },
     {
       "args": "check exists_dynamic_import.ts",
-      "output": "Check [WILDCARD]exists_dynamic_import.ts\n"
+      "output": "Check [WILDCARD]exists_dynamic_import.ts\nChecked 1 file\n"
     },
     {
       "args": "run --check --reload exists_dynamic_import.ts",

--- a/tests/specs/check/css_import/exists.out
+++ b/tests/specs/check/css_import/exists.out
@@ -1,2 +1,3 @@
 Download [WILDCARD]
 Check [WILDCARD]exists.ts
+Checked 1 file

--- a/tests/specs/check/css_import/exists_and_try_uses.out
+++ b/tests/specs/check/css_import/exists_and_try_uses.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]exists_and_try_uses.ts
+Checked 1 file

--- a/tests/specs/check/css_module_imports/valid.out
+++ b/tests/specs/check/css_module_imports/valid.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]valid.ts
+Checked 1 file

--- a/tests/specs/check/desktop_flag/with_flag.out
+++ b/tests/specs/check/desktop_flag/with_flag.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/check/express_with_koa/check.out
+++ b/tests/specs/check/express_with_koa/check.out
@@ -1,2 +1,3 @@
 [WILDCARD]
 Check main.ts
+Checked 1 file

--- a/tests/specs/check/extensionless/check.out
+++ b/tests/specs/check/extensionless/check.out
@@ -1,2 +1,3 @@
 [WILDCARD]
 Check http://localhost:4545/subdir/no_js_ext
+Checked 1 file

--- a/tests/specs/check/globbing/__test__.jsonc
+++ b/tests/specs/check/globbing/__test__.jsonc
@@ -2,12 +2,12 @@
   "tests": {
     "star": {
       "args": "check *.ts",
-      "output": "Check [WILDCARD]main.ts\n",
+      "output": "Check [WILDCARD]main.ts\nChecked 1 file\n",
       "exitCode": 0
     },
     "star_not_found": {
       "args": "check *.js",
-      "output": "Warning No matching files found.\n",
+      "output": "Warning No matching files found.\nChecked 0 files\n",
       "exitCode": 0
     },
     "glob_star": {

--- a/tests/specs/check/import_meta_no_errors/__test__.jsonc
+++ b/tests/specs/check/import_meta_no_errors/__test__.jsonc
@@ -13,7 +13,7 @@
         },
         {
           "args": "check --all ./main.ts",
-          "output": "Check [WILDCARD]main.ts\n"
+          "output": "Check [WILDCARD]main.ts\nChecked 1 file\n"
         }
       ]
     },
@@ -29,7 +29,7 @@
         },
         {
           "args": "check --all ./main.ts",
-          "output": "Check [WILDCARD]main.ts\n"
+          "output": "Check [WILDCARD]main.ts\nChecked 1 file\n"
         }
       ]
     },
@@ -45,7 +45,7 @@
         },
         {
           "args": "check --all ./main.ts",
-          "output": "Check [WILDCARD]main.ts\n"
+          "output": "Check [WILDCARD]main.ts\nChecked 1 file\n"
         }
       ]
     }

--- a/tests/specs/check/jsdoc_comment_dynamic_import/__test__.jsonc
+++ b/tests/specs/check/jsdoc_comment_dynamic_import/__test__.jsonc
@@ -2,12 +2,12 @@
   "tests": {
     "comment_text": {
       "args": "check main.js",
-      "output": "",
+      "output": "Checked 1 file\n",
       "exitCode": 0
     },
     "ts_nocheck": {
       "args": "check ts_nocheck.js",
-      "output": "",
+      "output": "Checked 1 file\n",
       "exitCode": 0
     }
   }

--- a/tests/specs/check/jsx_automatic_no_explicit_import_source/check.out
+++ b/tests/specs/check/jsx_automatic_no_explicit_import_source/check.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.tsx
+Checked 1 file

--- a/tests/specs/check/jsx_import_source_different_per_member/main.out
+++ b/tests/specs/check/jsx_import_source_different_per_member/main.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.tsx
+Checked 2 files

--- a/tests/specs/check/jsx_import_source_not_in_graph/main.out
+++ b/tests/specs/check/jsx_import_source_not_in_graph/main.out
@@ -1,3 +1,4 @@
 Download http://localhost:4260/preact
 Download http://localhost:4260/preact/preact-10.19.6.tgz
 Check [WILDCARD]main.tsx
+Checked 1 file

--- a/tests/specs/check/jsx_import_source_types/main.out
+++ b/tests/specs/check/jsx_import_source_types/main.out
@@ -1,3 +1,4 @@
 Download http://localhost:4545/jsx-types/jsx-runtime
 Download http://localhost:4545/jsx-types/jsx-runtime.d.ts
 Check [WILDCARD]main.tsx
+Checked 1 file

--- a/tests/specs/check/jsx_import_source_types_config/main.out
+++ b/tests/specs/check/jsx_import_source_types_config/main.out
@@ -1,3 +1,4 @@
 Download http://localhost:4545/jsx-types/jsx-runtime
 Download http://localhost:4545/jsx-types/jsx-runtime.d.ts
 Check [WILDCARD]main.tsx
+Checked 1 file

--- a/tests/specs/check/jsx_import_source_with_tsconfig/main.out
+++ b/tests/specs/check/jsx_import_source_with_tsconfig/main.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.tsx
+Checked 1 file

--- a/tests/specs/check/node_timer_types/main.out
+++ b/tests/specs/check/node_timer_types/main.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/check/npm_esm_shared_no_default_types/main.out
+++ b/tests/specs/check/npm_esm_shared_no_default_types/main.out
@@ -1,1 +1,2 @@
 [WILDCARD]Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/check/package_json/check.out
+++ b/tests/specs/check/package_json/check.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/check/package_json_auto_install/check.out
+++ b/tests/specs/check/package_json_auto_install/check.out
@@ -2,3 +2,4 @@ Download http://localhost:4260/@denotest%2fesm-basic
 Download http://localhost:4260/@denotest/esm-basic/1.0.0.tgz
 Initialize @denotest/esm-basic@1.0.0
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/check/random_extension/output.out
+++ b/tests/specs/check/random_extension/output.out
@@ -1,2 +1,3 @@
 [WILDCARD]
 Check http://localhost:4545/subdir/no_js_ext@1.0.0
+Checked 1 file

--- a/tests/specs/check/special_specifiers/check.out
+++ b/tests/specs/check/special_specifiers/check.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]mod.ts
+Checked 1 file

--- a/tests/specs/check/type_reference_import_meta/__test__.jsonc
+++ b/tests/specs/check/type_reference_import_meta/__test__.jsonc
@@ -13,7 +13,7 @@
         },
         {
           "args": "check ./main.ts",
-          "output": "Check [WILDCARD]main.ts\n"
+          "output": "Check [WILDCARD]main.ts\nChecked 1 file\n"
         }
       ]
     },
@@ -29,7 +29,7 @@
         },
         {
           "args": "check ./main.ts",
-          "output": "Check [WILDCARD]main.ts\n"
+          "output": "Check [WILDCARD]main.ts\nChecked 1 file\n"
         }
       ]
     },
@@ -45,7 +45,7 @@
         },
         {
           "args": "check ./main.ts",
-          "output": "Check [WILDCARD]main.ts\n"
+          "output": "Check [WILDCARD]main.ts\nChecked 1 file\n"
         }
       ]
     }

--- a/tests/specs/check/typecheck_doc_duplicate_identifiers/mod.out
+++ b/tests/specs/check/typecheck_doc_duplicate_identifiers/mod.out
@@ -1,2 +1,3 @@
 Check [WILDCARD]mod.ts
 Check [WILDCARD]mod.ts#2-8.ts
+Checked 2 files

--- a/tests/specs/check/typecheck_doc_success/mod.out
+++ b/tests/specs/check/typecheck_doc_success/mod.out
@@ -1,2 +1,3 @@
 Check [WILDCARD]mod.ts
 Check [WILDCARD]mod.ts#2-5.ts
+Checked 2 files

--- a/tests/specs/check/with_tsconfig_json/main.out
+++ b/tests/specs/check/with_tsconfig_json/main.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/check/workspace/package_a.out
+++ b/tests/specs/check/workspace/package_a.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]mod.ts
+Checked 1 file

--- a/tests/specs/jsr/no_unused_params/main.out
+++ b/tests/specs/jsr/no_unused_params/main.out
@@ -2,3 +2,4 @@ Download http://127.0.0.1:4250/@denotest/add/meta.json
 Download http://127.0.0.1:4250/@denotest/add/1.0.0_meta.json
 Download http://127.0.0.1:4250/@denotest/add/1.0.0/mod.ts
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/lint/sloppy_imports_dts/check.out
+++ b/tests/specs/lint/sloppy_imports_dts/check.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/lockfile/frozen_lockfile/__test__.jsonc
+++ b/tests/specs/lockfile/frozen_lockfile/__test__.jsonc
@@ -193,7 +193,7 @@
         },
         {
           "args": "check --frozen=false add.ts",
-          "output": "[WILDCARD]Check [WILDCARD]add.ts\n"
+          "output": "[WILDCARD]Check [WILDCARD]add.ts\nChecked 1 file\n"
         }
       ]
     }

--- a/tests/specs/npm/check_pkg_json_import/main.out
+++ b/tests/specs/npm/check_pkg_json_import/main.out
@@ -1,3 +1,4 @@
 Download http://localhost:4260/@denotest%2ftypes-pkg-json-import
 Download http://localhost:4260/@denotest/types-pkg-json-import/1.0.0.tgz
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/npm/no_types_cjs/main.out
+++ b/tests/specs/npm/no_types_cjs/main.out
@@ -1,3 +1,4 @@
 Download http://localhost:4260/@denotest%2fno-types-cjs
 Download http://localhost:4260/@denotest/no-types-cjs/1.0.0.tgz
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/npm/types_d_ext/d_ext/main.out
+++ b/tests/specs/npm/types_d_ext/d_ext/main.out
@@ -1,3 +1,4 @@
 Download http://localhost:4260/@denotest%2fd-ext
 Download http://localhost:4260/@denotest/d-ext/1.0.0.tgz
 Check [WILDCARD]main.ts
+Checked 1 file

--- a/tests/specs/permission/allow_import_main_module/__test__.jsonc
+++ b/tests/specs/permission/allow_import_main_module/__test__.jsonc
@@ -11,7 +11,7 @@
     },
     "check": {
       "args": "check http://localhost:4545/run/002_hello.ts",
-      "output": "Download http://localhost:4545/run/002_hello.ts\nCheck http://localhost:4545/run/002_hello.ts\n"
+      "output": "Download http://localhost:4545/run/002_hello.ts\nCheck http://localhost:4545/run/002_hello.ts\nChecked 1 file\n"
     }
   }
 }

--- a/tests/specs/run/import_defer/check.out
+++ b/tests/specs/run/import_defer/check.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]main_ts.ts
+Checked 1 file

--- a/tests/specs/run/node_prefix_missing/node_globals_check.out
+++ b/tests/specs/run/node_prefix_missing/node_globals_check.out
@@ -1,1 +1,2 @@
 Check [WILDCARD]node_globals.ts
+Checked 1 file

--- a/tests/specs/run/unicode_identifier_u30fb/check.out
+++ b/tests/specs/run/unicode_identifier_u30fb/check.out
@@ -1,1 +1,2 @@
 Check [WILDLINE]main.ts
+Checked 1 file

--- a/tests/specs/workspaces/auto_link_external_import_map/check.out
+++ b/tests/specs/workspaces/auto_link_external_import_map/check.out
@@ -1,1 +1,2 @@
 Check [WILDLINE]
+Checked 1 file

--- a/tests/specs/workspaces/auto_link_external_import_map_file/check.out
+++ b/tests/specs/workspaces/auto_link_external_import_map_file/check.out
@@ -1,1 +1,2 @@
 Check [WILDLINE]
+Checked 1 file


### PR DESCRIPTION
`deno fmt` and `deno lint` end with a `Checked N files` summary, but
`deno check` printed nothing beyond the per-root `Check <specifier>`
lines — and printed nothing at all when everything was already type
checked and cached. This adds the same summary line at the end of a
successful `deno check` run, counting the collected root specifiers.
The line is omitted when type checking fails and suppressed by
`--quiet`, matching the behavior of the other commands.

Two integration tests previously detected whether tsc ran by checking
`stderr.contains("Check")`, which the new summary would always satisfy;
they now match lines starting with `Check ` instead.

Closes #32709