### PR TITLE
feat(permissions): confine relaxed-profile read to cwd+tmp+imported-npm-packages, deny-write .git

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1456,9 +1456,15 @@ impl CliOptions {
     // write deny: the `.git` directory inside the cwd stays non-writable even
     // though the rest of the cwd is writable. This blocks planting a
     // `.git/hooks/pre-commit` (or similar) that would execute on the next git
-    // invocation. Deny always wins over the cwd write-allow above.
-    options.deny_write =
-      Some(relaxed_default_git_deny_write_paths(self.initial_cwd()));
+    // invocation. Deny always wins over the cwd write-allow above. Merge into
+    // any user-provided `--deny-write` rather than overwriting it, so an
+    // explicit `--deny-write` still composes (deny always wins).
+    let git_deny_write =
+      relaxed_default_git_deny_write_paths(self.initial_cwd());
+    match &mut options.deny_write {
+      Some(existing) => existing.extend(git_deny_write),
+      None => options.deny_write = Some(git_deny_write),
+    }
     // net, run, ffi and sys are intentionally left untouched so they keep
     // prompting in a TTY and denying non-interactively. import keeps its
     // existing implicit trusted-host allowance from augment_import_permissions.

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1389,30 +1389,43 @@ impl CliOptions {
     merge_default_allow_env(&mut options.allow_env, ALWAYS_ON_ENV_VARS);
   }
 
+  /// Whether the unstable relaxed default permission profile applies given the
+  /// gating inputs. The profile only applies to subcommands that run user code
+  /// with the prompt-based defaults, when the unstable gate is on, and when no
+  /// explicit allow-side configuration (--allow-*, -A, -P, or a config-file
+  /// permission set) was provided. `--deny-*` flags are intentionally not
+  /// consulted so they compose on top of the profile.
+  fn relaxed_default_profile_applies(
+    &self,
+    has_config_permissions: bool,
+  ) -> bool {
+    self.runs_user_code_with_prompt_defaults()
+      && relaxed_default_permissions_enabled()
+      && !self.flags.permissions.has_allow_permission()
+      && self.flags.permission_set.is_none()
+      && !has_config_permissions
+  }
+
+  /// Whether the relaxed default permission profile was applied to this
+  /// invocation. Mirrors `maybe_apply_relaxed_default_permissions` so callers
+  /// outside permission construction (for example the worker factory widening
+  /// read to this program's resolved npm package folders) can act only when the
+  /// profile is active. Must stay in sync via `relaxed_default_profile_applies`.
+  pub fn relaxed_default_permissions_applied(&self) -> bool {
+    let has_config_permissions = self
+      .resolve_config_permissions_for_dir(&self.start_dir)
+      .ok()
+      .flatten()
+      .is_some();
+    self.relaxed_default_profile_applies(has_config_permissions)
+  }
+
   fn maybe_apply_relaxed_default_permissions(
     &self,
     options: &mut PermissionsOptions,
     has_config_permissions: bool,
   ) {
-    // Only for subcommands that execute user code with the prompt-based
-    // defaults.
-    if !self.runs_user_code_with_prompt_defaults() {
-      return;
-    }
-
-    // Gated behind an unstable env var while we gather feedback.
-    if !relaxed_default_permissions_enabled() {
-      return;
-    }
-
-    // Any explicit allow-side configuration (--allow-*, -A, -P, or a
-    // permission set from the config file) opts out entirely, keeping
-    // behavior byte-for-byte identical to today. Note `--deny-*` flags are
-    // intentionally not consulted here so they compose on top of the profile.
-    if self.flags.permissions.has_allow_permission()
-      || self.flags.permission_set.is_some()
-      || has_config_permissions
-    {
+    if !self.relaxed_default_profile_applies(has_config_permissions) {
       return;
     }
 
@@ -1421,8 +1434,12 @@ impl CliOptions {
     // even with the gate off. Skipped here to keep the central default minimal.
     log::debug!("Applying unstable relaxed default permission profile.");
 
-    // read: allowed everywhere (empty allow-list means "allow all").
-    options.allow_read = Some(Vec::new());
+    // read: confined to the cwd (recorded at process start) and the OS temp
+    // directory, mirroring the write confinement below. A non-empty allow-list
+    // means reads outside these prefixes still prompt in a TTY and deny
+    // non-interactively, instead of the previous "allow all" behavior.
+    options.allow_read =
+      Some(relaxed_default_read_write_paths(self.initial_cwd()));
     // env: allowed for the curated default-readable allowlist (see #35950).
     // This is a deny-respecting allow-list (not an allow-all bypass), so
     // credential-shaped variables still prompt and `--deny-env` still wins.
@@ -1434,7 +1451,14 @@ impl CliOptions {
     );
     // write: confined to the cwd (recorded at process start) and the OS temp
     // directory.
-    options.allow_write = Some(relaxed_default_write_paths(self.initial_cwd()));
+    options.allow_write =
+      Some(relaxed_default_read_write_paths(self.initial_cwd()));
+    // write deny: the `.git` directory inside the cwd stays non-writable even
+    // though the rest of the cwd is writable. This blocks planting a
+    // `.git/hooks/pre-commit` (or similar) that would execute on the next git
+    // invocation. Deny always wins over the cwd write-allow above.
+    options.deny_write =
+      Some(relaxed_default_git_deny_write_paths(self.initial_cwd()));
     // net, run, ffi and sys are intentionally left untouched so they keep
     // prompting in a TTY and denying non-interactively. import keeps its
     // existing implicit trusted-host allowance from augment_import_permissions.
@@ -1850,27 +1874,48 @@ fn relaxed_default_permissions_enabled() -> bool {
   }
 }
 
-/// The write allow-list for the relaxed default profile: the process-start cwd
-/// and the OS temp directory. Both the raw and canonicalized forms of each path
-/// are included so that writes match regardless of symlinked prefixes (for
-/// example macOS's `/tmp` -> `/private/tmp` and `/var/folders` temp dirs, which
-/// are canonicalized at permission-check time). The OS temp directory honors
-/// the `TMPDIR` env var via `std::env::temp_dir`.
-fn relaxed_default_write_paths(initial_cwd: &Path) -> Vec<String> {
-  fn push_with_canonicalized(paths: &mut Vec<PathBuf>, path: PathBuf) {
-    if !paths.contains(&path) {
-      paths.push(path.clone());
-    }
-    if let Ok(canonical) = crate::util::fs::canonicalize_path(&path)
-      && !paths.contains(&canonical)
-    {
-      paths.push(canonical);
-    }
+/// Appends `path` and, when it resolves, its canonicalized form to `paths`,
+/// skipping duplicates. Both forms are recorded so that permission descriptors
+/// match regardless of symlinked prefixes (for example macOS's `/tmp` ->
+/// `/private/tmp` and `/var/folders` temp dirs, which are canonicalized at
+/// permission-check time).
+fn push_path_with_canonicalized(paths: &mut Vec<PathBuf>, path: PathBuf) {
+  if !paths.contains(&path) {
+    paths.push(path.clone());
   }
+  if let Ok(canonical) = crate::util::fs::canonicalize_path(&path)
+    && !paths.contains(&canonical)
+  {
+    paths.push(canonical);
+  }
+}
 
+/// The read/write allow-list for the relaxed default profile: the process-start
+/// cwd and the OS temp directory. Both read and write are confined to these
+/// same prefixes. Each entry contributes its raw and canonicalized form (see
+/// `push_path_with_canonicalized`). The OS temp directory honors the `TMPDIR`
+/// env var via `std::env::temp_dir`.
+fn relaxed_default_read_write_paths(initial_cwd: &Path) -> Vec<String> {
   let mut paths: Vec<PathBuf> = Vec::with_capacity(4);
-  push_with_canonicalized(&mut paths, initial_cwd.to_path_buf());
-  push_with_canonicalized(&mut paths, std::env::temp_dir());
+  push_path_with_canonicalized(&mut paths, initial_cwd.to_path_buf());
+  push_path_with_canonicalized(&mut paths, std::env::temp_dir());
+  paths
+    .into_iter()
+    .map(|path| path.to_string_lossy().into_owned())
+    .collect()
+}
+
+/// The write deny-list for the relaxed default profile: the `.git` directory
+/// inside the process-start cwd. This keeps the writable cwd from being used to
+/// plant a `.git/hooks/pre-commit` (or similar) that runs on the next git
+/// invocation. Both the raw and canonicalized forms of the cwd are recorded so
+/// the deny matches whether the write path is expressed relative to the raw or
+/// the canonicalized cwd. Note this is a lexical deny: like `--deny-write=.git`,
+/// it does not defend against a symlink inside the cwd that points at `.git`,
+/// because write permission checks are not symlink-canonicalized.
+fn relaxed_default_git_deny_write_paths(initial_cwd: &Path) -> Vec<String> {
+  let mut paths: Vec<PathBuf> = Vec::with_capacity(2);
+  push_path_with_canonicalized(&mut paths, initial_cwd.join(".git"));
   paths
     .into_iter()
     .map(|path| path.to_string_lossy().into_owned())

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -364,6 +364,11 @@ struct SharedCliModuleLoaderState {
   in_flight_loads_tracker: InFlightModuleLoadsTracker,
   maybe_eszip_loader: Option<Arc<EszipModuleLoader>>,
   watcher_communicator: Option<Arc<WatcherCommunicator>>,
+  /// Whether the unstable relaxed default permission profile is active. When
+  /// set, loading a module that lives in an npm package grants read on that
+  /// package's folder so the package can read its own bundled data files at
+  /// runtime without a prompt (see `maybe_grant_npm_package_read`).
+  relaxed_default_permissions: bool,
 }
 
 struct InFlightModuleLoadsTracker {
@@ -462,6 +467,8 @@ impl CliModuleLoaderFactory {
         },
         maybe_eszip_loader,
         watcher_communicator,
+        relaxed_default_permissions: options
+          .relaxed_default_permissions_applied(),
       }),
     }
   }
@@ -487,6 +494,7 @@ impl CliModuleLoaderFactory {
         graph_container: graph_container.clone(),
         shared: self.shared.clone(),
         loaded_files: Default::default(),
+        granted_npm_folders: Default::default(),
         hook_registry: hook_registry.clone(),
         maybe_main_module_blob,
       })));
@@ -579,6 +587,9 @@ struct CliModuleLoaderInner<TGraphContainer: ModuleGraphContainer> {
   shared: Arc<SharedCliModuleLoaderState>,
   graph_container: TGraphContainer,
   loaded_files: RefCell<HashSet<ModuleSpecifier>>,
+  /// npm package folders already granted read under the relaxed default
+  /// permission profile, to avoid re-locking permissions on every load.
+  granted_npm_folders: RefCell<HashSet<PathBuf>>,
   hook_registry: deno_runtime::deno_node::ops::module_hooks::LoaderHookRegistry,
   /// For blob/object-URL module workers, the captured root blob and its
   /// specifier. Captured synchronously at worker construction so that a
@@ -835,6 +846,59 @@ impl<TGraphContainer: ModuleGraphContainer>
     )))
   }
 
+  /// When the relaxed default permission profile is active and `specifier`
+  /// resolves into a managed (global cache) npm package, grants read on that
+  /// package's folder to this worker's own permissions. Byonm packages live in
+  /// the cwd `node_modules`, already covered by the cwd read grant, so only the
+  /// managed resolver is consulted. Grants target `self.permissions` (the
+  /// worker's own container, which the runtime `fs` ops check) to preserve
+  /// worker isolation, and are deduplicated per folder. Best-effort: failures
+  /// to resolve or grant are logged and skipped rather than aborting the load.
+  fn maybe_grant_npm_package_read(&self, specifier: &ModuleSpecifier) {
+    if !self.shared.relaxed_default_permissions {
+      return;
+    }
+    if !self.shared.in_npm_pkg_checker.in_npm_package(specifier) {
+      return;
+    }
+    let Some(managed) = self.shared.npm_resolver.as_managed() else {
+      return;
+    };
+    let pkg_id = match managed.resolve_pkg_id_from_specifier(specifier) {
+      Ok(Some(pkg_id)) => pkg_id,
+      Ok(None) => return,
+      Err(err) => {
+        log::debug!(
+          "Failed to resolve npm package id for {}: {}",
+          specifier,
+          err
+        );
+        return;
+      }
+    };
+    let folder = match managed.resolve_pkg_folder_from_pkg_id(&pkg_id) {
+      Ok(folder) => folder,
+      Err(err) => {
+        log::debug!(
+          "Failed to resolve npm package folder for {}: {}",
+          pkg_id.as_serialized(),
+          err
+        );
+        return;
+      }
+    };
+    if !self.granted_npm_folders.borrow_mut().insert(folder.clone()) {
+      return;
+    }
+    if let Err(err) = self.permissions.grant_read_path(&folder) {
+      log::debug!(
+        "Failed to grant read for npm package folder {}: {}",
+        folder.display(),
+        err
+      );
+    }
+  }
+
   async fn load_code_source(
     &self,
     specifier: &ModuleSpecifier,
@@ -870,6 +934,16 @@ impl<TGraphContainer: ModuleGraphContainer>
     } else {
       Cow::Borrowed(specifier)
     };
+
+    // Under the relaxed default permission profile, read is confined to the cwd
+    // and temp dir. When a module that lives in an npm package is loaded, grant
+    // read on that package's folder so the package can read its own bundled
+    // data files at runtime (for example cowsay reading its `.cow` files)
+    // without a prompt. Scoped to packages this program actually imports, so
+    // other cached packages stay unreadable. The grant happens here, before the
+    // module executes its runtime `fs.readFileSync`, so the folder is readable
+    // by the time the data file is read.
+    self.maybe_grant_npm_package_read(&specifier);
 
     let graph = self.graph_container.graph();
     let deno_resolver_requested_module_type =

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -4022,6 +4022,25 @@ impl PermissionsContainer {
     }
   }
 
+  /// Grants read access to `path` and everything beneath it by inserting a
+  /// granted read descriptor built with the container's descriptor parser.
+  /// Used by the unstable relaxed default permission profile to widen read to
+  /// this program's own resolved npm package folders without opening the whole
+  /// global cache. This is a real grant, so existing deny descriptors still
+  /// take precedence over it.
+  pub fn grant_read_path(&self, path: &Path) -> Result<(), PathResolveError> {
+    let desc = self
+      .descriptor_parser
+      .parse_read_descriptor(&path.to_string_lossy())?;
+    self
+      .inner
+      .lock()
+      .read
+      .descriptors
+      .insert(UnaryPermissionDesc::Granted(desc));
+    Ok(())
+  }
+
   pub fn allow_all(
     descriptor_parser: Arc<dyn PermissionDescriptorParser>,
   ) -> Self {

--- a/tests/specs/permission/relaxed_default/__test__.jsonc
+++ b/tests/specs/permission/relaxed_default/__test__.jsonc
@@ -6,8 +6,8 @@
   },
   "tests": {
     "profile_default": {
-      // gate on, no flags: read anywhere, write under cwd and temp, env allowed,
-      // write outside both denied naming --allow-write
+      // gate on, no flags: read and write confined to cwd and temp, env
+      // allowed, read/write outside both denied naming --allow-read/--allow-write
       "args": "run --quiet profile.ts",
       "output": "profile.out"
     },
@@ -39,8 +39,8 @@
       "output": "gate_off.out"
     },
     "worker_inherits": {
-      // a worker with default permissions inherits the profile: reads anywhere
-      // but cannot fetch
+      // a worker with default permissions inherits the profile: reads inside
+      // the cwd but cannot fetch
       "args": "run --quiet worker_main.ts",
       "output": "worker.out"
     },

--- a/tests/specs/permission/relaxed_default/profile.ts
+++ b/tests/specs/permission/relaxed_default/profile.ts
@@ -1,10 +1,26 @@
-// Relaxed default permission profile (gate on, no flags): read is allowed
-// everywhere, write is allowed under the cwd and the OS temp directory, and
-// env is allowed. net stays gated (see net.ts).
+// Relaxed default permission profile (gate on, no flags): read and write are
+// both confined to the cwd and the OS temp directory, and env is allowed. net
+// stays gated (see net.ts).
 
-// read a file outside the cwd (the deno executable)
-Deno.readFileSync(Deno.execPath());
-console.log("read outside cwd: ok");
+// read a file inside the cwd
+Deno.writeTextFileSync("./readable.txt", "data");
+Deno.readTextFileSync("./readable.txt");
+console.log("read cwd: ok");
+
+// read a file inside the OS temp directory
+const tempRead = Deno.makeTempFileSync();
+Deno.readTextFileSync(tempRead);
+console.log("read temp: ok");
+
+// read a file outside the cwd and the temp directory (the deno executable) is
+// denied
+try {
+  Deno.readFileSync(Deno.execPath());
+  console.log("read outside: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-read") ? "--allow-read" : "?";
+  console.log(`read outside: ${err.name} ${named}`);
+}
 
 // write inside the cwd
 Deno.writeTextFileSync("./in_cwd.txt", "data");

--- a/tests/specs/permission/relaxed_default/worker.ts
+++ b/tests/specs/permission/relaxed_default/worker.ts
@@ -1,8 +1,8 @@
-// Inherits the relaxed profile from the parent: read is allowed everywhere but
-// net stays gated.
+// Inherits the relaxed profile from the parent: read is confined to the cwd and
+// temp directory, and net stays gated. Reading a file inside the cwd succeeds.
 let read;
 try {
-  Deno.readFileSync(Deno.execPath());
+  Deno.readTextFileSync("./worker.ts");
   read = "ok";
 } catch (err) {
   read = err.name;

--- a/tests/specs/permission/relaxed_read_write/__test__.jsonc
+++ b/tests/specs/permission/relaxed_read_write/__test__.jsonc
@@ -1,0 +1,24 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_UNSTABLE_RELAXED_PERMISSIONS": "1"
+  },
+  "tests": {
+    "read_write_confinement": {
+      "steps": [
+        {
+          // setup runs with -A (which opts out of the profile) so it can create
+          // the .git/hooks directory that the confined run then tries to write
+          "args": "run --quiet -A setup.ts",
+          "output": "setup.out"
+        },
+        {
+          // read/write confined to cwd and temp; the .git directory inside the
+          // cwd is deny-listed for write
+          "args": "run --quiet main.ts",
+          "output": "main.out"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/permission/relaxed_read_write/main.out
+++ b/tests/specs/permission/relaxed_read_write/main.out
@@ -2,6 +2,5 @@ read cwd: ok
 read temp: ok
 read outside: NotCapable --allow-read
 write cwd: ok
-write temp: ok
-write outside: NotCapable --allow-write
-env: hello
+write .git: NotCapable --allow-write
+write elsewhere: ok

--- a/tests/specs/permission/relaxed_read_write/main.ts
+++ b/tests/specs/permission/relaxed_read_write/main.ts
@@ -1,0 +1,41 @@
+// Relaxed default profile (gate on, no flags): read and write are confined to
+// the cwd and the OS temp directory, and the .git directory inside the cwd is
+// deny-listed for write.
+
+// read: a file inside the cwd is readable (write to the cwd is allowed too)
+Deno.writeTextFileSync("./inside.txt", "data");
+Deno.readTextFileSync("./inside.txt");
+console.log("read cwd: ok");
+
+// read: a file inside the OS temp directory is readable
+const tempFile = Deno.makeTempFileSync();
+Deno.readTextFileSync(tempFile);
+console.log("read temp: ok");
+
+// read: a file outside the cwd and the temp directory (the deno executable) is
+// denied naming --allow-read
+try {
+  Deno.readFileSync(Deno.execPath());
+  console.log("read outside: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-read") ? "--allow-read" : "?";
+  console.log(`read outside: ${err.name} ${named}`);
+}
+
+// write: a file inside the cwd is writable
+Deno.writeTextFileSync("./writable.txt", "data");
+console.log("write cwd: ok");
+
+// write: the .git directory inside the cwd is denied even though the rest of
+// the cwd is writable (blocks the .git/hooks/pre-commit persistence vector)
+try {
+  Deno.writeTextFileSync("./.git/hooks/pre-commit", "#!/bin/sh\n");
+  console.log("write .git: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-write") ? "--allow-write" : "?";
+  console.log(`write .git: ${err.name} ${named}`);
+}
+
+// write: a file elsewhere in the cwd still succeeds
+Deno.writeTextFileSync("./elsewhere.txt", "data");
+console.log("write elsewhere: ok");

--- a/tests/specs/permission/relaxed_read_write/setup.out
+++ b/tests/specs/permission/relaxed_read_write/setup.out
@@ -1,0 +1,1 @@
+setup: ok

--- a/tests/specs/permission/relaxed_read_write/setup.ts
+++ b/tests/specs/permission/relaxed_read_write/setup.ts
@@ -1,0 +1,4 @@
+// Runs with -A so the profile is off. Creates the .git/hooks directory that the
+// confined main.ts run then attempts (and fails) to write into.
+Deno.mkdirSync(".git/hooks", { recursive: true });
+console.log("setup: ok");


### PR DESCRIPTION
This tightens the unstable relaxed default permission profile so that read is
no longer granted everywhere. It stacks on #35952 (the default-readable env
var allowlist) which stacks on #35710 (the relaxed default profile itself),
and only touches the relaxed profile; strict deny-by-default behavior is
unchanged.

Read is now confined to the same cwd and OS temp-dir paths the profile already
grants for write, computed once and shared by both via a
relaxed_default_read_write_paths helper (raw and canonicalized forms, honoring
TMPDIR). A default deny-write is added for the cwd's .git directory so the
writable cwd cannot be used to plant a .git/hooks/pre-commit that would run on
the next git invocation. This is a lexical deny: like --deny-write=.git it does
not defend against a symlink inside the cwd that points at .git, because write
permission checks are not symlink-canonicalized. The doc comment says so and
there is intentionally no test asserting the symlink is blocked, since it is
not.

Confining read to cwd and temp alone would regress npm packages that read
their own bundled data files from the global cache at runtime (for example
cowsay reading its .cow files). To keep those working without opening the whole
cache, the module loader grants read on an npm package's folder when it loads a
module from that package, scoped to the managed (global cache) resolver. The
grant targets the worker's own permissions container (which the runtime fs ops
check) and is deduplicated per folder. Because it runs at module load, it
covers every import style: deno run npm:pkg, static and dynamic import "npm:x"
from a script, with or without a manifest, and cold first runs. Byonm packages
live in the cwd node_modules and are already covered by the cwd grant, so they
are skipped. The grant only runs when the profile is active, so strict mode
never gains read it did not have.

This intentionally changes the relaxed_default spec's read behavior: reads
outside cwd and temp now fail non-interactively naming --allow-read instead of
succeeding, which is the point of the confinement. That spec and its worker
case are updated accordingly, and a new relaxed_read_write spec covers the
read confinement plus the .git direct-write denial.

The npm-read scoping (an imported package's files are readable, a cached but
not-imported package's files are not) is validated manually against the real
npm registry but is not covered by a hermetic spec: the spec harness places
DENO_DIR under the OS temp dir, which the profile allowlists, so the whole
cache is readable there regardless of the grant, and the scoping cannot be
demonstrated in that environment.
