### PR TITLE
fix(desktop): don't let op_desktop_send_error_report target caller-supplied URLs

### DIFF
--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -1153,7 +1153,11 @@ pub fn desktop_error_reporting_js(
         platform: Deno.build.os,
         arch: Deno.build.arch,
       }});
-      op_desktop_send_error_report(_errorReportingUrl, body);
+      // The destination is not passed from JS — the op reads the
+      // operator-configured `error_reporting_url` from native state so an
+      // untrusted caller can't retarget it. `_errorReportingUrl` here only
+      // gates whether there's anything to report.
+      op_desktop_send_error_report(body);
     }}
 
     try {{

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -1832,6 +1832,18 @@ pub async fn run_with_options(
       .js_runtime()
       .execute_script("ext:deno_desktop/auto_update", js)?;
 
+    // Make the operator-configured reporting URL available to the native
+    // op (and the panic hook) via `ERROR_REPORT_CONFIG`. The op reads the
+    // destination from here rather than trusting a JS-supplied URL, so an
+    // untrusted caller can't retarget it. `OnceLock::set` is a no-op if a
+    // path that already knows the URL (e.g. `run_desktop`) set it first.
+    if let Some(url) = options.error_reporting_url.as_deref() {
+      deno_runtime::ops::desktop::set_error_report_config(
+        url.to_string(),
+        options.auto_update_version.clone(),
+      );
+    }
+
     let js = crate::desktop::desktop_error_reporting_js(
       options.error_reporting_url.as_deref(),
       options.auto_update_version.as_deref(),

--- a/runtime/ops/desktop.rs
+++ b/runtime/ops/desktop.rs
@@ -1267,11 +1267,20 @@ pub fn send_error_report(url: &str, body: &str) {
 }
 
 #[op2(fast)]
-fn op_desktop_send_error_report(
-  state: &mut OpState,
-  #[string] url: &str,
-  #[string] body: &str,
-) {
+fn op_desktop_send_error_report(state: &mut OpState, #[string] body: &str) {
+  // The report destination is operator config — it is baked into the app at
+  // build time (`error_reporting_url`) and stored in `ERROR_REPORT_CONFIG`.
+  // It is deliberately NOT accepted from JS: this op is exposed on
+  // `core.ops` and survives `removeImportedOps()`, so any (untrusted) code
+  // in the runtime can call it. Trusting a caller-supplied URL would turn
+  // this into an unrestricted file-append (`file://`) or network-POST
+  // (`https://`) primitive that bypasses the `--allow-write`/`--allow-net`
+  // permission checks every other fs/net op performs.
+  let Some((url, _)) = error_report_config() else {
+    // No reporting URL configured (e.g. plain `deno run`, or a desktop app
+    // that didn't set one) — there is nowhere to send, so do nothing.
+    return;
+  };
   // Make sure the panic-hook path has a client too. The OpState client is
   // the one configured with the user's TLS roots/permissions, so we share
   // it across both code paths instead of creating an ad-hoc client.

--- a/tests/specs/run/desktop_error_report_no_escape/__test__.jsonc
+++ b/tests/specs/run/desktop_error_report_no_escape/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run --allow-read main.js",
+  "output": "pwned file exists: false\n",
+  "exitCode": 0
+}

--- a/tests/specs/run/desktop_error_report_no_escape/main.js
+++ b/tests/specs/run/desktop_error_report_no_escape/main.js
@@ -1,0 +1,30 @@
+// Regression test for a sandbox-escape via `op_desktop_send_error_report`.
+//
+// The op is exposed on `Deno[Deno.internal].core.ops` and survives
+// `removeImportedOps()` (it's in NOT_IMPORTED_OPS), so untrusted code can
+// call it in a plain `deno run`. It used to accept a caller-supplied `url`
+// and, without any permission check, append to that `file://` path (a
+// `--allow-write` bypass) or POST to that `https://` URL (a `--allow-net`
+// bypass).
+//
+// It now ignores any caller-supplied destination and only ever targets the
+// operator-configured `error_reporting_url`, which is unset here. So this
+// attempt must be an inert no-op: the file must not be created even though
+// the process has no `--allow-write`.
+const target = new URL("pwned.txt", import.meta.url);
+
+const { op_desktop_send_error_report } = Deno[Deno.internal].core.ops;
+// Old exploit shape: (attacker file:// url, attacker body).
+op_desktop_send_error_report(target.href, "malicious payload");
+
+let existed = true;
+try {
+  Deno.statSync(target);
+} catch (e) {
+  if (e instanceof Deno.errors.NotFound) {
+    existed = false;
+  } else {
+    throw e;
+  }
+}
+console.log("pwned file exists:", existed);


### PR DESCRIPTION
## Problem

`op_desktop_send_error_report` is registered on the **main worker** (`runtime/worker.rs`, via `deno_desktop::init()`), so it is present in every `deno run`. It is also in `NOT_IMPORTED_OPS`, so it **survives `removeImportedOps()`** and stays reachable from untrusted user code via `Deno[Deno.internal].core.ops`.

The op accepted a **caller-supplied `url`** and performed **no permission check**:

- `file://` → appended the caller-supplied body to that path via raw `std::fs` — a `--allow-write` bypass (arbitrary-file append, e.g. `~/.bashrc`, `authorized_keys`).
- `https://` → POSTed the caller-supplied body to that URL via a fetch client built from `OpState` — a `--allow-net` bypass (exfiltration).

So untrusted JS under a plain `deno run` (no permission flags) could append to an arbitrary local file or POST to an arbitrary host.

## Fix

The report destination is **operator config** — `error_reporting_url` is baked into the app at build time and stored in the `ERROR_REPORT_CONFIG` global. There is no legitimate reason for the op to trust a URL from JS.

- The op no longer takes a `url` argument. It reads the destination from `error_report_config()` and **returns early when it is unset** (e.g. a plain `deno run`), making it fully inert outside a configured desktop app.
- `cli/rt/run.rs` now populates `ERROR_REPORT_CONFIG` on its desktop code path too (the packaged-binary path already set it in `run_desktop`; `OnceLock` makes it idempotent), so legitimate error reporting keeps working.
- `cli/rt/desktop.rs` JS caller drops the URL argument.

In a real desktop app the only reachable destination is now the app's own configured sink; untrusted renderer code can at most send junk to that operator-owned endpoint — not an arbitrary-destination fs/net primitive.

## Test

Adds `tests/specs/run/desktop_error_report_no_escape/`, which reproduces the exact escape (calls the internal op directly with an attacker-chosen `file://` destination under `deno run` with no `--allow-write`) and asserts no file is written.