### PR TITLE
feat(bench): richer terminal output with distribution histograms

### DIFF
--- a/cli/js/40_bench.js
+++ b/cli/js/40_bench.js
@@ -20,6 +20,7 @@ const {
   ArrayPrototypeSort,
   ArrayPrototypeSlice,
   Error,
+  MathFloor,
   MathMax,
   MathMin,
   MathCeil,
@@ -210,6 +211,28 @@ function compareMeasurements(a, b) {
   return 0;
 }
 
+// Cap on the number of raw samples we forward to Rust for rendering the
+// distribution histogram. The measurement loop can collect millions of
+// samples, so we uniformly downsample the sorted array down to this many
+// points before crossing the boundary to bound serialization cost. A few
+// hundred buckets' worth of points is far more than the ~20 bucket terminal
+// histogram needs, while still faithfully preserving the shape.
+const sampleCap = 1000;
+
+// Uniformly downsample a sorted array to at most `cap` points. Because the
+// input is already sorted, striding by a fixed step preserves the underlying
+// distribution's shape.
+function downsampleSorted(sorted, length, cap) {
+  if (length <= cap) {
+    return ArrayPrototypeSlice(sorted, 0, length);
+  }
+  const out = new Array(cap);
+  for (let i = 0; i < cap; i++) {
+    out[i] = sorted[MathFloor((i * length) / cap)];
+  }
+  return out;
+}
+
 function benchStats(
   n,
   highPrecision,
@@ -231,6 +254,7 @@ function benchStats(
     avg: !highPrecision ? (avg / n) : MathCeil(avg / n),
     highPrecision,
     usedExplicitTimers,
+    samples: downsampleSorted(all, allLength, sampleCap),
   };
 }
 

--- a/cli/tools/bench/mitata.rs
+++ b/cli/tools/bench/mitata.rs
@@ -6,10 +6,8 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use crate::colors;
-
 /// Taken from https://stackoverflow.com/a/76572321
-fn precision_f64(x: f64, decimals: u32) -> f64 {
+pub fn precision_f64(x: f64, decimals: u32) -> f64 {
   if x == 0. || decimals == 0 {
     0.
   } else {
@@ -20,7 +18,7 @@ fn precision_f64(x: f64, decimals: u32) -> f64 {
   }
 }
 
-fn avg_to_iter_per_s(time: f64) -> String {
+pub fn avg_to_iter_per_s(time: f64) -> String {
   let iter_per_s = precision_f64(1e9 / time, 4);
   let (decimals, fractional) = into_decimal_and_fractional_parts(iter_per_s);
   human_readable_decimal_with_fractional(decimals, fractional)
@@ -157,207 +155,6 @@ pub mod cpu {
     }
 
     String::from("unknown")
-  }
-}
-
-pub mod reporter {
-  use super::*;
-
-  #[derive(Clone, PartialEq)]
-  pub struct Error {
-    pub message: String,
-    pub stack: Option<String>,
-  }
-
-  #[derive(Clone, PartialEq)]
-  pub struct BenchmarkStats {
-    pub avg: f64,
-    pub min: f64,
-    pub max: f64,
-    pub p75: f64,
-    pub p99: f64,
-    pub p995: f64,
-  }
-
-  #[derive(Clone, PartialEq)]
-  pub struct GroupBenchmark {
-    pub name: String,
-    pub group: String,
-    pub baseline: bool,
-    pub stats: BenchmarkStats,
-  }
-
-  #[derive(Clone, PartialEq)]
-  pub struct Options {
-    size: usize,
-    pub avg: bool,
-    pub min_max: bool,
-    pub percentiles: bool,
-  }
-
-  impl Options {
-    pub fn new(names: &[&str]) -> Options {
-      Options {
-        avg: true,
-        min_max: true,
-        size: size(names),
-        percentiles: true,
-      }
-    }
-  }
-
-  pub fn size(names: &[&str]) -> usize {
-    let mut max = 9;
-
-    for name in names {
-      if max < name.len() {
-        max = name.len();
-      }
-    }
-
-    2 + max
-  }
-
-  pub fn br(options: &Options) -> String {
-    let mut s = String::new();
-
-    s.push_str(&format!("| {} |", "-".repeat(options.size)));
-
-    if options.avg {
-      s.push_str(&format!(" {} | {} |", "-".repeat(15), "-".repeat(13)));
-    }
-    if options.min_max {
-      s.push_str(&format!(" {} |", "-".repeat(21)));
-    }
-    if options.percentiles {
-      s.push_str(&format!(
-        " {} | {} | {} |",
-        "-".repeat(8),
-        "-".repeat(8),
-        "-".repeat(8)
-      ));
-    }
-
-    s
-  }
-
-  pub fn benchmark_error(n: &str, e: &Error, options: &Options) -> String {
-    let size = options.size;
-    let mut s = String::new();
-
-    s.push_str(&format!("{:<size$}", n));
-    s.push_str(&format!(" {}: {}", colors::red("error"), e.message));
-
-    if let Some(ref stack) = e.stack {
-      s.push('\n');
-
-      s.push_str(&colors::gray(stack).to_string());
-    }
-
-    s
-  }
-
-  pub fn header(options: &Options) -> String {
-    let size = options.size;
-    let mut s = String::new();
-
-    s.push_str(&format!("| {:<size$} |", "benchmark"));
-    if options.avg {
-      s.push_str(&format!(" {:<15} |", "time/iter (avg)"));
-      s.push_str(&format!(" {:>13} |", "iter/s"));
-    }
-    if options.min_max {
-      s.push_str(&format!(" {:^21} |", "(min … max)"));
-    }
-    if options.percentiles {
-      s.push_str(&format!(" {:>8} | {:>8} | {:>8} |", "p75", "p99", "p995"));
-    }
-
-    s
-  }
-
-  pub fn benchmark(
-    name: &str,
-    stats: &BenchmarkStats,
-    options: &Options,
-  ) -> String {
-    let size = options.size;
-    let mut s = String::new();
-
-    s.push_str(&format!("| {:<size$} |", name));
-
-    if options.avg {
-      s.push_str(&format!(
-        " {} |",
-        colors::yellow(&format!("{:>15}", fmt_duration(stats.avg)))
-      ));
-      s.push_str(&format!(" {:>13} |", &avg_to_iter_per_s(stats.avg)));
-    }
-    if options.min_max {
-      s.push_str(&format!(
-        " ({} … {}) |",
-        colors::cyan(format!("{:>8}", fmt_duration(stats.min))),
-        colors::magenta(format!("{:>8}", fmt_duration(stats.max)))
-      ));
-    }
-    if options.percentiles {
-      s.push_str(
-        &colors::magenta(format!(
-          " {:>8} | {:>8} | {:>8} |",
-          fmt_duration(stats.p75),
-          fmt_duration(stats.p99),
-          fmt_duration(stats.p995)
-        ))
-        .to_string(),
-      );
-    }
-
-    s
-  }
-
-  pub fn summary(benchmarks: &[GroupBenchmark]) -> String {
-    let mut s = String::new();
-    let mut benchmarks = benchmarks.to_owned();
-    benchmarks.sort_by(|a, b| a.stats.avg.partial_cmp(&b.stats.avg).unwrap());
-    let baseline = benchmarks
-      .iter()
-      .find(|b| b.baseline)
-      .unwrap_or(&benchmarks[0]);
-
-    s.push_str(&format!(
-      "{}\n  {}",
-      colors::gray("summary"),
-      colors::cyan_bold(&baseline.name)
-    ));
-
-    for b in benchmarks.iter().filter(|b| *b != baseline) {
-      let faster = b.stats.avg >= baseline.stats.avg;
-      let x_faster = precision_f64(
-        if faster {
-          b.stats.avg / baseline.stats.avg
-        } else {
-          baseline.stats.avg / b.stats.avg
-        },
-        4,
-      );
-      let diff = if x_faster > 1000. {
-        &format!("{:>9.0}", x_faster)
-      } else {
-        &format!("{:>9.2}", x_faster)
-      };
-      s.push_str(&format!(
-        "\n{}x {} than {}",
-        if faster {
-          colors::green(diff)
-        } else {
-          colors::red(diff)
-        },
-        if faster { "faster" } else { "slower" },
-        colors::cyan_bold(&b.name)
-      ));
-    }
-
-    s
   }
 }
 

--- a/cli/tools/bench/mod.rs
+++ b/cli/tools/bench/mod.rs
@@ -56,6 +56,7 @@ use crate::worker::CliMainWorkerFactory;
 use crate::worker::CreateCustomWorkerError;
 
 mod mitata;
+mod render;
 mod reporters;
 
 use reporters::BenchReporter;
@@ -129,6 +130,12 @@ pub struct BenchStats {
   pub p999: f64,
   pub high_precision: bool,
   pub used_explicit_timers: bool,
+  // Raw per-iteration timings, sorted ascending and uniformly downsampled on
+  // the JS side (see `sampleCap` in 40_bench.js). Used to render the terminal
+  // distribution histogram. Skipped from `--json` output so the serialized
+  // shape stays compact.
+  #[serde(default, skip_serializing)]
+  pub samples: Vec<f64>,
 }
 
 impl BenchReport {

--- a/cli/tools/bench/render.rs
+++ b/cli/tools/bench/render.rs
@@ -1,0 +1,363 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Console rendering for `deno bench`.
+//!
+//! Each benchmark occupies a compact three-line block: the summary numbers
+//! (avg, min/max range, iter/s and a couple of percentiles) on the left, and a
+//! small vertical histogram of the sample distribution on the right. The
+//! histogram is drawn across all three lines so it has real height rather than
+//! being a flat sparkline, and its bins are clamped to the 99th percentile so a
+//! lone slow outlier doesn't squash the shape into the first bar. Bars are
+//! tinted by where they fall relative to the mean: faster-than-average cyan,
+//! the mean bucket yellow, slower-than-average magenta.
+//!
+//! Groups additionally get a horizontal barplot comparing average times before
+//! the textual "summary" block.
+
+use super::BenchStats;
+use super::mitata;
+use crate::colors;
+
+// Fixed column widths (in characters). The name column grows to fit the
+// longest benchmark name; everything to its right is fixed so the numbers line
+// up across benchmarks and across groups within a file.
+const NAME_MIN: usize = 9;
+// Wide column holding, across the three lines: avg, "(min ... max)", iter/s.
+// Sized so "(999.9 ms ... 999.9 ms)" fits exactly.
+const MAIN_W: usize = 21;
+// Narrow column holding p75 (line 1) and p99 (line 2).
+const SUB_W: usize = 9;
+// Histogram width in buckets and height in text rows.
+const HIST_W: usize = 22;
+const HIST_H: usize = 3;
+const GAP: &str = "  ";
+
+// Eight levels of vertical block glyphs (U+2581 ..= U+2588), written as escapes
+// so the source stays ASCII.
+const BLOCKS: [char; 8] = [
+  '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}',
+  '\u{2587}', '\u{2588}',
+];
+
+// Seven horizontal partial blocks (U+258F 1/8 .. U+2589 7/8) used for the
+// barplot; a full bar cell is U+2588.
+const HBLOCKS: [char; 7] = [
+  '\u{258F}', '\u{258E}', '\u{258D}', '\u{258C}', '\u{258B}', '\u{258A}',
+  '\u{2589}',
+];
+
+// U+2026 HORIZONTAL ELLIPSIS.
+const ELLIPSIS: &str = "\u{2026}";
+
+/// Width of the benchmark-name column for a set of names.
+pub fn name_width(names: &[&str]) -> usize {
+  let mut width = NAME_MIN;
+  for name in names {
+    width = width.max(name.chars().count());
+  }
+  width
+}
+
+/// The column header row.
+pub fn header(name_width: usize) -> String {
+  format!(
+    "{:<nw$}{GAP}{:>MAIN_W$}{GAP}{:>SUB_W$}{GAP}{}",
+    "benchmark",
+    format!("avg (min {ELLIPSIS} max)"),
+    "p75 / p99",
+    "distribution",
+    nw = name_width,
+  )
+}
+
+/// The dashed rule drawn under the header.
+pub fn separator(name_width: usize) -> String {
+  let width =
+    name_width + GAP.len() + MAIN_W + GAP.len() + SUB_W + GAP.len() + HIST_W;
+  "-".repeat(width)
+}
+
+/// A single successful benchmark result: a three-line block.
+pub fn benchmark(name: &str, stats: &BenchStats, name_width: usize) -> String {
+  let rows = histogram(stats);
+
+  let avg =
+    colors::yellow(format!("{:>MAIN_W$}", mitata::fmt_duration(stats.avg)));
+  let range = padded_range(stats.min, stats.max);
+  let iters =
+    colors::gray(format!("{:>MAIN_W$}", mitata::avg_to_iter_per_s(stats.avg)));
+  let p75 =
+    colors::gray(format!("{:>SUB_W$}", mitata::fmt_duration(stats.p75)));
+  let p99 =
+    colors::gray(format!("{:>SUB_W$}", mitata::fmt_duration(stats.p99)));
+  let blank_sub = " ".repeat(SUB_W);
+
+  let line1 = format!(
+    "{name:<nw$}{GAP}{avg}{GAP}{p75}{GAP}{}",
+    rows[0],
+    nw = name_width,
+  );
+  let line2 = format!(
+    "{:<nw$}{GAP}{range}{GAP}{p99}{GAP}{}",
+    "",
+    rows[1],
+    nw = name_width,
+  );
+  let line3 = format!(
+    "{:<nw$}{GAP}{iters}{GAP}{blank_sub}{GAP}{}",
+    "",
+    rows[2],
+    nw = name_width,
+  );
+
+  // Empty histogram buckets render as spaces; trim so we never emit trailing
+  // whitespace on any line.
+  [line1, line2, line3]
+    .iter()
+    .map(|l| l.trim_end())
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+/// A single failed benchmark result row.
+pub fn benchmark_error(name: &str, message: &str, name_width: usize) -> String {
+  format!(
+    "{name:<nw$} {}: {message}",
+    colors::red("error"),
+    nw = name_width,
+  )
+}
+
+/// Build the right-aligned "(min ... max)" cell with min tinted cyan and max
+/// magenta. Padding is computed on the plain text so color escapes don't throw
+/// off the alignment.
+fn padded_range(min: f64, max: f64) -> String {
+  let min = mitata::fmt_duration(min);
+  let max = mitata::fmt_duration(max);
+  // Width in characters: "(" min " <ellipsis> " max ")".
+  let plain_len = 1 + min.chars().count() + 3 + max.chars().count() + 1;
+  let pad = MAIN_W.saturating_sub(plain_len);
+  format!(
+    "{}({} {ELLIPSIS} {})",
+    " ".repeat(pad),
+    colors::cyan(min),
+    colors::magenta(max),
+  )
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Region {
+  Fast,
+  Mean,
+  Slow,
+}
+
+struct Bins {
+  bins: [u64; HIST_W],
+  peak: u64,
+  mean_bucket: usize,
+}
+
+/// Bin the samples into `HIST_W` buckets spanning min .. p99, so outliers past
+/// the 99th percentile don't dominate the range. Returns `None` when there
+/// isn't a usable spread to draw.
+fn compute_bins(samples: &[f64], avg: f64) -> Option<Bins> {
+  let n = samples.len();
+  if n < 2 {
+    return None;
+  }
+  // samples arrive sorted ascending from the JS side.
+  let offset = ((0.99 * (n as f64 - 1.0)) as usize).min(n - 1);
+  let min = samples[0];
+  let max = samples[offset];
+  let step = (max - min) / (HIST_W as f64 - 1.0);
+  if step <= 0.0 {
+    return None;
+  }
+
+  let mut bins = [0u64; HIST_W];
+  for &v in &samples[..=offset] {
+    let idx = (((v - min) / step).round() as isize)
+      .clamp(0, HIST_W as isize - 1) as usize;
+    bins[idx] += 1;
+  }
+  let peak = bins.iter().copied().max().unwrap_or(0);
+  if peak == 0 {
+    return None;
+  }
+  let mean_bucket = (((avg - min) / step).round() as isize)
+    .clamp(0, HIST_W as isize - 1) as usize;
+
+  Some(Bins {
+    bins,
+    peak,
+    mean_bucket,
+  })
+}
+
+/// Render the distribution as `HIST_H` stacked, colored rows (top to bottom).
+fn histogram(stats: &BenchStats) -> Vec<String> {
+  let Some(b) = compute_bins(&stats.samples, stats.avg) else {
+    return vec![String::new(); HIST_H];
+  };
+
+  // Total fill height of each bucket, in eighths of a cell across all rows.
+  let full_scale = (HIST_H * BLOCKS.len()) as f64;
+  let region_of = |bucket: usize| {
+    if bucket < b.mean_bucket {
+      Region::Fast
+    } else if bucket == b.mean_bucket {
+      Region::Mean
+    } else {
+      Region::Slow
+    }
+  };
+
+  let mut rows = Vec::with_capacity(HIST_H);
+  // Draw from the top row down so the tallest bars read naturally.
+  for row in (0..HIST_H).rev() {
+    let mut cells: [(char, Region); HIST_W] = [(' ', Region::Mean); HIST_W];
+    for (bucket, &count) in b.bins.iter().enumerate() {
+      let eighths =
+        ((count as f64 / b.peak as f64) * full_scale).round() as i64;
+      let portion = (eighths - (row as i64) * 8).clamp(0, 8);
+      let ch = if portion == 0 {
+        ' '
+      } else {
+        BLOCKS[(portion - 1) as usize]
+      };
+      cells[bucket] = (ch, region_of(bucket));
+    }
+    rows.push(colorize_cells(&cells));
+  }
+  rows
+}
+
+/// Coalesce adjacent cells sharing a tint into a single color span (spaces stay
+/// uncolored) so we emit one escape per run rather than one per character.
+fn colorize_cells(cells: &[(char, Region)]) -> String {
+  let mut out = String::new();
+  let mut i = 0;
+  while i < cells.len() {
+    // A space carries no tint; treat runs of spaces separately.
+    if cells[i].0 == ' ' {
+      let start = i;
+      while i < cells.len() && cells[i].0 == ' ' {
+        i += 1;
+      }
+      out.push_str(&" ".repeat(i - start));
+      continue;
+    }
+    let region = cells[i].1;
+    let mut run = String::new();
+    while i < cells.len() && cells[i].0 != ' ' && cells[i].1 == region {
+      run.push(cells[i].0);
+      i += 1;
+    }
+    match region {
+      Region::Fast => out.push_str(&colors::cyan(run).to_string()),
+      Region::Mean => out.push_str(&colors::yellow(run).to_string()),
+      Region::Slow => out.push_str(&colors::magenta(run).to_string()),
+    }
+  }
+  out
+}
+
+/// One benchmark's identity within a group summary.
+pub struct SummaryEntry<'a> {
+  pub name: &'a str,
+  pub baseline: bool,
+  pub avg: f64,
+}
+
+/// A horizontal barplot of average times, one bar per benchmark, scaled so the
+/// slowest fills the axis.
+pub fn barplot(entries: &[SummaryEntry]) -> String {
+  const BAR_W: usize = 42;
+  let name_w = entries
+    .iter()
+    .map(|e| e.name.chars().count())
+    .max()
+    .unwrap_or(0);
+  let max_avg = entries.iter().map(|e| e.avg).fold(0.0_f64, f64::max);
+
+  let mut lines = Vec::with_capacity(entries.len());
+  for e in entries {
+    let frac = if max_avg > 0.0 { e.avg / max_avg } else { 0.0 };
+    lines.push(format!(
+      "  {:>name_w$} {} {} {}",
+      e.name,
+      colors::gray("\u{2524}"),
+      colors::cyan(hbar(frac, BAR_W)),
+      colors::gray(mitata::fmt_duration(e.avg)),
+    ));
+  }
+  lines.join("\n")
+}
+
+/// A single horizontal bar filled to `frac` of `width` cells, using partial
+/// block glyphs for sub-cell resolution.
+fn hbar(frac: f64, width: usize) -> String {
+  let eighths = (frac * width as f64 * 8.0).round() as usize;
+  let full = eighths / 8;
+  let rem = eighths % 8;
+  let mut s = "\u{2588}".repeat(full);
+  if rem > 0 {
+    s.push(HBLOCKS[rem - 1]);
+  }
+  s
+}
+
+/// The "summary" block comparing every benchmark in a group against a baseline
+/// (the explicitly-marked one, or the fastest when none is marked).
+pub fn summary(entries: &[SummaryEntry]) -> String {
+  // Order fastest-first.
+  let mut order: Vec<usize> = (0..entries.len()).collect();
+  order.sort_by(|&a, &b| entries[a].avg.partial_cmp(&entries[b].avg).unwrap());
+
+  let baseline = order
+    .iter()
+    .copied()
+    .find(|&i| entries[i].baseline)
+    .unwrap_or(order[0]);
+  let base_avg = entries[baseline].avg;
+
+  let mut s = format!(
+    "{}\n  {}",
+    colors::gray("summary"),
+    colors::cyan_bold(entries[baseline].name),
+  );
+
+  for &i in &order {
+    if i == baseline {
+      continue;
+    }
+    let avg = entries[i].avg;
+    let faster = avg >= base_avg;
+    let ratio = mitata::precision_f64(
+      if faster {
+        avg / base_avg
+      } else {
+        base_avg / avg
+      },
+      4,
+    );
+    let ratio = if ratio > 1000.0 {
+      format!("{ratio:>9.0}")
+    } else {
+      format!("{ratio:>9.2}")
+    };
+    s.push_str(&format!(
+      "\n{}x {} than {}",
+      if faster {
+        colors::green(ratio)
+      } else {
+        colors::red(ratio)
+      },
+      if faster { "faster" } else { "slower" },
+      colors::cyan_bold(entries[i].name),
+    ));
+  }
+
+  s
+}

--- a/cli/tools/bench/reporters.rs
+++ b/cli/tools/bench/reporters.rs
@@ -109,7 +109,9 @@ pub struct ConsoleReporter {
   group: Option<String>,
   baseline: bool,
   group_measurements: Vec<(BenchDescription, BenchStats)>,
-  options: Option<mitata::reporter::Options>,
+  // Width of the benchmark-name column for the current file, or `None` before
+  // the first plan has been reported.
+  name_width: Option<usize>,
 }
 
 impl ConsoleReporter {
@@ -117,7 +119,7 @@ impl ConsoleReporter {
     Self {
       show_output,
       group: None,
-      options: None,
+      name_width: None,
       baseline: false,
       name: String::new(),
       group_measurements: Vec::new(),
@@ -139,13 +141,9 @@ impl BenchReporter for ConsoleReporter {
     self.baseline = false;
     self.name = String::new();
     self.group_measurements.clear();
-    self.options = Some(mitata::reporter::Options::new(
+    self.name_width = Some(render::name_width(
       &plan.names.iter().map(|x| x.as_str()).collect::<Vec<&str>>(),
     ));
-
-    let options = self.options.as_mut().unwrap();
-
-    options.percentiles = true;
 
     if FIRST_PLAN
       .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
@@ -167,11 +165,12 @@ impl BenchReporter for ConsoleReporter {
       println!();
     }
 
+    let name_width = self.name_width.unwrap();
     println!(
       "{}\n\n{}\n{}",
       colors::gray(&plan.origin),
-      mitata::reporter::header(options),
-      mitata::reporter::br(options)
+      render::header(name_width),
+      render::separator(name_width)
     );
   }
 
@@ -205,7 +204,7 @@ impl BenchReporter for ConsoleReporter {
       return;
     }
 
-    let options = self.options.as_ref().unwrap();
+    let name_width = self.name_width.unwrap();
     match result {
       BenchResult::Ok(stats) => {
         let mut desc = desc.clone();
@@ -216,21 +215,9 @@ impl BenchReporter for ConsoleReporter {
           desc.baseline = false;
         }
 
-        println!(
-          "{}",
-          mitata::reporter::benchmark(
-            &desc.name,
-            &mitata::reporter::BenchmarkStats {
-              avg: stats.avg,
-              min: stats.min,
-              max: stats.max,
-              p75: stats.p75,
-              p99: stats.p99,
-              p995: stats.p995,
-            },
-            options
-          )
-        );
+        // A benchmark is a three-line block; a blank line separates it from
+        // the next so the taller layout stays readable.
+        println!("{}\n", render::benchmark(&desc.name, stats, name_width));
 
         if !stats.high_precision && stats.used_explicit_timers {
           println!(
@@ -248,16 +235,10 @@ impl BenchReporter for ConsoleReporter {
       BenchResult::Failed(js_error) => {
         println!(
           "{}",
-          mitata::reporter::benchmark_error(
+          render::benchmark_error(
             &desc.name,
-            &mitata::reporter::Error {
-              stack: None,
-              message: format_test_error(
-                js_error,
-                &TestFailureFormatOptions::default()
-              ),
-            },
-            options
+            &format_test_error(js_error, &TestFailureFormatOptions::default()),
+            name_width,
           )
         )
       }
@@ -265,36 +246,24 @@ impl BenchReporter for ConsoleReporter {
   }
 
   fn report_group_summary(&mut self) {
-    if self.options.is_none() {
+    if self.name_width.is_none() {
       return;
     }
 
     if 2 <= self.group_measurements.len()
       && (self.group.is_some() || (self.group.is_none() && self.baseline))
     {
-      println!(
-        "\n{}",
-        mitata::reporter::summary(
-          &self
-            .group_measurements
-            .iter()
-            .map(|(d, s)| mitata::reporter::GroupBenchmark {
-              name: d.name.clone(),
-              baseline: d.baseline,
-              group: d.group.as_deref().unwrap_or("").to_owned(),
-
-              stats: mitata::reporter::BenchmarkStats {
-                avg: s.avg,
-                min: s.min,
-                max: s.max,
-                p75: s.p75,
-                p99: s.p99,
-                p995: s.p995,
-              },
-            })
-            .collect::<Vec<mitata::reporter::GroupBenchmark>>(),
-        )
-      );
+      let entries = self
+        .group_measurements
+        .iter()
+        .map(|(d, s)| render::SummaryEntry {
+          name: &d.name,
+          baseline: d.baseline,
+          avg: s.avg,
+        })
+        .collect::<Vec<render::SummaryEntry>>();
+      println!("{}\n", render::barplot(&entries));
+      println!("{}", render::summary(&entries));
     }
     println!();
 

--- a/tests/specs/bench/allow_all/allow_all.out
+++ b/tests/specs/bench/allow_all/allow_all.out
@@ -5,18 +5,29 @@ Runtime | Deno [WILDLINE] ([WILDLINE])
 
 [WILDLINE]/allow_all.ts
 
-| benchmark     | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ------------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| read false    | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| read true     | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| write false   | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| write true    | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| net false     | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| net true      | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| env false     | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| env true      | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| run false     | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| run true      | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| ffi false     | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| ffi true      | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+read false[WILDLINE]
+[WILDCARD]
+read true[WILDLINE]
+[WILDCARD]
+write false[WILDLINE]
+[WILDCARD]
+write true[WILDLINE]
+[WILDCARD]
+net false[WILDLINE]
+[WILDCARD]
+net true[WILDLINE]
+[WILDCARD]
+env false[WILDLINE]
+[WILDCARD]
+env true[WILDLINE]
+[WILDCARD]
+run false[WILDLINE]
+[WILDCARD]
+run true[WILDLINE]
+[WILDCARD]
+ffi false[WILDLINE]
+[WILDCARD]
+ffi true[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/allow_none/allow_none.out
+++ b/tests/specs/bench/allow_none/allow_none.out
@@ -4,18 +4,18 @@ Runtime | Deno [WILDLINE] ([WILDLINE])
 
 [WILDLINE]/allow_none.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-read        error: NotCapable: Can't escalate parent thread permissions
+benchmark[WILDLINE]
+[WILDLINE]
+read      error: NotCapable: Can't escalate parent thread permissions
 [WILDCARD]
-write       error: NotCapable: Can't escalate parent thread permissions
+write     error: NotCapable: Can't escalate parent thread permissions
 [WILDCARD]
-net         error: NotCapable: Can't escalate parent thread permissions
+net       error: NotCapable: Can't escalate parent thread permissions
 [WILDCARD]
-env         error: NotCapable: Can't escalate parent thread permissions
+env       error: NotCapable: Can't escalate parent thread permissions
 [WILDCARD]
-run         error: NotCapable: Can't escalate parent thread permissions
+run       error: NotCapable: Can't escalate parent thread permissions
 [WILDCARD]
-ffi         error: NotCapable: Can't escalate parent thread permissions
+ffi       error: NotCapable: Can't escalate parent thread permissions
 [WILDCARD]
 error: Bench failed

--- a/tests/specs/bench/before_unload_prevent_default/before_unload_prevent_default.out
+++ b/tests/specs/bench/before_unload_prevent_default/before_unload_prevent_default.out
@@ -3,7 +3,7 @@ Runtime | Deno [WILDCARD]
 
 [WILDCARD]/before_unload_prevent_default.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| foo         | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+foo[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/bench_explicit_start_end/explicit_start_and_end.out
+++ b/tests/specs/bench/bench_explicit_start_end/explicit_start_and_end.out
@@ -3,20 +3,20 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/explicit_start_and_end.ts
 
-| benchmark       | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| --------------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 [WILDCARD]
-double start    error: TypeError: BenchContext::start() has already been invoked
+double start  error: TypeError: BenchContext::start() has already been invoked
   t.start();
     ^
     at BenchContext.start ([WILDCARD])
     at [WILDCARD]/explicit_start_and_end.ts:[WILDCARD]
-double end      error: TypeError: BenchContext::end() has already been invoked
+double end    error: TypeError: BenchContext::end() has already been invoked
   t.end();
     ^
     at BenchContext.end ([WILDCARD])
     at [WILDCARD]/explicit_start_and_end.ts:[WILDCARD]
-captured        error: TypeError: The benchmark which this context belongs to is not being executed
+captured      error: TypeError: The benchmark which this context belongs to is not being executed
   captured!.start();
             ^
     at BenchContext.start ([WILDCARD])

--- a/tests/specs/bench/bench_formatting/bench_formatting.out
+++ b/tests/specs/bench/bench_formatting/bench_formatting.out
@@ -4,7 +4,7 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/bench_formatting.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| [WILDLINE] | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+[WILDLINE][WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/check_local_by_default/check_local_by_default.out
+++ b/tests/specs/bench/check_local_by_default/check_local_by_default.out
@@ -1,7 +1,6 @@
 [WILDCARD]
-
 [WILDCARD]/check_local_by_default.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 

--- a/tests/specs/bench/clear_timeout/clear_timeout.out
+++ b/tests/specs/bench/clear_timeout/clear_timeout.out
@@ -4,9 +4,11 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/clear_timeout.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| bench1      | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| bench2      | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-| bench3      | [WILDLINE] | [WILDLINE] | ([WILDLINE] … [WILDLINE]) | [WILDLINE] | [WILDLINE] | [WILDLINE] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+bench1[WILDLINE]
+[WILDCARD]
+bench2[WILDLINE]
+[WILDCARD]
+bench3[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/collect/collect.out
+++ b/tests/specs/bench/collect/collect.out
@@ -6,16 +6,16 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/collect/bench.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 
 [WILDCARD]/collect/include/2_bench.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 
 [WILDCARD]/collect/include/bench.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 

--- a/tests/specs/bench/collect/collect2.out
+++ b/tests/specs/bench/collect/collect2.out
@@ -5,11 +5,11 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/collect/bench.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 
 [WILDCARD]/collect/include/bench.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 

--- a/tests/specs/bench/config_permissions/empty/pass.out
+++ b/tests/specs/bench/config_permissions/empty/pass.out
@@ -4,7 +4,7 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/main.ts
 
-| benchmark                 | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ------------------------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| empty permissions bench   | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+empty permissions bench[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/default_ts/ext.out
+++ b/tests/specs/bench/default_ts/ext.out
@@ -1,5 +1,4 @@
 Check [WILDCARD]as_ts.js
 [WILDCARD]
-
 file:///[WILDCARD]/as_ts.js
 [WILDCARD]

--- a/tests/specs/bench/default_ts/extensionless.out
+++ b/tests/specs/bench/default_ts/extensionless.out
@@ -1,5 +1,4 @@
 Check [WILDCARD]extensionless
 [WILDCARD]
-
 file:///[WILDCARD]/extensionless
 [WILDCARD]

--- a/tests/specs/bench/exit_sanitizer/exit_sanitizer.out
+++ b/tests/specs/bench/exit_sanitizer/exit_sanitizer.out
@@ -4,12 +4,12 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/exit_sanitizer.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-exit(0)     error: Error: Bench attempted to exit with exit code: 0
+benchmark[WILDLINE]
+[WILDLINE]
+exit(0)   error: Error: Bench attempted to exit with exit code: 0
 [WILDCARD]
-exit(1)     error: Error: Bench attempted to exit with exit code: 1
+exit(1)   error: Error: Bench attempted to exit with exit code: 1
 [WILDCARD]
-exit(2)     error: Error: Bench attempted to exit with exit code: 2
+exit(2)   error: Error: Bench attempted to exit with exit code: 2
 [WILDCARD]
 error: Bench failed

--- a/tests/specs/bench/explicit_start_and_end_low_precision/main.bench.out
+++ b/tests/specs/bench/explicit_start_and_end_low_precision/main.bench.out
@@ -3,9 +3,10 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/main.bench.ts
 
-| benchmark                 | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ------------------------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| noop with start and end   | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
+benchmark[WILDLINE]
+[WILDLINE]
+noop with start and end[WILDLINE]
+[WILDCARD]
 Warning: start() and end() calls in "noop with start and end" are ignored because it averages less
 than 10µs per iteration. Remove them for better results.
 

--- a/tests/specs/bench/fail/fail.out
+++ b/tests/specs/bench/fail/fail.out
@@ -4,26 +4,26 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/fail.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-bench0      error: Error
+benchmark[WILDLINE]
+[WILDLINE]
+bench0    error: Error
 [WILDCARD]
-bench1      error: Error
+bench1    error: Error
 [WILDCARD]
-bench2      error: Error
+bench2    error: Error
 [WILDCARD]
-bench3      error: Error
+bench3    error: Error
 [WILDCARD]
-bench4      error: Error
+bench4    error: Error
 [WILDCARD]
-bench5      error: Error
+bench5    error: Error
 [WILDCARD]
-bench6      error: Error
+bench6    error: Error
 [WILDCARD]
-bench7      error: Error
+bench7    error: Error
 [WILDCARD]
-bench8      error: Error
+bench8    error: Error
 [WILDCARD]
-bench9      error: Error
+bench9    error: Error
 [WILDCARD]
 error: Bench failed

--- a/tests/specs/bench/file_protocol/file_protocol.out
+++ b/tests/specs/bench/file_protocol/file_protocol.out
@@ -4,7 +4,7 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/file_protocol.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| bench0      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+bench0[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/filter/filter.out
+++ b/tests/specs/bench/filter/filter.out
@@ -6,19 +6,19 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/bench/filter/a_bench.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| foo         | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+foo[WILDLINE]
+[WILDCARD]
 [WILDCARD]/bench/filter/b_bench.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| foo         | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+foo[WILDLINE]
+[WILDCARD]
 [WILDCARD]/bench/filter/c_bench.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| foo         | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+foo[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/filter_group_header/main.out
+++ b/tests/specs/bench/filter_group_header/main.out
@@ -3,12 +3,12 @@ Check [WILDCARD]
 Runtime | [WILDCARD]
 
 [WILDCARD]
-
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 
 group G1
-| G1-B        | [WILDCARD]
-
+G1-B[WILDLINE]
+[WILDCARD]
 group G2
-| G2-B        | [WILDCARD]
+G2-B[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/finally_timeout/finally_timeout.out
+++ b/tests/specs/bench/finally_timeout/finally_timeout.out
@@ -4,10 +4,10 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/finally_timeout.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-error       error: Error: fail
+benchmark[WILDLINE]
+[WILDLINE]
+error     error: Error: fail
 [WILDCARD]
-| success     | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+success[WILDLINE]
+[WILDCARD]
 error: Bench failed

--- a/tests/specs/bench/group_baseline/group_baseline.out
+++ b/tests/specs/bench/group_baseline/group_baseline.out
@@ -1,19 +1,22 @@
 [WILDCARD]/group_baseline.ts
 
-| benchmark        | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ---------------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| noop             | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| noop2            | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+noop[WILDLINE]
+[WILDCARD]
+noop2[WILDLINE]
+[WILDCARD]
 summary
   noo[WILDCARD]
    [WILDCARD]x [WILDCARD] than noo[WILDCARD]
 
 group url
-| noop3            | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| parse url 2x     | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| parse url 200x   | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+noop3[WILDLINE]
+[WILDCARD]
+parse url 2x[WILDLINE]
+[WILDCARD]
+parse url 200x[WILDLINE]
+[WILDCARD]
 summary
   parse url 2x
    [WILDCARD]x slower than noop3

--- a/tests/specs/bench/ignore/ignore.out
+++ b/tests/specs/bench/ignore/ignore.out
@@ -4,6 +4,6 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/ignore.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 

--- a/tests/specs/bench/ignore_permissions/ignore_permissions.out
+++ b/tests/specs/bench/ignore_permissions/ignore_permissions.out
@@ -4,6 +4,6 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/ignore_permissions.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 

--- a/tests/specs/bench/interval/interval.out
+++ b/tests/specs/bench/interval/interval.out
@@ -4,6 +4,6 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/interval.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 

--- a/tests/specs/bench/iterations/bench.out
+++ b/tests/specs/bench/iterations/bench.out
@@ -4,9 +4,11 @@ Runtime | [WILDLINE]
 
 file:///[WILDLINE]main.bench.ts
 
-| benchmark                     | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------------------------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| above 10,000,000 iterations   | [WILDLINE]
-| below 10,000,000 iterations   | [WILDLINE]
-| negative iterations           | [WILDLINE]
-
+benchmark[WILDLINE]
+[WILDLINE]
+above 10,000,000 iterations[WILDLINE]
+[WILDCARD]
+below 10,000,000 iterations[WILDLINE]
+[WILDCARD]
+negative iterations[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/load_unload/load_unload.out
+++ b/tests/specs/bench/load_unload/load_unload.out
@@ -4,7 +4,7 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/load_unload.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| bench       | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+bench[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/meta/meta.out
+++ b/tests/specs/bench/meta/meta.out
@@ -6,6 +6,6 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/meta.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 

--- a/tests/specs/bench/multifile_summary/multifile_summary.out
+++ b/tests/specs/bench/multifile_summary/multifile_summary.out
@@ -6,20 +6,23 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/group_baseline.ts
 
-| benchmark        | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ---------------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| noop             | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| noop2            | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+noop[WILDLINE]
+[WILDCARD]
+noop2[WILDLINE]
+[WILDCARD]
 summary
   noo[WILDCARD]
    [WILDCARD]x [WILDCARD] than noo[WILDCARD]
 
 group url
-| noop3            | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| parse url 2x     | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| parse url 200x   | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+noop3[WILDLINE]
+[WILDCARD]
+parse url 2x[WILDLINE]
+[WILDCARD]
+parse url 200x[WILDLINE]
+[WILDCARD]
 summary
   parse url 2x
    [WILDLINE]x slower than noop3
@@ -28,38 +31,48 @@ summary
 
 [WILDLINE]/pass.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| bench0      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench1      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench2      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench3      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench4      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench5      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench6      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench7      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench8      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench9      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
+benchmark[WILDLINE]
+[WILDLINE]
+bench0[WILDLINE]
+[WILDCARD]
+bench1[WILDLINE]
+[WILDCARD]
+bench2[WILDLINE]
+[WILDCARD]
+bench3[WILDLINE]
+[WILDCARD]
+bench4[WILDLINE]
+[WILDCARD]
+bench5[WILDLINE]
+[WILDCARD]
+bench6[WILDLINE]
+[WILDCARD]
+bench7[WILDLINE]
+[WILDCARD]
+bench8[WILDLINE]
+[WILDCARD]
+bench9[WILDLINE]
+[WILDCARD]/multiple_group.ts
 
-
-[WILDLINE]/multiple_group.ts
-
-| benchmark        | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ---------------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
+benchmark[WILDLINE]
+[WILDLINE]
 
 group noop
-| noop             | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| noop2            | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+noop[WILDLINE]
+[WILDCARD]
+noop2[WILDLINE]
+[WILDCARD]
 summary
   noo[WILDCARD]
    [WILDCARD]x [WILDCARD] than noo[WILDCARD]
 
 group url
-| noop3            | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| parse url 2x     | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| parse url 200x   | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+noop3[WILDLINE]
+[WILDCARD]
+parse url 2x[WILDLINE]
+[WILDCARD]
+parse url 200x[WILDLINE]
+[WILDCARD]
 summary
   parse url 2x
    [WILDCARD]x slower than noop3

--- a/tests/specs/bench/no_prompt_by_default/no_prompt_by_default.out
+++ b/tests/specs/bench/no_prompt_by_default/no_prompt_by_default.out
@@ -3,8 +3,8 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/no_prompt_by_default.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-no prompt   error: NotCapable: Requires read access to "./some_file.txt", run again with the --allow-read flag
+benchmark[WILDLINE]
+[WILDLINE]
+no prompt error: NotCapable: Requires read access to "./some_file.txt", run again with the --allow-read flag
 [WILDCARD]
 error: Bench failed

--- a/tests/specs/bench/no_prompt_with_denied_perms/no_prompt_with_denied_perms.out
+++ b/tests/specs/bench/no_prompt_with_denied_perms/no_prompt_with_denied_perms.out
@@ -3,8 +3,8 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/no_prompt_with_denied_perms.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-no prompt   error: NotCapable: Requires read access to "./some_file.txt", run again with the --allow-read flag
+benchmark[WILDLINE]
+[WILDLINE]
+no prompt error: NotCapable: Requires read access to "./some_file.txt", run again with the --allow-read flag
 [WILDCARD]
 error: Bench failed

--- a/tests/specs/bench/only/only.out
+++ b/tests/specs/bench/only/only.out
@@ -4,8 +4,8 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/only.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| only        | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+only[WILDLINE]
+[WILDCARD]
 error: Bench failed because the "only" option was used

--- a/tests/specs/bench/overloads/overloads.out
+++ b/tests/specs/bench/overloads/overloads.out
@@ -4,11 +4,15 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/overloads.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| bench0      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench1      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench2      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench3      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench4      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+bench0[WILDLINE]
+[WILDCARD]
+bench1[WILDLINE]
+[WILDCARD]
+bench2[WILDLINE]
+[WILDCARD]
+bench3[WILDLINE]
+[WILDCARD]
+bench4[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/package_json/install.out
+++ b/tests/specs/bench/package_json/install.out
@@ -9,4 +9,3 @@ Downloaded 1 package from npm
 
 Dependencies:
 [WILDCARD]
-

--- a/tests/specs/bench/package_json/lib.bench.out
+++ b/tests/specs/bench/package_json/lib.bench.out
@@ -4,6 +4,7 @@ Runtime | [WILDCARD]
 
 file:///[WILDCARD]/lib.bench.ts
 
-| benchmark    | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ------------ | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| should add   | [WILDCARD]
+benchmark[WILDLINE]
+[WILDLINE]
+should add[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/pass/pass.out
+++ b/tests/specs/bench/pass/pass.out
@@ -4,16 +4,25 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/pass.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| bench0      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench1      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench2      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench3      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench4      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench5      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench6      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench7      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench8      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| bench9      | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark        avg (min … max)  p75 / p99  distribution
+-------------------------------------------------------------------
+bench0[WILDLINE]
+[WILDCARD]
+bench1[WILDLINE]
+[WILDCARD]
+bench2[WILDLINE]
+[WILDCARD]
+bench3[WILDLINE]
+[WILDCARD]
+bench4[WILDLINE]
+[WILDCARD]
+bench5[WILDLINE]
+[WILDCARD]
+bench6[WILDLINE]
+[WILDCARD]
+bench7[WILDLINE]
+[WILDCARD]
+bench8[WILDLINE]
+[WILDCARD]
+bench9[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/preload_modules/main.out
+++ b/tests/specs/bench/preload_modules/main.out
@@ -10,7 +10,7 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/main_bench.ts
 
-| benchmark   | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| ----------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| hello       | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+hello[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/quiet/quiet.out
+++ b/tests/specs/bench/quiet/quiet.out
@@ -3,10 +3,13 @@ Runtime | Deno [WILDCARD] ([WILDCARD])
 
 [WILDCARD]/quiet.ts
 
-| benchmark       | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
-| --------------- | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
-| console.log     | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| console.error   | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| console.info    | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-| console.warn    | [WILDCARD] | [WILDCARD] | ([WILDCARD] … [WILDCARD]) | [WILDCARD] | [WILDCARD] | [WILDCARD] |
-
+benchmark[WILDLINE]
+[WILDLINE]
+console.log[WILDLINE]
+[WILDCARD]
+console.error[WILDLINE]
+[WILDCARD]
+console.info[WILDLINE]
+[WILDCARD]
+console.warn[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/workspace/package_b.out
+++ b/tests/specs/bench/workspace/package_b.out
@@ -4,7 +4,7 @@ Runtime | [WILDLINE]
 
 file:///[WILDLINE]/package-b/mod.bench.ts
 
-| benchmark[WILDLINE]
-| ---[WILDLINE]
-| addOne[WILDLINE]
-
+benchmark[WILDLINE]
+[WILDLINE]
+addOne[WILDLINE]
+[WILDCARD]

--- a/tests/specs/bench/workspace/root.out
+++ b/tests/specs/bench/workspace/root.out
@@ -5,14 +5,13 @@ Runtime | [WILDLINE]
 
 file:///[WILDLINE]/package-a/mod.bench.ts
 
-| benchmark[WILDLINE]
-| ---[WILDLINE]
-| add[WILDLINE]
-
-
+benchmark[WILDLINE]
+[WILDLINE]
+add[WILDLINE]
+[WILDCARD]
 file:///[WILDLINE]/package-b/mod.bench.ts
 
-| benchmark[WILDLINE]
-| ---[WILDLINE]
-| addOne[WILDLINE]
-
+benchmark[WILDLINE]
+[WILDLINE]
+addOne[WILDLINE]
+[WILDCARD]


### PR DESCRIPTION
This reworks the `deno bench` console output so each benchmark result is
easier to read at a glance. Instead of a single boxed table row, every
benchmark now gets a compact three-line block: the summary numbers (avg,
min/max range, iter/s, and a couple of percentiles) on the left, and a
small vertical histogram of the run's sample distribution on the right.
Groups additionally get a horizontal barplot comparing average times
above the existing textual summary.

The measurement harness in `cli/js/40_bench.js` already built a sorted
array of every per-iteration timing and then threw it away once the
summary stats were computed. It now forwards a uniformly downsampled,
capped copy of that array across the JS/Rust boundary as a new
`samples` field on `BenchStats`. The field is read on the Rust side via
`FromV8` but skipped from serialization, so the `--json` output shape is
unchanged; the downsampling bounds the serialization cost regardless of
how many iterations a benchmark ran.

The histogram bins are clamped to the 99th percentile so that a single
slow outlier does not squash the entire shape into the first bar, and it
is drawn across all three lines for real vertical resolution rather than
a flat one-line sparkline. Bars are tinted by where they fall relative
to the mean: faster than average is cyan, the mean bucket yellow, and the
slower tail magenta. The min/max range is tinted to match.

The old renderer, a frozen port that had drifted years behind, is
replaced by a new `render` module; the shared duration/number formatting
helpers and CPU detection are kept. All of the `tests/specs/bench`
expectation files are updated for the new layout.

This is intentionally scoped to terminal output. Per-benchmark GC time
and heap-allocation columns are a natural follow-up: the `samples`
payload is the load-bearing change they would build on, and the third
line of each block leaves a natural slot for a heap column.

Opening as a draft to gather feedback on the visual design before
polishing.