### PR TITLE
feat(cli): add --min-dep-age alias

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -5747,6 +5747,7 @@ fn require_arg() -> Arg {
 fn min_dep_age_arg() -> Arg {
   Arg::new("minimum-dependency-age")
     .long("minimum-dependency-age")
+    .alias("min-dep-age")
     .value_parser(minutes_duration_or_date_parser)
     .help("(Unstable) The age in minutes, ISO-8601 duration or RFC3339 absolute timestamp (e.g. '120' for two hours, 'P2D' for two days, '2025-09-16' for cutoff date, '2025-09-16T12:00:00+00:00' for cutoff time, '0' to disable)")
 }
@@ -12021,6 +12022,18 @@ mod tests {
         ..Flags::default()
       }
     );
+  }
+
+  #[test]
+  fn minimum_dependency_age_alias() {
+    for flag in ["--minimum-dependency-age=0", "--min-dep-age=0"] {
+      let flags =
+        flags_from_vec(svec!["deno", "run", flag, "script.ts"]).unwrap();
+      assert_eq!(
+        flags.minimum_dependency_age,
+        Some(NewestDependencyDate::Disabled)
+      );
+    }
   }
 
   #[test]

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -754,12 +754,13 @@ fn maybe_minimum_dependency_age_hint(error_string: &str) -> Option<String> {
       "\n\n{} This version is blocked by the minimum dependency age policy, ",
       "which avoids installing recently published versions to reduce supply ",
       "chain risk (the default is 24 hours). To use this version now, pass the ",
-      "{} flag (for example {} to disable it, or a shorter duration like {} ",
-      "minutes) or set {} in your deno.json, or wait until the version is old ",
-      "enough.\n{} {}"
+      "{} (or {}) flag (for example {} to disable it, or a shorter duration ",
+      "like {} minutes) or set {} in your deno.json, or wait until the version ",
+      "is old enough.\n{} {}"
     ),
     colors::yellow("hint:"),
     colors::bold("--minimum-dependency-age"),
+    colors::bold("--min-dep-age"),
     colors::bold("0"),
     colors::bold("60"),
     colors::bold("\"minimumDependencyAge\""),

--- a/tests/integration/pm_tests.rs
+++ b/tests/integration/pm_tests.rs
@@ -290,6 +290,7 @@ fn add_npm_minimum_dependency_age_no_matching_shows_hint() {
   assert_contains!(output, "minimum dependency date");
   assert_contains!(output, "minimumDependencyAge");
   assert_contains!(output, "--minimum-dependency-age");
+  assert_contains!(output, "--min-dep-age");
 }
 
 fn pm_context_builder() -> TestContextBuilder {

--- a/tests/specs/npm/npmrc_min_release_age/install.out
+++ b/tests/specs/npm/npmrc_min_release_age/install.out
@@ -3,5 +3,5 @@ error: Could not find npm package '@denotest/add' matching '*'.
 
 A newer matching version was found, but it was not used because it was newer than the specified minimum dependency date of [WILDLINE]
 
-hint: This version is blocked by the minimum dependency age policy, which avoids installing recently published versions to reduce supply chain risk (the default is 24 hours). To use this version now, pass the --minimum-dependency-age flag (for example 0 to disable it, or a shorter duration like 60 minutes) or set "minimumDependencyAge" in your deno.json, or wait until the version is old enough.
+hint: This version is blocked by the minimum dependency age policy, which avoids installing recently published versions to reduce supply chain risk (the default is 24 hours). To use this version now, pass the --minimum-dependency-age (or --min-dep-age) flag (for example 0 to disable it, or a shorter duration like 60 minutes) or set "minimumDependencyAge" in your deno.json, or wait until the version is old enough.
 docs: https://docs.deno.com/go/minimum-dependency-age


### PR DESCRIPTION
## Summary

- accept `--min-dep-age` as an alias for `--minimum-dependency-age`
- include the alias in minimum dependency age policy hints
- cover alias parsing and the updated user-facing hint

## Why

The shorter spelling is already used by the embedded CLI parser, but the main
Deno CLI only accepted the full `--minimum-dependency-age` spelling. This makes
the short form available consistently and ensures users can discover it when a
dependency is blocked by the age policy.

## Validation

- `cargo test -p deno --lib args::flags::tests::minimum_dependency_age_alias`
- `cargo build -p deno`
- `cargo test -p integration_tests add_npm_minimum_dependency_age_no_matching_shows_hint -- --nocapture`
- `cargo test -p specs_tests --test specs -- npmrc_min_release_age`
- `./tools/format.js --check cli/args/flags.rs cli/lib.rs tests/integration/pm_tests.rs tests/specs/npm/npmrc_min_release_age/install.out`
