### PR TITLE
chore: disable minimum-dependency-age in promote_to_release workflow

### DIFF
--- a/.github/workflows/promote_to_release.generated.yml
+++ b/.github/workflows/promote_to_release.generated.yml
@@ -42,7 +42,7 @@ jobs:
           Expand-Archive -Path "deno-windows.zip" -DestinationPath "."
           Expand-Archive -Path "denort-windows.zip" -DestinationPath "."
       - name: Run patchver for Windows
-        run: 'deno run -A ./tools/release/promote_to_release_windows.ts ${{github.event.inputs.releaseKind}}'
+        run: 'deno run -A --minimum-dependency-age=0 ./tools/release/promote_to_release_windows.ts ${{github.event.inputs.releaseKind}}'
       - name: Authenticate with Azure
         uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d
         with:
@@ -111,7 +111,7 @@ jobs:
         env:
           APPLE_CODESIGN_KEY: '${{ secrets.APPLE_CODESIGN_KEY }}'
           APPLE_CODESIGN_PASSWORD: '${{ secrets.APPLE_CODESIGN_PASSWORD }}'
-        run: 'deno run -A ./tools/release/promote_to_release.ts ${{github.event.inputs.releaseKind}} ${{github.event.inputs.commitHash}}'
+        run: 'deno run -A --minimum-dependency-age=0 ./tools/release/promote_to_release.ts ${{github.event.inputs.releaseKind}} ${{github.event.inputs.commitHash}}'
       - name: Download Windows binaries
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:

--- a/.github/workflows/promote_to_release.ts
+++ b/.github/workflows/promote_to_release.ts
@@ -40,7 +40,7 @@ const windowsJob = job("promote-to-release-windows", {
     step({
       name: "Run patchver for Windows",
       run:
-        "deno run -A ./tools/release/promote_to_release_windows.ts ${{github.event.inputs.releaseKind}}",
+        "deno run -A --minimum-dependency-age=0 ./tools/release/promote_to_release_windows.ts ${{github.event.inputs.releaseKind}}",
     }),
     step({
       name: "Authenticate with Azure",
@@ -157,7 +157,7 @@ const workflow = createWorkflow({
             APPLE_CODESIGN_PASSWORD: "${{ secrets.APPLE_CODESIGN_PASSWORD }}",
           },
           run:
-            "deno run -A ./tools/release/promote_to_release.ts ${{github.event.inputs.releaseKind}} ${{github.event.inputs.commitHash}}",
+            "deno run -A --minimum-dependency-age=0 ./tools/release/promote_to_release.ts ${{github.event.inputs.releaseKind}} ${{github.event.inputs.commitHash}}",
         }),
         step({
           name: "Download Windows binaries",


### PR DESCRIPTION
Deno applies a default minimum-dependency-age when resolving jsr
dependencies, refusing versions published more recently than ~1 day
ago. The promotion scripts import @deno/patchver, which is typically
bumped and republished right before a promotion, so the freshly
published version is always "too new" and the run aborts on the first
patchver call:

    error: Could not find version of '@deno/patchver' that matches '0.5.1'
    A newer matching version was found, but it was not used because it
    was newer than the specified minimum dependency date

These scripts only pull first-party and @std dependencies
(@deno/patchver, @david/dax, @std/fmt), so the supply-chain age gate
that protects user projects from freshly compromised third-party
packages does not apply here. Pass --minimum-dependency-age=0 to both
promote deno run invocations so a just-published patchver can be used.