### PR TITLE
fix(ext/net): require --allow-sys for node:dns.getServers()

### DIFF
--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -1182,7 +1182,16 @@ pub async fn op_dns_resolve(
 
 #[op2]
 #[serde]
-pub fn op_net_get_system_dns_servers() -> Result<Vec<(String, u16)>, NetError> {
+pub fn op_net_get_system_dns_servers(
+  state: &mut OpState,
+) -> Result<Vec<(String, u16)>, NetError> {
+  // Reading the host resolver configuration (the system nameservers, e.g.
+  // from /etc/resolv.conf) exposes host network configuration, so gate it
+  // behind the same `sys` permission as Deno.networkInterfaces(). Reachable
+  // from JS via node:dns.getServers().
+  state
+    .borrow_mut::<PermissionsContainer>()
+    .check_sys("networkInterfaces", "node:dns.getServers()")?;
   let (config, _opts) = system_conf::read_system_conf()
     .unwrap_or_else(|_| (ResolverConfig::default(), ResolverOpts::default()));
   let servers = config

--- a/tests/specs/permission/node_dns_getservers_no_perms/__test__.jsonc
+++ b/tests/specs/permission/node_dns_getservers_no_perms/__test__.jsonc
@@ -1,0 +1,12 @@
+{
+  "tests": {
+    "denied": {
+      "args": "run main.ts",
+      "output": "denied.out"
+    },
+    "granted": {
+      "args": "run --allow-sys=networkInterfaces main.ts",
+      "output": "granted.out"
+    }
+  }
+}

--- a/tests/specs/permission/node_dns_getservers_no_perms/denied.out
+++ b/tests/specs/permission/node_dns_getservers_no_perms/denied.out
@@ -1,0 +1,1 @@
+result: denied

--- a/tests/specs/permission/node_dns_getservers_no_perms/granted.out
+++ b/tests/specs/permission/node_dns_getservers_no_perms/granted.out
@@ -1,0 +1,1 @@
+result: allowed

--- a/tests/specs/permission/node_dns_getservers_no_perms/main.ts
+++ b/tests/specs/permission/node_dns_getservers_no_perms/main.ts
@@ -1,0 +1,18 @@
+// Regression test: node:dns.getServers() reads the host resolver
+// configuration (the system nameservers, e.g. from /etc/resolv.conf) via
+// op_net_get_system_dns_servers. That is host network configuration, the same
+// sys-info class as Deno.networkInterfaces(), so it must require
+// `--allow-sys`. Without it the call must throw NotCapable rather than leak
+// the host's configured nameservers.
+
+import dns from "node:dns";
+
+try {
+  dns.getServers();
+  console.log("result: allowed");
+} catch (e) {
+  console.log(
+    "result:",
+    (e as Error).name === "NotCapable" ? "denied" : `other:${(e as Error).name}`,
+  );
+}

--- a/tests/specs/permission/node_dns_getservers_no_perms/main.ts
+++ b/tests/specs/permission/node_dns_getservers_no_perms/main.ts
@@ -13,6 +13,8 @@ try {
 } catch (e) {
   console.log(
     "result:",
-    (e as Error).name === "NotCapable" ? "denied" : `other:${(e as Error).name}`,
+    (e as Error).name === "NotCapable"
+      ? "denied"
+      : `other:${(e as Error).name}`,
   );
 }


### PR DESCRIPTION
node:dns.getServers() reads the host resolver configuration (the system
nameservers, e.g. from /etc/resolv.conf) and returned it to JS with no
permission check. The backing op op_net_get_system_dns_servers took no
OpState, so it could not check anything, and the JS path in cares_wrap did
not check either. Code running without any --allow-sys grant could therefore
read the host's configured nameservers, which is host network configuration
that should be gated.

This is the same class of host information as Deno.networkInterfaces(),
which is already gated with check_sys("networkInterfaces"). This gates
getServers() through the same sys permission: the op now takes an OpState
and calls check_sys before reading, so it throws NotCapable without
--allow-sys and returns the servers with --allow-sys=networkInterfaces. A
spec test covers both the denied and granted cases.