### PR TITLE
fix(core): deactivate idle TTY write handles

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -998,70 +998,6 @@ const process = new Process();
 // reads see the real stream directly.
 const streamDelegates = new SafeWeakSet<object>();
 
-function autoUnrefStdioWriteStream(stream) {
-  const write = stream.write;
-  const ref = stream.ref;
-  const unref = stream.unref;
-  let pendingWrites = 0;
-  let userRefed = false;
-
-  stream.ref = function () {
-    userRefed = true;
-    return FunctionPrototypeCall(ref, this);
-  };
-
-  stream.unref = function () {
-    userRefed = false;
-    if (pendingWrites === 0) {
-      return FunctionPrototypeCall(unref, this);
-    }
-    return this;
-  };
-
-  stream.write = function (chunk, encoding, cb) {
-    let callback = cb;
-    if (typeof encoding === "function") {
-      callback = encoding;
-    }
-
-    pendingWrites++;
-    if (pendingWrites === 1 && !userRefed) {
-      FunctionPrototypeCall(ref, this);
-    }
-
-    const done = (...args) => {
-      try {
-        if (typeof callback === "function") {
-          ReflectApply(callback, this, args);
-        }
-      } finally {
-        pendingWrites--;
-        if (pendingWrites === 0 && !userRefed) {
-          FunctionPrototypeCall(unref, this);
-        }
-      }
-    };
-
-    try {
-      if (typeof encoding === "function") {
-        return FunctionPrototypeCall(write, this, chunk, done);
-      }
-      if (encoding !== undefined) {
-        return FunctionPrototypeCall(write, this, chunk, encoding, done);
-      }
-      return FunctionPrototypeCall(write, this, chunk, done);
-    } catch (err) {
-      pendingWrites--;
-      if (pendingWrites === 0 && !userRefed) {
-        FunctionPrototypeCall(unref, this);
-      }
-      throw err;
-    }
-  };
-
-  FunctionPrototypeCall(unref, stream);
-}
-
 function makeStreamDelegate(name: "stdin" | "stdout" | "stderr"): unknown {
   const delegate = new Proxy(ObjectCreate(null), {
     get(_target, prop) {
@@ -1961,9 +1897,6 @@ internals.__bootstrapNodeProcess = function (
           }
         };
         addSigwinchListener(s);
-        // Stdio streams should not keep the event loop alive while idle, but
-        // pending writes still need to hold the loop until callbacks run.
-        autoUnrefStdioWriteStream(s);
       } else {
         s = lazyStreamsMod().createWritableStdioStream(ioStream, name);
       }

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -1897,6 +1897,9 @@ internals.__bootstrapNodeProcess = function (
           }
         };
         addSigwinchListener(s);
+        // Node's process stdio streams do not keep the event loop alive on
+        // their own. Pending writes still complete, and users can call ref().
+        s.unref();
       } else {
         s = lazyStreamsMod().createWritableStdioStream(ioStream, name);
       }

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -998,6 +998,70 @@ const process = new Process();
 // reads see the real stream directly.
 const streamDelegates = new SafeWeakSet<object>();
 
+function autoUnrefStdioWriteStream(stream) {
+  const write = stream.write;
+  const ref = stream.ref;
+  const unref = stream.unref;
+  let pendingWrites = 0;
+  let userRefed = false;
+
+  stream.ref = function () {
+    userRefed = true;
+    return FunctionPrototypeCall(ref, this);
+  };
+
+  stream.unref = function () {
+    userRefed = false;
+    if (pendingWrites === 0) {
+      return FunctionPrototypeCall(unref, this);
+    }
+    return this;
+  };
+
+  stream.write = function (chunk, encoding, cb) {
+    let callback = cb;
+    if (typeof encoding === "function") {
+      callback = encoding;
+    }
+
+    pendingWrites++;
+    if (pendingWrites === 1 && !userRefed) {
+      FunctionPrototypeCall(ref, this);
+    }
+
+    const done = (...args) => {
+      try {
+        if (typeof callback === "function") {
+          ReflectApply(callback, this, args);
+        }
+      } finally {
+        pendingWrites--;
+        if (pendingWrites === 0 && !userRefed) {
+          FunctionPrototypeCall(unref, this);
+        }
+      }
+    };
+
+    try {
+      if (typeof encoding === "function") {
+        return FunctionPrototypeCall(write, this, chunk, done);
+      }
+      if (encoding !== undefined) {
+        return FunctionPrototypeCall(write, this, chunk, encoding, done);
+      }
+      return FunctionPrototypeCall(write, this, chunk, done);
+    } catch (err) {
+      pendingWrites--;
+      if (pendingWrites === 0 && !userRefed) {
+        FunctionPrototypeCall(unref, this);
+      }
+      throw err;
+    }
+  };
+
+  FunctionPrototypeCall(unref, stream);
+}
+
 function makeStreamDelegate(name: "stdin" | "stdout" | "stderr"): unknown {
   const delegate = new Proxy(ObjectCreate(null), {
     get(_target, prop) {
@@ -1897,9 +1961,9 @@ internals.__bootstrapNodeProcess = function (
           }
         };
         addSigwinchListener(s);
-        // Node's process stdio streams do not keep the event loop alive on
-        // their own. Pending writes still complete, and users can call ref().
-        s.unref();
+        // Stdio streams should not keep the event loop alive while idle, but
+        // pending writes still need to hold the loop until callbacks run.
+        autoUnrefStdioWriteStream(s);
       } else {
         s = lazyStreamsMod().createWritableStdioStream(ioStream, name);
       }

--- a/libs/core/uv_compat/tty.rs
+++ b/libs/core/uv_compat/tty.rs
@@ -1793,17 +1793,7 @@ pub(crate) unsafe fn read_stop_tty(tty: *mut uv_tty_t) -> c_int {
     // Notify the select fallback thread about interest change.
     #[cfg(target_os = "macos")]
     update_select_interest(tty);
-    if (*tty).internal_write_queue.is_empty()
-      && (*tty).internal_shutdown.is_none()
-    {
-      (*tty).flags &= !UV_HANDLE_ACTIVE;
-      // Remove from poll list when fully inactive.
-      let inner = get_inner((*tty).loop_);
-      inner
-        .tty_handles
-        .borrow_mut()
-        .retain(|&h| !std::ptr::eq(h, tty));
-    }
+    deactivate_tty_if_idle(tty);
   }
   0
 }
@@ -2010,6 +2000,31 @@ unsafe fn ensure_tty_registered(tty: *mut uv_tty_t) {
     // until something else wakes the loop (e.g. console input).
     #[cfg(windows)]
     inner.wake();
+  }
+}
+
+/// Deactivate a TTY handle when it has no active read, write, or shutdown
+/// work. A ref'ed but inactive libuv handle does not keep the loop alive.
+///
+/// # Safety
+/// `tty` must be a valid pointer to an initialized `uv_tty_t`.
+unsafe fn deactivate_tty_if_idle(tty: *mut uv_tty_t) {
+  unsafe {
+    if !(*tty).internal_reading
+      && (*tty).internal_write_queue.is_empty()
+      && (*tty).internal_shutdown.is_none()
+    {
+      (*tty).flags &= !UV_HANDLE_ACTIVE;
+
+      #[cfg(target_os = "macos")]
+      update_select_interest(tty);
+
+      let inner = get_inner((*tty).loop_);
+      inner
+        .tty_handles
+        .borrow_mut()
+        .retain(|&h| !std::ptr::eq(h, tty));
+    }
   }
 }
 
@@ -2572,20 +2587,9 @@ pub(crate) unsafe fn poll_tty_handle(
       if let Some(cb) = pending.cb {
         cb(pending.req, 0);
       }
-      // Deactivate the handle if there's no more pending work.
-      // In real libuv, uv__drain stops the I/O watcher so the
-      // handle no longer keeps the event loop alive. Our
-      // UV_HANDLE_ACTIVE flag serves the same purpose.
-      if !(*tty_ptr).internal_reading
-        && (*tty_ptr).internal_write_queue.is_empty()
-        && (*tty_ptr).internal_shutdown.is_none()
-      {
-        (*tty_ptr).flags &= !UV_HANDLE_ACTIVE;
-        #[cfg(target_os = "macos")]
-        update_select_interest(tty_ptr);
-      }
       any_work = true;
     }
+    deactivate_tty_if_idle(tty_ptr);
   }
 
   // Post the select fallback semaphore so the background thread can

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -3652,6 +3652,24 @@ fn process_stdout_destroy_undestroy_pty() {
     });
 }
 
+#[test]
+fn process_stderr_tty_write_exit() {
+  let deno_exe = util::deno_exe_path();
+  let testdata = util::testdata_path();
+  let env_vars = std::env::vars().collect();
+  let output = util::pty::run_in_pty(
+    deno_exe.as_path(),
+    &["run", "--quiet", "run/process_stderr_tty_write_exit.js"],
+    testdata.as_path(),
+    Some(env_vars),
+    std::time::Duration::from_secs(15),
+  );
+  assert_eq!(output.exit_code, Some(0));
+
+  let output_text = String::from_utf8_lossy(&output.output);
+  assert_contains!(&output_text, "stderr write callback");
+}
+
 // Regression test for https://github.com/denoland/deno/issues/32782
 // Verifies that consecutive readline prompts work (e.g. @inquirer/prompts).
 #[test]

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -3677,7 +3677,10 @@ fn process_stderr_tty_write_exit() {
   );
   assert_eq!(output.exit_code, Some(0));
 
-  assert_eq!(marker_path.read_to_string(), "stderr write callback");
+  assert_eq!(
+    marker_path.read_to_string(),
+    "stderr write callback before_has_ref=true callback_has_ref=true"
+  );
 }
 
 // Regression test for https://github.com/denoland/deno/issues/32782

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -3656,18 +3656,28 @@ fn process_stdout_destroy_undestroy_pty() {
 fn process_stderr_tty_write_exit() {
   let deno_exe = util::deno_exe_path();
   let testdata = util::testdata_path();
+  let temp_dir = TempDir::new();
+  let marker_path = temp_dir.path().join("stdio-write-callback.txt");
+  let marker_path_string = marker_path.to_string_lossy().to_string();
+  let allow_write_arg = format!("--allow-write={marker_path_string}");
+  let args = [
+    "run",
+    "--quiet",
+    &allow_write_arg,
+    "run/process_stderr_tty_write_exit.js",
+    &marker_path_string,
+  ];
   let env_vars = std::env::vars().collect();
   let output = util::pty::run_in_pty(
     deno_exe.as_path(),
-    &["run", "--quiet", "run/process_stderr_tty_write_exit.js"],
+    &args,
     testdata.as_path(),
     Some(env_vars),
     std::time::Duration::from_secs(15),
   );
   assert_eq!(output.exit_code, Some(0));
 
-  let output_text = String::from_utf8_lossy(&output.output);
-  assert_contains!(&output_text, "stderr write callback");
+  assert_eq!(marker_path.read_to_string(), "stderr write callback");
 }
 
 // Regression test for https://github.com/denoland/deno/issues/32782

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -3677,8 +3677,12 @@ fn process_stderr_tty_write_exit() {
   );
   assert_eq!(output.exit_code, Some(0));
 
+  let marker = marker_path.read_to_string();
+  assert_contains!(marker, "stderr write callback");
+
+  #[cfg(not(windows))]
   assert_eq!(
-    marker_path.read_to_string(),
+    marker,
     "stderr write callback before_has_ref=true callback_has_ref=true"
   );
 }

--- a/tests/testdata/run/process_stderr_tty_write_exit.js
+++ b/tests/testdata/run/process_stderr_tty_write_exit.js
@@ -1,0 +1,5 @@
+import process from "node:process";
+
+process.stderr.write("\0".repeat(32 * 1024), () => {
+  process.stdout.write("stderr write callback\n");
+});

--- a/tests/testdata/run/process_stderr_tty_write_exit.js
+++ b/tests/testdata/run/process_stderr_tty_write_exit.js
@@ -1,5 +1,11 @@
 import process from "node:process";
 
+const beforeHasRef = process.stderr._handle.hasRef();
+
 process.stderr.write("\0".repeat(32 * 1024), () => {
-  Deno.writeTextFileSync(Deno.args[0], "stderr write callback");
+  const callbackHasRef = process.stderr._handle.hasRef();
+  Deno.writeTextFileSync(
+    Deno.args[0],
+    `stderr write callback before_has_ref=${beforeHasRef} callback_has_ref=${callbackHasRef}`,
+  );
 });

--- a/tests/testdata/run/process_stderr_tty_write_exit.js
+++ b/tests/testdata/run/process_stderr_tty_write_exit.js
@@ -1,11 +1,18 @@
 import process from "node:process";
 
-const beforeHasRef = process.stderr._handle.hasRef();
+function handleHasRef(stream) {
+  return stream._handle?.hasRef?.();
+}
+
+const beforeHasRef = handleHasRef(process.stderr);
 
 process.stderr.write("\0".repeat(32 * 1024), () => {
-  const callbackHasRef = process.stderr._handle.hasRef();
+  const callbackHasRef = handleHasRef(process.stderr);
+  const refState = beforeHasRef === undefined && callbackHasRef === undefined
+    ? "handle_has_ref=unavailable"
+    : `before_has_ref=${beforeHasRef} callback_has_ref=${callbackHasRef}`;
   Deno.writeTextFileSync(
     Deno.args[0],
-    `stderr write callback before_has_ref=${beforeHasRef} callback_has_ref=${callbackHasRef}`,
+    `stderr write callback ${refState}`,
   );
 });

--- a/tests/testdata/run/process_stderr_tty_write_exit.js
+++ b/tests/testdata/run/process_stderr_tty_write_exit.js
@@ -1,5 +1,5 @@
 import process from "node:process";
 
 process.stderr.write("\0".repeat(32 * 1024), () => {
-  process.stdout.write("stderr write callback\n");
+  Deno.writeTextFileSync(Deno.args[0], "stderr write callback");
 });


### PR DESCRIPTION
## Summary

Allow Node-compatible TTY stdio writes to drain and then stop keeping Deno alive, without changing the observable ref state of the underlying stdio handle where that handle is exposed.

Adds a PTY integration regression for a large `process.stderr.write()` that verifies the write callback runs and the process exits. On platforms that expose `process.stderr._handle.hasRef()`, it also verifies the handle remains ref'ed before and inside the callback.

## Root Cause

`uv_tty_init()` creates TTY handles with `UV_HANDLE_REF`, matching Node's observable `process.stderr._handle.hasRef() === true` behavior for stdio TTYs where `_handle` is exposed.

Deno's `uv_compat` write path also marks TTY handles `UV_HANDLE_ACTIVE` via `ensure_tty_registered()`. Plain TTY writes drained their callbacks, but the normal write-drain path did not clear `UV_HANDLE_ACTIVE`; only the shutdown path deactivated the handle. Since loop liveness checks count handles that are both active and ref'ed, an idle stdio TTY write handle could keep Deno alive forever after all JS and children had finished.

The fix deactivates TTY handles once there is no pending read, write, or shutdown work. It leaves `UV_HANDLE_REF` untouched, so `_handle.hasRef()` remains Node-compatible while idle inactive handles no longer keep the loop alive.

Redirected output avoids the TTY stream path, which is why the same script exited with stdout/stderr redirected.

## Validation

- `./tools/format.js ext/node/polyfills/process.ts libs/core/uv_compat/tty.rs tests/integration/run_tests.rs tests/testdata/run/process_stderr_tty_write_exit.js`
- `cargo test --test integration process_stderr_tty_write_exit`
- `cargo test -p deno_core uv_compat`
- `./tools/lint.js`
- Manual PTY reduction: large `process.stderr.write()` exits and reports `_handle.hasRef()` as `true` before and inside the callback on macOS
- Manual PTY validation in `../v8x`: `target/debug/deno run -A tests/harness/run.mjs rusty_v8 quickjs --rescue` exits cleanly with `pass=267 fail=0 skip=0`
- CI: `test integration (1/2) debug windows-x86_64` passed on head `3a9f366bf34b16ad3b0c12117233460c5320e2a0`
