### PR TITLE
test: re-enable check_workspace with un-fork-compatible globals

### DIFF
--- a/tests/specs/check/check_workspace/__test__.jsonc
+++ b/tests/specs/check/check_workspace/__test__.jsonc
@@ -1,10 +1,4 @@
 {
-  // Disabled during the TypeScript un-fork: this asserts per-scope global
-  // availability (window vs worker), but the @types/node deferral markers
-  // (onmessage/onabort/ReportingObserver) intentionally make onmessage resolve
-  // in the window scope, so the test needs a redesigned discriminator.
-  // Re-enabled by a markers follow-up.
-  "ignore": true,
   "tests": {
     "discover": {
       "args": "check main.ts member/mod.ts",

--- a/tests/specs/check/check_workspace/check_config_flag.out
+++ b/tests/specs/check/check_workspace/check_config_flag.out
@@ -1,20 +1,20 @@
 Check [WILDCARD]main.ts
 Check [WILDCARD]mod.ts
-TS2304 [ERROR]: Cannot find name 'onmessage'.
-onmessage;
-~~~~~~~~~
+TS2304 [ERROR]: Cannot find name 'WorkerGlobalScope'.
+WorkerGlobalScope;
+~~~~~~~~~~~~~~~~~
     at file:///[WILDLINE]/main.ts:8:1
 
-TS2304 [ERROR]: Cannot find name 'onmessage'.
-onmessage;
-~~~~~~~~~
+TS2304 [ERROR]: Cannot find name 'WorkerGlobalScope'.
+WorkerGlobalScope;
+~~~~~~~~~~~~~~~~~
     at file:///[WILDLINE]/member/mod.ts:5:1
 
 Found 2 errors.
 
-TS2304 [ERROR]: Cannot find name 'localStorage'.
-localStorage;
-~~~~~~~~~~~~
+TS2304 [ERROR]: Cannot find name 'alert'.
+alert;
+~~~~~
     at file:///[WILDLINE]/member/mod.ts:2:1
 
 error: Type checking failed.

--- a/tests/specs/check/check_workspace/check_discover.out
+++ b/tests/specs/check/check_workspace/check_discover.out
@@ -1,20 +1,20 @@
 Check [WILDCARD]main.ts
 Check [WILDCARD]mod.ts
-TS2304 [ERROR]: Cannot find name 'onmessage'.
-onmessage;
-~~~~~~~~~
+TS2304 [ERROR]: Cannot find name 'WorkerGlobalScope'.
+WorkerGlobalScope;
+~~~~~~~~~~~~~~~~~
     at file:///[WILDLINE]/main.ts:8:1
 
-TS2304 [ERROR]: Cannot find name 'onmessage'.
-onmessage;
-~~~~~~~~~
+TS2304 [ERROR]: Cannot find name 'WorkerGlobalScope'.
+WorkerGlobalScope;
+~~~~~~~~~~~~~~~~~
     at file:///[WILDLINE]/member/mod.ts:5:1
 
 Found 2 errors.
 
-TS2304 [ERROR]: Cannot find name 'localStorage'.
-localStorage;
-~~~~~~~~~~~~
+TS2304 [ERROR]: Cannot find name 'alert'.
+alert;
+~~~~~
     at file:///[WILDLINE]/member/mod.ts:2:1
 
 error: Type checking failed.

--- a/tests/specs/check/check_workspace/main.ts
+++ b/tests/specs/check/check_workspace/main.ts
@@ -2,7 +2,7 @@
 import "./member/mod.ts";
 
 // Only defined for window.
-localStorage;
+alert;
 
 // Only defined for worker.
-onmessage;
+WorkerGlobalScope;

--- a/tests/specs/check/check_workspace/member/mod.ts
+++ b/tests/specs/check/check_workspace/member/mod.ts
@@ -1,5 +1,5 @@
 // Only defined for window.
-localStorage;
+alert;
 
 // Only defined for worker.
-onmessage;
+WorkerGlobalScope;


### PR DESCRIPTION
`check_workspace` was disabled in the TypeScript un-fork (#35642) because it
relied on `onmessage` as a worker-only discriminator, but the `@types/node`
deferral markers now make `onmessage` resolve in the window scope. Likewise
`localStorage` is no longer window-only, since stock `@types/node` provides it
globally (it was a node-only global under the fork).

This restores the test's per-scope lib-selection coverage using discriminators
that stock `@types/node` does not provide: `alert` (window-only) and
`WorkerGlobalScope` (worker-only). Verified passing on both the `discover` and
`config_flag` variants. See #35621 for context.