### PR TITLE
fix: discover config file for jsr: entrypoints

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -615,6 +615,7 @@ impl FlagsExt for Flags {
       if let Ok(module_specifier) = resolve_url_or_path(arg, current_dir) {
         if module_specifier.scheme() == "file"
           || module_specifier.scheme() == "npm"
+          || module_specifier.scheme() == "jsr"
         {
           if let Ok(p) = url_to_file_path(&module_specifier) {
             maybe_resolve_directory(p)
@@ -622,8 +623,9 @@ impl FlagsExt for Flags {
             Some(current_dir.to_path_buf())
           }
         } else {
-          // When the entrypoint doesn't have file: scheme (it's the remote
-          // script), then we don't auto discover the config file.
+          // When the entrypoint is a remote script (e.g. https:), then we
+          // don't auto discover the config file. Package entrypoints (npm:,
+          // jsr:) resolve within the project context, so they do.
           None
         }
       } else {
@@ -14384,6 +14386,12 @@ mod tests {
     let flags =
       flags_from_vec(svec!["deno", "https://example.com/foo.js"]).unwrap();
     assert_eq!(flags.config_path_args(&cwd), None);
+
+    let flags = flags_from_vec(svec!["deno", "run", "jsr:@scope/foo"]).unwrap();
+    assert_eq!(flags.config_path_args(&cwd), Some(vec![cwd.clone()]));
+
+    let flags = flags_from_vec(svec!["deno", "run", "npm:@scope/foo"]).unwrap();
+    assert_eq!(flags.config_path_args(&cwd), Some(vec![cwd.clone()]));
 
     let flags =
       flags_from_vec(svec!["deno", "lint", "dir/a/a.js", "dir/b/b.js"])

--- a/tests/specs/run/minimum_dependency_age_jsr_entrypoint/__test__.jsonc
+++ b/tests/specs/run/minimum_dependency_age_jsr_entrypoint/__test__.jsonc
@@ -1,0 +1,15 @@
+{
+  "tempDir": true,
+  "tests": {
+    "excluded": {
+      "cwd": "excluded",
+      "args": "run jsr:@denotest/add",
+      "output": "excluded.out"
+    },
+    "not_excluded": {
+      "cwd": "not_excluded",
+      "args": "run jsr:@denotest/add",
+      "output": "not_excluded.out"
+    }
+  }
+}

--- a/tests/specs/run/minimum_dependency_age_jsr_entrypoint/excluded.out
+++ b/tests/specs/run/minimum_dependency_age_jsr_entrypoint/excluded.out
@@ -1,0 +1,5 @@
+[UNORDERED_START]
+Download http://127.0.0.1:4250/@denotest/add/meta.json
+Download http://127.0.0.1:4250/@denotest/add/1.0.0_meta.json
+Download http://127.0.0.1:4250/@denotest/add/1.0.0/mod.ts
+[UNORDERED_END]

--- a/tests/specs/run/minimum_dependency_age_jsr_entrypoint/excluded/deno.json
+++ b/tests/specs/run/minimum_dependency_age_jsr_entrypoint/excluded/deno.json
@@ -1,0 +1,8 @@
+{
+  "minimumDependencyAge": {
+    "age": "2025-05-01T20:00:00.000Z",
+    "exclude": [
+      "jsr:@denotest/add"
+    ]
+  }
+}

--- a/tests/specs/run/minimum_dependency_age_jsr_entrypoint/not_excluded.out
+++ b/tests/specs/run/minimum_dependency_age_jsr_entrypoint/not_excluded.out
@@ -1,0 +1,5 @@
+[UNORDERED_START]
+Download http://127.0.0.1:4250/@denotest/add/meta.json
+Download http://127.0.0.1:4250/@denotest/add/0.2.0_meta.json
+Download http://127.0.0.1:4250/@denotest/add/0.2.0/mod.ts
+[UNORDERED_END]

--- a/tests/specs/run/minimum_dependency_age_jsr_entrypoint/not_excluded/deno.json
+++ b/tests/specs/run/minimum_dependency_age_jsr_entrypoint/not_excluded/deno.json
@@ -1,0 +1,5 @@
+{
+  "minimumDependencyAge": {
+    "age": "2025-05-01T20:00:00.000Z"
+  }
+}


### PR DESCRIPTION
Config auto-discovery was skipped when the entrypoint of `deno run` or
`deno compile` was a `jsr:` specifier, the same way it is for remote
`https:` scripts. As a result the project's `deno.json` was silently
ignored: in #35833 the configured `minimumDependencyAge` (both `age` and
`exclude`) never applied and the default minimum release age kicked in
instead, rejecting a package the user had explicitly excluded — while
`deno info` on the same specifier honored the config, since it discovers
from the cwd.

Unlike arbitrary remote scripts, package entrypoints resolve within the
project context, and `npm:` entrypoints already discover the config from
the cwd. This treats `jsr:` the same way.

Fixes #35833