### PR TITLE
fix(fmt): format Astro inline scripts as TypeScript

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -529,6 +529,14 @@ fn format_markup_embedded(
         "ts" | "typescript" | "mts" => "ts",
         "tsx" => "tsx",
         "jsx" => "jsx",
+        // Astro treats inline `<script>` contents as TypeScript by default,
+        // so a bare script tag (which `lax_markup` reports as `js`) must be
+        // formatted as TypeScript rather than JavaScript.
+        _ if file_path.extension().and_then(|e| e.to_str())
+          == Some("astro") =>
+        {
+          "ts"
+        }
         _ => "js",
       };
       let path = file_path.with_extension(ext);

--- a/tests/specs/fmt/astro_file_with_typescript_script/__test__.jsonc
+++ b/tests/specs/fmt/astro_file_with_typescript_script/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "fmt --unstable-component .",
+  "output": "fmt.out"
+}

--- a/tests/specs/fmt/astro_file_with_typescript_script/fmt.out
+++ b/tests/specs/fmt/astro_file_with_typescript_script/fmt.out
@@ -1,0 +1,2 @@
+[WILDCARD]main.astro
+Checked 1 file

--- a/tests/specs/fmt/astro_file_with_typescript_script/main.astro
+++ b/tests/specs/fmt/astro_file_with_typescript_script/main.astro
@@ -1,0 +1,4 @@
+<script>
+const a: string = ''
+console.log(a)
+</script>


### PR DESCRIPTION
Fixes #35850.

## Problem

Since the switch to `lax-markup` for component formatting (#35174, Deno 2.9.x), `deno fmt --unstable-component` fails on Astro files whose inline `<script>` uses TypeScript syntax:

```astro
<script>
const a: string = '';
</script>
```

```
Error formatting: /some-filepath/example.astro
   SyntaxError: Expected a semicolon
  |
2 | const a: string = '';
  |        ~
    at file:///some-filepath/example.js:2:8
error: Failed to format 1 of 1 checked file
```

This worked in Deno 2.8.3.

## Cause

`lax-markup` reports a bare `<script>` tag (no `lang`/`type` attribute) to the external formatter as `js`, regardless of file type. `format_markup_embedded` in `cli/tools/fmt.rs` then formatted the contents as `example.js` — note the `example.js` in the error above. Astro, however, treats inline `<script>` contents as **TypeScript by default**, so any TypeScript syntax fails to parse as JavaScript.

## Fix

For `.astro` files, format a bare script (reported as `js`) as TypeScript instead of JavaScript. TypeScript is a superset of JavaScript, so plain-JS Astro scripts continue to format correctly. Explicit `lang="ts"`/`lang="jsx"`/etc. are unaffected.

## Tests

Added spec test `tests/specs/fmt/astro_file_with_typescript_script/`. Verified the exact repro now formats without error, and that plain-JS Astro scripts still format correctly.