### PR TITLE
feat(lsp): report test coverage to editor

### DIFF
--- a/cli/lsp/client.rs
+++ b/cli/lsp/client.rs
@@ -23,6 +23,7 @@ pub enum TestingNotification {
   Module(testing_lsp_custom::TestModuleNotificationParams),
   DeleteModule(testing_lsp_custom::TestModuleDeleteNotificationParams),
   Progress(testing_lsp_custom::TestRunProgressParams),
+  Coverage(testing_lsp_custom::TestCoverageNotificationParams),
 }
 
 #[derive(Clone)]
@@ -269,6 +270,14 @@ impl ClientTrait for TowerClient {
         self
           .0
           .send_notification::<testing_lsp_custom::TestRunProgressNotification>(
+            params,
+          )
+          .await
+      }
+      TestingNotification::Coverage(params) => {
+        self
+          .0
+          .send_notification::<testing_lsp_custom::TestCoverageNotification>(
             params,
           )
           .await

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -40,6 +41,7 @@ use crate::lsp::logging::lsp_log;
 use crate::lsp::urls::uri_parse_unencoded;
 use crate::lsp::urls::uri_to_url;
 use crate::lsp::urls::url_to_uri;
+use crate::tools::coverage::collect_coverage_reports;
 use crate::tools::test;
 use crate::tools::test::FailFastTracker;
 use crate::tools::test::TestFailure;
@@ -237,7 +239,12 @@ impl TestRun {
     client: &Client,
     maybe_root_uri: Option<&ModuleSpecifier>,
   ) -> Result<(), AnyError> {
-    let args = self.get_args();
+    let coverage_dir = if self.kind == lsp_custom::TestRunKind::Coverage {
+      Some(tempfile::tempdir()?)
+    } else {
+      None
+    };
+    let args = self.get_args(coverage_dir.as_ref().map(|dir| dir.path()));
     lsp_log!("Executing test run with arguments: {}", args.join(" "));
     let flags = Arc::new(flags_from_vec(
       args.into_iter().map(|s| From::from(s.as_ref())).collect(),
@@ -520,12 +527,59 @@ impl TestRun {
       join_result??;
     }
 
-    result??;
+    let result = result?;
+    if let Some(coverage_dir) = coverage_dir.as_ref()
+      && let Err(err) = self.report_coverage(client, coverage_dir.path()).await
+    {
+      lsp_log!("Failed reporting test coverage: {err:#}");
+    }
+
+    result?;
 
     Ok(())
   }
 
-  fn get_args(&self) -> Vec<Cow<'_, str>> {
+  async fn report_coverage(
+    &self,
+    client: &Client,
+    coverage_dir: &Path,
+  ) -> Result<(), AnyError> {
+    let args = self.get_args(Some(coverage_dir));
+    let flags = Arc::new(flags_from_vec(
+      args.into_iter().map(|s| From::from(s.as_ref())).collect(),
+    )?);
+    let (_, reports) = collect_coverage_reports(
+      flags,
+      vec![coverage_dir.to_string_lossy().into_owned()],
+      vec![],
+      vec![],
+      vec![],
+      None,
+    )?;
+    let files = reports
+      .into_iter()
+      .filter_map(|(report, _)| {
+        let uri = url_to_uri(report.url()).ok()?;
+        Some(lsp_custom::TestCoverageFile {
+          text_document: lsp::TextDocumentIdentifier { uri },
+          lines: report
+            .found_lines()
+            .iter()
+            .map(|(line, count)| lsp_custom::TestCoverageLine {
+              line: *line as u32,
+              count: *count,
+            })
+            .collect(),
+        })
+      })
+      .collect();
+    client.send_test_notification(TestingNotification::Coverage(
+      lsp_custom::TestCoverageNotificationParams { id: self.id, files },
+    ));
+    Ok(())
+  }
+
+  fn get_args(&self, coverage_dir: Option<&Path>) -> Vec<Cow<'_, str>> {
     let mut args = vec![Cow::Borrowed("deno"), Cow::Borrowed("test")];
     args.extend(
       self
@@ -560,6 +614,19 @@ impl TestRun {
       && !args.contains(&Cow::Borrowed("--inspect-brk"))
     {
       args.push(Cow::Borrowed("--inspect"));
+    }
+    if let Some(coverage_dir) = coverage_dir {
+      args.retain(|a| {
+        let a = a.as_ref();
+        a != "--coverage" && !a.starts_with("--coverage=")
+      });
+      args.push(Cow::Owned(format!(
+        "--coverage={}",
+        coverage_dir.to_string_lossy()
+      )));
+      if !args.contains(&Cow::Borrowed("--coverage-raw-data-only")) {
+        args.push(Cow::Borrowed("--coverage-raw-data-only"));
+      }
     }
     // Inherit `--env-file` paths from the `test` task in deno.json when the
     // user hasn't already supplied one via `deno.testing.args`. Without this,

--- a/cli/lsp/testing/lsp_custom.rs
+++ b/cli/lsp/testing/lsp_custom.rs
@@ -84,7 +84,6 @@ pub enum TestRunKind {
   // The tests should be run and debugged, currently not implemented
   Debug,
   // The tests should be run, collecting and reporting coverage information,
-  // currently not implemented
   Coverage,
 }
 
@@ -185,4 +184,34 @@ impl lsp::notification::Notification for TestRunProgressNotification {
   type Params = TestRunProgressParams;
 
   const METHOD: &'static str = "deno/testRunProgress";
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestCoverageLine {
+  /// The zero-based line index in the text document.
+  pub line: u32,
+  pub count: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestCoverageFile {
+  pub text_document: lsp::TextDocumentIdentifier,
+  pub lines: Vec<TestCoverageLine>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestCoverageNotificationParams {
+  pub id: u32,
+  pub files: Vec<TestCoverageFile>,
+}
+
+pub enum TestCoverageNotification {}
+
+impl lsp::notification::Notification for TestCoverageNotification {
+  type Params = TestCoverageNotificationParams;
+
+  const METHOD: &'static str = "deno/testCoverage";
 }

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -73,6 +73,16 @@ pub struct CoverageReport {
   output: Option<PathBuf>,
 }
 
+impl CoverageReport {
+  pub fn url(&self) -> &ModuleSpecifier {
+    &self.url
+  }
+
+  pub fn found_lines(&self) -> &[(usize, i64)] {
+    &self.found_lines
+  }
+}
+
 struct GenerateCoverageReportOptions<'a> {
   script_module_specifier: Url,
   script_media_type: MediaType,
@@ -590,16 +600,14 @@ fn filter_coverages(
 }
 
 #[allow(clippy::too_many_arguments, reason = "coverage entry point")]
-pub fn cover_files(
+pub fn collect_coverage_reports(
   flags: Arc<Flags>,
   files_include: Vec<String>,
   files_ignore: Vec<String>,
   include: Vec<String>,
   exclude: Vec<String>,
   output: Option<String>,
-  cli_threshold: Option<f64>,
-  reporters: &[&dyn CoverageReporter],
-) -> Result<(), AnyError> {
+) -> Result<(PathBuf, Vec<(CoverageReport, String)>), AnyError> {
   if files_include.is_empty() {
     return Err(anyhow!("No matching coverage profiles found"));
   }
@@ -790,12 +798,37 @@ pub fn cover_files(
     return Err(anyhow!("No covered files included in the report"));
   }
 
+  Ok((coverage_root, file_reports))
+}
+
+#[allow(clippy::too_many_arguments, reason = "coverage entry point")]
+pub fn cover_files(
+  flags: Arc<Flags>,
+  files_include: Vec<String>,
+  files_ignore: Vec<String>,
+  include: Vec<String>,
+  exclude: Vec<String>,
+  output: Option<String>,
+  cli_threshold: Option<f64>,
+  reporters: &[&dyn CoverageReporter],
+) -> Result<(), AnyError> {
+  let (coverage_root, file_reports) = collect_coverage_reports(
+    flags.clone(),
+    files_include,
+    files_ignore,
+    include,
+    exclude,
+    output,
+  )?;
+
   for reporter in reporters {
     reporter.done(&coverage_root, &file_reports);
   }
 
   // Layer the `--threshold` CLI flag over per-metric thresholds from deno.json
   // (the flag wins) and fail the command if any configured threshold is unmet.
+  let factory = CliFactory::from_flags(flags);
+  let cli_options = factory.cli_options()?;
   let config_thresholds = cli_options.resolve_coverage_thresholds()?;
   let thresholds = CoverageThresholds {
     lines: cli_threshold.or(config_thresholds.lines),

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -16532,6 +16532,105 @@ fn lsp_testing_api_empty_test_name() {
   client.shutdown();
 }
 
+#[test(timeout = 300)]
+fn lsp_testing_api_coverage() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write("./deno.json", json!({}).to_string());
+  let module = temp_dir.source_file(
+    "mod.ts",
+    r#"
+export function classify(value: boolean): string {
+  if (value) {
+    return "covered";
+  }
+  return "uncovered";
+}
+"#,
+  );
+  let test_file = temp_dir.source_file(
+    "test.ts",
+    r#"
+import { classify } from "./mod.ts";
+
+Deno.test("classifies true", () => {
+  if (classify(true) !== "covered") {
+    throw new Error("unexpected result");
+  }
+});
+"#,
+  );
+
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.did_open_file(&test_file);
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testModule");
+  let params: TestModuleNotificationParams =
+    serde_json::from_value(notification.unwrap()).unwrap();
+  assert_eq!(params.tests.len(), 1);
+
+  client.write_request_with_res_as::<TestRunResponseParams>(
+    "deno/testRun",
+    json!({
+      "id": 1,
+      "kind": "coverage",
+    }),
+  );
+
+  loop {
+    let notification = client
+      .read_notification_with_method::<Value>("deno/testRunProgress")
+      .unwrap();
+    let message = notification
+      .as_object()
+      .unwrap()
+      .get("message")
+      .unwrap()
+      .as_object()
+      .unwrap();
+    if message.get("type").and_then(|v| v.as_str()) == Some("end") {
+      break;
+    }
+  }
+
+  let notification = client
+    .read_notification_with_method::<Value>("deno/testCoverage")
+    .unwrap();
+  assert_eq!(notification.get("id"), Some(&json!(1)));
+  let files = notification
+    .get("files")
+    .and_then(|value| value.as_array())
+    .unwrap();
+  let module_coverage = files
+    .iter()
+    .find(|file| {
+      file
+        .pointer("/textDocument/uri")
+        .and_then(|value| value.as_str())
+        == Some(module.uri().as_str())
+    })
+    .expect("expected coverage for imported module");
+  let lines = module_coverage
+    .get("lines")
+    .and_then(|value| value.as_array())
+    .unwrap();
+  assert!(
+    lines
+      .iter()
+      .any(|line| line.get("count").and_then(|value| value.as_i64()) == Some(0)),
+    "expected uncovered lines in coverage notification",
+  );
+  assert!(
+    lines.iter().any(|line| line
+      .get("count")
+      .and_then(|value| value.as_i64())
+      .is_some_and(|count| count > 0)),
+    "expected covered lines in coverage notification",
+  );
+  client.shutdown();
+}
+
 // Regression test for https://github.com/denoland/deno/issues/28797.
 // When deno.json declares a `test` task with `--env-file=...`, the LSP test
 // runner should load that env file too — otherwise tests that read env vars at


### PR DESCRIPTION
Closes #18147.

This adds LSP test coverage reporting for coverage test runs:

- collects raw coverage data into an LSP-owned temp dir
- reuses coverage report generation to send a deno/testCoverage notification
- adds an integration test for coverage notifications

Tests:

- cargo fmt --all -- --check
- git diff --check
- cargo check -p deno --lib -j 2
- cargo test -p deno --lib lsp::testing::execution::tests -j 2