### PR TITLE
chore: remove redundant unstable flags from node_compat runner

### DIFF
--- a/tests/node_compat/mod.rs
+++ b/tests/node_compat/mod.rs
@@ -33,16 +33,14 @@ const RUN_ARGS: &[&str] = &[
   "run",
   "-A",
   "--quiet",
-  "--unstable-unsafe-proto",
-  "--unstable-bare-node-builtins",
+  "--unsafe-proto",
 ];
 
 const TEST_ARGS: &[&str] = &[
   "test",
   "-A",
   "--quiet",
-  "--unstable-unsafe-proto",
-  "--unstable-bare-node-builtins",
+  "--unsafe-proto",
   "--no-check",
 ];
 

--- a/tests/node_compat/mod.rs
+++ b/tests/node_compat/mod.rs
@@ -29,20 +29,10 @@ mod report;
 /// Global counter for generating unique test serial IDs
 static TEST_SERIAL_ID: AtomicUsize = AtomicUsize::new(0);
 
-const RUN_ARGS: &[&str] = &[
-  "run",
-  "-A",
-  "--quiet",
-  "--unsafe-proto",
-];
+const RUN_ARGS: &[&str] = &["run", "-A", "--quiet", "--unsafe-proto"];
 
-const TEST_ARGS: &[&str] = &[
-  "test",
-  "-A",
-  "--quiet",
-  "--unsafe-proto",
-  "--no-check",
-];
+const TEST_ARGS: &[&str] =
+  &["test", "-A", "--quiet", "--unsafe-proto", "--no-check"];
 
 /// Per-platform value: either a boolean (true = enabled, false = disabled)
 /// or an object describing an expected failure.

--- a/tests/node_compat/mod.rs
+++ b/tests/node_compat/mod.rs
@@ -44,7 +44,6 @@ const TEST_ARGS: &[&str] = &[
   "--unstable-unsafe-proto",
   "--unstable-bare-node-builtins",
   "--no-check",
-  "--unstable-detect-cjs",
 ];
 
 /// Per-platform value: either a boolean (true = enabled, false = disabled)


### PR DESCRIPTION
The node_compat test runner passed several unstable flags that are no
longer needed:

`--unstable-detect-cjs` is redundant because the vendored suite has a root
`package.json` with `"type": "commonjs"`, so the stable CJS detection
(enabled whenever a package.json is present) already treats the test files
as CommonJS.

`--unstable-bare-node-builtins` is redundant for the same reason: inside
the suite's package.json scope, bare builtin specifiers already resolve
through node resolution.

`--unstable-unsafe-proto` is replaced with its stable alias
`--unsafe-proto`.