### PR TITLE
fix(ext/io): explicitly cancel pending I/O on FileResource drop

### DIFF
--- a/ext/io/fs.rs
+++ b/ext/io/fs.rs
@@ -520,3 +520,26 @@ impl deno_core::Resource for FileResource {
     FileResource::cancel_read_ops(&self);
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::rc::Rc;
+
+  #[test]
+  fn test_file_resource_drop_cancels_ops() {
+    // Open a dummy file to wrap
+    let file = std::fs::File::open("Cargo.toml").unwrap();
+    let file_inner = crate::StdFileResourceInner::file(file, None);
+    let resource = FileResource::new(Rc::new(file_inner), "Cargo.toml".to_string());
+    
+    let cancel_handle = resource.cancel_handle();
+    assert!(!cancel_handle.is_canceled(), "Cancel handle should not be canceled initially.");
+    
+    // Drop the resource, simulating ResourceTable unwinding during a panic
+    drop(resource);
+    
+    // Assert the cancellation token was explicitly fired by the Drop implementation
+    assert!(cancel_handle.is_canceled(), "Cancel handle was not explicitly canceled on drop! Pending I/O will leak.");
+  }
+}

--- a/ext/io/fs.rs
+++ b/ext/io/fs.rs
@@ -420,6 +420,12 @@ impl FileResource {
   }
 }
 
+impl Drop for FileResource {
+  fn drop(&mut self) {
+    self.cancel_read_ops();
+  }
+}
+
 impl deno_core::Resource for FileResource {
   fn name(&self) -> Cow<'_, str> {
     Cow::Borrowed(&self.name)


### PR DESCRIPTION
Previously, if a worker thread or isolate panicked, the `ResourceTable` would unwind and drop the `FileResource`. Because the explicit `close()` method was bypassed during a panic, pending asynchronous read/write operations were not aborted.

On Windows, dropping a Tokio file handle with pending Overlapped I/O leaves the kernel handle locked, leaking resources and eventually causing `ERROR_SHARING_VIOLATION` or "Too many open files".

This implements the `Drop` trait for `FileResource` to ensure the internal cancellation token is always fired, cleanly tearing down OS-level I/O even during abrupt isolate termination.

*(Note: I used an AI assistant to help investigate and implement this `Drop` trait fix.)*