### PR TITLE
perf(ext/web): synchronous transform fast path for TransformStream

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -63,6 +63,7 @@ const {
   PromiseResolve,
   PromiseWithResolvers,
   RangeError,
+  ReflectApply,
   ReflectHas,
   SafeFinalizationRegistry,
   SafePromiseAll,
@@ -4542,15 +4543,27 @@ function setUpTransformStreamDefaultControllerFromTransformer(
   let flushAlgorithm = _defaultFlushAlgorithm;
   let cancelAlgorithm = _defaultCancelAlgorithm;
   if (transformerDict.transform !== undefined) {
-    transformAlgorithm = (chunk, controller) =>
-      webidl.invokeCallbackFunction(
-        transformerDict.transform,
-        [chunk, controller],
-        transformer,
-        webidl.converters["Promise<undefined>"],
-        "Failed to execute 'transformAlgorithm' on 'TransformStreamDefaultController'",
-        true,
-      );
+    const transformCallback = transformerDict.transform;
+    // Synchronous-transform fast path: a transform() that enqueues and returns
+    // undefined (or any non-thenable) completes without a wrapper promise from
+    // the Promise<undefined> converter. Returning undefined signals synchronous
+    // completion to transformStreamDefaultControllerPerformTransform, which then
+    // skips that promise and the transformPromiseWith() microtask hop -- pure
+    // per-chunk overhead on the transform hot loop. A synchronous throw becomes
+    // a rejected promise so the stream errors as before; a thenable return keeps
+    // the full async path (matching webidl.invokeCallbackFunction).
+    transformAlgorithm = (chunk, controller) => {
+      let rv;
+      try {
+        rv = ReflectApply(transformCallback, transformer, [chunk, controller]);
+      } catch (err) {
+        return PromiseReject(err);
+      }
+      if (rv === undefined || typeof rv?.then !== "function") {
+        return undefined;
+      }
+      return PromiseResolve(rv);
+    };
   }
   if (transformerDict.flush !== undefined) {
     flushAlgorithm = (controller) =>
@@ -4837,6 +4850,13 @@ function transformStreamDefaultControllerPerformTransform(controller, chunk) {
     return resolvedPromise();
   }
   const transformPromise = transformAlgorithm(chunk, controller);
+  if (transformPromise === undefined) {
+    // The transform completed synchronously (see the transformAlgorithm set up
+    // in setUpTransformStreamDefaultControllerFromTransformer): the chunk was
+    // already enqueued, so resolve the write without a per-chunk promise or a
+    // microtask hop, exactly like the identity-transform fast path above.
+    return resolvedPromise();
+  }
   return transformPromiseWith(transformPromise, undefined, (r) => {
     transformStreamError(controller[_stream], r);
     throw r;

--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -371,18 +371,16 @@ class TextDecoderStream {
     this.#transform = new TransformStream({
       // The transform and flush functions need access to TextDecoderStream's
       // `this`, so they are defined as functions rather than methods.
+      // Synchronous transform: the TransformStream fast path resolves the write
+      // without a per-chunk promise or microtask hop when transform() returns
+      // undefined. Throws propagate to the stream via transformAlgorithm.
       transform: (chunk, controller) => {
-        try {
-          chunk = webidl.converters.BufferSource(chunk, prefix, "chunk", {
-            allowShared: true,
-          });
-          const decoded = this.#decoder.decode(chunk, { stream: true });
-          if (decoded) {
-            controller.enqueue(decoded);
-          }
-          return PromiseResolve();
-        } catch (err) {
-          return PromiseReject(err);
+        chunk = webidl.converters.BufferSource(chunk, prefix, "chunk", {
+          allowShared: true,
+        });
+        const decoded = this.#decoder.decode(chunk, { stream: true });
+        if (decoded) {
+          controller.enqueue(decoded);
         }
       },
       flush: (controller) => {
@@ -472,31 +470,29 @@ class TextEncoderStream {
     this.#transform = new TransformStream({
       // The transform and flush functions need access to TextEncoderStream's
       // `this`, so they are defined as functions rather than methods.
+      // Synchronous transform: the TransformStream fast path resolves the write
+      // without a per-chunk promise or microtask hop when transform() returns
+      // undefined. Throws propagate to the stream via transformAlgorithm.
       transform: (chunk, controller) => {
-        try {
-          chunk = webidl.converters.DOMString(chunk);
-          if (chunk === "") {
-            return PromiseResolve();
-          }
-          if (this.#pendingHighSurrogate !== null) {
-            chunk = this.#pendingHighSurrogate + chunk;
-          }
-          const lastCodeUnit = StringPrototypeCharCodeAt(
-            chunk,
-            chunk.length - 1,
-          );
-          if (0xD800 <= lastCodeUnit && lastCodeUnit <= 0xDBFF) {
-            this.#pendingHighSurrogate = StringPrototypeSlice(chunk, -1);
-            chunk = StringPrototypeSlice(chunk, 0, -1);
-          } else {
-            this.#pendingHighSurrogate = null;
-          }
-          if (chunk) {
-            controller.enqueue(core.encode(chunk));
-          }
-          return PromiseResolve();
-        } catch (err) {
-          return PromiseReject(err);
+        chunk = webidl.converters.DOMString(chunk);
+        if (chunk === "") {
+          return;
+        }
+        if (this.#pendingHighSurrogate !== null) {
+          chunk = this.#pendingHighSurrogate + chunk;
+        }
+        const lastCodeUnit = StringPrototypeCharCodeAt(
+          chunk,
+          chunk.length - 1,
+        );
+        if (0xD800 <= lastCodeUnit && lastCodeUnit <= 0xDBFF) {
+          this.#pendingHighSurrogate = StringPrototypeSlice(chunk, -1);
+          chunk = StringPrototypeSlice(chunk, 0, -1);
+        } else {
+          this.#pendingHighSurrogate = null;
+        }
+        if (chunk) {
+          controller.enqueue(core.encode(chunk));
         }
       },
       flush: (controller) => {


### PR DESCRIPTION
## Summary

A JS transformer's `transform()` was invoked through WebIDL's `Promise<undefined>`
return converter and its result chained with `transformPromiseWith()`, so every
chunk through a **non-identity** `TransformStream` allocated two promises and took
a microtask hop — even when `transform()` completed synchronously. Only the
identity transform had a fast path.

This invokes `transform()` directly and returns the synchronous-completion
sentinel (`undefined`) on any non-thenable result, so
`transformStreamDefaultControllerPerformTransform` resolves the write with a
shared resolved promise and no microtask hop — mirroring the existing identity
fast path and the default controller's synchronous-pull fast path (#35843). A
synchronous throw becomes a rejected promise (the stream errors as before); a
thenable return keeps the full async path (matching
`webidl.invokeCallbackFunction`'s `returnsPromise` behavior).

`TextEncoderStream` and `TextDecoderStream` transforms are made synchronous
(return `undefined` instead of `PromiseResolve()`) so they take this path.

## Benchmarks

macOS arm64, best-of-3, 100k chunks. Baseline is this branch with the change
reverted (identical build config).

| workload | baseline | this PR | Δ |
|---|---:|---:|---:|
| generic non-identity transform pipe | 2.39M/s | 2.54M/s | **+6%** |
| 3× transform chain | 1.12M/s | 1.24M/s | **+11%** |
| `TextEncoderStream` → `TextDecoderStream` pipe | 1.06M/s | 1.13M/s | **+6.6%** |

For reference (Bun 1.4 canary): generic transform 2.14M/s, 3× chain 1.03M/s,
Text En/Decode 1.21M/s. This change moves generic transform pipes **past Bun**;
the remaining Text En/Decode gap is `core.encode`/`TextDecoder.decode` op cost
(native in Bun), not the stream machinery.

## Correctness / notes

- Same class of timing change as the identity and sync-pull fast paths (write
  resolves synchronously instead of a microtask later). Reuses the existing
  `resolvedPromise()` used by the identity path.
- TE/TD correctness verified: encode/decode round-trip, surrogate pair split
  across chunks, lone high surrogate → replacement char, streaming multi-byte
  UTF-8 split across byte chunks, fatal decode error propagation, input
  coercion.
- `tests/unit/text_encoding_test.ts` + `tests/unit/streams_test.ts`: 89/89 pass.
- Relying on CI for full WPT `streams` + `encoding` coverage.