### PR TITLE
fix(ext/node): require --allow-net=unix for node:net unix sockets

### DIFF
--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -24,6 +24,51 @@ pub use quic::QuicError;
 
 pub const UNSTABLE_FEATURE_NAME: &str = "net";
 
+/// Permission check for opening a unix-domain socket path. Shared by the
+/// native unix-socket ops and the node-compat `PipeWrap` path in `ext/node`,
+/// which also backs Windows named pipes; unlike `ops_unix` this must compile
+/// on all platforms.
+///
+/// A unix socket is both a filesystem entry and an outbound network
+/// primitive, so this requires an `--allow-net=unix:<path>` rule in addition
+/// to filesystem access on the socket path. Without this, a script with only
+/// `--allow-read=/var/run/docker.sock` could connect to local IPC services
+/// (Docker, dbus, podman, etc.) with no `--allow-net` grant.
+///
+/// Abstract socket paths (Linux, leading NUL) have no filesystem entry, so
+/// they skip the filesystem check and rely on the network check alone.
+pub fn check_unix_socket_path<'a>(
+  permissions: &mut deno_permissions::PermissionsContainer,
+  path: std::borrow::Cow<'a, std::path::Path>,
+  access_kind: deno_permissions::OpenAccessKind,
+  api_name: Option<&str>,
+) -> Result<
+  deno_permissions::CheckedPath<'a>,
+  deno_permissions::PermissionCheckError,
+> {
+  let checked = if is_unix_socket_abstract_path(path.as_ref()) {
+    deno_permissions::CheckedPath::unsafe_new(path)
+  } else {
+    permissions.check_open(path, access_kind, api_name)?
+  };
+  permissions.check_net_unix_socket(&checked, api_name)?;
+  Ok(checked)
+}
+
+pub(crate) fn is_unix_socket_abstract_path(path: &std::path::Path) -> bool {
+  #[cfg(any(target_os = "android", target_os = "linux"))]
+  {
+    use std::os::unix::ffi::OsStrExt;
+    path.as_os_str().as_bytes().first() == Some(&0)
+  }
+
+  #[cfg(not(any(target_os = "android", target_os = "linux")))]
+  {
+    let _ = path;
+    false
+  }
+}
+
 /// Helper for checking unstable features. Used for sync ops.
 fn check_unstable(state: &OpState, api_name: &str) {
   state

--- a/ext/net/ops_unix.rs
+++ b/ext/net/ops_unix.rs
@@ -354,27 +354,28 @@ async fn send_to_unix_datagram(
   Ok(socket.send_to(buf, address_path).await?)
 }
 
-fn check_unix_socket_path<'a>(
+/// Permission check for opening a unix-domain socket path, shared with the
+/// node-compat `PipeWrap` path in `ext/node`.
+///
+/// Abstract socket paths (Linux, leading NUL) have no filesystem entry, so
+/// they skip the filesystem check and rely on the network check alone.
+pub fn check_unix_socket_path<'a>(
   permissions: &mut PermissionsContainer,
   path: Cow<'a, Path>,
   access_kind: OpenAccessKind,
   api_name: Option<&str>,
-) -> Result<CheckedPath<'a>, NetError> {
+) -> Result<CheckedPath<'a>, deno_permissions::PermissionCheckError> {
   let checked = if is_unix_socket_abstract_path(path.as_ref()) {
     CheckedPath::unsafe_new(path)
   } else {
-    permissions
-      .check_open(path, access_kind, api_name)
-      .map_err(NetError::Permission)?
+    permissions.check_open(path, access_kind, api_name)?
   };
   // Unix sockets are an outbound network primitive, so require an
   // `--allow-net=unix:<path>` rule in addition to filesystem access on the
   // socket path. Without this, a script with only
   // `--allow-read=/var/run/docker.sock` could connect to local IPC services
   // (Docker, dbus, podman, etc.) with no `--allow-net` grant.
-  permissions
-    .check_net_unix_socket(&checked, api_name)
-    .map_err(NetError::Permission)?;
+  permissions.check_net_unix_socket(&checked, api_name)?;
   Ok(checked)
 }
 

--- a/ext/net/ops_unix.rs
+++ b/ext/net/ops_unix.rs
@@ -29,7 +29,6 @@ use deno_core::RcRef;
 use deno_core::Resource;
 use deno_core::ResourceId;
 use deno_core::op2;
-use deno_permissions::CheckedPath;
 use deno_permissions::OpenAccessKind;
 use deno_permissions::PermissionsContainer;
 use serde::Deserialize;
@@ -38,7 +37,9 @@ use tokio::net::UnixDatagram;
 use tokio::net::UnixListener;
 pub use tokio::net::UnixStream;
 
+use crate::check_unix_socket_path;
 use crate::io::UnixStreamResource;
+use crate::is_unix_socket_abstract_path;
 use crate::ops::NetError;
 use crate::raw::NetworkListenerResource;
 
@@ -354,31 +355,6 @@ async fn send_to_unix_datagram(
   Ok(socket.send_to(buf, address_path).await?)
 }
 
-/// Permission check for opening a unix-domain socket path, shared with the
-/// node-compat `PipeWrap` path in `ext/node`.
-///
-/// Abstract socket paths (Linux, leading NUL) have no filesystem entry, so
-/// they skip the filesystem check and rely on the network check alone.
-pub fn check_unix_socket_path<'a>(
-  permissions: &mut PermissionsContainer,
-  path: Cow<'a, Path>,
-  access_kind: OpenAccessKind,
-  api_name: Option<&str>,
-) -> Result<CheckedPath<'a>, deno_permissions::PermissionCheckError> {
-  let checked = if is_unix_socket_abstract_path(path.as_ref()) {
-    CheckedPath::unsafe_new(path)
-  } else {
-    permissions.check_open(path, access_kind, api_name)?
-  };
-  // Unix sockets are an outbound network primitive, so require an
-  // `--allow-net=unix:<path>` rule in addition to filesystem access on the
-  // socket path. Without this, a script with only
-  // `--allow-read=/var/run/docker.sock` could connect to local IPC services
-  // (Docker, dbus, podman, etc.) with no `--allow-net` grant.
-  permissions.check_net_unix_socket(&checked, api_name)?;
-  Ok(checked)
-}
-
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn unix_sockaddr_from_abstract_path(
   path: &Path,
@@ -433,17 +409,4 @@ pub fn unix_socket_addr_path(
   }
 
   Ok(None)
-}
-
-fn is_unix_socket_abstract_path(path: &Path) -> bool {
-  #[cfg(any(target_os = "android", target_os = "linux"))]
-  {
-    path.as_os_str().as_bytes().first() == Some(&0)
-  }
-
-  #[cfg(not(any(target_os = "android", target_os = "linux")))]
-  {
-    let _ = path;
-    false
-  }
 }

--- a/ext/node/ops/pipe_wrap.rs
+++ b/ext/node/ops/pipe_wrap.rs
@@ -368,15 +368,19 @@ impl PipeWrap {
   ) -> Result<i32, deno_permissions::PermissionCheckError> {
     // Binding a unix-domain socket creates a socket inode on disk (and arms
     // the fchmod/unlink-on-close that operate on the bound path), so it
-    // requires filesystem read+write permission for the path -- matching
-    // `connect()` above and `Deno.listen({ transport: "unix" })`. Checking
-    // here (rather than only in `listen()`) ensures the path is never bound,
-    // chmod'd, or unlinked by permission-less code.
-    state.borrow_mut::<PermissionsContainer>().check_open(
+    // requires filesystem read+write permission for the path AND an
+    // `--allow-net=unix:<path>` grant -- matching `connect()` above and
+    // `Deno.listen({ transport: "unix" })`. Checking here (rather than only in
+    // `listen()`) ensures the path is never bound, chmod'd, or unlinked by
+    // permission-less code.
+    let permissions = state.borrow_mut::<PermissionsContainer>();
+    let checked = permissions.check_open(
       std::borrow::Cow::Borrowed(std::path::Path::new(path)),
       deno_permissions::OpenAccessKind::ReadWriteNoFollow,
       Some("node:net.Server.listen()"),
     )?;
+    permissions
+      .check_net_unix_socket(&checked, Some("node:net.Server.listen()"))?;
 
     let pipe = self.pipe_ptr();
     if pipe.is_null() {
@@ -396,14 +400,20 @@ impl PipeWrap {
     if pipe.is_null() {
       return Ok(uv_compat::UV_EBADF);
     }
-    // Permission check: verify the bind path is allowed.
+    // Permission check: verify the bind path is allowed. A listening unix
+    // socket needs both filesystem read+write access to the path and an
+    // `--allow-net=unix:<path>` grant, mirroring `bind()` and the native
+    // `Deno.listen({ transport: "unix" })` path.
     // SAFETY: pipe is valid (null-checked above).
     if let Some(path) = unsafe { &*pipe }.bind_path() {
-      state.borrow_mut::<PermissionsContainer>().check_open(
+      let permissions = state.borrow_mut::<PermissionsContainer>();
+      let checked = permissions.check_open(
         std::borrow::Cow::Borrowed(std::path::Path::new(path)),
         deno_permissions::OpenAccessKind::ReadWriteNoFollow,
         Some("node:net.Server.listen()"),
       )?;
+      permissions
+        .check_net_unix_socket(&checked, Some("node:net.Server.listen()"))?;
     }
     // SAFETY: pipe is valid (null-checked above).
     Ok(unsafe {
@@ -432,11 +442,21 @@ impl PipeWrap {
     #[string] path: &str,
     scope: &mut v8::PinScope,
   ) -> Result<i32, deno_permissions::PermissionCheckError> {
-    state.borrow_mut::<PermissionsContainer>().check_open(
+    // A Unix-domain socket is both a filesystem entry and an outbound network
+    // primitive, so connecting requires filesystem read+write permission for
+    // the path AND an `--allow-net=unix:<path>` grant -- matching the native
+    // `Deno.connect({ transport: "unix" })` path in `ext/net/ops_unix.rs`.
+    // Without the network check, `--allow-read`/`--allow-write` on a socket
+    // path alone could reach local IPC services (Docker, dbus, podman, etc.)
+    // under `--deny-net`.
+    let permissions = state.borrow_mut::<PermissionsContainer>();
+    let checked = permissions.check_open(
       std::borrow::Cow::Borrowed(std::path::Path::new(path)),
       deno_permissions::OpenAccessKind::ReadWriteNoFollow,
       Some("node:net.createConnection()"),
     )?;
+    permissions
+      .check_net_unix_socket(&checked, Some("node:net.createConnection()"))?;
 
     let pipe = self.pipe_ptr();
     if pipe.is_null() {

--- a/ext/node/ops/pipe_wrap.rs
+++ b/ext/node/ops/pipe_wrap.rs
@@ -21,6 +21,7 @@ use deno_core::uv_compat::UvConnect;
 use deno_core::uv_compat::UvLoop;
 use deno_core::uv_compat::UvStream;
 use deno_core::v8;
+use deno_net::ops_unix::check_unix_socket_path;
 use deno_permissions::PermissionsContainer;
 
 use crate::ops::handle_wrap::AsyncWrap;
@@ -373,14 +374,12 @@ impl PipeWrap {
     // `Deno.listen({ transport: "unix" })`. Checking here (rather than only in
     // `listen()`) ensures the path is never bound, chmod'd, or unlinked by
     // permission-less code.
-    let permissions = state.borrow_mut::<PermissionsContainer>();
-    let checked = permissions.check_open(
+    check_unix_socket_path(
+      state.borrow_mut::<PermissionsContainer>(),
       std::borrow::Cow::Borrowed(std::path::Path::new(path)),
       deno_permissions::OpenAccessKind::ReadWriteNoFollow,
       Some("node:net.Server.listen()"),
     )?;
-    permissions
-      .check_net_unix_socket(&checked, Some("node:net.Server.listen()"))?;
 
     let pipe = self.pipe_ptr();
     if pipe.is_null() {
@@ -406,14 +405,12 @@ impl PipeWrap {
     // `Deno.listen({ transport: "unix" })` path.
     // SAFETY: pipe is valid (null-checked above).
     if let Some(path) = unsafe { &*pipe }.bind_path() {
-      let permissions = state.borrow_mut::<PermissionsContainer>();
-      let checked = permissions.check_open(
+      check_unix_socket_path(
+        state.borrow_mut::<PermissionsContainer>(),
         std::borrow::Cow::Borrowed(std::path::Path::new(path)),
         deno_permissions::OpenAccessKind::ReadWriteNoFollow,
         Some("node:net.Server.listen()"),
       )?;
-      permissions
-        .check_net_unix_socket(&checked, Some("node:net.Server.listen()"))?;
     }
     // SAFETY: pipe is valid (null-checked above).
     Ok(unsafe {
@@ -448,15 +445,14 @@ impl PipeWrap {
     // `Deno.connect({ transport: "unix" })` path in `ext/net/ops_unix.rs`.
     // Without the network check, `--allow-read`/`--allow-write` on a socket
     // path alone could reach local IPC services (Docker, dbus, podman, etc.)
-    // under `--deny-net`.
-    let permissions = state.borrow_mut::<PermissionsContainer>();
-    let checked = permissions.check_open(
+    // under `--deny-net`. Abstract socket paths (Linux, leading NUL) have no
+    // filesystem entry and are covered by the network check alone.
+    check_unix_socket_path(
+      state.borrow_mut::<PermissionsContainer>(),
       std::borrow::Cow::Borrowed(std::path::Path::new(path)),
       deno_permissions::OpenAccessKind::ReadWriteNoFollow,
       Some("node:net.createConnection()"),
     )?;
-    permissions
-      .check_net_unix_socket(&checked, Some("node:net.createConnection()"))?;
 
     let pipe = self.pipe_ptr();
     if pipe.is_null() {

--- a/ext/node/ops/pipe_wrap.rs
+++ b/ext/node/ops/pipe_wrap.rs
@@ -21,7 +21,7 @@ use deno_core::uv_compat::UvConnect;
 use deno_core::uv_compat::UvLoop;
 use deno_core::uv_compat::UvStream;
 use deno_core::v8;
-use deno_net::ops_unix::check_unix_socket_path;
+use deno_net::check_unix_socket_path;
 use deno_permissions::PermissionsContainer;
 
 use crate::ops::handle_wrap::AsyncWrap;

--- a/tests/specs/permission/node_pipe_wrap_net_perm/__test__.jsonc
+++ b/tests/specs/permission/node_pipe_wrap_net_perm/__test__.jsonc
@@ -4,6 +4,11 @@
       "if": "unix",
       "args": "run --allow-read --allow-write --deny-net main.ts",
       "output": "main.out"
+    },
+    "node_pipe_wrap_abstract_socket": {
+      "if": "linux",
+      "args": "run --allow-net abstract.ts",
+      "output": "abstract.out"
     }
   }
 }

--- a/tests/specs/permission/node_pipe_wrap_net_perm/__test__.jsonc
+++ b/tests/specs/permission/node_pipe_wrap_net_perm/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tests": {
+    "node_pipe_wrap_net_perm": {
+      "if": "unix",
+      "args": "run --allow-read --allow-write --deny-net main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/permission/node_pipe_wrap_net_perm/abstract.out
+++ b/tests/specs/permission/node_pipe_wrap_net_perm/abstract.out
@@ -1,0 +1,2 @@
+bind abstract: PASS
+bind path: PASS

--- a/tests/specs/permission/node_pipe_wrap_net_perm/abstract.ts
+++ b/tests/specs/permission/node_pipe_wrap_net_perm/abstract.ts
@@ -1,0 +1,29 @@
+// Abstract unix sockets (Linux-only, leading NUL) have no filesystem entry,
+// so - matching the native `Deno.listen({ transport: "unix" })` path - they
+// must be usable with an `--allow-net` grant alone, no filesystem permission
+// required. Regular path-based sockets must still be denied without a
+// filesystem grant, proving the abstract special case is not over-applied.
+//
+// This process is granted `--allow-net` but no read/write permissions.
+
+import process from "node:process";
+
+// deno-lint-ignore no-explicit-any
+const { Pipe, constants } = (process as any).binding("pipe_wrap");
+
+// bind() on an abstract socket: no filesystem entry, --allow-net suffices.
+const ret = new Pipe(constants.SERVER).bind(
+  `\0deno-pipewrap-abstract-${process.pid}`,
+);
+console.log("bind abstract:", ret === 0 ? "PASS" : `FAIL:${ret}`);
+
+// bind() on a path-based socket: still requires the filesystem grant.
+try {
+  new Pipe(constants.SERVER).bind("/tmp/deno-pipewrap-abstract-fs.sock");
+  console.log("bind path: FAIL:allowed");
+} catch (e) {
+  console.log(
+    "bind path:",
+    (e as Error).name === "NotCapable" ? "PASS" : `FAIL:${(e as Error).name}`,
+  );
+}

--- a/tests/specs/permission/node_pipe_wrap_net_perm/main.out
+++ b/tests/specs/permission/node_pipe_wrap_net_perm/main.out
@@ -1,0 +1,2 @@
+connect: PASS
+bind: PASS

--- a/tests/specs/permission/node_pipe_wrap_net_perm/main.out
+++ b/tests/specs/permission/node_pipe_wrap_net_perm/main.out
@@ -1,2 +1,3 @@
 connect: PASS
 bind: PASS
+connect abstract: PASS

--- a/tests/specs/permission/node_pipe_wrap_net_perm/main.ts
+++ b/tests/specs/permission/node_pipe_wrap_net_perm/main.ts
@@ -1,0 +1,51 @@
+// Regression test: the node-compat PipeWrap handle (the native backing for
+// node:net unix sockets, reachable via process.binding("pipe_wrap")) must
+// honor Deno's *network* permission model, not just the filesystem one.
+//
+// A unix-domain socket is both a filesystem entry and an outbound network
+// primitive. The native path (`Deno.connect/listen({ transport: "unix" })`)
+// requires an `--allow-net=unix:<path>` grant *in addition to* filesystem
+// access, so that read/write on e.g. `/var/run/docker.sock` alone cannot reach
+// local IPC services (Docker, dbus, podman, custom RPC) under `--deny-net`.
+//
+// This process is granted full `--allow-read`/`--allow-write` but `--deny-net`.
+// With filesystem access satisfied, connect()/bind()/listen() must STILL be
+// denied because the unix-socket network grant is missing.
+
+import process from "node:process";
+
+// deno-lint-ignore no-explicit-any
+const { Pipe, constants } = (process as any).binding("pipe_wrap");
+
+const SOCK = "/tmp/deno-pipewrap-net-perm.sock";
+
+function classify(fn: () => void): string {
+  try {
+    fn();
+    return "allowed";
+  } catch (e) {
+    return (e as Error).name === "NotCapable"
+      ? "denied"
+      : `other:${(e as Error).name}`;
+  }
+}
+
+// connect(): outbound unix-socket connection must require --allow-net=unix.
+console.log(
+  "connect:",
+  classify(() => {
+      new Pipe(constants.SOCKET).connect({}, SOCK);
+    }) === "denied"
+    ? "PASS"
+    : "FAIL",
+);
+
+// bind(): creating a listening unix socket must require --allow-net=unix.
+console.log(
+  "bind:",
+  classify(() => {
+      new Pipe(constants.SERVER).bind(SOCK);
+    }) === "denied"
+    ? "PASS"
+    : "FAIL",
+);

--- a/tests/specs/permission/node_pipe_wrap_net_perm/main.ts
+++ b/tests/specs/permission/node_pipe_wrap_net_perm/main.ts
@@ -49,3 +49,16 @@ console.log(
     ? "PASS"
     : "FAIL",
 );
+
+// Abstract sockets (Linux, leading NUL) have no filesystem entry, but they
+// are still an outbound network primitive and must be denied under
+// --deny-net. On platforms without an abstract namespace the same path is
+// treated as a regular filesystem path; either way the net check denies it.
+console.log(
+  "connect abstract:",
+  classify(() => {
+      new Pipe(constants.SOCKET).connect({}, "\0deno-pipewrap-net-perm");
+    }) === "denied"
+    ? "PASS"
+    : "FAIL",
+);


### PR DESCRIPTION
Deno's native Unix-domain socket path treats a socket as both a
filesystem entry and an outbound network primitive. Connecting to or
listening on a Unix socket requires filesystem access to the socket path
*and* an `--allow-net=unix:<path>` grant. This is deliberate: read/write
access to a socket path such as `/var/run/docker.sock` should not, by
itself, be enough to reach local IPC services like Docker, dbus, or
podman. The native helper `check_unix_socket_path` in
`ext/net/ops_unix.rs` enforces both checks.

The node-compat `PipeWrap` path — the native backing for `node:net` Unix
sockets — only performed the filesystem `check_open` check. It never
required the Unix-socket network grant. As a result,
`node:net.createConnection(path)` and `net.createServer().listen(path)`
could reach a Unix socket under `--deny-net` as long as filesystem
permission for the socket path was granted, diverging from the native
`Deno.connect({ transport: "unix" })` and `Deno.listen({ transport:
"unix" })` behaviour.

Rather than duplicating the check pair, `check_unix_socket_path` is now
public in `deno_net` (returning `PermissionCheckError` directly; its
`ext/net` call sites keep working through the existing `#[from]`
conversion into `NetError`) and `PipeWrap::connect`, `bind`, and
`listen` call it, so the node-compat path enforces exactly the same
invariant as the native one and the two cannot drift apart again.

Sharing the helper also fixes abstract socket handling (Linux, leading
NUL). Abstract sockets have no filesystem entry, so — like the native
path — they now skip the filesystem check and are governed by the
network check alone. Previously the node-compat path incorrectly
required filesystem permission on the NUL-prefixed pseudo-path, which
no filesystem grant could meaningfully scope.

Note that on Windows `PipeWrap` backs `node:net` named pipes
(`\\.\pipe\...`), which now also require a net grant in addition to the
filesystem check. This is intentional: the threat model is the same
(e.g. Docker Desktop listens on `\\.\pipe\docker_engine`). `unix:` net
rules parse on all platforms and accept any absolute path, so named
pipes can be granted with `--allow-net=unix:\\.\pipe\<name>` or a
blanket `--allow-net`.

Spec tests: one step grants full `--allow-read`/`--allow-write` with
`--deny-net` and asserts that `connect` and `bind` through the
low-level pipe binding are denied, including for an abstract path. A
Linux-only step grants only `--allow-net` (no filesystem permissions)
and asserts that binding an abstract socket succeeds while binding a
path-based socket is still denied by the filesystem check.
