### PR TITLE
fix(release): strip Mach-O signature before patchver on apple targets

### DIFF
--- a/.github/workflows/promote_to_release.generated.yml
+++ b/.github/workflows/promote_to_release.generated.yml
@@ -42,7 +42,7 @@ jobs:
           Expand-Archive -Path "deno-windows.zip" -DestinationPath "."
           Expand-Archive -Path "denort-windows.zip" -DestinationPath "."
       - name: Run patchver for Windows
-        run: 'deno run -A ./tools/release/promote_to_release_windows.ts ${{github.event.inputs.releaseKind}}'
+        run: 'deno run -A --minimum-dependency-age=0 ./tools/release/promote_to_release_windows.ts ${{github.event.inputs.releaseKind}}'
       - name: Authenticate with Azure
         uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d
         with:
@@ -111,7 +111,7 @@ jobs:
         env:
           APPLE_CODESIGN_KEY: '${{ secrets.APPLE_CODESIGN_KEY }}'
           APPLE_CODESIGN_PASSWORD: '${{ secrets.APPLE_CODESIGN_PASSWORD }}'
-        run: 'deno run -A ./tools/release/promote_to_release.ts ${{github.event.inputs.releaseKind}} ${{github.event.inputs.commitHash}}'
+        run: 'deno run -A --minimum-dependency-age=0 ./tools/release/promote_to_release.ts ${{github.event.inputs.releaseKind}} ${{github.event.inputs.commitHash}}'
       - name: Download Windows binaries
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:

--- a/.github/workflows/promote_to_release.ts
+++ b/.github/workflows/promote_to_release.ts
@@ -40,7 +40,7 @@ const windowsJob = job("promote-to-release-windows", {
     step({
       name: "Run patchver for Windows",
       run:
-        "deno run -A ./tools/release/promote_to_release_windows.ts ${{github.event.inputs.releaseKind}}",
+        "deno run -A --minimum-dependency-age=0 ./tools/release/promote_to_release_windows.ts ${{github.event.inputs.releaseKind}}",
     }),
     step({
       name: "Authenticate with Azure",
@@ -157,7 +157,7 @@ const workflow = createWorkflow({
             APPLE_CODESIGN_PASSWORD: "${{ secrets.APPLE_CODESIGN_PASSWORD }}",
           },
           run:
-            "deno run -A ./tools/release/promote_to_release.ts ${{github.event.inputs.releaseKind}} ${{github.event.inputs.commitHash}}",
+            "deno run -A --minimum-dependency-age=0 ./tools/release/promote_to_release.ts ${{github.event.inputs.releaseKind}} ${{github.event.inputs.commitHash}}",
         }),
         step({
           name: "Download Windows binaries",

--- a/tools/release/promote_to_release.ts
+++ b/tools/release/promote_to_release.ts
@@ -161,6 +161,27 @@ async function runRcodesign(
   await $`codesign -dv --verbose=4 ./deno`;
 }
 
+async function removeExistingSignature(target: string, binaryName: string) {
+  // patchver runs as a Wasm module and can no longer strip a Mach-O code
+  // signature itself: libsui's Intel signature strip shells out to `codesign`,
+  // which is gated to Apple hosts and so is absent from the Wasm build.
+  // Injecting the channel section then leaves stale signature data in
+  // __LINKEDIT that rcodesign rejects with "data after signature". Strip it
+  // here first with the runner's native codesign so patchver writes into an
+  // unsigned binary that can be re-signed cleanly.
+  if (!target.includes("apple")) {
+    return;
+  }
+  $.logStep("Remove signature", binaryName);
+  const output = await $`codesign --remove-signature ./${binaryName}`.noThrow();
+  if (output.code !== 0) {
+    $.logError(
+      `Failed to remove existing signature from ${binaryName} (error code ${output.code})`,
+    );
+    Deno.exit(1);
+  }
+}
+
 async function promoteBinaryToRc(
   binary: string,
   target: string,
@@ -182,6 +203,8 @@ async function promoteBinaryToRc(
 
   await unzipArchive(archiveName, unzippedName);
   await remove(archiveName);
+
+  await removeExistingSignature(target, unzippedName);
 
   $.logStep(
     "Patchver",


### PR DESCRIPTION
rcodesign fails signing the x86_64-apple-darwin deno binary during LTS/RC
promotion with "__LINKEDIT segment contains data after signature".

patchver runs as a Wasm module. libsui used to strip an Intel Mach-O's
existing code signature before injecting a section by shelling out to
codesign, but that path is gated to Apple hosts and is absent from the
wasm32 build, so patchver appends the channel section after the stale
signature and leaves data in __LINKEDIT past the signature that rcodesign
refuses to parse. arm64 is unaffected because that path rebuilds the
binary through the in-memory signer.

The promotion job runs on a macOS runner, so strip the signature with
native codesign --remove-signature before patchver for apple targets.
patchver then writes into an unsigned binary and rcodesign re-signs it
cleanly.

Stacked on #35893 (min-dep-age) so both promote fixes are testable
together; retarget to main once that merges.