### PR TITLE
chore(ci): drop vestigial Google Cloud auth from promote_to_release

### DIFF
--- a/.github/workflows/promote_to_release.generated.yml
+++ b/.github/workflows/promote_to_release.generated.yml
@@ -99,17 +99,6 @@ jobs:
         with:
           token: '${{ secrets.DENOBOT_PAT }}'
           submodules: recursive
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-        with:
-          project_id: denoland
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
-          export_environment_variables: true
-          create_credentials_file: true
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
-        with:
-          project_id: denoland
       - name: Install deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
         with:
@@ -151,5 +140,3 @@ jobs:
 # gagen:pin actions/upload-artifact@v6 = b7c566a772e6b6bfb58ed0dc250532a479d7789f
 # gagen:pin azure/login@v1 = cb79c773a3cfa27f31f25eb3f677781210c9ce3d
 # gagen:pin denoland/setup-deno@v2 = 667a34cdef165d8d2b2e98dde39547c9daac7282
-# gagen:pin google-github-actions/auth@v3 = 7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-# gagen:pin google-github-actions/setup-gcloud@v3 = aa5489c8933f4cc7a4f7d45035b3b1440c9c10db

--- a/.github/workflows/promote_to_release.ts
+++ b/.github/workflows/promote_to_release.ts
@@ -139,21 +139,6 @@ const workflow = createWorkflow({
           },
         }),
         step({
-          name: "Authenticate with Google Cloud",
-          uses: "google-github-actions/auth@v3",
-          with: {
-            project_id: "denoland",
-            credentials_json: "${{ secrets.GCP_SA_KEY }}",
-            export_environment_variables: true,
-            create_credentials_file: true,
-          },
-        }),
-        step({
-          name: "Setup gcloud",
-          uses: "google-github-actions/setup-gcloud@v3",
-          with: { project_id: "denoland" },
-        }),
-        step({
           name: "Install deno",
           uses: "denoland/setup-deno@v2",
           with: { "deno-version": "v2.x" },


### PR DESCRIPTION
The promote_to_release workflow uploads channel binaries and the
release-<channel>-latest.txt pointer to dl.deno.land via aws s3 against
an S3-compatible endpoint (S3_ENDPOINT), so the storage is no longer on
Google Cloud. The "Promote to Release" job nonetheless still ran
"Authenticate with Google Cloud" (google-github-actions/auth with
GCP_SA_KEY) and "Setup gcloud" up front, and nothing after them uses
gcloud or gsutil.

Those steps are dead weight and a liability: if the GCP service account
or GCP_SA_KEY was removed during the storage migration, the auth step
fails and aborts the promotion before the S3 upload ever runs. This
removes both steps so the promotion depends only on the S3 credentials
it actually uses. No behavior change for the upload itself.