### PR TITLE
feat(desktop): enable `--hmr` for React Router

### DIFF
--- a/cli/tools/framework.rs
+++ b/cli/tools/framework.rs
@@ -394,7 +394,7 @@ Deno.serve(async (req) => {
       .into(),
       include_paths: vec!["build/client".into()],
       build_command: Some(deno_task_build()),
-      hmr_command: None, // TODO: add command to enable `deno desktop --hmr` for React Router
+      hmr_command: Some(deno_task_dev()),
     }
   } else {
     // SSR: serve immutable client assets from `build/client`, then hand all
@@ -426,7 +426,7 @@ Deno.serve(async (req) => {
       .into(),
       include_paths: vec!["build".into()],
       build_command: Some(deno_task_build()),
-      hmr_command: None, // TODO: add command to enable `deno desktop --hmr` for React Router
+      hmr_command: Some(deno_task_dev()),
     }
   }
 }
@@ -1224,6 +1224,8 @@ mod tests {
     assert_eq!(det.include_paths, vec!["build/client"]);
     let cmd = det.build_command.unwrap();
     assert_eq!(cmd[1..], vec!["task", "build"]);
+    let hmr = det.hmr_command.unwrap();
+    assert_eq!(hmr[1..], vec!["task", "dev"]);
   }
 
   #[test]
@@ -1269,6 +1271,8 @@ mod tests {
     assert!(det.entrypoint_code.contains("build/server/index.js"));
     assert!(det.entrypoint_code.contains("build/client"));
     assert_eq!(det.include_paths, vec!["build"]);
+    let hmr = det.hmr_command.unwrap();
+    assert_eq!(hmr[1..], vec!["task", "dev"]);
   }
 
   #[test]


### PR DESCRIPTION
`deno desktop --hmr` already supports running a detected framework dev server and using its `Local:` URL for desktop HMR.

React Router framework projects were detected correctly, but both the SPA and SSR branches left `hmr_command` unset. As a result, `deno desktop --hmr .` did not start the React Router dev server and could not use React Router's Vite-powered HMR flow.

## Change

Wire React Router's `hmr_command` to `deno task dev` for:

- SPA mode (`ssr: false`)
- SSR mode

This matches the existing Vite-based framework HMR path.

## Tests

- Extended the React Router SPA detection test to assert `hmr_command` is `deno task dev`
- Extended the React Router SSR detection test to assert `hmr_command` is `deno task dev`

```sh
cargo test -p deno --lib react_router
```
