### PR TITLE
chore(release): bump @deno/patchver to 0.5.1 in promotion scripts

### DIFF
--- a/tools/release/promote_to_release.ts
+++ b/tools/release/promote_to_release.ts
@@ -5,7 +5,7 @@
 
 import { $ } from "jsr:@david/dax@0.41.0";
 import { gray } from "jsr:@std/fmt@1/colors";
-import { patchver } from "jsr:@deno/patchver@0.5.0";
+import { patchver } from "jsr:@deno/patchver@0.5.1";
 
 const SUPPORTED_TARGETS = [
   "aarch64-apple-darwin",

--- a/tools/release/promote_to_release_windows.ts
+++ b/tools/release/promote_to_release_windows.ts
@@ -3,7 +3,7 @@
 
 // deno-lint-ignore-file no-console
 
-import { patchver } from "jsr:@deno/patchver@0.5.0";
+import { patchver } from "jsr:@deno/patchver@0.5.1";
 
 const CHANNEL = Deno.args[0];
 if (CHANNEL !== "rc" && CHANNEL !== "lts") {


### PR DESCRIPTION
@deno/patchver 0.5.0 panics when patching macOS binaries: its libsui
0.12.4 dependency calls std::env::temp_dir() in the Mach-O path, which
is unsupported in the wasm32 runtime patchver runs in ("no filesystem on
this platform"). That aborts promote_to_release on the first darwin
binary, so rc and lts promotions cannot finish. It surfaced while
promoting v2.9.2 to the LTS channel.

patchver 0.5.1 (denoland/patchver#1) bumps libsui to 0.12.6, which gates
that codesign shell-out behind #[cfg(target_vendor = "apple")] so it is
no longer compiled into the Wasm build. This bumps the pin in both
promotion scripts to pick it up. Verified locally that 0.5.1 patches
both x86_64-apple-darwin and aarch64-apple-darwin deno binaries to the
lts channel without panicking.