### PR TITLE
feat(cli): unstable allow-all default permission profile

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1206,11 +1206,16 @@ impl CliOptions {
     dir: &WorkspaceDirectory,
   ) -> Result<PermissionsOptions, AnyError> {
     let config_permissions = self.resolve_config_permissions_for_dir(dir)?;
+    let has_config_permissions = config_permissions.is_some();
     let mut permissions_options = flags_to_permissions_options(
       &self.flags.permissions,
       config_permissions,
     )?;
     self.augment_import_permissions(&mut permissions_options);
+    self.maybe_apply_allow_all_default_permissions(
+      &mut permissions_options,
+      has_config_permissions,
+    );
     if let DenoSubcommand::Serve(serve_flags) = &self.flags.subcommand {
       augment_permissions_with_serve_flags(
         &mut permissions_options,
@@ -1218,6 +1223,87 @@ impl CliOptions {
       )?;
     }
     Ok(permissions_options)
+  }
+
+  /// Applies the unstable allow-all default permission profile to the computed
+  /// permission options when the gate is on and the user provided no explicit
+  /// allow-side permission configuration.
+  ///
+  /// This is groundwork for the Deno 3 default-permissions change: instead of
+  /// denying every capability and prompting one by one, running user code with
+  /// no permission flags grants everything (equivalent to `-A`). Users then
+  /// scope back down with `--allow-*` (which switches to that explicit set) or
+  /// carve out exceptions with `--deny-*` (which composes on top since deny
+  /// always wins).
+  ///
+  /// Any explicit allow-side configuration (`--allow-*`, `-A`, `-P`, or a
+  /// permission set from the config file) opts out entirely, keeping behavior
+  /// byte-for-byte identical to today. `--deny-*` flags are intentionally not
+  /// consulted so they compose on top of the profile.
+  fn maybe_apply_allow_all_default_permissions(
+    &self,
+    options: &mut PermissionsOptions,
+    has_config_permissions: bool,
+  ) {
+    // Only for subcommands that execute user code with the prompt-based
+    // defaults. `deno eval` and `deno x` already imply allow-all, and
+    // `deno compile` bakes permissions at compile time (out of scope).
+    if !matches!(
+      self.flags.subcommand,
+      DenoSubcommand::Run(_)
+        | DenoSubcommand::Serve(_)
+        | DenoSubcommand::Test(_)
+        | DenoSubcommand::Bench(_)
+        | DenoSubcommand::Task(_)
+        | DenoSubcommand::Repl(_)
+    ) {
+      return;
+    }
+
+    // Gated behind an unstable env var while we gather feedback.
+    if !allow_all_default_permissions_enabled() {
+      return;
+    }
+
+    // Any explicit allow-side configuration opts out entirely. Note `--deny-*`
+    // flags are intentionally not consulted here so they compose on top of the
+    // profile.
+    if self.flags.permissions.has_allow_permission()
+      || self.flags.permission_set.is_some()
+      || has_config_permissions
+    {
+      return;
+    }
+
+    log::debug!("Applying unstable allow-all default permission profile.");
+
+    // Grant every capability (an empty allow-list means "allow all"), matching
+    // `--allow-all`. `--deny-*` flags already recorded in `options` still apply
+    // on top since deny wins at check time. `allow_import` is left untouched so
+    // it keeps the implicit trusted-host allowance from
+    // `augment_import_permissions`.
+    let allow_all = || Some(Vec::new());
+    options.allow_env = allow_all();
+    options.allow_net = allow_all();
+    options.allow_ffi = allow_all();
+    options.allow_read = allow_all();
+    options.allow_run = allow_all();
+    options.allow_sys = allow_all();
+    options.allow_write = allow_all();
+
+    // Warn once when `deno run` falls back to the default so it is not silently
+    // running with everything granted.
+    if matches!(self.flags.subcommand, DenoSubcommand::Run(_)) {
+      static WARNED: std::sync::Once = std::sync::Once::new();
+      WARNED.call_once(|| {
+        log::warn!(
+          "{} Running with all permissions granted by default. Use {} to restrict permissions, or {} to deny specific permissions.",
+          colors::yellow("Warning"),
+          colors::gray("--allow-*"),
+          colors::gray("--deny-*"),
+        );
+      });
+    }
   }
 
   fn resolve_config_permissions_for_dir<'a>(
@@ -1705,6 +1791,21 @@ fn allow_import_host_from_url(url: &Url) -> Option<String> {
       "http" => Some(format!("{}:80", host)),
       _ => None,
     }
+  }
+}
+
+/// Env var gating the unstable allow-all default permission profile.
+/// Groundwork for the Deno 3 default-permissions change: the profile is on by
+/// default and setting the var to `0` opts back out to today's deny-by-default
+/// behavior.
+const ALLOW_ALL_PERMISSIONS_ENV_VAR: &str =
+  "DENO_UNSTABLE_ALLOW_ALL_BY_DEFAULT";
+
+fn allow_all_default_permissions_enabled() -> bool {
+  match std::env::var(ALLOW_ALL_PERMISSIONS_ENV_VAR) {
+    // On by default; only an explicit `0` disables it.
+    Ok(value) => value != "0",
+    Err(_) => true,
   }
 }
 

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -1002,6 +1002,22 @@ pub struct PermissionFlags {
 }
 
 impl PermissionFlags {
+  /// Whether any explicit allow-side permission was configured on the command
+  /// line. Unlike `has_permission`, this ignores `--deny-*`/`--ignore-*` flags
+  /// so that a deny flag on its own does not count as "the user configured
+  /// permissions". Used to decide whether an implicit default profile applies.
+  pub fn has_allow_permission(&self) -> bool {
+    self.allow_all
+      || self.allow_env.is_some()
+      || self.allow_ffi.is_some()
+      || self.allow_net.is_some()
+      || self.allow_read.is_some()
+      || self.allow_run.is_some()
+      || self.allow_sys.is_some()
+      || self.allow_write.is_some()
+      || self.allow_import.is_some()
+  }
+
   pub fn has_permission(&self) -> bool {
     self.allow_all
       || self.allow_env.is_some()

--- a/tests/specs/permission/allow_all_default/__test__.jsonc
+++ b/tests/specs/permission/allow_all_default/__test__.jsonc
@@ -1,0 +1,42 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_UNSTABLE_ALLOW_ALL_BY_DEFAULT": "1",
+    "ALLOW_ALL_TEST_VAR": "hello"
+  },
+  "tests": {
+    "profile_default": {
+      // gate on, no flags: every capability is granted, equivalent to -A
+      "args": "run --quiet profile.ts",
+      "output": "profile.out"
+    },
+    "run_prints_warning": {
+      // `deno run` warns that it is running with all permissions by default
+      "args": "run warning.ts",
+      "output": "warning.out"
+    },
+    "deny_composes": {
+      // --deny-* composes on top of the default (deny wins): net is denied but
+      // read is still granted
+      "args": "run --quiet --deny-net deny_composes.ts",
+      "output": "deny_composes.out"
+    },
+    "explicit_flag_opts_out": {
+      // an explicit --allow-read flag disables the default entirely, so a write
+      // now fails naming --allow-write
+      "args": "run --quiet --allow-read opt_out.ts",
+      "output": "opt_out.out"
+    },
+    "gate_off": {
+      // gate off: byte-for-byte today's deny-by-default behavior
+      "args": "run --quiet gate_off.ts",
+      "envs": { "DENO_UNSTABLE_ALLOW_ALL_BY_DEFAULT": "0" },
+      "output": "gate_off.out"
+    },
+    "worker_inherits": {
+      // a worker with default permissions inherits the allow-all default
+      "args": "run --quiet worker_main.ts",
+      "output": "worker.out"
+    }
+  }
+}

--- a/tests/specs/permission/allow_all_default/deny_composes.out
+++ b/tests/specs/permission/allow_all_default/deny_composes.out
@@ -1,0 +1,1 @@
+net: NotCapable, read: granted

--- a/tests/specs/permission/allow_all_default/deny_composes.ts
+++ b/tests/specs/permission/allow_all_default/deny_composes.ts
@@ -1,0 +1,11 @@
+// --deny-net composes on top of the allow-all default (deny wins): net is
+// denied while read stays granted.
+let net;
+try {
+  await fetch("http://localhost/");
+  net = "UNEXPECTEDLY ALLOWED";
+} catch (err) {
+  net = err.name;
+}
+const read = (await Deno.permissions.query({ name: "read" })).state;
+console.log(`net: ${net}, read: ${read}`);

--- a/tests/specs/permission/allow_all_default/gate_off.out
+++ b/tests/specs/permission/allow_all_default/gate_off.out
@@ -1,0 +1,1 @@
+read: NotCapable --allow-read

--- a/tests/specs/permission/allow_all_default/gate_off.ts
+++ b/tests/specs/permission/allow_all_default/gate_off.ts
@@ -1,0 +1,13 @@
+// With the gate off (DENO_UNSTABLE_ALLOW_ALL_BY_DEFAULT=0), behavior is
+// byte-for-byte today's deny-by-default: reading outside the cwd is denied
+// non-interactively naming --allow-read.
+const path = Deno.build.os === "windows"
+  ? "C:\\Windows\\win.ini"
+  : "/etc/hosts";
+try {
+  Deno.readFileSync(path);
+  console.log("read: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-read") ? "--allow-read" : "?";
+  console.log(`read: ${err.name} ${named}`);
+}

--- a/tests/specs/permission/allow_all_default/opt_out.out
+++ b/tests/specs/permission/allow_all_default/opt_out.out
@@ -1,0 +1,1 @@
+write: NotCapable --allow-write

--- a/tests/specs/permission/allow_all_default/opt_out.ts
+++ b/tests/specs/permission/allow_all_default/opt_out.ts
@@ -1,0 +1,10 @@
+// Providing any explicit allow-side flag (here --allow-read) disables the
+// allow-all default entirely, so writing now requires --allow-write and is
+// denied non-interactively.
+try {
+  Deno.writeTextFileSync("./should_fail.txt", "data");
+  console.log("write: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-write") ? "--allow-write" : "?";
+  console.log(`write: ${err.name} ${named}`);
+}

--- a/tests/specs/permission/allow_all_default/profile.out
+++ b/tests/specs/permission/allow_all_default/profile.out
@@ -1,0 +1,7 @@
+read: granted
+write: granted
+net: granted
+env: granted
+run: granted
+sys: granted
+ffi: granted

--- a/tests/specs/permission/allow_all_default/profile.ts
+++ b/tests/specs/permission/allow_all_default/profile.ts
@@ -1,0 +1,7 @@
+// Allow-all default permission profile (gate on, no flags): every capability
+// is granted, exactly as if -A had been passed.
+const names = ["read", "write", "net", "env", "run", "sys", "ffi"] as const;
+for (const name of names) {
+  const status = await Deno.permissions.query({ name });
+  console.log(`${name}: ${status.state}`);
+}

--- a/tests/specs/permission/allow_all_default/warning.out
+++ b/tests/specs/permission/allow_all_default/warning.out
@@ -1,0 +1,2 @@
+Warning Running with all permissions granted by default. Use --allow-* to restrict permissions, or --deny-* to deny specific permissions.
+[WILDCARD]hello from user code

--- a/tests/specs/permission/allow_all_default/warning.ts
+++ b/tests/specs/permission/allow_all_default/warning.ts
@@ -1,0 +1,2 @@
+// Running without --quiet so the default-permissions warning is emitted.
+console.log("hello from user code");

--- a/tests/specs/permission/allow_all_default/worker.out
+++ b/tests/specs/permission/allow_all_default/worker.out
@@ -1,0 +1,1 @@
+worker read: granted, worker net: granted

--- a/tests/specs/permission/allow_all_default/worker.ts
+++ b/tests/specs/permission/allow_all_default/worker.ts
@@ -1,0 +1,4 @@
+// Inherits the allow-all default from the parent: every capability is granted.
+const read = (await Deno.permissions.query({ name: "read" })).state;
+const net = (await Deno.permissions.query({ name: "net" })).state;
+self.postMessage(`worker read: ${read}, worker net: ${net}`);

--- a/tests/specs/permission/allow_all_default/worker_main.ts
+++ b/tests/specs/permission/allow_all_default/worker_main.ts
@@ -1,0 +1,10 @@
+// A worker created with default permissions inherits the parent's allow-all
+// default.
+const worker = new Worker(import.meta.resolve("./worker.ts"), {
+  type: "module",
+});
+const result = await new Promise((resolve) => {
+  worker.onmessage = (e) => resolve(e.data);
+});
+console.log(result);
+worker.terminate();

--- a/tests/util/lib/builders.rs
+++ b/tests/util/lib/builders.rs
@@ -969,6 +969,16 @@ impl TestCommandBuilder {
     if !envs.contains_key("DENO_NO_UPDATE_CHECK") {
       envs.insert("DENO_NO_UPDATE_CHECK".to_string(), "1".to_string());
     }
+    if !envs.contains_key("DENO_UNSTABLE_ALLOW_ALL_BY_DEFAULT") {
+      // The unstable allow-all default permission profile is on by default in
+      // the real binary, but the existing test corpus asserts today's
+      // deny-by-default behavior. Disable it here so tests are deterministic;
+      // tests exercising the profile opt back in with `envs`.
+      envs.insert(
+        "DENO_UNSTABLE_ALLOW_ALL_BY_DEFAULT".to_string(),
+        "0".to_string(),
+      );
+    }
     if !envs.contains_key("JSR_URL") {
       envs.insert("JSR_URL".to_string(), jsr_registry_unset_url());
     }


### PR DESCRIPTION
This is groundwork for the Deno 3 default-permissions change, taking the
inverse approach to the relaxed profile in #35710: instead of denying every
capability by default and prompting one at a time, running user code with no
permission flags now grants everything, exactly as if `-A` had been passed.

Users scope back down from there. Passing any explicit `--allow-*` flag (or
`-A`, `-P`, or a permission set from the config file) disables the default
entirely and falls back to today's behavior, so `--allow-read` means "read
only". `--deny-*` flags compose on top of the default since deny always wins at
check time, so `--deny-net` grants everything except net.

When `deno run` falls back to the default, it prints a warning so it is not
silently running with all permissions granted:

    Warning Running with all permissions granted by default. Use --allow-* to
    restrict permissions, or --deny-* to deny specific permissions.

The profile applies to the subcommands that execute user code with the
prompt-based defaults: `run`, `serve`, `test`, `bench`, `task`, and the REPL.
`deno eval` and `deno x` already imply allow-all, and `deno compile` bakes
permissions at compile time, so those are left untouched.

The behavior is gated behind an unstable `DENO_UNSTABLE_ALLOW_ALL_BY_DEFAULT`
env var while we gather feedback. It is on by default; setting it to `0` reverts
to today's deny-by-default behavior byte-for-byte. The existing test corpus
opts out via this var in the shared spec-test command builder so it keeps
asserting current behavior, and the new `permission/allow_all_default` spec
tests opt back in to cover the granted profile, the warning, `--deny-*`
composition, explicit-flag opt-out, the gate-off control, and worker
inheritance.
