### PR TITLE
feat(permissions): default-readable environment variable allowlist

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1229,6 +1229,7 @@ impl CliOptions {
       &mut permissions_options,
       has_config_permissions,
     );
+    self.apply_always_on_env_vars(&mut permissions_options);
     if let DenoSubcommand::Serve(serve_flags) = &self.flags.subcommand {
       augment_permissions_with_serve_flags(
         &mut permissions_options,
@@ -1356,15 +1357,11 @@ impl CliOptions {
   ///
   /// `--deny-*` flags do not disable the profile; they compose on top since
   /// deny always wins.
-  fn maybe_apply_relaxed_default_permissions(
-    &self,
-    options: &mut PermissionsOptions,
-    has_config_permissions: bool,
-  ) {
-    // Only for subcommands that execute user code with the prompt-based
-    // defaults. `deno eval` and `deno x` already imply allow-all, and
-    // `deno compile` bakes permissions at compile time (out of scope).
-    if !matches!(
+  /// Whether the current subcommand executes user code with the prompt-based
+  /// permission defaults. `deno eval` and `deno x` already imply allow-all, and
+  /// `deno compile` bakes permissions at compile time (out of scope).
+  fn runs_user_code_with_prompt_defaults(&self) -> bool {
+    matches!(
       self.flags.subcommand,
       DenoSubcommand::Run(_)
         | DenoSubcommand::Serve(_)
@@ -1372,7 +1369,34 @@ impl CliOptions {
         | DenoSubcommand::Bench(_)
         | DenoSubcommand::Task(_)
         | DenoSubcommand::Repl(_)
-    ) {
+    )
+  }
+
+  /// Folds the always-on env variables (`ALWAYS_ON_ENV_VARS`) into the computed
+  /// `allow_env` descriptors so they remain readable without a prompt in every
+  /// profile, including the strict default. This replaces the historical
+  /// unconditional `skip_permission_check` bypass in `op_get_env`: because the
+  /// read now goes through the permission path, `--deny-env` wins over these
+  /// grants, which the bypass did not allow.
+  ///
+  /// Applied regardless of the relaxed-permissions gate. It composes on top of
+  /// whatever `allow_env` the flags, config or relaxed profile produced, and
+  /// preserves the "allow all" meaning of an empty `allow_env` list.
+  fn apply_always_on_env_vars(&self, options: &mut PermissionsOptions) {
+    if !self.runs_user_code_with_prompt_defaults() {
+      return;
+    }
+    merge_default_allow_env(&mut options.allow_env, ALWAYS_ON_ENV_VARS);
+  }
+
+  fn maybe_apply_relaxed_default_permissions(
+    &self,
+    options: &mut PermissionsOptions,
+    has_config_permissions: bool,
+  ) {
+    // Only for subcommands that execute user code with the prompt-based
+    // defaults.
+    if !self.runs_user_code_with_prompt_defaults() {
       return;
     }
 
@@ -1399,8 +1423,15 @@ impl CliOptions {
 
     // read: allowed everywhere (empty allow-list means "allow all").
     options.allow_read = Some(Vec::new());
-    // env: allowed everywhere.
-    options.allow_env = Some(Vec::new());
+    // env: allowed for the curated default-readable allowlist (see #35950).
+    // This is a deny-respecting allow-list (not an allow-all bypass), so
+    // credential-shaped variables still prompt and `--deny-env` still wins.
+    options.allow_env = Some(
+      RELAXED_DEFAULT_ENV_ALLOWLIST
+        .iter()
+        .map(|name| name.to_string())
+        .collect(),
+    );
     // write: confined to the cwd (recorded at process start) and the OS temp
     // directory.
     options.allow_write = Some(relaxed_default_write_paths(self.initial_cwd()));
@@ -1844,6 +1875,163 @@ fn relaxed_default_write_paths(initial_cwd: &Path) -> Vec<String> {
     .into_iter()
     .map(|path| path.to_string_lossy().into_owned())
     .collect()
+}
+
+/// Environment variables that Deno reads without an env permission prompt in
+/// every profile, including the strict default. These are the four Node compat
+/// variables that were historically read via an unconditional
+/// `skip_permission_check` bypass in `op_get_env` (see #15890). They are folded
+/// into the default `allow_env` descriptors here so that reads still go through
+/// the permission path and therefore honor `--deny-env` (deny always wins),
+/// while user code and the Node polyfills keep reading them without a prompt.
+///
+/// Every entry here is also part of `RELAXED_DEFAULT_ENV_ALLOWLIST`.
+const ALWAYS_ON_ENV_VARS: [&str; 4] =
+  ["FORCE_COLOR", "NODE_DEBUG", "NODE_OPTIONS", "NO_COLOR"];
+
+/// The curated default-readable environment variable allowlist applied by the
+/// relaxed default permission profile. These names are structurally
+/// non-sensitive (terminal/color, locale, standard directory paths, CI
+/// detection, common Node/runtime knobs, and the `npm_*` variables that
+/// `deno task` itself sets), so ordinary CLI tools run without env prompts
+/// while every credential-shaped variable still prompts exactly as before.
+///
+/// A trailing `*` denotes a prefix pattern (handled by `EnvDescriptor::new`).
+/// Wildcards are used only where an entire namespace is structurally
+/// non-secret. Namespaces that carry credentials, such as `npm_config_*`,
+/// `GITHUB_*`, `AWS_*` and `DENO_*`, are never wildcarded.
+///
+/// This list is intentionally curated and baked into the binary; see #35950.
+/// It must stay a superset of `ALWAYS_ON_ENV_VARS`.
+const RELAXED_DEFAULT_ENV_ALLOWLIST: &[&str] = &[
+  // Terminal / color / TTY.
+  "TERM",
+  "COLORTERM",
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+  "TERMINFO",
+  "COLUMNS",
+  "LINES",
+  "NO_COLOR",
+  "FORCE_COLOR",
+  "CLICOLOR",
+  "CLICOLOR_FORCE",
+  // Locale / timezone.
+  "LANG",
+  "LANGUAGE",
+  "LC_*",
+  "TZ",
+  // Shell / identity / cwd. `_` is the shell-provided path of the running
+  // executable (argv0), read by many Node CLIs such as yargs.
+  "SHELL",
+  "USER",
+  "LOGNAME",
+  "USERNAME",
+  "HOME",
+  "USERPROFILE",
+  "PWD",
+  "OLDPWD",
+  "_",
+  // Paths / XDG / Windows dirs.
+  "PATH",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "XDG_*",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "PROGRAMDATA",
+  "PROGRAMFILES",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "SYSTEMROOT",
+  "WINDIR",
+  "PATHEXT",
+  "COMSPEC",
+  // OS / platform.
+  "OS",
+  "OSTYPE",
+  "HOSTTYPE",
+  "MACHTYPE",
+  "PROCESSOR_ARCHITECTURE",
+  // Node / runtime knobs.
+  "NODE_ENV",
+  "NODE_OPTIONS",
+  "NODE_PATH",
+  "NODE_DEBUG",
+  "NODE_NO_WARNINGS",
+  "NODE_DISABLE_COLORS",
+  "NODE_PENDING_DEPRECATION",
+  "NODE_ICU_DATA",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_UPDATE_NOTIFIER",
+  // `deno task` npm_* vars (exactly what `deno task` sets; refs #35251,
+  // #35306).
+  "npm_package_name",
+  "npm_package_version",
+  "npm_package_json",
+  "npm_package_config_*",
+  "npm_execpath",
+  "npm_node_execpath",
+  "npm_command",
+  "npm_lifecycle_event",
+  "npm_lifecycle_script",
+  "npm_config_user_agent",
+  "INIT_CWD",
+  // Debug conventions.
+  "DEBUG",
+  "DEBUG_*",
+  // Editor / pager.
+  "EDITOR",
+  "VISUAL",
+  "PAGER",
+  "MANPAGER",
+  "GIT_PAGER",
+  "BROWSER",
+  // CI detection (boolean/name flags read by `ci-info` and friends; the
+  // enumerated set never includes CI secret tokens).
+  "CI",
+  "CONTINUOUS_INTEGRATION",
+  "BUILD_NUMBER",
+  "CI_NAME",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "CIRCLECI",
+  "TRAVIS",
+  "APPVEYOR",
+  "JENKINS_URL",
+  "TEAMCITY_VERSION",
+  "BUILDKITE",
+  "DRONE",
+  "TF_BUILD",
+  "NETLIFY",
+  "VERCEL",
+  "CODEBUILD_BUILD_ID",
+];
+
+/// Merges `additions` into `allow_env`, preserving the "allow all" meaning of an
+/// empty allow-list. When `allow_env` is `None` it becomes a fresh list of the
+/// additions; when it is a non-empty list the additions are appended (skipping
+/// duplicates); when it is `Some` but empty (allow all) it is left untouched.
+fn merge_default_allow_env(
+  allow_env: &mut Option<Vec<String>>,
+  additions: impl IntoIterator<Item = &'static str>,
+) {
+  match allow_env {
+    None => {
+      *allow_env = Some(additions.into_iter().map(|s| s.to_string()).collect());
+    }
+    Some(list) if list.is_empty() => {
+      // Empty list means "allow all"; adding names would narrow it. Leave it.
+    }
+    Some(list) => {
+      for addition in additions {
+        if !list.iter().any(|existing| existing == addition) {
+          list.push(addition.to_string());
+        }
+      }
+    }
+  }
 }
 
 // DO NOT make this public. People should use `cli_options.permissions_options/permissions_options_for_dir`

--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -23,11 +23,6 @@ pub mod sys_info;
 
 pub use ops::signal::SignalError;
 
-// The full list of environment variables supported by Node.js is available
-// at https://nodejs.org/api/cli.html#environment-variables
-const SORTED_NODE_ENV_VAR_ALLOWLIST: [&str; 4] =
-  ["FORCE_COLOR", "NODE_DEBUG", "NODE_OPTIONS", "NO_COLOR"];
-
 #[derive(Clone, Default)]
 pub struct ExitCode(Arc<AtomicI32>);
 
@@ -253,12 +248,23 @@ fn op_env(
   let grant_all = match permissions_container.check_env_all() {
     Ok(()) => true,
     Err(PermissionCheckError::PermissionDenied(err)) => match err.state {
-      PermissionState::Granted
-      | PermissionState::Prompt
-      | PermissionState::Denied => return Err(err.into()),
       PermissionState::GrantedPartial
       | PermissionState::DeniedPartial
       | PermissionState::Ignored => false,
+      // A partial allow-list (specific variables granted without a global
+      // grant) reports the "all" query as denied non-interactively, but
+      // enumeration should still return the granted subset rather than failing
+      // the whole call. Fall through to per-variable filtering when such a
+      // grant exists; genuine no-access keeps failing as before.
+      PermissionState::Granted
+      | PermissionState::Prompt
+      | PermissionState::Denied => {
+        if permissions_container.env_has_granted_list() {
+          false
+        } else {
+          return Err(err.into());
+        }
+      }
     },
     Err(err) => return Err(err),
   };
@@ -315,11 +321,7 @@ fn op_get_env(
   state: &mut OpState,
   #[string] key: &str,
 ) -> Result<Option<String>, OsError> {
-  let skip_permission_check =
-    SORTED_NODE_ENV_VAR_ALLOWLIST.binary_search(&key).is_ok();
-
-  if !skip_permission_check && check_env_with_maybe_exit(state, key)?.is_break()
-  {
+  if check_env_with_maybe_exit(state, key)?.is_break() {
     return Ok(None);
   }
 
@@ -818,17 +820,4 @@ fn os_uptime(state: &mut OpState) -> Result<u64, PermissionCheckError> {
 #[number]
 fn op_os_uptime(state: &mut OpState) -> Result<u64, PermissionCheckError> {
   os_uptime(state)
-}
-
-#[cfg(test)]
-mod test {
-  use crate::SORTED_NODE_ENV_VAR_ALLOWLIST;
-
-  #[test]
-  fn ensure_node_env_var_list_sorted() {
-    // ensure this is sorted for binary search
-    let mut items = SORTED_NODE_ENV_VAR_ALLOWLIST.to_vec();
-    items.sort();
-    assert_eq!(items, SORTED_NODE_ENV_VAR_ALLOWLIST);
-  }
 }

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -983,6 +983,19 @@ impl<
       && !has_broker()
   }
 
+  /// Whether a specific (non-global) descriptor has been granted, i.e. a
+  /// partial allow-list is in effect. Querying `None` (the "all" query) reports
+  /// `Prompt` in this case even though some individual descriptors are granted,
+  /// so enumeration APIs use this to fall back to per-descriptor filtering
+  /// instead of failing.
+  pub fn has_granted_list(&self) -> bool {
+    !self.granted_global
+      && self
+        .descriptors
+        .iter()
+        .any(|desc| matches!(desc, UnaryPermissionDesc::Granted(_)))
+  }
+
   pub fn check_all_api(
     &mut self,
     api_name: Option<&str>,
@@ -4397,6 +4410,14 @@ impl PermissionsContainer {
   pub fn check_env_all(&self) -> Result<(), PermissionCheckError> {
     self.inner.lock().env.check_all()?;
     Ok(())
+  }
+
+  /// Whether a partial env allow-list is in effect (specific variables granted
+  /// without a global grant). Enumeration via `Deno.env.toObject()` uses this
+  /// to return the granted subset rather than failing the whole call.
+  #[inline(always)]
+  pub fn env_has_granted_list(&self) -> bool {
+    self.inner.lock().env.has_granted_list()
   }
 
   #[inline(always)]

--- a/tests/specs/permission/env_allowlist/__test__.jsonc
+++ b/tests/specs/permission/env_allowlist/__test__.jsonc
@@ -1,0 +1,76 @@
+{
+  // The default-readable environment variable allowlist (#35950). Spec tests
+  // run non-interactively, so a would-be prompt surfaces as a hard NotCapable
+  // error; a step that reads a variable successfully therefore proves there was
+  // no prompt.
+  "tests": {
+    "relaxed_allowlisted": {
+      // gate on: allowlisted vars, including the LC_*, XDG_* and
+      // npm_package_config_* prefix members, read without a prompt
+      "args": "run --quiet allowlisted.ts",
+      "envs": {
+        "DENO_UNSTABLE_RELAXED_PERMISSIONS": "1",
+        "TERM": "xterm-256color",
+        "LC_ALL": "en_US.UTF-8",
+        "XDG_CONFIG_HOME": "/home/user/.config",
+        "npm_package_name": "myapp"
+      },
+      "output": "allowlisted.out"
+    },
+    "relaxed_deny_wins": {
+      // gate on: --deny-env=TERM removes TERM from the grant (deny wins)
+      "args": "run --quiet --deny-env=TERM deny_term.ts",
+      "envs": {
+        "DENO_UNSTABLE_RELAXED_PERMISSIONS": "1",
+        "TERM": "xterm-256color"
+      },
+      "output": "deny_term.out"
+    },
+    "relaxed_secrets_still_prompt": {
+      // gate on: credential-shaped variables are not on the allowlist and still
+      // fail non-interactively naming --allow-env
+      "args": "run --quiet secrets.ts",
+      "envs": {
+        "DENO_UNSTABLE_RELAXED_PERMISSIONS": "1",
+        "AWS_SECRET_ACCESS_KEY": "shhh",
+        "npm_config__authToken": "shhh"
+      },
+      "output": "secrets.out"
+    },
+    "relaxed_to_object_filters": {
+      // gate on: toObject returns only allowlisted vars present, without a
+      // prompt; secrets are absent
+      "args": "run --quiet to_object.ts",
+      "envs": {
+        "DENO_UNSTABLE_RELAXED_PERMISSIONS": "1",
+        "TERM": "xterm-256color",
+        "LANG": "C",
+        "MY_APP_SECRET": "shhh",
+        "APP_TOKEN": "shhh"
+      },
+      "output": "to_object.out"
+    },
+    "strict_always_on_readable": {
+      // gate off (strict default): the always-on NO_COLOR stays readable
+      // without a prompt, while an unlisted var like TERM still fails
+      "args": "run --quiet strict.ts",
+      "envs": {
+        "DENO_UNSTABLE_RELAXED_PERMISSIONS": "0",
+        "NO_COLOR": "1",
+        "TERM": "xterm-256color"
+      },
+      "output": "strict.out"
+    },
+    "strict_deny_always_on": {
+      // gate off: --deny-env=NO_COLOR now makes the always-on NO_COLOR fail
+      // (deny wins), which the old skip-check bypass did not allow
+      "args": "run --quiet --deny-env=NO_COLOR strict.ts",
+      "envs": {
+        "DENO_UNSTABLE_RELAXED_PERMISSIONS": "0",
+        "NO_COLOR": "1",
+        "TERM": "xterm-256color"
+      },
+      "output": "strict_deny.out"
+    }
+  }
+}

--- a/tests/specs/permission/env_allowlist/allowlisted.out
+++ b/tests/specs/permission/env_allowlist/allowlisted.out
@@ -1,0 +1,4 @@
+TERM: xterm-256color
+LC_ALL: en_US.UTF-8
+XDG_CONFIG_HOME: /home/user/.config
+npm_package_name: myapp

--- a/tests/specs/permission/env_allowlist/allowlisted.ts
+++ b/tests/specs/permission/env_allowlist/allowlisted.ts
@@ -1,0 +1,11 @@
+// Reading allowlisted variables (including prefix-pattern members) succeeds
+// without a prompt. Under --deny-env=TERM the TERM read instead fails naming
+// --allow-env (see deny_term.out).
+for (const key of ["TERM", "LC_ALL", "XDG_CONFIG_HOME", "npm_package_name"]) {
+  try {
+    console.log(`${key}: ${Deno.env.get(key)}`);
+  } catch (err) {
+    const named = err.message.includes("--allow-env") ? "--allow-env" : "?";
+    console.log(`${key}: ${err.name} ${named}`);
+  }
+}

--- a/tests/specs/permission/env_allowlist/deny_term.out
+++ b/tests/specs/permission/env_allowlist/deny_term.out
@@ -1,0 +1,1 @@
+TERM: NotCapable --allow-env

--- a/tests/specs/permission/env_allowlist/deny_term.ts
+++ b/tests/specs/permission/env_allowlist/deny_term.ts
@@ -1,0 +1,9 @@
+// TERM is normally allowlisted, but --deny-env=TERM removes it from the grant
+// because deny always wins, so the read fails naming --allow-env.
+try {
+  Deno.env.get("TERM");
+  console.log("TERM: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-env") ? "--allow-env" : "?";
+  console.log(`TERM: ${err.name} ${named}`);
+}

--- a/tests/specs/permission/env_allowlist/secrets.out
+++ b/tests/specs/permission/env_allowlist/secrets.out
@@ -1,0 +1,2 @@
+AWS_SECRET_ACCESS_KEY: NotCapable --allow-env
+npm_config__authToken: NotCapable --allow-env

--- a/tests/specs/permission/env_allowlist/secrets.ts
+++ b/tests/specs/permission/env_allowlist/secrets.ts
@@ -1,0 +1,12 @@
+// Credential-shaped variables are never on the allowlist, so reading them
+// still fails non-interactively naming --allow-env. `npm_config__authToken`
+// shows that the npm_config_* namespace is not wildcarded.
+for (const key of ["AWS_SECRET_ACCESS_KEY", "npm_config__authToken"]) {
+  try {
+    Deno.env.get(key);
+    console.log(`${key}: UNEXPECTEDLY ALLOWED`);
+  } catch (err) {
+    const named = err.message.includes("--allow-env") ? "--allow-env" : "?";
+    console.log(`${key}: ${err.name} ${named}`);
+  }
+}

--- a/tests/specs/permission/env_allowlist/strict.out
+++ b/tests/specs/permission/env_allowlist/strict.out
@@ -1,0 +1,2 @@
+NO_COLOR: 1
+TERM: NotCapable --allow-env

--- a/tests/specs/permission/env_allowlist/strict.ts
+++ b/tests/specs/permission/env_allowlist/strict.ts
@@ -1,0 +1,12 @@
+// In the strict default profile (relaxed gate off), the four always-on Node
+// compat variables stay readable without a prompt. NO_COLOR is one of them; an
+// unlisted variable such as TERM still fails naming --allow-env. With
+// --deny-env=NO_COLOR the always-on read fails too, since deny wins.
+for (const key of ["NO_COLOR", "TERM"]) {
+  try {
+    console.log(`${key}: ${Deno.env.get(key)}`);
+  } catch (err) {
+    const named = err.message.includes("--allow-env") ? "--allow-env" : "?";
+    console.log(`${key}: ${err.name} ${named}`);
+  }
+}

--- a/tests/specs/permission/env_allowlist/strict_deny.out
+++ b/tests/specs/permission/env_allowlist/strict_deny.out
@@ -1,0 +1,2 @@
+NO_COLOR: NotCapable --allow-env
+TERM: NotCapable --allow-env

--- a/tests/specs/permission/env_allowlist/to_object.out
+++ b/tests/specs/permission/env_allowlist/to_object.out
@@ -1,0 +1,4 @@
+TERM present: true
+LANG present: true
+MY_APP_SECRET present: false
+APP_TOKEN present: false

--- a/tests/specs/permission/env_allowlist/to_object.ts
+++ b/tests/specs/permission/env_allowlist/to_object.ts
@@ -1,0 +1,7 @@
+// toObject enumerates only the allowlisted variables present in the
+// environment, without a prompt. Credential-shaped variables are absent.
+const obj = Deno.env.toObject();
+console.log(`TERM present: ${"TERM" in obj}`);
+console.log(`LANG present: ${"LANG" in obj}`);
+console.log(`MY_APP_SECRET present: ${"MY_APP_SECRET" in obj}`);
+console.log(`APP_TOKEN present: ${"APP_TOKEN" in obj}`);

--- a/tests/specs/permission/relaxed_default/__test__.jsonc
+++ b/tests/specs/permission/relaxed_default/__test__.jsonc
@@ -2,7 +2,7 @@
   "tempDir": true,
   "envs": {
     "DENO_UNSTABLE_RELAXED_PERMISSIONS": "1",
-    "RELAXED_TEST_VAR": "hello"
+    "TERM": "hello"
   },
   "tests": {
     "profile_default": {

--- a/tests/specs/permission/relaxed_default/profile.ts
+++ b/tests/specs/permission/relaxed_default/profile.ts
@@ -27,5 +27,5 @@ try {
   console.log(`write outside: ${err.name} ${named}`);
 }
 
-// env access is allowed
-console.log(`env: ${Deno.env.get("RELAXED_TEST_VAR")}`);
+// env access is allowed for the curated default-readable allowlist
+console.log(`env: ${Deno.env.get("TERM")}`);


### PR DESCRIPTION
This expands the default-readable set of environment variables to a
curated allowlist of names that are structurally non-sensitive, so that
ordinary CLI tools run without env prompts while every credential-shaped
variable still prompts exactly as before. Reading TERM, LANG, CI,
NODE_ENV and friends no longer trains users to reach for -A.

The allowlist (~90 names) covers terminal/color, locale/timezone,
shell/identity, standard directory paths including the XDG and Windows
dir namespaces, OS/platform, common Node/runtime knobs, the npm_*
variables that deno task itself sets, debug conventions, editor/pager
and CI detection. It is hard-coded into the binary. Trailing-* prefix
patterns are used only where an entire namespace is non-secret (LC_*,
XDG_*, DEBUG_*, npm_package_config_*); namespaces that carry credentials
such as npm_config_*, GITHUB_*, AWS_* and DENO_* are never wildcarded.

The list is applied as the env grant of the unstable relaxed default
permission profile from #35710, replacing that profile's previous
allow-all-env behavior. It is a deny-respecting allow-list rather than a
bypass: --deny-env removes an entry (deny wins), --allow-env is additive,
querying a listed variable reports granted while an unlisted one reports
prompt, and Deno.env.toObject() returns only the allowlisted subset
present in the environment with no prompt.

As part of this, the four variables Deno already read unconditionally
(FORCE_COLOR, NODE_DEBUG, NODE_OPTIONS, NO_COLOR) are folded into these
descriptors and the skip_permission_check branch in op_get_env is
removed, so every user-facing env read now goes through the permission
path. These four are injected as default allow_env descriptors regardless
of the relaxed gate, so they keep reading without a prompt in the strict
default too, but they now honor --deny-env, which the old bypass did not
allow. Internal color detection does not depend on the removed bypass; it
reads std::env / deno_terminal::colors directly.

Enumerating via toObject with a partial allow-list previously failed the
whole call because the "all" env query reports as denied when only
specific names are granted. op_env now falls back to per-variable
filtering when a partial grant exists, and a new env_has_granted_list
helper keeps genuine no-access (for example a worker with env: false)
failing as before.

The shell/identity group additionally includes _, the shell-provided
path of the running executable that many Node CLIs such as yargs read, so
that running npm:cowsay completes with zero prompts. It is not in the
issue's enumerated list; flagging it here for review.

Rollout stays gated behind the existing relaxed-permissions unstable
flag; this stacks on #35710 and targets its branch.

Closes #35950
