### PR TITLE
perf(ext/web): reduce per-chunk allocations on stream read and tee paths

### DIFF
--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -18,7 +18,6 @@ const {
   ObjectDefineProperties,
   ObjectPrototypeIsPrototypeOf,
   PromisePrototypeCatch,
-  PromiseResolve,
   SafeWeakMap,
   TypedArrayPrototypeGetBuffer,
   TypedArrayPrototypeGetByteLength,
@@ -124,15 +123,15 @@ class InnerBody {
         // the encode is skipped entirely. `createReadableStream` also avoids
         // the webidl UnderlyingSource conversion `new ReadableStream({...})`
         // performs.
-        // The pull and cancel algorithms must return promises (see
-        // `createReadableStream`): `readableStreamCancel` and the controller's
-        // pull machinery call `.then` on the returned value directly.
+        // The cancel algorithm must return a promise (`readableStreamCancel`
+        // calls `.then` on it directly); the pull algorithm returns undefined,
+        // the synchronous completion sentinel understood by the controller's
+        // pull machinery (see `createReadableStream`).
         const stream = createReadableStream(
           noop,
           (controller) => {
             controller.enqueue(chunkToU8(body));
             controller.close();
-            return PromiseResolve(undefined);
           },
           noopAsync,
           0,

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -445,6 +445,8 @@ const _inFlightWriteRequest = Symbol("[[inFlightWriteRequest]]");
 const _pendingAbortRequest = Symbol("[pendingAbortRequest]");
 const _pendingPullIntos = Symbol("[[pendingPullIntos]]");
 const _preventCancel = Symbol("[[preventCancel]]");
+const _onPullFulfilled = Symbol("[[onPullFulfilled]]");
+const _onPullRejected = Symbol("[[onPullRejected]]");
 const _pullAgain = Symbol("[[pullAgain]]");
 const _pullAlgorithm = Symbol("[[pullAlgorithm]]");
 const _pulling = Symbol("[[pulling]]");
@@ -1456,18 +1458,32 @@ function readableByteStreamControllerCallPullIfNeeded(controller) {
   controller[_pulling] = true;
   /** @type {Promise<void>} */
   const pullPromise = controller[_pullAlgorithm](controller);
-  uponPromise(
-    pullPromise,
-    () => {
-      controller[_pulling] = false;
-      if (controller[_pullAgain]) {
-        controller[_pullAgain] = false;
-        readableByteStreamControllerCallPullIfNeeded(controller);
+  // See readableStreamDefaultControllerCallPullIfNeeded: reaction handlers
+  // are created once per controller instead of per pull.
+  if (controller[_onPullFulfilled] === undefined) {
+    controller[_onPullFulfilled] = () => {
+      try {
+        controller[_pulling] = false;
+        if (controller[_pullAgain]) {
+          controller[_pullAgain] = false;
+          readableByteStreamControllerCallPullIfNeeded(controller);
+        }
+      } catch (e) {
+        rethrowAssertionErrorRejection(e);
       }
-    },
-    (e) => {
-      readableByteStreamControllerError(controller, e);
-    },
+    };
+    controller[_onPullRejected] = (e) => {
+      try {
+        readableByteStreamControllerError(controller, e);
+      } catch (err) {
+        rethrowAssertionErrorRejection(err);
+      }
+    };
+  }
+  PromisePrototypeThen(
+    pullPromise,
+    controller[_onPullFulfilled],
+    controller[_onPullRejected],
   );
 }
 
@@ -1916,18 +1932,34 @@ function readableStreamDefaultControllerCallPullIfNeeded(controller) {
   assert(controller[_pullAgain] === false);
   controller[_pulling] = true;
   const pullPromise = controller[_pullAlgorithm](controller);
-  uponPromise(
-    pullPromise,
-    () => {
-      controller[_pulling] = false;
-      if (controller[_pullAgain] === true) {
-        controller[_pullAgain] = false;
-        readableStreamDefaultControllerCallPullIfNeeded(controller);
+  // The reaction handlers are created once per controller (lazily, so
+  // never-pulled streams don't pay for them) instead of per pull. They
+  // include the assertion-rethrow wrapping that uponPromise() would
+  // otherwise re-create on every call.
+  if (controller[_onPullFulfilled] === undefined) {
+    controller[_onPullFulfilled] = () => {
+      try {
+        controller[_pulling] = false;
+        if (controller[_pullAgain] === true) {
+          controller[_pullAgain] = false;
+          readableStreamDefaultControllerCallPullIfNeeded(controller);
+        }
+      } catch (e) {
+        rethrowAssertionErrorRejection(e);
       }
-    },
-    (e) => {
-      readableStreamDefaultControllerError(controller, e);
-    },
+    };
+    controller[_onPullRejected] = (e) => {
+      try {
+        readableStreamDefaultControllerError(controller, e);
+      } catch (err) {
+        rethrowAssertionErrorRejection(err);
+      }
+    };
+  }
+  PromisePrototypeThen(
+    pullPromise,
+    controller[_onPullFulfilled],
+    controller[_onPullRejected],
   );
 }
 
@@ -6244,6 +6276,10 @@ class ReadableByteStreamController {
   [_cancelAlgorithm];
   /** @type {boolean} */
   [_closeRequested];
+  /** @type {(() => void) | undefined} */
+  [_onPullFulfilled];
+  /** @type {((e: any) => void) | undefined} */
+  [_onPullRejected];
   /** @type {boolean} */
   [_pullAgain];
   /** @type {(controller: this) => Promise<void>} */
@@ -6448,6 +6484,10 @@ class ReadableStreamDefaultController {
   [_cancelAlgorithm];
   /** @type {boolean} */
   [_closeRequested];
+  /** @type {(() => void) | undefined} */
+  [_onPullFulfilled];
+  /** @type {((e: any) => void) | undefined} */
+  [_onPullRejected];
   /** @type {boolean} */
   [_pullAgain];
   /** @type {(controller: this) => Promise<void>} */

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -456,8 +456,9 @@ const _inFlightWriteRequest = Symbol("[[inFlightWriteRequest]]");
 const _pendingAbortRequest = Symbol("[pendingAbortRequest]");
 const _pendingPullIntos = Symbol("[[pendingPullIntos]]");
 const _preventCancel = Symbol("[[preventCancel]]");
-const _onPullFulfilled = Symbol("[[onPullFulfilled]]");
-const _onPullRejected = Symbol("[[onPullRejected]]");
+// Implementation slots (not spec slots): single-bracket convention.
+const _onPullFulfilled = Symbol("[onPullFulfilled]");
+const _onPullRejected = Symbol("[onPullRejected]");
 const _pullAgain = Symbol("[[pullAgain]]");
 const _pullAlgorithm = Symbol("[[pullAlgorithm]]");
 const _pulling = Symbol("[[pulling]]");
@@ -678,8 +679,11 @@ function extractSizeAlgorithm(strategy) {
 }
 
 /**
+ * The pull algorithm may return undefined instead of a promise to signal
+ * synchronous completion (see callPullIfNeeded); the cancel algorithm must
+ * return a promise.
  * @param {() => void} startAlgorithm
- * @param {() => Promise<void>} pullAlgorithm
+ * @param {() => Promise<void> | undefined} pullAlgorithm
  * @param {(reason: any) => Promise<void>} cancelAlgorithm
  * @returns {ReadableStream}
  */
@@ -3939,7 +3943,7 @@ function readableByteStreamTee(stream) {
  * @param {ReadableStream<ArrayBuffer>} stream
  * @param {ReadableByteStreamController} controller
  * @param {() => void} startAlgorithm
- * @param {() => Promise<void>} pullAlgorithm
+ * @param {() => Promise<void> | undefined} pullAlgorithm
  * @param {(reason: any) => Promise<void>} cancelAlgorithm
  * @param {number} highWaterMark
  * @param {number | undefined} autoAllocateChunkSize
@@ -4056,7 +4060,7 @@ function setUpReadableByteStreamControllerFromUnderlyingSource(
  * @param {ReadableStream<R>} stream
  * @param {ReadableStreamDefaultController<R>} controller
  * @param {(controller: ReadableStreamDefaultController<R>) => void | Promise<void>} startAlgorithm
- * @param {(controller: ReadableStreamDefaultController<R>) => Promise<void>} pullAlgorithm
+ * @param {(controller: ReadableStreamDefaultController<R>) => Promise<void> | undefined} pullAlgorithm
  * @param {(reason: any) => Promise<void>} cancelAlgorithm
  * @param {number} highWaterMark
  * @param {(chunk: R) => number} sizeAlgorithm

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -168,6 +168,17 @@ function resolvePromiseWith(value) {
   return new Promise((resolve) => resolve(value));
 }
 
+/** @type {Promise<undefined> | undefined} */
+let _resolvedPromise;
+/**
+ * Shared resolved promise for hot paths that only need a base to hang a
+ * `.then()` off of. Created lazily so it isn't baked into the snapshot.
+ * @returns {Promise<undefined>}
+ */
+function resolvedPromise() {
+  return _resolvedPromise ??= PromiseResolve(undefined);
+}
+
 /** @param {any} e */
 function rethrowAssertionErrorRejection(e) {
   if (e && ObjectPrototypeIsPrototypeOf(AssertionError.prototype, e)) {
@@ -480,7 +491,13 @@ const _defaultStartAlgorithm = noop;
 const _defaultWriteAlgorithm = noopAsync;
 const _defaultCloseAlgorithm = noopAsync;
 const _defaultAbortAlgorithm = noopAsync;
-const _defaultPullAlgorithm = noopAsync;
+// Pull algorithms may return undefined instead of a promise to signal
+// synchronous completion; callPullIfNeeded then subscribes its fulfilled
+// handler to the shared resolvedPromise() instead of allocating a fresh
+// one per pull. (Not queueMicrotask: its dispatch measures ~15ns/tick
+// slower than a reaction on a resolved promise, more than the saved
+// allocation buys back.)
+const _defaultPullAlgorithm = noop;
 const _defaultFlushAlgorithm = noopAsync;
 const _defaultCancelAlgorithm = noopAsync;
 
@@ -516,9 +533,12 @@ function acquireWritableStreamDefaultWriter(stream) {
 }
 
 /**
+ * The pull algorithm may return undefined instead of a promise to signal
+ * synchronous completion (see callPullIfNeeded); the cancel algorithm must
+ * return a promise.
  * @template R
  * @param {() => void} startAlgorithm
- * @param {() => Promise<void>} pullAlgorithm
+ * @param {() => Promise<void> | undefined} pullAlgorithm
  * @param {(reason: any) => Promise<void>} cancelAlgorithm
  * @param {number=} highWaterMark
  * @param {((chunk: R) => number)=} sizeAlgorithm
@@ -1480,6 +1500,13 @@ function readableByteStreamControllerCallPullIfNeeded(controller) {
       }
     };
   }
+  if (pullPromise === undefined) {
+    // See readableStreamDefaultControllerCallPullIfNeeded: synchronous
+    // internal pull algorithms return undefined; subscribe the handler
+    // to the shared pre-resolved promise instead.
+    PromisePrototypeThen(resolvedPromise(), controller[_onPullFulfilled]);
+    return;
+  }
   PromisePrototypeThen(
     pullPromise,
     controller[_onPullFulfilled],
@@ -1955,6 +1982,15 @@ function readableStreamDefaultControllerCallPullIfNeeded(controller) {
         rethrowAssertionErrorRejection(err);
       }
     };
+  }
+  if (pullPromise === undefined) {
+    // The pull algorithm completed synchronously (internal algorithms
+    // signal this by returning undefined instead of a resolved promise).
+    // Subscribing the handler to the shared pre-resolved promise enqueues
+    // the reaction at the same microtask position a fresh resolved
+    // promise would, minus the allocation.
+    PromisePrototypeThen(resolvedPromise(), controller[_onPullFulfilled]);
+    return;
   }
   PromisePrototypeThen(
     pullPromise,
@@ -3514,14 +3550,16 @@ function readableStreamDefaultTee(stream, cloneForBranch2) {
     },
   };
 
+  // Returns undefined (synchronous completion sentinel understood by
+  // readableStreamDefaultControllerCallPullIfNeeded) instead of a
+  // resolved promise.
   function pullAlgorithm() {
     if (reading === true) {
       readAgain = true;
-      return PromiseResolve(undefined);
+      return;
     }
     reading = true;
     readableStreamDefaultReaderRead(reader, readRequest);
-    return PromiseResolve(undefined);
   }
 
   /**
@@ -3818,10 +3856,13 @@ function readableByteStreamTee(stream) {
     readableStreamBYOBReaderRead(reader, view, 1, readIntoRequest);
   }
 
+  // pull1Algorithm/pull2Algorithm return undefined (synchronous completion
+  // sentinel understood by readableByteStreamControllerCallPullIfNeeded)
+  // instead of a resolved promise.
   function pull1Algorithm() {
     if (reading) {
       readAgainForBranch1 = true;
-      return PromiseResolve(undefined);
+      return;
     }
     reading = true;
     const byobRequest = readableByteStreamControllerGetBYOBRequest(
@@ -3832,13 +3873,12 @@ function readableByteStreamTee(stream) {
     } else {
       pullWithBYOBReader(byobRequest[_view], false);
     }
-    return PromiseResolve(undefined);
   }
 
   function pull2Algorithm() {
     if (reading) {
       readAgainForBranch2 = true;
-      return PromiseResolve(undefined);
+      return;
     }
     reading = true;
     const byobRequest = readableByteStreamControllerGetBYOBRequest(
@@ -3849,7 +3889,6 @@ function readableByteStreamTee(stream) {
     } else {
       pullWithBYOBReader(byobRequest[_view], true);
     }
-    return PromiseResolve(undefined);
   }
 
   function cancel1Algorithm(reason) {
@@ -6282,7 +6321,7 @@ class ReadableByteStreamController {
   [_onPullRejected];
   /** @type {boolean} */
   [_pullAgain];
-  /** @type {(controller: this) => Promise<void>} */
+  /** @type {(controller: this) => Promise<void> | undefined} */
   [_pullAlgorithm];
   /** @type {boolean} */
   [_pulling];
@@ -6490,7 +6529,7 @@ class ReadableStreamDefaultController {
   [_onPullRejected];
   /** @type {boolean} */
   [_pullAgain];
-  /** @type {(controller: this) => Promise<void>} */
+  /** @type {(controller: this) => Promise<void> | undefined} */
   [_pullAlgorithm];
   /** @type {boolean} */
   [_pulling];

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -3399,84 +3399,95 @@ function readableStreamDefaultTee(stream, cloneForBranch2) {
   /** @type {Deferred<void>} */
   const cancelPromise = new Deferred();
 
+  // The read request, its microtask callback, and the pending chunk slot are
+  // allocated once per tee() rather than once per chunk: the `reading` flag
+  // guarantees at most one read is in flight at a time.
+  /** @type {R | undefined} */
+  let pendingChunk;
+
+  function chunkStepsMicrotask() {
+    readAgain = false;
+    const value1 = pendingChunk;
+    let value2 = pendingChunk;
+    pendingChunk = undefined;
+
+    if (canceled2 === false && cloneForBranch2 === true) {
+      try {
+        value2 = structuredClone(value2);
+      } catch (cloneError) {
+        readableStreamDefaultControllerError(
+          branch1[_controller],
+          cloneError,
+        );
+        readableStreamDefaultControllerError(
+          branch2[_controller],
+          cloneError,
+        );
+        cancelPromise.resolve(readableStreamCancel(stream, cloneError));
+        return;
+      }
+    }
+
+    if (canceled1 === false) {
+      readableStreamDefaultControllerEnqueue(
+        /** @type {ReadableStreamDefaultController<any>} */ branch1[
+          _controller
+        ],
+        value1,
+      );
+    }
+    if (canceled2 === false) {
+      readableStreamDefaultControllerEnqueue(
+        /** @type {ReadableStreamDefaultController<any>} */ branch2[
+          _controller
+        ],
+        value2,
+      );
+    }
+
+    reading = false;
+    if (readAgain === true) {
+      pullAlgorithm();
+    }
+  }
+
+  /** @type {ReadRequest<R>} */
+  const readRequest = {
+    chunkSteps(value) {
+      pendingChunk = value;
+      queueMicrotask(chunkStepsMicrotask);
+    },
+    closeSteps() {
+      reading = false;
+      if (canceled1 === false) {
+        readableStreamDefaultControllerClose(
+          /** @type {ReadableStreamDefaultController<any>} */ branch1[
+            _controller
+          ],
+        );
+      }
+      if (canceled2 === false) {
+        readableStreamDefaultControllerClose(
+          /** @type {ReadableStreamDefaultController<any>} */ branch2[
+            _controller
+          ],
+        );
+      }
+      if (canceled1 === false || canceled2 === false) {
+        cancelPromise.resolve(undefined);
+      }
+    },
+    errorSteps() {
+      reading = false;
+    },
+  };
+
   function pullAlgorithm() {
     if (reading === true) {
       readAgain = true;
       return PromiseResolve(undefined);
     }
     reading = true;
-    /** @type {ReadRequest<R>} */
-    const readRequest = {
-      chunkSteps(value) {
-        queueMicrotask(() => {
-          readAgain = false;
-          const value1 = value;
-          let value2 = value;
-
-          if (canceled2 === false && cloneForBranch2 === true) {
-            try {
-              value2 = structuredClone(value2);
-            } catch (cloneError) {
-              readableStreamDefaultControllerError(
-                branch1[_controller],
-                cloneError,
-              );
-              readableStreamDefaultControllerError(
-                branch2[_controller],
-                cloneError,
-              );
-              cancelPromise.resolve(readableStreamCancel(stream, cloneError));
-              return;
-            }
-          }
-
-          if (canceled1 === false) {
-            readableStreamDefaultControllerEnqueue(
-              /** @type {ReadableStreamDefaultController<any>} */ branch1[
-                _controller
-              ],
-              value1,
-            );
-          }
-          if (canceled2 === false) {
-            readableStreamDefaultControllerEnqueue(
-              /** @type {ReadableStreamDefaultController<any>} */ branch2[
-                _controller
-              ],
-              value2,
-            );
-          }
-
-          reading = false;
-          if (readAgain === true) {
-            pullAlgorithm();
-          }
-        });
-      },
-      closeSteps() {
-        reading = false;
-        if (canceled1 === false) {
-          readableStreamDefaultControllerClose(
-            /** @type {ReadableStreamDefaultController<any>} */ branch1[
-              _controller
-            ],
-          );
-        }
-        if (canceled2 === false) {
-          readableStreamDefaultControllerClose(
-            /** @type {ReadableStreamDefaultController<any>} */ branch2[
-              _controller
-            ],
-          );
-        }
-        if (canceled1 === false || canceled2 === false) {
-          cancelPromise.resolve(undefined);
-        }
-      },
-      errorSteps() {
-        reading = false;
-      },
-    };
     readableStreamDefaultReaderRead(reader, readRequest);
     return PromiseResolve(undefined);
   }
@@ -3587,6 +3598,72 @@ function readableByteStreamTee(stream) {
     });
   }
 
+  // The read requests, their microtask callbacks, and the pending chunk and
+  // branch slots are allocated once per tee() rather than once per chunk: the
+  // `reading` flag guarantees at most one read is in flight at a time.
+  /** @type {ArrayBufferView | undefined} */
+  let pendingChunk;
+
+  function defaultReaderChunkStepsMicrotask() {
+    const chunk = pendingChunk;
+    pendingChunk = undefined;
+    readAgainForBranch1 = false;
+    readAgainForBranch2 = false;
+    const chunk1 = chunk;
+    let chunk2 = chunk;
+    if (!canceled1 && !canceled2) {
+      try {
+        chunk2 = cloneAsUint8Array(chunk);
+      } catch (e) {
+        readableByteStreamControllerError(branch1[_controller], e);
+        readableByteStreamControllerError(branch2[_controller], e);
+        cancelPromise.resolve(readableStreamCancel(stream, e));
+        return;
+      }
+    }
+    if (!canceled1) {
+      readableByteStreamControllerEnqueue(branch1[_controller], chunk1);
+    }
+    if (!canceled2) {
+      readableByteStreamControllerEnqueue(branch2[_controller], chunk2);
+    }
+    reading = false;
+    if (readAgainForBranch1) {
+      pull1Algorithm();
+    } else if (readAgainForBranch2) {
+      pull2Algorithm();
+    }
+  }
+
+  /** @type {ReadRequest} */
+  const readRequest = {
+    chunkSteps(chunk) {
+      pendingChunk = chunk;
+      queueMicrotask(defaultReaderChunkStepsMicrotask);
+    },
+    closeSteps() {
+      reading = false;
+      if (!canceled1) {
+        readableByteStreamControllerClose(branch1[_controller]);
+      }
+      if (!canceled2) {
+        readableByteStreamControllerClose(branch2[_controller]);
+      }
+      if (branch1[_controller][_pendingPullIntos].size !== 0) {
+        readableByteStreamControllerRespond(branch1[_controller], 0);
+      }
+      if (branch2[_controller][_pendingPullIntos].size !== 0) {
+        readableByteStreamControllerRespond(branch2[_controller], 0);
+      }
+      if (!canceled1 || !canceled2) {
+        cancelPromise.resolve(undefined);
+      }
+    },
+    errorSteps() {
+      reading = false;
+    },
+  };
+
   function pullWithDefaultReader() {
     if (isReadableStreamBYOBReader(reader)) {
       assert(reader[_readIntoRequests].size === 0);
@@ -3594,63 +3671,109 @@ function readableByteStreamTee(stream) {
       reader = acquireReadableStreamDefaultReader(stream);
       forwardReaderError(reader);
     }
-
-    /** @type {ReadRequest} */
-    const readRequest = {
-      chunkSteps(chunk) {
-        queueMicrotask(() => {
-          readAgainForBranch1 = false;
-          readAgainForBranch2 = false;
-          const chunk1 = chunk;
-          let chunk2 = chunk;
-          if (!canceled1 && !canceled2) {
-            try {
-              chunk2 = cloneAsUint8Array(chunk);
-            } catch (e) {
-              readableByteStreamControllerError(branch1[_controller], e);
-              readableByteStreamControllerError(branch2[_controller], e);
-              cancelPromise.resolve(readableStreamCancel(stream, e));
-              return;
-            }
-          }
-          if (!canceled1) {
-            readableByteStreamControllerEnqueue(branch1[_controller], chunk1);
-          }
-          if (!canceled2) {
-            readableByteStreamControllerEnqueue(branch2[_controller], chunk2);
-          }
-          reading = false;
-          if (readAgainForBranch1) {
-            pull1Algorithm();
-          } else if (readAgainForBranch2) {
-            pull2Algorithm();
-          }
-        });
-      },
-      closeSteps() {
-        reading = false;
-        if (!canceled1) {
-          readableByteStreamControllerClose(branch1[_controller]);
-        }
-        if (!canceled2) {
-          readableByteStreamControllerClose(branch2[_controller]);
-        }
-        if (branch1[_controller][_pendingPullIntos].size !== 0) {
-          readableByteStreamControllerRespond(branch1[_controller], 0);
-        }
-        if (branch2[_controller][_pendingPullIntos].size !== 0) {
-          readableByteStreamControllerRespond(branch2[_controller], 0);
-        }
-        if (!canceled1 || !canceled2) {
-          cancelPromise.resolve(undefined);
-        }
-      },
-      errorSteps() {
-        reading = false;
-      },
-    };
     readableStreamDefaultReaderRead(reader, readRequest);
   }
+
+  // Which branch the in-flight BYOB read is for; set before each BYOB read
+  // and consumed by the shared readIntoRequest below.
+  let byobForBranch2 = false;
+
+  function byobReaderChunkStepsMicrotask() {
+    const chunk = pendingChunk;
+    pendingChunk = undefined;
+    const forBranch2 = byobForBranch2;
+    const byobBranch = forBranch2 ? branch2 : branch1;
+    const otherBranch = forBranch2 ? branch1 : branch2;
+    readAgainForBranch1 = false;
+    readAgainForBranch2 = false;
+    const byobCanceled = forBranch2 ? canceled2 : canceled1;
+    const otherCanceled = forBranch2 ? canceled1 : canceled2;
+    if (!otherCanceled) {
+      let clonedChunk;
+      try {
+        clonedChunk = cloneAsUint8Array(chunk);
+      } catch (e) {
+        readableByteStreamControllerError(byobBranch[_controller], e);
+        readableByteStreamControllerError(otherBranch[_controller], e);
+        cancelPromise.resolve(readableStreamCancel(stream, e));
+        return;
+      }
+      if (!byobCanceled) {
+        readableByteStreamControllerRespondWithNewView(
+          byobBranch[_controller],
+          chunk,
+        );
+      }
+      readableByteStreamControllerEnqueue(
+        otherBranch[_controller],
+        clonedChunk,
+      );
+    } else if (!byobCanceled) {
+      readableByteStreamControllerRespondWithNewView(
+        byobBranch[_controller],
+        chunk,
+      );
+    }
+    reading = false;
+    if (readAgainForBranch1) {
+      pull1Algorithm();
+    } else if (readAgainForBranch2) {
+      pull2Algorithm();
+    }
+  }
+
+  /** @type {ReadIntoRequest} */
+  const readIntoRequest = {
+    chunkSteps(chunk) {
+      pendingChunk = chunk;
+      queueMicrotask(byobReaderChunkStepsMicrotask);
+    },
+    closeSteps(chunk) {
+      reading = false;
+      const forBranch2 = byobForBranch2;
+      const byobBranch = forBranch2 ? branch2 : branch1;
+      const otherBranch = forBranch2 ? branch1 : branch2;
+      const byobCanceled = forBranch2 ? canceled2 : canceled1;
+      const otherCanceled = forBranch2 ? canceled1 : canceled2;
+      if (!byobCanceled) {
+        readableByteStreamControllerClose(byobBranch[_controller]);
+      }
+      if (!otherCanceled) {
+        readableByteStreamControllerClose(otherBranch[_controller]);
+      }
+      if (chunk !== undefined) {
+        let byteLength;
+        if (isTypedArray(chunk)) {
+          byteLength = TypedArrayPrototypeGetByteLength(
+            /** @type {Uint8Array} */ (chunk),
+          );
+        } else {
+          byteLength = DataViewPrototypeGetByteLength(
+            /** @type {DataView} */ (chunk),
+          );
+        }
+        assert(byteLength === 0);
+        if (!byobCanceled) {
+          readableByteStreamControllerRespondWithNewView(
+            byobBranch[_controller],
+            chunk,
+          );
+        }
+        if (
+          !otherCanceled &&
+          otherBranch[_controller][_pendingPullIntos].size !== 0
+        ) {
+          readableByteStreamControllerRespond(otherBranch[_controller], 0);
+        }
+      }
+      if (!byobCanceled || !otherCanceled) {
+        cancelPromise.resolve(undefined);
+      }
+    },
+    errorSteps() {
+      reading = false;
+    },
+  };
 
   function pullWithBYOBReader(view, forBranch2) {
     if (isReadableStreamDefaultReader(reader)) {
@@ -3659,94 +3782,7 @@ function readableByteStreamTee(stream) {
       reader = acquireReadableStreamBYOBReader(stream);
       forwardReaderError(reader);
     }
-    const byobBranch = forBranch2 ? branch2 : branch1;
-    const otherBranch = forBranch2 ? branch1 : branch2;
-
-    /** @type {ReadIntoRequest} */
-    const readIntoRequest = {
-      chunkSteps(chunk) {
-        queueMicrotask(() => {
-          readAgainForBranch1 = false;
-          readAgainForBranch2 = false;
-          const byobCanceled = forBranch2 ? canceled2 : canceled1;
-          const otherCanceled = forBranch2 ? canceled1 : canceled2;
-          if (!otherCanceled) {
-            let clonedChunk;
-            try {
-              clonedChunk = cloneAsUint8Array(chunk);
-            } catch (e) {
-              readableByteStreamControllerError(byobBranch[_controller], e);
-              readableByteStreamControllerError(otherBranch[_controller], e);
-              cancelPromise.resolve(readableStreamCancel(stream, e));
-              return;
-            }
-            if (!byobCanceled) {
-              readableByteStreamControllerRespondWithNewView(
-                byobBranch[_controller],
-                chunk,
-              );
-            }
-            readableByteStreamControllerEnqueue(
-              otherBranch[_controller],
-              clonedChunk,
-            );
-          } else if (!byobCanceled) {
-            readableByteStreamControllerRespondWithNewView(
-              byobBranch[_controller],
-              chunk,
-            );
-          }
-          reading = false;
-          if (readAgainForBranch1) {
-            pull1Algorithm();
-          } else if (readAgainForBranch2) {
-            pull2Algorithm();
-          }
-        });
-      },
-      closeSteps(chunk) {
-        reading = false;
-        const byobCanceled = forBranch2 ? canceled2 : canceled1;
-        const otherCanceled = forBranch2 ? canceled1 : canceled2;
-        if (!byobCanceled) {
-          readableByteStreamControllerClose(byobBranch[_controller]);
-        }
-        if (!otherCanceled) {
-          readableByteStreamControllerClose(otherBranch[_controller]);
-        }
-        if (chunk !== undefined) {
-          let byteLength;
-          if (isTypedArray(chunk)) {
-            byteLength = TypedArrayPrototypeGetByteLength(
-              /** @type {Uint8Array} */ (chunk),
-            );
-          } else {
-            byteLength = DataViewPrototypeGetByteLength(
-              /** @type {DataView} */ (chunk),
-            );
-          }
-          assert(byteLength === 0);
-          if (!byobCanceled) {
-            readableByteStreamControllerRespondWithNewView(
-              byobBranch[_controller],
-              chunk,
-            );
-          }
-          if (
-            !otherCanceled &&
-            otherBranch[_controller][_pendingPullIntos].size !== 0
-          ) {
-            readableByteStreamControllerRespond(otherBranch[_controller], 0);
-          }
-        }
-        if (!byobCanceled || !otherCanceled) {
-          cancelPromise.resolve(undefined);
-        }
-      },
-      errorSteps() {
-        reading = false;
-      },
-    };
+    byobForBranch2 = forBranch2;
     readableStreamBYOBReaderRead(reader, view, 1, readIntoRequest);
   }
 
@@ -5781,6 +5817,31 @@ function errorReadableStream(stream, e) {
   readableStreamDefaultControllerError(stream[_controller], e);
 }
 
+// A ReadRequest backed by a class instead of an object literal with closure
+// methods: one allocation per read() rather than four.
+/** @template R */
+class ReadableStreamDefaultReadRequest {
+  /** @type {Deferred<ReadableStreamReadResult<R>>} */
+  #promise;
+
+  /** @param {Deferred<ReadableStreamReadResult<R>>} promise */
+  constructor(promise) {
+    this.#promise = promise;
+  }
+
+  chunkSteps(chunk) {
+    this.#promise.resolve({ value: chunk, done: false });
+  }
+
+  closeSteps() {
+    this.#promise.resolve({ value: undefined, done: true });
+  }
+
+  errorSteps(e) {
+    this.#promise.reject(e);
+  }
+}
+
 /** @template R */
 class ReadableStreamDefaultReader {
   /** @type {Deferred<void>} */
@@ -5839,19 +5900,10 @@ class ReadableStreamDefaultReader {
     }
     /** @type {Deferred<ReadableStreamReadResult<R>>} */
     const promise = new Deferred();
-    /** @type {ReadRequest<R>} */
-    const readRequest = {
-      chunkSteps(chunk) {
-        promise.resolve({ value: chunk, done: false });
-      },
-      closeSteps() {
-        promise.resolve({ value: undefined, done: true });
-      },
-      errorSteps(e) {
-        promise.reject(e);
-      },
-    };
-    readableStreamDefaultReaderRead(this, readRequest);
+    readableStreamDefaultReaderRead(
+      this,
+      new ReadableStreamDefaultReadRequest(promise),
+    );
     return promise.promise;
   }
 
@@ -5913,6 +5965,30 @@ class ReadableStreamDefaultReader {
 webidl.configureInterface(ReadableStreamDefaultReader);
 const ReadableStreamDefaultReaderPrototype =
   ReadableStreamDefaultReader.prototype;
+
+// See ReadableStreamDefaultReadRequest: one allocation per read(view)
+// rather than four.
+class ReadableStreamBYOBReadIntoRequest {
+  /** @type {Deferred<ReadableStreamBYOBReadResult>} */
+  #promise;
+
+  /** @param {Deferred<ReadableStreamBYOBReadResult>} promise */
+  constructor(promise) {
+    this.#promise = promise;
+  }
+
+  chunkSteps(chunk) {
+    this.#promise.resolve({ value: chunk, done: false });
+  }
+
+  closeSteps(chunk) {
+    this.#promise.resolve({ value: chunk, done: true });
+  }
+
+  errorSteps(e) {
+    this.#promise.reject(e);
+  }
+}
 
 /** @template R */
 class ReadableStreamBYOBReader {
@@ -6009,19 +6085,12 @@ class ReadableStreamBYOBReader {
     }
     /** @type {Deferred<ReadableStreamBYOBReadResult>} */
     const promise = new Deferred();
-    /** @type {ReadIntoRequest} */
-    const readIntoRequest = {
-      chunkSteps(chunk) {
-        promise.resolve({ value: chunk, done: false });
-      },
-      closeSteps(chunk) {
-        promise.resolve({ value: chunk, done: true });
-      },
-      errorSteps(e) {
-        promise.reject(e);
-      },
-    };
-    readableStreamBYOBReaderRead(this, view, options.min, readIntoRequest);
+    readableStreamBYOBReaderRead(
+      this,
+      view,
+      options.min,
+      new ReadableStreamBYOBReadIntoRequest(promise),
+    );
     return promise.promise;
   }
 


### PR DESCRIPTION
Profiling the Web Streams tee() hot loop (V8 sampling profiler plus GC
scavenge counting) showed the per-chunk cost concentrated in allocation
churn: read request object literals carrying three closure methods each,
tee read requests and their chunk-steps microtask callbacks recreated for
every chunk, pull-promise reaction closures recreated on every pull, and
a fresh resolved promise allocated per internal pull just so
callPullIfNeeded had something to subscribe to.

Three commits, each independently measured on release builds: read
requests in reader.read()/read(view) become classes holding the Deferred
(one allocation instead of four); both tee variants hoist their read
request and chunk-steps microtask callback to per-tee scope, reusing them
across chunks (safe: the reading flag guarantees one read in flight); and
pull reactions get per-controller handler pairs plus a
synchronous-completion sentinel so internal pull algorithms skip the
promise pair entirely. Observable ordering is unchanged; a
queueMicrotask-based dispatch was tried and rejected as a measured
regression, details in the commit message.

Benchmark (M1 Max, release build, 1000 chunks/stream):

| scenario | before | after | change |
|---|---|---|---|
| tee + drain both branches | 472 ns/chunk | 391 ns/chunk | -17% |
| drain, no tee | 168 ns/chunk | 155 ns/chunk | -8% |
| byte tee + drain both | 1468 ns/chunk | 1390 ns/chunk | -5% |
| GC share of profile ticks | 7.4% | ~3% | |

WPT streams is green (153 passed, 0 failed, 4 expected failures,
identical to baseline), as are fetch/api/response (54), streams/piping
(26), and streams/readable-byte-streams (20, including the BYOB tee
alternating-branch tests).

Towards #35768, #35771