### PR TITLE
fix(install): resolve lifecycle script dependency bins against the hoisted layout

### DIFF
--- a/cli/npm.rs
+++ b/cli/npm.rs
@@ -17,6 +17,7 @@ use deno_core::serde_json;
 use deno_core::url::Url;
 use deno_error::JsErrorBox;
 use deno_lib::version::DENO_VERSION_INFO;
+use deno_npm::NpmPackageId;
 use deno_npm::NpmResolutionPackage;
 use deno_npm::registry::NpmPackageInfo;
 use deno_npm::registry::NpmPackageVersionInfosIterator;
@@ -490,6 +491,7 @@ impl LifecycleScriptsExecutor for DenoTaskLifeCycleScriptsExecutor {
         &mut bin_entries,
         options.snapshot,
         options.system_packages,
+        options.resolve_pkg_folder,
       )
       .await;
 
@@ -644,6 +646,7 @@ impl DenoTaskLifeCycleScriptsExecutor {
         package,
         options.snapshot,
         options.additional_packages,
+        options.resolve_pkg_folder,
       )
       .await;
 
@@ -729,6 +732,7 @@ impl DenoTaskLifeCycleScriptsExecutor {
     bin_entries: &mut BinEntries<'a, CliSys>,
     snapshot: &'a NpmResolutionSnapshot,
     packages: &'a [NpmResolutionPackage],
+    resolve_pkg_folder: Option<&dyn Fn(&NpmPackageId) -> Option<PathBuf>>,
   ) -> crate::task_runner::TaskCustomCommands {
     let mut custom_commands = crate::task_runner::TaskCustomCommands::new();
     custom_commands
@@ -756,6 +760,7 @@ impl DenoTaskLifeCycleScriptsExecutor {
         custom_commands,
         snapshot,
         packages,
+        resolve_pkg_folder,
       )
       .await
   }
@@ -773,13 +778,24 @@ impl DenoTaskLifeCycleScriptsExecutor {
     mut commands: crate::task_runner::TaskCustomCommands,
     snapshot: &'a NpmResolutionSnapshot,
     packages: P,
+    resolve_pkg_folder: Option<&dyn Fn(&NpmPackageId) -> Option<PathBuf>>,
   ) -> crate::task_runner::TaskCustomCommands {
     for package in packages {
-      let Ok(package_path) = self
-        .npm_resolver
-        .resolve_pkg_folder_from_pkg_id(&package.id)
-      else {
-        continue;
+      // prefer the installer-provided resolver, which knows the layout
+      // being installed (e.g. hoisted); the npm resolver assumes the
+      // isolated `.deno` layout
+      let package_path = match resolve_pkg_folder {
+        Some(resolve_pkg_folder) => match resolve_pkg_folder(&package.id) {
+          Some(path) => path,
+          None => continue,
+        },
+        None => match self
+          .npm_resolver
+          .resolve_pkg_folder_from_pkg_id(&package.id)
+        {
+          Ok(path) => path,
+          Err(_) => continue,
+        },
       };
       let extra = if let Some(extra) = &package.extra {
         Cow::Borrowed(extra)
@@ -825,6 +841,7 @@ impl DenoTaskLifeCycleScriptsExecutor {
     package: &NpmResolutionPackage,
     snapshot: &NpmResolutionSnapshot,
     additional_packages: &[&NpmResolutionPackage],
+    resolve_pkg_folder: Option<&dyn Fn(&NpmPackageId) -> Option<PathBuf>>,
   ) -> crate::task_runner::TaskCustomCommands {
     let sys = CliSys::default();
     let mut bin_entries = BinEntries::new(sys.with_paths_in_errors());
@@ -849,6 +866,7 @@ impl DenoTaskLifeCycleScriptsExecutor {
           }
           Some(dep)
         }),
+        resolve_pkg_folder,
       )
       .await
   }

--- a/cli/npm.rs
+++ b/cli/npm.rs
@@ -17,7 +17,6 @@ use deno_core::serde_json;
 use deno_core::url::Url;
 use deno_error::JsErrorBox;
 use deno_lib::version::DENO_VERSION_INFO;
-use deno_npm::NpmPackageId;
 use deno_npm::NpmResolutionPackage;
 use deno_npm::registry::NpmPackageInfo;
 use deno_npm::registry::NpmPackageVersionInfosIterator;
@@ -32,6 +31,7 @@ use deno_npm_installer::lifecycle_scripts::LIFECYCLE_SCRIPTS_RUNNING_ENV_VAR;
 use deno_npm_installer::lifecycle_scripts::LifecycleScriptsExecutor;
 use deno_npm_installer::lifecycle_scripts::LifecycleScriptsExecutorOptions;
 use deno_npm_installer::lifecycle_scripts::PackageWithScript;
+use deno_npm_installer::lifecycle_scripts::ResolvePkgFolderFn;
 use deno_npm_installer::lifecycle_scripts::compute_lifecycle_script_layers;
 use deno_npm_installer::lifecycle_scripts::is_broken_default_install_script;
 use deno_npmrc::RegistryConfig;
@@ -732,7 +732,7 @@ impl DenoTaskLifeCycleScriptsExecutor {
     bin_entries: &mut BinEntries<'a, CliSys>,
     snapshot: &'a NpmResolutionSnapshot,
     packages: &'a [NpmResolutionPackage],
-    resolve_pkg_folder: Option<&dyn Fn(&NpmPackageId) -> Option<PathBuf>>,
+    resolve_pkg_folder: Option<ResolvePkgFolderFn<'_>>,
   ) -> crate::task_runner::TaskCustomCommands {
     let mut custom_commands = crate::task_runner::TaskCustomCommands::new();
     custom_commands
@@ -778,7 +778,7 @@ impl DenoTaskLifeCycleScriptsExecutor {
     mut commands: crate::task_runner::TaskCustomCommands,
     snapshot: &'a NpmResolutionSnapshot,
     packages: P,
-    resolve_pkg_folder: Option<&dyn Fn(&NpmPackageId) -> Option<PathBuf>>,
+    resolve_pkg_folder: Option<ResolvePkgFolderFn<'_>>,
   ) -> crate::task_runner::TaskCustomCommands {
     for package in packages {
       // prefer the installer-provided resolver, which knows the layout
@@ -841,7 +841,7 @@ impl DenoTaskLifeCycleScriptsExecutor {
     package: &NpmResolutionPackage,
     snapshot: &NpmResolutionSnapshot,
     additional_packages: &[&NpmResolutionPackage],
-    resolve_pkg_folder: Option<&dyn Fn(&NpmPackageId) -> Option<PathBuf>>,
+    resolve_pkg_folder: Option<ResolvePkgFolderFn<'_>>,
   ) -> crate::task_runner::TaskCustomCommands {
     let sys = CliSys::default();
     let mut bin_entries = BinEntries::new(sys.with_paths_in_errors());

--- a/libs/npm_installer/hoisted.rs
+++ b/libs/npm_installer/hoisted.rs
@@ -784,6 +784,9 @@ impl<
         crate::process_state::NpmProcessStateLinkerMode::Hoisted,
       )
       .as_serialized();
+      let resolve_pkg_folder = |id: &NpmPackageId| {
+        hoisted_package_path(&layout, &self.root_node_modules_path, &id.nv)
+      };
 
       self
         .lifecycle_scripts_executor
@@ -791,6 +794,7 @@ impl<
           init_cwd: &self.lifecycle_scripts_config.initial_cwd,
           process_state: process_state.as_str(),
           root_node_modules_dir_path: &self.root_node_modules_path,
+          resolve_pkg_folder: Some(&resolve_pkg_folder),
           on_ran_pkg_scripts: &|_pkg| Ok(()),
           snapshot,
           system_packages: &package_partitions.packages,

--- a/libs/npm_installer/lifecycle_scripts.rs
+++ b/libs/npm_installer/lifecycle_scripts.rs
@@ -41,6 +41,15 @@ pub struct LifecycleScriptsExecutorOptions<'a> {
   pub init_cwd: &'a Path,
   pub process_state: &'a str,
   pub root_node_modules_dir_path: &'a Path,
+  /// Resolves the on-disk folder of a package for the node_modules layout
+  /// being installed, so the executor can locate the dependency bins that
+  /// lifecycle scripts invoke. When `None`, the executor falls back to its
+  /// own npm resolver, which assumes the isolated (`.deno`) layout — the
+  /// hoisted installer must provide this to map packages to their hoisted
+  /// locations. Returning `None` for a package means it has no folder in
+  /// the layout (e.g. an optional dependency for another platform).
+  pub resolve_pkg_folder:
+    Option<&'a (dyn Fn(&NpmPackageId) -> Option<PathBuf> + 'a)>,
   pub on_ran_pkg_scripts:
     &'a dyn Fn(&NpmResolutionPackage) -> Result<(), JsErrorBox>,
   pub snapshot: &'a NpmResolutionSnapshot,

--- a/libs/npm_installer/lifecycle_scripts.rs
+++ b/libs/npm_installer/lifecycle_scripts.rs
@@ -37,6 +37,12 @@ pub struct PackageWithScript<'a> {
   pub init_cwds: Vec<PathBuf>,
 }
 
+/// Resolves the on-disk folder of a package for the node_modules layout
+/// being installed. Returning `None` for a package means it has no folder
+/// in the layout (e.g. an optional dependency for another platform).
+pub type ResolvePkgFolderFn<'a> =
+  &'a (dyn Fn(&NpmPackageId) -> Option<PathBuf> + 'a);
+
 pub struct LifecycleScriptsExecutorOptions<'a> {
   pub init_cwd: &'a Path,
   pub process_state: &'a str,
@@ -46,10 +52,8 @@ pub struct LifecycleScriptsExecutorOptions<'a> {
   /// lifecycle scripts invoke. When `None`, the executor falls back to its
   /// own npm resolver, which assumes the isolated (`.deno`) layout — the
   /// hoisted installer must provide this to map packages to their hoisted
-  /// locations. Returning `None` for a package means it has no folder in
-  /// the layout (e.g. an optional dependency for another platform).
-  pub resolve_pkg_folder:
-    Option<&'a (dyn Fn(&NpmPackageId) -> Option<PathBuf> + 'a)>,
+  /// locations.
+  pub resolve_pkg_folder: Option<ResolvePkgFolderFn<'a>>,
   pub on_ran_pkg_scripts:
     &'a dyn Fn(&NpmResolutionPackage) -> Result<(), JsErrorBox>,
   pub snapshot: &'a NpmResolutionSnapshot,

--- a/libs/npm_installer/local.rs
+++ b/libs/npm_installer/local.rs
@@ -1156,6 +1156,7 @@ impl<
           init_cwd: &self.lifecycle_scripts_config.initial_cwd,
           process_state: process_state.as_str(),
           root_node_modules_dir_path: &self.root_node_modules_path,
+          resolve_pkg_folder: None,
           on_ran_pkg_scripts: &|pkg| {
             create_initialized_file(
               sys.as_ref(),

--- a/tests/specs/npm/lifecycle_scripts/hoisted_dep_bins/__test__.jsonc
+++ b/tests/specs/npm/lifecycle_scripts/hoisted_dep_bins/__test__.jsonc
@@ -1,0 +1,29 @@
+{
+  "tempDir": true,
+  "tests": {
+    // Lifecycle scripts that invoke bins from the package's dependencies
+    // (e.g. prebuild-install, node-gyp) must resolve those bins to the
+    // hoisted locations, not the isolated `.deno` layout.
+    // https://github.com/denoland/deno/issues/35742
+    "install_with_dep_bins": {
+      "steps": [
+        {
+          "args": "install --allow-scripts",
+          "output": "install.out"
+        },
+        {
+          // the `install` script chains a dependency bin (`cli-esm` from
+          // @denotest/bin) with `node install.js`, which writes this file —
+          // so its presence proves the dependency bin resolved and ran
+          "args": "eval console.log(Deno.readTextFileSync('install.txt'))",
+          "output": "Installed by @denotest/node-lifecycle-scripts!\n"
+        },
+        {
+          // sanity check the layout is actually hoisted
+          "args": "eval console.log(Deno.statSync('node_modules/@denotest/bin').isDirectory)",
+          "output": "true\n"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/npm/lifecycle_scripts/hoisted_dep_bins/deno.json
+++ b/tests/specs/npm/lifecycle_scripts/hoisted_dep_bins/deno.json
@@ -1,0 +1,4 @@
+{
+  "nodeModulesDir": "manual",
+  "nodeModulesLinker": "hoisted"
+}

--- a/tests/specs/npm/lifecycle_scripts/hoisted_dep_bins/install.out
+++ b/tests/specs/npm/lifecycle_scripts/hoisted_dep_bins/install.out
@@ -1,0 +1,4 @@
+[WILDCARD]Initialize @denotest/node-lifecycle-scripts@1.0.0: running 'preinstall' script
+[WILDCARD]Initialize @denotest/node-lifecycle-scripts@1.0.0: running 'install' script
+[WILDCARD]Initialize @denotest/node-lifecycle-scripts@1.0.0: running 'postinstall' script
+[WILDCARD]

--- a/tests/specs/npm/lifecycle_scripts/hoisted_dep_bins/package.json
+++ b/tests/specs/npm/lifecycle_scripts/hoisted_dep_bins/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/node-lifecycle-scripts": "1.0.0"
+  }
+}


### PR DESCRIPTION
Under `nodeModulesLinker: "hoisted"`, lifecycle scripts fail whenever they invoke a bin from the package's own dependencies — which is how most native addons install (`prebuild-install`, `node-gyp`, `cmake-js` are all invoked this way):

```
error: Unable to load <project>/node_modules/.deno/prebuild-install@7.1.3/node_modules/prebuild-install/bin.js
```

First symptom of #35742.

### Root cause

`DenoTaskLifeCycleScriptsExecutor` resolves the bins' package folders through the managed npm resolver (`resolve_pkg_folder_from_pkg_id` → `LocalNpmPackageResolver::maybe_package_folder`), which unconditionally computes isolated-layout paths (`node_modules/.deno/<id>/node_modules/<name>`). Those paths don't exist in a hoisted node_modules directory, so every dependency-bin invocation fails. The same wrong paths also flow into the `.bin` re-link pass that runs after scripts complete (`bin_entries.finish_only`), which could overwrite the installer's correct `.bin` shims with dangling ones.

### Fix

`LifecycleScriptsExecutorOptions` gains an optional `resolve_pkg_folder` callback so the installer — the layer that knows the layout being installed — supplies the package-folder mapping:

- the hoisted installer passes a closure backed by its already-computed layout (`hoisted_package_path`), so dependency bins and re-linked `.bin` entries point at the real hoisted locations;
- the isolated installer passes `None`, keeping the executor's existing npm-resolver-based behavior byte-for-byte.

### Tests

- New spec `npm/lifecycle_scripts/hoisted_dep_bins`: reuses `@denotest/node-lifecycle-scripts`, whose `install` script invokes a dependency bin (`cli-esm` from `@denotest/bin`). Fails with the error above before this change.
- All existing lifecycle-script (24) and hoisted (13) specs pass.
- Verified end-to-end against the original repro from #35742: `node-datachannel@0.32.3` with `{"nodeModulesDir": "manual", "nodeModulesLinker": "hoisted"}` — `deno install --allow-scripts` now runs `prebuild-install` successfully, the prebuilt `.node` lands in `build/Release/`, and the addon loads at runtime.

### Notes

- The second symptom of #35742 (`npm run <script>` inside a lifecycle script resolving against the project root) is a separate, layout-independent issue — config discovery strips the path at the first `node_modules` component (`strip_up_to_node_modules` in workspace discovery), so it also reproduces under the isolated linker; it's just masked there because the primary bin invocation succeeds. Left out of scope; the issue stays open to track it.
- Orthogonal to #35589 (side-effects cache), but the layout-aware folder resolution here is also groundwork its planned hoisted-linker port will need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
