### PR TITLE
chore: allow alpha/beta version bumps and auto-flag prereleases

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -951,6 +951,7 @@ jobs:
             target/release/deno-*.bsdiff.sha256sum
           body_path: target/release/release-notes.md
           draft: true
+          prerelease: '${{ contains(github.ref_name, ''-'') }}'
   test-release-macos-x86_64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}release macos-x86_64'
     needs:
@@ -1998,6 +1999,7 @@ jobs:
             target/release/deno-*.bsdiff.sha256sum
           body_path: target/release/release-notes.md
           draft: true
+          prerelease: '${{ contains(github.ref_name, ''-'') }}'
   test-release-macos-aarch64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}release macos-aarch64'
     needs:
@@ -3004,6 +3006,7 @@ jobs:
             target/release/deno-*.bsdiff.sha256sum
           body_path: target/release/release-notes.md
           draft: true
+          prerelease: '${{ contains(github.ref_name, ''-'') }}'
   test-release-windows-x86_64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}release windows-x86_64'
     needs:
@@ -3868,6 +3871,7 @@ jobs:
             target/release/deno-*.bsdiff.sha256sum
           body_path: target/release/release-notes.md
           draft: true
+          prerelease: '${{ contains(github.ref_name, ''-'') }}'
   test-release-windows-aarch64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}release windows-aarch64'
     needs:
@@ -4441,6 +4445,7 @@ jobs:
             target/release/deno-*.bsdiff.sha256sum
           body_path: target/release/release-notes.md
           draft: true
+          prerelease: '${{ contains(github.ref_name, ''-'') }}'
       - name: Cache cargo home
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
@@ -6457,6 +6462,7 @@ jobs:
             target/release/deno-*.bsdiff.sha256sum
           body_path: target/release/release-notes.md
           draft: true
+          prerelease: '${{ contains(github.ref_name, ''-'') }}'
   test-release-linux-aarch64:
     name: 'test ${{ matrix.test_crate }} ${{ matrix.shard_label }}release linux-aarch64'
     needs:

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -1116,6 +1116,9 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               ].join("\n"),
               body_path: "target/release/release-notes.md",
               draft: true,
+              // Flag pre-release tags (e.g. -alpha./-beta./-rc.) as pre-releases
+              // so they are not marked "Latest" when the draft is published.
+              prerelease: "${{ contains(github.ref_name, '-') }}",
             },
           },
         );

--- a/.github/workflows/version_bump.generated.yml
+++ b/.github/workflows/version_bump.generated.yml
@@ -13,6 +13,8 @@ on:
           - minor
           - major
           - rc
+          - alpha
+          - beta
         required: true
 jobs:
   build:

--- a/.github/workflows/version_bump.ts
+++ b/.github/workflows/version_bump.ts
@@ -11,7 +11,7 @@ const workflow = createWorkflow({
           description: "Kind of version bump",
           default: "patch",
           type: "choice",
-          options: ["patch", "minor", "major", "rc"],
+          options: ["patch", "minor", "major", "rc", "alpha", "beta"],
           required: true,
         },
       },


### PR DESCRIPTION
Two small gaps that make cutting alpha/beta pre-releases awkward.

The version_bump workflow only offered patch/minor/major/rc, even though
01_bump_crate_versions.ts already handles --alpha and --beta. This adds
both to the releaseKind choices so an alpha/beta cycle can be started
from the workflow UI, matching what the script already supports.

The GitHub release created for a tag build is a draft but was never
flagged as a pre-release, so publishing an alpha/beta draft would mark it
as "Latest" on the repo. This sets prerelease on the release step from
the tag name (contains(github.ref_name, '-')), so any -alpha./-beta./-rc.
tag publishes as a pre-release while stable tags do not. Cosmetic — deno
upgrade reads the dl.deno.land pointers, not GitHub's "Latest" — but it
keeps the releases page correct.