### PR TITLE
chore: add missing package metadata

### DIFF
--- a/libs/fast-registry-json/Cargo.toml
+++ b/libs/fast-registry-json/Cargo.toml
@@ -3,7 +3,11 @@
 [package]
 name = "fast-registry-json"
 version = "0.1.0"
-edition = "2024"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "SIMD-accelerated JSON scanner for indexing npm registry packuments"
 
 [dependencies]
 arrayref = "0.3.9"


### PR DESCRIPTION
The fast-registry-json crate manifest was missing the description and
license fields required for publishing. This adds them, inheriting
authors, edition, license, and repository from the workspace to match
the other crates in libs/.