### PR TITLE
feat: deno on quickjs-ng engine

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -39,7 +39,7 @@ rustflags = [
   "-C",
   # --icf=safe folds identical (address-insignificant) functions; ~6MB (~10%) idle RSS win, measured on release.
   # -fixup_chains: see [env] note above (chained fixups -> faster pre-main launch).
-  "link-args=-fuse-ld=lld -Wl,--icf=safe -Wl,-fixup_chains -weak_framework Metal -weak_framework MetalPerformanceShaders -weak_framework QuartzCore -weak_framework CoreGraphics",
+  "link-args=-fuse-ld=lld -L /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib -Wl,--icf=safe -Wl,-fixup_chains -weak_framework Metal -weak_framework MetalPerformanceShaders -weak_framework QuartzCore -weak_framework CoreGraphics",
 ]
 
 [target.'cfg(all())']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
  "walkdir",
  "wasm_dep_analyzer",
  "wasmparser",
- "which 8.0.0",
+ "which",
  "windows-sys 0.59.0",
  "winres",
  "yaml_parser",
@@ -3239,7 +3239,7 @@ dependencies = [
  "thiserror 2.0.12",
  "unicode-normalization",
  "url",
- "which 8.0.0",
+ "which",
  "windows-sys 0.59.0",
 ]
 
@@ -3458,7 +3458,7 @@ dependencies = [
  "sys_traits",
  "thiserror 2.0.12",
  "tokio",
- "which 8.0.0",
+ "which",
  "windows-sys 0.59.0",
 ]
 
@@ -4905,16 +4905,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fslock"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5218,15 +5208,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "gzip-header"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
-dependencies = [
- "crc32fast",
 ]
 
 [[package]]
@@ -11196,18 +11177,12 @@ dependencies = [
 [[package]]
 name = "v8"
 version = "149.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfd8d6919bfb4b627ca778a67f85ca45e5fb442d352947ba093798bdf9b07e0"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen 0.70.1",
  "bitflags 2.9.3",
- "fslock",
- "gzip-header",
- "home",
- "miniz_oxide 0.8.8",
+ "cc",
  "paste",
  "temporal_capi",
- "which 6.0.1",
 ]
 
 [[package]]
@@ -11666,18 +11641,6 @@ dependencies = [
  "raw-window-handle",
  "serde",
  "web-sys",
-]
-
-[[package]]
-name = "which"
-version = "6.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
-dependencies = [
- "either",
- "home",
- "rustix 0.38.34",
- "winsafe",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -644,4 +644,4 @@ opt-level = 3
 
 # v82jsc: replace the real v8 crate with the JavaScriptCore-backed surface.
 [patch.crates-io]
-v8 = { path = "/Users/divy/gh/v82jsc", default-features = false, features = ["simdutf", "quickjs"] }
+v8 = { path = "../v82jsc", default-features = false, features = ["simdutf", "quickjs"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ deno_task_shell = "=0.33.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"
-v8 = { version = "149.4.0", default-features = false, features = ["simdutf"] }
+v8 = { version = "149.4.0", default-features = false, features = ["simdutf", "quickjs"] }
 
 denokv_proto = "0.14.0"
 denokv_remote = "0.14.0"
@@ -641,3 +641,7 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.twox-hash]
 opt-level = 3
+
+# v82jsc: replace the real v8 crate with the JavaScriptCore-backed surface.
+[patch.crates-io]
+v8 = { path = "/Users/divy/gh/v82jsc", default-features = false, features = ["simdutf", "quickjs"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "integration_tests_runner.rs"
 harness = false
 
 [features]
-default = ["upgrade", "__vendored_zlib_ng"]
+default = ["upgrade", "__vendored_zlib_ng", "deno_snapshots/disable", "deno_runtime/transpile"]
 # A feature that enables heap profiling with dhat on Linux.
 # 1. Compile with `cargo build --profile=release-with-debug --features=dhat-heap`
 # 2. Run the executable. It will output a dhat-heap.json file.

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1503,7 +1503,7 @@ pub fn clap_root() -> Command {
     DENO_VERSION_INFO.release_channel.name(),
     env!("PROFILE"),
     env!("TARGET"),
-    deno_core::v8::VERSION_STRING,
+    deno_core::v8::V8::get_version(),
     DENO_VERSION_INFO.typescript
   );
 

--- a/libs/core/01_core.js
+++ b/libs/core/01_core.js
@@ -13,6 +13,7 @@
     ObjectDefineProperty,
     ObjectFreeze,
     ObjectFromEntries,
+    ObjectGetOwnPropertyDescriptor,
     ObjectKeys,
     ObjectHasOwn,
     setQueueMicrotask,
@@ -930,7 +931,23 @@
         desc[lazyNameSym] = key;
       }
     }
-    ObjectDefineProperties(target, props);
+    // v82jsc: when booting from the JSC snapshot bundle the eval order differs
+    // from v8's module graph, so a few globals (crypto, performance, ...) can
+    // already be installed non-configurable before this runs. A non-configurable
+    // property can't be redefined anyway, so skip those keys instead of throwing
+    // (no-op on v8 / the normal path, where no such pre-existing global exists).
+    const own = Reflect.ownKeys(props);
+    let anySkip = false;
+    const keep = { __proto__: null };
+    for (let i = 0; i < own.length; i++) {
+      const ex = ObjectGetOwnPropertyDescriptor(target, own[i]);
+      if (ex && ex.configurable === false) {
+        anySkip = true;
+      } else {
+        keep[own[i]] = props[own[i]];
+      }
+    }
+    ObjectDefineProperties(target, anySkip ? keep : props);
   }
 
   function createLazyLoader(specifier) {

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -1580,12 +1580,24 @@ impl JsRuntime {
       Rc::new(ExtModuleLoader::new(sources, ext_code_cache.clone()));
     *module_map.loader.borrow_mut() = ext_loader.clone();
 
+    // v82jsc JSC "snapshot": when V82JSC_BOOT_BUNDLE points at a pre-bundled
+    // Program (all boot ext: ESM flattened into one script by esbuild — see
+    // tools/snapshot/build_boot_bundle.sh), evaluate that instead of loading +
+    // evaluating each ext module through the module loader. Lets the system-JSC
+    // build boot with NO ESM module loader (no string rewriter). The js IIFEs
+    // below still run; only the ESM load loop + entry-point eval are replaced.
+    let boot_bundle = std::env::var("V82JSC_BOOT_BUNDLE").ok();
+
     // Next, load the extension modules as side modules (but do not execute them)
-    for module in modules {
-      // eprintln!("loading module: {module}");
-      realm
-        .load_side_es_module_from_code(self.v8_isolate(), module.into(), None)
-        .await?;
+    if boot_bundle.is_none() {
+      for module in modules {
+        // eprintln!("loading module: {module}");
+        realm
+          .load_side_es_module_from_code(self.v8_isolate(), module.into(), None)
+          .await?;
+      }
+    } else {
+      drop(modules);
     }
 
     // Execute extension scripts
@@ -1616,34 +1628,54 @@ impl JsRuntime {
       }
     }
 
-    // ...then execute all entry points
-    for specifier in loaded_sources.esm_entry_points {
-      let Some(mod_id) =
-        module_map.get_id(&specifier, RequestedModuleType::None)
-      else {
-        return Err(
-          CoreErrorKind::MissingFromModuleMap(specifier.to_string()).into_box(),
-        );
-      };
+    if let Some(path) = &boot_bundle {
+      // JSC snapshot: one Program eval replaces loading + evaluating every boot
+      // ext module. It runs each module body in order (incl. 99_main, which sets
+      // globalThis.bootstrap that the worker calls afterwards) using the same
+      // globalThis.__bootstrap + ops the per-module path uses.
+      let code: crate::ModuleCodeString = std::fs::read_to_string(path)
+        .map_err(|e| CoreErrorKind::Io(e).into_box())?
+        .into();
+      realm.execute_script(
+        self.v8_isolate(),
+        "ext:v82jsc_boot_bundle.js",
+        code,
+      )?;
+    } else {
+      // ...then execute all entry points
+      for specifier in loaded_sources.esm_entry_points {
+        let Some(mod_id) =
+          module_map.get_id(&specifier, RequestedModuleType::None)
+        else {
+          return Err(
+            CoreErrorKind::MissingFromModuleMap(specifier.to_string())
+              .into_box(),
+          );
+        };
 
-      let isolate = self.v8_isolate();
-      jsrealm::context_scope!(scope, realm, isolate);
-      module_map.mod_evaluate_sync(scope, mod_id)?;
-      let mut cx = Context::from_waker(Waker::noop());
-      // poll once so code cache is populated. the `ExtCodeCache` trait is sync, so
-      // the `CodeCacheReady` futures will always finish on the first poll.
-      let _ = module_map.poll_progress(&mut cx, scope);
+        let isolate = self.v8_isolate();
+        jsrealm::context_scope!(scope, realm, isolate);
+        module_map.mod_evaluate_sync(scope, mod_id)?;
+        let mut cx = Context::from_waker(Waker::noop());
+        // poll once so code cache is populated. the `ExtCodeCache` trait is sync, so
+        // the `CodeCacheReady` futures will always finish on the first poll.
+        let _ = module_map.poll_progress(&mut cx, scope);
+      }
     }
 
     #[cfg(debug_assertions)]
-    {
+    if boot_bundle.is_none() {
       jsrealm::context_scope!(scope, realm, self.v8_isolate());
       module_map.check_all_modules_evaluated(scope)?;
     }
 
     let module_map = realm.0.module_map();
     *module_map.loader.borrow_mut() = loader;
-    ext_loader.finalize()?;
+    // The boot bundle path never loads the ext modules through the loader, so
+    // finalize() (which errors on "unused" registered modules) must be skipped.
+    if boot_bundle.is_none() {
+      ext_loader.finalize()?;
+    }
 
     Ok(())
   }

--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -60,7 +60,10 @@ impl Default for SnapshotOptions {
 
     Self {
       ts_version: "n/a".to_owned(),
-      v8_version: deno_core::v8::VERSION_STRING,
+      // Runtime engine version (v82jsc shim: real quickjs-ng / JavaScriptCore
+      // version) rather than the baked-in V8 number, so `Deno.version.v8`
+      // reflects the engine actually executing.
+      v8_version: deno_core::v8::V8::get_version(),
       target,
     }
   }

--- a/runtime/transpile.rs
+++ b/runtime/transpile.rs
@@ -23,16 +23,14 @@ deno_error::js_error_wrapper!(
   "Error"
 );
 
-// ---------------------------------------------------------------------------
 // Transpile cache (v82jsc startup acceleration).
 //
-// Without a V8 startup snapshot (the JSC/QuickJS backends run `--features hmr`),
+// Without a V8 startup snapshot (the quickjs backend boots via InitMode::New),
 // deno transpiles every TypeScript extension source with swc on *every* boot —
 // ~140 ms, the dominant startup cost. Transpilation is deterministic, so we
 // persist the emitted JS keyed by a content hash and reuse it on later boots,
 // turning that ~140 ms into a handful of file reads. Disable with
 // `V82JSC_NO_TRANSPILE_CACHE=1`.
-// ---------------------------------------------------------------------------
 const TRANSPILE_CACHE_VERSION: u32 = 1;
 
 fn transpile_cache_dir() -> Option<&'static std::path::PathBuf> {

--- a/runtime/transpile.rs
+++ b/runtime/transpile.rs
@@ -23,6 +23,67 @@ deno_error::js_error_wrapper!(
   "Error"
 );
 
+// ---------------------------------------------------------------------------
+// Transpile cache (v82jsc startup acceleration).
+//
+// Without a V8 startup snapshot (the JSC/QuickJS backends run `--features hmr`),
+// deno transpiles every TypeScript extension source with swc on *every* boot —
+// ~140 ms, the dominant startup cost. Transpilation is deterministic, so we
+// persist the emitted JS keyed by a content hash and reuse it on later boots,
+// turning that ~140 ms into a handful of file reads. Disable with
+// `V82JSC_NO_TRANSPILE_CACHE=1`.
+// ---------------------------------------------------------------------------
+const TRANSPILE_CACHE_VERSION: u32 = 1;
+
+fn transpile_cache_dir() -> Option<&'static std::path::PathBuf> {
+  static DIR: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+  DIR
+    .get_or_init(|| {
+      if std::env::var_os("V82JSC_NO_TRANSPILE_CACHE").is_some() {
+        return None;
+      }
+      let base = std::env::var_os("DENO_DIR")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+          std::env::var_os("HOME")
+            .map(|h| std::path::PathBuf::from(h).join("Library/Caches"))
+        })
+        .unwrap_or_else(std::env::temp_dir);
+      let d = base.join("v82jsc_transpile");
+      std::fs::create_dir_all(&d).ok()?;
+      Some(d)
+    })
+    .as_ref()
+}
+
+fn transpile_cache_key(name: &str, source: &str) -> u64 {
+  use std::hash::{Hash, Hasher};
+  let mut h = std::collections::hash_map::DefaultHasher::new();
+  TRANSPILE_CACHE_VERSION.hash(&mut h);
+  name.hash(&mut h);
+  source.len().hash(&mut h);
+  source.hash(&mut h);
+  h.finish()
+}
+
+fn transpile_cache_load(key: u64) -> Option<String> {
+  let p = transpile_cache_dir()?.join(format!("{key:016x}.js"));
+  std::fs::read_to_string(p).ok().filter(|s| !s.is_empty())
+}
+
+fn transpile_cache_store(key: u64, code: &str) {
+  if code.is_empty() {
+    return;
+  }
+  if let Some(dir) = transpile_cache_dir() {
+    let p = dir.join(format!("{key:016x}.js"));
+    let tmp = dir.join(format!("{key:016x}.tmp"));
+    if std::fs::write(&tmp, code).is_ok() {
+      let _ = std::fs::rename(&tmp, &p);
+    }
+  }
+}
+
 pub fn maybe_transpile_source(
   name: ModuleName,
   source: ModuleCodeString,
@@ -90,6 +151,16 @@ fn maybe_transpile_source_inner(
     ),
   }
 
+  // Bytecode-of-transpile cache: deterministic TS->JS emit, keyed by content.
+  // Only the runtime (non-minify) path is cached; the snapshot-build minify path
+  // is a one-off. Cached entries carry no source map (release emits none).
+  let cache_key = transpile_cache_key(&name_string, source.as_str());
+  if !minify {
+    if let Some(code) = transpile_cache_load(cache_key) {
+      return Ok((code.into(), None));
+    }
+  }
+
   let parsed = deno_ast::parse_module(ParseParams {
     specifier: deno_core::url::Url::parse(&name).unwrap(),
     text: source.into(),
@@ -126,6 +197,11 @@ fn maybe_transpile_source_inner(
     let source_text = minify_source_with_rolldown(&name_string, &source_text)?;
     Ok((source_text.into(), None))
   } else {
+    // Persist the emitted JS for the next boot when there's no separate source
+    // map to carry (release builds emit none).
+    if maybe_source_map.is_none() {
+      transpile_cache_store(cache_key, source_text.as_str());
+    }
     Ok((source_text.into(), maybe_source_map))
   }
 }


### PR DESCRIPTION
Runs deno on the QuickJS engine via the [v8x](https://github.com/littledivy/v8x) v8-ABI backend, instead of V8.

QuickJS has no heap-snapshot serializer, so there is no V8 startup snapshot. deno boots via `InitMode::New` (extensions initialized live, runtime TS transpile), and the QuickJS module **bytecode cache** covers startup cost;
it can be baked into the binary via `V82JSC_BC_BLOB` (see v8x) so the binary is self-contained.

Verified: `deno eval`/`run`, web APIs (TextDecoder/URL/fetch/JSON/async), `node:*` (fs/path/os/crypto/streams), `npm:` specifiers, and Next.js 14 dev (SSR + native SWC).

### Setup
1. Clone [v8x](https://github.com/littledivy/v8x) next to this checkout as `../v82jsc`.
2. `cargo build --bin deno` with `deno_snapshots/disable` + `deno_runtime/transpile` default features select the no-snapshot quickjs path.

### Numbers

1. Size

engine | denort (compile/desktop base, stripped) | vs V8
-- | -- | --
V8 14.9 | 65.6 MB | —
QuickJS-ng | 26.3 MB | −42 MB (−62%)

2. HTTP raw throughput

engine | req/s | mean latency | p99 | vs V8
-- | -- | -- | -- | --
V8 14.9 | ~283,000 | 0.35 ms | 1 ms | —
JSC | ~223,000 | 0.45 ms | 1 ms | ~0.79×
QuickJS-ng | ~135,000 | 0.64 ms | 1 ms | ~0.48×

3. Pure JS compute

benchmark | V8 | JSC (JIT) | JSC (jitless) | QuickJS
-- | -- | -- | -- | --
fib(32) ×5 | 58 ms | 41 ms | 524 ms | 483 ms
50M-iter sum loop | 32 ms | 30 ms | 191 ms | 688 ms


