### PR TITLE
fix(lint): include config file in workspace member invalid version error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147261611819fb4dfe339b53e3b45d6704c7e32c86ce33a88511d5bcebebaaa3"
+checksum = "ff487e9bf55c39bfbc47418a009a0de0988c4fea5e48e8ca787fa7dbff8056cc"
 dependencies = [
  "capacity_builder",
  "deno_error",
@@ -6576,7 +6576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ deno_lint = "=0.84.1"
 deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_path_util = "=0.6.4"
-deno_semver = "=0.10.0"
+deno_semver = "=0.10.1"
 deno_task_shell = "=0.33.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -34,6 +34,7 @@ use deno_config::workspace::WorkspaceDirLintConfig;
 use deno_config::workspace::WorkspaceDirectory;
 use deno_config::workspace::WorkspaceDirectoryRc;
 use deno_config::workspace::WorkspaceLintConfig;
+use deno_core::anyhow::Context;
 use deno_core::anyhow::bail;
 use deno_core::error::AnyError;
 use deno_core::url::Url;
@@ -1657,7 +1658,11 @@ pub fn config_to_deno_graph_workspace_member(
     None => bail!("Missing 'name' field in config file."),
   };
   let version = match &config.json.version {
-    Some(name) => Some(deno_semver::Version::parse_standard(name)?),
+    Some(version) => {
+      Some(deno_semver::Version::parse_standard(version).with_context(
+        || format!("Invalid 'version' field in '{}'", config.specifier),
+      )?)
+    }
     None => None,
   };
   Ok(deno_graph::WorkspaceMember {

--- a/tests/specs/lint/workspace_member_invalid_version/__test__.jsonc
+++ b/tests/specs/lint/workspace_member_invalid_version/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "lint",
+  "output": "lint.out",
+  "exitCode": 1
+}

--- a/tests/specs/lint/workspace_member_invalid_version/deno.json
+++ b/tests/specs/lint/workspace_member_invalid_version/deno.json
@@ -1,0 +1,3 @@
+{
+  "workspace": ["./foo"]
+}

--- a/tests/specs/lint/workspace_member_invalid_version/foo/deno.json
+++ b/tests/specs/lint/workspace_member_invalid_version/foo/deno.json
@@ -1,0 +1,5 @@
+{
+  "name": "@test/foo",
+  "version": "1.0",
+  "exports": "./mod.ts"
+}

--- a/tests/specs/lint/workspace_member_invalid_version/foo/mod.ts
+++ b/tests/specs/lint/workspace_member_invalid_version/foo/mod.ts
@@ -1,0 +1,1 @@
+export const hi: string = "hi";

--- a/tests/specs/lint/workspace_member_invalid_version/lint.out
+++ b/tests/specs/lint/workspace_member_invalid_version/lint.out
@@ -1,0 +1,3 @@
+error: Invalid 'version' field in 'file://[WILDCARD]/foo/deno.json': Invalid version: Missing patch version. Versions must be in the form MAJOR.MINOR.PATCH (ex. 1.0.0).
+  1.0
+  ~


### PR DESCRIPTION
An invalid `version` in a workspace member's `deno.json` produced a bare semver parse error with no indication of which file it came from:

```
error: Invalid version: Unexpected character.
  1.0
  ~
```

This PR fixes both halves of the diagnostic:

- **Config-file context**: `config_to_deno_graph_workspace_member` now annotates the version parse error with the member's config file specifier.
- **Better parse error**: bumps `deno_semver` to 0.10.1, which includes denoland/deno_semver#54 — the parser now names the missing component instead of the generic "Unexpected character.".

Result for the reported repro:

```
error: Invalid 'version' field in 'file:///.../foo/deno.json': Invalid version: Missing patch version. Versions must be in the form MAJOR.MINOR.PATCH (ex. 1.0.0).
  1.0
  ~
```

Added a spec test (`lint/workspace_member_invalid_version`) reproducing the issue's exact scenario. Existing specs asserting semver range-parse errors (`package_json/invalid_value`, `dynamic_npm_resolution_failure`, `upgrade/invalid_version`) are unaffected by the 0.10.1 bump — verified they still pass.

Closes #27226
Supersedes #34835 (closed due to inactivity / unsigned CLA; implemented independently)
