### PR TITLE
docs: document that ServeHandlerInfo.completed can reject

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5679,8 +5679,9 @@ declare namespace Deno {
      * response has been sent.
      *
      * It resolves once the response (including its body) has been completely
-     * delivered to the client. It **rejects** with an `Interrupted` error if the
-     * response could not be sent successfully — for example when the client
+     * delivered to the client. It **rejects** with a
+     * {@linkcode Deno.errors.Interrupted} error if the response could not be
+     * sent successfully — for example when the client
      * disconnects before the response body has been fully written. Attach a
      * `.catch()` (or wrap an `await` in `try`/`catch`) if you need to observe
      * these failures. */

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5675,7 +5675,15 @@ declare namespace Deno {
   export interface ServeHandlerInfo<Addr extends Deno.Addr = Deno.Addr> {
     /** The remote address of the connection. */
     remoteAddr: Addr;
-    /** The completion promise */
+    /** A promise that settles when the request has been fully handled and the
+     * response has been sent.
+     *
+     * It resolves once the response (including its body) has been completely
+     * delivered to the client. It **rejects** with an `Interrupted` error if the
+     * response could not be sent successfully — for example when the client
+     * disconnects before the response body has been fully written. Attach a
+     * `.catch()` (or wrap an `await` in `try`/`catch`) if you need to observe
+     * these failures. */
     completed: Promise<void>;
   }
 


### PR DESCRIPTION
## Summary

The `completed` promise exposed on the handler's info argument (`Deno.ServeHandlerInfo.completed`) was documented only as "The completion promise", with a type of `Promise<void>`. This undersells its behavior: the promise **rejects** with an `Interrupted` error when the response cannot be fully sent (e.g. the client disconnects before the response body is fully written), rather than only resolving.

This PR clarifies the JSDoc so users know the promise can reject and should be handled accordingly (via `.catch()` or `try`/`catch`). No behavior or type changes.

## Why

The reject path is real and reachable:

- `ServeHandlerInfo.completed` → `InnerRequest.completed` → the `#completed` deferred, settled in `InnerRequest.close(success)`. On failure it calls `this.#completed.reject(new Interrupted("HTTP response was not sent successfully"))` (`ext/http/00_serve.ts`).
- `close(success)` is invoked with the dynamic result of `op_http_set_response_body_resource`, which returns `record.response_body_finished().await`.
- `response_body_finished()` resolves to `response_body.is_complete() && trailers.is_none()` (`ext/http/service.rs`), which is `false` when the body wasn't fully delivered — e.g. a mid-stream client disconnect.

The existing legacy-abort warning already points users at `completed` "to detect when a request has been fully delivered", so documenting the rejection makes that contract accurate.