### PR TITLE
fix(pm): hint about minimumDependencyAge when no version is old enough

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -753,14 +753,18 @@ fn maybe_minimum_dependency_age_hint(error_string: &str) -> Option<String> {
     concat!(
       "\n\n{} This version is blocked by the minimum dependency age policy, ",
       "which avoids installing recently published versions to reduce supply ",
-      "chain risk (the default is 24 hours). To use this version now, set {} ",
-      "in your deno.json (for example {} to disable it, or a shorter duration ",
-      "like {}), or wait until the version is old enough."
+      "chain risk (the default is 24 hours). To use this version now, pass the ",
+      "{} flag (for example {} to disable it, or a shorter duration like {} ",
+      "minutes) or set {} in your deno.json, or wait until the version is old ",
+      "enough.\n{} {}"
     ),
     colors::yellow("hint:"),
-    colors::bold("\"minimumDependencyAge\""),
+    colors::bold("--minimum-dependency-age"),
     colors::bold("0"),
-    colors::bold("\"1 hour\""),
+    colors::bold("60"),
+    colors::bold("\"minimumDependencyAge\""),
+    colors::yellow("docs:"),
+    colors::cyan("https://docs.deno.com/go/minimum-dependency-age"),
   ))
 }
 

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -729,7 +729,39 @@ fn exit_for_error(error: AnyError, initial_cwd: Option<&std::path::Path>) -> ! {
     error_string.push_str(&hint);
   }
 
+  // When a package couldn't be resolved because the only matching version is
+  // newer than the configured minimum dependency age, the error doesn't
+  // mention the setting that caused it. Point the user at it.
+  if let Some(hint) = maybe_minimum_dependency_age_hint(&error_string) {
+    error_string.push_str(&hint);
+  }
+
   exit_with_message(&error_string, 1);
+}
+
+/// Substring present in every "package rejected because it is newer than the
+/// minimum dependency age" error (both the jsr and npm resolvers include it).
+const MINIMUM_DEPENDENCY_AGE_MARKER: &str = "minimum dependency date";
+
+/// If `error_string` is a resolution failure caused by the minimum dependency
+/// age safeguard, returns a note explaining the setting and how to override it.
+fn maybe_minimum_dependency_age_hint(error_string: &str) -> Option<String> {
+  if !error_string.contains(MINIMUM_DEPENDENCY_AGE_MARKER) {
+    return None;
+  }
+  Some(format!(
+    concat!(
+      "\n\n{} This version is blocked by the minimum dependency age policy, ",
+      "which avoids installing recently published versions to reduce supply ",
+      "chain risk (the default is 24 hours). To use this version now, set {} ",
+      "in your deno.json (for example {} to disable it, or a shorter duration ",
+      "like {}), or wait until the version is old enough."
+    ),
+    colors::yellow("hint:"),
+    colors::bold("\"minimumDependencyAge\""),
+    colors::bold("0"),
+    colors::bold("\"1 hour\""),
+  ))
 }
 
 pub(crate) fn unstable_exit_cb(feature: &str, api_name: &str) {

--- a/tests/integration/pm_tests.rs
+++ b/tests/integration/pm_tests.rs
@@ -272,6 +272,25 @@ fn add_npm_latest_npmrc_min_release_age_downgrades() {
   }));
 }
 
+#[test]
+fn add_npm_minimum_dependency_age_no_matching_shows_hint() {
+  let context = pm_context_builder().build();
+
+  // 2.0.0 of this package has a publish date far in the future, so it is
+  // always newer than the minimum dependency age. Requesting it specifically
+  // leaves no installable version, and the error should point the user at the
+  // "minimumDependencyAge" setting.
+  let output = context
+    .new_command()
+    .env_remove("NPM_CONFIG_MIN_RELEASE_AGE")
+    .args("add npm:@denotest/min-release-age-latest@2.0.0")
+    .run();
+  output.assert_exit_code(1);
+  let output = output.combined_output();
+  assert_contains!(output, "minimum dependency date");
+  assert_contains!(output, "minimumDependencyAge");
+}
+
 fn pm_context_builder() -> TestContextBuilder {
   TestContextBuilder::new()
     .use_http_server()

--- a/tests/integration/pm_tests.rs
+++ b/tests/integration/pm_tests.rs
@@ -289,6 +289,7 @@ fn add_npm_minimum_dependency_age_no_matching_shows_hint() {
   let output = output.combined_output();
   assert_contains!(output, "minimum dependency date");
   assert_contains!(output, "minimumDependencyAge");
+  assert_contains!(output, "--minimum-dependency-age");
 }
 
 fn pm_context_builder() -> TestContextBuilder {

--- a/tests/specs/npm/npmrc_min_release_age/install.out
+++ b/tests/specs/npm/npmrc_min_release_age/install.out
@@ -3,4 +3,5 @@ error: Could not find npm package '@denotest/add' matching '*'.
 
 A newer matching version was found, but it was not used because it was newer than the specified minimum dependency date of [WILDLINE]
 
-hint: This version is blocked by the minimum dependency age policy, which avoids installing recently published versions to reduce supply chain risk (the default is 24 hours). To use this version now, set "minimumDependencyAge" in your deno.json (for example 0 to disable it, or a shorter duration like "1 hour"), or wait until the version is old enough.
+hint: This version is blocked by the minimum dependency age policy, which avoids installing recently published versions to reduce supply chain risk (the default is 24 hours). To use this version now, pass the --minimum-dependency-age flag (for example 0 to disable it, or a shorter duration like 60 minutes) or set "minimumDependencyAge" in your deno.json, or wait until the version is old enough.
+docs: https://docs.deno.com/go/minimum-dependency-age

--- a/tests/specs/npm/npmrc_min_release_age/install.out
+++ b/tests/specs/npm/npmrc_min_release_age/install.out
@@ -2,3 +2,5 @@ Download http://localhost:4260/@denotest%2fadd
 error: Could not find npm package '@denotest/add' matching '*'.
 
 A newer matching version was found, but it was not used because it was newer than the specified minimum dependency date of [WILDLINE]
+
+hint: This version is blocked by the minimum dependency age policy, which avoids installing recently published versions to reduce supply chain risk (the default is 24 hours). To use this version now, set "minimumDependencyAge" in your deno.json (for example 0 to disable it, or a shorter duration like "1 hour"), or wait until the version is old enough.


### PR DESCRIPTION
Adding a freshly published package currently fails with an error that never
names the setting responsible. For example, adding a package whose only
matching version was published a few hours ago produces:

```
error: Could not find version of '@scope/pkg' that matches specified version constraint '^0.1.1'

A newer matching version was found, but it was not used because it was newer than the specified minimum dependency date of 2026-07-07 20:38:44 UTC
```

The minimum dependency age is a supply chain safeguard: by default Deno does
not install versions published in the last 24 hours. When you publish a
package and immediately try to consume it, that is exactly the case you hit,
and the message reads like the registry is broken. Nothing points at the
`minimumDependencyAge` option or explains how to override it, which is what
happened in the linked issue.

This appends a hint on the shared terminal error path (`exit_for_error`, next
to the existing pnpm-workspace hint) whenever the rendered error contains the
"minimum dependency date" marker that both the jsr and npm resolvers emit:

```
hint: This version is blocked by the minimum dependency age policy, which
avoids installing recently published versions to reduce supply chain risk
(the default is 24 hours). To use this version now, set "minimumDependencyAge"
in your deno.json (for example 0 to disable it, or a shorter duration like
"1 hour"), or wait until the version is old enough.
```

Because it hangs off the single error-rendering function, it covers both
registries and every command that surfaces the failure (`add`, `run`,
`install`, `cache`). A test covers the npm `add` path using the existing
`min-release-age-latest` fixture, whose `2.0.0` has a far-future publish date
so it is always newer than the age floor.

Closes #35883
