### PR TITLE
fix(inspector): close WebSocket connections when the runtime is torn down

### DIFF
--- a/libs/inspector_server/lib.rs
+++ b/libs/inspector_server/lib.rs
@@ -375,9 +375,7 @@ fn handle_ws_request(
       // the runtime is being torn down for a watcher restart). Close the
       // socket instead of leaving the client attached to a session that will
       // never respond.
-      let _ = websocket
-        .write_frame(Frame::close(1001, b"runtime restarted"))
-        .await;
+      close_going_away(&mut websocket).await;
       return;
     }
     log::info!("Debugger session started.");
@@ -708,6 +706,15 @@ async fn listen_for_new_inspectors(
   }
 }
 
+/// Closes the websocket with code 1001 ("going away"), telling the client
+/// that the server-side session is gone, e.g. because the runtime was torn
+/// down for a watcher restart or the process is exiting.
+async fn close_going_away(
+  websocket: &mut WebSocket<TokioIo<hyper::upgrade::Upgraded>>,
+) {
+  let _ = websocket.write_frame(Frame::close(1001, b"going away")).await;
+}
+
 /// The pump future takes care of forwarding messages between the websocket
 /// and channels. It resolves when either side disconnects, ignoring any
 /// errors.
@@ -740,9 +747,7 @@ async fn pump_websocket_messages(
                     // lives on. Close the socket so the client can detect the
                     // restart and reconnect to the new session; otherwise the
                     // connection stays open but silently ignores all messages.
-                    let _ = websocket
-                        .write_frame(Frame::close(1001, b"runtime restarted"))
-                        .await;
+                    close_going_away(&mut websocket).await;
                     log::info!("Debugger session ended (runtime was torn down)");
                     break 'pump;
                 }

--- a/libs/inspector_server/lib.rs
+++ b/libs/inspector_server/lib.rs
@@ -712,7 +712,9 @@ async fn listen_for_new_inspectors(
 async fn close_going_away(
   websocket: &mut WebSocket<TokioIo<hyper::upgrade::Upgraded>>,
 ) {
-  let _ = websocket.write_frame(Frame::close(1001, b"going away")).await;
+  let _ = websocket
+    .write_frame(Frame::close(1001, b"going away"))
+    .await;
 }
 
 /// The pump future takes care of forwarding messages between the websocket

--- a/libs/inspector_server/lib.rs
+++ b/libs/inspector_server/lib.rs
@@ -341,7 +341,7 @@ fn handle_ws_request(
   // spawn a task that will wait for websocket connection and then pump messages between
   // the socket and inspector proxy
   spawn(async move {
-    let websocket = match upgrade_fut.await {
+    let mut websocket = match upgrade_fut.await {
       Ok(w) => w,
       Err(err) => {
         log::error!(
@@ -367,8 +367,20 @@ fn handle_ws_request(
       },
     };
 
+    if new_session_tx
+      .unbounded_send(inspector_session_proxy)
+      .is_err()
+    {
+      // The inspector was deregistered between the map lookup and now (e.g.
+      // the runtime is being torn down for a watcher restart). Close the
+      // socket instead of leaving the client attached to a session that will
+      // never respond.
+      let _ = websocket
+        .write_frame(Frame::close(1001, b"runtime restarted"))
+        .await;
+      return;
+    }
     log::info!("Debugger session started.");
-    let _ = new_session_tx.unbounded_send(inspector_session_proxy);
     pump_websocket_messages(websocket, inbound_tx, outbound_rx).await;
   });
 
@@ -715,9 +727,26 @@ async fn pump_websocket_messages(
 ) {
   'pump: loop {
     tokio::select! {
-        Some(msg) = outbound_rx.next() => {
-            let msg = Frame::text(msg.content.into_bytes().into());
-            let _ = websocket.write_frame(msg).await;
+        maybe_msg = outbound_rx.next() => {
+            match maybe_msg {
+                Some(msg) => {
+                    let msg = Frame::text(msg.content.into_bytes().into());
+                    let _ = websocket.write_frame(msg).await;
+                }
+                None => {
+                    // The isolate-side session was dropped without the client
+                    // disconnecting first, e.g. the file watcher tore down the
+                    // runtime while this server (a process-wide singleton)
+                    // lives on. Close the socket so the client can detect the
+                    // restart and reconnect to the new session; otherwise the
+                    // connection stays open but silently ignores all messages.
+                    let _ = websocket
+                        .write_frame(Frame::close(1001, b"runtime restarted"))
+                        .await;
+                    log::info!("Debugger session ended (runtime was torn down)");
+                    break 'pump;
+                }
+            }
         }
         result = websocket.read_frame() => {
             match result {
@@ -743,9 +772,6 @@ async fn pump_websocket_messages(
                     break 'pump;
                 }
             }
-        }
-        else => {
-          break 'pump;
         }
     }
   }

--- a/tests/specs/inspector/watch_restart_closes_session/__test__.jsonc
+++ b/tests/specs/inspector/watch_restart_closes_session/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "run -A main.js",
+  "output": "main.out"
+}

--- a/tests/specs/inspector/watch_restart_closes_session/main.js
+++ b/tests/specs/inspector/watch_restart_closes_session/main.js
@@ -9,6 +9,7 @@ Deno.writeTextFileSync(watched, "setInterval(() => {}, 1000);\n");
 
 const deadline = setTimeout(() => {
   console.error("test timed out waiting for the inspector to close the socket");
+  child.kill();
   Deno.exit(1);
 }, 60_000);
 Deno.unrefTimer(deadline);
@@ -92,6 +93,7 @@ for (let attempt = 0; attempt < 10 && !reconnected; attempt++) {
 }
 if (!reconnected) {
   console.error("failed to reconnect to the restarted runtime");
+  child.kill();
   Deno.exit(1);
 }
 console.log("reconnected to new session");

--- a/tests/specs/inspector/watch_restart_closes_session/main.js
+++ b/tests/specs/inspector/watch_restart_closes_session/main.js
@@ -1,0 +1,101 @@
+// Regression test: when the file watcher restarts the runtime, the global
+// inspector server must close the WebSocket connections of the torn-down
+// session. Otherwise debugger clients are left attached to a socket that
+// stays open but silently ignores all messages, so they can never detect
+// the restart and reconnect (broken since 2.7.0).
+
+const watched = `${Deno.cwd()}/watched.js`;
+Deno.writeTextFileSync(watched, "setInterval(() => {}, 1000);\n");
+
+const deadline = setTimeout(() => {
+  console.error("test timed out waiting for the inspector to close the socket");
+  Deno.exit(1);
+}, 60_000);
+Deno.unrefTimer(deadline);
+
+const child = new Deno.Command(Deno.execPath(), {
+  args: ["run", "--watch", "--inspect=127.0.0.1:0", watched],
+  stdout: "null",
+  stderr: "piped",
+  env: { NO_COLOR: "1" },
+}).spawn();
+
+// Scan the child's stderr for "Debugger listening on ws://..." lines and keep
+// draining the stream afterwards so the child can't block on a full pipe.
+const wsUrls = [];
+let notifyUrl = () => {};
+(async () => {
+  let buffered = "";
+  for await (const chunk of child.stderr.pipeThrough(new TextDecoderStream())) {
+    buffered += chunk;
+    let newlineIndex;
+    while ((newlineIndex = buffered.indexOf("\n")) >= 0) {
+      const line = buffered.slice(0, newlineIndex);
+      buffered = buffered.slice(newlineIndex + 1);
+      const match = line.match(/Debugger listening on (ws:\/\/\S+)/);
+      if (match) {
+        wsUrls.push(match[1]);
+        notifyUrl();
+      }
+    }
+  }
+})();
+
+async function waitForWsUrlCount(count) {
+  while (wsUrls.length < count) {
+    await new Promise((resolve) => notifyUrl = resolve);
+  }
+}
+
+await waitForWsUrlCount(1);
+const ws = new WebSocket(wsUrls[0]);
+const closed = new Promise((resolve) => ws.onclose = (e) => resolve(e));
+await new Promise((resolve, reject) => {
+  ws.onopen = resolve;
+  ws.onerror = () => reject(new Error("failed to connect to inspector"));
+});
+console.log("connected");
+
+// Trigger watcher restarts until the server closes our socket; re-writing
+// the file guards against a change event being missed or debounced away.
+let socketClosed = false;
+closed.then(() => socketClosed = true);
+(async () => {
+  for (let i = 0; !socketClosed; i++) {
+    Deno.writeTextFileSync(watched, `setInterval(() => {}, 1000); // ${i}\n`);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+})();
+
+const closeEvent = await closed;
+console.log(
+  `websocket closed on watch restart: ${closeEvent.code} ${closeEvent.reason}`,
+);
+
+// The restarted runtime must expose a connectable session again. The touch
+// loop above may have queued more than one restart, so always try the most
+// recently announced URL and retry while the watcher settles.
+await waitForWsUrlCount(2);
+let reconnected = false;
+for (let attempt = 0; attempt < 10 && !reconnected; attempt++) {
+  const ws2 = new WebSocket(wsUrls[wsUrls.length - 1]);
+  reconnected = await new Promise((resolve) => {
+    ws2.onopen = () => {
+      ws2.close();
+      resolve(true);
+    };
+    ws2.onerror = () => resolve(false);
+  });
+  if (!reconnected) {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  }
+}
+if (!reconnected) {
+  console.error("failed to reconnect to the restarted runtime");
+  Deno.exit(1);
+}
+console.log("reconnected to new session");
+
+child.kill();
+await child.status;
+Deno.exit(0);

--- a/tests/specs/inspector/watch_restart_closes_session/main.out
+++ b/tests/specs/inspector/watch_restart_closes_session/main.out
@@ -1,0 +1,3 @@
+connected
+websocket closed on watch restart: 1001 runtime restarted
+reconnected to new session

--- a/tests/specs/inspector/watch_restart_closes_session/main.out
+++ b/tests/specs/inspector/watch_restart_closes_session/main.out
@@ -1,3 +1,3 @@
 connected
-websocket closed on watch restart: 1001 runtime restarted
+websocket closed on watch restart: 1001 going away
 reconnected to new session


### PR DESCRIPTION
Since the inspector server became a process-wide singleton (#31895) it outlives the JS runtime it serves. When the file watcher restarts the runtime, the sessions of the old isolate are dropped, but the WebSocket connections attached to them were left open: the per-connection pump parked on the next client frame once the outbound channel closed, so the socket stayed ESTABLISHED while silently discarding every incoming message. Debugger clients (VS Code js-debug, IntelliJ, Chrome DevTools) never learned the session died and could not reconnect, while the new runtime waited forever under `--inspect-brk` / `--inspect-wait`.

Bisected: 2.6.5 behaves correctly (the per-worker server was dropped on restart and the socket died with it), 2.7.0 is broken.

This PR closes the WebSocket connections of a torn-down session with close code 1001 ("runtime restarted"), so clients get a clean disconnect signal and can re-attach to the new session — `attach` + `"restart": true` in VS Code works again (see denoland/vscode_deno#979).

Includes a regression spec test (`inspector::watch_restart_closes_session`).

Part of a series fixing VS Code debugging with `--watch` (preloads under watch, console bridging on late inspector activation, waitForDebugger semantics).