### PR TITLE
fix(update): don't downgrade lockfile when npm cache is stale

### DIFF
--- a/cli/tools/pm/outdated/mod.rs
+++ b/cli/tools/pm/outdated/mod.rs
@@ -470,31 +470,20 @@ async fn update(
       }
     };
 
-    // Determine whether re-resolution could move this npm package to a version
-    // that a stale cached packument might be hiding, in which case its metadata
-    // must be refetched first.
-    let force_reload_npm = dep.kind == DepKind::Npm
-      && if cache_options.lockfile_only {
-        // `--lockfile-only` leaves the version requirement untouched, so the
-        // package can only move if a newer version already exists within its
-        // existing range. Refetching the others would emit spurious downloads
-        // (and network requests) without ever changing the lockfile.
-        match (
-          resolved.as_ref(),
-          latest_versions.semver_compatible.as_ref(),
-        ) {
-          (Some(resolved), Some(compatible)) => {
-            compatible.version > resolved.version
-          }
-          // No resolved version (or unknown compatible version) -- refetch to
-          // be safe.
-          _ => true,
-        }
-      } else {
-        // Otherwise the requirement is rewritten to `new_version_req`, so the
-        // package is going to be re-resolved to a new version regardless.
-        true
-      };
+    // The post-modification install re-resolves each package through the npm
+    // installer, which reads the npm registry cache with the default
+    // `CacheSetting::Use`. That cache is *separate* from the one behind
+    // `latest_versions` (the `NpmFetchResolver` fetched those fresh with
+    // `RespectHeaders`), so it can be stale in ways the displayed "latest"
+    // versions don't reveal. A stale installer cache re-resolves to whatever
+    // version it happens to know about, which can move the lockfile up (hiding
+    // a newer in-range version, #35348) or, worse, *down* -- silently
+    // downgrading a lockfile entry that was pinned ahead of the stale cache
+    // (#35822). Comparing `latest_versions` against the resolved version can't
+    // detect this: both can read a fresh newest version while the installer
+    // cache lags behind. So refetch the installer's metadata for every npm
+    // package we might re-resolve.
+    let force_reload_npm = dep.kind == DepKind::Npm;
 
     to_update.push(ToUpdate {
       dep_id,

--- a/tests/specs/outdated/deno_json/update_latest_lockfile_only/update.out
+++ b/tests/specs/outdated/deno_json/update_latest_lockfile_only/update.out
@@ -1,5 +1,7 @@
 [UNORDERED_START]
 Download http://localhost:4260/@denotest%2fhas-patch-versions
+Download http://localhost:4260/@denotest%2fbin
+Download http://localhost:4260/@denotest%2fbreaking-change-between-versions
 Download http://127.0.0.1:4250/@denotest/add/0.2.1/mod.ts
 [UNORDERED_END]
 Updated 2 dependencies:

--- a/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/__test__.jsonc
+++ b/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/__test__.jsonc
@@ -1,0 +1,45 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_DIR": "$PWD/deno_dir"
+  },
+  "tests": {
+    // Regression test for denoland/deno#35822: `--lockfile-only` must not
+    // downgrade a lockfile entry that is pinned *ahead* of a stale npm registry
+    // cache. `setup.ts` simulates that stale cache by dropping 0.2.0 (the locked
+    // version) from the cached registry.json, leaving 0.1.1 as the newest known
+    // version. Before the fix the installer re-resolved against the stale cache
+    // and silently downgraded 0.2.0 -> 0.1.1; now it refetches metadata for the
+    // package and keeps 0.2.0.
+    "stale_cache_no_downgrade": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run -A setup.ts",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "update --lockfile-only",
+          "output": "update.out"
+        },
+        {
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('./deno.lock').trim());"
+          ],
+          "output": "deno.lock.out"
+        },
+        {
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('./package.json').trim());"
+          ],
+          "output": "package.json.out"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/deno.lock.out
+++ b/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/deno.lock.out
@@ -1,0 +1,14 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@denotest/has-patch-versions@*": "0.2.0"
+  },
+[WILDCARD]
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@denotest/has-patch-versions@*"
+      ]
+    }
+  }
+}

--- a/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/package.json
+++ b/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/has-patch-versions": "*"
+  }
+}

--- a/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/package.json.out
+++ b/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/package.json.out
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/has-patch-versions": "*"
+  }
+}

--- a/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/setup.ts
+++ b/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/setup.ts
@@ -1,0 +1,25 @@
+// Simulate a stale npm registry metadata cache whose newest known version is
+// *older* than the version already pinned in the lockfile. The user installed
+// @denotest/has-patch-versions@0.2.0 (the newest, via the `*` range), but their
+// cached packument later went stale and no longer lists 0.2.0. `deno update
+// --lockfile-only` must NOT downgrade the lockfile: it has to refetch metadata
+// for the package and keep 0.2.0. Before the fix the installer re-resolved
+// against the stale cache and silently downgraded 0.2.0 -> 0.1.1. See
+// denoland/deno#35822.
+
+// Drop 0.2.0 from the cached packument so the npm registry cache no longer
+// knows about the version the lockfile is pinned at. The host directory is the
+// fixed test registry port (PUBLIC_NPM_REGISTRY_PORT = 4260).
+const registryPath =
+  "deno_dir/npm/localhost_4260/@denotest/has-patch-versions/registry.json";
+const registry = JSON.parse(Deno.readTextFileSync(registryPath));
+delete registry.versions["0.2.0"];
+if (registry["dist-tags"]) {
+  registry["dist-tags"].latest = "0.1.1";
+}
+// Drop the cached etag so the conditional refetch is unconditional, mirroring a
+// genuinely stale cache entry whose stored etag no longer matches the registry.
+// (The test registry always serves the full packument, so a kept etag would
+// yield a spurious 304 Not Modified and hand back this truncated cache.)
+delete registry["_deno.etag"];
+Deno.writeTextFileSync(registryPath, JSON.stringify(registry));

--- a/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/update.out
+++ b/tests/specs/outdated/update_lockfile_only_stale_cache_no_downgrade/update.out
@@ -1,0 +1,1 @@
+[WILDCARD]Updated 0 dependencies:


### PR DESCRIPTION
`deno update --lockfile-only` could silently downgrade an npm dependency
when the local npm registry cache was stale. The reported case bumped
`@dprint/json` the wrong way, `0.23.0 -> 0.22.0`, and `deno clean`
worked around it.

The re-resolution that rewrites the lockfile runs through the npm
installer, which reads the installer's own registry metadata cache with
the default `CacheSetting::Use`. That cache is separate from the fresh
packuments behind the "latest" versions shown by `deno outdated`, so it
can be stale in ways the displayed versions never reveal. The previous
guard only refetched metadata when a newer in-range version appeared to
exist (`compatible > resolved`). When the lockfile was pinned ahead of
the stale cache the two versions matched, no refetch happened, and the
installer re-resolved downward to whatever older version it still knew
about. Comparing the versions cannot catch this, because both can read a
fresh newest version while the installer cache lags behind.

Refetch the installer's npm metadata for every npm package that might be
re-resolved under `--lockfile-only`. This also covers the earlier
"stale cache hides a newer version" case (#35348) that the previous
guard was written for.

Closes #35822