### PR TITLE
fix(ext/web): resolve pending BYOB read when teeing a byte stream that closes

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -3891,16 +3891,44 @@ function readableByteStreamTee(stream) {
    * @param {ReadableStreamBYOBReader} thisReader
    */
   function forwardReaderError(thisReader) {
-    PromisePrototypeCatch(thisReader[_closedPromise].promise, (e) => {
-      if (thisReader !== reader) {
-        return;
-      }
-      readableByteStreamControllerError(branch1[_controller], e);
-      readableByteStreamControllerError(branch2[_controller], e);
-      if (!canceled1 || !canceled2) {
-        cancelPromise.resolve(undefined);
-      }
-    });
+    PromisePrototypeThen(
+      thisReader[_closedPromise].promise,
+      () => {
+        // The source closed. If the in-flight source read was a BYOB read, its
+        // read-into request was orphaned: readableStreamClose() only runs the
+        // close steps of a default reader's read requests, not a BYOB reader's
+        // read-into requests, so the readIntoRequest close steps that propagate
+        // the close to the branches never ran and `reading` is still set. (When
+        // the close instead arrives on a default source read, readRequest's
+        // close steps already cleared `reading` and settled both branches, so
+        // this is a no-op.) Commit the source's still-pending zero-filled
+        // pull-into to run those close steps, which return the lent buffer to
+        // the BYOB branch and settle both branches with `{ done: true }`.
+        if (
+          thisReader !== reader ||
+          !reading ||
+          !isReadableStreamBYOBReader(reader) ||
+          stream[_controller][_pendingPullIntos].size === 0
+        ) {
+          return;
+        }
+        const firstDescriptor = stream[_controller][_pendingPullIntos].peek();
+        readableByteStreamControllerRespondInClosedState(
+          stream[_controller],
+          firstDescriptor,
+        );
+      },
+      (e) => {
+        if (thisReader !== reader) {
+          return;
+        }
+        readableByteStreamControllerError(branch1[_controller], e);
+        readableByteStreamControllerError(branch2[_controller], e);
+        if (!canceled1 || !canceled2) {
+          cancelPromise.resolve(undefined);
+        }
+      },
+    );
   }
 
   // The read requests, their microtask callbacks, and the pending chunk and

--- a/tests/unit/streams_test.ts
+++ b/tests/unit/streams_test.ts
@@ -242,6 +242,46 @@ Deno.test(async function readableStreamCloseWithoutRead2() {
   assertEquals(await cancel.promise, "resource closed");
 });
 
+// Regression test for https://github.com/denoland/deno/issues/35807: teeing a
+// byte stream, reading one branch with a BYOB reader while the other branch is
+// drained by a default reader. When the source closes, the tee reads the source
+// with its BYOB reader; readableStreamClose() does not run a BYOB reader's
+// read-into close steps, so without the fix the pending BYOB read on the first
+// branch (and the default drain on the other) would hang forever.
+Deno.test(async function readableByteStreamTeeByobReadResolvesOnSourceClose() {
+  function makeByteStream(chunks: number[][]) {
+    let i = 0;
+    return new ReadableStream({
+      type: "bytes",
+      pull(c) {
+        if (i < chunks.length) c.enqueue(new Uint8Array(chunks[i++]));
+        else c.close();
+      },
+    });
+  }
+  async function collect(s: ReadableStream<Uint8Array>) {
+    const out = [];
+    for await (const c of s) out.push(c);
+    return out;
+  }
+
+  const [a, b] = makeByteStream([[1, 2, 3], [4, 5, 6]]).tee();
+  const bDone = collect(b);
+  const reader = a.getReader({ mode: "byob" });
+  assertEquals(
+    (await reader.read(new Uint8Array(3))).value,
+    new Uint8Array([1, 2, 3]),
+  );
+  assertEquals(
+    (await reader.read(new Uint8Array(3))).value,
+    new Uint8Array([4, 5, 6]),
+  );
+  // Previously this read hung ("Top-level await promise never resolved").
+  const r3 = await reader.read(new Uint8Array(3));
+  assertEquals(r3.done, true);
+  assertEquals((await bDone).length, 2);
+});
+
 Deno.test(async function readableStreamPartial() {
   const rid = resourceForReadableStream(helloWorldStream());
   const buffer = new Uint8Array(5);


### PR DESCRIPTION
Fixes #35807.

## Problem

Teeing a byte stream and reading one branch with a BYOB reader while the source
closes hangs the pending BYOB read forever; Node resolves it with `{ done: true }`.

```js
const [a, b] = makeByteStream([[1, 2, 3], [4, 5, 6]]).tee();
const bDone = collect(b);                 // default-reader drain of the other branch
const reader = a.getReader({ mode: "byob" });
await reader.read(new Uint8Array(3));      // 1,2,3
await reader.read(new Uint8Array(3));      // 4,5,6
await reader.read(new Uint8Array(3));      // hung on Deno; { done: true } on Node
```

## Root cause

`readableByteStreamTee()` reads the source with a single shared reader, switching
between a default and a BYOB reader depending on which branch pulls. It relies on
the in-flight source read's close steps to propagate the source close to both
branches.

`readableStreamClose()` runs the close steps of a **default** reader's pending read
requests, but it does **not** touch a **BYOB** reader's pending read-into requests
(this matches the spec, and a lone BYOB read on a plain byte stream stays pending on
Deno, Node and Bun alike). So when the source happens to close while the tee is
mid-read on its BYOB reader, the tee's read-into request close steps never run,
`reading` stays set, and both branches hang.

Whether the close lands on a BYOB or a default source read comes down to
microtask scheduling: Node's tee ends up doing a default source read at close
(so its `readRequest` close steps settle everything), while Deno's branch-1 BYOB
reader monopolizes the source reads, so the close lands on an orphaned BYOB read.

## Fix

In the tee's source-reader closed handler (`forwardReaderError`, which already
watches the shared reader's `closedPromise`), handle the fulfilled (closed) case:
if the source closed while the tee is still mid-read on a BYOB reader with a
pending pull-into, commit that zero-filled pull-into via
`readableByteStreamControllerRespondInClosedState`. That runs the tee's own
read-into request close steps, which return the lent buffer to the BYOB branch and
settle both branches with `{ done: true }`. When the close instead arrives on a
default source read, `readRequest`'s close steps already cleared `reading`, so the
handler is a no-op.

The change is scoped to `readableByteStreamTee()` — the global behavior of closing
a byte stream with a pending BYOB read is unchanged (a plain BYOB read still stays
pending, matching the spec and Node).

## Validation

- New unit regression test in `tests/unit/streams_test.ts` (the exact repro).
- `tests/unit/streams_test.ts`: 64 passed / 0 failed.
- WPT `streams/`: **153 passed, 0 failed, 4 expected failure** (unchanged baseline;
  `readable-byte-streams/tee.any` in particular stays green).
