### PR TITLE
test(permissions): comprehensive coverage for the relaxed-default profile

### DIFF
--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -5819,6 +5819,80 @@ mod tests {
   }
 
   #[test]
+  fn grant_read_path_scopes_to_granted_folder() {
+    set_prompter(Box::new(TestPrompter));
+    let parser = TestPermissionDescriptorParser;
+    // Baseline mirrors the relaxed default profile before any module loads:
+    // read has no allow-list, so every path is in the Prompt state and is
+    // denied non-interactively.
+    let perms =
+      Permissions::from_options(&parser, &PermissionsOptions::default())
+        .unwrap();
+    let perms = PermissionsContainer::new(Arc::new(parser), perms);
+
+    let read_query = |path: &str| {
+      TestPermissionDescriptorParser
+        .parse_path_query(Cow::Owned(PathBuf::from(path)))
+        .unwrap()
+        .into_read()
+    };
+    let query =
+      |path: &str| perms.inner.lock().read.query(Some(&read_query(path)));
+
+    // The module loader calls grant_read_path for a package's folder when that
+    // package is imported under the relaxed profile.
+    perms.grant_read_path(Path::new("/cache/pkg_a")).unwrap();
+
+    // The granted folder and everything beneath it becomes readable.
+    assert_eq!(query("/cache/pkg_a"), PermissionState::Granted);
+    assert_eq!(
+      query("/cache/pkg_a/data/file.txt"),
+      PermissionState::Granted
+    );
+
+    // A sibling package folder that was never granted stays in Prompt: the
+    // grant is scoped to the one folder and does not widen read to its parent
+    // (the whole cache) or to unrelated siblings. This is the per-package
+    // scoping security property.
+    assert_eq!(query("/cache/pkg_b"), PermissionState::Prompt);
+    assert_eq!(query("/cache/pkg_b/data/file.txt"), PermissionState::Prompt);
+    assert_eq!(query("/cache"), PermissionState::Prompt);
+  }
+
+  #[test]
+  fn grant_read_path_respects_prior_deny() {
+    set_prompter(Box::new(TestPrompter));
+    let parser = TestPermissionDescriptorParser;
+    // An explicit --deny-read on the folder is in effect before the grant.
+    let perms = Permissions::from_options(
+      &parser,
+      &PermissionsOptions {
+        deny_read: Some(svec!["/cache/pkg_a"]),
+        ..Default::default()
+      },
+    )
+    .unwrap();
+    let perms = PermissionsContainer::new(Arc::new(parser), perms);
+
+    let read_query = |path: &str| {
+      TestPermissionDescriptorParser
+        .parse_path_query(Cow::Owned(PathBuf::from(path)))
+        .unwrap()
+        .into_read()
+    };
+    let query =
+      |path: &str| perms.inner.lock().read.query(Some(&read_query(path)));
+
+    // The loader still grants read on the folder when the package is imported.
+    perms.grant_read_path(Path::new("/cache/pkg_a")).unwrap();
+
+    // Deny always wins: the folder and its contents remain denied despite the
+    // grant, so grant_read_path cannot be used to escape a --deny-read.
+    assert_eq!(query("/cache/pkg_a"), PermissionState::Denied);
+    assert_eq!(query("/cache/pkg_a/data.txt"), PermissionState::Denied);
+  }
+
+  #[test]
   #[cfg(target_os = "macos")]
   fn check_paths_macos_unicode_normalization() {
     set_prompter(Box::new(TestPrompter));

--- a/tests/registry/npm/@denotest/relaxed-pkg-a/1.0.0/data.txt
+++ b/tests/registry/npm/@denotest/relaxed-pkg-a/1.0.0/data.txt
@@ -1,0 +1,1 @@
+package A bundled data

--- a/tests/registry/npm/@denotest/relaxed-pkg-a/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/relaxed-pkg-a/1.0.0/index.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+const path = require("path");
+
+const dataPath = path.join(__dirname, "data.txt");
+
+module.exports.dataPath = dataPath;
+module.exports.readOwnData = function readOwnData() {
+  return fs.readFileSync(dataPath, "utf8");
+};

--- a/tests/registry/npm/@denotest/relaxed-pkg-a/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/relaxed-pkg-a/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/relaxed-pkg-a",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tests/registry/npm/@denotest/relaxed-pkg-b/1.0.0/data.txt
+++ b/tests/registry/npm/@denotest/relaxed-pkg-b/1.0.0/data.txt
@@ -1,0 +1,1 @@
+package B bundled data

--- a/tests/registry/npm/@denotest/relaxed-pkg-b/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/relaxed-pkg-b/1.0.0/index.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+const path = require("path");
+
+const dataPath = path.join(__dirname, "data.txt");
+
+module.exports.dataPath = dataPath;
+module.exports.readOwnData = function readOwnData() {
+  return fs.readFileSync(dataPath, "utf8");
+};

--- a/tests/registry/npm/@denotest/relaxed-pkg-b/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/relaxed-pkg-b/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/relaxed-pkg-b",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tests/specs/permission/env_allowlist/__test__.jsonc
+++ b/tests/specs/permission/env_allowlist/__test__.jsonc
@@ -13,7 +13,10 @@
         "TERM": "xterm-256color",
         "LC_ALL": "en_US.UTF-8",
         "XDG_CONFIG_HOME": "/home/user/.config",
-        "npm_package_name": "myapp"
+        "npm_package_name": "myapp",
+        "DEBUG_MYAPP": "1",
+        "GITHUB_ACTIONS": "true",
+        "_": "/usr/bin/deno"
       },
       "output": "allowlisted.out"
     },
@@ -33,7 +36,9 @@
       "envs": {
         "DENO_UNSTABLE_RELAXED_PERMISSIONS": "1",
         "AWS_SECRET_ACCESS_KEY": "shhh",
-        "npm_config__authToken": "shhh"
+        "npm_config__authToken": "shhh",
+        "GITHUB_TOKEN": "shhh",
+        "APP_SECRET": "shhh"
       },
       "output": "secrets.out"
     },
@@ -49,6 +54,19 @@
         "APP_TOKEN": "shhh"
       },
       "output": "to_object.out"
+    },
+    "strict_always_on_four": {
+      // gate off (strict default): all four always-on Node compat variables
+      // (FORCE_COLOR, NODE_DEBUG, NODE_OPTIONS, NO_COLOR) read without a prompt
+      "args": "run --quiet always_on.ts",
+      "envs": {
+        "DENO_UNSTABLE_RELAXED_PERMISSIONS": "0",
+        "FORCE_COLOR": "",
+        "NODE_DEBUG": "",
+        "NODE_OPTIONS": "",
+        "NO_COLOR": "1"
+      },
+      "output": "always_on.out"
     },
     "strict_always_on_readable": {
       // gate off (strict default): the always-on NO_COLOR stays readable

--- a/tests/specs/permission/env_allowlist/allowlisted.out
+++ b/tests/specs/permission/env_allowlist/allowlisted.out
@@ -2,3 +2,6 @@ TERM: xterm-256color
 LC_ALL: en_US.UTF-8
 XDG_CONFIG_HOME: /home/user/.config
 npm_package_name: myapp
+DEBUG_MYAPP: 1
+GITHUB_ACTIONS: true
+_: /usr/bin/deno

--- a/tests/specs/permission/env_allowlist/allowlisted.ts
+++ b/tests/specs/permission/env_allowlist/allowlisted.ts
@@ -1,7 +1,20 @@
-// Reading allowlisted variables (including prefix-pattern members) succeeds
-// without a prompt. Under --deny-env=TERM the TERM read instead fails naming
-// --allow-env (see deny_term.out).
-for (const key of ["TERM", "LC_ALL", "XDG_CONFIG_HOME", "npm_package_name"]) {
+// Reading allowlisted variables succeeds without a prompt. This covers a
+// representative from each category: terminal (TERM), the LC_* locale wildcard
+// (LC_ALL), the XDG_* wildcard (XDG_CONFIG_HOME), a `deno task` npm var
+// (npm_package_name), the DEBUG_* wildcard (DEBUG_MYAPP), a CI detection var
+// (GITHUB_ACTIONS) and the shell argv0 var (_). Under --deny-env=TERM the TERM
+// read instead fails naming --allow-env (see deny_term.out).
+for (
+  const key of [
+    "TERM",
+    "LC_ALL",
+    "XDG_CONFIG_HOME",
+    "npm_package_name",
+    "DEBUG_MYAPP",
+    "GITHUB_ACTIONS",
+    "_",
+  ]
+) {
   try {
     console.log(`${key}: ${Deno.env.get(key)}`);
   } catch (err) {

--- a/tests/specs/permission/env_allowlist/always_on.out
+++ b/tests/specs/permission/env_allowlist/always_on.out
@@ -1,0 +1,4 @@
+FORCE_COLOR: readable
+NODE_DEBUG: readable
+NODE_OPTIONS: readable
+NO_COLOR: readable

--- a/tests/specs/permission/env_allowlist/always_on.ts
+++ b/tests/specs/permission/env_allowlist/always_on.ts
@@ -1,0 +1,13 @@
+// The four always-on Node compat variables stay readable without a prompt even
+// in the strict default profile (relaxed gate off), because they are folded
+// into the default allow_env descriptors. Only readability is asserted (the
+// values are left empty) so that setting them cannot perturb runtime behavior.
+for (const key of ["FORCE_COLOR", "NODE_DEBUG", "NODE_OPTIONS", "NO_COLOR"]) {
+  try {
+    Deno.env.get(key);
+    console.log(`${key}: readable`);
+  } catch (err) {
+    const named = err.message.includes("--allow-env") ? "--allow-env" : "?";
+    console.log(`${key}: ${err.name} ${named}`);
+  }
+}

--- a/tests/specs/permission/env_allowlist/secrets.out
+++ b/tests/specs/permission/env_allowlist/secrets.out
@@ -1,2 +1,4 @@
 AWS_SECRET_ACCESS_KEY: NotCapable --allow-env
 npm_config__authToken: NotCapable --allow-env
+GITHUB_TOKEN: NotCapable --allow-env
+APP_SECRET: NotCapable --allow-env

--- a/tests/specs/permission/env_allowlist/secrets.ts
+++ b/tests/specs/permission/env_allowlist/secrets.ts
@@ -1,7 +1,16 @@
 // Credential-shaped variables are never on the allowlist, so reading them
 // still fails non-interactively naming --allow-env. `npm_config__authToken`
-// shows that the npm_config_* namespace is not wildcarded.
-for (const key of ["AWS_SECRET_ACCESS_KEY", "npm_config__authToken"]) {
+// shows that the npm_config_* namespace is not wildcarded, `GITHUB_TOKEN` that
+// the GITHUB_* namespace is not wildcarded (only the boolean GITHUB_ACTIONS is
+// listed), and `APP_SECRET` that an arbitrary unlisted variable is denied.
+for (
+  const key of [
+    "AWS_SECRET_ACCESS_KEY",
+    "npm_config__authToken",
+    "GITHUB_TOKEN",
+    "APP_SECRET",
+  ]
+) {
   try {
     Deno.env.get(key);
     console.log(`${key}: UNEXPECTEDLY ALLOWED`);

--- a/tests/specs/permission/relaxed_default/worker.out
+++ b/tests/specs/permission/relaxed_default/worker.out
@@ -1,1 +1,1 @@
-worker read: ok, worker fetch: NotCapable
+worker read: ok, worker read outside: NotCapable, worker env: ok, worker fetch: NotCapable

--- a/tests/specs/permission/relaxed_default/worker.ts
+++ b/tests/specs/permission/relaxed_default/worker.ts
@@ -1,11 +1,26 @@
 // Inherits the relaxed profile from the parent: read is confined to the cwd and
-// temp directory, and net stays gated. Reading a file inside the cwd succeeds.
+// temp directory, env is the curated allowlist, and net stays gated. Reading a
+// file inside the cwd succeeds; reading outside the cwd and temp is denied.
 let read;
 try {
   Deno.readTextFileSync("./worker.ts");
   read = "ok";
 } catch (err) {
   read = err.name;
+}
+let readOutside;
+try {
+  Deno.readFileSync(Deno.execPath());
+  readOutside = "UNEXPECTEDLY ALLOWED";
+} catch (err) {
+  readOutside = err.name;
+}
+let env;
+try {
+  Deno.env.get("TERM");
+  env = "ok";
+} catch (err) {
+  env = err.name;
 }
 let net;
 try {
@@ -14,4 +29,7 @@ try {
 } catch (err) {
   net = err.name;
 }
-self.postMessage(`worker read: ${read}, worker fetch: ${net}`);
+self.postMessage(
+  `worker read: ${read}, worker read outside: ${readOutside}, ` +
+    `worker env: ${env}, worker fetch: ${net}`,
+);

--- a/tests/specs/permission/relaxed_npm_scoping/__test__.jsonc
+++ b/tests/specs/permission/relaxed_npm_scoping/__test__.jsonc
@@ -1,0 +1,37 @@
+{
+  // The per-package npm read scoping property of the relaxed default profile.
+  // Under the profile, read is confined to the cwd and the OS temp dir, and a
+  // managed npm package's folder becomes readable only once the program imports
+  // that package. This proves a cached-but-unimported sibling package stays
+  // unreadable.
+  //
+  // Unix only: the test moves the temp read grant off DENO_DIR by redirecting
+  // TMPDIR, and `std::env::temp_dir` honors TMPDIR on unix but TMP/TEMP on
+  // Windows.
+  "tempDir": true,
+  "envs": {
+    "DENO_UNSTABLE_RELAXED_PERMISSIONS": "1"
+  },
+  "tests": {
+    "npm_read_scoped_to_imported_package": {
+      "if": "unix",
+      "steps": [
+        {
+          // setup runs with -A (profile off) to cache both packages into
+          // DENO_DIR and record B's bundled data-file path. DENO_DIR is a
+          // sibling of the cwd under the OS temp root.
+          "args": "run --quiet -A setup.ts",
+          "output": "setup.out"
+        },
+        {
+          // TMPDIR is redirected to a subdir of the cwd so the temp read grant
+          // cannot cover DENO_DIR. Importing A grants read on A's folder; B
+          // stays cached but ungranted, so reading B's bundled file is denied.
+          "args": "run --quiet --cached-only main.ts",
+          "envs": { "TMPDIR": "$PWD/tmpgrant" },
+          "output": "main.out"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/permission/relaxed_npm_scoping/deno.json
+++ b/tests/specs/permission/relaxed_npm_scoping/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@denotest/relaxed-pkg-a": "npm:@denotest/relaxed-pkg-a@1.0.0",
+    "@denotest/relaxed-pkg-b": "npm:@denotest/relaxed-pkg-b@1.0.0"
+  }
+}

--- a/tests/specs/permission/relaxed_npm_scoping/main.out
+++ b/tests/specs/permission/relaxed_npm_scoping/main.out
@@ -1,0 +1,2 @@
+A read own data: package A bundled data
+B read: NotCapable --allow-read

--- a/tests/specs/permission/relaxed_npm_scoping/main.ts
+++ b/tests/specs/permission/relaxed_npm_scoping/main.ts
@@ -1,0 +1,26 @@
+// Relaxed default profile (gate on, no flags): read is confined to the cwd and
+// the OS temp directory. Loading a module that lives in a managed npm package
+// grants read on that package's own folder, scoped to packages this program
+// actually imports.
+//
+// DENO_DIR (where the packages are cached) is a sibling of the cwd under the OS
+// temp root, and TMPDIR is redirected to a subdir of the cwd, so DENO_DIR is
+// outside both the cwd read grant and the temp read grant. A package folder is
+// therefore only readable when the per-package grant fires.
+import pkgA from "@denotest/relaxed-pkg-a";
+
+// Package A was imported, so its folder was granted: it can read its own
+// bundled data file at runtime without a prompt.
+console.log(`A read own data: ${pkgA.readOwnData().trim()}`);
+
+// Package B was cached by setup but is never imported here, so its folder is
+// not granted. Its absolute path was recorded into a cwd file (readable because
+// it is inside the cwd), but reading the file itself is denied.
+const bDataPath = Deno.readTextFileSync("./b_data_path.txt").trim();
+try {
+  Deno.readTextFileSync(bDataPath);
+  console.log("B read: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-read") ? "--allow-read" : "?";
+  console.log(`B read: ${err.name} ${named}`);
+}

--- a/tests/specs/permission/relaxed_npm_scoping/setup.out
+++ b/tests/specs/permission/relaxed_npm_scoping/setup.out
@@ -1,0 +1,1 @@
+setup: ok

--- a/tests/specs/permission/relaxed_npm_scoping/setup.ts
+++ b/tests/specs/permission/relaxed_npm_scoping/setup.ts
@@ -1,0 +1,11 @@
+// Runs with -A so the relaxed profile is off. Caches both npm packages into
+// DENO_DIR and records package B's bundled data-file path so the confined run
+// can attempt to read it without importing B.
+import pkgA from "@denotest/relaxed-pkg-a";
+import pkgB from "@denotest/relaxed-pkg-b";
+
+// Touch A so it is cached too (the confined run imports it).
+void pkgA.dataPath;
+
+Deno.writeTextFileSync("./b_data_path.txt", pkgB.dataPath);
+console.log("setup: ok");

--- a/tests/specs/permission/relaxed_read_write/main.out
+++ b/tests/specs/permission/relaxed_read_write/main.out
@@ -1,6 +1,8 @@
 read cwd: ok
+read/write nested cwd: ok
 read temp: ok
 read outside: NotCapable --allow-read
 write cwd: ok
 write .git: NotCapable --allow-write
+write .git config: NotCapable --allow-write
 write elsewhere: ok

--- a/tests/specs/permission/relaxed_read_write/main.ts
+++ b/tests/specs/permission/relaxed_read_write/main.ts
@@ -7,6 +7,12 @@ Deno.writeTextFileSync("./inside.txt", "data");
 Deno.readTextFileSync("./inside.txt");
 console.log("read cwd: ok");
 
+// read/write: a nested subdirectory of the cwd is covered by the cwd grant
+Deno.mkdirSync("./nested/deep", { recursive: true });
+Deno.writeTextFileSync("./nested/deep/file.txt", "data");
+Deno.readTextFileSync("./nested/deep/file.txt");
+console.log("read/write nested cwd: ok");
+
 // read: a file inside the OS temp directory is readable
 const tempFile = Deno.makeTempFileSync();
 Deno.readTextFileSync(tempFile);
@@ -34,6 +40,15 @@ try {
 } catch (err) {
   const named = err.message.includes("--allow-write") ? "--allow-write" : "?";
   console.log(`write .git: ${err.name} ${named}`);
+}
+
+// write: a direct .git/config write is denied by the same lexical .git deny
+try {
+  Deno.writeTextFileSync("./.git/config", "[core]\n");
+  console.log("write .git config: UNEXPECTEDLY ALLOWED");
+} catch (err) {
+  const named = err.message.includes("--allow-write") ? "--allow-write" : "?";
+  console.log(`write .git config: ${err.name} ${named}`);
 }
 
 // write: a file elsewhere in the cwd still succeeds


### PR DESCRIPTION
Adds test coverage for the unstable relaxed default permission profile, on
top of the env allowlist and read/write confinement commits.

The headline addition is the per-package npm read scoping property, which
previously had no automated test. Under the profile, read is confined to the
cwd and the OS temp directory, and a managed npm package's folder becomes
readable only once the program imports that package. Proving this in a spec is
awkward because the harness DENO_DIR sits under the OS temp directory, which
the temp read grant covers. The new relaxed_npm_scoping spec sidesteps that by
placing DENO_DIR and TMPDIR in sibling directories that are outside both the
cwd and the temp grant: the harness already creates DENO_DIR as a sibling of
the cwd under the OS temp root, and the spec redirects TMPDIR to a subdirectory
of the cwd so the temp grant cannot reach DENO_DIR. A setup step caches two npm
packages with -A; the confined run then imports package A and reads A's own
bundled file successfully, while a read of package B's bundled file (cached but
never imported) fails with NotCapable naming --allow-read. Two small npm
fixtures back this. The spec is unix-only because it relies on TMPDIR, which
std::env::temp_dir honors on unix but not on Windows.

Because that spec depends on a caching registry, the same scoping mechanism is
also covered by harness-independent unit tests on grant_read_path in the
permissions crate: a grant widens read only to the granted folder and its
children, not to sibling folders or the parent, and a prior deny still wins
over the grant.

The env allowlist tests are broadened to cover a representative of each
remaining category (the DEBUG_* wildcard, a CI detection var, and the shell
argv0 var), to prove GITHUB_* is not wildcarded and that an arbitrary secret
is denied, and to confirm all four always-on Node compat variables stay
readable in the strict default. The read/write confinement test gains a nested
cwd subdirectory case and a direct .git/config write denial, and the worker
inheritance test now also checks that an inherited worker cannot read outside
the cwd and can read an allowlisted env var.

Two pre-existing tests on the base branch, deny_write_composes and
chdir_does_not_widen, fail independently of this change and are left untouched
here. deny_write_composes surfaces a real bug: while the profile is active a
user --deny-write is silently discarded, because the profile assigns
options.deny_write the .git deny list rather than appending to it. The fix is
to merge the .git deny into any existing deny_write. chdir_does_not_widen is
stale: it calls Deno.chdir("/"), which the read confinement now denies because
chdir requires read on its target, so the test never reaches its write
assertion; with the read and write grants now identical the chdir-does-not-
widen-write property is no longer cleanly expressible and the test needs
rethinking. Both are reported rather than papered over.
