### PR TITLE
perf(ext/web): ring buffer for WHATWG stream queues

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -311,17 +311,19 @@ function uponPromise(promise, onFulfilled, onRejected) {
 
 // Number of (value, size) entries in a freshly allocated ring.
 const QUEUE_INITIAL_CAPACITY = 8;
-// Rings larger than this are dropped (not retained) when the queue
-// empties, so a burst does not pin a large backing array forever.
-const QUEUE_RETAIN_CAPACITY = 512;
+// Rings holding more than this many entries are dropped (not retained) when
+// the queue empties, so a burst does not pin a large backing array forever.
+// Values cribbed from nodejs/node#64312 (initial 8, retain 1024 entries),
+// which uses the same ring for the same spec structure.
+const QUEUE_RETAIN_CAPACITY = 1024;
 
 // A power-of-two ring buffer holding (value, size) pairs in two
 // consecutive slots. Compared to the previous linked list this allocates
 // nothing per enqueued chunk in steady state (the ring is reused), keeps
 // entries cache-adjacent, and defers all storage allocation until a chunk
 // is actually buffered (`#ring` starts null), which keeps stream
-// construction allocation-free on this axis. Layout mirrors what other
-// engines use for the same spec structure.
+// construction allocation-free on this axis. Layout mirrors the ring
+// nodejs/node#64312 uses for the same spec structure.
 class Queue {
   /** @type {any[] | null} */
   #ring = null;

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -35,6 +35,8 @@ const {
   ArrayBufferPrototypeSlice,
   ArrayBufferPrototypeTransferToFixedLength,
   ArrayPrototypeMap,
+  Array,
+  ArrayPrototypeFill,
   ArrayPrototypePush,
   AsyncGeneratorPrototype,
   BigInt64Array,
@@ -307,56 +309,93 @@ function uponPromise(promise, onFulfilled, onRejected) {
   );
 }
 
+// Number of (value, size) entries in a freshly allocated ring.
+const QUEUE_INITIAL_CAPACITY = 8;
+// Rings larger than this are dropped (not retained) when the queue
+// empties, so a burst does not pin a large backing array forever.
+const QUEUE_RETAIN_CAPACITY = 512;
+
+// A power-of-two ring buffer holding (value, size) pairs in two
+// consecutive slots. Compared to the previous linked list this allocates
+// nothing per enqueued chunk in steady state (the ring is reused), keeps
+// entries cache-adjacent, and defers all storage allocation until a chunk
+// is actually buffered (`#ring` starts null), which keeps stream
+// construction allocation-free on this axis. Layout mirrors what other
+// engines use for the same spec structure.
 class Queue {
-  #head = null;
-  #tail = null;
+  /** @type {any[] | null} */
+  #ring = null;
+  /** Entry index of the head; always in [0, capacity). */
+  #head = 0;
   #size = 0;
 
   enqueue(value) {
     return this.enqueueWithSize(value, 1);
   }
 
-  // Stores the chunk size inline in the list node instead of a separate
-  // { value, size } wrapper, so a sized enqueue costs a single allocation.
   enqueueWithSize(value, size) {
-    const node = { value, size, next: null };
-    if (this.#head === null) {
-      this.#head = node;
-      this.#tail = node;
-    } else {
-      this.#tail.next = node;
-      this.#tail = node;
+    let ring = this.#ring;
+    if (ring === null) {
+      ring = this.#ring = ArrayPrototypeFill(
+        new Array(QUEUE_INITIAL_CAPACITY * 2),
+        undefined,
+      );
+    } else if (this.#size === ring.length >> 1) {
+      ring = this.#grow();
     }
+    const mask = (ring.length >> 1) - 1;
+    const slot = ((this.#head + this.#size) & mask) << 1;
+    ring[slot] = value;
+    ring[slot + 1] = size;
     return ++this.#size;
   }
 
-  dequeue() {
-    const node = this.dequeueNode();
-    return node === null ? null : node.value;
+  #grow() {
+    const old = this.#ring;
+    const oldMask = (old.length >> 1) - 1;
+    const ring = ArrayPrototypeFill(new Array(old.length * 2), undefined);
+    for (let i = 0; i < this.#size; i++) {
+      const from = ((this.#head + i) & oldMask) << 1;
+      ring[i << 1] = old[from];
+      ring[(i << 1) + 1] = old[from + 1];
+    }
+    this.#head = 0;
+    this.#ring = ring;
+    return ring;
   }
 
-  // Returns the internal { value, size, next } node. Only for use by
-  // dequeueValue(), which needs both the value and its size.
-  dequeueNode() {
-    const node = this.#head;
-    if (node === null) {
+  dequeue() {
+    if (this.#size === 0) {
       return null;
     }
-
-    if (this.#head === this.#tail) {
-      this.#tail = null;
+    const ring = this.#ring;
+    const mask = (ring.length >> 1) - 1;
+    const slot = this.#head << 1;
+    const value = ring[slot];
+    ring[slot] = undefined;
+    ring[slot + 1] = undefined;
+    this.#head = (this.#head + 1) & mask;
+    if (--this.#size === 0) {
+      this.#head = 0;
+      if (ring.length >> 1 > QUEUE_RETAIN_CAPACITY) {
+        this.#ring = null;
+      }
     }
-    this.#head = this.#head.next;
-    this.#size--;
-    return node;
+    return value;
   }
 
   peek() {
-    if (this.#head === null) {
+    if (this.#size === 0) {
       return null;
     }
+    return this.#ring[this.#head << 1];
+  }
 
-    return this.#head.value;
+  // The size stored alongside the head entry. Only meaningful when
+  // size > 0; used by dequeueValue(), which needs the entry's size
+  // before dequeuing it.
+  peekSize() {
+    return this.#ring[(this.#head << 1) + 1];
   }
 
   get size() {
@@ -677,12 +716,14 @@ function createWritableStream(
 function dequeueValue(container) {
   assert(container[_queue] && typeof container[_queueTotalSize] === "number");
   assert(container[_queue].size);
-  const node = container[_queue].dequeueNode();
-  container[_queueTotalSize] -= node.size;
+  const queue = container[_queue];
+  const size = queue.peekSize();
+  const value = queue.dequeue();
+  container[_queueTotalSize] -= size;
   if (container[_queueTotalSize] < 0) {
     container[_queueTotalSize] = 0;
   }
-  return node.value;
+  return value;
 }
 /**
  * @template T


### PR DESCRIPTION
## Benchmark result: this regresses on V8 — do not land as-is

Measured on Apple M5, `--release` builds. Baseline is this branch with the
ring-buffer commit reverted (its parent, `ece646183c^`), i.e. the existing
singly-linked-list `Queue`. Treatment is the ring buffer (retain 1024).
Both binaries built from the identical tree apart from the `Queue`
implementation, so the delta is attributable to the queue change alone.
Lower time/iter is better; the last column is the ring buffer's slowdown
vs the linked list.

### In-repo hot-path suite (`tests/bench/streams.js`)

| benchmark | linked list | ring buffer | Δ |
| --- | --- | --- | --- |
| readable_stream_default_read | 736 ns | 953 ns | **+29% slower** |
| writable_stream_many_writes | 3.2 µs | 4.1 µs | **+28% slower** |
| readable_byte_stream_byob_read | 15.3 µs | 15.3 µs | ~0% (neutral) |
| transform_stream_pipe_through | 15.1 µs | 16.8 µs | **+11% slower** |

### Buffered-read / pipe-to / tee shapes from the brief

| benchmark | linked list | ring buffer | Δ |
| --- | --- | --- | --- |
| buffered read n=1 | 282 ns | 318 ns | **+13% slower** |
| buffered read n=10 | 547 ns | 614 ns | **+12% slower** |
| buffered read n=100 | 3.0 µs | 3.55 µs | **+18% slower** |
| buffered read n=1000 | 27.2 µs | 32.0 µs | **+18% slower** |
| pipe_to hwm16 | 103 µs | ~106 µs | ~neutral (noise) |
| tee slow branch | 134 µs | 150 µs | **+12% slower** |

Results reproduce across repeated runs and with the run order reversed, so
they are not thermal/ordering artifacts.

### Why the Node win does not transfer

nodejs/node#64312 measured +12–49% on the same engine, but against a
baseline that still wrapped every buffered chunk in a `{value, size}`
object. Deno already removed that allocation in #35773 (inline chunk size
in the list node), so there is almost nothing left for the ring to save.
What remains is a net cost on V8:

- The `{value, size, next}` nodes are tiny, short-lived, and bump-allocated
  in new space; V8's generational GC collects them essentially for free.
- The ring's backing array interleaves object `value`s with SMI `size`s, so
  it takes a generic elements kind. Every `enqueue`/`dequeue`/`peek` then
  pays a type-checked element load/store, and `dequeue` writes two
  `undefined` holes back to release references. That per-op overhead
  outweighs the eliminated allocation, uniformly across queue depths.

The regression appears even at n=1 and on small queues (pipe_to hwm16, the
write-request queue), which never reach the retain threshold — so it is
inherent to the ring, not a function of `QUEUE_INITIAL_CAPACITY` /
`QUEUE_RETAIN_CAPACITY` tuning.

### Recommendation

Do not land. Keep the linked-list `Queue` (already optimal on this stack
after #35773). Closing / parking this pending a fundamentally different
approach (e.g. a size-free queue that keeps homogeneous element kinds, or
a typed-array sidecar for sizes) if per-chunk queue cost is revisited.

---

<details>
<summary>Original handoff brief (superseded by the result above)</summary>

Ports the queue mechanism from nodejs/node#64312 to Deno's streams. The
singly-linked-list Queue backing every controller queue, read/write
request queue, and the byte controller's pending pull-intos becomes a
power-of-two ring buffer holding (value, size) pairs in two consecutive
slots. See commit history for the full implementation and the fuzz
validation (200 trials x 5000 ops against an array model, passing).

Towards #35768, ref #35770 (remainder of that issue's territory after #35773).

</details>
