### PR TITLE
feat(workers): support `{ deno: { memoryMb } }` to limit heap size

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -4625,6 +4625,15 @@ interface WorkerOptions {
   deno?: {
     /** Set to `"none"` to disable all the permissions in the worker. */
     permissions?: Deno.PermissionOptions;
+    /**
+     * The maximum size of the worker's V8 heap, in MB. Reaching this limit
+     * terminates the worker with an `ERR_WORKER_OUT_OF_MEMORY` error.
+     *
+     * This only bounds the JavaScript heap, not external allocations such as
+     * `ArrayBuffer`s, and the process may still abort on a global
+     * out-of-memory situation.
+     */
+    memoryMb?: number;
   };
 }
 

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -58,6 +58,7 @@ function createWorker(
   name,
   workerType,
   closeOnIdle,
+  resourceLimits,
 ) {
   return op_create_worker({
     hasSourceCode,
@@ -67,6 +68,7 @@ function createWorker(
     specifier,
     workerType,
     closeOnIdle,
+    resourceLimits,
   });
 }
 
@@ -149,6 +151,13 @@ class Worker extends EventTarget {
       sourceCode = "";
     }
 
+    // `deno.memoryMb` caps the worker's V8 heap (old generation). Reaching the
+    // limit terminates the worker with an `ERR_WORKER_OUT_OF_MEMORY` error.
+    let resourceLimits;
+    if (deno?.memoryMb !== undefined) {
+      resourceLimits = { maxOldGenerationSizeMb: deno.memoryMb };
+    }
+
     const id = createWorker(
       specifier,
       hasSourceCode,
@@ -157,6 +166,7 @@ class Worker extends EventTarget {
       this.#name,
       workerType,
       false,
+      resourceLimits,
     );
     this.#id = id;
     this.#pollControl();

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -236,7 +236,7 @@ pub enum CreateWorkerError {
 #[op2(stack_trace)]
 fn op_create_worker(
   state: &mut OpState,
-  #[scoped] args: CreateWorkerArgs,
+  #[scoped] mut args: CreateWorkerArgs,
   #[serde] maybe_worker_metadata: Option<JsMessageData>,
 ) -> Result<WorkerId, CreateWorkerError> {
   let specifier = args.specifier.clone();
@@ -259,6 +259,15 @@ fn op_create_worker(
       UNSTABLE_FEATURE_NAME,
       "Worker.deno.permissions",
     );
+  }
+
+  if args.resource_limits.is_some()
+    && !matches!(worker_type, WorkerThreadType::Node)
+    && !state
+      .borrow::<Arc<crate::FeatureChecker>>()
+      .check(UNSTABLE_FEATURE_NAME)
+  {
+    args.resource_limits = None;
   }
 
   let parent_permissions = state.borrow_mut::<PermissionsContainer>();

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -1154,11 +1154,9 @@ pub async fn run_web_worker(
   };
 
   if let Err(e) = result {
-    // For Node workers with OOM, skip script execution (V8 is terminated)
+    // For workers with OOM, skip script execution (V8 is terminated)
     // and use a dedicated error type with exit code 1.
-    if internal_handle.worker_type == WorkerThreadType::Node
-      && worker.oom_triggered.load(Ordering::SeqCst)
-    {
+    if worker.oom_triggered.load(Ordering::SeqCst) {
       let oom_error: CoreError = CoreErrorKind::JsBox(
         deno_error::JsErrorBox::new(
           "ERR_WORKER_OUT_OF_MEMORY",

--- a/tests/specs/worker/worker_memory_limit/__test__.jsonc
+++ b/tests/specs/worker/worker_memory_limit/__test__.jsonc
@@ -1,0 +1,16 @@
+{
+  "tests": {
+    "oom": {
+      "args": "run -A --unstable-worker-options main.ts --memoryMb 8",
+      "output": "oom.out"
+    },
+    "success": {
+      "args": "run -A --unstable-worker-options main.ts --memoryMb 64",
+      "output": "success.out"
+    },
+    "ignored_without_flag": {
+      "args": "run -A main.ts --memoryMb 8",
+      "output": "success.out"
+    }
+  }
+}

--- a/tests/specs/worker/worker_memory_limit/main.ts
+++ b/tests/specs/worker/worker_memory_limit/main.ts
@@ -1,0 +1,22 @@
+// Caps the worker's heap at `--memoryMb` MB. The worker allocates ~8 MB, so a
+// small limit terminates it with ERR_WORKER_OUT_OF_MEMORY, a larger one lets
+// it finish, and without `--unstable-worker-options` the limit is ignored.
+const idx = Deno.args.indexOf("--memoryMb");
+const memoryMb = idx >= 0 ? Number(Deno.args[idx + 1]) : undefined;
+
+const worker = new Worker(import.meta.resolve("./worker.ts"), {
+  type: "module",
+  deno: memoryMb !== undefined ? { memoryMb } : undefined,
+});
+
+worker.onmessage = (e) => {
+  console.log(e.data);
+  worker.terminate();
+  Deno.exit(0);
+};
+
+worker.onerror = (e) => {
+  e.preventDefault();
+  console.log(e.message);
+  Deno.exit(0);
+};

--- a/tests/specs/worker/worker_memory_limit/oom.out
+++ b/tests/specs/worker/worker_memory_limit/oom.out
@@ -1,0 +1,1 @@
+Worker terminated due to reaching memory limit: JS heap out of memory

--- a/tests/specs/worker/worker_memory_limit/success.out
+++ b/tests/specs/worker/worker_memory_limit/success.out
@@ -1,0 +1,1 @@
+allocated 4 chunks

--- a/tests/specs/worker/worker_memory_limit/worker.ts
+++ b/tests/specs/worker/worker_memory_limit/worker.ts
@@ -1,0 +1,4 @@
+// Allocate ~16 MB on the JS heap at module-eval time, then report success.
+const chunks = [];
+for (let i = 0; i < 4; i++) chunks.push(new Array(1024 * 1024).fill(0));
+globalThis.postMessage(`allocated ${chunks.length} chunks`);


### PR DESCRIPTION
The `node:workers` already supports `resourceLimits` but these are not exposed to regular `WebWorker` (which is normal since it's not part of the spec)

But for users who prefers using `WebWorker`, they currently have no way to specify such limits AFAIK.
This PR adds a single `memoryMb` in the worker deno namespace options (next to the permissions one) so end users have more controls on them, as they'd now be able to limit memory along with permissions (ideally limiting cpu would be nice too but it doesn't seem possible within the runtime itself)

I chose to only expose a single `memoryMb` (which maps to `maxOldGenerationSizeMb`) rather than all resource limit options supported by node to make the api simpler and more friendly

PR assisted by claude