### PR TITLE
perf(ext/crypto): batch randomUUID generation

### DIFF
--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -17,6 +17,8 @@
 (function () {
 const { core, primordials, internals } = __bootstrap;
 const {
+  op_crypto_is_seeded,
+  op_crypto_random_uuid_batch,
   Crypto,
   CryptoKey,
   SubtleCrypto,
@@ -27,6 +29,7 @@ const {
   ObjectDefineProperty,
   ObjectPrototypeIsPrototypeOf,
   SafeArrayIterator,
+  StringPrototypeSlice,
   SymbolFor,
 } = primordials;
 
@@ -239,12 +242,41 @@ function getSubtleSingleton() {
   return subtleSingleton;
 }
 
-// `Crypto` is the cppgc-wrapped Rust class imported above; `getRandomValues`,
-// `randomUUID` and the `subtle` getter are implemented natively in
-// `crypto.rs`. Here we only decorate the prototype with the inspector hook
-// and the WebIDL `Symbol.toStringTag` machinery, then mint the singleton
-// via `Crypto.create(subtle)` (a static method on the cppgc class).
+// `Crypto` is the cppgc-wrapped Rust class imported above. `getRandomValues`
+// and the `subtle` getter are implemented natively in `crypto.rs`. The normal
+// `randomUUID` path batches complete UUID strings so calls after a refill stay
+// in JS; seeded runtimes use the native method to preserve exact RNG call order.
 const CryptoPrototype = Crypto.prototype;
+const cppgcRandomUUID = CryptoPrototype.randomUUID;
+
+const UUID_STRING_BYTES = 36;
+const UUID_BATCH_SIZE = 128;
+let uuidBatchData;
+let uuidBatch = UUID_BATCH_SIZE;
+
+function randomUUID() {
+  if (this !== cryptoSingleton || usesSeededRng) {
+    return FunctionPrototypeCall(cppgcRandomUUID, this);
+  }
+  if (uuidBatch === UUID_BATCH_SIZE) {
+    uuidBatchData = op_crypto_random_uuid_batch();
+    uuidBatch = 0;
+  }
+  const start = uuidBatch++ * UUID_STRING_BYTES;
+  return StringPrototypeSlice(
+    uuidBatchData,
+    start,
+    start + UUID_STRING_BYTES,
+  );
+}
+
+ObjectDefineProperty(CryptoPrototype, "randomUUID", {
+  __proto__: null,
+  value: randomUUID,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
 ObjectDefineProperty(CryptoPrototype, SymbolFor("Deno.privateCustomInspect"), {
   __proto__: null,
   value: function (inspect, inspectOptions) {
@@ -265,9 +297,11 @@ webidl.configureInterface(Crypto);
 applyWebIdlInterfaceShape(Crypto);
 
 let cryptoSingleton;
+let usesSeededRng = false;
 function getCryptoSingleton() {
   if (cryptoSingleton === undefined) {
     cryptoSingleton = Crypto.create(getSubtleSingleton());
+    usesSeededRng = op_crypto_is_seeded();
     // Stamp the WebIDL brand so `Reflect.getPrototypeOf(crypto)` and
     // the IDL `Crypto interface: operation randomUUID()` invariants
     // resolve through the same brand-check path as `SubtleCrypto`.

--- a/ext/crypto/crypto.rs
+++ b/ext/crypto/crypto.rs
@@ -19,8 +19,33 @@ use rand::rngs::StdRng;
 use rand::thread_rng;
 
 use crate::CryptoError;
-use crate::fast_uuid_v4;
+use crate::fast_uuid_v4_bytes;
 use crate::shared::SharedError;
+
+const UUID_BYTES: usize = 16;
+const UUID_STRING_BYTES: usize = 36;
+const UUID_BATCH_SIZE: usize = 128;
+
+#[op2]
+pub fn op_crypto_random_uuid_batch<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+) -> Result<v8::Local<'s, v8::String>, CryptoError> {
+  let mut entropy = [0u8; UUID_BYTES * UUID_BATCH_SIZE];
+  let mut output = [0u8; UUID_STRING_BYTES * UUID_BATCH_SIZE];
+  thread_rng().fill(&mut entropy[..]);
+
+  for (bytes, uuid_output) in entropy
+    .chunks_exact_mut(UUID_BYTES)
+    .zip(output.chunks_exact_mut(UUID_STRING_BYTES))
+  {
+    let bytes: &mut [u8; UUID_BYTES] = bytes.try_into().unwrap();
+    let uuid = fast_uuid_v4_bytes(bytes);
+    uuid_output.copy_from_slice(&uuid);
+  }
+
+  v8::String::new_from_one_byte(scope, &output, v8::NewStringType::Normal)
+    .ok_or(CryptoError::UuidStringAllocation)
+}
 
 pub struct Crypto {
   /// The single `SubtleCrypto` instance returned by the `subtle` getter.
@@ -148,18 +173,23 @@ impl Crypto {
     crate::make_key::register_symbols(scope, webidl_brand, k_key_object)
   }
 
-  #[string]
   #[rename("randomUUID")]
   #[required(0)]
-  fn random_uuid(&self, state: &mut OpState) -> String {
+  fn random_uuid<'s>(
+    &self,
+    state: &mut OpState,
+    scope: &mut v8::PinScope<'s, '_>,
+  ) -> Result<v8::Local<'s, v8::String>, CryptoError> {
     let maybe_seeded_rng = state.try_borrow_mut::<StdRng>();
-    let mut bytes = [0u8; 16];
+    let mut bytes = [0u8; UUID_BYTES];
     if let Some(seeded_rng) = maybe_seeded_rng {
       seeded_rng.fill(&mut bytes);
     } else {
       let mut rng = thread_rng();
       rng.fill(&mut bytes);
     }
-    fast_uuid_v4(&mut bytes)
+    let uuid = fast_uuid_v4_bytes(&mut bytes);
+    v8::String::new_from_one_byte(scope, &uuid, v8::NewStringType::Normal)
+      .ok_or(CryptoError::UuidStringAllocation)
   }
 }

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -6,7 +6,9 @@ use aws_lc_rs::hkdf;
 use aws_lc_rs::hmac::Algorithm as HmacAlgorithm;
 use aws_lc_rs::hmac::Key as HmacKey;
 use aws_lc_rs::pbkdf2;
+use deno_core::OpState;
 use deno_core::convert::Uint8Array;
+use deno_core::op2;
 use deno_error::JsErrorBox;
 use p256::ecdsa::Signature as P256Signature;
 use p256::ecdsa::SigningKey as P256SigningKey;
@@ -97,13 +99,24 @@ pub use crate::shared::SharedError;
 pub use crate::x448::X448Error;
 pub use crate::x25519::X25519Error;
 
-// No standalone ops — every WebCrypto entry point is implemented as a
-// method on the `Crypto`/`SubtleCrypto`/`CryptoKey` cppgc classes
-// registered below under `objects`. The per-algorithm helpers
+#[op2(fast)]
+fn op_crypto_is_seeded(state: &OpState) -> bool {
+  state.try_borrow::<StdRng>().is_some()
+}
+
+// WebCrypto entry points are implemented as methods on the
+// `Crypto`/`SubtleCrypto`/`CryptoKey` cppgc classes registered below under
+// `objects`. The standalone ops select the seeded `randomUUID` path once when
+// the runtime mints its Crypto singleton and refill the normal path's UUID
+// batch. The per-algorithm helpers
 // (`subtle_*::run`, `import_key_inner`, `export_key_inner`, etc.) are
 // pure-Rust and called directly from those method bodies.
 deno_core::extension!(deno_crypto,
   deps = [ deno_webidl, deno_web ],
+  ops = [
+    crypto::op_crypto_random_uuid_batch,
+    op_crypto_is_seeded,
+  ],
   objects = [
     crypto::Crypto,
     subtle_crypto::SubtleCrypto,
@@ -210,6 +223,9 @@ pub enum CryptoError {
   #[class("DOMExceptionNotSupportedError")]
   #[error("Algorithm '{0}' is not supported")]
   UnsupportedDigestAlgorithm(String),
+  #[class(generic)]
+  #[error("failed to allocate UUID string")]
+  UuidStringAllocation,
   #[class(inherit)]
   #[error(transparent)]
   Other(
@@ -895,12 +911,12 @@ fn read_rsa_public_key(key_data: KeyData) -> Result<RsaPublicKey, CryptoError> {
 
 const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
 
-pub(crate) fn fast_uuid_v4(bytes: &mut [u8; 16]) -> String {
+pub(crate) fn fast_uuid_v4_bytes(bytes: &mut [u8; 16]) -> [u8; 36] {
   // Set UUID version to 4 and variant to 1.
   bytes[6] = (bytes[6] & 0x0f) | 0x40;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
 
-  let buf = [
+  [
     HEX_CHARS[(bytes[0] >> 4) as usize],
     HEX_CHARS[(bytes[0] & 0x0f) as usize],
     HEX_CHARS[(bytes[1] >> 4) as usize],
@@ -937,7 +953,12 @@ pub(crate) fn fast_uuid_v4(bytes: &mut [u8; 16]) -> String {
     HEX_CHARS[(bytes[14] & 0x0f) as usize],
     HEX_CHARS[(bytes[15] >> 4) as usize],
     HEX_CHARS[(bytes[15] & 0x0f) as usize],
-  ];
+  ]
+}
+
+#[cfg(test)]
+fn fast_uuid_v4(bytes: &mut [u8; 16]) -> String {
+  let buf = fast_uuid_v4_bytes(bytes);
 
   // Safety: the buffer is all valid UTF-8.
   unsafe { String::from_utf8_unchecked(buf.to_vec()) }

--- a/ext/node/polyfills/internal/crypto/random.ts
+++ b/ext/node/polyfills/internal/crypto/random.ts
@@ -409,7 +409,34 @@ function randomUUID(options) {
 
   validateBoolean(disableEntropyCache, "options.disableEntropyCache");
 
+  if (disableEntropyCache) {
+    return randomUUIDUncached();
+  }
+
   return globalThis.crypto.randomUUID();
+}
+
+function randomUUIDUncached() {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const chars: number[] = new Array(36);
+  let charIndex = 0;
+  for (let byteIndex = 0; byteIndex < 16; byteIndex++) {
+    if (
+      byteIndex === 4 || byteIndex === 6 || byteIndex === 8 ||
+      byteIndex === 10
+    ) {
+      chars[charIndex++] = 45;
+    }
+    const byte = bytes[byteIndex];
+    chars[charIndex++] = numberToHexCharCode(byte >> 4);
+    chars[charIndex++] = numberToHexCharCode(byte & 0x0f);
+  }
+
+  return StringFromCharCode(...new SafeArrayIterator(chars));
 }
 
 return {

--- a/tests/unit_node/crypto/crypto_misc_test.ts
+++ b/tests/unit_node/crypto/crypto_misc_test.ts
@@ -1,12 +1,24 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 import { randomFillSync, randomUUID, timingSafeEqual } from "node:crypto";
 import { Buffer } from "node:buffer";
-import { assert, assertEquals, assertThrows } from "../../unit/test_util.ts";
+import {
+  assert,
+  assertEquals,
+  assertMatch,
+  assertThrows,
+} from "../../unit/test_util.ts";
 import { assertNotEquals } from "@std/assert";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 Deno.test("[node/crypto.getRandomUUID] works the same way as Web Crypto API", () => {
   assertEquals(randomUUID().length, crypto.randomUUID().length);
   assertEquals(typeof randomUUID(), typeof crypto.randomUUID());
+});
+
+Deno.test("[node/crypto.randomUUID] supports disableEntropyCache", () => {
+  assertMatch(randomUUID({ disableEntropyCache: true }), UUID_REGEX);
 });
 
 Deno.test("[node/crypto.randomFillSync] supported arguments", () => {


### PR DESCRIPTION
## Summary

- generate 128 formatted UUIDs per native refill and return them as one packed one-byte V8 string
- serve normal `crypto.randomUUID()` calls from JavaScript slices, reducing native transitions to one per batch
- retain the native per-call implementation for `--seed` so mixed `randomUUID()` and `getRandomValues()` calls preserve deterministic RNG ordering
- honor `node:crypto.randomUUID({ disableEntropyCache: true })` with an uncached generation path

## Performance

Focused `release-lite` benchmark using the website benchmark helper:

| Runtime | ops/sec |
| --- | ---: |
| Deno website baseline | 9.50M |
| Deno patched | 16.60M-17.12M |
| Node 26.3.0, same local harness | 16.97M |

The implementation uses the same 128-UUID batch size as Node, but formats the whole batch in Rust into one packed string. The JavaScript hot path only slices the next 36-byte UUID, avoiding both a native call and per-byte formatting for 127 of every 128 calls.

## Validation

- `cargo check -p deno_crypto`
- `cargo test -p deno_crypto test_fast_uuid_v4_correctness`
- `cargo fmt --check`
- `./tools/lint.js ext/crypto/00_crypto.js ext/crypto/crypto.rs ext/crypto/lib.rs ext/node/polyfills/internal/crypto/random.ts tests/unit_node/crypto/crypto_misc_test.ts`
- `./target/release-lite/deno test --config tests/config/deno.json tests/unit_node/crypto/crypto_misc_test.ts`
- `PYENV_VERSION=3.11.8 ./tests/wpt/wpt.ts run --binary=./target/release-lite/deno -- WebCryptoAPI/randomUUID`
- generated 1,000 UUIDs across multiple refills and checked UUID v4 shape and uniqueness
- repeated mixed `randomUUID()` / `getRandomValues()` calls under `--seed=100` in separate processes and confirmed identical output
