### PR TITLE
Revert "fix(node/process): make `process.stdin.isTTY` writable"

### DIFF
--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -349,18 +349,12 @@ export const initStdin = (warmup = false) => {
   // so that the process can close down.
   stdin.on("pause", () => nextTick(onpause));
 
-  // Allow users to overwrite isTTY for test isolation and terminal mocking.
-  // This mirrors the stdout/stderr behavior added in #26130.
-  let getStdinIsTTY = () => io.stdin?.isTerminal();
   ObjectDefineProperty(stdin, "isTTY", {
     __proto__: null,
     enumerable: true,
     configurable: true,
     get() {
-      return getStdinIsTTY();
-    },
-    set(value) {
-      getStdinIsTTY = () => value;
+      return io.stdin.isTerminal();
     },
   });
   stdin._isRawMode = false;

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -572,19 +572,7 @@ Deno.test({
   fn() {
     // @ts-ignore `Deno.stdin.rid` was soft-removed in Deno 2.
     assertEquals(process.stdin.fd, Deno.stdin.rid);
-    const isTTY = Deno.stdin.isTerminal();
-    assertEquals(process.stdin.isTTY, isTTY);
-
-    // Allows overwriting `process.stdin.isTTY` (mirrors stdout/stderr from #26130)
-    const original = process.stdin.isTTY;
-    try {
-      // @ts-ignore isTTY is defined as readonly in types but we allow setting it
-      process.stdin.isTTY = !isTTY;
-      assertEquals(process.stdin.isTTY, !isTTY);
-    } finally {
-      // @ts-ignore isTTY is defined as readonly in types but we allow setting it
-      process.stdin.isTTY = original;
-    }
+    assertEquals(process.stdin.isTTY, Deno.stdin.isTerminal());
   },
 });
 


### PR DESCRIPTION
Reverts denoland/deno#31464