### PR TITLE
chore: collapse multi-line lint diagnostic snippets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,8 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.53.2"
-source = "git+https://github.com/bartlomieju/deno_ast?rev=77c4b62316874dded8cbd74e0a823d3445f6a433#77c4b62316874dded8cbd74e0a823d3445f6a433"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f7c1384d87fc0a6439a065312fbef8f6ac6128689dbc2831b28b3a1d4f3a4e6"
 dependencies = [
  "base64 0.22.1",
  "capacity_builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,8 +2092,7 @@ dependencies = [
 [[package]]
 name = "deno_ast"
 version = "0.53.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05792fb2b77938767ffeb0853289e86501fddc84b1cdba9e5dc860c52baa2ff7"
+source = "git+https://github.com/bartlomieju/deno_ast?rev=77c4b62316874dded8cbd74e0a823d3445f6a433#77c4b62316874dded8cbd74e0a823d3445f6a433"
 dependencies = [
  "base64 0.22.1",
  "capacity_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ license = "MIT"
 repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
-deno_ast = { version = "=0.53.2", features = ["transpiling"] }
+deno_ast = { version = "=0.53.3", features = ["transpiling"] }
 deno_core_icudata = "0.77.0"
 deno_doc = "=0.202.0"
 deno_error = "=0.7.1"
@@ -635,8 +635,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.twox-hash]
 opt-level = 3
-
-# TODO(bartlomieju): remove once a deno_ast release with the collapsed
-# multi-line diagnostic snippets (denoland/deno_ast#334) is published.
-[patch.crates-io]
-deno_ast = { git = "https://github.com/bartlomieju/deno_ast", rev = "77c4b62316874dded8cbd74e0a823d3445f6a433" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -635,3 +635,8 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.twox-hash]
 opt-level = 3
+
+# TODO(bartlomieju): remove once a deno_ast release with the collapsed
+# multi-line diagnostic snippets (denoland/deno_ast#334) is published.
+[patch.crates-io]
+deno_ast = { git = "https://github.com/bartlomieju/deno_ast", rev = "77c4b62316874dded8cbd74e0a823d3445f6a433" }


### PR DESCRIPTION
Bumps `deno_ast` to `0.53.3`, which includes denoland/deno_ast#334.

`deno lint` currently renders a diagnostic whose highlighted span covers many lines by underlining **every** line of the span at full width, producing snippets that can be dozens of lines long. `deno_ast` 0.53.3 reworks the snippet renderer to collapse these.

### Before

```
error[no-async-promise-executor]: Async promise executors are not allowed
 --> big.ts:1:11
  |
1 | const p = new Promise(async (resolve) => {
  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
2 |   const a = 1;
  | ^^^^^^^^^^^^^^
  |
... (every line, full width) ...
12 | });
  | ^^
```

### After

```
error[no-async-promise-executor]: Async promise executors are not allowed
    --> big.ts:1:11
     |
>  1 | const p = new Promise(async (resolve) => {
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>  2 |   const a = 1;
    ...
> 11 |   resolve(a + b + c + d + e + f + g + h + i);
> 12 | });
     | ^^
```

The upstream change: caps the frame (first two + `...` + last two lines), draws carets only on the first and last line of a multi-line span (trimming leading indentation on the last), and adds a `>` gutter marker next to the line numbers of a multi-line span. Single-line diagnostics are unchanged.

All 82 `lint` spec tests pass against this build.