### PR TITLE
feat(desktop): move desktop runtime APIs under Deno.desktop namespace

### DIFF
--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -14,7 +14,8 @@ pub use deno_runtime::ops::desktop::AutoUpdateState;
 pub use deno_runtime::ops::desktop::DesktopApi;
 pub use deno_runtime::ops::desktop::MenuItem;
 
-/// JS code that exposes desktop APIs via `Deno.BrowserWindow` and `Deno.desktop`.
+/// JS code that exposes desktop APIs under the `Deno.desktop` namespace
+/// (`Deno.desktop.BrowserWindow`, `Deno.desktop.dock`, `Deno.desktop.Tray`, …).
 pub const DESKTOP_JS: &str = r#"
 (() => {
   const internals = Deno[Deno.internal];
@@ -35,6 +36,13 @@ pub const DESKTOP_JS: &str = r#"
   } = internals.core.ops;
   const BrowserWindowPrototype = BrowserWindow.prototype;
   Object.setPrototypeOf(BrowserWindowPrototype, EventTarget.prototype);
+
+  // Namespace object holding the desktop-specific `Deno.*` APIs
+  // (`Deno.desktop.BrowserWindow`, `Deno.desktop.dock`, etc.). The
+  // auto-update init script executed afterwards adds `desktopVersion`
+  // and `autoUpdate` to this same object.
+  const desktop = Deno.desktop ?? {};
+  Object.defineProperty(Deno, "desktop", internals.core.propReadOnly(desktop));
 
   class UIEvent extends Event {
     #detail = 0;
@@ -183,7 +191,7 @@ pub const DESKTOP_JS: &str = r#"
   };
   Object.setPrototypeOf(OrigBW, nativeConstructor);
   Object.setPrototypeOf(OrigBW.prototype, nativeConstructor.prototype);
-  Deno.BrowserWindow = OrigBW;
+  desktop.BrowserWindow = OrigBW;
 
   internals.defineEventHandler(BrowserWindowPrototype, "keydown");
   internals.defineEventHandler(BrowserWindowPrototype, "keyup");
@@ -320,13 +328,13 @@ pub const DESKTOP_JS: &str = r#"
   };
   Object.setPrototypeOf(OrigDock, nativeDockConstructor);
   Object.setPrototypeOf(OrigDock.prototype, nativeDockConstructor.prototype);
-  Deno.Dock = OrigDock;
+  desktop.Dock = OrigDock;
 
   internals.defineEventHandler(DockPrototype, "menuclick");
   internals.defineEventHandler(DockPrototype, "reopen");
 
   const dock = new OrigDock();
-  Object.defineProperty(Deno, "dock", internals.core.propReadOnly(dock));
+  Object.defineProperty(desktop, "dock", internals.core.propReadOnly(dock));
 
   const TrayPrototype = Tray.prototype;
   Object.setPrototypeOf(TrayPrototype, EventTarget.prototype);
@@ -340,7 +348,7 @@ pub const DESKTOP_JS: &str = r#"
   };
   Object.setPrototypeOf(OrigTray, nativeTrayConstructor);
   Object.setPrototypeOf(OrigTray.prototype, nativeTrayConstructor.prototype);
-  Deno.Tray = OrigTray;
+  desktop.Tray = OrigTray;
 
   const nativeTrayDestroy = TrayPrototype.destroy;
   TrayPrototype.destroy = function() {
@@ -368,7 +376,7 @@ pub const DESKTOP_JS: &str = r#"
     const positionFn = options.position;
     const tray = this;
 
-    const window = new Deno.BrowserWindow({
+    const window = new desktop.BrowserWindow({
       width,
       height,
       frameless: true,
@@ -992,22 +1000,22 @@ pub fn desktop_auto_update_js(
     if (_rolledBack && typeof onRollback === "function") {{
       queueMicrotask(() => {{
         try {{ onRollback(ROLLBACK_REASON); }} catch (e) {{
-          console.error("Deno.autoUpdate onRollback threw:", e);
+          console.error("Deno.desktop.autoUpdate onRollback threw:", e);
         }}
       }});
     }}
 
     if (!_version) {{
-      console.warn("Deno.autoUpdate: no version in deno.json, skipping");
+      console.warn("Deno.desktop.autoUpdate: no version in deno.json, skipping");
       return;
     }}
     if (typeof url !== "string" || url.length === 0) {{
-      console.warn("Deno.autoUpdate: missing 'url' option, skipping");
+      console.warn("Deno.desktop.autoUpdate: missing 'url' option, skipping");
       return;
     }}
     if (!isHttpsUrl(url)) {{
       console.error(
-        "Deno.autoUpdate: refusing non-https url (got %s); ignoring.", url,
+        "Deno.desktop.autoUpdate: refusing non-https url (got %s); ignoring.", url,
       );
       return;
     }}
@@ -1027,7 +1035,7 @@ pub fn desktop_auto_update_js(
         try {{
           manifest = JSON.parse(manifestText);
         }} catch {{
-          console.warn("Deno.autoUpdate: latest.json is not valid JSON");
+          console.warn("Deno.desktop.autoUpdate: latest.json is not valid JSON");
           return;
         }}
         if (manifest.version === _version) return;
@@ -1036,7 +1044,7 @@ pub fn desktop_auto_update_js(
           const sig = manifest.signature;
           if (typeof sig !== "string" || !sig) {{
             console.error(
-              "Deno.autoUpdate: publicKey configured but manifest has no signature",
+              "Deno.desktop.autoUpdate: publicKey configured but manifest has no signature",
             );
             return;
           }}
@@ -1048,19 +1056,19 @@ pub fn desktop_auto_update_js(
           const signed = manifest.signed;
           if (typeof signed !== "string") {{
             console.error(
-              "Deno.autoUpdate: signed manifest must include a `signed` string field",
+              "Deno.desktop.autoUpdate: signed manifest must include a `signed` string field",
             );
             return;
           }}
           if (!op_desktop_verify_ed25519(publicKey, sig, te.encode(signed))) {{
-            console.error("Deno.autoUpdate: manifest signature verification failed");
+            console.error("Deno.desktop.autoUpdate: manifest signature verification failed");
             return;
           }}
           // Re-parse the signed payload — only its contents are trusted.
           try {{
             manifest = JSON.parse(signed);
           }} catch {{
-            console.error("Deno.autoUpdate: signed payload is not valid JSON");
+            console.error("Deno.desktop.autoUpdate: signed payload is not valid JSON");
             return;
           }}
           if (manifest.version === _version) return;
@@ -1068,7 +1076,7 @@ pub fn desktop_auto_update_js(
 
         const patchEntry = manifest.patches?.[_version];
         if (!patchEntry) {{
-          console.warn("Deno.autoUpdate: no patch available for",
+          console.warn("Deno.desktop.autoUpdate: no patch available for",
             _version, "->", manifest.version);
           return;
         }}
@@ -1081,12 +1089,12 @@ pub fn desktop_auto_update_js(
           ? patchEntry?.sha256
           : undefined;
         if (!patchName) {{
-          console.error("Deno.autoUpdate: malformed patch entry");
+          console.error("Deno.desktop.autoUpdate: malformed patch entry");
           return;
         }}
         if (typeof patchSha256 !== "string" || patchSha256.length !== 64) {{
           console.error(
-            "Deno.autoUpdate: manifest patch entry must include sha256",
+            "Deno.desktop.autoUpdate: manifest patch entry must include sha256",
           );
           return;
         }}
@@ -1099,7 +1107,7 @@ pub fn desktop_auto_update_js(
         op_desktop_apply_patch(patchBytes, patchSha256);
         if (typeof onUpdateReady === "function") {{
           try {{ onUpdateReady(manifest.version); }} catch (e) {{
-            console.error("Deno.autoUpdate onUpdateReady threw:", e);
+            console.error("Deno.desktop.autoUpdate onUpdateReady threw:", e);
           }}
         }}
         if (autoUpdateTimer) {{
@@ -1107,7 +1115,7 @@ pub fn desktop_auto_update_js(
           autoUpdateTimer = null;
         }}
       }} catch (e) {{
-        console.warn("Deno.autoUpdate: check failed:", e.message);
+        console.warn("Deno.desktop.autoUpdate: check failed:", e.message);
       }}
     }};
 
@@ -1117,7 +1125,7 @@ pub fn desktop_auto_update_js(
     }}
   }}
 
-  Object.defineProperties(Deno, {{
+  Object.defineProperties(Deno.desktop, {{
     desktopVersion: propReadOnly(_version),
     autoUpdate: propWritable(autoUpdate),
   }});
@@ -1282,7 +1290,9 @@ mod tests {
 
   #[test]
   fn desktop_js_installs_browser_window_constructor() {
-    assert!(DESKTOP_JS.contains("Deno.BrowserWindow"));
+    // The desktop APIs live under the `Deno.desktop` namespace.
+    assert!(DESKTOP_JS.contains(r#"Object.defineProperty(Deno, "desktop""#));
+    assert!(DESKTOP_JS.contains("desktop.BrowserWindow = OrigBW"));
     // The original BrowserWindow is wrapped so per-window state is
     // recorded.
     assert!(DESKTOP_JS.contains("windows.set"));
@@ -1303,6 +1313,9 @@ mod tests {
     );
     assert!(js.contains("const _version ="));
     assert!(js.contains("const _rolledBack = false"));
+    // `desktopVersion`/`autoUpdate` are attached to the `Deno.desktop`
+    // namespace, not `Deno` directly.
+    assert!(js.contains("Object.defineProperties(Deno.desktop, {"));
   }
 
   #[test]
@@ -1316,7 +1329,7 @@ mod tests {
   #[test]
   fn auto_update_js_inlines_release_base_url() {
     // The configured `desktop.release.baseUrl` is baked in as the default
-    // `url` for `Deno.autoUpdate`, so a no-arg call uses it.
+    // `url` for `Deno.desktop.autoUpdate`, so a no-arg call uses it.
     let js = desktop_auto_update_js(
       Some("1.0.0"),
       false,

--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -39,7 +39,7 @@ pub const DESKTOP_JS: &str = r#"
 
   // Namespace object holding the desktop-specific `Deno.*` APIs
   // (`Deno.desktop.BrowserWindow`, `Deno.desktop.dock`, etc.). The
-  // auto-update init script executed afterwards adds `desktopVersion`
+  // auto-update init script executed afterwards adds `appVersion`
   // and `autoUpdate` to this same object.
   const desktop = Deno.desktop ?? {};
   Object.defineProperty(Deno, "desktop", internals.core.propReadOnly(desktop));
@@ -1126,7 +1126,7 @@ pub fn desktop_auto_update_js(
   }}
 
   Object.defineProperties(Deno.desktop, {{
-    desktopVersion: propReadOnly(_version),
+    appVersion: propReadOnly(_version),
     autoUpdate: propWritable(autoUpdate),
   }});
 }})();
@@ -1313,7 +1313,7 @@ mod tests {
     );
     assert!(js.contains("const _version ="));
     assert!(js.contains("const _rolledBack = false"));
-    // `desktopVersion`/`autoUpdate` are attached to the `Deno.desktop`
+    // `appVersion`/`autoUpdate` are attached to the `Deno.desktop`
     // namespace, not `Deno` directly.
     assert!(js.contains("Object.defineProperties(Deno.desktop, {"));
   }

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -1289,7 +1289,7 @@ pub struct RunOptions {
   /// Error reporting URL from deno.json `desktop.errorReporting.url`.
   pub error_reporting_url: Option<String>,
   /// Auto-update release base URL from deno.json `desktop.release.baseUrl`.
-  /// Used as the default `url` for `Deno.autoUpdate` when none is passed.
+  /// Used as the default `url` for `Deno.desktop.autoUpdate` when none is passed.
   pub release_base_url: Option<String>,
   /// Stop on the first line of user code. Mirrors `--inspect-brk`.
   pub inspect_brk: bool,

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -1775,7 +1775,7 @@ async fn run_desktop(
 
       // Forward macOS dock-reopen callbacks (clicking the dock icon while
       // no windows are visible) into the shared event channel so JS can
-      // observe them as `Deno.dock` "reopen" events.
+      // observe them as `Deno.desktop.dock` "reopen" events.
       {
         let reopen_tx = event_tx.0.clone();
         laufey::on_dock_reopen(move |has_visible_windows| {

--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -3075,7 +3075,7 @@ async fn package_macos_app_bundle(
   // a `--runtime` argument (see `macos_runtime_dylib_name`). We deliberately do
   // NOT write a shell-script launcher that execs the backend with `--runtime`:
   // under LaunchServices (open / Finder / double-click) that `exec` breaks the
-  // app's foreground-GUI registration, so an `NSStatusItem` (Deno.Tray) is
+  // app's foreground-GUI registration, so an `NSStatusItem` (Deno.desktop.Tray) is
   // created but never attaches to the menu bar. Instead the backend binary is
   // the bundle's CFBundleExecutable directly (see Info.plist below), so the
   // process LaunchServices launches IS the GUI process. See denoland/deno#35619.

--- a/cli/tsc/dts/lib.deno.desktop.d.ts
+++ b/cli/tsc/dts/lib.deno.desktop.d.ts
@@ -252,7 +252,7 @@ declare namespace Deno.desktop {
   /** The application version read from `deno.json` at compile time, or
    * `null` if no version was configured. Only available in apps compiled
    * with `deno desktop`. */
-  export const desktopVersion: string | null;
+  export const appVersion: string | null;
 
   export interface AutoUpdateOptions {
     /** Base URL of the release server hosting `latest.json` and patch
@@ -292,7 +292,7 @@ declare namespace Deno.desktop {
    * library, so only the bytes that changed between versions are
    * downloaded. On each check, the manifest at `<url>/latest.json` is
    * fetched and its `version` compared against {@linkcode
-   * Deno.desktop.desktopVersion}:
+   * Deno.desktop.appVersion}:
    *
    * - If `publicKey` is set, the manifest signature is verified first and
    *   an unsigned or invalid manifest is rejected.

--- a/cli/tsc/dts/lib.deno.desktop.d.ts
+++ b/cli/tsc/dts/lib.deno.desktop.d.ts
@@ -246,7 +246,7 @@ declare interface Navigator {
   readonly permissions: Permissions;
 }
 
-declare namespace Deno {
+declare namespace Deno.desktop {
   export {}; // stop default export type behavior
 
   /** The application version read from `deno.json` at compile time, or
@@ -292,7 +292,7 @@ declare namespace Deno {
    * library, so only the bytes that changed between versions are
    * downloaded. On each check, the manifest at `<url>/latest.json` is
    * fetched and its `version` compared against {@linkcode
-   * Deno.desktopVersion}:
+   * Deno.desktop.desktopVersion}:
    *
    * - If `publicKey` is set, the manifest signature is verified first and
    *   an unsigned or invalid manifest is rejected.
@@ -327,7 +327,7 @@ declare namespace Deno {
    * Only available in apps compiled with `deno desktop`.
    *
    * ```ts
-   * Deno.autoUpdate({
+   * Deno.desktop.autoUpdate({
    *   url: "https://releases.example.com/myapp",
    *   interval: 60 * 60 * 1000, // hourly
    *   publicKey: "b64EncodedEd25519PublicKey==",
@@ -639,7 +639,7 @@ declare namespace Deno {
      * `null` to remove any menu previously set.
      *
      * macOS only. Click events are delivered as `"menuclick"` events on
-     * {@linkcode Deno.dock}. No-op on Windows and Linux. */
+     * {@linkcode Deno.desktop.dock}. No-op on Windows and Linux. */
     setMenu(menu: MenuItem[] | null): void;
 
     /** Show or hide the app's dock icon.
@@ -780,7 +780,7 @@ declare namespace Deno {
      * `frameless` + `noActivate` {@linkcode BrowserWindow} yourself.
      *
      * ```ts
-     * const tray = new Deno.Tray();
+     * const tray = new Deno.desktop.Tray();
      * tray.setIcon(iconBytes);
      * const panel = tray.attachPanel({ url: "https://localhost:8000/panel" });
      * panel.window.bind("doThing", async () => { ... });

--- a/tests/specs/check/desktop_flag/main.ts
+++ b/tests/specs/check/desktop_flag/main.ts
@@ -2,3 +2,8 @@
 // fails to type-check without `--desktop` and succeeds with it.
 const n: Notification = new Notification("hi");
 console.log(n);
+
+// Desktop-specific APIs live under the `Deno.desktop` namespace, also only
+// available with `--desktop`.
+const win = new Deno.desktop.BrowserWindow();
+console.log(win);


### PR DESCRIPTION
## Summary

Moves the desktop-specific runtime APIs off the top-level `Deno` namespace and onto a dedicated `Deno.desktop` namespace. Every name is kept identical — this is a pure re-namespacing, not a rename:

| Before | After |
| --- | --- |
| `Deno.BrowserWindow` | `Deno.desktop.BrowserWindow` |
| `Deno.Dock` | `Deno.desktop.Dock` |
| `Deno.dock` | `Deno.desktop.dock` |
| `Deno.Tray` | `Deno.desktop.Tray` |
| `Deno.desktopVersion` | `Deno.desktop.desktopVersion` |
| `Deno.autoUpdate` | `Deno.desktop.autoUpdate` |

Web-standard globals that were never on the `Deno` namespace — `Notification`, `alert`/`confirm`/`prompt`, the UI `Event` subclasses (`UIEvent`, `KeyboardEvent`, `MouseEvent`, `WheelEvent`, `FocusEvent`), and `navigator.permissions` — are intentionally left as globals.

## Changes

- **`cli/rt/desktop.rs`**: `DESKTOP_JS` now creates a `Deno.desktop` namespace object and hangs `BrowserWindow`, `Dock`, `dock`, and `Tray` off it; the auto-update init script attaches `desktopVersion`/`autoUpdate` to `Deno.desktop`. Log/comment strings and the structural unit tests updated accordingly.
- **`cli/tsc/dts/lib.deno.desktop.d.ts`**: `declare namespace Deno` → `declare namespace Deno.desktop`; internal `{@linkcode}` references updated. Global declarations (Notification, Permissions, UI events) unchanged.
- **`cli/rt/run.rs`, `cli/rt_desktop/lib.rs`, `cli/tools/desktop.rs`**: comment references updated.
- **`tests/specs/check/desktop_flag`**: extended `main.ts` to also exercise `Deno.desktop.BrowserWindow`, verifying the namespace only resolves with `--desktop`.

## Testing

- `cargo test -p denort --lib desktop` — 14 passing.
- `cargo test specs::check::desktop_flag` — both `with_flag` and `without_flag` pass.
- Manually verified `deno check --desktop` succeeds and `deno check` reports `Property 'desktop' does not exist on type 'typeof Deno'` without the flag.

Docs are updated in a companion PR on `denoland/docs`.