### PR TITLE
fix(dprint): exclude `tools/lzld` submodule

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -83,7 +83,8 @@
     "tests/specs/run/shebang_with_json_imports_tsc",
     "tests/specs/run/shebang_with_json_imports_swc",
     "tests/specs/run/ext_flag_takes_precedence_over_extension",
-    "tests/specs/run/error_syntax_empty_trailing_line/error_syntax_empty_trailing_line.mjs"
+    "tests/specs/run/error_syntax_empty_trailing_line/error_syntax_empty_trailing_line.mjs",
+    "tools/lzld"
   ],
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.96.0.wasm",


### PR DESCRIPTION
Otherwise running `./x fmt` will format files in that submodule: 

```sh
# format
./x fmt
Formatting code...
...
Formatting complete.

# check changes
git -C tools/lzld status
HEAD detached at cbf98cf
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   README.md
        modified:   tests/.cargo/config.toml
        modified:   tests/Cargo.toml
        modified:   tests/src/main.rs
        modified:   tests/test.ts

no changes added to commit (use "git add" and/or "git commit -a")
```

Note: `tools/lzld` has been added recently in #35341
