### PR TITLE
perf(ext/node): speed up sqlite.StatementSync.all() and run()

### DIFF
--- a/ext/node_sqlite/statement.rs
+++ b/ext/node_sqlite/statement.rs
@@ -45,8 +45,15 @@ impl<'a> ToV8<'a> for RunStatementResult {
       v8::Number::new(scope, self.last_insert_rowid as f64).into()
     };
 
+    // create_data_property defines own data properties directly, avoiding the
+    // generic [[Set]] runtime path (property-key lookup + hidden-class
+    // transitions) that showed up as ~half the cost of a `run()` in profiles.
     obj
-      .set(scope, last_insert_row_id_str.into(), last_insert_row_id)
+      .create_data_property(
+        scope,
+        last_insert_row_id_str.into(),
+        last_insert_row_id,
+      )
       .unwrap();
 
     let changes_str = CHANGES.v8_string(scope).unwrap();
@@ -56,7 +63,9 @@ impl<'a> ToV8<'a> for RunStatementResult {
       v8::Number::new(scope, self.changes as f64).into()
     };
 
-    obj.set(scope, changes_str.into(), changes).unwrap();
+    obj
+      .create_data_property(scope, changes_str.into(), changes)
+      .unwrap();
     Ok(obj.into())
   }
 }
@@ -697,13 +706,44 @@ impl StatementSync {
     #[varargs] params: Option<&v8::FunctionCallbackArguments>,
   ) -> Result<v8::Local<'a, v8::Array>, SqliteError> {
     self.invalidate_iter();
-    let mut arr = vec![];
 
     self.bind_params(scope, params)?;
 
     let _reset = ResetGuard(self);
-    while let Some(result) = self.read_row(scope)? {
-      arr.push(result);
+
+    // Column names are constant across every row of the result set. Build the
+    // V8 name strings once here and reuse them for all rows, instead of
+    // re-creating them per row (as the generic `read_row` does): this drops a
+    // `sqlite3_column_name` FFI call and a string allocation per column per
+    // row, and gives every row object the same shape (hidden class).
+    let num_cols = self.column_count()?;
+    let return_arrays = self.return_arrays();
+    let mut names = Vec::with_capacity(num_cols as usize);
+    if !return_arrays {
+      for i in 0..num_cols {
+        let name = self.column_name(i)?;
+        names.push(
+          v8::String::new_from_utf8(scope, name, v8::NewStringType::Normal)
+            .unwrap()
+            .into(),
+        );
+      }
+    }
+    let null = v8::null(scope).into();
+
+    let mut arr = vec![];
+    while !self.step()? {
+      let mut values = Vec::with_capacity(num_cols as usize);
+      for i in 0..num_cols {
+        values.push(self.column_value(i, scope)?);
+      }
+      let row = if return_arrays {
+        v8::Array::new_with_elements(scope, &values).into()
+      } else {
+        v8::Object::with_prototype_and_properties(scope, null, &names, &values)
+          .into()
+      };
+      arr.push(row);
     }
 
     let arr = v8::Array::new_with_elements(scope, &arr);


### PR DESCRIPTION
Two hot-path fixes for `node:sqlite`, from profiling the insert/select benchmark (was ~2× slower than Node).

**`all()`** rebuilt the column-name V8 strings *per row* (`read_row` recreates them every row). For a 500-row × 4-col result that's ~2000 redundant string allocations + `sqlite3_column_name` FFI calls. Hoisted the names out of the row loop — built once, reused for every row, which also gives every row object the same shape.

**`run()`** built the `{ lastInsertRowid, changes }` result with `Object::set`, which goes through V8's generic `[[Set]]` runtime path. Switched to `create_data_property` (defines own data properties directly). Smaller effect — the result object turned out to be a minor part of insert cost, not the dominant one.

Throughput (1 MiB in-memory, aarch64, interleaved best-of-N):

| | before | after | Node |
|---|---:|---:|---:|
| `select.all` (500 rows) | ~5.0k | ~9.4k (**+85%**) | ~8.6k |
| `insert` (1000-row tx) | ~2.0k | ~2.1k (+6%) | ~3.9k |

Select now matches/beats Node. Insert's remaining gap is diffuse per-call overhead (slow-op dispatch + `bind_params` + `step`), not any single hot spot. Result objects verified unchanged: `Object.prototype`, same keys/values. `tests/unit_node/sqlite_test.ts`: 77/77 pass.