### PR TITLE
fix(types): make import.meta.dirname/filename required string

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -30,7 +30,9 @@ interface ImportMeta {
 
   /** The absolute path of the current module.
    *
-   * This property is only provided for local modules (ie. using `file://` URLs).
+   * > **Caveat**: only present at runtime for local modules (ie. using
+   * > `file://` URLs); `undefined` for non-local modules (eg. `https://` or
+   * > `data:`).
    *
    * Example:
    * ```
@@ -41,11 +43,13 @@ interface ImportMeta {
    * console.log(import.meta.filename); // C:\alice\my_module.ts
    * ```
    */
-  filename?: string;
+  filename: string;
 
   /** The absolute path of the directory containing the current module.
    *
-   * This property is only provided for local modules (ie. using `file://` URLs).
+   * > **Caveat**: only present at runtime for local modules (ie. using
+   * > `file://` URLs); `undefined` for non-local modules (eg. `https://` or
+   * > `data:`).
    *
    * * Example:
    * ```
@@ -56,7 +60,7 @@ interface ImportMeta {
    * console.log(import.meta.dirname); // C:\alice
    * ```
    */
-  dirname?: string;
+  dirname: string;
 
   /** A flag that indicates if the current module is the main module that was
    * called when starting the program under Deno.

--- a/cli/tsc/dts/node/module.d.cts
+++ b/cli/tsc/dts/node/module.d.cts
@@ -636,7 +636,7 @@ declare module "module" {
              * > **Caveat**: only present on `file:` modules.
              * @since v21.2.0, v20.11.0
              */
-            dirname?: string;
+            dirname: string;
             /**
              * The full absolute path and filename of the current module, with
              * symlinks resolved.
@@ -647,7 +647,7 @@ declare module "module" {
              * > `file:` protocol will not provide it.
              * @since v21.2.0, v20.11.0
              */
-            filename?: string;
+            filename: string;
             /**
              * The absolute `file:` URL of the module.
              *

--- a/tools/update_types_node.ts
+++ b/tools/update_types_node.ts
@@ -350,12 +350,6 @@ function aliasWebStreamGlobals(
 
 function handleInterface(decl: InterfaceDeclaration) {
   switch (decl.getName()) {
-    case "ImportMeta": {
-      // make these align with our ImportMeta, which is optional
-      decl.getPropertyOrThrow("dirname").setHasQuestionToken(true);
-      decl.getPropertyOrThrow("filename").setHasQuestionToken(true);
-      break;
-    }
     case "Blob":
     case "ByteLengthQueuingStrategy":
     case "CompressionStream":


### PR DESCRIPTION
`@types/node` declares `ImportMeta.dirname`/`filename` as required `string`
unconditionally (not behind its conditional web-global probes), so Deno's
optional `string | undefined` declarations conflict when the two interfaces
merge in a single global scope (TS2687/TS2717). This tightens Deno's lib and
the vendored `@types/node` copy to required `string`, following upstream
DefinitelyTyped's convention of a required type with a JSDoc caveat that the
properties are only present at runtime for local (`file:`) modules. It also
drops the `update_types_node.ts` rewrite that forced the question token onto
the vendored copy, keeping it closer to upstream.

Factored out of #35642 (the TypeScript un-fork); on the un-fork branch this
single mismatch accounted for 19 of 24 check spec failures. See #35621 for
context.