### PR TITLE
perf(fetch): cache Headers iteration entries

### DIFF
--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -39,9 +39,6 @@ const _headerList = Symbol("header list");
 const _lowerNames = Symbol("lowercase header names");
 const _iterableHeaders = Symbol("iterable headers");
 const _iterableHeadersCache = Symbol("iterable headers cache");
-const _iterableHeadersCacheListLength = Symbol(
-  "iterable headers cache list length",
-);
 const _guard = Symbol("guard");
 const _headerListGetter = Symbol("header list getter");
 const _headerGet = Symbol("header get");
@@ -77,8 +74,9 @@ function ensureLowerNames(headers) {
 }
 
 function invalidateIterableHeaders(headers) {
-  headers[_iterableHeadersCache] = undefined;
-  headers[_iterableHeadersCacheListLength] = undefined;
+  const cache = headers[_iterableHeadersCache];
+  cache[0] = undefined;
+  cache[1] = undefined;
 }
 
 /**
@@ -366,17 +364,23 @@ class Headers {
   [_headerListGetter] = null;
   [_headerGet] = null;
   [_headerTarget] = null;
+  /**
+   * Mutable cell so freezing Headers does not freeze its internal cache.
+   * @type {[HeaderList | undefined, number | undefined]}
+   */
+  [_iterableHeadersCache] = [undefined, undefined];
   /** @type {"immutable" | "request" | "request-no-cors" | "response" | "none"} */
   [_guard];
 
   get [_iterableHeaders]() {
     const list = headerListFromHeaders(this);
+    const cache = this[_iterableHeadersCache];
 
     if (
-      this[_iterableHeadersCache] !== undefined &&
-      this[_iterableHeadersCacheListLength] === list.length
+      cache[0] !== undefined &&
+      cache[1] === list.length
     ) {
-      return this[_iterableHeadersCache];
+      return cache[0];
     }
 
     // The order of steps are not similar to the ones suggested by the
@@ -424,8 +428,8 @@ class Headers {
       },
     );
 
-    this[_iterableHeadersCache] = entries;
-    this[_iterableHeadersCacheListLength] = list.length;
+    cache[0] = entries;
+    cache[1] = list.length;
 
     return entries;
   }

--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -39,6 +39,9 @@ const _headerList = Symbol("header list");
 const _lowerNames = Symbol("lowercase header names");
 const _iterableHeaders = Symbol("iterable headers");
 const _iterableHeadersCache = Symbol("iterable headers cache");
+const _iterableHeadersCacheListLength = Symbol(
+  "iterable headers cache list length",
+);
 const _guard = Symbol("guard");
 const _headerListGetter = Symbol("header list getter");
 const _headerGet = Symbol("header get");
@@ -71,6 +74,11 @@ function ensureLowerNames(headers) {
     headers[_lowerNames] = lower;
   }
   return lower;
+}
+
+function invalidateIterableHeaders(headers) {
+  headers[_iterableHeadersCache] = undefined;
+  headers[_iterableHeadersCacheListLength] = undefined;
 }
 
 /**
@@ -193,6 +201,7 @@ function appendHeader(headers, name, value) {
   }
   ArrayPrototypePush(list, [name, value]);
   ArrayPrototypePush(lowerNames, lowercaseName);
+  invalidateIterableHeaders(headers);
 }
 
 function appendHeaderToList(list, name, value) {
@@ -364,8 +373,8 @@ class Headers {
     const list = headerListFromHeaders(this);
 
     if (
-      this[_guard] === "immutable" &&
-      this[_iterableHeadersCache] !== undefined
+      this[_iterableHeadersCache] !== undefined &&
+      this[_iterableHeadersCacheListLength] === list.length
     ) {
       return this[_iterableHeadersCache];
     }
@@ -374,9 +383,10 @@ class Headers {
     // spec but produce the same result.
     const seenHeaders = { __proto__: null };
     const entries = [];
+    const lowerNames = ensureLowerNames(this);
     for (let i = 0; i < list.length; ++i) {
       const entry = list[i];
-      const name = byteLowerCase(entry[0]);
+      const name = lowerNames[i];
       const value = entry[1];
       if (value === null) throw new TypeError("Unreachable");
       // The following if statement is not spec compliant.
@@ -415,6 +425,7 @@ class Headers {
     );
 
     this[_iterableHeadersCache] = entries;
+    this[_iterableHeadersCacheListLength] = list.length;
 
     return entries;
   }
@@ -481,6 +492,7 @@ class Headers {
     if (writeIdx !== list.length) {
       ArrayPrototypeSplice(list, writeIdx);
       ArrayPrototypeSplice(lowerNames, writeIdx);
+      invalidateIterableHeaders(this);
     }
   }
 
@@ -627,6 +639,7 @@ class Headers {
       ArrayPrototypeSplice(list, writeIdx);
       ArrayPrototypeSplice(lowerNames, writeIdx);
     }
+    invalidateIterableHeaders(this);
   }
 
   [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
@@ -732,11 +745,11 @@ function headersFromHeaderListLazyTarget(target, guard) {
  * IMPORTANT: callers must change the list length when mutating (push, splice,
  * or empty-and-refill). Equal-length in-place mutations
  * (`list[i] = [...]` or `list[i][0] = ...`, pop-and-push pairs) silently leave
- * the parallel `[_lowerNames]` cache (see `ensureLowerNames`) stale, because
- * the rebuild trigger is a length divergence between `_headerList` and
- * `[_lowerNames]`. There is currently no caller doing this; the next one to
- * reach for an equal-length in-place mutation needs to add a cache-invalidator
- * (and a test) alongside it.
+ * the parallel `[_lowerNames]` cache (see `ensureLowerNames`) and iterable
+ * cache stale, because both rebuild triggers use the raw list length. There is
+ * currently no caller doing this; the next one to reach for an equal-length
+ * in-place mutation needs to add a cache-invalidator (and a test) alongside
+ * it.
  *
  * @param {Headers} headers
  * @returns {HeaderList}

--- a/ext/fetch/benches/headers_methods.rs
+++ b/ext/fetch/benches/headers_methods.rs
@@ -10,11 +10,11 @@ fn setup() -> Vec<Extension> {
   deno_core::extension!(
     bench_setup,
     esm_entry_point = "ext:bench_setup/setup",
-    esm = [
-      "ext:deno_fetch/20_headers.js" = "20_headers.js",
-      "ext:bench_setup/setup" = {
-        source = r#"
-          import { Headers } from "ext:deno_fetch/20_headers.js";
+    esm = ["ext:bench_setup/setup" = {
+      source = r#"
+          const { Headers } = __bootstrap.core.loadExtScript(
+            "ext:deno_fetch/20_headers.js",
+          );
           globalThis.Headers = Headers;
           globalThis.makeHeaders = () => new Headers({
             "content-type": "application/json",
@@ -26,9 +26,26 @@ fn setup() -> Vec<Extension> {
             "user-agent": "deno-bench/1.0",
           });
           globalThis.h7 = makeHeaders();
+          globalThis.headerSeq100 = Array.from(
+            { length: 100 },
+            (_, i) => [`x-many-${i}`, `value-${i}`],
+          );
+          globalThis.headerRecord100 = Object.fromEntries(headerSeq100);
+          globalThis.headerDupSeq100 = Array.from(
+            { length: 100 },
+            (_, i) => [`x-dup-${i % 10}`, `value-${i}`],
+          );
+          globalThis.h100 = new Headers(headerSeq100);
+          globalThis.iterateHeaders = (headers) => {
+            let total = 0;
+            for (const [key, value] of headers) {
+              total += key.length + value.length;
+            }
+            return total;
+          };
         "#
-      },
-    ]
+    },],
+    lazy_loaded_js = ["ext:deno_fetch/20_headers.js" = "20_headers.js",]
   );
 
   vec![
@@ -50,6 +67,26 @@ fn bench_construct_headers_7(b: &mut Bencher) {
   // that's 0+1+2+3+4+5+6 = 21 redundant `toLowerCase` allocations on top
   // of the 7 input-name lowercasings.
   bench_js_sync(b, r#"makeHeaders();"#, setup);
+}
+
+fn bench_construct_headers_sequence_100(b: &mut Bencher) {
+  bench_js_sync(b, r#"new Headers(headerSeq100);"#, setup);
+}
+
+fn bench_construct_headers_record_100(b: &mut Bencher) {
+  bench_js_sync(b, r#"new Headers(headerRecord100);"#, setup);
+}
+
+fn bench_construct_headers_duplicate_sequence_100(b: &mut Bencher) {
+  bench_js_sync(b, r#"new Headers(headerDupSeq100);"#, setup);
+}
+
+fn bench_iterate_headers_100(b: &mut Bencher) {
+  bench_js_sync(b, r#"iterateHeaders(h100);"#, setup);
+}
+
+fn bench_construct_iterate_headers_100(b: &mut Bencher) {
+  bench_js_sync(b, r#"iterateHeaders(new Headers(headerSeq100));"#, setup);
 }
 
 fn bench_has_hit(b: &mut Bencher) {
@@ -83,6 +120,11 @@ fn bench_get_miss(b: &mut Bencher) {
 benchmark_group!(
   benches,
   bench_construct_headers_7,
+  bench_construct_headers_sequence_100,
+  bench_construct_headers_record_100,
+  bench_construct_headers_duplicate_sequence_100,
+  bench_iterate_headers_100,
+  bench_construct_iterate_headers_100,
   bench_has_hit,
   bench_has_miss,
   bench_set_replace,

--- a/tests/bench_util/js_runtime.rs
+++ b/tests/bench_util/js_runtime.rs
@@ -51,6 +51,11 @@ pub fn bench_js_sync_with(
   setup: impl FnOnce() -> Vec<Extension>,
   opts: BenchOptions,
 ) {
+  let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .unwrap();
+  let _tokio_enter = tokio_runtime.enter();
   let mut runtime = create_js_runtime(setup);
   deno_core::scope!(scope, runtime);
 
@@ -89,11 +94,12 @@ pub fn bench_js_async_with(
   setup: impl FnOnce() -> Vec<Extension>,
   opts: BenchOptions,
 ) {
-  let mut runtime = create_js_runtime(setup);
   let tokio_runtime = tokio::runtime::Builder::new_current_thread()
     .enable_all()
     .build()
     .unwrap();
+  let _tokio_enter = tokio_runtime.enter();
+  let mut runtime = create_js_runtime(setup);
 
   // Looped code
   let inner_iters = if is_profiling() {

--- a/tests/unit/headers_test.ts
+++ b/tests/unit/headers_test.ts
@@ -418,6 +418,40 @@ Deno.test(function headersIterationReflectsMutationsAfterCache() {
   ]);
 });
 
+Deno.test(function headersIterationCacheSupportsFrozenHeaders() {
+  const headers = new Headers([
+    ["X-A", "1"],
+    ["X-B", "2"],
+  ]);
+
+  assertEquals([...headers], [
+    ["x-a", "1"],
+    ["x-b", "2"],
+  ]);
+  Object.freeze(headers);
+
+  headers.set("X-B", "updated");
+  assertEquals([...headers], [
+    ["x-a", "1"],
+    ["x-b", "updated"],
+  ]);
+
+  headers.append("X-C", "3");
+  headers.delete("X-A");
+  assertEquals([...headers], [
+    ["x-b", "updated"],
+    ["x-c", "3"],
+  ]);
+});
+
+Deno.test(function headersIterationCacheSupportsNonExtensibleHeaders() {
+  const headers = new Headers();
+  Object.preventExtensions(headers);
+
+  headers.append("X-A", "1");
+  assertEquals([...headers], [["x-a", "1"]]);
+});
+
 Deno.test(function headersAppendDuplicateSetCookieKey() {
   const headers = new Headers([["Set-Cookie", "foo=bar"]]);
   headers.append("set-Cookie", "foo=baz");

--- a/tests/unit/headers_test.ts
+++ b/tests/unit/headers_test.ts
@@ -386,6 +386,38 @@ Deno.test(function headersAppendMultiple() {
   ]);
 });
 
+Deno.test(function headersIterationReflectsMutationsAfterCache() {
+  const headers = new Headers([
+    ["X-A", "1"],
+    ["X-B", "2"],
+  ]);
+
+  assertEquals([...headers], [
+    ["x-a", "1"],
+    ["x-b", "2"],
+  ]);
+
+  headers.append("X-C", "3");
+  assertEquals([...headers], [
+    ["x-a", "1"],
+    ["x-b", "2"],
+    ["x-c", "3"],
+  ]);
+
+  headers.set("X-B", "updated");
+  assertEquals([...headers], [
+    ["x-a", "1"],
+    ["x-b", "updated"],
+    ["x-c", "3"],
+  ]);
+
+  headers.delete("X-A");
+  assertEquals([...headers], [
+    ["x-b", "updated"],
+    ["x-c", "3"],
+  ]);
+});
+
 Deno.test(function headersAppendDuplicateSetCookieKey() {
   const headers = new Headers([["Set-Cookie", "foo=bar"]]);
   headers.append("set-Cookie", "foo=baz");


### PR DESCRIPTION
## Summary

- cache the normalized, combined, and sorted entries used by `Headers` iteration
- invalidate the cache for `append`, `set`, and `delete`, and guard it with the raw header-list length for fetch-internal push/splice mutations
- reuse the existing lowercase-name cache while building iterable entries
- add construction and iteration benchmarks covering sequences, records, duplicate names, and existing `Headers` objects
- enter a Tokio runtime before benchmark `JsRuntime` creation so lazy-loaded extension scripts can schedule delayed V8 tasks

## Motivation

The Web IDL pair iterator reads the iterable data on every `next()`. For mutable `Headers`, that getter rebuilt, combined, lowercased, and sorted the entire header list for every yielded entry. Iterating 100 headers therefore repeatedly paid the full list cost.

This caches that derived representation broadly rather than adding a benchmark-shaped path. Public mutations explicitly invalidate it, while the list-length guard covers existing fetch internals that mutate backing lists directly with push/splice.

On a local release-lite build, `headers.construct.iterate.100` improved from about 1,137 ops/s to 31,430 ops/s (about 27.6x).

## Validation

- `PATH="/opt/homebrew/opt/llvm@22/bin:$PATH" cargo build -p deno --profile release-lite`
- `./target/release-lite/deno test -A --quiet --config tests/config/deno.json --no-lock tests/unit/headers_test.ts` (29 passed)
- `PATH="/opt/homebrew/opt/llvm@22/bin:$PATH" cargo bench -p deno_fetch --bench headers_methods construct_iterate_headers_100` (32,197,945 ns per 1,000 operations)
- `./target/release-lite/deno fmt --check tests/unit/headers_test.ts`
- `cargo fmt --check -- tests/bench_util/js_runtime.rs ext/fetch/benches/headers_methods.rs`
