### PR TITLE
fix(npm): don't re-fetch packuments on every run when registry has no time data

### DIFF
--- a/libs/fast-registry-json/src/lib.rs
+++ b/libs/fast-registry-json/src/lib.rs
@@ -938,6 +938,7 @@ enum PackumentState<'i> {
   Start,
   WantNameValue,
   WantDenoEtagValue,
+  WantDenoPackumentFormatValue,
   InVersions,
   WantVersion(&'i str),
   InDistTags,
@@ -992,6 +993,7 @@ struct PackumentIndexer<'i> {
   state: PackumentState<'i>,
   name: Option<&'i str>,
   deno_etag: Option<&'i str>,
+  deno_packument_format: Option<&'i str>,
   versions: Vec<&'i str>,
   version_ranges: Vec<(u32, u32)>,
   dist_tags: rustc_hash::FxHashMap<&'i str, &'i str>,
@@ -1011,6 +1013,7 @@ impl<'i> PackumentIndexer<'i> {
       state: PackumentState::Start,
       name: None,
       deno_etag: None,
+      deno_packument_format: None,
       versions: Vec::new(),
       version_ranges: Vec::new(),
       dist_tags: rustc_hash::FxHashMap::default(),
@@ -1062,10 +1065,17 @@ impl<'i> PackumentIndexer<'i> {
       {
         self.deno_etag = Some(self.string_value(start, end));
         self.state = PackumentState::Start;
+      } else if !is_key
+        && matches!(self.state, PackumentState::WantDenoPackumentFormatValue)
+      {
+        self.deno_packument_format = Some(self.string_value(start, end));
+        self.state = PackumentState::Start;
       } else if is_key && v == b"name" {
         self.state = PackumentState::WantNameValue;
       } else if is_key && v == b"_deno.etag" {
         self.state = PackumentState::WantDenoEtagValue;
+      } else if is_key && v == b"_deno.packumentFormat" {
+        self.state = PackumentState::WantDenoPackumentFormatValue;
       } else if is_key && v == b"versions" {
         self.state = PackumentState::InVersions;
       } else if is_key && v == b"dist-tags" {
@@ -1257,6 +1267,7 @@ impl<'i> PackumentIndexer<'i> {
     Ok(PackumentIndex {
       name: self.name,
       deno_etag: self.deno_etag,
+      deno_packument_format: self.deno_packument_format,
       versions: self.versions,
       version_ranges: self.version_ranges,
       dist_tags: self.dist_tags,
@@ -1323,6 +1334,9 @@ pub enum TrustEvidence {
 pub struct PackumentIndex<'i> {
   pub name: Option<&'i str>,
   pub deno_etag: Option<&'i str>,
+  /// Custom top-level property written by the cache to record which format
+  /// the packument was fetched in (currently only `"full"`).
+  pub deno_packument_format: Option<&'i str>,
   pub versions: Vec<&'i str>,
   pub version_ranges: Vec<(u32, u32)>,
   pub dist_tags: rustc_hash::FxHashMap<&'i str, &'i str>,
@@ -1683,6 +1697,23 @@ mod tests {
     let index = pluck_packument_index(input).unwrap();
     assert_eq!(index.name, Some("pkg"));
     assert_eq!(index.deno_etag, None);
+    assert_eq!(index.versions, vec!["1.0.0"]);
+  }
+
+  #[test]
+  fn packument_index_plucks_deno_packument_format() {
+    let input = r#"{"name":"pkg","versions":{"1.0.0":{"version":"1.0.0"}},"time":{},"_deno.packumentFormat":"full"}"#;
+    let index = pluck_packument_index(input).unwrap();
+    assert_eq!(index.deno_packument_format, Some("full"));
+    assert_eq!(index.versions, vec!["1.0.0"]);
+    assert!(index.time.is_empty());
+  }
+
+  #[test]
+  fn packument_index_ignores_nested_deno_packument_format() {
+    let input = r#"{"name":"pkg","versions":{"1.0.0":{"version":"1.0.0","_deno.packumentFormat":"full"}}}"#;
+    let index = pluck_packument_index(input).unwrap();
+    assert_eq!(index.deno_packument_format, None);
     assert_eq!(index.versions, vec!["1.0.0"]);
   }
 

--- a/libs/npm/registry.rs
+++ b/libs/npm/registry.rs
@@ -42,6 +42,18 @@ pub struct NpmPackageInfo {
   pub time: HashMap<Version, chrono::DateTime<chrono::Utc>>,
 }
 
+/// Custom `_deno.*` properties stored alongside a cached packument.
+#[derive(Debug, Default, Clone)]
+pub struct NpmPackageInfoCacheMetadata {
+  /// The `_deno.etag` property.
+  pub etag: Option<String>,
+  /// Whether the `_deno.packumentFormat` property records that this cache
+  /// entry was created from a full packument response. When set, an empty
+  /// `time` map means the registry provides no publish dates rather than
+  /// that the abbreviated install manifest omitted them.
+  pub full_packument: bool,
+}
+
 impl NpmPackageInfo {
   /// Fill in each version's `exports` subpath keys from the raw packument JSON
   /// this info was parsed from.
@@ -90,19 +102,27 @@ impl NpmPackageInfo {
     bytes: &[u8],
   ) -> Result<(Self, Option<String>), String> {
     let text = std::str::from_utf8(bytes).map_err(|err| err.to_string())?;
-    Self::from_packument_source_with_etag(Arc::new(text.to_owned()))
+    Self::from_packument_source_with_cache_info(Arc::new(text.to_owned()))
+      .map(|(info, cache_info)| (info, cache_info.etag))
   }
 
   pub fn from_packument_bytes_with_etag(
     bytes: Vec<u8>,
   ) -> Result<(Self, Option<String>), String> {
-    let text = String::from_utf8(bytes).map_err(|err| err.to_string())?;
-    Self::from_packument_source_with_etag(Arc::new(text))
+    Self::from_packument_bytes_with_cache_info(bytes)
+      .map(|(info, cache_info)| (info, cache_info.etag))
   }
 
-  fn from_packument_source_with_etag(
+  pub fn from_packument_bytes_with_cache_info(
+    bytes: Vec<u8>,
+  ) -> Result<(Self, NpmPackageInfoCacheMetadata), String> {
+    let text = String::from_utf8(bytes).map_err(|err| err.to_string())?;
+    Self::from_packument_source_with_cache_info(Arc::new(text))
+  }
+
+  fn from_packument_source_with_cache_info(
     source: Arc<String>,
-  ) -> Result<(Self, Option<String>), String> {
+  ) -> Result<(Self, NpmPackageInfoCacheMetadata), String> {
     let text = source.as_str();
     let index = fast_registry_json::pluck_packument_index(text)
       .map_err(|err| format!("error indexing npm packument: {err:?}"))?;
@@ -175,6 +195,8 @@ impl NpmPackageInfo {
       );
     }
 
+    let full_packument = index.deno_packument_format == Some("full");
+
     Ok((
       Self {
         name,
@@ -186,7 +208,10 @@ impl NpmPackageInfo {
         dist_tags,
         time,
       },
-      deno_etag,
+      NpmPackageInfoCacheMetadata {
+        etag: deno_etag,
+        full_packument,
+      },
     ))
   }
 

--- a/libs/npm_cache/lib.rs
+++ b/libs/npm_cache/lib.rs
@@ -335,12 +335,16 @@ impl<TSys: NpmCacheSys> NpmCache<TSys> {
     };
 
     spawn_blocking(move || {
-      let (info, etag) =
-        deno_npm::registry::NpmPackageInfo::from_packument_bytes_with_etag(
+      let (info, cache_metadata) =
+        deno_npm::registry::NpmPackageInfo::from_packument_bytes_with_cache_info(
           file_bytes.into_owned(),
         )
         .map_err(|err| serde_json::Error::io(std::io::Error::other(err)))?;
-      Ok(Some(SerializedCachedPackageInfo { info, etag }))
+      Ok(Some(SerializedCachedPackageInfo {
+        info,
+        etag: cache_metadata.etag,
+        full_packument: cache_metadata.full_packument,
+      }))
     })
     .await
     .unwrap()
@@ -368,8 +372,13 @@ impl<TSys: NpmCacheSys> NpmCache<TSys> {
     &self,
     package_info_bytes: &[u8],
     etag: Option<&str>,
+    packument_format: NpmPackumentFormat,
   ) -> Result<Vec<u8>, JsErrorBox> {
-    slim_package_info_bytes(package_info_bytes, etag)
+    slim_package_info_bytes(
+      package_info_bytes,
+      etag,
+      packument_format == NpmPackumentFormat::Full,
+    )
   }
 
   pub fn save_package_info_bytes(
@@ -397,6 +406,7 @@ impl<TSys: NpmCacheSys> NpmCache<TSys> {
 fn slim_package_info_bytes(
   package_info_bytes: &[u8],
   etag: Option<&str>,
+  full_packument: bool,
 ) -> Result<Vec<u8>, JsErrorBox> {
   let text = std::str::from_utf8(package_info_bytes)
     .map_err(|err| JsErrorBox::generic(err.to_string()))?;
@@ -447,6 +457,15 @@ fn slim_package_info_bytes(
     write_json_property_name(&mut output, &mut first, "_deno.etag")
       .map_err(JsErrorBox::from_err)?;
     serde_json::to_writer(&mut output, etag).map_err(JsErrorBox::from_err)?;
+  }
+
+  if full_packument {
+    // Record that this cache entry came from a full packument response, so
+    // an empty `time` map means the registry provides no publish dates and
+    // there's no point re-fetching to look for them (see #35761).
+    write_json_property_name(&mut output, &mut first, "_deno.packumentFormat")
+      .map_err(JsErrorBox::from_err)?;
+    output.extend_from_slice(b"\"full\"");
   }
 
   output.push(b'}');
@@ -779,7 +798,7 @@ mod tests {
 
     let original =
       deno_npm::registry::NpmPackageInfo::from_packument_slice(input).unwrap();
-    let output = slim_package_info_bytes(input, Some("etag")).unwrap();
+    let output = slim_package_info_bytes(input, Some("etag"), true).unwrap();
     let reparsed =
       deno_npm::registry::NpmPackageInfo::from_packument_slice(&output)
         .unwrap();
@@ -798,11 +817,60 @@ mod tests {
 
     assert_eq!(value["name"], "pkg");
     assert_eq!(value["_deno.etag"], "etag");
+    assert_eq!(value["_deno.packumentFormat"], "full");
     assert_eq!(version_json["hasInstallScript"], true);
     assert_eq!(version_json["_npmUser"]["trustedPublisher"], true);
     assert!(version_json.get("exports").is_none());
     assert!(version_json.get("scripts").is_none());
     assert!(version_json["dist"].get("fileCount").is_none());
     assert!(value.get("readme").is_none());
+  }
+
+  #[test]
+  fn slim_package_info_bytes_full_packument_marker() {
+    // a registry response with no time data at all
+    let input = br#"{
+      "name":"pkg",
+      "dist-tags":{"latest":"1.0.0"},
+      "versions":{"1.0.0":{"version":"1.0.0"}}
+    }"#;
+
+    // abbreviated fetches don't write the marker
+    let output = slim_package_info_bytes(input, None, false).unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert!(value.get("_deno.packumentFormat").is_none());
+    let (_, cache_metadata) =
+      deno_npm::registry::NpmPackageInfo::from_packument_bytes_with_cache_info(
+        output,
+      )
+      .unwrap();
+    assert!(!cache_metadata.full_packument);
+
+    // full packument fetches record the marker even when the registry
+    // provides no `time` data, so it doesn't get re-fetched on every
+    // process start (see #35761)
+    let output = slim_package_info_bytes(input, None, true).unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(value["_deno.packumentFormat"], "full");
+    let (info, cache_metadata) =
+      deno_npm::registry::NpmPackageInfo::from_packument_bytes_with_cache_info(
+        output,
+      )
+      .unwrap();
+    assert!(cache_metadata.full_packument);
+    assert!(info.time.is_empty());
+
+    // a marker nested inside a version object is ignored
+    let nested = br#"{
+      "name":"pkg",
+      "dist-tags":{"latest":"1.0.0"},
+      "versions":{"1.0.0":{"version":"1.0.0","_deno.packumentFormat":"full"}}
+    }"#;
+    let (_, cache_metadata) =
+      deno_npm::registry::NpmPackageInfo::from_packument_bytes_with_cache_info(
+        nested.to_vec(),
+      )
+      .unwrap();
+    assert!(!cache_metadata.full_packument);
   }
 }

--- a/libs/npm_cache/registry_info.rs
+++ b/libs/npm_cache/registry_info.rs
@@ -42,6 +42,34 @@ pub struct SerializedCachedPackageInfo {
     rename = "_deno.etag"
   )]
   pub etag: Option<String>,
+  /// Custom property recording that this cache entry was created from a full
+  /// packument response, so an empty `time` map means the registry provides
+  /// no publish dates rather than that the abbreviated install manifest
+  /// omitted them (see #35761).
+  #[serde(
+    default,
+    skip_serializing_if = "std::ops::Not::not",
+    rename = "_deno.packumentFormat",
+    with = "full_packument_marker"
+  )]
+  pub full_packument: bool,
+}
+
+mod full_packument_marker {
+  pub fn serialize<S: serde::Serializer>(
+    value: &bool,
+    serializer: S,
+  ) -> Result<S::Ok, S::Error> {
+    debug_assert!(*value, "skipped via skip_serializing_if when false");
+    serializer.serialize_str("full")
+  }
+
+  pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+  ) -> Result<bool, D::Error> {
+    let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+    Ok(value == "full")
+  }
 }
 
 #[derive(Debug, Clone)]
@@ -266,11 +294,22 @@ impl<THttpClient: NpmCacheHttpClient, TSys: NpmCacheSys>
       {
         // attempt to load from the file cache
         match downloader.cache.load_package_info(&name, downloader.packument_format).await.map_err(JsErrorBox::from_err)? { Some(cached_info) => {
-          if downloader.packument_format == NpmPackumentFormat::Full && cached_info.info.time.is_empty() && !cached_info.info.versions.is_empty() {
+          if downloader.packument_format == NpmPackumentFormat::Full
+            && cached_info.info.time.is_empty()
+            && !cached_info.info.versions.is_empty()
+            && !cached_info.full_packument
+          {
             // Cached data is from the abbreviated install manifest which
             // doesn't include the `time` field. Since minimumDependencyAge
             // is configured, we need to re-fetch the full packument.
             // Don't use the etag since it corresponds to the abbreviated format.
+            //
+            // When the cache entry records that it already came from a full
+            // packument response (`full_packument`), an empty `time` map means
+            // the registry provides no publish dates at all, so re-fetching
+            // would find nothing new — doing so anyway made every process
+            // start re-download every packument against such registries
+            // (see #35761).
             Some(SerializedCachedPackageInfo { etag: None, ..cached_info })
           } else {
             return Ok(FutureResult::SavedFsCache(Arc::new(cached_info.info)));
@@ -325,6 +364,7 @@ impl<THttpClient: NpmCacheHttpClient, TSys: NpmCacheSys>
                 .build_package_info_cache_bytes(
                   &response.bytes,
                   response.etag.as_deref(),
+                  downloader.packument_format,
                 )?;
               let package_info =
                 NpmPackageInfo::from_packument_bytes(package_info_bytes)

--- a/tests/specs/install/minimum_dependency_age_no_time_refetch/__test__.jsonc
+++ b/tests/specs/install/minimum_dependency_age_no_time_refetch/__test__.jsonc
@@ -1,0 +1,25 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_DIR": "$PWD/deno_dir"
+  },
+  "steps": [
+    {
+      // minimumDependencyAge forces the full packument to be requested, but
+      // the test registry serves no publish dates for this package, so the
+      // cached packument has an empty `time` map.
+      "args": "run --no-lock main.ts",
+      "output": "first.out"
+    },
+    {
+      // A second run must resolve entirely from the cache: the cache entry
+      // records that the full packument was already fetched and the registry
+      // simply has no `time` data. Previously the empty `time` map was
+      // mistaken for an abbreviated cache entry and the packument was
+      // re-downloaded on every process start (any `Download` line here fails
+      // the test).
+      "args": "run --no-lock main.ts",
+      "output": "ok\n"
+    }
+  ]
+}

--- a/tests/specs/install/minimum_dependency_age_no_time_refetch/deno.json
+++ b/tests/specs/install/minimum_dependency_age_no_time_refetch/deno.json
@@ -1,0 +1,3 @@
+{
+  "minimumDependencyAge": "2025-01-01T00:00:00.000Z"
+}

--- a/tests/specs/install/minimum_dependency_age_no_time_refetch/first.out
+++ b/tests/specs/install/minimum_dependency_age_no_time_refetch/first.out
@@ -1,0 +1,2 @@
+Download http://localhost:4260/@denotest%2fesm-basic
+[WILDCARD]ok

--- a/tests/specs/install/minimum_dependency_age_no_time_refetch/main.ts
+++ b/tests/specs/install/minimum_dependency_age_no_time_refetch/main.ts
@@ -1,0 +1,3 @@
+import "npm:@denotest/esm-basic";
+
+console.log("ok");


### PR DESCRIPTION
Since 2.9.0 enabled `minimumDependencyAge` by default, packuments are fetched
in the full format because the age gate needs the `time` field that the
abbreviated install manifest omits. When a cached packument has versions but
an empty `time` map, the cache assumes it's a stale abbreviated entry and
re-fetches the full packument.

That heuristic can't distinguish "we never asked for `time`" from "the
registry has no `time` data": against a registry that doesn't include
publish dates in its packuments (some mirrors and self-hosted registries),
the re-fetched response still has no `time`, so every process start
re-downloaded every packument. With no lockfile and auto-install this adds
seconds to every boot — reproduced locally at 0.24s vs 2.9s for a 422-package
project. Versions without publish dates already pass the age gate, so the
re-fetch could never change resolution anyway.

The cache entry now records a `_deno.packumentFormat` marker (alongside the
existing `_deno.etag` custom property) when it was created from a full
packument response, and the re-fetch is skipped when the marker is present.
Existing abbreviated cache entries still upgrade to the full format exactly
once.

Refs #35761