### PR TITLE
fix(watch): terminate on Ctrl+C while blocked in synchronous code

### DIFF
--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -421,7 +421,14 @@ where
 
     select! {
       _ = receiver_future => {},
-      _ = deno_signals::ctrl_c() => {
+      // Watch for Ctrl+C without preventing the default signal behavior:
+      // if the program has no signal listeners, the process is terminated
+      // by the default handler right away, even while the event loop is
+      // blocked in synchronous JS code and this branch cannot be polled
+      // (https://github.com/denoland/deno/issues/35824). This branch is
+      // reached when a JS signal listener prevented the default behavior,
+      // in which case we shut down gracefully below.
+      _ = deno_signals::ctrl_c_allow_default() => {
         // Dispatch SIGINT (matching what Ctrl+C normally sends) and
         // SIGTERM to give JS code a chance for async cleanup. Some
         // libraries only listen for SIGINT, others for SIGTERM.
@@ -494,7 +501,7 @@ where
     // watched paths has changed.
     select! {
       _ = receiver_future => {},
-      _ = deno_signals::ctrl_c() => {
+      _ = deno_signals::ctrl_c_allow_default() => {
         return Ok(());
       },
       _ = restart_rx.recv() => {

--- a/ext/signals/lib.rs
+++ b/ext/signals/lib.rs
@@ -285,16 +285,46 @@ impl SignalStream {
 }
 
 pub fn signal_stream(signo: i32) -> Result<SignalStream, std::io::Error> {
+  signal_stream_inner(signo, true)
+}
+
+/// Like [`signal_stream`], but does not prevent the default signal behavior.
+///
+/// The stream only observes the signal: if no other registered handler
+/// (e.g. a JS signal listener) prevents the default, the default action
+/// still runs, terminating the process for signals like SIGINT. This is
+/// important for consumers that poll the stream from the main event loop,
+/// which may be blocked in synchronous JS execution and unable to react
+/// to the notification.
+pub fn signal_stream_allow_default(
+  signo: i32,
+) -> Result<SignalStream, std::io::Error> {
+  signal_stream_inner(signo, false)
+}
+
+fn signal_stream_inner(
+  signo: i32,
+  prevent_default: bool,
+) -> Result<SignalStream, std::io::Error> {
   let (tx, rx) = watch::channel(());
   let cb = Box::new(move || {
     tx.send_replace(());
   });
-  register(signo, true, cb)?;
+  register(signo, prevent_default, cb)?;
   Ok(SignalStream { rx })
 }
 
 pub async fn ctrl_c() -> std::io::Result<()> {
-  let mut stream = signal_stream(libc::SIGINT)?;
+  ctrl_c_inner(signal_stream(libc::SIGINT)?).await
+}
+
+/// Like [`ctrl_c`], but does not prevent the default SIGINT behavior.
+/// See [`signal_stream_allow_default`].
+pub async fn ctrl_c_allow_default() -> std::io::Result<()> {
+  ctrl_c_inner(signal_stream_allow_default(libc::SIGINT)?).await
+}
+
+async fn ctrl_c_inner(mut stream: SignalStream) -> std::io::Result<()> {
   match stream.recv().await {
     Some(_) => Ok(()),
     None => Err(std::io::Error::other("failed to receive SIGINT signal")),

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -2402,6 +2402,52 @@ async fn test_watch_sigint_and_sigterm_on_ctrlc() {
   assert_eq!(exit_status.code(), Some(0));
 }
 
+/// Test that Ctrl+C terminates the watcher right away while the
+/// watched program is blocked in synchronous JS code and has no
+/// signal listeners registered.
+/// Regression test for https://github.com/denoland/deno/issues/35824.
+#[cfg(unix)]
+#[test(flaky)]
+async fn test_watch_sigint_during_blocking_sync_code() {
+  use std::os::unix::process::ExitStatusExt;
+
+  use nix::sys::signal;
+  use nix::sys::signal::Signal;
+  use nix::unistd::Pid;
+
+  let t = TempDir::new();
+  let file_to_watch = t.path().join("file_to_watch.js");
+  file_to_watch.write(
+    r#"
+      console.log("looping");
+      const start = Date.now();
+      while (Date.now() - start < 60000) {}
+    "#,
+  );
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, _stderr_lines) = child_lines(&mut child);
+
+  wait_contains("looping", &mut stdout_lines).await;
+
+  // Send SIGINT (simulating Ctrl+C) while the program is inside the
+  // synchronous busy loop and cannot service the event loop.
+  signal::kill(Pid::from_raw(child.id() as i32), Signal::SIGINT).unwrap();
+
+  // The process must be terminated by the default SIGINT behavior
+  // without waiting for the synchronous code to finish.
+  let exit_status = child.wait().unwrap();
+  assert_eq!(exit_status.signal(), Some(Signal::SIGINT as i32));
+}
+
 #[test(flaky)]
 async fn bench_watch_basic() {
   let t = TempDir::new();


### PR DESCRIPTION
Since v2.5.3 (#30635), Ctrl+C in watch mode had no effect while the
watched program was blocked in synchronous code: the watcher registered
its SIGINT observer with `prevent_default: true`, which replaced the
default terminate action, and the notification was consumed by a
`select!` on the main thread, which cannot be polled while JS runs
synchronously. As a result the signal sat unhandled until the
synchronous code finished.

The watcher now observes SIGINT without claiming it. When the program
has no signal listeners, the default handler terminates the process
immediately, even mid-computation, matching the pre-2.5.3 behavior and
plain `deno run`. When a JS SIGINT listener is registered (the #30587
scenario that #30635 fixed), the default is prevented as before and the
watcher still performs its graceful shutdown, so the existing
`test_watch_sigint_and_sigterm_on_ctrlc` behavior is unchanged.

Fixes #35824