### PR TITLE
fix(web): support Event subclasses with readonly toStringTag

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -141,8 +141,6 @@ const _path = Symbol("[[path]]");
 
 class Event {
   constructor(type, eventInitDict = { __proto__: null }) {
-    // TODO(lucacasonato): remove when this interface is spec aligned
-    this[SymbolToStringTag] = "Event";
     this[_canceledFlag] = false;
     this[_stopPropagationFlag] = false;
     this[_stopImmediatePropagationFlag] = false;
@@ -423,6 +421,14 @@ ObjectDefineProperty(Event, "BUBBLING_PHASE", {
 });
 
 const EventPrototype = Event.prototype;
+
+ObjectDefineProperty(EventPrototype, SymbolToStringTag, {
+  __proto__: null,
+  value: "Event",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 // Not spec compliant. The spec defines it as [LegacyUnforgeable]
 // but doing so has a big performance hit

--- a/tests/unit/event_test.ts
+++ b/tests/unit/event_test.ts
@@ -26,6 +26,21 @@ Deno.test(function eventInitializedWithTypeAndDict() {
   assertEquals(event.cancelable, true);
 });
 
+Deno.test(function eventSubclassWithReadOnlyToStringTag() {
+  class SubclassedEvent extends Event {}
+  Object.defineProperty(SubclassedEvent.prototype, Symbol.toStringTag, {
+    value: "SubclassedEvent",
+    configurable: true,
+  });
+
+  const event = new SubclassedEvent("test");
+  assertEquals(
+    Object.prototype.toString.call(event),
+    "[object SubclassedEvent]",
+  );
+  assertEquals(Object.hasOwn(event, Symbol.toStringTag), false);
+});
+
 Deno.test(function eventComposedPathSuccess() {
   const type = "click";
   const event = new Event(type);


### PR DESCRIPTION
## Summary

- define `Event.prototype[Symbol.toStringTag]` with the standard read-only descriptor instead of assigning it on each instance
- add regression coverage for subclasses that define their own read-only `Symbol.toStringTag`

## Root cause

The `Event` constructor assigned `this[Symbol.toStringTag] = "Event"`. When a subclass, such as Undici's `MessageEvent`, defines a read-only `Symbol.toStringTag` on its prototype, that assignment resolves to the inherited non-writable property and throws during `super()`.

Moving the tag to `Event.prototype` matches Web IDL behavior and allows subclasses to provide their own class string.

## Validation

- `cargo b --bin deno -p deno`
- `./target/debug/deno test -A --config tests/config/deno.json tests/unit/event_test.ts`
- constructed Undici 8.5.0's `MessageEvent` with the rebuilt binary
- sent a message successfully with `@earendil-works/pi-coding-agent` running under the rebuilt Deno
