### PR TITLE
fix(types): add marker globals so @types/node defers web globals to Deno's

### DIFF
--- a/cli/tsc/dts/lib.deno.window.d.ts
+++ b/cli/tsc/dts/lib.deno.window.d.ts
@@ -616,3 +616,36 @@ declare var location: Location;
  *
  * @category Platform */
 declare var name: string;
+
+// Marker globals so `@types/node` defers its web-platform globals to Deno's,
+// mirroring how it defers to `lib.dom`. `@types/node` guards each of its web
+// globals with a probe of the form
+// `typeof globalThis extends { <marker>; <Name>: infer T } ? T : <fallback>`,
+// where the markers are `onmessage` (most globals), `onabort` (`Storage`) and
+// `ReportingObserver` (`CompressionStream`/`DecompressionStream`). Declaring
+// them here makes those probes resolve to Deno's own globals. Each marker
+// itself uses the document-deferral form so it still merges cleanly when real
+// `lib.dom` is loaded. (The worker scope already declares `onmessage`; these
+// exist for the main scope and are not backed by the runtime.)
+
+/** Marker so `@types/node` defers its web-platform globals to Deno's; not
+ * backed by the runtime in the main scope.
+ *
+ * @category Platform */
+declare var onmessage: typeof globalThis extends
+  { document: any; onmessage: infer T } ? T
+  : ((this: void, ev: MessageEvent) => unknown) | null;
+/** Marker so `@types/node` defers its `Storage` global to Deno's; not backed
+ * by the runtime in the main scope.
+ *
+ * @category Platform */
+declare var onabort: typeof globalThis extends
+  { document: any; onabort: infer T } ? T
+  : ((this: void, ev: Event) => unknown) | null;
+/** Marker so `@types/node` defers its `CompressionStream` and
+ * `DecompressionStream` globals to Deno's; not backed by the runtime.
+ *
+ * @category Platform */
+declare var ReportingObserver: typeof globalThis extends
+  { document: any; ReportingObserver: infer T } ? T
+  : { readonly prototype: unknown; new (...args: any[]): unknown };

--- a/tests/specs/check/check_workspace/check_config_flag.out
+++ b/tests/specs/check/check_workspace/check_config_flag.out
@@ -1,14 +1,14 @@
 Check [WILDCARD]main.ts
 Check [WILDCARD]mod.ts
-TS2304 [ERROR]: Cannot find name 'onmessage'.
-onmessage;
-~~~~~~~~~
-    at file:///[WILDLINE]/main.ts:8:1
+TS2304 [ERROR]: Cannot find name 'postMessage'.
+postMessage;
+~~~~~~~~~~~
+    at file:///[WILDLINE]/main.ts:11:1
 
-TS2304 [ERROR]: Cannot find name 'onmessage'.
-onmessage;
-~~~~~~~~~
-    at file:///[WILDLINE]/member/mod.ts:5:1
+TS2304 [ERROR]: Cannot find name 'postMessage'.
+postMessage;
+~~~~~~~~~~~
+    at file:///[WILDLINE]/member/mod.ts:8:1
 
 Found 2 errors.
 

--- a/tests/specs/check/check_workspace/check_discover.out
+++ b/tests/specs/check/check_workspace/check_discover.out
@@ -1,14 +1,14 @@
 Check [WILDCARD]main.ts
 Check [WILDCARD]mod.ts
-TS2304 [ERROR]: Cannot find name 'onmessage'.
-onmessage;
-~~~~~~~~~
-    at file:///[WILDLINE]/main.ts:8:1
+TS2304 [ERROR]: Cannot find name 'postMessage'.
+postMessage;
+~~~~~~~~~~~
+    at file:///[WILDLINE]/main.ts:11:1
 
-TS2304 [ERROR]: Cannot find name 'onmessage'.
-onmessage;
-~~~~~~~~~
-    at file:///[WILDLINE]/member/mod.ts:5:1
+TS2304 [ERROR]: Cannot find name 'postMessage'.
+postMessage;
+~~~~~~~~~~~
+    at file:///[WILDLINE]/member/mod.ts:8:1
 
 Found 2 errors.
 

--- a/tests/specs/check/check_workspace/main.ts
+++ b/tests/specs/check/check_workspace/main.ts
@@ -4,5 +4,8 @@ import "./member/mod.ts";
 // Only defined for window.
 localStorage;
 
-// Only defined for worker.
+// Defined for worker; in window it resolves via the @types/node marker global.
 onmessage;
+
+// Only defined for worker.
+postMessage;

--- a/tests/specs/check/check_workspace/member/mod.ts
+++ b/tests/specs/check/check_workspace/member/mod.ts
@@ -1,5 +1,8 @@
 // Only defined for window.
 localStorage;
 
-// Only defined for worker.
+// Defined for worker; in window it resolves via the @types/node marker global.
 onmessage;
+
+// Only defined for worker.
+postMessage;


### PR DESCRIPTION
`@types/node` guards each of its web-platform globals with a conditional
probe (`typeof globalThis extends { <marker>; <Name>: infer T } ? T :
<fallback>`) and stands down when a DOM-like scope is detected — this is how
it coexists with `lib.dom` on stock TypeScript. The markers it probes for are
`onmessage` (most globals), `onabort` (`Storage`), and `ReportingObserver`
(`CompressionStream`/`DecompressionStream`). Deno's main scope never declared
them, so `@types/node` emitted its own conflicting copies of the web globals.

This declares the three markers in `lib.deno.window`, making stock
`@types/node` defer to Deno's web globals the same way it defers to
`lib.dom`. Each marker uses the document-deferral form so it merges cleanly
if real `lib.dom` is loaded. The `check_workspace` spec relied on `onmessage`
being window-undefined to prove per-scope lib selection; its discriminator is
switched to `postMessage` (still worker-only), keeping an `onmessage` line as
positive coverage for the marker.

Factored out of #35642 (the TypeScript un-fork). See #35621 for context.