### PR TITLE
fix(npm): normalize path in BYONM read permission check

### DIFF
--- a/cli/lib/npm/permission_checker.rs
+++ b/cli/lib/npm/permission_checker.rs
@@ -58,6 +58,11 @@ impl<TSys: DenoLibSys> NpmRegistryReadPermissionChecker<TSys> {
 
     match &self.mode {
       NpmRegistryReadPermissionCheckerMode::Byonm => {
+        // Normalize the path to collapse `.` and `..` components before
+        // checking for a `node_modules` ancestor. Otherwise a traversal path
+        // such as `./node_modules/../../../etc/passwd` would slip through the
+        // check and be read without `--allow-read`.
+        let path = deno_path_util::normalize_path(path);
         if path.components().any(|c| c.as_os_str() == "node_modules") {
           Ok(path)
         } else {

--- a/tests/specs/npm/byonm_main_path_traversal/__test__.jsonc
+++ b/tests/specs/npm/byonm_main_path_traversal/__test__.jsonc
@@ -19,6 +19,11 @@
       "args": "run main_nested_escape.cjs",
       "output": "main_nested_escape.out",
       "exitCode": 1
+    },
+    "register_hooks_traversal": {
+      "args": "run main_register_hooks.mjs",
+      "output": "main_register_hooks.out",
+      "exitCode": 1
     }
   }
 }

--- a/tests/specs/npm/byonm_main_path_traversal/main_register_hooks.mjs
+++ b/tests/specs/npm/byonm_main_path_traversal/main_register_hooks.mjs
@@ -1,0 +1,20 @@
+import module from "node:module";
+
+// The path is intentionally left un-normalized. When passed through a
+// `registerHooks` `load` hook it reaches `op_require_read_file` without the
+// normalization that a regular `require` would apply, exercising the BYONM
+// permission bypass (GHSA-prvv-4rg3-43v6).
+const TARGET_FILE = "./node_modules/../secret.json";
+
+module.registerHooks({
+  resolve(_spec, _context, _next) {
+    return { url: "file://node_modules", shortCircuit: true };
+  },
+  load(_url, _context, nextLoad) {
+    const { source } = nextLoad(TARGET_FILE);
+    console.log("ERROR: should not have loaded:", source);
+    Deno.exit(0);
+  },
+});
+
+module._load("foobar", null, false);

--- a/tests/specs/npm/byonm_main_path_traversal/main_register_hooks.out
+++ b/tests/specs/npm/byonm_main_path_traversal/main_register_hooks.out
@@ -1,0 +1,1 @@
+error: [WILDCARD]Requires read access[WILDCARD]secret.json[WILDCARD]


### PR DESCRIPTION
When BYONM is enabled, the npm read permission checker treated any path
containing a `node_modules` component as readable without consulting
`--allow-read`. The path was not normalized before that check, so a
traversal sequence like `./node_modules/../../../etc/passwd` still
contained a `node_modules` component and was allowed through, letting it
be read outside of `node_modules`.

Normally `require` normalizes a path before it reaches
`op_require_read_file`, which collapses the `..` segments and removes the
`node_modules` component, so the check behaves correctly. However a
`node:module` `registerHooks` `load` hook can pass an un-normalized path
straight to `op_require_read_file`, bypassing that normalization.

The fix normalizes the path with `deno_path_util::normalize_path` before
looking for the `node_modules` component, so `.`/`..` segments are
collapsed first and a path that escapes `node_modules` falls through to
the regular read permission check. Paths that genuinely live inside
`node_modules` (including ones with interior `..` that stay within the
tree) are unaffected.

A spec test is added to the existing `byonm_main_path_traversal` suite
that drives the `registerHooks` path and asserts the read is denied.