### PR TITLE
fix(ext/node): require --allow-read for op_require_try_self

### DIFF
--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -510,9 +510,15 @@ pub fn op_require_try_self<
   #[string] parent_path: &str,
   #[string] request: &str,
 ) -> Result<Option<String>, RequireError> {
+  // Reading package.json by walking up from `parent_path` touches the
+  // filesystem at a caller-controlled location, so require read permission
+  // for it first, mirroring op_require_package_imports_resolve below.
+  let parent_path =
+    ensure_read_permission(state, Cow::Borrowed(Path::new(parent_path)))
+      .map_err(RequireErrorKind::Permission)?;
   let pkg_json_resolver = state.borrow::<PackageJsonResolverRc<TSys>>();
   let pkg = pkg_json_resolver
-    .get_closest_package_json(Path::new(parent_path))
+    .get_closest_package_json(&parent_path)
     .ok()
     .flatten();
   let Some(pkg) = pkg else {

--- a/tests/specs/permission/node_require_try_self_no_perms/__test__.jsonc
+++ b/tests/specs/permission/node_require_try_self_no_perms/__test__.jsonc
@@ -1,0 +1,12 @@
+{
+  "tests": {
+    "denied": {
+      "args": "run main.mjs",
+      "output": "denied.out"
+    },
+    "granted": {
+      "args": "run --allow-read main.mjs",
+      "output": "granted.out"
+    }
+  }
+}

--- a/tests/specs/permission/node_require_try_self_no_perms/denied.out
+++ b/tests/specs/permission/node_require_try_self_no_perms/denied.out
@@ -1,0 +1,1 @@
+result: denied

--- a/tests/specs/permission/node_require_try_self_no_perms/granted.out
+++ b/tests/specs/permission/node_require_try_self_no_perms/granted.out
@@ -1,0 +1,1 @@
+result: resolved

--- a/tests/specs/permission/node_require_try_self_no_perms/main.mjs
+++ b/tests/specs/permission/node_require_try_self_no_perms/main.mjs
@@ -1,0 +1,22 @@
+// Regression test: op_require_try_self walks up from a caller-controlled
+// parent path reading package.json files, so it must require read permission
+// for that path, like its sibling op_require_package_imports_resolve. Here the
+// require's parent path points inside ./selfpkg, whose package.json declares a
+// self-referential "exports". Without --allow-read, resolving the package's
+// own name must throw NotCapable rather than silently read package.json off
+// disk.
+
+import { createRequire } from "node:module";
+
+const parent = new URL("./selfpkg/sub/x.js", import.meta.url).pathname;
+const require = createRequire(parent);
+
+try {
+  require.resolve("selfpkg");
+  console.log("result: resolved");
+} catch (e) {
+  console.log(
+    "result:",
+    e.name === "NotCapable" ? "denied" : `other:${e.name}`,
+  );
+}

--- a/tests/specs/permission/node_require_try_self_no_perms/main.mjs
+++ b/tests/specs/permission/node_require_try_self_no_perms/main.mjs
@@ -7,8 +7,12 @@
 // disk.
 
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
-const parent = new URL("./selfpkg/sub/x.js", import.meta.url).pathname;
+// Use fileURLToPath rather than URL.pathname: on Windows `.pathname` yields a
+// leading-slash path like `/C:/...` that isn't a valid OS path, which makes
+// createRequire fail before it reaches op_require_try_self.
+const parent = fileURLToPath(new URL("./selfpkg/sub/x.js", import.meta.url));
 const require = createRequire(parent);
 
 try {

--- a/tests/specs/permission/node_require_try_self_no_perms/selfpkg/index.js
+++ b/tests/specs/permission/node_require_try_self_no_perms/selfpkg/index.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/tests/specs/permission/node_require_try_self_no_perms/selfpkg/package.json
+++ b/tests/specs/permission/node_require_try_self_no_perms/selfpkg/package.json
@@ -1,0 +1,1 @@
+{ "name": "selfpkg", "version": "1.0.0", "exports": { ".": "./index.js" } }


### PR DESCRIPTION
op_require_try_self walked up from a caller-controlled parent path reading
package.json files (via get_closest_package_json) with no permission check.
That parent path is attacker-controllable through
Module.createRequire(path).resolve(name), so code running without
--allow-read could probe for and read package.json files at arbitrary
locations on the filesystem, a read the sandbox is supposed to prevent.

The sibling op op_require_package_imports_resolve already guards the exact
same helper with ensure_read_permission before touching the filesystem;
op_require_try_self simply omitted it. This adds the same guard, so the
parent path is permission-checked first: resolving a package's own name now
throws NotCapable without --allow-read and works with it. A spec test covers
both cases.