### PR TITLE
perf(core): pooled ArrayBuffer backing store allocator

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1673,6 +1673,16 @@ pub fn get_default_v8_flags() -> Vec<String> {
     "--stack-size=1024".to_string(),
     "--inspector-live-edit".to_string(),
     "--external-memory-max-reasonable-size=0".to_string(),
+    // V8 only grows the external-memory GC limit by
+    // `external-memory-max-growing-factor` (default 1.1) per GC, so a workload
+    // cycling large ArrayBuffer backing stores (streaming fetch/file/encoder
+    // bodies) keeps the limit pinned near current usage and drives continuous
+    // concurrent marking/sweeping. Raising the factor lets the limit jump well
+    // above churn so far fewer majors fire; combined with the pooled backing
+    // store allocator (block reuse bounds retention), this trades a modest
+    // memory headroom increase for a large GC-time reduction under buffer
+    // churn. See denoland/deno#35808.
+    "--external-memory-max-growing-factor=8".to_string(),
   ]
 }
 

--- a/libs/core/runtime/buffer_pool.rs
+++ b/libs/core/runtime/buffer_pool.rs
@@ -59,14 +59,22 @@ const ALIGN: usize = 16;
 
 /// Smallest pooled block: 16 KiB. log2 = 14.
 const MIN_POOLED_SHIFT: u32 = 14;
-/// Largest pooled block: 4 MiB. log2 = 22.
-const MAX_POOLED_SHIFT: u32 = 22;
+/// Largest pooled block: 16 MiB. log2 = 24. Covers whole-body assembly
+/// buffers (Body consumers collect into one allocation), which benefit
+/// from pooled, pre-zeroed blocks just like streaming chunks do.
+const MAX_POOLED_SHIFT: u32 = 24;
 const NUM_CLASSES: usize = (MAX_POOLED_SHIFT - MIN_POOLED_SHIFT + 1) as usize;
 
-/// Maximum bytes retained per size class across both tiers. With 9 classes
-/// this bounds total retention at 9 * 8 MiB = 72 MiB, reached only by a
-/// workload that actively cycles buffers of every class.
+/// Maximum bytes retained per size class across both tiers; classes at
+/// least this big retain a single block. Bounds total retention at
+/// 9 * 8 MiB + 8 MiB + 16 MiB = 96 MiB, reached only by a workload that
+/// actively cycles buffers of every class.
 const CLASS_CAP_BYTES: usize = 8 * 1024 * 1024;
+
+#[inline]
+fn class_cap_bytes(class: usize) -> usize {
+  CLASS_CAP_BYTES.max(class_size(class))
+}
 
 /// Raw block pointers stored in the freelists.
 struct Blocks(Vec<*mut u8>);
@@ -159,7 +167,8 @@ impl BufferPool {
   }
 
   fn release(self: &Arc<Self>, class: usize, ptr: *mut u8) {
-    if self.retained_bytes(class) + class_size(class) > CLASS_CAP_BYTES {
+    if self.retained_bytes(class) + class_size(class) > class_cap_bytes(class)
+    {
       // SAFETY: ptr was allocated with class_layout(class).
       unsafe { dealloc(ptr, class_layout(class)) };
       return;
@@ -321,7 +330,9 @@ mod tests {
     assert_eq!(class_for(16 * 1024 + 1), Some(1));
     assert_eq!(class_for(64 * 1024), Some(2));
     assert_eq!(class_for(4 * 1024 * 1024), Some(8));
-    assert_eq!(class_for(4 * 1024 * 1024 + 1), None);
+    assert_eq!(class_for(4 * 1024 * 1024 + 1), Some(9));
+    assert_eq!(class_for(16 * 1024 * 1024), Some(10));
+    assert_eq!(class_for(16 * 1024 * 1024 + 1), None);
   }
 
   #[test]

--- a/libs/core/runtime/buffer_pool.rs
+++ b/libs/core/runtime/buffer_pool.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-//! Pooled ArrayBuffer backing-store allocator with background pre-zeroing.
+//! Pooled ArrayBuffer backing-store allocator.
 //!
 //! V8's default ArrayBuffer allocator malloc+zeroes every backing store and
 //! frees it back to the system allocator when the buffer dies. For the
@@ -12,26 +12,20 @@
 //! equivalent allocation in JavaScriptCore (which hands out lazily-zeroed
 //! pages) is under 1us.
 //!
-//! This allocator keeps freed backing stores of pooled size classes on
-//! per-class freelists instead of returning them to the system, split into
-//! two tiers:
-//!
-//! - `clean`: fully zeroed blocks. `allocate` pops one and returns it with
-//!   no zeroing at all on the hot path.
-//! - `dirty`: blocks as freed by V8. A lazily spawned background thread
-//!   drains the dirty tier, zeroing whole blocks and promoting them to
-//!   `clean`. If `allocate` finds no clean block it falls back to zeroing a
-//!   dirty block inline (still resident pages, memset speed), and finally
-//!   to `alloc_zeroed` (which obtains pre-zeroed pages from the OS for
-//!   these sizes). `allocate_uninitialized` prefers dirty blocks so clean
-//!   ones are saved for zeroed allocations.
+//! This allocator keeps freed backing stores of pooled size classes on a
+//! per-class freelist instead of returning them to the system. `allocate`
+//! pops a freed block and zeroes it inline before handing it back; because the
+//! block is still resident (its pages were never madvised away), that zeroing
+//! runs at memset speed rather than paying the page-fault-then-zero cost of a
+//! fresh allocation. A miss falls back to `alloc_zeroed`, which obtains
+//! pre-zeroed pages from the OS for these sizes. `allocate_uninitialized` skips
+//! the zeroing entirely.
 //!
 //! Size classes are powers of two from MIN_POOLED (16 KiB) to MAX_POOLED
-//! (4 MiB). Requests outside that range, including all small allocations
+//! (16 MiB). Requests outside that range, including all small allocations
 //! (cheap already) and giant buffers (retention risk), fall through to the
-//! plain global allocator. Each class retains at most CLASS_CAP_BYTES
-//! across both tiers; blocks freed beyond the cap go straight back to the
-//! system.
+//! plain global allocator. Each class retains at most CLASS_CAP_BYTES; blocks
+//! freed beyond the cap go straight back to the system.
 //!
 //! The pool is process-global and shared by all isolates: allocator
 //! callbacks can fire on GC and background threads, and buffers regularly
@@ -48,9 +42,7 @@ use std::alloc::dealloc;
 use std::ffi::c_void;
 use std::ptr;
 use std::sync::Arc;
-use std::sync::Condvar;
 use std::sync::Mutex;
-use std::sync::Once;
 use std::sync::OnceLock;
 
 /// Backing stores are at most 8-byte aligned as far as V8 is concerned, but
@@ -61,14 +53,13 @@ const ALIGN: usize = 16;
 const MIN_POOLED_SHIFT: u32 = 14;
 /// Largest pooled block: 16 MiB. log2 = 24. Covers whole-body assembly
 /// buffers (Body consumers collect into one allocation), which benefit
-/// from pooled, pre-zeroed blocks just like streaming chunks do.
+/// from pooled blocks just like streaming chunks do.
 const MAX_POOLED_SHIFT: u32 = 24;
 const NUM_CLASSES: usize = (MAX_POOLED_SHIFT - MIN_POOLED_SHIFT + 1) as usize;
 
-/// Maximum bytes retained per size class across both tiers; classes at
-/// least this big retain a single block. Bounds total retention at
-/// 9 * 8 MiB + 8 MiB + 16 MiB = 96 MiB, reached only by a workload that
-/// actively cycles buffers of every class.
+/// Maximum bytes retained per size class; classes at least this big retain a
+/// single block. Bounds total retention at 9 * 8 MiB + 8 MiB + 16 MiB = 96 MiB,
+/// reached only by a workload that actively cycles buffers of every class.
 const CLASS_CAP_BYTES: usize = 8 * 1024 * 1024;
 
 #[inline]
@@ -76,27 +67,22 @@ fn class_cap_bytes(class: usize) -> usize {
   CLASS_CAP_BYTES.max(class_size(class))
 }
 
-/// Raw block pointers stored in the freelists.
+/// Raw block pointers stored in the freelist.
 struct Blocks(Vec<*mut u8>);
 
 // SAFETY: the raw pointers are owned, unaliased heap blocks; the Mutex
-// around each tier serializes access.
+// around the freelist serializes access.
 unsafe impl Send for Blocks {}
 
 struct SizeClass {
-  clean: Mutex<Blocks>,
-  dirty: Mutex<Blocks>,
+  free: Mutex<Blocks>,
 }
 
 pub(crate) struct BufferPool {
   classes: [SizeClass; NUM_CLASSES],
-  /// Signals the zeroer thread that dirty blocks are waiting.
-  zeroer_wakeup: Condvar,
-  zeroer_mutex: Mutex<bool>,
-  zeroer_spawn: Once,
 }
 
-// SAFETY: all interior state is behind Mutexes/Condvar.
+// SAFETY: all interior state is behind Mutexes.
 unsafe impl Send for BufferPool {}
 unsafe impl Sync for BufferPool {}
 
@@ -139,80 +125,42 @@ impl BufferPool {
   fn new() -> Self {
     Self {
       classes: std::array::from_fn(|_| SizeClass {
-        clean: Mutex::new(Blocks(Vec::new())),
-        dirty: Mutex::new(Blocks(Vec::new())),
+        free: Mutex::new(Blocks(Vec::new())),
       }),
-      zeroer_wakeup: Condvar::new(),
-      zeroer_mutex: Mutex::new(false),
-      zeroer_spawn: Once::new(),
     }
   }
 
-  /// Pop a fully-zeroed block, if one is available.
+  /// Pop a freed block off the class freelist, if one is available.
   #[inline]
-  fn pop_clean(&self, class: usize) -> Option<*mut u8> {
-    self.classes[class].clean.lock().unwrap().0.pop()
+  fn pop(&self, class: usize) -> Option<*mut u8> {
+    self.classes[class].free.lock().unwrap().0.pop()
   }
 
-  /// Pop a freed, not-yet-zeroed block, if one is available.
-  #[inline]
-  fn pop_dirty(&self, class: usize) -> Option<*mut u8> {
-    self.classes[class].dirty.lock().unwrap().0.pop()
-  }
-
-  fn retained_bytes(&self, class: usize) -> usize {
-    let clean = self.classes[class].clean.lock().unwrap().0.len();
-    let dirty = self.classes[class].dirty.lock().unwrap().0.len();
-    (clean + dirty) * class_size(class)
-  }
-
-  fn release(self: &Arc<Self>, class: usize, ptr: *mut u8) {
-    if self.retained_bytes(class) + class_size(class) > class_cap_bytes(class) {
+  fn release(&self, class: usize, ptr: *mut u8) {
+    let mut free = self.classes[class].free.lock().unwrap();
+    if (free.0.len() + 1) * class_size(class) > class_cap_bytes(class) {
+      drop(free);
       // SAFETY: ptr was allocated with class_layout(class).
       unsafe { dealloc(ptr, class_layout(class)) };
       return;
     }
-    self.classes[class].dirty.lock().unwrap().0.push(ptr);
-    self.ensure_zeroer();
-    let mut pending = self.zeroer_mutex.lock().unwrap();
-    *pending = true;
-    drop(pending);
-    self.zeroer_wakeup.notify_one();
+    free.0.push(ptr);
   }
+}
 
-  /// Spawns the background zeroing thread on first use. The thread parks on
-  /// the condvar and wakes when blocks land in a dirty tier; it zeroes whole
-  /// blocks outside any lock and promotes them to the clean tier.
-  fn ensure_zeroer(self: &Arc<Self>) {
-    if self.zeroer_spawn.is_completed() {
-      return;
+impl Drop for BufferPool {
+  fn drop(&mut self) {
+    // Free every block still retained on the freelists. In production the pool
+    // is an immortal process-global singleton, so this never runs there; it
+    // only fires for the short-lived pools in tests / under Miri, keeping the
+    // leak checker happy.
+    for class in 0..NUM_CLASSES {
+      for ptr in self.classes[class].free.lock().unwrap().0.drain(..) {
+        // SAFETY: ptr was allocated with class_layout(class) and is owned
+        // exclusively by this freelist.
+        unsafe { dealloc(ptr, class_layout(class)) };
+      }
     }
-    let pool = self.clone();
-    self.zeroer_spawn.call_once(move || {
-      std::thread::Builder::new()
-        .name("deno-buffer-zeroer".into())
-        .spawn(move || {
-          loop {
-            {
-              let mut pending = pool.zeroer_mutex.lock().unwrap();
-              while !*pending {
-                pending = pool.zeroer_wakeup.wait(pending).unwrap();
-              }
-              *pending = false;
-            }
-            // Drain all dirty tiers. New blocks freed while we work set
-            // `pending` again, so nothing is lost between passes.
-            for class in 0..NUM_CLASSES {
-              while let Some(ptr) = pool.pop_dirty(class) {
-                // SAFETY: ptr is a valid block of class_size(class) bytes.
-                unsafe { ptr::write_bytes(ptr, 0, class_size(class)) };
-                pool.classes[class].clean.lock().unwrap().0.push(ptr);
-              }
-            }
-          }
-        })
-        .ok();
-    });
   }
 }
 
@@ -222,12 +170,9 @@ unsafe extern "C" fn pool_allocate(
 ) -> *mut c_void {
   match class_for(len) {
     Some(class) => {
-      // Fast path: a pre-zeroed block, no zeroing at all.
-      if let Some(ptr) = pool.pop_clean(class) {
-        return ptr as *mut c_void;
-      }
-      // Warm fallback: zero a resident dirty block at memset speed.
-      if let Some(ptr) = pool.pop_dirty(class) {
+      // Reuse a freed block, zeroing it inline. The block is still resident,
+      // so this is a memset rather than a page-fault-then-zero.
+      if let Some(ptr) = pool.pop(class) {
         // SAFETY: ptr is valid for class_size(class) >= len bytes.
         unsafe { ptr::write_bytes(ptr, 0, len) };
         return ptr as *mut c_void;
@@ -248,11 +193,7 @@ unsafe extern "C" fn pool_allocate_uninitialized(
 ) -> *mut c_void {
   match class_for(len) {
     Some(class) => {
-      // Prefer dirty blocks so clean ones are saved for zeroed allocations.
-      if let Some(ptr) = pool.pop_dirty(class) {
-        return ptr as *mut c_void;
-      }
-      if let Some(ptr) = pool.pop_clean(class) {
+      if let Some(ptr) = pool.pop(class) {
         return ptr as *mut c_void;
       }
       // SAFETY: class_layout is a valid non-zero layout.
@@ -352,8 +293,8 @@ mod tests {
       assert_eq!(*(a as *const u8), 0);
       ptr::write_bytes(a as *mut u8, 0xab, len);
       pool_free(&pool, a, len);
-      // The block sits in the dirty tier (or clean, if the zeroer ran);
-      // either way the next allocation must observe zeroed memory again.
+      // The freed block is now on the freelist; the next allocation reuses it
+      // and must observe zeroed memory again.
       let b = pool_allocate(&pool, len);
       assert!(!b.is_null());
       let bytes = std::slice::from_raw_parts(b as *const u8, len);
@@ -363,7 +304,7 @@ mod tests {
   }
 
   #[test]
-  fn uninitialized_prefers_dirty() {
+  fn uninitialized_roundtrip_reuses_block() {
     let pool = Arc::new(BufferPool::new());
     let len = 32 * 1024;
     // SAFETY: exercising the allocator callbacks directly.

--- a/libs/core/runtime/buffer_pool.rs
+++ b/libs/core/runtime/buffer_pool.rs
@@ -167,8 +167,7 @@ impl BufferPool {
   }
 
   fn release(self: &Arc<Self>, class: usize, ptr: *mut u8) {
-    if self.retained_bytes(class) + class_size(class) > class_cap_bytes(class)
-    {
+    if self.retained_bytes(class) + class_size(class) > class_cap_bytes(class) {
       // SAFETY: ptr was allocated with class_layout(class).
       unsafe { dealloc(ptr, class_layout(class)) };
       return;
@@ -204,8 +203,7 @@ impl BufferPool {
             // Drain all dirty tiers. New blocks freed while we work set
             // `pending` again, so nothing is lost between passes.
             for class in 0..NUM_CLASSES {
-              loop {
-                let Some(ptr) = pool.pop_dirty(class) else { break };
+              while let Some(ptr) = pool.pop_dirty(class) {
                 // SAFETY: ptr is a valid block of class_size(class) bytes.
                 unsafe { ptr::write_bytes(ptr, 0, class_size(class)) };
                 pool.classes[class].clean.lock().unwrap().0.push(ptr);
@@ -300,10 +298,17 @@ static POOL: OnceLock<Option<Arc<BufferPool>>> = OnceLock::new();
 /// Returns a pooled ArrayBuffer allocator, or None when disabled via
 /// DENO_DISABLE_BUFFER_POOL (callers then fall back to V8's default
 /// allocator).
-pub(crate) fn array_buffer_allocator()
--> Option<v8::UniqueRef<v8::Allocator>> {
+pub(crate) fn array_buffer_allocator() -> Option<v8::UniqueRef<v8::Allocator>> {
   let pool = POOL.get_or_init(|| {
-    if std::env::var_os("DENO_DISABLE_BUFFER_POOL").is_some() {
+    // The pool is a process-global allocator installed on the V8 CreateParams
+    // before any `sys_traits` environment is available, so read the opt-out
+    // escape hatch directly here.
+    #[allow(
+      clippy::disallowed_methods,
+      reason = "process-global allocator init runs before sys_traits is set up"
+    )]
+    let disabled = std::env::var_os("DENO_DISABLE_BUFFER_POOL").is_some();
+    if disabled {
       None
     } else {
       Some(Arc::new(BufferPool::new()))

--- a/libs/core/runtime/buffer_pool.rs
+++ b/libs/core/runtime/buffer_pool.rs
@@ -1,0 +1,250 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Pooled ArrayBuffer backing-store allocator.
+//!
+//! V8's default ArrayBuffer allocator malloc+zeroes every backing store and
+//! frees it back to the system allocator when the buffer dies. For the
+//! mid-size buffers that dominate streaming workloads (fetch body chunks,
+//! file reads, encoder output; typically 16 KiB - 2 MiB), that cycle is
+//! expensive on macOS and Linux alike: the allocator's medium-size magazines
+//! madvise pages away on free, so the next allocation page-faults the memory
+//! back in just to zero it again. A `new Uint8Array(64 * 1024)` costs ~5.5us
+//! on an M1 Max; the equivalent allocation in JavaScriptCore (which hands out
+//! lazily-zeroed pages) is under 1us.
+//!
+//! This allocator keeps freed backing stores of pooled size classes on
+//! freelists instead of returning them to the system. A pooled allocation
+//! pops a warm block and zeroes only the requested length: the pages are
+//! still resident, so the zeroing runs at memset speed instead of
+//! page-fault speed, and the malloc magazine churn disappears entirely.
+//!
+//! Size classes are powers of two from MIN_POOLED (16 KiB) to MAX_POOLED
+//! (4 MiB). Requests outside that range, including all small allocations
+//! (cheap already) and giant buffers (retention risk), fall through to the
+//! plain global allocator. Each class retains at most CLASS_CAP_BYTES; blocks
+//! freed beyond the cap go straight back to the system.
+//!
+//! The pool is process-global and shared by all isolates: allocator
+//! callbacks can fire on GC and background threads, and buffers regularly
+//! outlive the isolate that allocated them (transfers), so per-isolate
+//! pools would need the same synchronization anyway.
+//!
+//! Set DENO_DISABLE_BUFFER_POOL=1 to fall back to V8's default allocator
+//! (useful for benchmarking and as an escape hatch).
+
+use std::alloc::Layout;
+use std::alloc::alloc;
+use std::alloc::alloc_zeroed;
+use std::alloc::dealloc;
+use std::ffi::c_void;
+use std::ptr;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::OnceLock;
+
+/// Backing stores are at most 8-byte aligned as far as V8 is concerned, but
+/// the default allocator provides malloc alignment; match it.
+const ALIGN: usize = 16;
+
+/// Smallest pooled block: 16 KiB. log2 = 14.
+const MIN_POOLED_SHIFT: u32 = 14;
+/// Largest pooled block: 4 MiB. log2 = 22.
+const MAX_POOLED_SHIFT: u32 = 22;
+const NUM_CLASSES: usize = (MAX_POOLED_SHIFT - MIN_POOLED_SHIFT + 1) as usize;
+
+/// Maximum bytes retained per size class (not per allocation site). With 9
+/// classes this bounds total retention at 9 * 8 MiB = 72 MiB, reached only
+/// by a workload that actively cycles buffers of every class.
+const CLASS_CAP_BYTES: usize = 8 * 1024 * 1024;
+
+struct SizeClass {
+  blocks: Mutex<Vec<*mut u8>>,
+}
+
+// SAFETY: the raw pointers are owned, unaliased heap blocks; the Mutex
+// serializes access.
+unsafe impl Send for SizeClass {}
+unsafe impl Sync for SizeClass {}
+
+pub(crate) struct BufferPool {
+  classes: [SizeClass; NUM_CLASSES],
+}
+
+/// Returns the class index for a pooled length, or None for the fall-through
+/// path.
+#[inline]
+fn class_for(len: usize) -> Option<usize> {
+  if len == 0 || len > (1 << MAX_POOLED_SHIFT) {
+    return None;
+  }
+  let shift = usize::BITS - (len - 1).leading_zeros();
+  let shift = shift.max(MIN_POOLED_SHIFT);
+  // Small allocations are cheap through the system allocator and pooling
+  // them would waste most of a 16 KiB block.
+  if len <= (1 << MIN_POOLED_SHIFT) / 2 {
+    return None;
+  }
+  Some((shift - MIN_POOLED_SHIFT) as usize)
+}
+
+#[inline]
+fn class_size(class: usize) -> usize {
+  1 << (class as u32 + MIN_POOLED_SHIFT)
+}
+
+#[inline]
+fn class_layout(class: usize) -> Layout {
+  // SAFETY: size is a power of two >= ALIGN, ALIGN is a power of two.
+  unsafe { Layout::from_size_align_unchecked(class_size(class), ALIGN) }
+}
+
+#[inline]
+fn raw_layout(len: usize) -> Layout {
+  // SAFETY: ALIGN is a power of two; len was accepted by V8 so it does not
+  // overflow when rounded up to alignment.
+  unsafe { Layout::from_size_align_unchecked(len.max(1), ALIGN) }
+}
+
+impl BufferPool {
+  fn new() -> Self {
+    Self {
+      classes: std::array::from_fn(|_| SizeClass {
+        blocks: Mutex::new(Vec::new()),
+      }),
+    }
+  }
+
+  /// Pop a warm block or allocate a fresh one. Returns an uninitialized
+  /// block of at least `len` bytes.
+  #[inline]
+  fn acquire(&self, class: usize) -> *mut u8 {
+    let popped = self.classes[class].blocks.lock().unwrap().pop();
+    match popped {
+      Some(ptr) => ptr,
+      // SAFETY: class_layout is a valid non-zero layout.
+      None => unsafe { alloc(class_layout(class)) },
+    }
+  }
+
+  #[inline]
+  fn release(&self, class: usize, ptr: *mut u8) {
+    let mut blocks = self.classes[class].blocks.lock().unwrap();
+    if (blocks.len() + 1) * class_size(class) <= CLASS_CAP_BYTES {
+      blocks.push(ptr);
+    } else {
+      drop(blocks);
+      // SAFETY: ptr was allocated with class_layout(class).
+      unsafe { dealloc(ptr, class_layout(class)) };
+    }
+  }
+}
+
+unsafe extern "C" fn pool_allocate(pool: &BufferPool, len: usize) -> *mut c_void {
+  match class_for(len) {
+    Some(class) => {
+      let ptr = pool.acquire(class);
+      if !ptr.is_null() {
+        // Zero only the requested length: V8 never exposes the block's
+        // tail. The pages are resident for pooled hits, so this runs at
+        // memset speed.
+        // SAFETY: ptr is valid for class_size(class) >= len bytes.
+        unsafe { ptr::write_bytes(ptr, 0, len) };
+      }
+      ptr as *mut c_void
+    }
+    // SAFETY: raw_layout is a valid non-zero layout. alloc_zeroed uses
+    // calloc under the hood, which gets pre-zeroed pages from the OS for
+    // large requests.
+    None => unsafe { alloc_zeroed(raw_layout(len)) as *mut c_void },
+  }
+}
+
+unsafe extern "C" fn pool_allocate_uninitialized(
+  pool: &BufferPool,
+  len: usize,
+) -> *mut c_void {
+  match class_for(len) {
+    Some(class) => pool.acquire(class) as *mut c_void,
+    // SAFETY: raw_layout is a valid non-zero layout.
+    None => unsafe { alloc(raw_layout(len)) as *mut c_void },
+  }
+}
+
+unsafe extern "C" fn pool_free(
+  pool: &BufferPool,
+  data: *mut c_void,
+  len: usize,
+) {
+  if data.is_null() {
+    return;
+  }
+  match class_for(len) {
+    Some(class) => pool.release(class, data as *mut u8),
+    // SAFETY: data was allocated with raw_layout(len) by the functions
+    // above.
+    None => unsafe { dealloc(data as *mut u8, raw_layout(len)) },
+  }
+}
+
+unsafe extern "C" fn pool_drop(pool: *const BufferPool) {
+  // SAFETY: the handle was created with Arc::into_raw in allocator().
+  drop(unsafe { Arc::from_raw(pool) });
+}
+
+static VTABLE: v8::RustAllocatorVtable<BufferPool> =
+  v8::RustAllocatorVtable {
+    allocate: pool_allocate,
+    allocate_uninitialized: pool_allocate_uninitialized,
+    free: pool_free,
+    drop: pool_drop,
+  };
+
+static POOL: OnceLock<Option<Arc<BufferPool>>> = OnceLock::new();
+
+/// Returns a pooled ArrayBuffer allocator, or None when disabled via
+/// DENO_DISABLE_BUFFER_POOL (callers then fall back to V8's default
+/// allocator).
+pub(crate) fn array_buffer_allocator()
+-> Option<v8::UniqueRef<v8::Allocator>> {
+  let pool = POOL.get_or_init(|| {
+    if std::env::var_os("DENO_DISABLE_BUFFER_POOL").is_some() {
+      None
+    } else {
+      Some(Arc::new(BufferPool::new()))
+    }
+  });
+  let pool = pool.as_ref()?;
+  // SAFETY: the handle is a strong Arc reference released in pool_drop, and
+  // VTABLE matches the BufferPool handle type.
+  Some(unsafe { v8::new_rust_allocator(Arc::into_raw(pool.clone()), &VTABLE) })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn class_selection() {
+    assert_eq!(class_for(0), None);
+    assert_eq!(class_for(1), None);
+    assert_eq!(class_for(8 * 1024), None);
+    assert_eq!(class_for(8 * 1024 + 1), Some(0));
+    assert_eq!(class_for(16 * 1024), Some(0));
+    assert_eq!(class_for(16 * 1024 + 1), Some(1));
+    assert_eq!(class_for(64 * 1024), Some(2));
+    assert_eq!(class_for(4 * 1024 * 1024), Some(8));
+    assert_eq!(class_for(4 * 1024 * 1024 + 1), None);
+  }
+
+  #[test]
+  fn acquire_release_roundtrip() {
+    let pool = BufferPool::new();
+    let class = class_for(64 * 1024).unwrap();
+    let a = pool.acquire(class);
+    assert!(!a.is_null());
+    pool.release(class, a);
+    let b = pool.acquire(class);
+    assert_eq!(a, b, "released block is reused");
+    pool.release(class, b);
+  }
+}

--- a/libs/core/runtime/buffer_pool.rs
+++ b/libs/core/runtime/buffer_pool.rs
@@ -1,28 +1,37 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-//! Pooled ArrayBuffer backing-store allocator.
+//! Pooled ArrayBuffer backing-store allocator with background pre-zeroing.
 //!
 //! V8's default ArrayBuffer allocator malloc+zeroes every backing store and
 //! frees it back to the system allocator when the buffer dies. For the
 //! mid-size buffers that dominate streaming workloads (fetch body chunks,
 //! file reads, encoder output; typically 16 KiB - 2 MiB), that cycle is
-//! expensive on macOS and Linux alike: the allocator's medium-size magazines
-//! madvise pages away on free, so the next allocation page-faults the memory
-//! back in just to zero it again. A `new Uint8Array(64 * 1024)` costs ~5.5us
-//! on an M1 Max; the equivalent allocation in JavaScriptCore (which hands out
-//! lazily-zeroed pages) is under 1us.
+//! expensive: the allocator's medium-size magazines madvise pages away on
+//! free, so the next allocation page-faults the memory back in just to zero
+//! it again. A `new Uint8Array(64 * 1024)` costs ~5.5us on an M1 Max; the
+//! equivalent allocation in JavaScriptCore (which hands out lazily-zeroed
+//! pages) is under 1us.
 //!
 //! This allocator keeps freed backing stores of pooled size classes on
-//! freelists instead of returning them to the system. A pooled allocation
-//! pops a warm block and zeroes only the requested length: the pages are
-//! still resident, so the zeroing runs at memset speed instead of
-//! page-fault speed, and the malloc magazine churn disappears entirely.
+//! per-class freelists instead of returning them to the system, split into
+//! two tiers:
+//!
+//! - `clean`: fully zeroed blocks. `allocate` pops one and returns it with
+//!   no zeroing at all on the hot path.
+//! - `dirty`: blocks as freed by V8. A lazily spawned background thread
+//!   drains the dirty tier, zeroing whole blocks and promoting them to
+//!   `clean`. If `allocate` finds no clean block it falls back to zeroing a
+//!   dirty block inline (still resident pages, memset speed), and finally
+//!   to `alloc_zeroed` (which obtains pre-zeroed pages from the OS for
+//!   these sizes). `allocate_uninitialized` prefers dirty blocks so clean
+//!   ones are saved for zeroed allocations.
 //!
 //! Size classes are powers of two from MIN_POOLED (16 KiB) to MAX_POOLED
 //! (4 MiB). Requests outside that range, including all small allocations
 //! (cheap already) and giant buffers (retention risk), fall through to the
-//! plain global allocator. Each class retains at most CLASS_CAP_BYTES; blocks
-//! freed beyond the cap go straight back to the system.
+//! plain global allocator. Each class retains at most CLASS_CAP_BYTES
+//! across both tiers; blocks freed beyond the cap go straight back to the
+//! system.
 //!
 //! The pool is process-global and shared by all isolates: allocator
 //! callbacks can fire on GC and background threads, and buffers regularly
@@ -39,7 +48,9 @@ use std::alloc::dealloc;
 use std::ffi::c_void;
 use std::ptr;
 use std::sync::Arc;
+use std::sync::Condvar;
 use std::sync::Mutex;
+use std::sync::Once;
 use std::sync::OnceLock;
 
 /// Backing stores are at most 8-byte aligned as far as V8 is concerned, but
@@ -52,23 +63,34 @@ const MIN_POOLED_SHIFT: u32 = 14;
 const MAX_POOLED_SHIFT: u32 = 22;
 const NUM_CLASSES: usize = (MAX_POOLED_SHIFT - MIN_POOLED_SHIFT + 1) as usize;
 
-/// Maximum bytes retained per size class (not per allocation site). With 9
-/// classes this bounds total retention at 9 * 8 MiB = 72 MiB, reached only
-/// by a workload that actively cycles buffers of every class.
+/// Maximum bytes retained per size class across both tiers. With 9 classes
+/// this bounds total retention at 9 * 8 MiB = 72 MiB, reached only by a
+/// workload that actively cycles buffers of every class.
 const CLASS_CAP_BYTES: usize = 8 * 1024 * 1024;
 
-struct SizeClass {
-  blocks: Mutex<Vec<*mut u8>>,
-}
+/// Raw block pointers stored in the freelists.
+struct Blocks(Vec<*mut u8>);
 
 // SAFETY: the raw pointers are owned, unaliased heap blocks; the Mutex
-// serializes access.
-unsafe impl Send for SizeClass {}
-unsafe impl Sync for SizeClass {}
+// around each tier serializes access.
+unsafe impl Send for Blocks {}
+
+struct SizeClass {
+  clean: Mutex<Blocks>,
+  dirty: Mutex<Blocks>,
+}
 
 pub(crate) struct BufferPool {
   classes: [SizeClass; NUM_CLASSES],
+  /// Signals the zeroer thread that dirty blocks are waiting.
+  zeroer_wakeup: Condvar,
+  zeroer_mutex: Mutex<bool>,
+  zeroer_spawn: Once,
 }
+
+// SAFETY: all interior state is behind Mutexes/Condvar.
+unsafe impl Send for BufferPool {}
+unsafe impl Sync for BufferPool {}
 
 /// Returns the class index for a pooled length, or None for the fall-through
 /// path.
@@ -77,13 +99,13 @@ fn class_for(len: usize) -> Option<usize> {
   if len == 0 || len > (1 << MAX_POOLED_SHIFT) {
     return None;
   }
-  let shift = usize::BITS - (len - 1).leading_zeros();
-  let shift = shift.max(MIN_POOLED_SHIFT);
   // Small allocations are cheap through the system allocator and pooling
   // them would waste most of a 16 KiB block.
   if len <= (1 << MIN_POOLED_SHIFT) / 2 {
     return None;
   }
+  let shift = usize::BITS - (len - 1).leading_zeros();
+  let shift = shift.max(MIN_POOLED_SHIFT);
   Some((shift - MIN_POOLED_SHIFT) as usize)
 }
 
@@ -109,69 +131,133 @@ impl BufferPool {
   fn new() -> Self {
     Self {
       classes: std::array::from_fn(|_| SizeClass {
-        blocks: Mutex::new(Vec::new()),
+        clean: Mutex::new(Blocks(Vec::new())),
+        dirty: Mutex::new(Blocks(Vec::new())),
       }),
+      zeroer_wakeup: Condvar::new(),
+      zeroer_mutex: Mutex::new(false),
+      zeroer_spawn: Once::new(),
     }
   }
 
-  /// Pop a warm block or allocate a fresh one. Returns an uninitialized
-  /// block of at least `len` bytes.
+  /// Pop a fully-zeroed block, if one is available.
   #[inline]
-  fn acquire(&self, class: usize) -> *mut u8 {
-    let popped = self.classes[class].blocks.lock().unwrap().pop();
-    match popped {
-      Some(ptr) => ptr,
-      // SAFETY: class_layout is a valid non-zero layout.
-      None => unsafe { alloc(class_layout(class)) },
-    }
+  fn pop_clean(&self, class: usize) -> Option<*mut u8> {
+    self.classes[class].clean.lock().unwrap().0.pop()
   }
 
+  /// Pop a freed, not-yet-zeroed block, if one is available.
   #[inline]
-  fn release(&self, class: usize, ptr: *mut u8) {
-    let mut blocks = self.classes[class].blocks.lock().unwrap();
-    if (blocks.len() + 1) * class_size(class) <= CLASS_CAP_BYTES {
-      blocks.push(ptr);
-    } else {
-      drop(blocks);
+  fn pop_dirty(&self, class: usize) -> Option<*mut u8> {
+    self.classes[class].dirty.lock().unwrap().0.pop()
+  }
+
+  fn retained_bytes(&self, class: usize) -> usize {
+    let clean = self.classes[class].clean.lock().unwrap().0.len();
+    let dirty = self.classes[class].dirty.lock().unwrap().0.len();
+    (clean + dirty) * class_size(class)
+  }
+
+  fn release(self: &Arc<Self>, class: usize, ptr: *mut u8) {
+    if self.retained_bytes(class) + class_size(class) > CLASS_CAP_BYTES {
       // SAFETY: ptr was allocated with class_layout(class).
       unsafe { dealloc(ptr, class_layout(class)) };
+      return;
     }
+    self.classes[class].dirty.lock().unwrap().0.push(ptr);
+    self.ensure_zeroer();
+    let mut pending = self.zeroer_mutex.lock().unwrap();
+    *pending = true;
+    drop(pending);
+    self.zeroer_wakeup.notify_one();
+  }
+
+  /// Spawns the background zeroing thread on first use. The thread parks on
+  /// the condvar and wakes when blocks land in a dirty tier; it zeroes whole
+  /// blocks outside any lock and promotes them to the clean tier.
+  fn ensure_zeroer(self: &Arc<Self>) {
+    if self.zeroer_spawn.is_completed() {
+      return;
+    }
+    let pool = self.clone();
+    self.zeroer_spawn.call_once(move || {
+      std::thread::Builder::new()
+        .name("deno-buffer-zeroer".into())
+        .spawn(move || {
+          loop {
+            {
+              let mut pending = pool.zeroer_mutex.lock().unwrap();
+              while !*pending {
+                pending = pool.zeroer_wakeup.wait(pending).unwrap();
+              }
+              *pending = false;
+            }
+            // Drain all dirty tiers. New blocks freed while we work set
+            // `pending` again, so nothing is lost between passes.
+            for class in 0..NUM_CLASSES {
+              loop {
+                let Some(ptr) = pool.pop_dirty(class) else { break };
+                // SAFETY: ptr is a valid block of class_size(class) bytes.
+                unsafe { ptr::write_bytes(ptr, 0, class_size(class)) };
+                pool.classes[class].clean.lock().unwrap().0.push(ptr);
+              }
+            }
+          }
+        })
+        .ok();
+    });
   }
 }
 
-unsafe extern "C" fn pool_allocate(pool: &BufferPool, len: usize) -> *mut c_void {
+unsafe extern "C" fn pool_allocate(
+  pool: &Arc<BufferPool>,
+  len: usize,
+) -> *mut c_void {
   match class_for(len) {
     Some(class) => {
-      let ptr = pool.acquire(class);
-      if !ptr.is_null() {
-        // Zero only the requested length: V8 never exposes the block's
-        // tail. The pages are resident for pooled hits, so this runs at
-        // memset speed.
+      // Fast path: a pre-zeroed block, no zeroing at all.
+      if let Some(ptr) = pool.pop_clean(class) {
+        return ptr as *mut c_void;
+      }
+      // Warm fallback: zero a resident dirty block at memset speed.
+      if let Some(ptr) = pool.pop_dirty(class) {
         // SAFETY: ptr is valid for class_size(class) >= len bytes.
         unsafe { ptr::write_bytes(ptr, 0, len) };
+        return ptr as *mut c_void;
       }
-      ptr as *mut c_void
+      // Miss: alloc_zeroed obtains pre-zeroed pages from the OS for these
+      // sizes (calloc), avoiding an explicit memset of cold pages.
+      // SAFETY: class_layout is a valid non-zero layout.
+      unsafe { alloc_zeroed(class_layout(class)) as *mut c_void }
     }
-    // SAFETY: raw_layout is a valid non-zero layout. alloc_zeroed uses
-    // calloc under the hood, which gets pre-zeroed pages from the OS for
-    // large requests.
+    // SAFETY: raw_layout is a valid non-zero layout.
     None => unsafe { alloc_zeroed(raw_layout(len)) as *mut c_void },
   }
 }
 
 unsafe extern "C" fn pool_allocate_uninitialized(
-  pool: &BufferPool,
+  pool: &Arc<BufferPool>,
   len: usize,
 ) -> *mut c_void {
   match class_for(len) {
-    Some(class) => pool.acquire(class) as *mut c_void,
+    Some(class) => {
+      // Prefer dirty blocks so clean ones are saved for zeroed allocations.
+      if let Some(ptr) = pool.pop_dirty(class) {
+        return ptr as *mut c_void;
+      }
+      if let Some(ptr) = pool.pop_clean(class) {
+        return ptr as *mut c_void;
+      }
+      // SAFETY: class_layout is a valid non-zero layout.
+      unsafe { alloc(class_layout(class)) as *mut c_void }
+    }
     // SAFETY: raw_layout is a valid non-zero layout.
     None => unsafe { alloc(raw_layout(len)) as *mut c_void },
   }
 }
 
 unsafe extern "C" fn pool_free(
-  pool: &BufferPool,
+  pool: &Arc<BufferPool>,
   data: *mut c_void,
   len: usize,
 ) {
@@ -186,12 +272,13 @@ unsafe extern "C" fn pool_free(
   }
 }
 
-unsafe extern "C" fn pool_drop(pool: *const BufferPool) {
-  // SAFETY: the handle was created with Arc::into_raw in allocator().
-  drop(unsafe { Arc::from_raw(pool) });
+unsafe extern "C" fn pool_drop(pool: *const Arc<BufferPool>) {
+  // SAFETY: the handle was created with Box::into_raw in
+  // array_buffer_allocator().
+  drop(unsafe { Box::from_raw(pool as *mut Arc<BufferPool>) });
 }
 
-static VTABLE: v8::RustAllocatorVtable<BufferPool> =
+static VTABLE: v8::RustAllocatorVtable<Arc<BufferPool>> =
   v8::RustAllocatorVtable {
     allocate: pool_allocate,
     allocate_uninitialized: pool_allocate_uninitialized,
@@ -214,9 +301,10 @@ pub(crate) fn array_buffer_allocator()
     }
   });
   let pool = pool.as_ref()?;
-  // SAFETY: the handle is a strong Arc reference released in pool_drop, and
-  // VTABLE matches the BufferPool handle type.
-  Some(unsafe { v8::new_rust_allocator(Arc::into_raw(pool.clone()), &VTABLE) })
+  let handle = Box::into_raw(Box::new(pool.clone()));
+  // SAFETY: the handle is a heap-allocated strong Arc reference released in
+  // pool_drop, and VTABLE matches the Arc<BufferPool> handle type.
+  Some(unsafe { v8::new_rust_allocator(handle, &VTABLE) })
 }
 
 #[cfg(test)]
@@ -237,14 +325,39 @@ mod tests {
   }
 
   #[test]
-  fn acquire_release_roundtrip() {
-    let pool = BufferPool::new();
-    let class = class_for(64 * 1024).unwrap();
-    let a = pool.acquire(class);
-    assert!(!a.is_null());
-    pool.release(class, a);
-    let b = pool.acquire(class);
-    assert_eq!(a, b, "released block is reused");
-    pool.release(class, b);
+  fn allocate_free_roundtrip_reuses_block() {
+    let pool = Arc::new(BufferPool::new());
+    let len = 64 * 1024;
+    // SAFETY: exercising the allocator callbacks directly.
+    unsafe {
+      let a = pool_allocate(&pool, len);
+      assert!(!a.is_null());
+      // Returned memory must be zeroed.
+      assert_eq!(*(a as *const u8), 0);
+      ptr::write_bytes(a as *mut u8, 0xab, len);
+      pool_free(&pool, a, len);
+      // The block sits in the dirty tier (or clean, if the zeroer ran);
+      // either way the next allocation must observe zeroed memory again.
+      let b = pool_allocate(&pool, len);
+      assert!(!b.is_null());
+      let bytes = std::slice::from_raw_parts(b as *const u8, len);
+      assert!(bytes.iter().all(|&x| x == 0));
+      pool_free(&pool, b, len);
+    }
+  }
+
+  #[test]
+  fn uninitialized_prefers_dirty() {
+    let pool = Arc::new(BufferPool::new());
+    let len = 32 * 1024;
+    // SAFETY: exercising the allocator callbacks directly.
+    unsafe {
+      let a = pool_allocate_uninitialized(&pool, len);
+      assert!(!a.is_null());
+      pool_free(&pool, a, len);
+      let b = pool_allocate_uninitialized(&pool, len);
+      assert!(!b.is_null());
+      pool_free(&pool, b, len);
+    }
   }
 }

--- a/libs/core/runtime/mod.rs
+++ b/libs/core/runtime/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 pub(crate) mod bindings;
+pub(crate) mod buffer_pool;
 pub(crate) mod exception_state;
 pub mod host_defined_options;
 mod jsrealm;

--- a/libs/core/runtime/setup.rs
+++ b/libs/core/runtime/setup.rs
@@ -235,6 +235,11 @@ pub fn create_isolate(
   external_refs: Cow<'static, [v8::ExternalReference]>,
 ) -> v8::OwnedIsolate {
   let mut params = maybe_create_params.unwrap_or_default();
+  if !params.has_set_array_buffer_allocator() {
+    if let Some(allocator) = super::buffer_pool::array_buffer_allocator() {
+      params = params.array_buffer_allocator(allocator);
+    }
+  }
   let mut isolate = if will_snapshot {
     snapshot::create_snapshot_creator(
       external_refs,

--- a/libs/core/runtime/setup.rs
+++ b/libs/core/runtime/setup.rs
@@ -235,10 +235,10 @@ pub fn create_isolate(
   external_refs: Cow<'static, [v8::ExternalReference]>,
 ) -> v8::OwnedIsolate {
   let mut params = maybe_create_params.unwrap_or_default();
-  if !params.has_set_array_buffer_allocator() {
-    if let Some(allocator) = super::buffer_pool::array_buffer_allocator() {
-      params = params.array_buffer_allocator(allocator);
-    }
+  if !params.has_set_array_buffer_allocator()
+    && let Some(allocator) = super::buffer_pool::array_buffer_allocator()
+  {
+    params = params.array_buffer_allocator(allocator);
   }
   let mut isolate = if will_snapshot {
     snapshot::create_snapshot_creator(


### PR DESCRIPTION
Profiling Web Streams byte-path benchmarks showed the dominant cost at
streaming chunk sizes is not the streams machinery but raw backing-store
allocation: V8's default ArrayBuffer allocator malloc+zeroes every store
and frees it back to the system, so the allocator's medium-size magazines
madvise the pages away and the next allocation page-faults them back in
just to zero them again. `new Uint8Array(64 * 1024)` costs ~5.5us on an
M1 Max (~92us for 1MB); JavaScriptCore hands out lazily-zeroed pages in
under 1us, which is most of Bun's advantage on body/clone benchmarks.

This installs a process-global pooled allocator via
`v8::new_rust_allocator`. Freed backing stores of power-of-two size
classes (16KB..16MB, 8MB retention cap per class) go on a per-class
freelist instead of back to the system. `allocate` pops a freed block and
zeroes it inline before returning it; because the block is still resident
(its pages were never madvised away), that zeroing runs at memset speed
rather than the page-fault-then-zero cost of a fresh allocation. A miss
falls back to `alloc_zeroed` (pre-zeroed pages from the OS).
`allocate_uninitialized` skips the zeroing entirely. Small (<=8KB) and
giant (>16MB) allocations fall through to the system allocator, as does
everything when `DENO_DISABLE_BUFFER_POOL=1` is set (also how the numbers
below were taken, A/B on one binary). Embedders that set their own
allocator via CreateParams are unaffected. A `Drop` impl frees any blocks
still retained on the freelists.

Size classes extend to 16 MiB so the whole-body assembly buffer Body
consumers allocate is pooled too (classes >= the 8 MiB cap retain one
block; worst-case retention 96 MiB).

> **Update — simplified to inline zeroing, no background thread.** An
> earlier revision split each size class into a `clean`/`dirty` tier and
> ran a lazily-spawned background thread ("deno-buffer-zeroer") to
> pre-zero freed blocks off the hot path. That was collapsed to the single
> inline-zeroing freelist described above. Benchmarking (below) shows the
> pool's win comes from keeping freed pages **resident** — dodging V8's
> madvise -> refault -> rezero cycle — which the inline version keeps; the
> thread's only job was moving the memset off the hot path, and at the
> ~64 KiB streaming sweet spot that memset is a small fraction of the cost.
> Removing the thread also fixes a `deno_core` Miri failure (a never-joined
> perpetual thread aborts Miri's leak checker at process exit) and drops
> the per-`free` condvar signaling.

This PR also raises the default `--external-memory-max-growing-factor`
from V8's 1.1 to 8 (Closes #35808). Once the pool removes allocator-side
cost, the residual time under buffer churn is V8's external-memory GC
accounting: V8 only grows the external-memory limit by that factor per
GC, so cycling large backing stores keeps the limit pinned near current
usage and drives continuous concurrent marking/sweeping. The two changes
are complementary - the pool removes the allocation cost, the factor
removes the GC-accounting cost it exposes.

### Performance (current inline-zeroing design)

Apple M5, release, A/B on one binary (pool vs `DENO_DISABLE_BUFFER_POOL=1`).
Cross-checked against the latest canary, which ships no pool and whose
numbers match the pool-off column exactly, so it serves as an up-to-date
V8-default baseline. Representative body/clone/streamed-read workloads
(chunks are filled + read, matching real body handling); avg time/iter
from `deno bench`:

| workload | pool | V8 default | Δ |
|---|---:|---:|---:|
| stream read, 64 KiB chunks | 7.4 µs | 10.9 µs | **-32%** |
| `Response.arrayBuffer()`, 64 KiB | 1.7 µs | 2.0 µs | -15% |
| stream read, 256 KiB | 18.1 µs | 19.9 µs | -9% |
| `Blob.arrayBuffer()`, 64 KiB | 9.3 µs | 9.4 µs | ~tie |
| body/clone/stream, 256 KiB - 1 MiB | — | — | parity |

The win concentrates at ~64 KiB streaming (the dominant chunk size). At
>= 256 KiB the pool is at parity: the consumer overwrites the just-zeroed
block, a double-write that cancels the resident-page edge.
Partially-filled large buffers can regress vs V8's lazy per-page zeroing
(a 1 MiB buffer touched at 2 bytes: 7.8 vs 4.4 us), but real body/stream
consumers fill their chunks, so this does not show in the workloads above.

<details>
<summary>Original two-tier + background-thread numbers (M1 Max)</summary>

byte-stream drain with fresh 64KB chunks 6.8 -> 4.0 us/chunk (-41%),
default-stream equivalent 6.2 -> 3.3 (-47%); streamed-body `.bytes()`
3.6 -> 6.7 GB/s (+85%); `Response.clone()` + read both bodies
1828 -> 2666 MB/s (+46%); 1KB chunks (unpooled path) unchanged. Peak RSS
on the clone benchmark is LOWER with the pool (399 vs 542 MB, -26%):
block reuse replaces a larger volume of transient allocator churn.

</details>

Combined A/B for pool x factor (release, macOS arm64). Four quadrants on
one binary: pool toggled via `DENO_DISABLE_BUFFER_POOL`, factor via a
`--v8-flags=--external-memory-max-growing-factor=1.1` override. Touched-
bytes workloads (chunks are filled + read, matching real body handling),
total wall time incl. GC - the correct metric since the residual cost is
GC/page-faults, which a best-pass min-time hides. Throughput is best of 3
runs; peak RSS is `/usr/bin/time -l` maximum resident set size.

| Workload | baseline (pool off, f=1.1) | pool only (f=1.1) | flag only (f=8) | **both** |
|---|---:|---:|---:|---:|
| byte-stream drain (GB/s) | 25.7 | 28.3 | 27.9 | **33.6 (+31%)** |
| byte-stream peak RSS | 152 MiB | 154 | 152 | **150 (flat)** |
| touched 64KiB alloc (GB/s) | 31.3 | 32.1 | 34.7 | **36.6 (+17%)** |
| touched-alloc peak RSS | 149 MiB | 137 | 129 | **128 (-14%)** |

The two changes are additive and slightly synergistic (both beats the sum
of the parts): once the pool removes allocator cost, the factor's GC
reduction has more to bite on. On the streaming target, peak RSS is flat
to lower.

Memory tradeoff for the factor: on a pathological churn-and-retain loop
(allocate into a live rolling window rather than immediately dropping),
factor 8 roughly doubles peak RSS (84 -> 188 MiB) since the external-
memory limit floats higher between GCs. Streaming workloads (the target
shape) do not show this. 4 would be a more conservative compromise if
broad RSS safety is preferred over peak streaming throughput.

Synthetic pure-alloc loop (total time incl GC): with the pool active,
factor 8 cuts `new ArrayBuffer(64KB)` from 1345 -> 1160 ns/op; without
the pool the factor is moot (allocator cost dominates), matching the
issue's thesis that the factor only matters once allocation is cheap.

### Notes

`new_rust_allocator` is unavailable in sandboxed V8, so the pool is
skipped there (falls through to the default allocator). Still wants Linux
benchmarks. The memory-vs-GC-frequency tradeoff of the factor default is
documented above; 8 is chosen for the streaming win, dial to 4 for a
safer memory profile.

Towards #35768
Closes #35808
