### PR TITLE
feat(check): add --ignore flag for deno check

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2295,6 +2295,15 @@ Unless --reload is specified, this command will not re-download already cached d
             .num_args(1..)
             .value_hint(ValueHint::FilePath),
         )
+        .arg(
+          Arg::new("ignore")
+            .long("ignore")
+            .num_args(1..)
+            .action(ArgAction::Append)
+            .require_equals(true)
+            .help("Ignore type-checking particular source files")
+            .value_hint(ValueHint::AnyPath),
+        )
         .arg(allow_import_arg())
         .arg(deny_import_arg())
         .arg(v8_flags_arg())
@@ -6789,6 +6798,12 @@ fn check_parse(
     Some(f) => f.collect(),
     None => vec![".".to_string()], // default
   };
+  let ignore = match matches.remove_many::<String>("ignore") {
+    Some(f) => f
+      .flat_map(flat_escape_split_commas)
+      .collect::<Result<Vec<_>, _>>()?,
+    None => vec![],
+  };
   if matches.get_flag("all") || matches.get_flag("remote") {
     flags.type_check_mode = TypeCheckMode::All;
   }
@@ -6797,7 +6812,10 @@ fn check_parse(
   }
   flags.watch = watch_arg_parse(matches)?;
   flags.subcommand = DenoSubcommand::Check(CheckFlags {
-    files,
+    files: FileFlags {
+      include: files,
+      ignore,
+    },
     doc: matches.get_flag("doc"),
     doc_only: matches.get_flag("doc-only"),
     check_js: matches.get_flag("check-js"),
@@ -10587,7 +10605,10 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Check(CheckFlags {
-          files: svec!["script.ts"],
+          files: FileFlags {
+            include: svec!["script.ts"],
+            ignore: vec![],
+          },
           doc: false,
           doc_only: false,
           check_js: false,
@@ -10603,7 +10624,10 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Check(CheckFlags {
-          files: svec!["."],
+          files: FileFlags {
+            include: svec!["."],
+            ignore: vec![],
+          },
           doc: false,
           doc_only: false,
           check_js: false,
@@ -10619,7 +10643,10 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Check(CheckFlags {
-          files: svec!["script.ts"],
+          files: FileFlags {
+            include: svec!["script.ts"],
+            ignore: vec![],
+          },
           doc: true,
           doc_only: false,
           check_js: false,
@@ -10635,7 +10662,10 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Check(CheckFlags {
-          files: svec!["markdown.md"],
+          files: FileFlags {
+            include: svec!["markdown.md"],
+            ignore: vec![],
+          },
           doc: false,
           doc_only: true,
           check_js: false,
@@ -10665,7 +10695,10 @@ mod tests {
         r.unwrap(),
         Flags {
           subcommand: DenoSubcommand::Check(CheckFlags {
-            files: svec!["script.ts"],
+            files: FileFlags {
+              include: svec!["script.ts"],
+              ignore: vec![],
+            },
             doc: false,
             doc_only: false,
             check_js: false,
@@ -10694,7 +10727,10 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Check(CheckFlags {
-          files: svec!["script.js"],
+          files: FileFlags {
+            include: svec!["script.js"],
+            ignore: vec![],
+          },
           doc: false,
           doc_only: false,
           check_js: true,
@@ -10710,7 +10746,10 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Check(CheckFlags {
-          files: svec!["script.ts"],
+          files: FileFlags {
+            include: svec!["script.ts"],
+            ignore: vec![],
+          },
           doc: false,
           doc_only: false,
           check_js: false,
@@ -10721,6 +10760,30 @@ mod tests {
           is_desktop: true,
           ..Default::default()
         },
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec![
+      "deno",
+      "check",
+      "--ignore=generated.ts,vendor",
+      "."
+    ]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Check(CheckFlags {
+          files: FileFlags {
+            include: svec!["."],
+            ignore: svec!["generated.ts", "vendor"],
+          },
+          doc: false,
+          doc_only: false,
+          check_js: false,
+        }),
+        type_check_mode: TypeCheckMode::Local,
+        code_cache_enabled: true,
         ..Flags::default()
       }
     );
@@ -17365,7 +17428,10 @@ Usage: deno lint [OPTIONS] [files]...\n"
       flags,
       Flags {
         subcommand: DenoSubcommand::Check(CheckFlags {
-          files: svec!["script.ts"],
+          files: FileFlags {
+            include: svec!["script.ts"],
+            ignore: vec![],
+          },
           doc: false,
           doc_only: false,
           check_js: false,

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1337,7 +1337,7 @@ impl CliOptions {
           Some(files_to_urls(&cache_flags.files))
         }
         DenoSubcommand::Check(check_flags) => {
-          Some(files_to_urls(&check_flags.files))
+          Some(files_to_urls(&check_flags.files.include))
         }
         DenoSubcommand::Install(InstallFlags::Global(flags)) => flags
           .module_urls

--- a/cli/graph_container.rs
+++ b/cli/graph_container.rs
@@ -107,9 +107,18 @@ impl MainModuleGraphContainer {
   pub fn collect_specifiers(
     &self,
     files: &[String],
+    ignore: &[String],
     options: CollectSpecifiersOptions,
   ) -> Result<Vec<ModuleSpecifier>, AnyError> {
-    let excludes = self.cli_options.workspace().resolve_config_excludes()?;
+    let mut excludes = self.cli_options.workspace().resolve_config_excludes()?;
+    if !ignore.is_empty() {
+      let ignore_patterns =
+        PathOrPatternSet::from_exclude_relative_path_or_patterns(
+          self.cli_options.initial_cwd(),
+          ignore,
+        )?;
+      excludes.append(ignore_patterns.into_path_or_patterns().into_iter());
+    }
     let include_patterns =
       PathOrPatternSet::from_include_relative_path_or_patterns(
         self.cli_options.initial_cwd(),

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -320,6 +320,7 @@ pub async fn bundle(
       check_factory.main_module_graph_container().await?;
     let specifiers = main_graph_container.collect_specifiers(
       &bundle_flags.entrypoints,
+      &[],
       CollectSpecifiersOptions {
         include_ignored_specified: false,
       },

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -48,7 +48,8 @@ async fn check_with_factory(
   let main_graph_container = factory.main_module_graph_container().await?;
 
   let specifiers = main_graph_container.collect_specifiers(
-    &check_flags.files,
+    &check_flags.files.include,
+    &check_flags.files.ignore,
     CollectSpecifiersOptions {
       include_ignored_specified: false,
     },

--- a/cli/tools/clean.rs
+++ b/cli/tools/clean.rs
@@ -263,6 +263,7 @@ async fn clean_except(
   let main_graph_container = factory.main_module_graph_container().await?;
   let roots = main_graph_container.collect_specifiers(
     entrypoints,
+    &[],
     CollectSpecifiersOptions {
       include_ignored_specified: true,
     },

--- a/cli/tools/installer/mod.rs
+++ b/cli/tools/installer/mod.rs
@@ -211,6 +211,7 @@ pub async fn install_from_entrypoints(
   let main_graph_container = factory.main_module_graph_container().await?;
   let specifiers = main_graph_container.collect_specifiers(
     &entrypoints_flags.entrypoints,
+    &[],
     CollectSpecifiersOptions {
       include_ignored_specified: true,
     },

--- a/libs/cli_parser/src/convert.rs
+++ b/libs/cli_parser/src/convert.rs
@@ -1652,13 +1652,21 @@ fn check_parse(result: &ParseResult, flags: &mut Flags) {
     .map(|v| v.iter().map(|s| s.to_string()).collect())
     .unwrap_or_else(|| vec![".".to_string()]);
 
+  let ignore = result
+    .get_many("ignore")
+    .map(|v| v.iter().map(|s| s.to_string()).collect())
+    .unwrap_or_default();
+
   if result.get_bool("all") || result.get_bool("remote") {
     flags.type_check_mode = TypeCheckMode::All;
   }
 
   flags.watch = watch_arg_parse(result);
   flags.subcommand = DenoSubcommand::Check(CheckFlags {
-    files,
+    files: FileFlags {
+      include: files,
+      ignore,
+    },
     doc: result.get_bool("doc"),
     doc_only: result.get_bool("doc-only"),
     check_js: result.get_bool("check-js"),

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -154,7 +154,7 @@ pub struct CacheFlags {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CheckFlags {
-  pub files: Vec<String>,
+  pub files: FileFlags,
   pub doc: bool,
   pub doc_only: bool,
   pub check_js: bool,

--- a/tests/specs/check/check_ignore/__test__.jsonc
+++ b/tests/specs/check/check_ignore/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tests": {
+    "ignore_flag_excludes_file": {
+      "args": "check --ignore=error.ts .",
+      "output": "ignore_pass.out",
+      "exitCode": 0
+    },
+    "without_ignore_flag_errors": {
+      "args": "check .",
+      "output": "no_ignore.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/check/check_ignore/error.ts
+++ b/tests/specs/check/check_ignore/error.ts
@@ -1,0 +1,3 @@
+// This file has a type error on purpose.
+const x: number = "not a number";
+console.log(x);

--- a/tests/specs/check/check_ignore/ignore_pass.out
+++ b/tests/specs/check/check_ignore/ignore_pass.out
@@ -1,0 +1,1 @@
+Check [WILDCARD]

--- a/tests/specs/check/check_ignore/no_ignore.out
+++ b/tests/specs/check/check_ignore/no_ignore.out
@@ -1,0 +1,6 @@
+TS2322 [ERROR]: Type 'string' is not assignable to type 'number'.
+const x: number = "not a number";
+      ~
+    at [WILDCARD]
+
+error: Type checking failed.

--- a/tests/specs/check/check_ignore/valid.ts
+++ b/tests/specs/check/check_ignore/valid.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}


### PR DESCRIPTION
## What

Add an `--ignore` CLI flag to `deno check`, bringing it to parity with `deno fmt --ignore` and `deno lint --ignore`.

## Why

Since Deno 2.x, `deno check` type-checks the entire project recursively by default. This is great for catching errors early, but there's no CLI-level escape hatch to exclude specific files or directories — unlike `deno fmt` and `deno lint`, which both support `--ignore`.

This is a frequently requested feature tracked across **7 separate issues**:
- **#29424** — `Add deno check --ignore`
- **#34840** — Tracking issue for `deno check` file selection (`--ignore` + per-command `include`/`exclude`)
- **#34426** — Add `check.exclude` option for `deno check`
- **#30841** — `deno check` add support for configuring `include` and `exclude`
- #30934, #18089 (closed duplicates)

**Real-world use case:** Enable `deno check` in CI while temporarily excluding a subset of files that have known/in-progress type errors, without needing to edit `deno.json`.

Community research (Reddit, X, HN) also consistently surfaces "permission model friction" and "verbose configuration" as Deno pain points — this directly reduces configuration friction for type checking.

## How

### Core changes

1. **`libs/cli_parser/src/flags.rs`**: Changed `CheckFlags.files` from `Vec<String>` to `FileFlags` (the same struct used by `LintFlags` and `FmtFlags`), which carries both `include` and `ignore` vectors.

2. **`cli/args/flags.rs`**: Added `--ignore` argument to `check_subcommand()` with the same signature as lint/fmt (`--ignore=<paths>`, comma-separated, `require_equals`). Updated `check_parse()` to populate the new `FileFlags`.

3. **`cli/graph_container.rs`**: Extended `collect_specifiers()` to accept an `ignore: &[String]` parameter. When non-empty, the ignore patterns are resolved relative to CWD and merged into the exclude set alongside the top-level `exclude` from `deno.json`.

4. **`libs/cli_parser/src/convert.rs`**: Updated the alternative parser path to match.

5. **Callers updated**: `cli/tools/check.rs`, `cli/tools/bundle/mod.rs`, `cli/tools/clean.rs`, `cli/tools/installer/mod.rs` — all pass `&[]` for the new ignore parameter (no behavior change for non-check commands).

### Usage

```sh
# Ignore a single file
deno check --ignore=generated.ts .

# Ignore multiple paths (comma-separated)
deno check --ignore=generated.ts,vendor .

# Ignore a directory
deno check --ignore=legacy/ .
```

## Testing

- **Unit tests**: Added a test case for `--ignore` flag parsing in `cli/args/flags.rs`, verifying the flag is correctly parsed into `FileFlags { include, ignore }`.
- **Spec test**: Added `tests/specs/check/check_ignore/` with two scenarios:
  - `ignore_flag_excludes_file`: Runs `deno check --ignore=error.ts .` — passes because the file with a type error is excluded
  - `without_ignore_flag_errors`: Runs `deno check .` — fails because the type error is detected
- All existing unit tests updated to use the new `FileFlags` struct and continue to pass.
- `cargo check -p deno` passes cleanly.

## AI Usage Disclosure

This PR was written with assistance from GitHub Copilot (Claude). All code was reviewed before submission.

Closes #29424
Refs #34840, #34426, #30841
