### PR TITLE
fix(ext/node): flush StringDecoder in cipher final() for stream ciphers

### DIFF
--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -228,12 +228,12 @@ Cipheriv.prototype.final = function (
     throw new ERR_CRYPTO_INVALID_STATE("final");
   }
 
+  _lazyInitCipherDecoder(this, encoding);
+
   if (this._isAesWrap) {
     this._finalized = true;
-    return encoding === "buffer" ? Buffer.from([]) : "";
+    return encoding === "buffer" ? Buffer.from([]) : this._decoder!.end();
   }
-
-  _lazyInitCipherDecoder(this, encoding);
 
   const bs = this._blockSize;
   const buf = new FastBuffer(bs);
@@ -245,7 +245,7 @@ Cipheriv.prototype.final = function (
     const maybeTag = op_node_cipheriv_take(this._context);
     if (maybeTag) this._authTag = Buffer.from(maybeTag);
     this._finalized = true;
-    return encoding === "buffer" ? Buffer.from([]) : "";
+    return encoding === "buffer" ? Buffer.from([]) : this._decoder!.end();
   }
 
   if (
@@ -266,7 +266,7 @@ Cipheriv.prototype.final = function (
   if (maybeTag) {
     this._authTag = Buffer.from(maybeTag);
     this._finalized = true;
-    return encoding === "buffer" ? Buffer.from([]) : "";
+    return encoding === "buffer" ? Buffer.from([]) : this._decoder!.end();
   }
 
   this._finalized = true;
@@ -530,12 +530,12 @@ Decipheriv.prototype.final = function (
     throw new ERR_CRYPTO_INVALID_STATE("final");
   }
 
+  _lazyInitDecipherDecoder(this, encoding);
+
   if (this._isAesWrap) {
     this._finalized = true;
-    return encoding === "buffer" ? Buffer.from([]) : "";
+    return encoding === "buffer" ? Buffer.from([]) : this._decoder!.end();
   }
-
-  _lazyInitDecipherDecoder(this, encoding);
 
   const bs = this._blockSize;
   let buf = new FastBuffer(bs);
@@ -552,7 +552,7 @@ Decipheriv.prototype.final = function (
     TypedArrayPrototypeGetByteLength(this._cache.cache) === 0
   ) {
     this._finalized = true;
-    return encoding === "buffer" ? Buffer.from([]) : "";
+    return encoding === "buffer" ? Buffer.from([]) : this._decoder!.end();
   }
   if (TypedArrayPrototypeGetByteLength(this._cache.cache) != bs) {
     throw opensslError(

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -1185,3 +1185,65 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "Decipheriv final(utf8) flushes a truncated multibyte tail as U+FFFD",
+  fn() {
+    // Exercises the Decipheriv-side final() flush directly: the plaintext
+    // ends with a lone UTF-8 lead byte, so the utf8 StringDecoder buffers
+    // that byte during update() and only end() (invoked by final()) emits
+    // the U+FFFD replacement char. Before the fix, final() returned "" and
+    // dropped it. Matches Node, which returns "a�".
+    const key = Buffer.alloc(32, 1);
+    const iv = Buffer.alloc(16, 2);
+    const raw = Buffer.from([0x61, 0xc3]); // "a" + incomplete 2-byte lead
+
+    const cipher = crypto.createCipheriv("aes-256-ctr", key, iv);
+    const enc = Buffer.concat([cipher.update(raw), cipher.final()]);
+
+    const decipher = crypto.createDecipheriv("aes-256-ctr", key, iv);
+    const dec = decipher.update(enc, undefined, "utf8") +
+      decipher.final("utf8");
+    assertEquals(dec, "a�");
+  },
+});
+
+Deno.test({
+  name: "Cipheriv/Decipheriv AES key wrap flushes StringDecoder in final()",
+  fn() {
+    // The AES key-wrap path computes its whole output in update() and takes
+    // an early return in final(). With a base64 output encoding the decoder
+    // buffers the trailing bytes, so final() must flush them too.
+    const kek = Buffer.alloc(32, 7);
+    // 24-byte key -> 32-byte wrapped output -> 32 % 3 === 2 buffered bytes.
+    const keyToWrap = Buffer.alloc(24, 9);
+    const iv = Buffer.alloc(8, 0xa6);
+
+    const cipher = crypto.createCipheriv("aes256-wrap", kek, iv);
+    const wrapped = cipher.update(keyToWrap, undefined, "base64") +
+      cipher.final("base64");
+    assertEquals(
+      Buffer.from(wrapped, "base64").length,
+      keyToWrap.length + 8,
+      "wrapped length",
+    );
+
+    const decipher = crypto.createDecipheriv("aes256-wrap", kek, iv);
+    const unwrapped = Buffer.concat([
+      decipher.update(wrapped, "base64"),
+      decipher.final(),
+    ]);
+    assertEquals(unwrapped, keyToWrap, "unwrap round-trip");
+
+    // final() with an unknown output encoding now throws ERR_UNKNOWN_ENCODING
+    // on the wrap path instead of silently returning "" (matches Node).
+    const bad = crypto.createCipheriv("aes256-wrap", kek, iv);
+    bad.update(keyToWrap);
+    assertThrows(
+      // deno-lint-ignore no-explicit-any
+      () => bad.final("not-an-encoding" as any),
+      Error,
+      "Unknown encoding",
+    );
+  },
+});

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -1142,3 +1142,46 @@ Deno.test({
     assertEquals(dec.toString("utf8"), "ok");
   },
 });
+
+Deno.test({
+  name:
+    "Cipheriv/Decipheriv final(encoding) flushes StringDecoder for stream ciphers",
+  fn() {
+    // Regression test for https://github.com/denoland/deno/issues/35797:
+    // stream-mode ciphers (GCM/CTR/ChaCha20) took early-return paths in
+    // final() that returned "" without flushing the StringDecoder used by
+    // update(). A base64 decoder withholds up to 2 trailing bytes until
+    // end(), so any plaintext whose byte length was not a multiple of 3 was
+    // silently truncated with no error.
+    const key = Buffer.alloc(32, 1);
+    const plaintext = "hello"; // 5 bytes, 5 % 3 !== 0
+
+    for (
+      const [algo, iv, isAead] of [
+        ["aes-256-gcm", Buffer.alloc(12, 2), true],
+        ["aes-256-ctr", Buffer.alloc(16, 2), false],
+        ["chacha20-poly1305", Buffer.alloc(12, 2), true],
+      ] as const
+    ) {
+      const cipher = crypto.createCipheriv(algo, key, iv);
+      const enc = cipher.update(plaintext, "utf8", "base64") +
+        cipher.final("base64");
+      // The full ciphertext must survive base64 round-tripping.
+      assertEquals(
+        Buffer.from(enc, "base64").length,
+        plaintext.length,
+        `${algo}: encrypted length`,
+      );
+
+      const decipher = crypto.createDecipheriv(algo, key, iv);
+      if (isAead) {
+        (decipher as crypto.DecipherGCM).setAuthTag(
+          (cipher as crypto.CipherGCM).getAuthTag(),
+        );
+      }
+      const dec = decipher.update(enc, "base64", "utf8") +
+        decipher.final("utf8");
+      assertEquals(dec, plaintext, `${algo}: round-trip`);
+    }
+  },
+});


### PR DESCRIPTION
Fixes #35797

## Problem

`node:crypto` `Cipheriv`/`Decipheriv` silently truncate their output when a string output encoding (e.g. `base64`) is used with a stream-mode cipher (AES-GCM, AES-CTR, ChaCha20-Poly1305, AES key wrap).

```js
import { createCipheriv } from "node:crypto";
const key = Buffer.alloc(32, 1), iv = Buffer.alloc(12, 2);
const c = createCipheriv("aes-256-gcm", key, iv);
const out = c.update("hello", "utf8", "base64") + c.final("base64");
// before: "b7Ol"      (3 bytes — TRUNCATED)
// after:  "b7OlJSU="  (5 bytes — correct, matches Node)
```

Because encryption still "succeeds", there is no signal — GCM/CTR ciphertext gets stored truncated and only fails later at decryption time (`Unsupported state or unable to authenticate data`).

## Root cause

`update()` routes string output through a `StringDecoder`, and a base64 decoder withholds up to `len % 3` trailing bytes until `end()` is called. The early-return paths in `Cipheriv.prototype.final` / `Decipheriv.prototype.final` (AES-wrap, the no-block-cache/stream-cipher path, and the auth-tag path) returned `""` without calling `this._decoder.end()`, so the buffered tail was dropped whenever the input byte length was not a multiple of 3. Only the CBC/ECB block path flushed.

Node does **not** have this bug — its `final()` always returns `this._decoder.end(ret)` on the string-output path. This PR makes every `final()` return path flush the decoder to match. The `buffer`-output paths are unchanged.

## Test

Added a regression test in `tests/unit_node/crypto/crypto_cipher_test.ts` covering GCM, CTR, and ChaCha20-Poly1305 base64 round-trips with a 5-byte plaintext (length not a multiple of 3). Existing `crypto_cipher_test` and `crypto_cipher_gcm_test` suites pass.