### PR TITLE
fix(ext/node): allow adopting inherited extra stdio TCP fds

### DIFF
--- a/ext/io/fd_table.rs
+++ b/ext/io/fd_table.rs
@@ -108,6 +108,38 @@ impl FdTable {
       Some(FdOwnership::InheritedExtraStdio(_))
     )
   }
+
+  /// Check whether a libuv stream wrap (`PipeWrap::open`, `TCPWrap::open`)
+  /// may adopt `fd`. Stdio fds (0-2) are pre-registered and may be re-opened;
+  /// inherited extra stdio fds may be adopted (e.g. via `net.Socket({ fd })`)
+  /// and are consumed by `finish_uv_adopt` only once the uv open actually
+  /// claims the fd, so a failed open leaves the fd usable by node:fs. Any
+  /// other tracked fd is a duplicate.
+  ///
+  /// Returns `Some(was_inherited)` if adoption may proceed (pass the flag to
+  /// `finish_uv_adopt` on success), or `None` if the fd is already tracked
+  /// and the caller should reject with `EEXIST`.
+  pub fn begin_uv_adopt(&self, fd: i32) -> Option<bool> {
+    if self.is_inherited_extra_stdio(fd) {
+      Some(true)
+    } else if self.contains(fd) && !(0..=2).contains(&fd) {
+      None
+    } else {
+      Some(false)
+    }
+  }
+
+  /// Record a successful uv adoption started with `begin_uv_adopt`. Drops the
+  /// inherited entry if there was one (libuv now owns the original fd; only
+  /// the node:fs dup is released, and its close is deferred until any
+  /// `Rc<dyn File>` clone held by an in-flight node:fs stream drops), then
+  /// tracks the fd as UvOwned so it can't be re-adopted by another wrap.
+  pub fn finish_uv_adopt(&mut self, fd: i32, was_inherited: bool) {
+    if was_inherited {
+      self.remove(fd);
+    }
+    self.register_uv_owned(fd);
+  }
 }
 
 impl Default for FdTable {

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -211,11 +211,15 @@ fn inherited_extra_stdio_fd(fd: i32) -> Option<StdFile> {
   if fd < 3 {
     return None;
   }
-  // SAFETY: dup validates the descriptor and gives FdTable its own handle.
-  let dup_fd = unsafe { libc::dup(fd) };
+  // The dup exists purely for in-process node:fs use, so mark it
+  // close-on-exec: unlike the original fd (which must stay inheritable, as
+  // in Node), the dup must not leak into spawned grandchildren, where it
+  // would hold pipe ends open and delay EOF for the parent.
+  // SAFETY: fcntl validates the descriptor and gives FdTable its own handle.
+  let dup_fd = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
   if dup_fd == -1 {
     log::debug!(
-      "dup() failed for inherited extra stdio fd {}: {}",
+      "duplicating inherited extra stdio fd {} failed: {}",
       fd,
       std::io::Error::last_os_error()
     );

--- a/ext/node/ops/pipe_wrap.rs
+++ b/ext/node/ops/pipe_wrap.rs
@@ -312,23 +312,13 @@ impl PipeWrap {
 
   #[fast]
   fn open(&self, state: &mut OpState, #[smi] fd: i32) -> i32 {
-    // Check FdTable for duplicate fds. Stdio fds (0-2) are pre-registered
-    // as TableOwned; for those, open is allowed (no-op check). Inherited
-    // extra stdio fds are also allowed, because child process code may open
-    // them through net.Socket({ fd }); their entry is consumed below only
-    // once uv_pipe_open actually claims the fd, so a failed open leaves the
-    // fd usable by node:fs. Other non-stdio fds already in FdTable are
-    // rejected (EEXIST).
-    let is_inherited_extra_stdio = {
-      let fd_table = state.borrow::<deno_io::FdTable>();
-      if fd_table.is_inherited_extra_stdio(fd) {
-        true
-      } else {
-        if fd_table.contains(fd) && !(0..=2).contains(&fd) {
-          return -libc::EEXIST;
-        }
-        false
-      }
+    // See `FdTable::begin_uv_adopt` for the duplicate-fd policy (stdio and
+    // inherited extra stdio fds may be adopted; other tracked fds are
+    // rejected).
+    let Some(was_inherited) =
+      state.borrow::<deno_io::FdTable>().begin_uv_adopt(fd)
+    else {
+      return -libc::EEXIST;
     };
     let pipe = self.pipe_ptr();
     if pipe.is_null() {
@@ -347,14 +337,9 @@ impl PipeWrap {
       unsafe { uv_compat::uv_pipe_open(pipe, fd) }
     };
     if ret == 0 {
-      let fd_table = state.borrow_mut::<deno_io::FdTable>();
-      // libuv now owns the original fd, so drop the inherited dup (only the
-      // dup is closed; the original numeric fd stays open under uv).
-      if is_inherited_extra_stdio {
-        fd_table.remove(fd);
-      }
-      // Register as UvOwned - the native handle owns the fd.
-      fd_table.register_uv_owned(fd);
+      state
+        .borrow_mut::<deno_io::FdTable>()
+        .finish_uv_adopt(fd, was_inherited);
       self.base.set_fd(fd);
     }
     ret

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -383,24 +383,14 @@ impl TCPWrap {
     if fd < 0 {
       return uv_compat::UV_EBADF;
     }
-    // Refuse to adopt a descriptor Deno already tracks. Stdio (0-2) is
-    // pre-registered and may be re-opened. Inherited extra stdio fds are
-    // also allowed, because the inherited descriptor may be a TCP socket
-    // that child process code adopts through net.Socket({ fd }) or
-    // server.listen({ fd }); their entry is consumed below only once
-    // uv_tcp_open actually claims the fd, so a failed open leaves the fd
-    // usable by node:fs. Any other fd already in the FdTable is rejected,
-    // matching `PipeWrap::open`.
-    let is_inherited_extra_stdio = {
-      let fd_table = state.borrow::<deno_io::FdTable>();
-      if fd_table.is_inherited_extra_stdio(fd) {
-        true
-      } else {
-        if fd_table.contains(fd) && !(0..=2).contains(&fd) {
-          return -libc::EEXIST;
-        }
-        false
-      }
+    // See `FdTable::begin_uv_adopt` for the duplicate-fd policy (stdio and
+    // inherited extra stdio fds may be adopted — the latter covers an
+    // inherited TCP socket claimed via net.Socket({ fd }) or
+    // server.listen({ fd }); other tracked fds are rejected).
+    let Some(was_inherited) =
+      state.borrow::<deno_io::FdTable>().begin_uv_adopt(fd)
+    else {
+      return -libc::EEXIST;
     };
     let tcp = self.tcp_ptr();
     if tcp.is_null() {
@@ -438,13 +428,9 @@ impl TCPWrap {
     // Track the adopted fd so it can't be re-adopted by another wrap and is
     // dropped from the FdTable on close.
     if ret == 0 {
-      let fd_table = state.borrow_mut::<deno_io::FdTable>();
-      // libuv now owns the original fd, so drop the inherited dup (only the
-      // dup is closed; the original numeric fd stays open under uv).
-      if is_inherited_extra_stdio {
-        fd_table.remove(fd);
-      }
-      fd_table.register_uv_owned(fd);
+      state
+        .borrow_mut::<deno_io::FdTable>()
+        .finish_uv_adopt(fd, was_inherited);
       self.base.set_fd(fd);
     }
     ret

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -384,14 +384,24 @@ impl TCPWrap {
       return uv_compat::UV_EBADF;
     }
     // Refuse to adopt a descriptor Deno already tracks. Stdio (0-2) is
-    // pre-registered and may be re-opened; any other fd already in the
-    // FdTable is rejected, matching `PipeWrap::open`.
-    {
+    // pre-registered and may be re-opened. Inherited extra stdio fds are
+    // also allowed, because the inherited descriptor may be a TCP socket
+    // that child process code adopts through net.Socket({ fd }) or
+    // server.listen({ fd }); their entry is consumed below only once
+    // uv_tcp_open actually claims the fd, so a failed open leaves the fd
+    // usable by node:fs. Any other fd already in the FdTable is rejected,
+    // matching `PipeWrap::open`.
+    let is_inherited_extra_stdio = {
       let fd_table = state.borrow::<deno_io::FdTable>();
-      if fd_table.contains(fd) && !(0..=2).contains(&fd) {
-        return -libc::EEXIST;
+      if fd_table.is_inherited_extra_stdio(fd) {
+        true
+      } else {
+        if fd_table.contains(fd) && !(0..=2).contains(&fd) {
+          return -libc::EEXIST;
+        }
+        false
       }
-    }
+    };
     let tcp = self.tcp_ptr();
     if tcp.is_null() {
       return uv_compat::UV_EBADF;
@@ -428,7 +438,13 @@ impl TCPWrap {
     // Track the adopted fd so it can't be re-adopted by another wrap and is
     // dropped from the FdTable on close.
     if ret == 0 {
-      state.borrow_mut::<deno_io::FdTable>().register_uv_owned(fd);
+      let fd_table = state.borrow_mut::<deno_io::FdTable>();
+      // libuv now owns the original fd, so drop the inherited dup (only the
+      // dup is closed; the original numeric fd stays open under uv).
+      if is_inherited_extra_stdio {
+        fd_table.remove(fd);
+      }
+      fd_table.register_uv_owned(fd);
       self.base.set_fd(fd);
     }
     ret

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -758,6 +758,56 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "[node/child_process spawn] Deno child adopts a listening TCP fd passed as extra stdio",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const cmdFinished = Promise.withResolvers<void>();
+    const received = Promise.withResolvers<string>();
+    let stderr = "";
+    const script = path.join(
+      path.dirname(path.fromFileUrl(import.meta.url)),
+      "testdata",
+      "child_process_extra_stdio_fd3_tcp_listen.js",
+    );
+    // Create a listening socket, then hand a raw dup of it to the child and
+    // close our copy; the kernel keeps the socket listening through the dup
+    // (which is intentionally left open in this process).
+    const bootstrap = net.createServer();
+    bootstrap.listen(0, "127.0.0.1", () => {
+      const address = bootstrap.address() as net.AddressInfo;
+      // deno-lint-ignore no-explicit-any
+      const rawFd = (bootstrap as any)._handle.fdForIpc();
+      assert(rawFd >= 0);
+      bootstrap.close(() => {
+        const cp = spawn(Deno.execPath(), ["run", "-A", script], {
+          stdio: ["ignore", "ignore", "pipe", rawFd],
+        });
+        cp.stderr?.on("data", (data) => {
+          stderr += data;
+        });
+        cp.on("close", (code) => {
+          assertEquals(code, 0, stderr);
+          assertEquals(stderr, "");
+          cmdFinished.resolve();
+        });
+        // The kernel queues this connection on the still-listening socket
+        // until the child adopts fd 3 and accepts it.
+        const client = net.connect(address.port, "127.0.0.1");
+        let data = "";
+        client.on("data", (chunk) => {
+          data += chunk;
+        });
+        client.on("end", () => received.resolve(data));
+        client.on("error", (err) => received.reject(err));
+      });
+    });
+    await cmdFinished.promise;
+    assertEquals(await received.promise, "hello from fd 3 listener");
+  },
+});
+
+Deno.test({
   name: "[node/child_process spawn] supports SIGIOT signal",
   ignore: Deno.build.os === "windows",
   async fn() {

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import CP from "node:child_process";
+import net from "node:net";
 import { Buffer } from "node:buffer";
 import {
   assert,
@@ -700,6 +701,59 @@ Deno.test({
       cmdFinished.resolve();
     });
     await cmdFinished.promise;
+  },
+});
+
+Deno.test({
+  name:
+    "[node/child_process spawn] Deno child adopts a TCP fd passed as extra stdio",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const cmdFinished = Promise.withResolvers<void>();
+    const received = Promise.withResolvers<string>();
+    const serverClosed = Promise.withResolvers<void>();
+    let stderr = "";
+    const script = path.join(
+      path.dirname(path.fromFileUrl(import.meta.url)),
+      "testdata",
+      "child_process_extra_stdio_fd3_tcp.js",
+    );
+    const server = net.createServer((conn) => {
+      let data = "";
+      conn.on("data", (chunk) => {
+        data += chunk;
+      });
+      conn.on("end", () => received.resolve(data));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as net.AddressInfo;
+      const client = net.connect(address.port, "127.0.0.1", () => {
+        client.pause();
+        // Grab a raw duplicate of the connected TCP fd to pass through the
+        // child's stdio slot 3. The dup is intentionally left open here; only
+        // the child writes to the connection, and its shutdown() delivers the
+        // FIN to the server regardless of this process's remaining handles.
+        // deno-lint-ignore no-explicit-any
+        const rawFd = (client as any)._handle.fdForIpc();
+        assert(rawFd >= 0);
+        const cp = spawn(Deno.execPath(), ["run", "-A", script], {
+          stdio: ["ignore", "ignore", "pipe", rawFd],
+        });
+        cp.stderr?.on("data", (data) => {
+          stderr += data;
+        });
+        cp.on("close", (code) => {
+          client.destroy();
+          server.close(() => serverClosed.resolve());
+          assertEquals(code, 0, stderr);
+          assertEquals(stderr, "");
+          cmdFinished.resolve();
+        });
+      });
+    });
+    await cmdFinished.promise;
+    assertEquals(await received.promise, "hello from fd 3 tcp");
+    await serverClosed.promise;
   },
 });
 

--- a/tests/unit_node/testdata/child_process_extra_stdio_fd3_tcp.js
+++ b/tests/unit_node/testdata/child_process_extra_stdio_fd3_tcp.js
@@ -1,0 +1,16 @@
+import { Socket } from "node:net";
+
+// fd 3 is an inherited TCP connection registered at startup as an extra
+// stdio fd. Adopting it via net.Socket({ fd }) routes through TCPWrap::open,
+// which must consume the inherited registration instead of rejecting the fd
+// with EEXIST.
+const socket = new Socket({ fd: 3, readable: false, writable: true });
+
+socket.on("error", (err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+socket.end("hello from fd 3 tcp", () => {
+  process.exit(0);
+});

--- a/tests/unit_node/testdata/child_process_extra_stdio_fd3_tcp_listen.js
+++ b/tests/unit_node/testdata/child_process_extra_stdio_fd3_tcp_listen.js
@@ -1,0 +1,18 @@
+import { createServer } from "node:net";
+
+// fd 3 is an inherited *listening* TCP socket. Adopting it via
+// net.createServer().listen({ fd }) routes through TCPWrap::open with
+// SocketType::Server (uv_tcp_open_listener), which must consume the
+// inherited registration instead of rejecting the fd with EEXIST.
+const server = createServer((conn) => {
+  conn.end("hello from fd 3 listener", () => {
+    server.close(() => process.exit(0));
+  });
+});
+
+server.on("error", (err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+server.listen({ fd: 3 });


### PR DESCRIPTION
Follow-up to #34133, which registers inherited extra stdio fds in the child's
FdTable so node:fs fd APIs can use them. That registration broke adopting an
inherited fd that is a TCP socket: `net.Socket({ fd })` routes through
`TCPWrap::open`, whose duplicate-fd check was not taught about
`InheritedExtraStdio` entries and rejected the fd with `EEXIST` (`PipeWrap`
got the exemption, `TCPWrap` did not). This mirrors the `PipeWrap` logic in
`TCPWrap::open`: inherited extra stdio fds are allowed, and their entry (with
the node:fs dup it holds) is consumed only once `uv_tcp_open` actually claims
the fd. The new regression test fails with `EEXIST` without this change.

The startup dup is now also created with `F_DUPFD_CLOEXEC` instead of
`dup()`. It exists purely for in-process node:fs use, but without
close-on-exec it leaked into spawned grandchildren, holding pipe ends open
and delaying EOF for the parent past what Node exhibits.

AI assistance was used to prepare this PR.