### PR TITLE
fix(runtime): map notify's Windows missing-path error to NotFound

### DIFF
--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -3488,11 +3488,13 @@ function watch(
   let resolvedWatchPath = watchPath;
   try {
     // Pre-validate path existence so missing-path failures surface as a
-    // typed `Deno.errors.NotFound` consistently across platforms. notify
-    // 6.1.1's Windows backend (`add_watch` in src/windows.rs) returns a
-    // Generic error rather than a typed NotFound when the path doesn't
-    // exist, which would otherwise bypass the prototype check in
-    // makeWatchNodeError above.
+    // typed `Deno.errors.NotFound` consistently across platforms. The
+    // notify crate's Windows backend (`add_watch` in src/windows.rs)
+    // reports a missing path as a Generic error rather than a typed
+    // NotFound; runtime/ops/fs_events.rs maps that message to NotFound so
+    // the prototype check in makeWatchNodeError above also covers paths
+    // that vanish between this check and the watch (or mid-watch), see
+    // denoland/deno#35855.
     Deno.lstatSync(watchPath);
     iterator = Deno.watchFs(watchPath, { recursive });
     // Resolve the watched path once so we can compute relative paths.

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -710,6 +710,37 @@ mod tests {
     assert_eq!(other.get_class(), GENERIC_ERROR);
   }
 
+  // The test above only proves the match arm fires for our own constant. This
+  // drives the real notify backend against a path that does not exist so a
+  // notify upgrade that rewords the Windows missing-path message fails loudly
+  // here instead of silently regressing fs.watch to a non-ENOENT error (see
+  // denoland/deno#35855). notify's `watch_inner` returns this Generic error
+  // synchronously from its is_dir/is_file check, so no real watch is opened.
+  #[cfg(windows)]
+  #[test]
+  fn notify_windows_missing_path_message_matches_constant() {
+    let mut watcher: RecommendedWatcher = Watcher::new(
+      |_res: Result<NotifyEvent, NotifyError>| {},
+      Default::default(),
+    )
+    .unwrap();
+
+    let missing = PathBuf::from(r"C:\deno-nonexistent\watch\target");
+    let err = watcher
+      .watch(&missing, RecursiveMode::NonRecursive)
+      .expect_err("watching a nonexistent path should fail");
+
+    assert!(
+      matches!(
+        &err.kind,
+        notify::ErrorKind::Generic(msg) if msg == WINDOWS_PATH_NOT_FOUND_MSG
+      ),
+      "notify no longer reports the expected Generic message; got {:?}",
+      err.kind,
+    );
+    assert_eq!(JsNotifyError(err).get_class(), "NotFound");
+  }
+
   #[test]
   fn clone_notify_error_preserves_kind_and_paths() {
     let err = NotifyError {

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -315,8 +315,21 @@ fn is_file_removed(event_path: &Path) -> bool {
   }
 }
 
+// The notify crate's Windows backend reports a missing watch path as a
+// Generic error with this message (see `add_watch` in notify's
+// src/windows.rs), unlike the inotify backend which reports PathNotFound.
+// Normalize it so a watch on a vanished path surfaces as NotFound on all
+// platforms; the node:fs `fs.watch` polyfill relies on this to emit a
+// recoverable ENOENT instead of an unrecognized error that kills watchers
+// like chokidar/vite (see denoland/deno#35855).
+const WINDOWS_PATH_NOT_FOUND_MSG: &str =
+  "Input watch path is neither a file nor a directory.";
+
 deno_error::js_error_wrapper!(NotifyError, JsNotifyError, |err| {
   match &err.kind {
+    notify::ErrorKind::Generic(msg) if msg == WINDOWS_PATH_NOT_FOUND_MSG => {
+      "NotFound".into()
+    }
     notify::ErrorKind::Generic(_) => GENERIC_ERROR.into(),
     notify::ErrorKind::Io(e) => e.get_class(),
     notify::ErrorKind::PathNotFound => "NotFound".into(),
@@ -680,6 +693,21 @@ mod tests {
 
     assert!(!is_ignored_notify_event(&event));
     assert_eq!(FsEvent::from(event).kind, "access");
+  }
+
+  #[test]
+  fn maps_windows_missing_path_generic_error_to_not_found() {
+    let err = JsNotifyError(NotifyError {
+      kind: notify::ErrorKind::Generic(WINDOWS_PATH_NOT_FOUND_MSG.to_string()),
+      paths: vec![PathBuf::from("watched/file.txt")],
+    });
+    assert_eq!(err.get_class(), "NotFound");
+
+    let other = JsNotifyError(NotifyError {
+      kind: notify::ErrorKind::Generic("some other failure".to_string()),
+      paths: vec![],
+    });
+    assert_eq!(other.get_class(), GENERIC_ERROR);
   }
 
   #[test]


### PR DESCRIPTION
The notify crate's Windows backend reports a watch path that doesn't exist
(or vanished mid-watch) as a Generic error with the message "Input watch
path is neither a file nor a directory.", unlike the inotify backend which
reports a typed PathNotFound. That generic error reached the node:fs
fs.watch polyfill without an ENOENT code, so watchers like chokidar
re-emitted it and killed the process, e.g. a Vite dev server crashing when
an external editor saves a file on Windows. This happens because editors
that save via write-and-rename race chokidar's per-path watch creation with
a moment where the path doesn't resolve.

This maps that error message to the NotFound class so the existing fs.watch
open-failure handling from #34398 converts it to a recoverable ENOENT
'error' event on all platforms, for both the watch-open and mid-watch error
paths. Direct Deno.watchFs callers also now get Deno.errors.NotFound on
Windows, matching Linux behavior.

Closes #35855

https://claude.ai/code/session_01Tze6CEbTtUS4CdQSa8bAXD