### PR TITLE
feat(unstable): add deno sync-types subcommand for stock TypeScript config

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1314,6 +1314,7 @@ pub fn flags_from_vec_with_initial_cwd(
         "jupyter" => jupyter_parse(&mut flags, &mut m),
         "lint" => lint_parse(&mut flags, &mut m)?,
         "lsp" => lsp_parse(&mut flags, &mut m),
+        "sync-types" => sync_types_parse(&mut flags, &mut m),
         "outdated" => outdated_parse(&mut flags, &mut m, false)?,
         "repl" => repl_parse(&mut flags, &mut m)?,
         "run" => run_parse(&mut flags, &mut m, app, false, false)?,
@@ -1597,6 +1598,7 @@ pub fn clap_root() -> Command {
         .subcommand(link_subcommand())
         .subcommand(unlink_subcommand())
         .subcommand(lsp_subcommand())
+        .subcommand(sync_types_subcommand())
         .subcommand(lint_subcommand())
         .subcommand(publish_subcommand())
         .subcommand(pack_subcommand())
@@ -3786,6 +3788,18 @@ using the Language Server Protocol. Usually humans do not use this subcommand di
 For example, 'deno lsp' can provide IDEs with go-to-definition support and automatic code formatting.
 
 How to connect various editors and IDEs to 'deno lsp': https://docs.deno.com/go/lsp",
+  )
+}
+
+fn sync_types_subcommand() -> Command {
+  command(
+    "sync-types",
+    cstr!(
+      "Generate a <c>tsconfig.json</> and type mappings so stock TypeScript tooling (tsc, tsgo, editors) can type-check the project.
+
+Run after installing dependencies; it materializes <c>jsr:</>/<c>http(s):</> types and writes <p(245)>.deno/tsconfig.json</>."
+    ),
+    UnstableArgsConfig::None,
   )
 }
 
@@ -7656,6 +7670,10 @@ fn uninstall_parse(flags: &mut Flags, matches: &mut ArgMatches) {
 
 fn lsp_parse(flags: &mut Flags, _matches: &mut ArgMatches) {
   flags.subcommand = DenoSubcommand::Lsp;
+}
+
+fn sync_types_parse(flags: &mut Flags, _matches: &mut ArgMatches) {
+  flags.subcommand = DenoSubcommand::SyncTypes;
 }
 
 fn lint_parse(

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -654,6 +654,7 @@ impl CliFactory {
             | DenoSubcommand::JSONReference { .. }
             | DenoSubcommand::Jupyter { .. }
             | DenoSubcommand::Lsp
+            | DenoSubcommand::SyncTypes
             | DenoSubcommand::Lint { .. }
             | DenoSubcommand::Repl { .. }
             | DenoSubcommand::Run { .. }

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -237,6 +237,9 @@ async fn run_subcommand(
     DenoSubcommand::Ci(ci_flags) => spawn_subcommand(async {
       tools::installer::ci_command(Arc::new(flags), ci_flags).await
     }),
+    DenoSubcommand::SyncTypes => spawn_subcommand(async {
+      tools::installer::sync_types_command(Arc::new(flags)).await
+    }),
     DenoSubcommand::JSONReference(json_reference) => {
       spawn_subcommand(async move {
         display::write_json_to_stdout(&json_reference.json)

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -178,6 +178,25 @@ async fn install_top_level(
     lockfile.write_if_changed()?;
   }
 
+  // Post-install: set up jsr packages in node_modules and generate tsconfig
+  // mappings so stock TypeScript tooling understands the project.
+  {
+    let cli_options = factory.cli_options()?;
+    let file_fetcher = factory.file_fetcher()?.clone();
+    let http_client = factory.http_client_provider().get_or_create()?;
+    let permissions = factory.root_permissions_container()?.clone();
+    if let Err(e) = super::npm_compat::setup_npm_compat(
+      cli_options.initial_cwd(),
+      &file_fetcher,
+      &http_client,
+      &permissions,
+    )
+    .await
+    {
+      log::warn!("Failed to set up TypeScript compatibility: {e}");
+    }
+  }
+
   let install_reporter = factory.install_reporter()?.unwrap().clone();
   let workspace = factory.workspace_resolver().await?;
   let npm_resolver = factory.npm_resolver().await?;

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -322,8 +322,19 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
     specifiers.into_iter().collect::<Vec<_>>()
   };
 
+  // Generate at the workspace/config root, not the current working directory,
+  // so running `deno sync-types` from a subdirectory still writes the config
+  // next to deno.json and picks up the root import map.
+  let project_root = cli_options
+    .workspace()
+    .root_dir_url()
+    .to_file_path()
+    .map_err(|_| {
+      deno_core::anyhow::anyhow!("workspace root is not a local directory")
+    })?;
+
   super::npm_compat::setup_npm_compat(
-    cli_options.initial_cwd(),
+    &project_root,
     &file_fetcher,
     &http_client,
     &permissions,

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -234,9 +234,7 @@ pub async fn ci_command(
 /// installed (run `deno install` first); materializes `jsr:`/`http(s):` types
 /// and writes `.deno/tsconfig.json`.
 pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
-  use crate::graph_container::CheckSpecifiersOptions;
   use crate::graph_container::CollectSpecifiersOptions;
-  use crate::graph_container::ModuleGraphContainer;
 
   let factory = CliFactory::from_flags(flags);
   let cli_options = factory.cli_options()?;
@@ -256,21 +254,55 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
         include_ignored_specified: false,
       },
     )?;
-    // Best-effort: build the graph; type/resolution errors here shouldn't stop
-    // us from generating config for whatever did resolve.
-    if let Err(e) = graph_container
-      .check_specifiers(
-        &roots,
-        CheckSpecifiersOptions {
-          ext_overwrite: None,
-          allow_unknown_media_types: true,
-        },
-      )
+    // `collect_specifiers` honors deno.json excludes and the vendor dir, but not
+    // `node_modules`, our generated `.deno/`, or the DENO_DIR cache. On a real
+    // project those trees hold tens of thousands of files; feeding them as graph
+    // roots makes the build choke. Keep only the project's own source so we
+    // discover the external specifiers it actually imports.
+    let deno_dir_root = factory.deno_dir().ok().map(|d| d.root.clone());
+    let roots: Vec<_> = roots
+      .into_iter()
+      .filter(|u| {
+        let Ok(path) = u.to_file_path() else {
+          return true;
+        };
+        if path.components().any(|c| {
+          matches!(c.as_os_str().to_str(), Some("node_modules") | Some(".deno"))
+        }) {
+          return false;
+        }
+        match &deno_dir_root {
+          Some(root) => !path.starts_with(root),
+          None => true,
+        }
+      })
+      .collect();
+
+    // Build the graph error-tolerantly: `create_graph_with_options` populates
+    // the graph and records unresolved modules as error entries without failing
+    // the whole build (unlike `check_specifiers`, which validates and discards
+    // everything on the first missing module). A real project always has some
+    // broken file (dead example scripts, etc.); we want every specifier that
+    // *did* resolve regardless.
+    let graph_creator = factory.module_graph_creator().await?;
+    let graph = match graph_creator
+      .create_graph_with_options(crate::graph_util::CreateGraphOptions {
+        graph_kind: deno_graph::GraphKind::All,
+        roots,
+        imports: vec![],
+        is_dynamic: false,
+        loader: None,
+        npm_caching: cli_options.default_npm_caching_strategy(),
+      })
       .await
     {
-      log::debug!("sync-types: graph build had errors (continuing): {e}");
-    }
-    let graph = graph_container.graph();
+      Ok(graph) => graph,
+      Err(e) => {
+        log::debug!("sync-types: graph build failed (continuing): {e}");
+        deno_graph::ModuleGraph::new(deno_graph::GraphKind::All)
+      }
+    };
+
     let mut specifiers = std::collections::BTreeSet::new();
     for module in graph.modules() {
       for (raw, _dep) in module.dependencies() {

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -242,6 +242,17 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
   let http_client = factory.http_client_provider().get_or_create()?;
   let permissions = factory.root_permissions_container()?.clone();
 
+  // Generate at the workspace/config root, not the current working directory,
+  // so running `deno sync-types` from a subdirectory still writes the config
+  // next to deno.json and picks up the root import map.
+  let project_root = cli_options
+    .workspace()
+    .root_dir_url()
+    .to_file_path()
+    .map_err(|_| {
+      deno_core::anyhow::anyhow!("workspace root is not a local directory")
+    })?;
+
   // Build the module graph over the whole project to discover every external
   // (npm:/jsr:/http(s):) specifier the code actually uses — including specifiers
   // written directly in source and across workspace members, not just the ones
@@ -259,6 +270,12 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
     // project those trees hold tens of thousands of files; feeding them as graph
     // roots makes the build choke. Keep only the project's own source so we
     // discover the external specifiers it actually imports.
+    //
+    // The `node_modules`/`.deno` check is on the path RELATIVE to the project
+    // root, so a project that happens to live beneath an ancestor directory
+    // named `node_modules` (e.g. developed in place) isn't filtered away
+    // entirely. DENO_DIR is filtered by prefix when resolvable; it's normally
+    // outside the project so its files aren't collected as roots regardless.
     let deno_dir_root = factory.deno_dir().ok().map(|d| d.root.clone());
     let roots: Vec<_> = roots
       .into_iter()
@@ -266,15 +283,15 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
         let Ok(path) = u.to_file_path() else {
           return true;
         };
-        if path.components().any(|c| {
-          matches!(c.as_os_str().to_str(), Some("node_modules") | Some(".deno"))
-        }) {
+        if let Some(root) = &deno_dir_root
+          && path.starts_with(root)
+        {
           return false;
         }
-        match &deno_dir_root {
-          Some(root) => !path.starts_with(root),
-          None => true,
-        }
+        let rel = path.strip_prefix(&project_root).unwrap_or(&path);
+        !rel.components().any(|c| {
+          matches!(c.as_os_str().to_str(), Some("node_modules") | Some(".deno"))
+        })
       })
       .collect();
 
@@ -328,17 +345,6 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
     }
     specifiers.into_iter().collect::<Vec<_>>()
   };
-
-  // Generate at the workspace/config root, not the current working directory,
-  // so running `deno sync-types` from a subdirectory still writes the config
-  // next to deno.json and picks up the root import map.
-  let project_root = cli_options
-    .workspace()
-    .root_dir_url()
-    .to_file_path()
-    .map_err(|_| {
-      deno_core::anyhow::anyhow!("workspace root is not a local directory")
-    })?;
 
   let installed = super::npm_compat::setup_npm_compat(
     &project_root,

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -285,7 +285,13 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
     // broken file (dead example scripts, etc.); we want every specifier that
     // *did* resolve regardless.
     let graph_creator = factory.module_graph_creator().await?;
-    let graph = match graph_creator
+    // Silence warn-level diagnostics during this discovery build. It's an
+    // internal step (not the user's `deno check`), and the graph the user
+    // installed was already validated by `deno install` — re-emitting e.g.
+    // "workspace member ... was not used" warnings here is just noise.
+    let prev_log_level = log::max_level();
+    log::set_max_level(log::LevelFilter::Error);
+    let graph_result = graph_creator
       .create_graph_with_options(crate::graph_util::CreateGraphOptions {
         graph_kind: deno_graph::GraphKind::All,
         roots,
@@ -294,8 +300,9 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
         loader: None,
         npm_caching: cli_options.default_npm_caching_strategy(),
       })
-      .await
-    {
+      .await;
+    log::set_max_level(prev_log_level);
+    let graph = match graph_result {
       Ok(graph) => graph,
       Err(e) => {
         log::debug!("sync-types: graph build failed (continuing): {e}");

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -333,7 +333,7 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
       deno_core::anyhow::anyhow!("workspace root is not a local directory")
     })?;
 
-  super::npm_compat::setup_npm_compat(
+  let installed = super::npm_compat::setup_npm_compat(
     &project_root,
     &file_fetcher,
     &http_client,
@@ -341,6 +341,18 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
     &graph_specifiers,
   )
   .await?;
+
+  log::info!(
+    "{} tsconfig for stock TypeScript at {}",
+    deno_terminal::colors::green("Synced"),
+    project_root.join("tsconfig.json").display(),
+  );
+  for pkg in &installed {
+    log::debug!("  installed jsr package {}@{}", pkg.name, pkg.version);
+  }
+  if !installed.is_empty() {
+    log::info!("  installed {} jsr package(s)", installed.len());
+  }
   Ok(())
 }
 

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -178,25 +178,6 @@ async fn install_top_level(
     lockfile.write_if_changed()?;
   }
 
-  // Post-install: set up jsr packages in node_modules and generate tsconfig
-  // mappings so stock TypeScript tooling understands the project.
-  {
-    let cli_options = factory.cli_options()?;
-    let file_fetcher = factory.file_fetcher()?.clone();
-    let http_client = factory.http_client_provider().get_or_create()?;
-    let permissions = factory.root_permissions_container()?.clone();
-    if let Err(e) = super::npm_compat::setup_npm_compat(
-      cli_options.initial_cwd(),
-      &file_fetcher,
-      &http_client,
-      &permissions,
-    )
-    .await
-    {
-      log::warn!("Failed to set up TypeScript compatibility: {e}");
-    }
-  }
-
   let install_reporter = factory.install_reporter()?.unwrap().clone();
   let workspace = factory.workspace_resolver().await?;
   let npm_resolver = factory.npm_resolver().await?;
@@ -246,6 +227,26 @@ pub async fn ci_command(
     },
   )
   .await
+}
+
+/// `deno sync-types`: generate a tsconfig + type mappings so stock TypeScript
+/// tooling can type-check the project. Assumes dependencies are already
+/// installed (run `deno install` first); materializes `jsr:`/`http(s):` types
+/// and writes `.deno/tsconfig.json`.
+pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
+  let factory = CliFactory::from_flags(flags);
+  let cli_options = factory.cli_options()?;
+  let file_fetcher = factory.file_fetcher()?.clone();
+  let http_client = factory.http_client_provider().get_or_create()?;
+  let permissions = factory.root_permissions_container()?.clone();
+  super::npm_compat::setup_npm_compat(
+    cli_options.initial_cwd(),
+    &file_fetcher,
+    &http_client,
+    &permissions,
+  )
+  .await?;
+  Ok(())
 }
 
 pub fn check_if_installs_a_single_package_globally(

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -274,13 +274,17 @@ pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
     let mut specifiers = std::collections::BTreeSet::new();
     for module in graph.modules() {
       for (raw, _dep) in module.dependencies() {
-        if raw.starts_with("npm:")
-          || raw.starts_with("jsr:")
-          || raw.starts_with("http://")
-          || raw.starts_with("https://")
+        // Collect scheme specifiers (npm:/jsr:/http:) and bare specifiers
+        // (import-map aliases like `@std/fmt/colors`, `fresh/runtime`). Skip
+        // relative imports and node: builtins. setup_npm_compat resolves the
+        // bare ones against the import map.
+        if raw.starts_with('.')
+          || raw.starts_with('/')
+          || raw.starts_with("node:")
         {
-          specifiers.insert(raw.clone());
+          continue;
         }
+        specifiers.insert(raw.clone());
       }
     }
     specifiers.into_iter().collect::<Vec<_>>()

--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -234,16 +234,64 @@ pub async fn ci_command(
 /// installed (run `deno install` first); materializes `jsr:`/`http(s):` types
 /// and writes `.deno/tsconfig.json`.
 pub async fn sync_types_command(flags: Arc<Flags>) -> Result<(), AnyError> {
+  use crate::graph_container::CheckSpecifiersOptions;
+  use crate::graph_container::CollectSpecifiersOptions;
+  use crate::graph_container::ModuleGraphContainer;
+
   let factory = CliFactory::from_flags(flags);
   let cli_options = factory.cli_options()?;
   let file_fetcher = factory.file_fetcher()?.clone();
   let http_client = factory.http_client_provider().get_or_create()?;
   let permissions = factory.root_permissions_container()?.clone();
+
+  // Build the module graph over the whole project to discover every external
+  // (npm:/jsr:/http(s):) specifier the code actually uses — including specifiers
+  // written directly in source and across workspace members, not just the ones
+  // declared in the root deno.json import map.
+  let graph_specifiers = {
+    let graph_container = factory.main_module_graph_container().await?;
+    let roots = graph_container.collect_specifiers(
+      &[".".to_string()],
+      CollectSpecifiersOptions {
+        include_ignored_specified: false,
+      },
+    )?;
+    // Best-effort: build the graph; type/resolution errors here shouldn't stop
+    // us from generating config for whatever did resolve.
+    if let Err(e) = graph_container
+      .check_specifiers(
+        &roots,
+        CheckSpecifiersOptions {
+          ext_overwrite: None,
+          allow_unknown_media_types: true,
+        },
+      )
+      .await
+    {
+      log::debug!("sync-types: graph build had errors (continuing): {e}");
+    }
+    let graph = graph_container.graph();
+    let mut specifiers = std::collections::BTreeSet::new();
+    for module in graph.modules() {
+      for (raw, _dep) in module.dependencies() {
+        if raw.starts_with("npm:")
+          || raw.starts_with("jsr:")
+          || raw.starts_with("http://")
+          || raw.starts_with("https://")
+        {
+          specifiers.insert(raw.clone());
+        }
+      }
+    }
+    specifiers.into_iter().collect::<Vec<_>>()
+  };
+
   super::npm_compat::setup_npm_compat(
     cli_options.initial_cwd(),
     &file_fetcher,
     &http_client,
     &permissions,
+    &graph_specifiers,
   )
   .await?;
   Ok(())

--- a/cli/tools/installer/mod.rs
+++ b/cli/tools/installer/mod.rs
@@ -27,6 +27,7 @@ use crate::util::display;
 mod bin_name_resolver;
 mod global;
 mod local;
+mod npm_compat;
 
 pub use global::uninstall;
 use local::CategorizedInstalledDeps;

--- a/cli/tools/installer/mod.rs
+++ b/cli/tools/installer/mod.rs
@@ -33,6 +33,7 @@ pub use global::uninstall;
 use local::CategorizedInstalledDeps;
 use local::categorize_installed_npm_deps;
 pub use local::ci_command;
+pub use local::sync_types_command;
 
 #[derive(Default)]
 pub struct InstallStats {

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -41,37 +41,53 @@ pub struct InstalledJsrPackage {
 ///
 /// Called after `deno install` completes npm resolution and node_modules setup.
 /// Returns the list of newly installed JSR packages for reporting.
+fn is_special_specifier(s: &str) -> bool {
+  s.starts_with("jsr:")
+    || s.starts_with("npm:")
+    || s.starts_with("http://")
+    || s.starts_with("https://")
+}
+
 pub async fn setup_npm_compat(
   project_root: &Path,
   file_fetcher: &CliFileFetcher,
   http_client: &HttpClient,
   permissions: &PermissionsContainer,
+  graph_specifiers: &[String],
 ) -> Result<Vec<InstalledJsrPackage>, AnyError> {
   let deno_json = read_deno_json(project_root)?;
-  let Some(deno_json) = deno_json else {
-    return Ok(vec![]);
-  };
+  let deno_compiler_options = deno_json
+    .as_ref()
+    .and_then(|d| d.get("compilerOptions"))
+    .cloned();
 
-  let deno_imports = deno_json.get("imports");
-  let deno_compiler_options = deno_json.get("compilerOptions");
-
-  // Check if there are any jsr:, npm:, or http(s): specifiers — if not, skip
-  let has_special_specifiers = deno_imports
+  // Combine the root import-map targets with the specifiers discovered in the
+  // module graph. Graph specifiers (e.g. `jsr:@std/path` written directly in
+  // source, or a workspace member's deps) are keyed by themselves so the
+  // existing import-map-driven generation maps them to their installed location
+  // just like an import-map alias.
+  let mut combined = deno_json
+    .as_ref()
+    .and_then(|d| d.get("imports"))
     .and_then(|v| v.as_object())
-    .is_some_and(|imports| {
-      imports.values().any(|v| {
-        v.as_str().is_some_and(|s| {
-          s.starts_with("jsr:")
-            || s.starts_with("npm:")
-            || s.starts_with("http://")
-            || s.starts_with("https://")
-        })
-      })
-    });
+    .cloned()
+    .unwrap_or_default();
+  for spec in graph_specifiers {
+    combined
+      .entry(spec.clone())
+      .or_insert_with(|| Value::String(spec.clone()));
+  }
 
+  let has_special_specifiers = combined.iter().any(|(k, v)| {
+    is_special_specifier(k) || v.as_str().is_some_and(is_special_specifier)
+  });
   if !has_special_specifiers {
     return Ok(vec![]);
   }
+
+  let combined_imports = Value::Object(combined);
+  let deno_imports = Some(&combined_imports);
+  let deno_compiler_options = deno_compiler_options.as_ref();
 
   // Install jsr: packages to node_modules/@jsr/
   let installed =

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -744,6 +744,12 @@ pub async fn install_http_modules(
     if paths.contains_key(&requested_url) {
       continue;
     }
+    // A trailing-slash URL is a directory/prefix specifier, not a module; the
+    // files under it are discovered and mirrored per-subpath. Skip silently
+    // (fetching the bare prefix just 404s).
+    if requested_url.path().ends_with('/') {
+      continue;
+    }
 
     // Fetch (cached) source + headers via the standard file fetcher, gated
     // by --allow-import the same way runtime http imports are. Follows

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -64,7 +64,7 @@ pub async fn setup_npm_compat(
   // Workspace member aliases (`@std/assert` -> the local `./assert` member's
   // exports) shadow any published jsr mapping, so compute them up front and let
   // them win in the generated `paths`.
-  let member_paths = deno_json
+  let mut member_paths = deno_json
     .as_ref()
     .map(|d| workspace_member_paths(project_root, d))
     .unwrap_or_default();
@@ -93,6 +93,14 @@ pub async fn setup_npm_compat(
     .iter()
     .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
     .collect();
+
+  // An alias that points at `jsr:`/`npm:<name>` where `<name>` is itself a
+  // workspace member (e.g. `"fresh": "jsr:@fresh/core"` in a repo whose
+  // `packages/fresh` member is named `@fresh/core`) must resolve to the LOCAL
+  // member, not the published registry copy. Otherwise imports through the alias
+  // get the registry package's types while local/relative imports get the
+  // member's, and the two identical-looking types don't unify.
+  add_member_alias_paths(&mut member_paths, &alias_targets);
   for spec in graph_specifiers {
     if is_special_specifier(spec) {
       // Direct scheme specifier: key it to itself.
@@ -316,8 +324,10 @@ fn workspace_member_paths(
   else {
     return paths;
   };
-  for member in members.iter().filter_map(|m| m.as_str()) {
-    let member_rel = member.trim_start_matches("./").trim_end_matches('/');
+  let member_patterns: Vec<&str> =
+    members.iter().filter_map(|m| m.as_str()).collect();
+  for member_rel in expand_member_patterns(project_root, &member_patterns) {
+    let member_rel = member_rel.as_str();
     let Some(member_json) = read_deno_json(&project_root.join(member_rel))
       .ok()
       .flatten()
@@ -355,6 +365,89 @@ fn workspace_member_paths(
     }
   }
   paths
+}
+
+/// Expand workspace member patterns into concrete member directories (relative
+/// to the project root). A trailing `/*` (e.g. `./packages/*`) enumerates the
+/// immediate subdirectories that contain a `deno.json(c)`; everything else is
+/// treated as a literal member path. Deno's own workspace config supports this
+/// glob form, and it's common in monorepos.
+fn expand_member_patterns(
+  project_root: &Path,
+  patterns: &[&str],
+) -> Vec<String> {
+  let mut out = Vec::new();
+  for pattern in patterns {
+    let cleaned = pattern.trim_start_matches("./").trim_end_matches('/');
+    if let Some(parent) = cleaned.strip_suffix("/*") {
+      let Ok(entries) = std::fs::read_dir(project_root.join(parent)) else {
+        continue;
+      };
+      for entry in entries.flatten() {
+        if !entry.path().is_dir() {
+          continue;
+        }
+        let dir = entry.path();
+        if (dir.join("deno.json").exists() || dir.join("deno.jsonc").exists())
+          && let Some(name) = entry.file_name().to_str()
+        {
+          out.push(format!("{parent}/{name}"));
+        }
+      }
+    } else {
+      out.push(cleaned.to_string());
+    }
+  }
+  out.sort();
+  out
+}
+
+/// Extract the bare package name from a `jsr:`/`npm:` specifier, dropping the
+/// scheme and any version/subpath (`jsr:@fresh/core@^2` -> `@fresh/core`,
+/// `npm:chalk@5` -> `chalk`, `npm:@scope/pkg@1` -> `@scope/pkg`).
+fn scheme_package_name(spec: &str) -> Option<String> {
+  let rest = spec
+    .strip_prefix("jsr:")
+    .or_else(|| spec.strip_prefix("npm:"))?;
+  if let Some(scoped) = rest.strip_prefix('@') {
+    let (scope, name_and_rest) = scoped.split_once('/')?;
+    let name = name_and_rest.split('@').next()?;
+    Some(format!("@{scope}/{name}"))
+  } else {
+    Some(rest.split('@').next()?.to_string())
+  }
+}
+
+/// For each import-map alias whose target's package name matches a workspace
+/// member, mirror that member's `paths` entries under the alias so imports
+/// through the alias resolve to the local member's source rather than a
+/// materialized registry copy.
+fn add_member_alias_paths(
+  member_paths: &mut serde_json::Map<String, Value>,
+  alias_targets: &[(String, String)],
+) {
+  // Snapshot member entries so we can extend `member_paths` while iterating.
+  let member_entries: Vec<(String, Value)> = member_paths
+    .iter()
+    .map(|(k, v)| (k.clone(), v.clone()))
+    .collect();
+  for (alias, target) in alias_targets {
+    let Some(base) = scheme_package_name(target) else {
+      continue;
+    };
+    let sub_prefix = format!("{base}/");
+    for (member_key, member_val) in &member_entries {
+      if member_key == &base {
+        member_paths
+          .entry(alias.clone())
+          .or_insert_with(|| member_val.clone());
+      } else if let Some(sub) = member_key.strip_prefix(&sub_prefix) {
+        member_paths
+          .entry(format!("{alias}/{sub}"))
+          .or_insert_with(|| member_val.clone());
+      }
+    }
+  }
 }
 
 fn read_deno_json(project_root: &Path) -> Result<Option<Value>, AnyError> {
@@ -874,5 +967,61 @@ fn resolve_jsr_version(
         anyhow!("No version matching '{req_str}' for {registry_name}")
       })
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_scheme_package_name() {
+    assert_eq!(
+      scheme_package_name("jsr:@fresh/core@^2.0.0").as_deref(),
+      Some("@fresh/core")
+    );
+    assert_eq!(scheme_package_name("npm:chalk@5").as_deref(), Some("chalk"));
+    assert_eq!(
+      scheme_package_name("npm:@scope/pkg@1.2.3").as_deref(),
+      Some("@scope/pkg")
+    );
+    assert_eq!(scheme_package_name("npm:chalk").as_deref(), Some("chalk"));
+    assert_eq!(scheme_package_name("./local.ts"), None);
+    assert_eq!(scheme_package_name("https://example.com/x.ts"), None);
+  }
+
+  #[test]
+  fn test_add_member_alias_paths() {
+    // `packages/fresh` (name `@fresh/core`) is a workspace member; the root
+    // import map aliases `fresh` -> `jsr:@fresh/core`.
+    let mut member_paths = serde_json::Map::new();
+    member_paths.insert(
+      "@fresh/core".into(),
+      json!(["../packages/fresh/src/mod.ts"]),
+    );
+    member_paths.insert(
+      "@fresh/core/runtime".into(),
+      json!(["../packages/fresh/src/runtime.ts"]),
+    );
+
+    let alias_targets = vec![
+      ("fresh".to_string(), "jsr:@fresh/core@^2.0.0".to_string()),
+      // an alias to a non-member package is left alone
+      ("chalk".to_string(), "npm:chalk@5".to_string()),
+    ];
+
+    add_member_alias_paths(&mut member_paths, &alias_targets);
+
+    // alias and its subpath now point at the local member source
+    assert_eq!(
+      member_paths.get("fresh").unwrap(),
+      &json!(["../packages/fresh/src/mod.ts"])
+    );
+    assert_eq!(
+      member_paths.get("fresh/runtime").unwrap(),
+      &json!(["../packages/fresh/src/runtime.ts"])
+    );
+    // non-member alias produced no new entry
+    assert!(!member_paths.contains_key("chalk"));
   }
 }

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -659,6 +659,14 @@ fn extract_tarball_gz(gz_bytes: &[u8], dest: &Path) -> Result<(), AnyError> {
   let mut archive = tar::Archive::new(GzDecoder::new(gz_bytes));
   for entry in archive.entries()? {
     let mut entry = entry?;
+    // Never materialize link entries. A symlink entry pointing outside `dest`,
+    // followed by a regular-file entry nested "under" it, would let `unpack`
+    // (via `create_dir_all` following the symlink) write outside `dest`. We only
+    // need regular files/dirs for type extraction, so skip links entirely.
+    let entry_type = entry.header().entry_type();
+    if entry_type.is_symlink() || entry_type.is_hard_link() {
+      continue;
+    }
     let path = entry.path()?.into_owned();
     // Skip the leading "package/" (or whatever the single root dir is named).
     let stripped: PathBuf = path.components().skip(1).collect();

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -182,7 +182,7 @@ pub async fn setup_npm_compat(
   // The project's own `exclude` (from deno.json) tells us which paths Deno
   // doesn't check (test fixtures, generated output); mirror it into the tsconfig
   // so we don't surface diagnostics for files Deno itself skips.
-  let excludes: Vec<String> = deno_json
+  let mut excludes: Vec<String> = deno_json
     .as_ref()
     .and_then(|d| d.get("exclude"))
     .and_then(|v| v.as_array())
@@ -193,6 +193,20 @@ pub async fn setup_npm_compat(
         .collect()
     })
     .unwrap_or_default();
+
+  // Exclude Deno's vendor directory. Vendored deps are third-party code Deno
+  // doesn't type-check, and their `jsr:`/`npm:` imports resolve through Deno's
+  // vendor map (not ours), so type-checking them here just surfaces the deps'
+  // own errors. The vendor dir is `vendor/` at the project root when `vendor`
+  // is enabled in deno.json or the directory is present.
+  let vendor_enabled = deno_json
+    .as_ref()
+    .and_then(|d| d.get("vendor"))
+    .and_then(|v| v.as_bool())
+    .unwrap_or(false);
+  if vendor_enabled || project_root.join("vendor").is_dir() {
+    excludes.push("vendor".to_string());
+  }
 
   // Generate .deno/tsconfig.json and ensure root tsconfig.json extends it
   generate_deno_tsconfig(

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -127,6 +127,10 @@ pub async fn setup_npm_compat(
     }
   };
 
+  // Ensure @types/node is available so Node globals (timers, node: builtins,
+  // Buffer, URLPattern, ...) resolve under stock tooling.
+  let has_node_types = ensure_types_node(project_root, http_client).await;
+
   // Generate .deno/tsconfig.json and ensure root tsconfig.json extends it
   generate_deno_tsconfig(
     project_root,
@@ -134,9 +138,108 @@ pub async fn setup_npm_compat(
     deno_imports,
     &http_modules,
     &member_paths,
+    has_node_types,
   )?;
 
   Ok(installed)
+}
+
+/// Ensure a stock `@types/node` (and its `undici-types` dependency) is present
+/// in `node_modules/@types` so the generated tsconfig can load Node globals
+/// (timers, `node:` builtins, `Buffer`, `URLPattern`, ...). No-op when the
+/// project already has `@types/node` installed. Returns whether it's available.
+///
+/// This is the interim: once #35889 lands, node types come from the global
+/// cache instead of being materialized per-project here.
+async fn ensure_types_node(
+  project_root: &Path,
+  http_client: &HttpClient,
+) -> bool {
+  if project_root.join("node_modules/@types/node").exists() {
+    return true;
+  }
+  match download_npm_package(project_root, "@types/node", None, http_client)
+    .await
+  {
+    Ok(Some((_version, deps))) => {
+      if let Some(req) = deps.get("undici-types").and_then(|v| v.as_str()) {
+        let _ = download_npm_package(
+          project_root,
+          "undici-types",
+          Some(req),
+          http_client,
+        )
+        .await;
+      }
+      project_root.join("node_modules/@types/node").exists()
+    }
+    _ => false,
+  }
+}
+
+/// Download an npm package tarball from registry.npmjs.org into
+/// `node_modules/<pkg>` and return its resolved version + dependency map.
+/// Resolves `req` (a semver range) if given, otherwise the `latest` dist-tag.
+async fn download_npm_package(
+  project_root: &Path,
+  pkg: &str,
+  req: Option<&str>,
+  http_client: &HttpClient,
+) -> Result<Option<(String, serde_json::Map<String, Value>)>, AnyError> {
+  let meta_url =
+    format!("https://registry.npmjs.org/{}", pkg.replace('/', "%2f"));
+  let bytes = match http_client.download(Url::parse(&meta_url)?).await {
+    Ok(b) => b,
+    Err(e) => {
+      log::debug!("Failed to fetch metadata for {pkg}: {e}");
+      return Ok(None);
+    }
+  };
+  let meta: Value = serde_json::from_slice(&bytes)?;
+  let version = match req {
+    Some(r) => resolve_version_req(&meta, r),
+    None => meta
+      .get("dist-tags")
+      .and_then(|t| t.get("latest"))
+      .and_then(|v| v.as_str())
+      .map(String::from),
+  };
+  let Some(version) = version else {
+    return Ok(None);
+  };
+  let vinfo = meta.get("versions").and_then(|vs| vs.get(&version));
+  let Some(tarball) = vinfo
+    .and_then(|v| v.get("dist"))
+    .and_then(|d| d.get("tarball"))
+    .and_then(|t| t.as_str())
+  else {
+    return Ok(None);
+  };
+  let tb = http_client.download(Url::parse(tarball)?).await?;
+  let dest = project_root.join("node_modules").join(pkg);
+  if let Err(e) = extract_tarball_gz(&tb, &dest) {
+    log::debug!("Failed to extract {pkg}: {e}");
+    let _ = std::fs::remove_dir_all(&dest);
+    return Ok(None);
+  }
+  let deps = vinfo
+    .and_then(|v| v.get("dependencies"))
+    .and_then(|d| d.as_object())
+    .cloned()
+    .unwrap_or_default();
+  Ok(Some((version, deps)))
+}
+
+/// Highest version in the packument satisfying the npm semver range `req`.
+fn resolve_version_req(meta: &Value, req: &str) -> Option<String> {
+  let vr = VersionReq::parse_from_npm(req).ok()?;
+  let versions = meta.get("versions")?.as_object()?;
+  versions
+    .keys()
+    .filter_map(|v| Version::parse_from_npm(v).ok())
+    .filter(|v| vr.matches(v))
+    .max()
+    .map(|v| v.to_string())
 }
 
 /// If `deno_json` references an external import map via `importMap`, read that
@@ -226,12 +329,14 @@ fn read_deno_json(project_root: &Path) -> Result<Option<Value>, AnyError> {
 }
 
 /// Generate tsconfig.deno.json at the project root with paths mappings.
+#[allow(clippy::too_many_arguments)]
 fn generate_deno_tsconfig(
   project_root: &Path,
   deno_compiler_options: Option<&Value>,
   deno_imports: Option<&Value>,
   http_modules: &BTreeMap<Url, String>,
   member_paths: &serde_json::Map<String, Value>,
+  has_node_types: bool,
 ) -> Result<(), AnyError> {
   let generated = crate::tsc::tsconfig_gen::generate_tsconfig(
     project_root,
@@ -240,6 +345,7 @@ fn generate_deno_tsconfig(
     &[],
     http_modules,
     member_paths,
+    has_node_types,
   )
   .map_err(|e| anyhow!("Failed to generate tsconfig: {e}"))?;
 

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -719,7 +719,25 @@ fn write_mirror(
   if let Some(parent) = local_path.parent() {
     std::fs::create_dir_all(parent)?;
   }
-  std::fs::write(&local_path, bytes)?;
+  // Mark mirrored script modules `// @ts-nocheck`. Remote dependencies are not
+  // the user's code and Deno itself doesn't re-type-check them; without this,
+  // stock tsc/tsgo would report every type error inside the dependency (which
+  // dwarfs the project's own diagnostics). `@ts-nocheck` suppresses errors in
+  // the file while keeping its exported and ambient types available to
+  // importers, and triple-slash directives (which may follow a leading comment)
+  // still apply.
+  let is_script = matches!(
+    local_path.extension().and_then(|e| e.to_str()),
+    Some("ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs")
+  );
+  if is_script {
+    let mut content = Vec::with_capacity(bytes.len() + 16);
+    content.extend_from_slice(b"// @ts-nocheck\n");
+    content.extend_from_slice(bytes);
+    std::fs::write(&local_path, &content)?;
+  } else {
+    std::fs::write(&local_path, bytes)?;
+  }
   url_to_tsconfig_path(url)
     .ok_or_else(|| anyhow!("URL has no resolvable mirror path: {url}"))
 }

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -87,10 +87,28 @@ pub async fn setup_npm_compat(
       combined.entry(k).or_insert(v);
     }
   }
+  // Snapshot the import-map alias -> target pairs (before adding graph specs)
+  // so we can resolve bare specifiers against them.
+  let alias_targets: Vec<(String, String)> = combined
+    .iter()
+    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+    .collect();
   for spec in graph_specifiers {
-    combined
-      .entry(spec.clone())
-      .or_insert_with(|| Value::String(spec.clone()));
+    if is_special_specifier(spec) {
+      // Direct scheme specifier: key it to itself.
+      combined
+        .entry(spec.clone())
+        .or_insert_with(|| Value::String(spec.clone()));
+    } else if let Some(resolved) =
+      resolve_bare_against_import_map(spec, &alias_targets)
+    {
+      // Bare alias (+ maybe subpath): map it to the resolved scheme specifier
+      // so the per-flavor path generators handle it (e.g. `@std/fmt/colors` ->
+      // `jsr:@std/fmt@^1/colors`, `lume/foo` -> `https://.../lume@3/foo`).
+      combined
+        .entry(spec.clone())
+        .or_insert(Value::String(resolved));
+    }
   }
 
   let has_special_specifiers = combined.iter().any(|(k, v)| {
@@ -142,6 +160,36 @@ pub async fn setup_npm_compat(
   )?;
 
   Ok(installed)
+}
+
+/// Resolve a bare specifier (import-map alias, possibly with a subpath) against
+/// the import map by longest-prefix match, returning the composed scheme
+/// specifier if the matched alias targets `npm:`/`jsr:`/`http(s):`.
+///
+/// - exact alias:            `@fresh/core`      + `@fresh/core` -> `jsr:@fresh/core@^2`
+/// - alias + subpath:        `@std/fmt/colors`  + `@std/fmt`    -> `jsr:@std/fmt@^1/colors`
+/// - trailing-slash prefix:  `lume/foo`         + `lume/`       -> `https://.../lume@3/foo`
+fn resolve_bare_against_import_map(
+  spec: &str,
+  alias_targets: &[(String, String)],
+) -> Option<String> {
+  let mut best: Option<(&str, &str)> = None;
+  for (alias, target) in alias_targets {
+    let matches = spec == alias
+      || (alias.ends_with('/') && spec.starts_with(alias.as_str()))
+      || (!alias.ends_with('/') && spec.starts_with(&format!("{alias}/")));
+    if matches && best.is_none_or(|(b, _)| alias.len() > b.len()) {
+      best = Some((alias, target));
+    }
+  }
+  let (alias, target) = best?;
+  if !is_special_specifier(target) {
+    return None;
+  }
+  // Append whatever of `spec` extends past the matched alias. For a trailing-
+  // slash prefix that's `foo`; for a non-slash alias it's `/subpath` (or empty
+  // for an exact match).
+  Some(format!("{}{}", target, &spec[alias.len()..]))
 }
 
 /// Ensure a stock `@types/node` (and its `undici-types` dependency) is present

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -119,15 +119,10 @@ pub async fn setup_npm_compat(
     }
   }
 
-  let has_special_specifiers = combined.iter().any(|(k, v)| {
-    is_special_specifier(k) || v.as_str().is_some_and(is_special_specifier)
-  });
-  // Generate if there's anything to map: external specifiers, or a workspace
-  // whose members need local-path aliases (e.g. std).
-  if !has_special_specifiers && member_paths.is_empty() {
-    return Ok(vec![]);
-  }
-
+  // Always generate the base config: even a project with no external deps needs
+  // the generated tsconfig + private `@types/deno` so stock tooling sees the
+  // Deno globals. There's simply nothing to map into `paths` when there are no
+  // external specifiers or workspace members.
   let combined_imports = Value::Object(combined);
   let deno_imports = Some(&combined_imports);
   let deno_compiler_options = deno_compiler_options.as_ref();
@@ -152,6 +147,33 @@ pub async fn setup_npm_compat(
       BTreeMap::new()
     }
   };
+
+  // Warn about npm packages that aren't materialized under `node_modules`. With
+  // Deno's default global-cache mode, `deno install` can resolve npm deps
+  // without a local `node_modules/<pkg>`, so their `paths` are skipped (see
+  // generate_npm_paths) and stock tsc can't resolve them.
+  let mut unmaterialized: Vec<String> = combined_imports
+    .as_object()
+    .into_iter()
+    .flatten()
+    .filter_map(|(_k, v)| v.as_str())
+    .filter(|s| s.starts_with("npm:"))
+    .filter_map(|s| deno_semver::npm::NpmPackageReqReference::from_str(s).ok())
+    .map(|r| r.req().name.to_string())
+    .filter(|name| !project_root.join(format!("node_modules/{name}")).exists())
+    .collect();
+  unmaterialized.sort();
+  unmaterialized.dedup();
+  if !unmaterialized.is_empty() {
+    log::warn!(
+      "sync-types: {} npm package(s) are not present under node_modules and \
+       were left unmapped ({}). Enable a node_modules directory (e.g. set \
+       \"nodeModulesDir\": \"auto\" in deno.json) so stock TypeScript can \
+       resolve them.",
+      unmaterialized.len(),
+      unmaterialized.join(", "),
+    );
+  }
 
   // Ensure @types/node is available so Node globals (timers, node: builtins,
   // Buffer, URLPattern, ...) resolve under stock tooling.
@@ -853,32 +875,68 @@ fn write_mirror(
     .ok_or_else(|| anyhow!("URL has no resolvable mirror path: {url}"))
 }
 
+/// Compute the mirror location for `url` relative to the remote root, e.g.
+/// `https://example.com/x/foo.ts` → `example.com/x/foo.ts`. Includes a
+/// non-default port and a hash of the query string so URLs that share a path
+/// but differ by port or query (common on CDNs like esm.sh) don't collide on
+/// disk or in the generated `paths`. The query hash goes into the last
+/// segment's stem (before its first `.`), keeping the file in the same
+/// directory and preserving its extension so relative imports still resolve.
+/// Returns None for directory-like URLs (path ends in `/`), since we can't
+/// infer an index filename without server cooperation.
+fn url_to_mirror_rel(url: &Url) -> Option<String> {
+  let host = url.host_str()?;
+  let path = url.path();
+  if path.ends_with('/') || path.is_empty() {
+    return None;
+  }
+  let mut host_seg = host.to_string();
+  if let Some(port) = url.port() {
+    host_seg.push_str(&format!("__{port}"));
+  }
+  let rel = path.trim_start_matches('/');
+  let rel = match url.query() {
+    Some(query) => {
+      let hash = short_hash(query);
+      match rel.rsplit_once('/') {
+        Some((dir, file)) => {
+          format!("{dir}/{}", inject_stem_suffix(file, &hash))
+        }
+        None => inject_stem_suffix(rel, &hash),
+      }
+    }
+    None => rel.to_string(),
+  };
+  Some(format!("{host_seg}/{rel}"))
+}
+
+/// Insert `suffix` into a filename before its first `.` (`mod.d.ts` ->
+/// `mod.<suffix>.d.ts`), or append it when there's no extension.
+fn inject_stem_suffix(file: &str, suffix: &str) -> String {
+  match file.split_once('.') {
+    Some((stem, ext)) => format!("{stem}.{suffix}.{ext}"),
+    None => format!("{file}.{suffix}"),
+  }
+}
+
+/// Deterministic short hex hash, used to disambiguate mirror paths by query.
+fn short_hash(s: &str) -> String {
+  use std::hash::Hash;
+  use std::hash::Hasher;
+  let mut hasher = std::collections::hash_map::DefaultHasher::new();
+  s.hash(&mut hasher);
+  format!("{:08x}", hasher.finish() as u32)
+}
+
 /// Compute the `paths`-relative mirror location for `url`, e.g.
 /// `https://example.com/x/foo.ts` → `./remote/example.com/x/foo.ts`.
 fn url_to_tsconfig_path(url: &Url) -> Option<String> {
-  let host = url.host_str()?;
-  let path = url.path();
-  if path.ends_with('/') || path.is_empty() {
-    return None;
-  }
-  let rel = path.trim_start_matches('/');
-  Some(format!("./remote/{host}/{rel}"))
+  Some(format!("./remote/{}", url_to_mirror_rel(url)?))
 }
 
-/// Map a URL to its mirror file path under `<remote_root>/<host><path>`.
-/// Returns None for URLs that don't yield a sensible file path (e.g. ending
-/// in `/`, since we can't infer an index filename without server cooperation).
+/// Map a URL to its mirror file path under `<remote_root>/<mirror-rel>`.
 fn url_to_local_path(remote_root: &Path, url: &Url) -> Option<PathBuf> {
-  let host = url.host_str()?;
-  let path = url.path();
-  if path.ends_with('/') || path.is_empty() {
-    // Directory-like URL — would need server to tell us the actual filename.
-    // Skip for the prototype; full deno_graph handles this via redirects.
-    return None;
-  }
-  // Strip leading '/', percent-decoding left as-is for the prototype.
-  let rel = path.trim_start_matches('/');
-  Some(remote_root.join(host).join(rel))
+  Some(remote_root.join(url_to_mirror_rel(url)?))
 }
 
 /// Extract module specifier string literals from a JS/TS source via
@@ -1041,5 +1099,26 @@ mod tests {
     );
     // non-member alias produced no new entry
     assert!(!member_paths.contains_key("chalk"));
+  }
+
+  #[test]
+  fn test_url_to_mirror_rel_disambiguates_query_and_port() {
+    let rel = |u: &str| url_to_mirror_rel(&Url::parse(u).unwrap()).unwrap();
+
+    // Plain URL: host/path, unchanged.
+    assert_eq!(rel("https://example.com/x/foo.ts"), "example.com/x/foo.ts");
+
+    // Distinct queries must not collide, and the extension is preserved.
+    let a = rel("https://esm.sh/react.ts?a=1");
+    let b = rel("https://esm.sh/react.ts?a=2");
+    assert_ne!(a, b);
+    assert!(a.ends_with(".ts") && b.ends_with(".ts"));
+    assert!(a.starts_with("esm.sh/") && b.starts_with("esm.sh/"));
+
+    // Non-default port is part of the host segment.
+    let p = rel("https://example.com:8443/x/foo.ts");
+    assert!(p.starts_with("example.com__8443/"));
+    // Same host, different port -> different mirror path.
+    assert_ne!(p, rel("https://example.com:9443/x/foo.ts"));
   }
 }

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -305,6 +305,12 @@ fn extract_tarball_gz(gz_bytes: &[u8], dest: &Path) -> Result<(), AnyError> {
       ));
     }
     let out_path = dest.join(stripped);
+    // tar entries aren't guaranteed to list a directory before the files under
+    // it, and `Entry::unpack` won't create missing parents — so ensure the
+    // parent exists first (otherwise nested files like `_dist/mod.d.ts` fail).
+    if let Some(parent) = out_path.parent() {
+      std::fs::create_dir_all(parent)?;
+    }
     entry.unpack(&out_path)?;
   }
   Ok(())

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -157,6 +157,21 @@ pub async fn setup_npm_compat(
   // Buffer, URLPattern, ...) resolve under stock tooling.
   let has_node_types = ensure_types_node(project_root, http_client).await;
 
+  // The project's own `exclude` (from deno.json) tells us which paths Deno
+  // doesn't check (test fixtures, generated output); mirror it into the tsconfig
+  // so we don't surface diagnostics for files Deno itself skips.
+  let excludes: Vec<String> = deno_json
+    .as_ref()
+    .and_then(|d| d.get("exclude"))
+    .and_then(|v| v.as_array())
+    .map(|arr| {
+      arr
+        .iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect()
+    })
+    .unwrap_or_default();
+
   // Generate .deno/tsconfig.json and ensure root tsconfig.json extends it
   generate_deno_tsconfig(
     project_root,
@@ -165,6 +180,7 @@ pub async fn setup_npm_compat(
     &http_modules,
     &member_paths,
     has_node_types,
+    &excludes,
   )?;
 
   Ok(installed)
@@ -478,6 +494,7 @@ fn generate_deno_tsconfig(
   http_modules: &BTreeMap<Url, String>,
   member_paths: &serde_json::Map<String, Value>,
   has_node_types: bool,
+  excludes: &[String],
 ) -> Result<(), AnyError> {
   let generated = crate::tsc::tsconfig_gen::generate_tsconfig(
     project_root,
@@ -487,6 +504,7 @@ fn generate_deno_tsconfig(
     http_modules,
     member_paths,
     has_node_types,
+    excludes,
   )
   .map_err(|e| anyhow!("Failed to generate tsconfig: {e}"))?;
 

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -1,0 +1,597 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Post-install setup for stock TypeScript compatibility.
+//!
+//! After `deno install` sets up node_modules/, this module:
+//! 1. Installs jsr: packages to node_modules/@jsr/ via npm.jsr.io
+//! 2. Mirrors http(s): modules into .deno/remote/<host><path>/...
+//! 3. Generates .deno/tsconfig.json with paths mappings for npm:/jsr:/https:
+//!
+//! This enables stock TypeScript tooling (tsc, tsserver, VS Code) to work
+//! with Deno projects that use jsr:, npm:, and http(s): specifiers.
+
+use std::collections::BTreeMap;
+use std::collections::VecDeque;
+use std::path::Path;
+use std::path::PathBuf;
+
+use deno_core::anyhow::anyhow;
+use deno_core::error::AnyError;
+use deno_core::serde_json;
+use deno_core::serde_json::Value;
+use deno_core::serde_json::json;
+use deno_core::url::Url;
+use deno_runtime::deno_permissions::PermissionsContainer;
+use deno_semver::Version;
+use deno_semver::VersionReq;
+use flate2::read::GzDecoder;
+
+use crate::file_fetcher::CliFileFetcher;
+use crate::http_util::HttpClient;
+
+/// Installed JSR package info for reporting.
+pub struct InstalledJsrPackage {
+  /// e.g. "@jsr/std__assert"
+  pub name: String,
+  /// e.g. "1.0.19"
+  pub version: String,
+}
+
+/// Run post-install setup: install jsr packages and generate tsconfig.
+///
+/// Called after `deno install` completes npm resolution and node_modules setup.
+/// Returns the list of newly installed JSR packages for reporting.
+pub async fn setup_npm_compat(
+  project_root: &Path,
+  file_fetcher: &CliFileFetcher,
+  http_client: &HttpClient,
+  permissions: &PermissionsContainer,
+) -> Result<Vec<InstalledJsrPackage>, AnyError> {
+  let deno_json = read_deno_json(project_root)?;
+  let Some(deno_json) = deno_json else {
+    return Ok(vec![]);
+  };
+
+  let deno_imports = deno_json.get("imports");
+  let deno_compiler_options = deno_json.get("compilerOptions");
+
+  // Check if there are any jsr:, npm:, or http(s): specifiers — if not, skip
+  let has_special_specifiers = deno_imports
+    .and_then(|v| v.as_object())
+    .is_some_and(|imports| {
+      imports.values().any(|v| {
+        v.as_str().is_some_and(|s| {
+          s.starts_with("jsr:")
+            || s.starts_with("npm:")
+            || s.starts_with("http://")
+            || s.starts_with("https://")
+        })
+      })
+    });
+
+  if !has_special_specifiers {
+    return Ok(vec![]);
+  }
+
+  // Install jsr: packages to node_modules/@jsr/
+  let installed =
+    install_jsr_packages(project_root, deno_imports, http_client).await?;
+
+  // Mirror http(s): modules (and their transitive remote/relative imports)
+  // into .deno/remote/<host><path>/...
+  let http_modules = match install_http_modules(
+    project_root,
+    deno_imports,
+    file_fetcher,
+    permissions,
+  )
+  .await
+  {
+    Ok(map) => map,
+    Err(e) => {
+      log::warn!("Failed to materialize remote modules: {e}");
+      BTreeMap::new()
+    }
+  };
+
+  // Generate .deno/tsconfig.json and ensure root tsconfig.json extends it
+  generate_deno_tsconfig(
+    project_root,
+    deno_compiler_options,
+    deno_imports,
+    &http_modules,
+  )?;
+
+  Ok(installed)
+}
+
+fn read_deno_json(project_root: &Path) -> Result<Option<Value>, AnyError> {
+  let deno_json_path = project_root.join("deno.json");
+  let deno_jsonc_path = project_root.join("deno.jsonc");
+
+  if deno_json_path.exists() {
+    let content = std::fs::read_to_string(&deno_json_path)?;
+    Ok(Some(serde_json::from_str(&content)?))
+  } else if deno_jsonc_path.exists() {
+    let content = std::fs::read_to_string(&deno_jsonc_path)?;
+    let parsed: Option<Value> = jsonc_parser::parse_to_serde_value(
+      &content,
+      &jsonc_parser::ParseOptions::default(),
+    )?;
+    Ok(Some(parsed.unwrap_or(json!({}))))
+  } else {
+    Ok(None)
+  }
+}
+
+/// Generate tsconfig.deno.json at the project root with paths mappings.
+fn generate_deno_tsconfig(
+  project_root: &Path,
+  deno_compiler_options: Option<&Value>,
+  deno_imports: Option<&Value>,
+  http_modules: &BTreeMap<Url, String>,
+) -> Result<(), AnyError> {
+  let generated = crate::tsc::tsconfig_gen::generate_tsconfig(
+    project_root,
+    deno_compiler_options,
+    deno_imports,
+    &[],
+    http_modules,
+  )
+  .map_err(|e| anyhow!("Failed to generate tsconfig: {e}"))?;
+
+  log::debug!("Generated {}", generated.tsconfig_path.display());
+
+  Ok(())
+}
+
+/// Install jsr: packages to node_modules/@jsr/ by downloading from npm.jsr.io.
+///
+/// Uses `HttpClient::download` directly (not `CliFileFetcher`) because we
+/// don't want each registry/tarball URL surfacing as a user-visible
+/// "Download …" line in `deno install` output — those are an
+/// implementation detail of the stock-tsc compatibility setup. The
+/// fetcher's caching and redirect handling are unnecessary for npm.jsr.io.
+async fn install_jsr_packages(
+  project_root: &Path,
+  deno_imports: Option<&Value>,
+  http_client: &HttpClient,
+) -> Result<Vec<InstalledJsrPackage>, AnyError> {
+  let mut installed = Vec::new();
+  let imports = match deno_imports.and_then(|v| v.as_object()) {
+    Some(imports) => imports,
+    None => return Ok(installed),
+  };
+
+  for (_alias, target) in imports {
+    let target_str = match target.as_str() {
+      Some(s) if s.starts_with("jsr:") => s,
+      _ => continue,
+    };
+
+    let Some((scope, name, req_version)) =
+      crate::tsc::tsconfig_gen::parse_jsr_specifier(target_str)
+    else {
+      continue;
+    };
+
+    let npm_name = format!("{}__{}", scope.trim_start_matches('@'), name);
+    let pkg_dir = project_root
+      .join("node_modules")
+      .join("@jsr")
+      .join(&npm_name);
+    if pkg_dir.exists() {
+      continue;
+    }
+
+    let registry_name = format!("@jsr/{npm_name}");
+    let npm_jsr_registry = std::env::var("DENO_NPM_JSR_REGISTRY")
+      .unwrap_or_else(|_| "https://npm.jsr.io".to_string());
+    let metadata_url = format!(
+      "{}/{}",
+      npm_jsr_registry.trim_end_matches('/'),
+      registry_name.replace('/', "%2f")
+    );
+    let metadata_url = match Url::parse(&metadata_url) {
+      Ok(u) => u,
+      Err(e) => {
+        log::debug!("Invalid jsr registry URL {metadata_url}: {e}");
+        continue;
+      }
+    };
+
+    log::debug!("Installing {} from {}", registry_name, npm_jsr_registry);
+
+    let metadata_bytes = match http_client.download(metadata_url).await {
+      Ok(b) => b,
+      Err(e) => {
+        log::debug!("Failed to fetch metadata for {registry_name}: {e}");
+        continue;
+      }
+    };
+
+    let metadata: Value =
+      serde_json::from_slice(&metadata_bytes).map_err(|e| {
+        anyhow!("Failed to parse metadata for {registry_name}: {e}")
+      })?;
+
+    let resolved_version =
+      resolve_jsr_version(&metadata, req_version.as_deref(), &registry_name)?;
+
+    let tarball_url = metadata
+      .get("versions")
+      .and_then(|vs| vs.get(&resolved_version))
+      .and_then(|v| v.get("dist"))
+      .and_then(|d| d.get("tarball"))
+      .and_then(|t| t.as_str())
+      .ok_or_else(|| {
+        anyhow!("No tarball URL for {registry_name}@{resolved_version}")
+      })?;
+    let tarball_url = match Url::parse(tarball_url) {
+      Ok(u) => u,
+      Err(e) => {
+        log::debug!(
+          "Invalid tarball URL {tarball_url} for {registry_name}: {e}"
+        );
+        continue;
+      }
+    };
+
+    let tarball_bytes = match http_client.download(tarball_url).await {
+      Ok(b) => b,
+      Err(e) => {
+        log::debug!("Failed to download {registry_name}: {e}");
+        continue;
+      }
+    };
+
+    if let Err(e) = extract_tarball_gz(&tarball_bytes, &pkg_dir) {
+      log::debug!("Failed to extract {registry_name}: {e}");
+      let _ = std::fs::remove_dir_all(&pkg_dir);
+      continue;
+    }
+
+    installed.push(InstalledJsrPackage {
+      name: registry_name,
+      version: resolved_version,
+    });
+  }
+
+  Ok(installed)
+}
+
+/// Extract a gzipped npm-style tarball into `dest`, stripping the leading
+/// `package/` directory the way `tar --strip-components=1` does. Replaces
+/// the previous `tar` shell-out so the install works the same on Linux,
+/// macOS (BSD tar), Windows, and minimal containers without `tar`/`curl`.
+fn extract_tarball_gz(gz_bytes: &[u8], dest: &Path) -> Result<(), AnyError> {
+  std::fs::create_dir_all(dest)?;
+  let mut archive = tar::Archive::new(GzDecoder::new(gz_bytes));
+  for entry in archive.entries()? {
+    let mut entry = entry?;
+    let path = entry.path()?.into_owned();
+    // Skip the leading "package/" (or whatever the single root dir is named).
+    let stripped: PathBuf = path.components().skip(1).collect();
+    if stripped.as_os_str().is_empty() {
+      continue;
+    }
+    if stripped.is_absolute()
+      || stripped.components().any(|c| {
+        matches!(
+          c,
+          std::path::Component::ParentDir | std::path::Component::RootDir
+        )
+      })
+    {
+      return Err(anyhow!(
+        "Refusing to extract tar entry outside dest: {}",
+        path.display()
+      ));
+    }
+    let out_path = dest.join(stripped);
+    entry.unpack(&out_path)?;
+  }
+  Ok(())
+}
+
+/// A resolved entry for the tsconfig `paths` table: maps a user-facing URL
+/// (whatever appears in source as `import "..."`) to the local mirror file
+/// path (relative to `.deno/`) that tsc should resolve it to.
+pub type HttpModulePaths = BTreeMap<Url, String>;
+
+/// Materialize http(s): modules referenced from `deno.json` `imports` (and
+/// their transitive remote/relative imports) into `.deno/remote/<host><path>`.
+///
+/// Uses `CliFileFetcher`, which transparently reuses `DENO_DIR` cache, follows
+/// redirects, and exposes response headers. When a module advertises types via
+/// the `X-TypeScript-Types` header (esm.sh and friends), the types URL is
+/// fetched too and the paths entry for the original URL is pointed at the
+/// types file so tsc gets real declarations.
+///
+/// Module specifier discovery within source still uses a regex scanner — this
+/// is acknowledged tech debt; a deno_graph walk is the production answer.
+///
+/// Returns a map from user-facing URL to the local mirror path (relative to
+/// `.deno/`), suitable for direct use as tsconfig `paths` values.
+pub async fn install_http_modules(
+  project_root: &Path,
+  deno_imports: Option<&Value>,
+  file_fetcher: &CliFileFetcher,
+  permissions: &PermissionsContainer,
+) -> Result<HttpModulePaths, AnyError> {
+  let mut paths: HttpModulePaths = BTreeMap::new();
+  let mut queue: VecDeque<Url> = VecDeque::new();
+
+  let Some(imports) = deno_imports.and_then(|v| v.as_object()) else {
+    return Ok(paths);
+  };
+
+  for (_alias, target) in imports {
+    let Some(s) = target.as_str() else {
+      continue;
+    };
+    if !(s.starts_with("http://") || s.starts_with("https://")) {
+      continue;
+    }
+    if let Ok(url) = Url::parse(s) {
+      queue.push_back(url);
+    }
+  }
+
+  if queue.is_empty() {
+    return Ok(paths);
+  }
+
+  let remote_root = project_root.join(".deno").join("remote");
+
+  while let Some(requested_url) = queue.pop_front() {
+    if paths.contains_key(&requested_url) {
+      continue;
+    }
+
+    // Fetch (cached) source + headers via the standard file fetcher, gated
+    // by --allow-import the same way runtime http imports are. Follows
+    // redirects; `file.url` is the canonical post-redirect URL.
+    let file = match file_fetcher.fetch(&requested_url, permissions).await {
+      Ok(f) => f,
+      Err(e) => {
+        log::warn!(
+          "Skipping {requested_url}: {e} (try running `deno install --allow-import` to grant access)"
+        );
+        continue;
+      }
+    };
+    let final_url = file.url.clone();
+
+    // If the module advertises a separate types file (X-TypeScript-Types,
+    // common on esm.sh), fetch *that* and use it as the source-of-truth for
+    // both mirroring and import scanning. Otherwise use the module itself.
+    let types_url = file
+      .maybe_headers
+      .as_ref()
+      .and_then(|h| {
+        h.get("x-typescript-types")
+          .or_else(|| h.get("types"))
+          .or_else(|| h.get("typescript-types"))
+      })
+      .and_then(|v| Url::parse(v).ok().or_else(|| final_url.join(v).ok()));
+
+    let (effective_url, effective_bytes) = if let Some(t) = types_url.as_ref() {
+      match file_fetcher.fetch(t, permissions).await {
+        Ok(f) => (f.url.clone(), f.source.clone()),
+        Err(e) => {
+          log::debug!(
+            "X-TypeScript-Types fetch failed for {t} ({e}), falling back to source"
+          );
+          (final_url.clone(), file.source.clone())
+        }
+      }
+    } else {
+      (final_url.clone(), file.source.clone())
+    };
+
+    // Mirror the chosen content. We deliberately don't mirror both the JS
+    // and the .d.ts: their URL paths often collide on disk (e.g.
+    // `cowsay@1.6.0` as file vs `cowsay@1.6.0/index.d.ts` under a dir).
+    let local = match write_mirror(
+      &remote_root,
+      &effective_url,
+      effective_bytes.as_ref(),
+    ) {
+      Ok(p) => p,
+      Err(e) => {
+        log::debug!("Failed to mirror {effective_url} ({e})");
+        continue;
+      }
+    };
+    // Emit paths entries for every URL form the user (or transitive imports)
+    // might reference for this module — all pointing at the same mirror.
+    paths.insert(requested_url.clone(), local.clone());
+    if final_url != requested_url {
+      paths.insert(final_url.clone(), local.clone());
+    }
+    if effective_url != final_url {
+      paths.insert(effective_url.clone(), local.clone());
+    }
+
+    // Scan the effective (type-bearing) source for transitive imports.
+    let scan_source =
+      String::from_utf8_lossy(effective_bytes.as_ref()).into_owned();
+    for spec in scan_import_specifiers(&effective_url, &scan_source) {
+      let resolved =
+        if spec.starts_with("http://") || spec.starts_with("https://") {
+          Url::parse(&spec).ok()
+        } else if spec.starts_with("./")
+          || spec.starts_with("../")
+          || spec.starts_with('/')
+        {
+          // `./`, `../`, and same-host absolute paths (e.g. `/src/foo.ts`,
+          // common on deno.land/x and esm.sh CDNs) all resolve against the
+          // effective URL via Url::join.
+          effective_url.join(&spec).ok()
+        } else {
+          None
+        };
+      if let Some(child) = resolved
+        && (child.scheme() == "http" || child.scheme() == "https")
+        && !paths.contains_key(&child)
+      {
+        queue.push_back(child);
+      }
+    }
+  }
+
+  Ok(paths)
+}
+
+/// Write `bytes` to the local mirror file for `url`, returning the path
+/// relative to `.deno/` (suitable for tsconfig `paths`).
+fn write_mirror(
+  remote_root: &Path,
+  url: &Url,
+  bytes: &[u8],
+) -> Result<String, AnyError> {
+  let local_path = url_to_local_path(remote_root, url)
+    .ok_or_else(|| anyhow!("URL has no resolvable mirror path: {url}"))?;
+  if let Some(parent) = local_path.parent() {
+    std::fs::create_dir_all(parent)?;
+  }
+  std::fs::write(&local_path, bytes)?;
+  url_to_tsconfig_path(url)
+    .ok_or_else(|| anyhow!("URL has no resolvable mirror path: {url}"))
+}
+
+/// Compute the `paths`-relative mirror location for `url`, e.g.
+/// `https://example.com/x/foo.ts` → `./remote/example.com/x/foo.ts`.
+fn url_to_tsconfig_path(url: &Url) -> Option<String> {
+  let host = url.host_str()?;
+  let path = url.path();
+  if path.ends_with('/') || path.is_empty() {
+    return None;
+  }
+  let rel = path.trim_start_matches('/');
+  Some(format!("./remote/{host}/{rel}"))
+}
+
+/// Map a URL to its mirror file path under `<remote_root>/<host><path>`.
+/// Returns None for URLs that don't yield a sensible file path (e.g. ending
+/// in `/`, since we can't infer an index filename without server cooperation).
+fn url_to_local_path(remote_root: &Path, url: &Url) -> Option<PathBuf> {
+  let host = url.host_str()?;
+  let path = url.path();
+  if path.ends_with('/') || path.is_empty() {
+    // Directory-like URL — would need server to tell us the actual filename.
+    // Skip for the prototype; full deno_graph handles this via redirects.
+    return None;
+  }
+  // Strip leading '/', percent-decoding left as-is for the prototype.
+  let rel = path.trim_start_matches('/');
+  Some(remote_root.join(host).join(rel))
+}
+
+/// Extract module specifier string literals from a JS/TS source via
+/// `deno_ast` + `deno_graph` analysis. Returns the raw specifier strings for
+/// static imports/exports and string-literal dynamic imports. Template/expr
+/// dynamic imports are skipped — they aren't statically analyzable.
+///
+/// Returns an empty vec if the source can't be parsed; the caller will simply
+/// stop walking that branch.
+fn scan_import_specifiers(specifier: &Url, source: &str) -> Vec<String> {
+  use deno_ast::MediaType;
+  use deno_graph::analysis::DependencyDescriptor;
+  use deno_graph::analysis::DynamicArgument;
+
+  let media_type = MediaType::from_specifier(specifier);
+  if !matches!(
+    media_type,
+    MediaType::JavaScript
+      | MediaType::Jsx
+      | MediaType::Mjs
+      | MediaType::Cjs
+      | MediaType::TypeScript
+      | MediaType::Mts
+      | MediaType::Cts
+      | MediaType::Dts
+      | MediaType::Dmts
+      | MediaType::Dcts
+      | MediaType::Tsx
+  ) {
+    return Vec::new();
+  }
+
+  let parsed = match deno_ast::parse_module(deno_ast::ParseParams {
+    specifier: specifier.clone(),
+    text: source.into(),
+    media_type,
+    capture_tokens: false,
+    maybe_syntax: None,
+    scope_analysis: false,
+  }) {
+    Ok(p) => p,
+    Err(e) => {
+      log::debug!("Failed to parse {specifier} for import scan: {e}");
+      return Vec::new();
+    }
+  };
+
+  let module_info = deno_graph::ast::ParserModuleAnalyzer::module_info(&parsed);
+  let mut out = Vec::new();
+  for dep in &module_info.dependencies {
+    match dep {
+      DependencyDescriptor::Static(d) => out.push(d.specifier.to_string()),
+      DependencyDescriptor::Dynamic(d) => {
+        if let DynamicArgument::String(s) = &d.argument {
+          out.push(s.clone());
+        }
+      }
+    }
+  }
+  out
+}
+
+fn resolve_jsr_version(
+  metadata: &Value,
+  req_version: Option<&str>,
+  registry_name: &str,
+) -> Result<String, AnyError> {
+  match req_version {
+    None => metadata
+      .get("dist-tags")
+      .and_then(|dt| dt.get("latest"))
+      .and_then(|v| v.as_str())
+      .map(|s| s.to_string())
+      .ok_or_else(|| anyhow!("No latest version for {registry_name}")),
+    Some(req_str) => {
+      if let Ok(exact) = Version::parse_standard(req_str)
+        && metadata
+          .get("versions")
+          .and_then(|vs| vs.get(exact.to_string()))
+          .is_some()
+      {
+        return Ok(exact.to_string());
+      }
+
+      let version_req = VersionReq::parse_from_npm(req_str)
+        .map_err(|e| anyhow!("Invalid version req '{req_str}': {e}"))?;
+
+      let versions = metadata
+        .get("versions")
+        .and_then(|vs| vs.as_object())
+        .ok_or_else(|| anyhow!("No versions for {registry_name}"))?;
+
+      let mut best: Option<Version> = None;
+      for key in versions.keys() {
+        if let Ok(v) = Version::parse_standard(key)
+          && version_req.matches(&v)
+          && best.as_ref().is_none_or(|b| v > *b)
+        {
+          best = Some(v);
+        }
+      }
+
+      best.map(|v| v.to_string()).ok_or_else(|| {
+        anyhow!("No version matching '{req_str}' for {registry_name}")
+      })
+    }
+  }
+}

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -61,17 +61,32 @@ pub async fn setup_npm_compat(
     .and_then(|d| d.get("compilerOptions"))
     .cloned();
 
-  // Combine the root import-map targets with the specifiers discovered in the
-  // module graph. Graph specifiers (e.g. `jsr:@std/path` written directly in
-  // source, or a workspace member's deps) are keyed by themselves so the
-  // existing import-map-driven generation maps them to their installed location
-  // just like an import-map alias.
+  // Workspace member aliases (`@std/assert` -> the local `./assert` member's
+  // exports) shadow any published jsr mapping, so compute them up front and let
+  // them win in the generated `paths`.
+  let member_paths = deno_json
+    .as_ref()
+    .map(|d| workspace_member_paths(project_root, d))
+    .unwrap_or_default();
+
+  // Combine the root import map (inline `imports`, or an `importMap` file) with
+  // the specifiers discovered in the module graph. Graph specifiers (e.g.
+  // `jsr:@std/path` written directly in source) are keyed by themselves so the
+  // import-map-driven generation maps them like an alias.
   let mut combined = deno_json
     .as_ref()
     .and_then(|d| d.get("imports"))
     .and_then(|v| v.as_object())
     .cloned()
     .unwrap_or_default();
+  if let Some(map_imports) = deno_json
+    .as_ref()
+    .and_then(|d| read_referenced_import_map(project_root, d))
+  {
+    for (k, v) in map_imports {
+      combined.entry(k).or_insert(v);
+    }
+  }
   for spec in graph_specifiers {
     combined
       .entry(spec.clone())
@@ -81,7 +96,9 @@ pub async fn setup_npm_compat(
   let has_special_specifiers = combined.iter().any(|(k, v)| {
     is_special_specifier(k) || v.as_str().is_some_and(is_special_specifier)
   });
-  if !has_special_specifiers {
+  // Generate if there's anything to map: external specifiers, or a workspace
+  // whose members need local-path aliases (e.g. std).
+  if !has_special_specifiers && member_paths.is_empty() {
     return Ok(vec![]);
   }
 
@@ -116,9 +133,77 @@ pub async fn setup_npm_compat(
     deno_compiler_options,
     deno_imports,
     &http_modules,
+    &member_paths,
   )?;
 
   Ok(installed)
+}
+
+/// If `deno_json` references an external import map via `importMap`, read that
+/// file and return its `imports` object.
+fn read_referenced_import_map(
+  project_root: &Path,
+  deno_json: &Value,
+) -> Option<serde_json::Map<String, Value>> {
+  let rel = deno_json.get("importMap").and_then(|v| v.as_str())?;
+  let content = std::fs::read_to_string(project_root.join(rel)).ok()?;
+  let parsed: Value = serde_json::from_str(&content).ok()?;
+  parsed.get("imports").and_then(|v| v.as_object()).cloned()
+}
+
+/// Build tsconfig `paths` entries that map each workspace member's package name
+/// (and subpath exports) to its local source files, so stock tooling resolves
+/// e.g. `@std/assert` and `@std/assert/equals` to `../assert/mod.ts` and
+/// `../assert/equals.ts` rather than a published copy. Paths are relative to
+/// the generated `.deno/tsconfig.json`.
+fn workspace_member_paths(
+  project_root: &Path,
+  deno_json: &Value,
+) -> serde_json::Map<String, Value> {
+  let mut paths = serde_json::Map::new();
+  let Some(members) = deno_json.get("workspace").and_then(|w| w.as_array())
+  else {
+    return paths;
+  };
+  for member in members.iter().filter_map(|m| m.as_str()) {
+    let member_rel = member.trim_start_matches("./").trim_end_matches('/');
+    let Some(member_json) = read_deno_json(&project_root.join(member_rel))
+      .ok()
+      .flatten()
+    else {
+      continue;
+    };
+    let Some(name) = member_json.get("name").and_then(|n| n.as_str()) else {
+      continue;
+    };
+    let Some(exports) = member_json.get("exports") else {
+      continue;
+    };
+    let mut add = |sub: &str, file: &str| {
+      let file = file.trim_start_matches("./");
+      let target = format!("../{member_rel}/{file}");
+      let key = if sub == "." {
+        name.to_string()
+      } else {
+        format!("{name}/{}", sub.trim_start_matches("./"))
+      };
+      paths.insert(key, json!([target]));
+    };
+    match exports {
+      // `"exports": "./mod.ts"`
+      Value::String(file) => add(".", file),
+      // `"exports": { ".": "./mod.ts", "./x": "./x.ts" }`
+      Value::Object(map) => {
+        for (sub, target) in map {
+          if let Some(file) = target.as_str() {
+            add(sub, file);
+          }
+        }
+      }
+      _ => {}
+    }
+  }
+  paths
 }
 
 fn read_deno_json(project_root: &Path) -> Result<Option<Value>, AnyError> {
@@ -146,6 +231,7 @@ fn generate_deno_tsconfig(
   deno_compiler_options: Option<&Value>,
   deno_imports: Option<&Value>,
   http_modules: &BTreeMap<Url, String>,
+  member_paths: &serde_json::Map<String, Value>,
 ) -> Result<(), AnyError> {
   let generated = crate::tsc::tsconfig_gen::generate_tsconfig(
     project_root,
@@ -153,6 +239,7 @@ fn generate_deno_tsconfig(
     deno_imports,
     &[],
     http_modules,
+    member_paths,
   )
   .map_err(|e| anyhow!("Failed to generate tsconfig: {e}"))?;
 

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -508,7 +508,10 @@ fn read_deno_json(project_root: &Path) -> Result<Option<Value>, AnyError> {
 }
 
 /// Generate tsconfig.deno.json at the project root with paths mappings.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+  clippy::too_many_arguments,
+  reason = "threads the independent inputs needed to generate a tsconfig"
+)]
 fn generate_deno_tsconfig(
   project_root: &Path,
   deno_compiler_options: Option<&Value>,

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -48,6 +48,7 @@ use crate::sys::CliSys;
 use crate::util::path::mapped_specifier_for_tsc;
 
 mod diagnostics;
+pub mod tsconfig_gen;
 
 pub use self::diagnostics::Diagnostic;
 pub use self::diagnostics::DiagnosticCategory;

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -1,0 +1,941 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Generate `.deno/tsconfig.json` for use with stock TypeScript tooling
+//! (tsc, tsgo).
+//!
+//! This module translates Deno's compiler options (from `deno.json`) into a
+//! standard `tsconfig.json` that stock TypeScript understands. It also injects
+//! Deno type definitions so that the `Deno` namespace and other Deno-specific
+//! globals are available.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::path::PathBuf;
+
+use deno_core::serde_json;
+use deno_core::serde_json::Map;
+use deno_core::serde_json::Value;
+use deno_core::serde_json::json;
+use deno_core::url::Url;
+
+use super::get_types_declaration_file_text;
+
+/// Result of generating a tsconfig for stock TypeScript.
+#[derive(Debug)]
+pub struct GeneratedTsConfig {
+  /// Path to the generated `.deno/tsconfig.json`.
+  pub tsconfig_path: PathBuf,
+}
+
+/// Generate `.deno/tsconfig.json` and Deno type definitions for use with
+/// stock TypeScript tooling.
+///
+/// Writes Deno types to `.deno/types/deno/index.d.ts` (a private typeRoot
+/// only the generated tsconfig points at). They deliberately do NOT go to
+/// `node_modules/@types/deno/`: TypeScript auto-discovers everything under
+/// `node_modules/@types/*` whenever `compilerOptions.types` is unset, which
+/// is exactly the state Deno's own type checker sees after the resolver
+/// filters our generated tsconfig out of the extends chain. With @types/deno
+/// auto-loaded into Deno's checker, every global also declared in
+/// `lib.deno.shared_globals.d.ts` would duplicate (TS2403).
+///
+/// Generates `.deno/tsconfig.json` with compiler options and paths mappings
+/// for npm:/jsr: specifiers. Also ensures a root `tsconfig.json` exists
+/// that extends it.
+pub fn generate_tsconfig(
+  project_root: &Path,
+  deno_compiler_options: Option<&Value>,
+  deno_imports: Option<&Value>,
+  files: &[String],
+  http_modules: &BTreeMap<Url, String>,
+) -> Result<GeneratedTsConfig, std::io::Error> {
+  // Write Deno type definitions to .deno/types/deno/ (private typeRoot).
+  let types_dir = project_root.join(".deno/types/deno");
+  std::fs::create_dir_all(&types_dir)?;
+  write_deno_types(&types_dir.join("index.d.ts"))?;
+
+  // Write a package.json for the @types/deno package so the typeRoots lookup
+  // resolves the directory as a package.
+  std::fs::write(
+    types_dir.join("package.json"),
+    serde_json::to_string_pretty(&json!({
+      "name": "@types/deno",
+      "version": "0.0.0",
+      "types": "index.d.ts"
+    }))
+    .unwrap(),
+  )?;
+
+  // Build tsconfig
+  let tsconfig = build_tsconfig(
+    project_root,
+    deno_compiler_options,
+    deno_imports,
+    files,
+    http_modules,
+  );
+
+  // Write to .deno/tsconfig.json
+  let deno_dir = project_root.join(".deno");
+  std::fs::create_dir_all(&deno_dir)?;
+  let tsconfig_path = deno_dir.join("tsconfig.json");
+  let content = serde_json::to_string_pretty(&tsconfig)
+    .expect("failed to serialize tsconfig");
+  std::fs::write(&tsconfig_path, &content)?;
+
+  // Ensure root tsconfig.json exists and extends .deno/tsconfig.json
+  ensure_root_tsconfig(project_root)?;
+
+  Ok(GeneratedTsConfig { tsconfig_path })
+}
+
+/// Ensure a root `tsconfig.json` exists that extends `.deno/tsconfig.json`.
+///
+/// - No existing tsconfig: create one with `extends: "./.deno/tsconfig.json"`.
+/// - Existing `extends` is a single string (or absent): coerce into an array
+///   that includes the original entry followed by our generated path. TS 5.0+
+///   resolves array extends left-to-right, with later entries overriding
+///   earlier ones — putting ours last lets us add the URL `paths` mappings
+///   without clobbering user-managed settings inherited from e.g. a shared
+///   team config.
+/// - Existing `extends` is already an array: append our path if missing,
+///   otherwise leave it alone.
+fn ensure_root_tsconfig(project_root: &Path) -> Result<(), std::io::Error> {
+  let root_tsconfig_path = project_root.join("tsconfig.json");
+  let extends_path = "./.deno/tsconfig.json";
+
+  if !root_tsconfig_path.exists() {
+    let tsconfig = json!({ "extends": extends_path });
+    let content = serde_json::to_string_pretty(&tsconfig)
+      .expect("failed to serialize tsconfig");
+    return std::fs::write(&root_tsconfig_path, &content);
+  }
+
+  let content = std::fs::read_to_string(&root_tsconfig_path)?;
+  let mut tsconfig: Value =
+    serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
+
+  let Some(obj) = tsconfig.as_object_mut() else {
+    return Ok(());
+  };
+
+  match obj.get("extends").cloned() {
+    None => {
+      obj.insert("extends".to_string(), json!(extends_path));
+    }
+    Some(Value::String(s)) if s == extends_path => {
+      return Ok(());
+    }
+    Some(Value::String(existing)) => {
+      obj.insert("extends".to_string(), json!([existing, extends_path]));
+    }
+    Some(Value::Array(arr)) => {
+      let already = arr
+        .iter()
+        .any(|v| v.as_str().is_some_and(|s| s == extends_path));
+      if already {
+        return Ok(());
+      }
+      let mut new_arr = arr;
+      new_arr.push(json!(extends_path));
+      obj.insert("extends".to_string(), Value::Array(new_arr));
+    }
+    Some(_) => {
+      // Non-string, non-array extends — leave the user's config alone rather
+      // than guessing.
+      log::warn!(
+        "tsconfig.json has a non-string `extends`; not modifying. \
+         Add \"{extends_path}\" to it manually for stock tsc support."
+      );
+      return Ok(());
+    }
+  }
+
+  let content = serde_json::to_string_pretty(&tsconfig)
+    .expect("failed to serialize tsconfig");
+  std::fs::write(&root_tsconfig_path, &content)
+}
+
+/// Write the Deno type declarations to a `.d.ts` file.
+fn write_deno_types(path: &Path) -> Result<(), std::io::Error> {
+  let types_text = get_types_declaration_file_text();
+  // Strip triple-slash reference directives that conflict with stock tsc
+  let filtered: String = types_text
+    .lines()
+    .filter(|line| {
+      let trimmed = line.trim();
+      !(trimmed.starts_with("/// <reference no-default-lib")
+        || trimmed.starts_with("/// <reference lib="))
+    })
+    .collect::<Vec<_>>()
+    .join("\n");
+
+  std::fs::write(
+    path,
+    format!(
+      "// Auto-generated by Deno for stock TypeScript tooling.\n\
+       // Do not edit — this file is regenerated as needed.\n\n\
+       {filtered}"
+    ),
+  )
+}
+
+/// Build the tsconfig JSON object.
+///
+/// The generated tsconfig lives at `.deno/tsconfig.json`, so all paths
+/// are relative to that directory (e.g. `../node_modules/...`).
+fn build_tsconfig(
+  project_root: &Path,
+  deno_compiler_options: Option<&Value>,
+  deno_imports: Option<&Value>,
+  check_files: &[String],
+  http_modules: &BTreeMap<Url, String>,
+) -> Value {
+  let mut compiler_options = base_compiler_options();
+
+  // Merge user's deno.json compilerOptions (filtered to stock-tsc-compatible
+  // options only)
+  if let Some(user_opts) = deno_compiler_options {
+    merge_deno_options(&mut compiler_options, user_opts);
+  }
+
+  // Generate "paths" for npm: and jsr: specifiers only
+  let mut specifier_paths = generate_npm_paths(project_root, deno_imports);
+  let jsr_paths = generate_jsr_paths(project_root, deno_imports);
+  specifier_paths.extend(jsr_paths);
+  let http_paths = generate_http_paths(http_modules);
+  specifier_paths.extend(http_paths);
+
+  // Merge user-defined paths from deno.json compilerOptions — these take
+  // priority over generated specifier mappings.
+  if let Some(user_paths) = deno_compiler_options
+    .and_then(|co| co.get("paths"))
+    .and_then(|p| p.as_object())
+  {
+    for (key, value) in user_paths {
+      specifier_paths.insert(key.clone(), value.clone());
+    }
+  }
+
+  if !specifier_paths.is_empty() {
+    compiler_options.insert("paths".to_string(), json!(specifier_paths));
+  }
+
+  // The `_deno_generated` sentinel lets Deno's own resolver identify this
+  // tsconfig and exclude it from extends chains it processes — see
+  // libs/resolver/deno_json.rs. Stock tsc/tsgo ignore unknown top-level
+  // properties.
+  if check_files.is_empty() {
+    // No specific files — check entire project
+    json!({
+      "_deno_generated": true,
+      "compilerOptions": compiler_options,
+      "include": ["../**/*"],
+      "exclude": ["../**/node_modules"],
+    })
+  } else {
+    // Specific files requested — only check those
+    let files_array: Vec<Value> =
+      check_files.iter().map(|f| json!(f)).collect();
+    json!({
+      "_deno_generated": true,
+      "compilerOptions": compiler_options,
+      "files": files_array,
+    })
+  }
+}
+
+/// Generate tsconfig "paths" entries for npm: specifiers.
+///
+/// Scans `deno.json` `"imports"` for entries like:
+///   `"express": "npm:express@4"` -> `{ "npm:express": ["../node_modules/express"] }`
+///
+/// Only generates `npm:<pkg>` keys -- bare aliases are resolved by
+/// TypeScript via `node_modules` with `moduleResolution: "bundler"`.
+fn generate_npm_paths(
+  _project_root: &Path,
+  deno_imports: Option<&Value>,
+) -> Map<String, Value> {
+  let mut paths = Map::new();
+
+  if let Some(imports) = deno_imports.and_then(|v| v.as_object()) {
+    for (_alias, target) in imports {
+      let target_str = match target.as_str() {
+        Some(s) => s,
+        None => continue,
+      };
+
+      if let Some(pkg_name) = parse_npm_specifier(target_str) {
+        // Paths are relative to .deno/ directory
+        let nm_path = format!("../node_modules/{pkg_name}");
+
+        // Map the npm: specifier
+        // e.g. "npm:express" -> ["../node_modules/express"]
+        let npm_key = format!("npm:{pkg_name}");
+        paths.entry(npm_key).or_insert_with(|| json!([&nm_path]));
+      }
+    }
+  }
+
+  paths
+}
+
+/// Parse an npm specifier like "npm:express@4", "npm:@scope/pkg@1.2.3",
+/// or "npm:express/foo" and return just the package name (without version
+/// or subpath). Returns `None` if `specifier` is not a valid npm: reference.
+pub fn parse_npm_specifier(specifier: &str) -> Option<String> {
+  deno_semver::npm::NpmPackageReqReference::from_str(specifier)
+    .ok()
+    .map(|r| r.req().name.to_string())
+}
+
+/// Generate tsconfig "paths" entries for jsr: specifiers.
+///
+/// JSR packages are available via npm compatibility at `npm.jsr.io` and install
+/// to `node_modules/@jsr/<scope>__<name>`. Maps `jsr:@scope/name` to that path.
+///
+/// Only generates `jsr:<scope>/<name>` keys.
+fn generate_jsr_paths(
+  project_root: &Path,
+  deno_imports: Option<&Value>,
+) -> Map<String, Value> {
+  let mut paths = Map::new();
+
+  if let Some(imports) = deno_imports.and_then(|v| v.as_object()) {
+    for (_alias, target) in imports {
+      let target_str = match target.as_str() {
+        Some(s) => s,
+        None => continue,
+      };
+
+      if let Some((scope, name, _version)) = parse_jsr_specifier(target_str) {
+        // JSR npm compat uses @jsr/<scope>__<name>
+        let jsr_npm_name =
+          format!("{}__{}", scope.trim_start_matches('@'), name);
+        let nm_path = format!("../node_modules/@jsr/{jsr_npm_name}");
+
+        // Check if the package actually exists in node_modules
+        let abs_path =
+          project_root.join(format!("node_modules/@jsr/{jsr_npm_name}"));
+        if !abs_path.exists() {
+          continue;
+        }
+
+        // Resolve the types entry point from package.json exports
+        let types_entry = resolve_jsr_types_entry(&abs_path)
+          .unwrap_or_else(|| nm_path.to_string());
+
+        // Map the jsr: specifier
+        let jsr_key = format!("jsr:{scope}/{name}");
+        paths
+          .entry(jsr_key)
+          .or_insert_with(|| json!([&types_entry]));
+      }
+    }
+  }
+
+  paths
+}
+
+/// Resolve the types entry point from a JSR package's package.json.
+///
+/// Reads the `"exports"` field and looks for `"."` -> `"types"` condition.
+/// Returns a path relative to `.deno/` (e.g., `../node_modules/@jsr/std__assert/_dist/mod.d.ts`).
+fn resolve_jsr_types_entry(pkg_dir: &Path) -> Option<String> {
+  let pkg_json_path = pkg_dir.join("package.json");
+  let content = std::fs::read_to_string(&pkg_json_path).ok()?;
+  let pkg_json: Value = serde_json::from_str(&content).ok()?;
+
+  // Try exports["."]["types"]
+  let types_path = pkg_json
+    .get("exports")
+    .and_then(|e| e.get("."))
+    .and_then(|dot| dot.get("types"))
+    .and_then(|t| t.as_str())
+    .or_else(|| {
+      // Fallback: top-level "types" field
+      pkg_json.get("types").and_then(|t| t.as_str())
+    })?;
+
+  // Convert package-relative path to .deno/-relative path
+  let pkg_name = pkg_dir.file_name()?.to_string_lossy();
+  let parent_name = pkg_dir
+    .parent()
+    .and_then(|p| p.file_name())
+    .map(|f| f.to_string_lossy())
+    .unwrap_or_default();
+
+  let types_path = types_path.strip_prefix("./").unwrap_or(types_path);
+
+  if parent_name == "@jsr" {
+    Some(format!("../node_modules/@jsr/{pkg_name}/{types_path}"))
+  } else {
+    Some(format!("../node_modules/{pkg_name}/{types_path}"))
+  }
+}
+
+/// Generate tsconfig "paths" entries for http(s): specifiers.
+///
+/// The installer returns a map from user-facing URL → local mirror path
+/// (already relative to `.deno/`). For X-TypeScript-Types-bearing modules
+/// the local path points at the `.d.ts` rather than the JS source.
+///
+/// With `moduleResolution: "bundler"`, stock tsc accepts colon-containing
+/// keys like `https://...`, which lets us redirect URL imports to local
+/// files.
+fn generate_http_paths(
+  http_modules: &BTreeMap<Url, String>,
+) -> Map<String, Value> {
+  let mut paths = Map::new();
+  for (url, local) in http_modules {
+    paths.insert(url.as_str().to_string(), json!([local]));
+  }
+  paths
+}
+
+/// Parse a jsr specifier like "jsr:@std/assert@1" or "jsr:@scope/name@1.2.3"
+/// and return (scope, name, optional_version). E.g. ("@std", "assert", Some("1")).
+pub fn parse_jsr_specifier(
+  specifier: &str,
+) -> Option<(String, String, Option<String>)> {
+  let rest = specifier.strip_prefix("jsr:")?;
+  // JSR specifiers are always scoped: @scope/name@version
+  if !rest.starts_with('@') {
+    return None;
+  }
+  let slash_pos = rest.find('/')?;
+  let scope = &rest[..slash_pos];
+  let after_slash = &rest[slash_pos + 1..];
+  let (name, version) = if let Some(at_pos) = after_slash.find('@') {
+    (
+      &after_slash[..at_pos],
+      Some(after_slash[at_pos + 1..].to_string()),
+    )
+  } else {
+    (after_slash, None)
+  };
+  Some((scope.to_string(), name.to_string(), version))
+}
+
+/// Base compiler options for stock tsc that approximate Deno's defaults.
+fn base_compiler_options() -> Map<String, Value> {
+  let obj = json!({
+    // Deno defaults
+    "strict": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "checkJs": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
+    // Module settings for stock tsc
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+
+    // Allow .ts extensions in imports (TS 5.0+)
+    "allowImportingTsExtensions": true,
+
+    // Standard libs (Deno-specific libs like deno.window are replaced by
+    // the @types/deno package under .deno/types/)
+    "lib": ["esnext"],
+
+    // typeRoots points at our private .deno/types/ dir; "types: [deno]"
+    // tells tsc to load exactly that and nothing else. Without this, tsc
+    // would auto-include every @types/* in node_modules, which would
+    // collide with Deno's runtime types when this file is read by Deno's
+    // own checker.
+    "typeRoots": ["./types"],
+    "types": ["deno"],
+
+    // Skip checking node_modules types for speed
+    "skipLibCheck": true,
+  });
+
+  match obj {
+    Value::Object(map) => map,
+    _ => unreachable!(),
+  }
+}
+
+/// Merge user's deno.json compilerOptions into the base, filtering to only
+/// options that stock tsc understands.
+fn merge_deno_options(base: &mut Map<String, Value>, user_opts: &Value) {
+  let Some(user_map) = user_opts.as_object() else {
+    return;
+  };
+
+  // Options from deno.json that map directly to tsconfig.json
+  const PASSTHROUGH_OPTIONS: &[&str] = &[
+    "allowUnreachableCode",
+    "allowUnusedLabels",
+    "checkJs",
+    "emitDecoratorMetadata",
+    "exactOptionalPropertyTypes",
+    "experimentalDecorators",
+    "isolatedDeclarations",
+    "jsx",
+    "jsxFactory",
+    "jsxFragmentFactory",
+    "jsxImportSource",
+    "noErrorTruncation",
+    "noFallthroughCasesInSwitch",
+    "noImplicitAny",
+    "noImplicitOverride",
+    "noImplicitReturns",
+    "noImplicitThis",
+    "noPropertyAccessFromIndexSignature",
+    "noUncheckedIndexedAccess",
+    "noUnusedLocals",
+    "noUnusedParameters",
+    "paths",
+    "baseUrl",
+    "rootDirs",
+    "skipLibCheck",
+    "strict",
+    "strictBindCallApply",
+    "strictBuiltinIteratorReturn",
+    "strictFunctionTypes",
+    "strictNullChecks",
+    "strictPropertyInitialization",
+    "useUnknownInCatchVariables",
+    "verbatimModuleSyntax",
+  ];
+
+  for &key in PASSTHROUGH_OPTIONS {
+    if let Some(value) = user_map.get(key) {
+      base.insert(key.to_string(), value.clone());
+    }
+  }
+
+  // Handle jsx: "precompile" -> "react-jsx" (stock tsc doesn't know precompile)
+  if let Some(jsx) = user_map.get("jsx").and_then(|v| v.as_str())
+    && jsx == "precompile"
+  {
+    base.insert("jsx".to_string(), json!("react-jsx"));
+  }
+
+  // Handle lib: merge with our base lib
+  if let Some(user_lib) = user_map.get("lib").and_then(|v| v.as_array()) {
+    let mut libs: Vec<Value> = vec![json!("esnext")];
+    for lib in user_lib {
+      if let Some(s) = lib.as_str() {
+        // Skip Deno-specific libs that stock tsc doesn't know
+        if !s.starts_with("deno.") && s != "esnext" {
+          libs.push(lib.clone());
+        }
+      }
+    }
+    base.insert("lib".to_string(), Value::Array(libs));
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_base_compiler_options() {
+    let opts = base_compiler_options();
+    assert_eq!(opts.get("strict").unwrap(), &json!(true));
+    assert_eq!(opts.get("target").unwrap(), &json!("esnext"));
+    assert_eq!(opts.get("module").unwrap(), &json!("esnext"));
+    assert_eq!(opts.get("noEmit").unwrap(), &json!(true));
+  }
+
+  #[test]
+  fn test_merge_deno_options_passthrough() {
+    let mut base = base_compiler_options();
+    let user = json!({
+      "strict": false,
+      "jsx": "react-jsx",
+      "jsxImportSource": "preact",
+    });
+    merge_deno_options(&mut base, &user);
+    assert_eq!(base.get("strict").unwrap(), &json!(false));
+    assert_eq!(base.get("jsx").unwrap(), &json!("react-jsx"));
+    assert_eq!(base.get("jsxImportSource").unwrap(), &json!("preact"));
+  }
+
+  #[test]
+  fn test_merge_deno_options_precompile_jsx() {
+    let mut base = base_compiler_options();
+    let user = json!({ "jsx": "precompile" });
+    merge_deno_options(&mut base, &user);
+    assert_eq!(base.get("jsx").unwrap(), &json!("react-jsx"));
+  }
+
+  #[test]
+  fn test_merge_deno_options_filters_deno_libs() {
+    let mut base = base_compiler_options();
+    let user = json!({ "lib": ["deno.window", "dom", "esnext"] });
+    merge_deno_options(&mut base, &user);
+    let lib = base.get("lib").unwrap().as_array().unwrap();
+    assert!(lib.contains(&json!("esnext")));
+    assert!(lib.contains(&json!("dom")));
+    assert!(!lib.iter().any(|v| v.as_str() == Some("deno.window")));
+  }
+
+  #[test]
+  fn test_merge_deno_options_ignores_unknown() {
+    let mut base = base_compiler_options();
+    let user = json!({
+      "strict": false,
+      "unknownOption": true,
+      "target": "es2020",
+    });
+    merge_deno_options(&mut base, &user);
+    assert_eq!(base.get("strict").unwrap(), &json!(false));
+    // unknownOption and target should not pass through
+    assert!(base.get("unknownOption").is_none());
+    // target stays at the base value
+    assert_eq!(base.get("target").unwrap(), &json!("esnext"));
+  }
+
+  #[test]
+  fn test_parse_npm_specifier_unscoped() {
+    assert_eq!(
+      parse_npm_specifier("npm:chalk@5"),
+      Some("chalk".to_string())
+    );
+    assert_eq!(
+      parse_npm_specifier("npm:express"),
+      Some("express".to_string())
+    );
+    assert_eq!(
+      parse_npm_specifier("npm:foo@1.2.3"),
+      Some("foo".to_string())
+    );
+  }
+
+  #[test]
+  fn test_parse_npm_specifier_scoped() {
+    assert_eq!(
+      parse_npm_specifier("npm:@types/node@20"),
+      Some("@types/node".to_string())
+    );
+    assert_eq!(
+      parse_npm_specifier("npm:@scope/pkg@1.2.3"),
+      Some("@scope/pkg".to_string())
+    );
+    assert_eq!(
+      parse_npm_specifier("npm:@scope/pkg"),
+      Some("@scope/pkg".to_string())
+    );
+  }
+
+  #[test]
+  fn test_parse_npm_specifier_with_subpath() {
+    assert_eq!(
+      parse_npm_specifier("npm:express/foo"),
+      Some("express".to_string())
+    );
+    assert_eq!(
+      parse_npm_specifier("npm:express@4/foo"),
+      Some("express".to_string())
+    );
+    assert_eq!(
+      parse_npm_specifier("npm:@scope/pkg/subpath"),
+      Some("@scope/pkg".to_string())
+    );
+    assert_eq!(
+      parse_npm_specifier("npm:@scope/pkg@1.0.0/subpath"),
+      Some("@scope/pkg".to_string())
+    );
+  }
+
+  #[test]
+  fn test_parse_npm_specifier_not_npm() {
+    assert_eq!(parse_npm_specifier("jsr:@std/assert@1"), None);
+    assert_eq!(parse_npm_specifier("chalk@5"), None);
+    assert_eq!(parse_npm_specifier("https://example.com"), None);
+  }
+
+  #[test]
+  fn test_parse_jsr_specifier() {
+    assert_eq!(
+      parse_jsr_specifier("jsr:@std/assert@1"),
+      Some((
+        "@std".to_string(),
+        "assert".to_string(),
+        Some("1".to_string())
+      ))
+    );
+    assert_eq!(
+      parse_jsr_specifier("jsr:@std/path"),
+      Some(("@std".to_string(), "path".to_string(), None))
+    );
+    assert_eq!(
+      parse_jsr_specifier("jsr:@scope/name@1.2.3"),
+      Some((
+        "@scope".to_string(),
+        "name".to_string(),
+        Some("1.2.3".to_string())
+      ))
+    );
+  }
+
+  #[test]
+  fn test_parse_jsr_specifier_not_jsr() {
+    assert_eq!(parse_jsr_specifier("npm:chalk@5"), None);
+    // jsr requires scoped packages
+    assert_eq!(parse_jsr_specifier("jsr:assert@1"), None);
+  }
+
+  #[test]
+  fn test_generate_npm_paths_only_npm_keys() {
+    let imports = json!({
+      "chalk": "npm:chalk@5",
+      "express": "npm:express@4",
+      "@mylib/foo": "npm:@mylib/foo@1",
+    });
+    let paths = generate_npm_paths(Path::new("/tmp/project"), Some(&imports));
+
+    // Should have npm: prefixed keys only
+    assert!(paths.contains_key("npm:chalk"));
+    assert!(paths.contains_key("npm:express"));
+    assert!(paths.contains_key("npm:@mylib/foo"));
+
+    // Should NOT have bare alias keys
+    assert!(!paths.contains_key("chalk"));
+    assert!(!paths.contains_key("express"));
+    assert!(!paths.contains_key("@mylib/foo"));
+
+    // Should NOT have /* glob keys
+    assert!(!paths.contains_key("npm:chalk/*"));
+    assert!(!paths.contains_key("chalk/*"));
+
+    // Paths should be relative to .deno/
+    assert_eq!(
+      paths.get("npm:chalk").unwrap(),
+      &json!(["../node_modules/chalk"])
+    );
+    assert_eq!(
+      paths.get("npm:@mylib/foo").unwrap(),
+      &json!(["../node_modules/@mylib/foo"])
+    );
+  }
+
+  #[test]
+  fn test_generate_npm_paths_skips_jsr() {
+    let imports = json!({
+      "@std/assert": "jsr:@std/assert@1",
+      "chalk": "npm:chalk@5",
+    });
+    let paths = generate_npm_paths(Path::new("/tmp/project"), Some(&imports));
+
+    assert!(paths.contains_key("npm:chalk"));
+    // jsr specifiers should not appear in npm paths
+    assert!(!paths.contains_key("jsr:@std/assert"));
+    assert!(!paths.contains_key("@std/assert"));
+    assert_eq!(paths.len(), 1);
+  }
+
+  #[test]
+  fn test_generate_npm_paths_empty_imports() {
+    let paths = generate_npm_paths(Path::new("/tmp/project"), None);
+    assert!(paths.is_empty());
+
+    let imports = json!({});
+    let paths = generate_npm_paths(Path::new("/tmp/project"), Some(&imports));
+    assert!(paths.is_empty());
+  }
+
+  #[test]
+  fn test_build_tsconfig_includes_relative_to_deno_dir() {
+    let project_root = Path::new("/tmp/project");
+    let tsconfig =
+      build_tsconfig(project_root, None, None, &[], &BTreeMap::new());
+
+    let include = tsconfig.get("include").unwrap().as_array().unwrap();
+    assert_eq!(include, &vec![json!("../**/*")]);
+
+    let exclude = tsconfig.get("exclude").unwrap().as_array().unwrap();
+    assert_eq!(exclude, &vec![json!("../**/node_modules")]);
+  }
+
+  #[test]
+  fn test_build_tsconfig_with_files() {
+    let project_root = Path::new("/tmp/project");
+    let files = vec!["main.ts".to_string(), "lib.ts".to_string()];
+    let tsconfig =
+      build_tsconfig(project_root, None, None, &files, &BTreeMap::new());
+
+    // Should use "files" instead of "include"/"exclude"
+    assert!(tsconfig.get("include").is_none());
+    assert!(tsconfig.get("exclude").is_none());
+    let files_arr = tsconfig.get("files").unwrap().as_array().unwrap();
+    assert_eq!(files_arr, &vec![json!("main.ts"), json!("lib.ts")]);
+  }
+
+  #[test]
+  fn test_build_tsconfig_user_paths_override() {
+    let project_root = Path::new("/tmp/project");
+    let imports = json!({
+      "chalk": "npm:chalk@5",
+    });
+    let compiler_options = json!({
+      "paths": {
+        "npm:chalk": ["./my-custom-chalk"],
+        "~/*": ["./src/*"],
+      },
+    });
+    let tsconfig = build_tsconfig(
+      project_root,
+      Some(&compiler_options),
+      Some(&imports),
+      &[],
+      &BTreeMap::new(),
+    );
+
+    let paths = tsconfig
+      .get("compilerOptions")
+      .unwrap()
+      .get("paths")
+      .unwrap()
+      .as_object()
+      .unwrap();
+
+    // User's custom path should override generated one
+    assert_eq!(
+      paths.get("npm:chalk").unwrap(),
+      &json!(["./my-custom-chalk"])
+    );
+    // User's custom path alias should be present
+    assert_eq!(paths.get("~/*").unwrap(), &json!(["./src/*"]));
+  }
+
+  #[test]
+  fn test_ensure_root_tsconfig_creates_new() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    ensure_root_tsconfig(root).unwrap();
+
+    let content = std::fs::read_to_string(root.join("tsconfig.json")).unwrap();
+    let tsconfig: Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(
+      tsconfig.get("extends").unwrap(),
+      &json!("./.deno/tsconfig.json")
+    );
+  }
+
+  #[test]
+  fn test_ensure_root_tsconfig_updates_existing() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Create an existing tsconfig.json with some settings
+    std::fs::write(
+      root.join("tsconfig.json"),
+      r#"{ "compilerOptions": { "strict": true } }"#,
+    )
+    .unwrap();
+
+    ensure_root_tsconfig(root).unwrap();
+
+    let content = std::fs::read_to_string(root.join("tsconfig.json")).unwrap();
+    let tsconfig: Value = serde_json::from_str(&content).unwrap();
+    // Should add extends
+    assert_eq!(
+      tsconfig.get("extends").unwrap(),
+      &json!("./.deno/tsconfig.json")
+    );
+    // Should preserve existing options
+    assert_eq!(
+      tsconfig
+        .get("compilerOptions")
+        .unwrap()
+        .get("strict")
+        .unwrap(),
+      &json!(true)
+    );
+  }
+
+  #[test]
+  fn test_ensure_root_tsconfig_preserves_string_extends() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(
+      root.join("tsconfig.json"),
+      r#"{ "extends": "./team-shared.json" }"#,
+    )
+    .unwrap();
+
+    ensure_root_tsconfig(root).unwrap();
+
+    let content = std::fs::read_to_string(root.join("tsconfig.json")).unwrap();
+    let tsconfig: Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(
+      tsconfig.get("extends").unwrap(),
+      &json!(["./team-shared.json", "./.deno/tsconfig.json"])
+    );
+  }
+
+  #[test]
+  fn test_ensure_root_tsconfig_preserves_array_extends() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(
+      root.join("tsconfig.json"),
+      r#"{ "extends": ["./a.json", "./b.json"] }"#,
+    )
+    .unwrap();
+
+    ensure_root_tsconfig(root).unwrap();
+
+    let content = std::fs::read_to_string(root.join("tsconfig.json")).unwrap();
+    let tsconfig: Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(
+      tsconfig.get("extends").unwrap(),
+      &json!(["./a.json", "./b.json", "./.deno/tsconfig.json"])
+    );
+  }
+
+  #[test]
+  fn test_ensure_root_tsconfig_array_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(
+      root.join("tsconfig.json"),
+      r#"{ "extends": ["./a.json", "./.deno/tsconfig.json"] }"#,
+    )
+    .unwrap();
+
+    ensure_root_tsconfig(root).unwrap();
+
+    let content = std::fs::read_to_string(root.join("tsconfig.json")).unwrap();
+    let tsconfig: Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(
+      tsconfig.get("extends").unwrap(),
+      &json!(["./a.json", "./.deno/tsconfig.json"])
+    );
+  }
+
+  #[test]
+  fn test_ensure_root_tsconfig_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Create tsconfig with correct extends already set
+    std::fs::write(
+      root.join("tsconfig.json"),
+      r#"{ "extends": "./.deno/tsconfig.json", "compilerOptions": {} }"#,
+    )
+    .unwrap();
+
+    ensure_root_tsconfig(root).unwrap();
+
+    let content = std::fs::read_to_string(root.join("tsconfig.json")).unwrap();
+    let tsconfig: Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(
+      tsconfig.get("extends").unwrap(),
+      &json!("./.deno/tsconfig.json")
+    );
+  }
+}

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -477,7 +477,13 @@ fn generate_jsr_paths(
           Some(v) => format!("jsr:{scope}/{name}@{v}"),
           None => format!("jsr:{scope}/{name}"),
         };
-        let subpath = target_str
+        // Normalize a `jsr:/…` (deno_graph resolved form) to `jsr:…` so the
+        // prefix match below works; the emitted key keeps the original spelling.
+        let norm_target = target_str
+          .strip_prefix("jsr:/")
+          .map(|r| format!("jsr:{r}"))
+          .unwrap_or_else(|| target_str.to_string());
+        let subpath = norm_target
           .strip_prefix(&prefix)
           .map(|s| s.trim_start_matches('/'))
           .unwrap_or("");
@@ -619,6 +625,9 @@ pub fn parse_jsr_specifier(
   specifier: &str,
 ) -> Option<(String, String, Option<String>)> {
   let rest = specifier.strip_prefix("jsr:")?;
+  // deno_graph emits resolved jsr specifiers as `jsr:/@scope/...` (slash after
+  // the scheme); accept that form too.
+  let rest = rest.strip_prefix('/').unwrap_or(rest);
   // JSR specifiers are always scoped: @scope/name@version
   if !rest.starts_with('@') {
     return None;
@@ -907,6 +916,16 @@ mod tests {
         "@scope".to_string(),
         "name".to_string(),
         Some("1.2.3".to_string())
+      ))
+    );
+    // deno_graph resolved form: `jsr:/` with a slash after the scheme, plus a
+    // subpath after the version.
+    assert_eq!(
+      parse_jsr_specifier("jsr:/@std/async@^1/deadline"),
+      Some((
+        "@std".to_string(),
+        "async".to_string(),
+        Some("^1".to_string())
       ))
     );
   }

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -406,13 +406,24 @@ pub fn parse_jsr_specifier(
   let slash_pos = rest.find('/')?;
   let scope = &rest[..slash_pos];
   let after_slash = &rest[slash_pos + 1..];
+  // `after_slash` is `name`, `name@version`, `name/subpath`, or
+  // `name@version/subpath`. Split off the version (if any), and drop any
+  // trailing `/subpath` from both the version and the bare name so we never
+  // feed a subpath into a semver requirement (e.g. `jsr:@std/x@1/walk`).
   let (name, version) = if let Some(at_pos) = after_slash.find('@') {
-    (
-      &after_slash[..at_pos],
-      Some(after_slash[at_pos + 1..].to_string()),
-    )
+    let name = &after_slash[..at_pos];
+    let version_and_subpath = &after_slash[at_pos + 1..];
+    let version = version_and_subpath
+      .split_once('/')
+      .map(|(v, _subpath)| v)
+      .unwrap_or(version_and_subpath);
+    (name, Some(version.to_string()))
   } else {
-    (after_slash, None)
+    let name = after_slash
+      .split_once('/')
+      .map(|(n, _subpath)| n)
+      .unwrap_or(after_slash);
+    (name, None)
   };
   Some((scope.to_string(), name.to_string(), version))
 }

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -122,8 +122,18 @@ fn ensure_root_tsconfig(project_root: &Path) -> Result<(), std::io::Error> {
   }
 
   let content = std::fs::read_to_string(&root_tsconfig_path)?;
-  let parsed: Option<Value> = jsonc_parser::parse_to_serde_value(
+
+  // Parse as JSONC and edit the raw text by byte range (rather than
+  // re-serializing) so the user's comments and formatting are preserved. An
+  // unparseable file is a hard error rather than being silently overwritten.
+  use jsonc_parser::ast::ObjectPropName;
+  use jsonc_parser::ast::Value as JsoncValue;
+  let ast = jsonc_parser::parse_to_ast(
     &content,
+    &jsonc_parser::CollectOptions {
+      comments: jsonc_parser::CommentCollectionStrategy::Off,
+      tokens: false,
+    },
     &jsonc_parser::ParseOptions::default(),
   )
   .map_err(|e| {
@@ -136,47 +146,67 @@ fn ensure_root_tsconfig(project_root: &Path) -> Result<(), std::io::Error> {
       ),
     )
   })?;
-  let mut tsconfig = parsed.unwrap_or_else(|| json!({}));
 
-  let Some(obj) = tsconfig.as_object_mut() else {
+  let Some(JsoncValue::Object(obj)) = ast.value else {
+    // Not a JSON object (empty file, array, ...) — leave it alone.
     return Ok(());
   };
+  let extends = obj.properties.iter().find(|p| {
+    let name = match &p.name {
+      ObjectPropName::String(s) => s.value.as_ref(),
+      ObjectPropName::Word(w) => w.value,
+    };
+    name == "extends"
+  });
 
-  match obj.get("extends").cloned() {
+  let quoted = format!("\"{extends_path}\"");
+  // Each arm yields Some((start, end, replacement)) as a byte-range splice, or
+  // None when no change is needed.
+  let edit: Option<(usize, usize, String)> = match extends.map(|p| &p.value) {
+    // No `extends` yet: insert it as the first member, right after the `{`.
     None => {
-      obj.insert("extends".to_string(), json!(extends_path));
+      let at = obj.range.start + 1;
+      let comma = if obj.properties.is_empty() { "" } else { "," };
+      Some((at, at, format!("\n  \"extends\": {quoted}{comma}")))
     }
-    Some(Value::String(s)) if s == extends_path => {
-      return Ok(());
+    // Already ours: nothing to do.
+    Some(JsoncValue::StringLit(s)) if s.value.as_ref() == extends_path => None,
+    // A single string: coerce to an array with ours first, original verbatim.
+    Some(JsoncValue::StringLit(s)) => {
+      let orig = &content[s.range.start..s.range.end];
+      Some((s.range.start, s.range.end, format!("[{quoted}, {orig}]")))
     }
-    Some(Value::String(existing)) => {
-      obj.insert("extends".to_string(), json!([extends_path, existing]));
-    }
-    Some(Value::Array(arr)) => {
-      let already = arr
-        .iter()
-        .any(|v| v.as_str().is_some_and(|s| s == extends_path));
-      if already {
-        return Ok(());
+    // An array: prepend ours (right after `[`) unless it's already present.
+    Some(JsoncValue::Array(arr)) => {
+      let present = arr.elements.iter().any(|e| {
+        matches!(e, JsoncValue::StringLit(s) if s.value.as_ref() == extends_path)
+      });
+      if present {
+        None
+      } else {
+        let at = arr.range.start + 1;
+        Some((at, at, format!("{quoted}, ")))
       }
-      let mut new_arr = vec![json!(extends_path)];
-      new_arr.extend(arr);
-      obj.insert("extends".to_string(), Value::Array(new_arr));
     }
+    // Non-string/array `extends` — leave the user's config alone.
     Some(_) => {
-      // Non-string, non-array extends — leave the user's config alone rather
-      // than guessing.
       log::warn!(
-        "tsconfig.json has a non-string `extends`; not modifying. \
+        "tsconfig.json has a non-string/array `extends`; not modifying. \
          Add \"{extends_path}\" to it manually for stock tsc support."
       );
-      return Ok(());
+      None
     }
-  }
+  };
 
-  let content = serde_json::to_string_pretty(&tsconfig)
-    .expect("failed to serialize tsconfig");
-  std::fs::write(&root_tsconfig_path, &content)
+  let Some((start, end, replacement)) = edit else {
+    return Ok(());
+  };
+  let mut new_content =
+    String::with_capacity(content.len() + replacement.len());
+  new_content.push_str(&content[..start]);
+  new_content.push_str(&replacement);
+  new_content.push_str(&content[end..]);
+  std::fs::write(&root_tsconfig_path, &new_content)
 }
 
 /// Web-global types that `@types/node` also declares (globally, via `node:url`)
@@ -254,16 +284,18 @@ fn strip_top_level_type_decls(text: &str, names: &[&str]) -> String {
       line.starts_with(&format!("type {n} =")) || line == format!("type {n}")
     });
     if is_interface || is_type_alias {
-      // Drop the JSDoc block immediately preceding this declaration.
-      while out.last().is_some_and(|l| l.trim().is_empty()) {
+      // Drop the leading comment block (JSDoc etc.) immediately preceding this
+      // declaration. Bounded to contiguous comment-looking / blank lines so we
+      // never pop real code — a `*/` that closes a non-JSDoc `/* */` block would
+      // otherwise send an unbounded "pop until /**" loop through earlier decls.
+      while out.last().is_some_and(|l| {
+        let t = l.trim_start();
+        t.is_empty()
+          || t.starts_with('*')
+          || t.starts_with("/*")
+          || t.starts_with("//")
+      }) {
         out.pop();
-      }
-      if out.last().is_some_and(|l| l.trim().ends_with("*/")) {
-        while let Some(popped) = out.pop() {
-          if popped.trim_start().starts_with("/**") {
-            break;
-          }
-        }
       }
       if is_interface {
         // Skip to the matching top-level `}` (column 0).
@@ -273,11 +305,25 @@ fn strip_top_level_type_decls(text: &str, names: &[&str]) -> String {
         }
         i += 1;
       } else {
-        // Type alias: skip until the line that ends the statement.
-        while i < lines.len() && !lines[i].trim_end().ends_with(';') {
+        // Type alias. Skip until the statement terminates: a `;` at bracket
+        // depth 0, so an interior `;` inside an object/union type doesn't end it
+        // early. Bounded by end-of-input.
+        let mut depth: i32 = 0;
+        while i < lines.len() {
+          let l = lines[i];
+          for ch in l.chars() {
+            match ch {
+              '{' | '(' | '[' => depth += 1,
+              '}' | ')' | ']' => depth -= 1,
+              _ => {}
+            }
+          }
+          let done = depth <= 0 && l.trim_end().ends_with(';');
           i += 1;
+          if done {
+            break;
+          }
         }
-        i += 1;
       }
       continue;
     }
@@ -285,6 +331,19 @@ fn strip_top_level_type_decls(text: &str, names: &[&str]) -> String {
     i += 1;
   }
   out.join("\n")
+}
+
+/// Rebase a project-root-relative path onto `.deno/`, where the generated
+/// tsconfig lives one level down: `.` -> `..`, `./src` -> `../src`,
+/// `src` -> `../src`, `../x` -> `../../x`. Absolute paths are left untouched.
+fn rebase_onto_deno_dir(path: &str) -> String {
+  if path == "." {
+    return "..".to_string();
+  }
+  if path.starts_with('/') {
+    return path.to_string();
+  }
+  format!("../{}", path.trim_start_matches("./"))
 }
 
 /// Build the tsconfig JSON object.
@@ -339,14 +398,38 @@ fn build_tsconfig(
   }
 
   // Merge user-defined paths from deno.json compilerOptions — these take
-  // priority over generated specifier mappings.
+  // priority over generated specifier mappings. The user's values are relative
+  // to the project root, but the generated tsconfig lives in `.deno/`, so each
+  // value is rebased one level up (like every generated mapping above).
   if let Some(user_paths) = deno_compiler_options
     .and_then(|co| co.get("paths"))
     .and_then(|p| p.as_object())
   {
     for (key, value) in user_paths {
-      specifier_paths.insert(key.clone(), value.clone());
+      let rebased = match value.as_array() {
+        Some(arr) => Value::Array(
+          arr
+            .iter()
+            .map(|v| match v.as_str() {
+              Some(s) => Value::String(rebase_onto_deno_dir(s)),
+              None => v.clone(),
+            })
+            .collect(),
+        ),
+        None => value.clone(),
+      };
+      specifier_paths.insert(key.clone(), rebased);
     }
+  }
+
+  // Rebase the user's `baseUrl` onto `.deno/` too (`.` -> `..`, `./src` ->
+  // `../src`), for the same reason.
+  if let Some(base_url) = deno_compiler_options
+    .and_then(|co| co.get("baseUrl"))
+    .and_then(|b| b.as_str())
+  {
+    compiler_options
+      .insert("baseUrl".to_string(), json!(rebase_onto_deno_dir(base_url)));
   }
 
   // Merge the user's bare-package `compilerOptions.types` with the deno/node
@@ -849,8 +932,11 @@ fn merge_deno_options(base: &mut Map<String, Value>, user_opts: &Value) {
     "noUncheckedIndexedAccess",
     "noUnusedLocals",
     "noUnusedParameters",
-    "paths",
-    "baseUrl",
+    // NOTE: `paths`, `baseUrl` are deliberately NOT passed through here — they
+    // hold project-root-relative paths that must be rebased onto `.deno/` (the
+    // generated tsconfig lives one level down). They're handled in
+    // `build_tsconfig`. (`rootDirs` has the same hazard but is passed through
+    // for now; rebase it too if it ever matters.)
     "rootDirs",
     "skipLibCheck",
     "strict",
@@ -1265,13 +1351,23 @@ interface AlsoKeep {
       .as_object()
       .unwrap();
 
-    // User's custom path should override generated one
+    // User's custom path should override the generated one, rebased onto
+    // `.deno/` (the generated tsconfig lives one level below the project root).
     assert_eq!(
       paths.get("npm:chalk").unwrap(),
-      &json!(["./my-custom-chalk"])
+      &json!(["../my-custom-chalk"])
     );
-    // User's custom path alias should be present
-    assert_eq!(paths.get("~/*").unwrap(), &json!(["./src/*"]));
+    // User's custom path alias is present and rebased.
+    assert_eq!(paths.get("~/*").unwrap(), &json!(["../src/*"]));
+  }
+
+  #[test]
+  fn test_rebase_onto_deno_dir() {
+    assert_eq!(rebase_onto_deno_dir("."), "..");
+    assert_eq!(rebase_onto_deno_dir("./src/*"), "../src/*");
+    assert_eq!(rebase_onto_deno_dir("src/*"), "../src/*");
+    assert_eq!(rebase_onto_deno_dir("../shared"), "../../shared");
+    assert_eq!(rebase_onto_deno_dir("/abs/path"), "/abs/path");
   }
 
   #[test]
@@ -1378,16 +1474,22 @@ interface AlsoKeep {
     ensure_root_tsconfig(root).unwrap();
 
     let content = std::fs::read_to_string(root.join("tsconfig.json")).unwrap();
-    let tsconfig: Value = serde_json::from_str(&content).unwrap();
-    // extends added (ours first), and the user's options are NOT dropped.
+    // The user's comment and trailing comma are PRESERVED (text is spliced, not
+    // re-serialized), so it's still JSONC — parse it as such.
+    assert!(content.contains("// team config"));
+    assert!(content.contains("\"strict\": false,"));
+    let parsed = jsonc_parser::parse_to_serde_value::<Value>(
+      &content,
+      &jsonc_parser::ParseOptions::default(),
+    )
+    .unwrap();
+    // extends added, user's options not dropped.
     assert_eq!(
-      tsconfig.get("extends").unwrap(),
+      parsed.get("extends").unwrap(),
       &json!("./.deno/tsconfig.json")
     );
     assert_eq!(
-      tsconfig
-        .get("compilerOptions")
-        .and_then(|c| c.get("strict")),
+      parsed.get("compilerOptions").and_then(|c| c.get("strict")),
       Some(&json!(false))
     );
   }

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -246,6 +246,25 @@ fn build_tsconfig(
     }
   }
 
+  // Merge the user's `compilerOptions.types` with the deno/node types we inject,
+  // rather than dropping them. Such an entry (e.g. `lume/types.ts`) can carry
+  // both ambient declarations (a `Lume` namespace) and `/// <reference
+  // lib="dom" />`, so clobbering it loses DOM globals and project namespaces the
+  // code relies on.
+  //
+  // Guard: only emit an entry we can actually resolve. A bare name (no `/`)
+  // resolves via typeRoots/node_modules (`deno`, `node`, `@types/*`); a slashed
+  // entry needs a matching `paths` mapping. Emitting an unresolvable `types`
+  // entry makes stock tsc/tsgo fail the whole program build (TS2688) and skip
+  // every file, which masks all real diagnostics — worse than dropping it.
+  if let Some(user_types) = deno_compiler_options
+    .and_then(|co| co.get("types"))
+    .and_then(|t| t.as_array())
+    && let Some(Value::Array(types)) = compiler_options.get_mut("types")
+  {
+    merge_user_types(types, user_types, &specifier_paths);
+  }
+
   if !specifier_paths.is_empty() {
     compiler_options.insert("paths".to_string(), json!(specifier_paths));
   }
@@ -358,52 +377,67 @@ fn generate_npm_paths(
       };
       let pkg_name = npm_ref.req().name.to_string();
       let pkg_dir = project_root.join(format!("node_modules/{pkg_name}"));
-      if !pkg_dir.exists() {
-        continue;
-      }
-      let subpath = npm_ref.sub_path();
 
-      // For a subpath (`npm:preact/compat`, `react/jsx-runtime`), resolve it
-      // through the package's `exports` to a concrete .d.ts (a relative path,
-      // to avoid TS5090). For the bare package, map to the package directory,
-      // which resolves via its package.json `types`/`exports["."]`.
-      let target_paths: Value = match subpath {
+      // A plain alias whose name matches the package (`"chalk": "npm:chalk"`,
+      // and its subpaths like `chalk/foo`) resolves natively through
+      // `node_modules` under `moduleResolution: bundler`, so an alias key would
+      // be redundant. A *renamed* alias (`"$prism": "npm:prismjs"`, so source
+      // writes `$prism/components/x`) has no `node_modules/$prism`, so it needs
+      // an explicit mapping. `npm:`-scheme keys are always emitted since bundler
+      // can't resolve the scheme on its own.
+      let alias_renamed = alias != &pkg_name;
+      match npm_ref.sub_path() {
         Some(sub) => {
-          let Some(types_rel) =
-            resolve_jsr_types_entry(&pkg_dir, &format!("./{sub}"))
-          else {
-            continue;
-          };
-          json!([types_rel])
-        }
-        None => json!([format!("../node_modules/{pkg_name}")]),
-      };
-
-      // Key on the exact `npm:` specifier as written, and on the import-map
-      // alias (which is what most source actually imports).
-      paths
-        .entry(target_str.to_string())
-        .or_insert_with(|| target_paths.clone());
-      if alias != target_str {
-        paths.entry(alias.clone()).or_insert(target_paths);
-      }
-
-      // For a bare alias -> package, enumerate the package's exports and map
-      // each subpath under the alias and the npm: specifier (e.g. `preact/hooks`).
-      if subpath.is_none() {
-        for exp_key in package_export_keys(&pkg_dir) {
-          let sub = exp_key.trim_start_matches("./");
-          let Some(sub_rel) = resolve_jsr_types_entry(&pkg_dir, &exp_key)
-          else {
-            continue;
-          };
+          // `npm:preact/compat`: resolve through the package's `exports` to a
+          // concrete .d.ts (relative, to avoid TS5090). Fall back to the naive
+          // subpath under the package dir when exports can't be read (e.g. the
+          // package isn't materialized yet). Key both the version-less scheme
+          // (`npm:preact/compat`) and the exact specifier as written, plus the
+          // source-written alias form when the alias is renamed.
+          let rel = resolve_jsr_types_entry(&pkg_dir, &format!("./{sub}"))
+            .unwrap_or_else(|| format!("../node_modules/{pkg_name}/{sub}"));
           paths
             .entry(format!("npm:{pkg_name}/{sub}"))
-            .or_insert_with(|| json!([&sub_rel]));
-          if alias != target_str {
+            .or_insert_with(|| json!([&rel]));
+          paths
+            .entry(target_str.to_string())
+            .or_insert_with(|| json!([&rel]));
+          if alias_renamed {
+            paths.entry(alias.clone()).or_insert_with(|| json!([&rel]));
+          }
+        }
+        None => {
+          // Bare `npm:preact`: map to the package directory, which resolves via
+          // its package.json `types`/`exports["."]`. Emitted unconditionally so
+          // the mapping exists even if generation runs before install. Key both
+          // the version-less scheme (`npm:preact`) and the exact specifier.
+          let dir = format!("../node_modules/{pkg_name}");
+          paths
+            .entry(format!("npm:{pkg_name}"))
+            .or_insert_with(|| json!([&dir]));
+          paths
+            .entry(target_str.to_string())
+            .or_insert_with(|| json!([&dir]));
+          if alias_renamed {
+            paths.entry(alias.clone()).or_insert_with(|| json!([&dir]));
+          }
+          // Enumerate the package's own `exports` so subpaths written in source
+          // map to their concrete .d.ts: the `npm:` scheme form always, and the
+          // renamed-alias form (`$prism/components`) when applicable.
+          for exp_key in package_export_keys(&pkg_dir) {
+            let sub = exp_key.trim_start_matches("./");
+            let Some(sub_rel) = resolve_jsr_types_entry(&pkg_dir, &exp_key)
+            else {
+              continue;
+            };
             paths
-              .entry(format!("{alias}/{sub}"))
+              .entry(format!("npm:{pkg_name}/{sub}"))
               .or_insert_with(|| json!([&sub_rel]));
+            if alias_renamed {
+              paths
+                .entry(format!("{alias}/{sub}"))
+                .or_insert_with(|| json!([&sub_rel]));
+            }
           }
         }
       }
@@ -734,6 +768,41 @@ fn merge_deno_options(base: &mut Map<String, Value>, user_opts: &Value) {
   }
 }
 
+/// Merge the user's `compilerOptions.types` into `base_types`, skipping any
+/// entry we can't resolve.
+///
+/// A bare name (no `/`) resolves via typeRoots/node_modules (`deno`, `node`,
+/// `@types/*`); a slashed entry (e.g. `lume/types.ts`) needs a matching `paths`
+/// mapping. Emitting an unresolvable `types` entry makes stock tsc/tsgo fail the
+/// whole program build (TS2688) and skip every file, masking all real
+/// diagnostics, so it is dropped rather than passed through.
+fn merge_user_types(
+  base_types: &mut Vec<Value>,
+  user_types: &[Value],
+  specifier_paths: &Map<String, Value>,
+) {
+  for entry in user_types {
+    let Some(s) = entry.as_str() else { continue };
+    // A bare package name resolves via typeRoots/node_modules: either unscoped
+    // (`node`, no slash) or scoped (`@types/react`, `@`-prefixed, one slash). A
+    // subpath entry (`lume/types.ts`, `@scope/pkg/sub`) needs a `paths` mapping.
+    let is_bare_package = match s.strip_prefix('@') {
+      Some(rest) => rest.matches('/').count() == 1,
+      None => !s.contains('/'),
+    };
+    let resolvable = is_bare_package || specifier_paths.contains_key(s);
+    if !resolvable {
+      log::debug!(
+        "sync-types: dropping unresolvable `types` entry {s:?} (no mapping)"
+      );
+      continue;
+    }
+    if !base_types.iter().any(|e| e == entry) {
+      base_types.push(entry.clone());
+    }
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -794,6 +863,35 @@ mod tests {
     assert!(base.get("unknownOption").is_none());
     // target stays at the base value
     assert_eq!(base.get("target").unwrap(), &json!("esnext"));
+  }
+
+  #[test]
+  fn test_merge_user_types() {
+    let mut base = vec![json!("deno"), json!("node")];
+    let user = vec![
+      // bare name -> resolves via node_modules/@types, kept
+      json!("@types/react"),
+      // slashed with a matching paths mapping -> kept
+      json!("lume/types.ts"),
+      // slashed without a mapping -> dropped (would abort the build)
+      json!("unmapped/types.ts"),
+      // duplicate of an injected type -> not added twice
+      json!("node"),
+    ];
+    let mut paths = Map::new();
+    paths.insert("lume/types.ts".to_string(), json!(["../.deno/x.d.ts"]));
+
+    merge_user_types(&mut base, &user, &paths);
+
+    assert_eq!(
+      base,
+      vec![
+        json!("deno"),
+        json!("node"),
+        json!("@types/react"),
+        json!("lume/types.ts"),
+      ]
+    );
   }
 
   #[test]
@@ -870,10 +968,10 @@ mod tests {
     let paths = generate_npm_paths(Path::new("/tmp/project"), Some(&imports));
 
     assert!(paths.contains_key("npm:chalk"));
-    // jsr specifiers should not appear in npm paths
+    // jsr specifiers should not appear in npm paths; every key is npm:-scheme
     assert!(!paths.contains_key("jsr:@std/assert"));
     assert!(!paths.contains_key("@std/assert"));
-    assert_eq!(paths.len(), 1);
+    assert!(paths.keys().all(|k| k.starts_with("npm:")));
   }
 
   #[test]
@@ -889,8 +987,15 @@ mod tests {
   #[test]
   fn test_build_tsconfig_includes_relative_to_deno_dir() {
     let project_root = Path::new("/tmp/project");
-    let tsconfig =
-      build_tsconfig(project_root, None, None, &[], &BTreeMap::new());
+    let tsconfig = build_tsconfig(
+      project_root,
+      None,
+      None,
+      &[],
+      &BTreeMap::new(),
+      &Map::new(),
+      false,
+    );
 
     let include = tsconfig.get("include").unwrap().as_array().unwrap();
     assert_eq!(include, &vec![json!("../**/*")]);
@@ -903,8 +1008,15 @@ mod tests {
   fn test_build_tsconfig_with_files() {
     let project_root = Path::new("/tmp/project");
     let files = vec!["main.ts".to_string(), "lib.ts".to_string()];
-    let tsconfig =
-      build_tsconfig(project_root, None, None, &files, &BTreeMap::new());
+    let tsconfig = build_tsconfig(
+      project_root,
+      None,
+      None,
+      &files,
+      &BTreeMap::new(),
+      &Map::new(),
+      false,
+    );
 
     // Should use "files" instead of "include"/"exclude"
     assert!(tsconfig.get("include").is_none());
@@ -931,6 +1043,8 @@ mod tests {
       Some(&imports),
       &[],
       &BTreeMap::new(),
+      &Map::new(),
+      false,
     );
 
     let paths = tsconfig

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -42,7 +42,10 @@ pub struct GeneratedTsConfig {
 /// Generates `.deno/tsconfig.json` with compiler options and paths mappings
 /// for npm:/jsr: specifiers. Also ensures a root `tsconfig.json` exists
 /// that extends it.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+  clippy::too_many_arguments,
+  reason = "threads the independent inputs needed to generate a tsconfig"
+)]
 pub fn generate_tsconfig(
   project_root: &Path,
   deno_compiler_options: Option<&Value>,
@@ -350,7 +353,10 @@ fn rebase_onto_deno_dir(path: &str) -> String {
 ///
 /// The generated tsconfig lives at `.deno/tsconfig.json`, so all paths
 /// are relative to that directory (e.g. `../node_modules/...`).
-#[allow(clippy::too_many_arguments)]
+#[allow(
+  clippy::too_many_arguments,
+  reason = "threads the independent inputs needed to generate a tsconfig"
+)]
 fn build_tsconfig(
   project_root: &Path,
   deno_compiler_options: Option<&Value>,

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -224,6 +224,8 @@ fn build_tsconfig(
   specifier_paths.extend(jsr_paths);
   let local_paths = generate_local_alias_paths(deno_imports);
   specifier_paths.extend(local_paths);
+  let http_alias_paths = generate_http_alias_paths(deno_imports, http_modules);
+  specifier_paths.extend(http_alias_paths);
   let http_paths = generate_http_paths(http_modules);
   specifier_paths.extend(http_paths);
 
@@ -283,6 +285,34 @@ fn build_tsconfig(
 /// `"@/": "./"`, `"utils": "./src/utils.ts"`) to project-relative paths. The
 /// generated tsconfig lives in `.deno/`, so a project-root path `./x` becomes
 /// `../x`. Trailing-slash prefix aliases become `<alias>*` -> `../<base>*`.
+/// Map import-map aliases whose target is a mirrored http(s) URL to the local
+/// mirror file, so code (and `jsxImportSource`) that imports the *alias* — e.g.
+/// `lume/jsx-runtime` -> `https://.../jsx-runtime.ts` — resolves. Without this
+/// only the raw URL is mapped, not the alias the source actually uses.
+fn generate_http_alias_paths(
+  deno_imports: Option<&Value>,
+  http_modules: &BTreeMap<Url, String>,
+) -> Map<String, Value> {
+  let mut paths = Map::new();
+  let Some(imports) = deno_imports.and_then(|v| v.as_object()) else {
+    return paths;
+  };
+  for (alias, target) in imports {
+    let Some(target) = target.as_str() else {
+      continue;
+    };
+    if !(target.starts_with("http://") || target.starts_with("https://")) {
+      continue;
+    }
+    if let Ok(url) = Url::parse(target)
+      && let Some(mirrored) = http_modules.get(&url)
+    {
+      paths.insert(alias.clone(), json!([mirrored]));
+    }
+  }
+  paths
+}
+
 fn generate_local_alias_paths(
   deno_imports: Option<&Value>,
 ) -> Map<String, Value> {

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -56,7 +56,7 @@ pub fn generate_tsconfig(
   // Write Deno type definitions to .deno/types/deno/ (private typeRoot).
   let types_dir = project_root.join(".deno/types/deno");
   std::fs::create_dir_all(&types_dir)?;
-  write_deno_types(&types_dir.join("index.d.ts"))?;
+  write_deno_types(&types_dir.join("index.d.ts"), has_node_types)?;
 
   // Write a package.json for the @types/deno package so the typeRoots lookup
   // resolves the directory as a package.
@@ -163,8 +163,35 @@ fn ensure_root_tsconfig(project_root: &Path) -> Result<(), std::io::Error> {
   std::fs::write(&root_tsconfig_path, &content)
 }
 
+/// Web-global types that `@types/node` also declares (globally, via `node:url`)
+/// and that must be owned by a single source. Deno ships the `URLPattern`
+/// *interface* but lets `@types/node` own the *constructor var* (a second
+/// unconditional `declare var URLPattern` would collide, TS2403). That split
+/// means `new URLPattern()` yields Node's type while `x: URLPattern`
+/// annotations use Deno's, and the shapes diverge (`@types/node`'s
+/// `URLPatternResult.inputs` is `URLPatternInput[]`, Deno's/the DOM lib's is the
+/// `[URLPatternInit] | [URLPatternInit, string]` tuple) -> TS2322.
+///
+/// This is a deliberate hack: when generating types we drop Deno's declarations
+/// for the whole family so both the constructor and the instance type come from
+/// `@types/node`. It assumes the `@types/node` we always install provides these
+/// globals; a project pinning an `@types/node` that doesn't is on its own. The
+/// proper fix is dual-globals reconciliation in Deno's core libs (which also
+/// fixes `deno check`, broken on this today), not this generator.
+const NODE_OWNED_GLOBAL_TYPES: &[&str] = &[
+  "URLPattern",
+  "URLPatternInit",
+  "URLPatternInput",
+  "URLPatternComponentResult",
+  "URLPatternResult",
+  "URLPatternOptions",
+];
+
 /// Write the Deno type declarations to a `.d.ts` file.
-fn write_deno_types(path: &Path) -> Result<(), std::io::Error> {
+fn write_deno_types(
+  path: &Path,
+  has_node_types: bool,
+) -> Result<(), std::io::Error> {
   let types_text = get_types_declaration_file_text();
   // Strip triple-slash reference directives that conflict with stock tsc
   let filtered: String = types_text
@@ -177,6 +204,14 @@ fn write_deno_types(path: &Path) -> Result<(), std::io::Error> {
     .collect::<Vec<_>>()
     .join("\n");
 
+  // Defer node-owned web globals to @types/node so the instance type and the
+  // constructor agree (see NODE_OWNED_GLOBAL_TYPES).
+  let filtered = if has_node_types {
+    strip_top_level_type_decls(&filtered, NODE_OWNED_GLOBAL_TYPES)
+  } else {
+    filtered
+  };
+
   std::fs::write(
     path,
     format!(
@@ -185,6 +220,55 @@ fn write_deno_types(path: &Path) -> Result<(), std::io::Error> {
        {filtered}"
     ),
   )
+}
+
+/// Remove top-level `interface NAME {...}` and `type NAME = ...;` declarations
+/// (and their leading JSDoc block) for each NAME in `names`. Deno's lib types
+/// are formatted with each top-level declaration's opening at column 0 and its
+/// closing `}` at column 0, which this relies on.
+fn strip_top_level_type_decls(text: &str, names: &[&str]) -> String {
+  let lines: Vec<&str> = text.lines().collect();
+  let mut out: Vec<&str> = Vec::with_capacity(lines.len());
+  let mut i = 0;
+  while i < lines.len() {
+    let line = lines[i];
+    let is_interface =
+      names.iter().any(|n| line == format!("interface {n} {{"));
+    let is_type_alias = names.iter().any(|n| {
+      line.starts_with(&format!("type {n} =")) || line == format!("type {n}")
+    });
+    if is_interface || is_type_alias {
+      // Drop the JSDoc block immediately preceding this declaration.
+      while out.last().is_some_and(|l| l.trim().is_empty()) {
+        out.pop();
+      }
+      if out.last().is_some_and(|l| l.trim().ends_with("*/")) {
+        while let Some(popped) = out.pop() {
+          if popped.trim_start().starts_with("/**") {
+            break;
+          }
+        }
+      }
+      if is_interface {
+        // Skip to the matching top-level `}` (column 0).
+        i += 1;
+        while i < lines.len() && lines[i] != "}" {
+          i += 1;
+        }
+        i += 1;
+      } else {
+        // Type alias: skip until the line that ends the statement.
+        while i < lines.len() && !lines[i].trim_end().ends_with(';') {
+          i += 1;
+        }
+        i += 1;
+      }
+      continue;
+    }
+    out.push(line);
+    i += 1;
+  }
+  out.join("\n")
 }
 
 /// Build the tsconfig JSON object.
@@ -818,6 +902,35 @@ fn merge_user_types(base_types: &mut Vec<Value>, user_types: &[Value]) {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn test_strip_top_level_type_decls() {
+    let text = "\
+interface Keep {
+  a: number;
+}
+
+/** JSDoc for URLPattern. */
+interface URLPattern {
+  exec(): void;
+}
+
+type URLPatternInput = string | URLPatternInit;
+
+interface AlsoKeep {
+  b: string;
+}";
+    let out =
+      strip_top_level_type_decls(text, &["URLPattern", "URLPatternInput"]);
+    assert!(out.contains("interface Keep {"));
+    assert!(out.contains("interface AlsoKeep {"));
+    // stripped: the interface, the type alias, and the JSDoc block
+    assert!(!out.contains("interface URLPattern {"));
+    assert!(!out.contains("type URLPatternInput"));
+    assert!(!out.contains("JSDoc for URLPattern"));
+    // nested/other members untouched
+    assert!(!out.contains("exec(): void"));
+  }
 
   #[test]
   fn test_base_compiler_options() {

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -387,6 +387,26 @@ fn generate_npm_paths(
       if alias != target_str {
         paths.entry(alias.clone()).or_insert(target_paths);
       }
+
+      // For a bare alias -> package, enumerate the package's exports and map
+      // each subpath under the alias and the npm: specifier (e.g. `preact/hooks`).
+      if subpath.is_none() {
+        for exp_key in package_export_keys(&pkg_dir) {
+          let sub = exp_key.trim_start_matches("./");
+          let Some(sub_rel) = resolve_jsr_types_entry(&pkg_dir, &exp_key)
+          else {
+            continue;
+          };
+          paths
+            .entry(format!("npm:{pkg_name}/{sub}"))
+            .or_insert_with(|| json!([&sub_rel]));
+          if alias != target_str {
+            paths
+              .entry(format!("{alias}/{sub}"))
+              .or_insert_with(|| json!([&sub_rel]));
+          }
+        }
+      }
     }
   }
 
@@ -455,11 +475,50 @@ fn generate_jsr_paths(
             .entry(alias.clone())
             .or_insert_with(|| json!([&types_rel]));
         }
+
+        // For a bare alias -> package (no subpath), enumerate the package's own
+        // exports and map each under both the alias and the jsr: specifier, so
+        // subpath imports like `fresh/runtime` resolve without depending on the
+        // module graph having discovered them.
+        if subpath.is_empty() {
+          for exp_key in package_export_keys(&pkg_dir) {
+            let sub = exp_key.trim_start_matches("./");
+            let Some(sub_rel) = resolve_jsr_types_entry(&pkg_dir, &exp_key)
+            else {
+              continue;
+            };
+            paths
+              .entry(format!("{prefix}/{sub}"))
+              .or_insert_with(|| json!([&sub_rel]));
+            if alias != target_str {
+              paths
+                .entry(format!("{alias}/{sub}"))
+                .or_insert_with(|| json!([&sub_rel]));
+            }
+          }
+        }
       }
     }
   }
 
   paths
+}
+
+/// List a package's `exports` subpath keys (`"./foo"`), excluding the root
+/// `"."`. Used to enumerate what an import-map alias can reach by subpath.
+fn package_export_keys(pkg_dir: &Path) -> Vec<String> {
+  let Ok(content) = std::fs::read_to_string(pkg_dir.join("package.json"))
+  else {
+    return vec![];
+  };
+  let Ok(pkg) = serde_json::from_str::<Value>(&content) else {
+    return vec![];
+  };
+  pkg
+    .get("exports")
+    .and_then(|e| e.as_object())
+    .map(|m| m.keys().filter(|k| k.starts_with("./")).cloned().collect())
+    .unwrap_or_default()
 }
 
 /// Resolve the types entry point from a JSR package's package.json.

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -100,13 +100,16 @@ pub fn generate_tsconfig(
 ///
 /// - No existing tsconfig: create one with `extends: "./.deno/tsconfig.json"`.
 /// - Existing `extends` is a single string (or absent): coerce into an array
-///   that includes the original entry followed by our generated path. TS 5.0+
-///   resolves array extends left-to-right, with later entries overriding
-///   earlier ones — putting ours last lets us add the URL `paths` mappings
-///   without clobbering user-managed settings inherited from e.g. a shared
-///   team config.
-/// - Existing `extends` is already an array: append our path if missing,
-///   otherwise leave it alone.
+///   with our generated path FIRST, then the original entry. TS 5.0+ resolves
+///   array extends left-to-right with later entries overriding earlier ones, so
+///   putting ours first makes our config the base and lets the user's own
+///   config (e.g. a shared team config) override it — while our `paths`, which a
+///   team config won't set, survive.
+/// - Existing `extends` is already an array: prepend our path if missing.
+///
+/// The existing file is parsed as JSONC (tsconfig commonly has comments and
+/// trailing commas); an unparseable file is a hard error rather than being
+/// silently overwritten, which would drop the user's compiler options.
 fn ensure_root_tsconfig(project_root: &Path) -> Result<(), std::io::Error> {
   let root_tsconfig_path = project_root.join("tsconfig.json");
   let extends_path = "./.deno/tsconfig.json";
@@ -119,8 +122,21 @@ fn ensure_root_tsconfig(project_root: &Path) -> Result<(), std::io::Error> {
   }
 
   let content = std::fs::read_to_string(&root_tsconfig_path)?;
-  let mut tsconfig: Value =
-    serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
+  let parsed: Option<Value> = jsonc_parser::parse_to_serde_value(
+    &content,
+    &jsonc_parser::ParseOptions::default(),
+  )
+  .map_err(|e| {
+    std::io::Error::new(
+      std::io::ErrorKind::InvalidData,
+      format!(
+        "existing {} is not valid JSON/JSONC: {e}. Fix or remove it and re-run \
+         `deno sync-types`.",
+        root_tsconfig_path.display()
+      ),
+    )
+  })?;
+  let mut tsconfig = parsed.unwrap_or_else(|| json!({}));
 
   let Some(obj) = tsconfig.as_object_mut() else {
     return Ok(());
@@ -134,7 +150,7 @@ fn ensure_root_tsconfig(project_root: &Path) -> Result<(), std::io::Error> {
       return Ok(());
     }
     Some(Value::String(existing)) => {
-      obj.insert("extends".to_string(), json!([existing, extends_path]));
+      obj.insert("extends".to_string(), json!([extends_path, existing]));
     }
     Some(Value::Array(arr)) => {
       let already = arr
@@ -143,8 +159,8 @@ fn ensure_root_tsconfig(project_root: &Path) -> Result<(), std::io::Error> {
       if already {
         return Ok(());
       }
-      let mut new_arr = arr;
-      new_arr.push(json!(extends_path));
+      let mut new_arr = vec![json!(extends_path)];
+      new_arr.extend(arr);
       obj.insert("extends".to_string(), Value::Array(new_arr));
     }
     Some(_) => {
@@ -464,6 +480,14 @@ fn generate_npm_paths(
       };
       let pkg_name = npm_ref.req().name.to_string();
       let pkg_dir = project_root.join(format!("node_modules/{pkg_name}"));
+      // Only map a package that is actually materialized under `node_modules`.
+      // With Deno's default global-cache mode, `deno install` may resolve npm
+      // deps without a local `node_modules/<pkg>`; emitting a path to a
+      // nonexistent directory just makes stock tsc fail. The caller warns when
+      // this happens so the user knows to enable a node_modules directory.
+      if !pkg_dir.exists() {
+        continue;
+      }
 
       // A plain alias whose name matches the package (`"chalk": "npm:chalk"`,
       // and its subpaths like `chalk/foo`) resolves natively through
@@ -1061,14 +1085,24 @@ interface AlsoKeep {
     assert_eq!(parse_jsr_specifier("jsr:assert@1"), None);
   }
 
+  // Create empty `node_modules/<pkg>` dirs so generate_npm_paths (which only
+  // maps materialized packages) has something to map.
+  fn touch_node_modules(root: &Path, pkgs: &[&str]) {
+    for pkg in pkgs {
+      std::fs::create_dir_all(root.join("node_modules").join(pkg)).unwrap();
+    }
+  }
+
   #[test]
   fn test_generate_npm_paths_only_npm_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    touch_node_modules(dir.path(), &["chalk", "express", "@mylib/foo"]);
     let imports = json!({
       "chalk": "npm:chalk@5",
       "express": "npm:express@4",
       "@mylib/foo": "npm:@mylib/foo@1",
     });
-    let paths = generate_npm_paths(Path::new("/tmp/project"), Some(&imports));
+    let paths = generate_npm_paths(dir.path(), Some(&imports));
 
     // Should have npm: prefixed keys only
     assert!(paths.contains_key("npm:chalk"));
@@ -1096,12 +1130,23 @@ interface AlsoKeep {
   }
 
   #[test]
+  fn test_generate_npm_paths_skips_unmaterialized() {
+    // No node_modules on disk -> nothing to map (avoids dangling paths).
+    let dir = tempfile::tempdir().unwrap();
+    let imports = json!({ "chalk": "npm:chalk@5" });
+    let paths = generate_npm_paths(dir.path(), Some(&imports));
+    assert!(paths.is_empty());
+  }
+
+  #[test]
   fn test_generate_npm_paths_skips_jsr() {
+    let dir = tempfile::tempdir().unwrap();
+    touch_node_modules(dir.path(), &["chalk"]);
     let imports = json!({
       "@std/assert": "jsr:@std/assert@1",
       "chalk": "npm:chalk@5",
     });
-    let paths = generate_npm_paths(Path::new("/tmp/project"), Some(&imports));
+    let paths = generate_npm_paths(dir.path(), Some(&imports));
 
     assert!(paths.contains_key("npm:chalk"));
     // jsr specifiers should not appear in npm paths; every key is npm:-scheme
@@ -1291,9 +1336,10 @@ interface AlsoKeep {
 
     let content = std::fs::read_to_string(root.join("tsconfig.json")).unwrap();
     let tsconfig: Value = serde_json::from_str(&content).unwrap();
+    // Ours goes first so the user's team config overrides our defaults.
     assert_eq!(
       tsconfig.get("extends").unwrap(),
-      &json!(["./team-shared.json", "./.deno/tsconfig.json"])
+      &json!(["./.deno/tsconfig.json", "./team-shared.json"])
     );
   }
 
@@ -1314,8 +1360,45 @@ interface AlsoKeep {
     let tsconfig: Value = serde_json::from_str(&content).unwrap();
     assert_eq!(
       tsconfig.get("extends").unwrap(),
-      &json!(["./a.json", "./b.json", "./.deno/tsconfig.json"])
+      &json!(["./.deno/tsconfig.json", "./a.json", "./b.json"])
     );
+  }
+
+  #[test]
+  fn test_ensure_root_tsconfig_preserves_jsonc_options() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // JSONC: line comment + trailing comma + user compilerOptions.
+    std::fs::write(
+      root.join("tsconfig.json"),
+      "{\n  // team config\n  \"compilerOptions\": { \"strict\": false, },\n}",
+    )
+    .unwrap();
+
+    ensure_root_tsconfig(root).unwrap();
+
+    let content = std::fs::read_to_string(root.join("tsconfig.json")).unwrap();
+    let tsconfig: Value = serde_json::from_str(&content).unwrap();
+    // extends added (ours first), and the user's options are NOT dropped.
+    assert_eq!(
+      tsconfig.get("extends").unwrap(),
+      &json!("./.deno/tsconfig.json")
+    );
+    assert_eq!(
+      tsconfig
+        .get("compilerOptions")
+        .and_then(|c| c.get("strict")),
+      Some(&json!(false))
+    );
+  }
+
+  #[test]
+  fn test_ensure_root_tsconfig_rejects_invalid() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("tsconfig.json"), "{ not valid").unwrap();
+    // Fails loudly rather than silently overwriting the user's file.
+    assert!(ensure_root_tsconfig(root).is_err());
   }
 
   #[test]

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -42,12 +42,14 @@ pub struct GeneratedTsConfig {
 /// Generates `.deno/tsconfig.json` with compiler options and paths mappings
 /// for npm:/jsr: specifiers. Also ensures a root `tsconfig.json` exists
 /// that extends it.
+#[allow(clippy::too_many_arguments)]
 pub fn generate_tsconfig(
   project_root: &Path,
   deno_compiler_options: Option<&Value>,
   deno_imports: Option<&Value>,
   files: &[String],
   http_modules: &BTreeMap<Url, String>,
+  member_paths: &Map<String, Value>,
 ) -> Result<GeneratedTsConfig, std::io::Error> {
   // Write Deno type definitions to .deno/types/deno/ (private typeRoot).
   let types_dir = project_root.join(".deno/types/deno");
@@ -73,6 +75,7 @@ pub fn generate_tsconfig(
     deno_imports,
     files,
     http_modules,
+    member_paths,
   );
 
   // Write to .deno/tsconfig.json
@@ -184,12 +187,14 @@ fn write_deno_types(path: &Path) -> Result<(), std::io::Error> {
 ///
 /// The generated tsconfig lives at `.deno/tsconfig.json`, so all paths
 /// are relative to that directory (e.g. `../node_modules/...`).
+#[allow(clippy::too_many_arguments)]
 fn build_tsconfig(
   project_root: &Path,
   deno_compiler_options: Option<&Value>,
   deno_imports: Option<&Value>,
   check_files: &[String],
   http_modules: &BTreeMap<Url, String>,
+  member_paths: &Map<String, Value>,
 ) -> Value {
   let mut compiler_options = base_compiler_options();
 
@@ -205,6 +210,12 @@ fn build_tsconfig(
   specifier_paths.extend(jsr_paths);
   let http_paths = generate_http_paths(http_modules);
   specifier_paths.extend(http_paths);
+
+  // Workspace-member aliases map to local source and shadow any published jsr
+  // mapping for the same name, so apply them after the specifier paths.
+  for (key, value) in member_paths {
+    specifier_paths.insert(key.clone(), value.clone());
+  }
 
   // Merge user-defined paths from deno.json compilerOptions — these take
   // priority over generated specifier mappings.

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -222,6 +222,8 @@ fn build_tsconfig(
   let mut specifier_paths = generate_npm_paths(project_root, deno_imports);
   let jsr_paths = generate_jsr_paths(project_root, deno_imports);
   specifier_paths.extend(jsr_paths);
+  let local_paths = generate_local_alias_paths(deno_imports);
+  specifier_paths.extend(local_paths);
   let http_paths = generate_http_paths(http_modules);
   specifier_paths.extend(http_paths);
 
@@ -277,41 +279,88 @@ fn build_tsconfig(
 ///
 /// Only generates `npm:<pkg>` keys -- bare aliases are resolved by
 /// TypeScript via `node_modules` with `moduleResolution: "bundler"`.
+/// Map import-map aliases that point at local files/directories (e.g.
+/// `"@/": "./"`, `"utils": "./src/utils.ts"`) to project-relative paths. The
+/// generated tsconfig lives in `.deno/`, so a project-root path `./x` becomes
+/// `../x`. Trailing-slash prefix aliases become `<alias>*` -> `../<base>*`.
+fn generate_local_alias_paths(
+  deno_imports: Option<&Value>,
+) -> Map<String, Value> {
+  let mut paths = Map::new();
+  let Some(imports) = deno_imports.and_then(|v| v.as_object()) else {
+    return paths;
+  };
+  for (alias, target) in imports {
+    let Some(target) = target.as_str() else {
+      continue;
+    };
+    if !(target.starts_with("./") || target.starts_with("../")) {
+      continue;
+    }
+    // Re-base a project-root-relative path onto `.deno/` (one level down).
+    let rebased = format!("../{}", target.trim_start_matches("./"));
+    if let Some(prefix) = alias.strip_suffix('/') {
+      // Prefix alias: `@/` -> `./` becomes `@/*` -> `../*`.
+      paths.insert(format!("{prefix}/*"), json!([format!("{}*", rebased)]));
+    } else {
+      paths.insert(alias.clone(), json!([rebased]));
+    }
+  }
+  paths
+}
+
 fn generate_npm_paths(
-  _project_root: &Path,
+  project_root: &Path,
   deno_imports: Option<&Value>,
 ) -> Map<String, Value> {
   let mut paths = Map::new();
 
   if let Some(imports) = deno_imports.and_then(|v| v.as_object()) {
-    for (_alias, target) in imports {
+    for (alias, target) in imports {
       let target_str = match target.as_str() {
-        Some(s) => s,
-        None => continue,
+        Some(s) if s.starts_with("npm:") => s,
+        _ => continue,
+      };
+      let Ok(npm_ref) =
+        deno_semver::npm::NpmPackageReqReference::from_str(target_str)
+      else {
+        continue;
+      };
+      let pkg_name = npm_ref.req().name.to_string();
+      let pkg_dir = project_root.join(format!("node_modules/{pkg_name}"));
+      if !pkg_dir.exists() {
+        continue;
+      }
+      let subpath = npm_ref.sub_path();
+
+      // For a subpath (`npm:preact/compat`, `react/jsx-runtime`), resolve it
+      // through the package's `exports` to a concrete .d.ts (a relative path,
+      // to avoid TS5090). For the bare package, map to the package directory,
+      // which resolves via its package.json `types`/`exports["."]`.
+      let target_paths: Value = match subpath {
+        Some(sub) => {
+          let Some(types_rel) =
+            resolve_jsr_types_entry(&pkg_dir, &format!("./{sub}"))
+          else {
+            continue;
+          };
+          json!([types_rel])
+        }
+        None => json!([format!("../node_modules/{pkg_name}")]),
       };
 
-      if let Some(pkg_name) = parse_npm_specifier(target_str) {
-        // Paths are relative to .deno/ directory
-        let nm_path = format!("../node_modules/{pkg_name}");
-
-        // Map the npm: specifier
-        // e.g. "npm:express" -> ["../node_modules/express"]
-        let npm_key = format!("npm:{pkg_name}");
-        paths.entry(npm_key).or_insert_with(|| json!([&nm_path]));
+      // Key on the exact `npm:` specifier as written, and on the import-map
+      // alias (which is what most source actually imports).
+      paths
+        .entry(target_str.to_string())
+        .or_insert_with(|| target_paths.clone());
+      if alias != target_str {
+        paths.entry(alias.clone()).or_insert(target_paths);
       }
     }
   }
 
   paths
-}
-
-/// Parse an npm specifier like "npm:express@4", "npm:@scope/pkg@1.2.3",
-/// or "npm:express/foo" and return just the package name (without version
-/// or subpath). Returns `None` if `specifier` is not a valid npm: reference.
-pub fn parse_npm_specifier(specifier: &str) -> Option<String> {
-  deno_semver::npm::NpmPackageReqReference::from_str(specifier)
-    .ok()
-    .map(|r| r.req().name.to_string())
 }
 
 /// Generate tsconfig "paths" entries for jsr: specifiers.
@@ -656,65 +705,6 @@ mod tests {
     assert!(base.get("unknownOption").is_none());
     // target stays at the base value
     assert_eq!(base.get("target").unwrap(), &json!("esnext"));
-  }
-
-  #[test]
-  fn test_parse_npm_specifier_unscoped() {
-    assert_eq!(
-      parse_npm_specifier("npm:chalk@5"),
-      Some("chalk".to_string())
-    );
-    assert_eq!(
-      parse_npm_specifier("npm:express"),
-      Some("express".to_string())
-    );
-    assert_eq!(
-      parse_npm_specifier("npm:foo@1.2.3"),
-      Some("foo".to_string())
-    );
-  }
-
-  #[test]
-  fn test_parse_npm_specifier_scoped() {
-    assert_eq!(
-      parse_npm_specifier("npm:@types/node@20"),
-      Some("@types/node".to_string())
-    );
-    assert_eq!(
-      parse_npm_specifier("npm:@scope/pkg@1.2.3"),
-      Some("@scope/pkg".to_string())
-    );
-    assert_eq!(
-      parse_npm_specifier("npm:@scope/pkg"),
-      Some("@scope/pkg".to_string())
-    );
-  }
-
-  #[test]
-  fn test_parse_npm_specifier_with_subpath() {
-    assert_eq!(
-      parse_npm_specifier("npm:express/foo"),
-      Some("express".to_string())
-    );
-    assert_eq!(
-      parse_npm_specifier("npm:express@4/foo"),
-      Some("express".to_string())
-    );
-    assert_eq!(
-      parse_npm_specifier("npm:@scope/pkg/subpath"),
-      Some("@scope/pkg".to_string())
-    );
-    assert_eq!(
-      parse_npm_specifier("npm:@scope/pkg@1.0.0/subpath"),
-      Some("@scope/pkg".to_string())
-    );
-  }
-
-  #[test]
-  fn test_parse_npm_specifier_not_npm() {
-    assert_eq!(parse_npm_specifier("jsr:@std/assert@1"), None);
-    assert_eq!(parse_npm_specifier("chalk@5"), None);
-    assert_eq!(parse_npm_specifier("https://example.com"), None);
   }
 
   #[test]

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -50,6 +50,7 @@ pub fn generate_tsconfig(
   files: &[String],
   http_modules: &BTreeMap<Url, String>,
   member_paths: &Map<String, Value>,
+  has_node_types: bool,
 ) -> Result<GeneratedTsConfig, std::io::Error> {
   // Write Deno type definitions to .deno/types/deno/ (private typeRoot).
   let types_dir = project_root.join(".deno/types/deno");
@@ -76,6 +77,7 @@ pub fn generate_tsconfig(
     files,
     http_modules,
     member_paths,
+    has_node_types,
   );
 
   // Write to .deno/tsconfig.json
@@ -195,8 +197,20 @@ fn build_tsconfig(
   check_files: &[String],
   http_modules: &BTreeMap<Url, String>,
   member_paths: &Map<String, Value>,
+  has_node_types: bool,
 ) -> Value {
   let mut compiler_options = base_compiler_options();
+
+  // When @types/node is available, load it alongside @types/deno so Node
+  // globals (timers, node: builtins, Buffer, URLPattern, ...) resolve. It lives
+  // in node_modules/@types, so add that typeRoot too.
+  if has_node_types {
+    compiler_options.insert(
+      "typeRoots".to_string(),
+      json!(["./types", "../node_modules/@types"]),
+    );
+    compiler_options.insert("types".to_string(), json!(["deno", "node"]));
+  }
 
   // Merge user's deno.json compilerOptions (filtered to stock-tsc-compatible
   // options only)

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -246,23 +246,15 @@ fn build_tsconfig(
     }
   }
 
-  // Merge the user's `compilerOptions.types` with the deno/node types we inject,
-  // rather than dropping them. Such an entry (e.g. `lume/types.ts`) can carry
-  // both ambient declarations (a `Lume` namespace) and `/// <reference
-  // lib="dom" />`, so clobbering it loses DOM globals and project namespaces the
-  // code relies on.
-  //
-  // Guard: only emit an entry we can actually resolve. A bare name (no `/`)
-  // resolves via typeRoots/node_modules (`deno`, `node`, `@types/*`); a slashed
-  // entry needs a matching `paths` mapping. Emitting an unresolvable `types`
-  // entry makes stock tsc/tsgo fail the whole program build (TS2688) and skip
-  // every file, which masks all real diagnostics — worse than dropping it.
+  // Merge the user's bare-package `compilerOptions.types` with the deno/node
+  // types we inject, rather than dropping them (see `merge_user_types` for why
+  // subpath entries like `lume/types.ts` are handled via `include` instead).
   if let Some(user_types) = deno_compiler_options
     .and_then(|co| co.get("types"))
     .and_then(|t| t.as_array())
     && let Some(Value::Array(types)) = compiler_options.get_mut("types")
   {
-    merge_user_types(types, user_types, &specifier_paths);
+    merge_user_types(types, user_types);
   }
 
   if !specifier_paths.is_empty() {
@@ -768,32 +760,29 @@ fn merge_deno_options(base: &mut Map<String, Value>, user_opts: &Value) {
   }
 }
 
-/// Merge the user's `compilerOptions.types` into `base_types`, skipping any
-/// entry we can't resolve.
+/// Merge the user's `compilerOptions.types` into `base_types`, keeping only the
+/// entries that actually resolve as `types` entries.
 ///
-/// A bare name (no `/`) resolves via typeRoots/node_modules (`deno`, `node`,
-/// `@types/*`); a slashed entry (e.g. `lume/types.ts`) needs a matching `paths`
-/// mapping. Emitting an unresolvable `types` entry makes stock tsc/tsgo fail the
-/// whole program build (TS2688) and skip every file, masking all real
-/// diagnostics, so it is dropped rather than passed through.
-fn merge_user_types(
-  base_types: &mut Vec<Value>,
-  user_types: &[Value],
-  specifier_paths: &Map<String, Value>,
-) {
+/// `compilerOptions.types` resolves entries as type *packages* via
+/// typeRoots/node_modules; it does NOT consult `paths`. So only a bare package
+/// name belongs here: unscoped (`node`) or scoped (`@types/react`). A subpath
+/// entry (`lume/types.ts`) can't resolve this way and would make stock tsc/tsgo
+/// fail the whole program build (TS2688), masking every real diagnostic, so it
+/// is dropped. Deno accepts such entries because it loads them as modules; the
+/// stock-tooling equivalent is that the (materialized) file is pulled into the
+/// program by the tsconfig `include` glob, which carries its ambient
+/// declarations and `/// <reference lib=... />` directives just the same.
+fn merge_user_types(base_types: &mut Vec<Value>, user_types: &[Value]) {
   for entry in user_types {
     let Some(s) = entry.as_str() else { continue };
-    // A bare package name resolves via typeRoots/node_modules: either unscoped
-    // (`node`, no slash) or scoped (`@types/react`, `@`-prefixed, one slash). A
-    // subpath entry (`lume/types.ts`, `@scope/pkg/sub`) needs a `paths` mapping.
     let is_bare_package = match s.strip_prefix('@') {
       Some(rest) => rest.matches('/').count() == 1,
       None => !s.contains('/'),
     };
-    let resolvable = is_bare_package || specifier_paths.contains_key(s);
-    if !resolvable {
+    if !is_bare_package {
       log::debug!(
-        "sync-types: dropping unresolvable `types` entry {s:?} (no mapping)"
+        "sync-types: dropping non-package `types` entry {s:?} \
+         (resolved via `include` instead)"
       );
       continue;
     }
@@ -869,27 +858,28 @@ mod tests {
   fn test_merge_user_types() {
     let mut base = vec![json!("deno"), json!("node")];
     let user = vec![
-      // bare name -> resolves via node_modules/@types, kept
+      // unscoped bare package -> resolves via typeRoots/node_modules, kept
+      json!("react"),
+      // scoped bare package -> kept
       json!("@types/react"),
-      // slashed with a matching paths mapping -> kept
+      // subpath entry -> `types` can't resolve it (would TS2688); dropped and
+      // instead covered by the `include` glob pulling in the mirrored file
       json!("lume/types.ts"),
-      // slashed without a mapping -> dropped (would abort the build)
-      json!("unmapped/types.ts"),
+      // scoped subpath entry -> also dropped
+      json!("@scope/pkg/sub"),
       // duplicate of an injected type -> not added twice
       json!("node"),
     ];
-    let mut paths = Map::new();
-    paths.insert("lume/types.ts".to_string(), json!(["../.deno/x.d.ts"]));
 
-    merge_user_types(&mut base, &user, &paths);
+    merge_user_types(&mut base, &user);
 
     assert_eq!(
       base,
       vec![
         json!("deno"),
         json!("node"),
+        json!("react"),
         json!("@types/react"),
-        json!("lume/types.ts"),
       ]
     );
   }

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -51,6 +51,7 @@ pub fn generate_tsconfig(
   http_modules: &BTreeMap<Url, String>,
   member_paths: &Map<String, Value>,
   has_node_types: bool,
+  excludes: &[String],
 ) -> Result<GeneratedTsConfig, std::io::Error> {
   // Write Deno type definitions to .deno/types/deno/ (private typeRoot).
   let types_dir = project_root.join(".deno/types/deno");
@@ -78,6 +79,7 @@ pub fn generate_tsconfig(
     http_modules,
     member_paths,
     has_node_types,
+    excludes,
   );
 
   // Write to .deno/tsconfig.json
@@ -198,6 +200,7 @@ fn build_tsconfig(
   http_modules: &BTreeMap<Url, String>,
   member_paths: &Map<String, Value>,
   has_node_types: bool,
+  excludes: &[String],
 ) -> Value {
   let mut compiler_options = base_compiler_options();
 
@@ -266,12 +269,20 @@ fn build_tsconfig(
   // libs/resolver/deno_json.rs. Stock tsc/tsgo ignore unknown top-level
   // properties.
   if check_files.is_empty() {
-    // No specific files — check entire project
+    // No specific files — check entire project. Mirror the project's own
+    // `exclude` (from deno.json) so we don't type-check paths Deno itself skips
+    // (test fixtures, generated output, etc.); the tsconfig lives in `.deno/`,
+    // so a project-root pattern `x` is rebased to `../x`.
+    let mut exclude = vec![json!("../**/node_modules")];
+    for pattern in excludes {
+      let rebased = format!("../{}", pattern.trim_start_matches("./"));
+      exclude.push(json!(rebased));
+    }
     json!({
       "_deno_generated": true,
       "compilerOptions": compiler_options,
       "include": ["../**/*"],
-      "exclude": ["../**/node_modules"],
+      "exclude": exclude,
     })
   } else {
     // Specific files requested — only check those
@@ -1007,6 +1018,7 @@ mod tests {
       &BTreeMap::new(),
       &Map::new(),
       false,
+      &[],
     );
 
     let include = tsconfig.get("include").unwrap().as_array().unwrap();
@@ -1014,6 +1026,32 @@ mod tests {
 
     let exclude = tsconfig.get("exclude").unwrap().as_array().unwrap();
     assert_eq!(exclude, &vec![json!("../**/node_modules")]);
+  }
+
+  #[test]
+  fn test_build_tsconfig_propagates_excludes() {
+    let project_root = Path::new("/tmp/project");
+    let excludes = vec!["jsonc/testdata".to_string(), "./_site".to_string()];
+    let tsconfig = build_tsconfig(
+      project_root,
+      None,
+      None,
+      &[],
+      &BTreeMap::new(),
+      &Map::new(),
+      false,
+      &excludes,
+    );
+    let exclude = tsconfig.get("exclude").unwrap().as_array().unwrap();
+    // node_modules always excluded; project excludes are rebased onto `../`.
+    assert_eq!(
+      exclude,
+      &vec![
+        json!("../**/node_modules"),
+        json!("../jsonc/testdata"),
+        json!("../_site"),
+      ]
+    );
   }
 
   #[test]
@@ -1028,6 +1066,7 @@ mod tests {
       &BTreeMap::new(),
       &Map::new(),
       false,
+      &[],
     );
 
     // Should use "files" instead of "include"/"exclude"
@@ -1057,6 +1096,7 @@ mod tests {
       &BTreeMap::new(),
       &Map::new(),
       false,
+      &[],
     );
 
     let paths = tsconfig

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -492,11 +492,14 @@ fn generate_jsr_paths(
         };
 
         // Key on the exact specifier as written in source. Also map the
-        // import-map alias form (bare) when this came from an alias entry.
+        // import-map alias form when this came from an alias entry, including
+        // aliases that point straight at a jsr subpath (e.g.
+        // `"$std/fs/walk.ts": "jsr:@std/fs@1/walk"`), which the source imports
+        // by the alias, not the scheme.
         paths
           .entry(target_str.to_string())
           .or_insert_with(|| json!([&types_rel]));
-        if alias != target_str && subpath.is_empty() {
+        if alias != target_str {
           paths
             .entry(alias.clone())
             .or_insert_with(|| json!([&types_rel]));

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -302,34 +302,55 @@ fn generate_jsr_paths(
   let mut paths = Map::new();
 
   if let Some(imports) = deno_imports.and_then(|v| v.as_object()) {
-    for (_alias, target) in imports {
+    for (alias, target) in imports {
       let target_str = match target.as_str() {
         Some(s) => s,
         None => continue,
       };
 
-      if let Some((scope, name, _version)) = parse_jsr_specifier(target_str) {
-        // JSR npm compat uses @jsr/<scope>__<name>
+      if let Some((scope, name, version)) = parse_jsr_specifier(target_str) {
+        // JSR npm compat installs to node_modules/@jsr/<scope>__<name>.
         let jsr_npm_name =
           format!("{}__{}", scope.trim_start_matches('@'), name);
-        let nm_path = format!("../node_modules/@jsr/{jsr_npm_name}");
-
-        // Check if the package actually exists in node_modules
-        let abs_path =
+        let pkg_dir =
           project_root.join(format!("node_modules/@jsr/{jsr_npm_name}"));
-        if !abs_path.exists() {
+        if !pkg_dir.exists() {
           continue;
         }
 
-        // Resolve the types entry point from package.json exports
-        let types_entry = resolve_jsr_types_entry(&abs_path)
-          .unwrap_or_else(|| nm_path.to_string());
+        // Recover the subpath the source actually imports (everything after
+        // `jsr:@scope/name[@version]`), and resolve it through the installed
+        // package's `exports` to a concrete .d.ts. We map to that *relative*
+        // file rather than a non-relative `@jsr/*` wildcard so tsc/tsgo doesn't
+        // emit TS5090 ("non-relative paths are not allowed") - verified.
+        let prefix = match &version {
+          Some(v) => format!("jsr:{scope}/{name}@{v}"),
+          None => format!("jsr:{scope}/{name}"),
+        };
+        let subpath = target_str
+          .strip_prefix(&prefix)
+          .map(|s| s.trim_start_matches('/'))
+          .unwrap_or("");
+        let export_key = if subpath.is_empty() {
+          ".".to_string()
+        } else {
+          format!("./{subpath}")
+        };
+        let Some(types_rel) = resolve_jsr_types_entry(&pkg_dir, &export_key)
+        else {
+          continue;
+        };
 
-        // Map the jsr: specifier
-        let jsr_key = format!("jsr:{scope}/{name}");
+        // Key on the exact specifier as written in source. Also map the
+        // import-map alias form (bare) when this came from an alias entry.
         paths
-          .entry(jsr_key)
-          .or_insert_with(|| json!([&types_entry]));
+          .entry(target_str.to_string())
+          .or_insert_with(|| json!([&types_rel]));
+        if alias != target_str && subpath.is_empty() {
+          paths
+            .entry(alias.clone())
+            .or_insert_with(|| json!([&types_rel]));
+        }
       }
     }
   }
@@ -341,20 +362,27 @@ fn generate_jsr_paths(
 ///
 /// Reads the `"exports"` field and looks for `"."` -> `"types"` condition.
 /// Returns a path relative to `.deno/` (e.g., `../node_modules/@jsr/std__assert/_dist/mod.d.ts`).
-fn resolve_jsr_types_entry(pkg_dir: &Path) -> Option<String> {
+fn resolve_jsr_types_entry(pkg_dir: &Path, export_key: &str) -> Option<String> {
   let pkg_json_path = pkg_dir.join("package.json");
   let content = std::fs::read_to_string(&pkg_json_path).ok()?;
   let pkg_json: Value = serde_json::from_str(&content).ok()?;
 
-  // Try exports["."]["types"]
-  let types_path = pkg_json
-    .get("exports")
-    .and_then(|e| e.get("."))
-    .and_then(|dot| dot.get("types"))
-    .and_then(|t| t.as_str())
+  // Resolve `exports[export_key]` (e.g. "." or "./cookie_map"), preferring the
+  // "types" condition; the entry may be a conditions object or a bare string.
+  let entry = pkg_json.get("exports").and_then(|e| e.get(export_key));
+  let types_path = entry
+    .and_then(|v| {
+      v.get("types")
+        .and_then(|t| t.as_str())
+        .or_else(|| v.as_str())
+    })
     .or_else(|| {
-      // Fallback: top-level "types" field
-      pkg_json.get("types").and_then(|t| t.as_str())
+      // Fallback: top-level "types" field, only for the root export.
+      if export_key == "." {
+        pkg_json.get("types").and_then(|t| t.as_str())
+      } else {
+        None
+      }
     })?;
 
   // Convert package-relative path to .deno/-relative path

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -793,6 +793,7 @@ pub enum DenoSubcommand {
   Link(LinkFlags),
   Unlink(UnlinkFlags),
   Lsp,
+  SyncTypes,
   Lint(LintFlags),
   Repl(ReplFlags),
   Run(RunFlags),

--- a/libs/node_shim/lib.rs
+++ b/libs/node_shim/lib.rs
@@ -3270,6 +3270,7 @@ const DENO_SUBCOMMANDS: &[&str] = &[
   "run",
   "sandbox",
   "serve",
+  "sync-types",
   "task",
   "tasks",
   "test",


### PR DESCRIPTION
Adds a `deno sync-types` subcommand that generates a root `tsconfig.json` and a
`.deno/tsconfig.json`, writes Deno's own types as a private `@types/deno`, and
materializes `jsr:`, `http(s):`, and `npm:` dependency types, so stock
TypeScript tooling (tsc, tsgo, VS Code's built-in TS server, JetBrains) can
type-check a Deno project without a Deno-specific plugin.

This reworks the generator from #33163 into an explicit subcommand run after
dependencies are installed, rather than running implicitly at the end of `deno
install`. Keeping it explicit leaves `deno install` unchanged and gives users
(and our own tooling) a single command to re-sync the generated config as the
dependency graph changes.

Rather than reading only the root import map, the generator discovers the
specifiers a project actually uses by building its module graph, tolerating
unresolved modules so one broken file doesn't abort discovery. It resolves
import-map aliases, `jsr:`/`npm:` subpaths through package `exports`, and
workspace members (including `./packages/*` globs and aliases that point at a
local member). It mirrors remote modules and marks them `// @ts-nocheck` so a
dependency's own type errors aren't reported as the project's, defers
node-owned web globals (`URLPattern`) to `@types/node` to avoid
duplicate-declaration conflicts, and excludes `node_modules`, `.deno`, and the
Deno vendor directory from checking. It also mirrors the project's `deno.json`
`exclude`, merges the user's own `compilerOptions` `paths`/`baseUrl` rebased
onto `.deno/`, and edits an existing root `tsconfig.json` in place via a
JSONC-preserving splice so the user's comments and formatting survive.

Part of the TypeScript un-fork effort (#35621): now that Deno runs on stock
TypeScript, this generated static config is the mechanism that lets every stock
TS tool -- and, later, `deno check` via tsgo -- understand a Deno project. It
has been validated end to end on several real projects (std, the Deno docs
site, dotcom, Fresh, oak), taking them from unusable with stock tooling to
type-checking with only a small tail of genuine or known-limitation
diagnostics.

Known limitations tracked for follow-ups: web globals that both Deno and
`@types/node` declare (`ReadableStream.from`) still need dual-globals
reconciliation in Deno's core libs; and `npm:`-scheme deep subpaths, CSS/asset
imports, and npm resolution under `nodeModulesDir: none` are not yet handled.

Reworks #33163.