### PR TITLE
perf(ext/web): sync fast path for ReadableStream async iterator next()

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -5708,42 +5708,91 @@ class ReadableStreamAsyncIteratorReadRequest {
   }
 }
 
+/**
+ * The generic (async) path for the default async iterator's next(): allocate a
+ * Deferred + read request and hand it to the reader. Hoisted out of next() so
+ * the closure isn't allocated on every iteration, and reused by the chained
+ * (concurrent next()) path.
+ * @param {ReadableStreamDefaultReader} reader
+ * @returns {Promise<IteratorResult<unknown>>}
+ */
+function readableStreamAsyncIteratorNextSteps(reader) {
+  if (reader[_iteratorFinished]) {
+    return PromiseResolve({ value: undefined, done: true });
+  }
+
+  if (reader[_stream] === undefined) {
+    return PromiseReject(
+      new TypeError(
+        "Cannot get the next iteration result once the reader has been released.",
+      ),
+    );
+  }
+
+  /** @type {Deferred<IteratorResult<any>>} */
+  const promise = new Deferred();
+  // internal values (_iteratorNext & _iteratorFinished) are modified inside
+  // ReadableStreamAsyncIteratorReadRequest methods
+  // see: https://webidl.spec.whatwg.org/#es-default-asynchronous-iterator-object
+  const readRequest = new ReadableStreamAsyncIteratorReadRequest(
+    reader,
+    promise,
+  );
+
+  readableStreamDefaultReaderRead(reader, readRequest);
+  // The extra PromisePrototypeThen hop is load-bearing, not redundant: for a
+  // lazily-pulling source the queue is empty here, so the read triggers pull()
+  // and the controller schedules a follow-up pull a microtask later. This hop
+  // delays next()'s resolution by that one tick so the follow-up pull is
+  // observed before the consumer acts on the result (e.g. calls return() to
+  // cancel). Returning promise.promise directly resolves a tick too early and
+  // drops that pull -- see WPT streams async-iterator "next() ...; return()".
+  return PromisePrototypeThen(promise.promise);
+}
+
 /** @type {AsyncIterator<unknown>} */
 const readableStreamAsyncIteratorPrototype = ObjectSetPrototypeOf({
   /** @returns {Promise<IteratorResult<unknown>>} */
   next() {
     /** @type {ReadableStreamDefaultReader} */
     const reader = this[_reader];
-    function nextSteps() {
-      if (reader[_iteratorFinished]) {
-        return PromiseResolve({ value: undefined, done: true });
-      }
 
-      if (reader[_stream] === undefined) {
-        return PromiseReject(
-          new TypeError(
-            "Cannot get the next iteration result once the reader has been released.",
-          ),
-        );
-      }
-
-      /** @type {Deferred<IteratorResult<any>>} */
-      const promise = new Deferred();
-      // internal values (_iteratorNext & _iteratorFinished) are modified inside
-      // ReadableStreamAsyncIteratorReadRequest methods
-      // see: https://webidl.spec.whatwg.org/#es-default-asynchronous-iterator-object
-      const readRequest = new ReadableStreamAsyncIteratorReadRequest(
-        reader,
-        promise,
+    // A prior next() is still in flight: chain after it so iteration results are
+    // delivered in call order (per the WebIDL default async iterator).
+    const ongoing = reader[_iteratorNext];
+    if (ongoing) {
+      return reader[_iteratorNext] = PromisePrototypeThen(
+        ongoing,
+        () => readableStreamAsyncIteratorNextSteps(reader),
+        () => readableStreamAsyncIteratorNextSteps(reader),
       );
-
-      readableStreamDefaultReaderRead(reader, readRequest);
-      return PromisePrototypeThen(promise.promise);
     }
 
-    return reader[_iteratorNext] = reader[_iteratorNext]
-      ? PromisePrototypeThen(reader[_iteratorNext], nextSteps, nextSteps)
-      : nextSteps();
+    // Sync fast path: nothing in flight, stream readable, default (non-byte)
+    // controller with a chunk already queued. Mirrors
+    // ReadableStreamDefaultReader.read()'s fast path, skips allocating a
+    // Deferred, a ReadRequest object, and a microtask hop, and leaves
+    // _iteratorNext null so subsequent iterations stay on this path.
+    const stream = reader[_stream];
+    if (stream !== undefined && stream[_state] === "readable") {
+      const controller = stream[_controller];
+      if (
+        controller[_pendingPullIntos] === undefined &&
+        controller[_queue].size !== 0
+      ) {
+        stream[_disturbed] = true;
+        const chunk = dequeueValue(controller);
+        if (controller[_closeRequested] && controller[_queue].size === 0) {
+          readableStreamDefaultControllerClearAlgorithms(controller);
+          readableStreamClose(stream);
+        } else {
+          readableStreamDefaultControllerCallPullIfNeeded(controller);
+        }
+        return PromiseResolve({ value: chunk, done: false });
+      }
+    }
+
+    return reader[_iteratorNext] = readableStreamAsyncIteratorNextSteps(reader);
   },
   /**
    * @param {unknown} arg


### PR DESCRIPTION
## Summary

`for await (const chunk of stream)` — the most common way to consume a
`ReadableStream` — goes through the default async iterator's `next()`, which
allocated a `Deferred`, a `ReadableStreamAsyncIteratorReadRequest`, and a
`nextSteps` closure on **every** iteration, plus an extra microtask hop before
resolving.

This gives `next()` the same synchronous fast path that
`ReadableStreamDefaultReader.read()` already has: when nothing is in flight, the
stream is readable, and a default (non-byte) controller already has a chunk
queued, dequeue it and resolve synchronously — skipping the `Deferred`, the read
request object, the closure, and a microtask hop. `nextSteps` is hoisted out of
`next()` so it isn't reallocated per call; the chained (concurrent `next()`) path
reuses it.

## Benchmarks

macOS arm64, best-of-3, 200k × 16-byte chunks. Baseline is **this branch with the
change reverted** (identical build config), so the delta isolates this change.

| workload | baseline | this PR | Δ |
|---|---:|---:|---:|
| `for await` (single stream) | 8.26M chunks/s | 13.20M chunks/s | **+60%** |
| `for await` (1000 concurrent) | 6.19M chunks/s | 9.65M chunks/s | **+56%** |
| `reader.read()` / `pipeTo` / `tee` (untouched) | — | unchanged | 0% |

The non-iterator paths are byte-for-byte unchanged in the benchmark, confirming
the change is isolated to the async-iteration path.

## Correctness / notes

- The slow (empty-queue) path deliberately keeps its
  `PromisePrototypeThen(promise.promise)` hop — it is **load-bearing, not
  redundant**. For a lazily-pulling source it delays `next()`'s resolution by one
  microtask so the controller's follow-up `pull()` is observed before the
  consumer can act on the result (e.g. call `return()` to cancel). Dropping it
  makes lazily-pulling sources skip a `pull()` and fails WPT `streams`
  `async-iterator` "next() that succeeds; return()". A comment documents this.
- `tests/unit/streams_test.ts`: 64/64 pass locally.
- WPT `streams` validated on CI.