### PR TITLE
feat(sync-types): support --allow-import to extend the type-fetch allowlist

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1314,7 +1314,7 @@ pub fn flags_from_vec_with_initial_cwd(
         "jupyter" => jupyter_parse(&mut flags, &mut m),
         "lint" => lint_parse(&mut flags, &mut m)?,
         "lsp" => lsp_parse(&mut flags, &mut m),
-        "sync-types" => sync_types_parse(&mut flags, &mut m),
+        "sync-types" => sync_types_parse(&mut flags, &mut m)?,
         "outdated" => outdated_parse(&mut flags, &mut m, false)?,
         "repl" => repl_parse(&mut flags, &mut m)?,
         "run" => run_parse(&mut flags, &mut m, app, false, false)?,
@@ -3797,10 +3797,15 @@ fn sync_types_subcommand() -> Command {
     cstr!(
       "Generate a <c>tsconfig.json</> and type mappings so stock TypeScript tooling (tsc, tsgo, editors) can type-check the project.
 
-Run after installing dependencies; it materializes <c>jsr:</>/<c>http(s):</> types and writes <p(245)>.deno/tsconfig.json</>."
+Run after installing dependencies; it materializes <c>jsr:</>/<c>http(s):</> types and writes <p(245)>.deno/tsconfig.json</>.
+
+Type declarations are fetched from the same trusted hosts as <c>deno run</> (jsr.io, esm.sh, ...). To also materialize types imported from another host, extend the allowlist with <c>--allow-import</>; unlike <c>deno run</>, the hosts you pass are added to the trusted defaults rather than replacing them, since this only downloads type declarations and never executes them:
+  <p(245)>deno sync-types --allow-import=html.spec.whatwg.org</>"
     ),
     UnstableArgsConfig::None,
   )
+  .arg(allow_import_arg())
+  .arg(deny_import_arg())
 }
 
 fn lint_subcommand() -> Command {
@@ -7673,8 +7678,13 @@ fn lsp_parse(flags: &mut Flags, _matches: &mut ArgMatches) {
   flags.subcommand = DenoSubcommand::Lsp;
 }
 
-fn sync_types_parse(flags: &mut Flags, _matches: &mut ArgMatches) {
+fn sync_types_parse(
+  flags: &mut Flags,
+  matches: &mut ArgMatches,
+) -> clap::error::Result<()> {
   flags.subcommand = DenoSubcommand::SyncTypes;
+  allow_and_deny_import_parse(flags, matches)?;
+  Ok(())
 }
 
 fn lint_parse(
@@ -16721,6 +16731,35 @@ Usage: deno lint [OPTIONS] [files]...\n"
     assert_eq!(
       r.unwrap_err().to_string(),
       "error: invalid value 'https://example.com': URLs are not supported, only domains and ips"
+    );
+  }
+
+  #[test]
+  fn sync_types_subcommand() {
+    let r = flags_from_vec(svec!["deno", "sync-types"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::SyncTypes,
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec![
+      "deno",
+      "sync-types",
+      "--allow-import=html.spec.whatwg.org"
+    ]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::SyncTypes,
+        permissions: PermissionFlags {
+          allow_import: Some(svec!["html.spec.whatwg.org"]),
+          ..Default::default()
+        },
+        ..Flags::default()
+      }
     );
   }
 

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3799,7 +3799,7 @@ fn sync_types_subcommand() -> Command {
 
 Run after installing dependencies; it materializes <c>jsr:</>/<c>http(s):</> types and writes <p(245)>.deno/tsconfig.json</>.
 
-Type declarations are fetched from the same trusted hosts as <c>deno run</> (jsr.io, esm.sh, ...). To also materialize types imported from another host, extend the allowlist with <c>--allow-import</>; unlike <c>deno run</>, the hosts you pass are added to the trusted defaults rather than replacing them, since this only downloads type declarations and never executes them:
+Remote <c>http(s):</> types are fetched under the same import permission as <c>deno run</>: only from the trusted default hosts unless you pass <c>--allow-import</>. To materialize types imported from another host, allow it explicitly:
   <p(245)>deno sync-types --allow-import=html.spec.whatwg.org</>"
     ),
     UnstableArgsConfig::None,

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1276,9 +1276,32 @@ impl CliOptions {
   }
 
   fn augment_import_permissions(&self, options: &mut PermissionsOptions) {
-    // do not add if the user specified --allow-all or --allow-import
-    if options.allow_import.is_none() {
-      options.allow_import = Some(self.implicit_allow_import());
+    match &options.allow_import {
+      // do not add if the user specified --allow-all or --allow-import
+      None => {
+        options.allow_import = Some(self.implicit_allow_import());
+      }
+      // For `deno sync-types` the import allowlist is additive: the command
+      // only downloads type declarations to materialize them for stock
+      // TypeScript tooling and never executes them, so a user extending the
+      // allowlist (e.g. to fetch a JSON schema referenced by a source file)
+      // should not lose the built-in trusted hosts (jsr.io, esm.sh, ...) that
+      // the rest of the project's dependencies rely on.
+      Some(allowlist) => {
+        if matches!(self.sub_command(), DenoSubcommand::SyncTypes) {
+          let mut merged = self.implicit_allow_import();
+          // An empty implicit list means "allow all" (e.g. `--cached-only`);
+          // in that case there is nothing to narrow, so leave it untouched.
+          if !merged.is_empty() {
+            for host in allowlist {
+              if !merged.contains(host) {
+                merged.push(host.clone());
+              }
+            }
+            options.allow_import = Some(merged);
+          }
+        }
+      }
     }
   }
 

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1276,32 +1276,9 @@ impl CliOptions {
   }
 
   fn augment_import_permissions(&self, options: &mut PermissionsOptions) {
-    match &options.allow_import {
-      // do not add if the user specified --allow-all or --allow-import
-      None => {
-        options.allow_import = Some(self.implicit_allow_import());
-      }
-      // For `deno sync-types` the import allowlist is additive: the command
-      // only downloads type declarations to materialize them for stock
-      // TypeScript tooling and never executes them, so a user extending the
-      // allowlist (e.g. to fetch a JSON schema referenced by a source file)
-      // should not lose the built-in trusted hosts (jsr.io, esm.sh, ...) that
-      // the rest of the project's dependencies rely on.
-      Some(allowlist) => {
-        if matches!(self.sub_command(), DenoSubcommand::SyncTypes) {
-          let mut merged = self.implicit_allow_import();
-          // An empty implicit list means "allow all" (e.g. `--cached-only`);
-          // in that case there is nothing to narrow, so leave it untouched.
-          if !merged.is_empty() {
-            for host in allowlist {
-              if !merged.contains(host) {
-                merged.push(host.clone());
-              }
-            }
-            options.allow_import = Some(merged);
-          }
-        }
-      }
+    // do not add if the user specified --allow-all or --allow-import
+    if options.allow_import.is_none() {
+      options.allow_import = Some(self.implicit_allow_import());
     }
   }
 


### PR DESCRIPTION
`deno sync-types` materializes the types of a project's `jsr:`/`http(s):`
dependencies so stock TypeScript tooling can type-check the project. Like
`deno run`, it fetches remote `http(s):` modules only from a built-in set
of trusted hosts (jsr.io, esm.sh, ...), so a source file importing types
from any other host was silently skipped and left unresolved (a `TS2307`
in the generated config). The most common case is a `.json` imported for
its inferred type, e.g. `https://html.spec.whatwg.org/entities.json`.

This exposes `--allow-import` (and `--deny-import`) on the subcommand so
that host can be allowed. It uses the same import-permission semantics as
`deno run`; jsr/npm resolution does not go through the http import
allowlist, so allowing an extra host does not disturb the project's jsr
dependencies.