### PR TITLE
fix(lsp): respect lint rule exclusion for no-slow-types diagnostics

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1974,6 +1974,13 @@ async fn generate_no_slow_types_diagnostics(
   if config_data.member_dir.jsr_packages_for_publish().is_empty() {
     return Vec::new();
   }
+  // Respect the lint configuration: if `no-slow-types` is excluded (or not
+  // otherwise enabled) for this document, don't report its diagnostics. This
+  // keeps the LSP in sync with `deno lint`, which filters the rule out.
+  let linter = snapshot.linter_resolver.for_module(module);
+  if !linter.inner.has_package_rule("no-slow-types") {
+    return Vec::new();
+  }
   let scope = config_data.scope.clone();
   let cell = no_slow_types_cache
     .entry(scope.clone())

--- a/cli/tools/lint/linter.rs
+++ b/cli/tools/lint/linter.rs
@@ -84,6 +84,10 @@ impl CliLinter {
     !self.package_rules.is_empty()
   }
 
+  pub fn has_package_rule(&self, code: &str) -> bool {
+    self.package_rules.iter().any(|r| r.code() == code)
+  }
+
   pub fn lint_package(
     &self,
     graph: &ModuleGraph,

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -15488,6 +15488,57 @@ fn lsp_no_slow_types_diagnostics() {
   client.shutdown();
 }
 
+// Regression test for https://github.com/denoland/deno/issues/35922: the LSP
+// should respect `lint.rules.exclude` for `no-slow-types` just like the CLI.
+#[test(timeout = 300)]
+fn lsp_no_slow_types_diagnostics_excluded() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+
+  // a publishable JSR package that excludes the `no-slow-types` rule
+  temp_dir.write(
+    "deno.json",
+    r#"{
+  "name": "@foo/bar",
+  "version": "1.0.0",
+  "exports": "./mod.ts",
+  "lint": {
+    "rules": {
+      "exclude": ["no-slow-types"]
+    }
+  }
+}
+"#,
+  );
+  // `add` is missing an explicit return type, which is a slow type, but the
+  // rule is excluded so it should not be reported
+  temp_dir.write(
+    "mod.ts",
+    "export function add(a: number, b: number) {\n  return a + b;\n}\n",
+  );
+
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+
+  let diagnostics = client.did_open(json!({
+    "textDocument": {
+      "uri": url_to_uri(&temp_dir.url().join("mod.ts").unwrap()).unwrap(),
+      "languageId": "typescript",
+      "version": 1,
+      "text": temp_dir.read_to_string("mod.ts"),
+    }
+  }));
+  let mod_diagnostics = diagnostics.all();
+  assert!(
+    !mod_diagnostics.iter().any(|d| {
+      d.code == Some(lsp::NumberOrString::String("no-slow-types".to_string()))
+    }),
+    "expected no no-slow-types diagnostics when the rule is excluded, got: {mod_diagnostics:#?}"
+  );
+
+  client.shutdown();
+}
+
 #[test(timeout = 300)]
 fn lsp_no_slow_types_unanalyzable_exports() {
   let context = TestContextBuilder::new().use_temp_cwd().build();


### PR DESCRIPTION
The language server reported no-slow-types diagnostics for every
publishable JSR package without ever consulting the resolved lint
rules. As a result, excluding the rule via lint.rules.exclude in
deno.json had no effect in the editor, even though deno lint on the
command line correctly stayed silent. This left editors like VS Code
and Zed showing warnings the user had explicitly turned off.

The LSP already builds a linter per module whose configured rules honor
the exclusion, so this gates the slow-types diagnostics on that linter
before doing the expensive fast-check graph build, bringing the editor
in line with the CLI.

Fixes #35922