### PR TITLE
feat(permissions): support glob patterns in --allow-read/--allow-write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,6 +3226,7 @@ dependencies = [
  "deno_unsync",
  "dunce",
  "fqdn",
+ "glob",
  "ipnet",
  "libc",
  "log",

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -5078,10 +5078,10 @@ fn permission_args(app: Command, requires: Option<&'static str>) -> Command {
   <g>-P, --permission-set[=<<NAME>]</>            Loads the permission set from the config file.
   <g>--no-prompt</>                               Always throw if required permission wasn't passed.
                                              <p(245)>Can also be set via the DENO_NO_PROMPT environment variable.</>
-  <g>-R, --allow-read[=<<PATH>...]</>             Allow file system read access. Optionally specify allowed paths.
-                                             <p(245)>--allow-read  |  --allow-read="/etc,/var/log.txt"</>
-  <g>-W, --allow-write[=<<PATH>...]</>            Allow file system write access. Optionally specify allowed paths.
-                                             <p(245)>--allow-write  |  --allow-write="/etc,/var/log.txt"</>
+  <g>-R, --allow-read[=<<PATH>...]</>             Allow file system read access. Optionally specify allowed paths. Glob patterns (with <p(245)>*</>, <p(245)>**</> or <p(245)>?</>) restrict access to matching files.
+                                             <p(245)>--allow-read  |  --allow-read="/etc,/var/log.txt"  |  --allow-read="/data/**/*.json"</>
+  <g>-W, --allow-write[=<<PATH>...]</>            Allow file system write access. Optionally specify allowed paths. Glob patterns (with <p(245)>*</>, <p(245)>**</> or <p(245)>?</>) restrict access to matching files.
+                                             <p(245)>--allow-write  |  --allow-write="/etc,/var/log.txt"  |  --allow-write="/tmp/*.log"</>
   <g>-I, --allow-import[=<<IP_OR_HOSTNAME>...]</> Allow importing from remote hosts. Optionally specify allowed IP addresses and host names, with ports as necessary.
                                             Default value: <p(245)>deno.land:443,jsr.io:443,esm.sh:443,raw.esm.sh:443,cdn.jsdelivr.net:443,raw.githubusercontent.com:443,gist.githubusercontent.com:443</>
                                              <p(245)>--allow-import  |  --allow-import="example.com,github.com"</>

--- a/runtime/permissions/Cargo.toml
+++ b/runtime/permissions/Cargo.toml
@@ -21,6 +21,7 @@ deno_path_util.workspace = true
 deno_terminal.workspace = true
 deno_unsync.workspace = true
 fqdn.workspace = true
+glob.workspace = true
 ipnet.workspace = true
 libc.workspace = true
 log.workspace = true

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1441,6 +1441,11 @@ impl<'a> PathQueryDescriptor<'a> {
   }
 
   pub fn starts_with(&self, base: &PathDescriptor) -> bool {
+    // When the list entry is a glob pattern, it grants exactly the paths it
+    // matches rather than a whole subtree by prefix.
+    if let Some(pattern) = &base.pattern {
+      return pattern.matches(&self.path);
+    }
     self.cmp_path.starts_with(&base.cmp_path)
   }
 
@@ -1457,6 +1462,8 @@ impl<'a> PathQueryDescriptor<'a> {
       cmp_path: self.cmp_path.clone(),
       requested: self.requested.clone(),
       is_windows_device_path: self.is_windows_device_path,
+      // A query is always a concrete path, never a glob.
+      pattern: None,
     }
   }
 
@@ -1466,6 +1473,8 @@ impl<'a> PathQueryDescriptor<'a> {
       cmp_path: self.cmp_path,
       requested: self.requested,
       is_windows_device_path: self.is_windows_device_path,
+      // A query is always a concrete path, never a glob.
+      pattern: None,
     }
   }
 
@@ -1543,20 +1552,174 @@ impl QueryDescriptor for ReadQueryDescriptor<'_> {
   }
 }
 
+/// Whether a read/write list entry should be parsed as a glob pattern rather
+/// than a literal path. True when it contains a `*` or `?` glob character.
+///
+/// `[`/`]` are deliberately *not* treated as glob characters, so paths such as
+/// `pages/[id].ts` keep matching literally (mirrors `deno_config`'s globs).
+fn is_glob_pattern_entry(entry: &str) -> bool {
+  entry.chars().any(|c| matches!(c, '*' | '?'))
+}
+
+/// Escape `[`/`]` in a glob pattern so they are matched literally. We don't
+/// support character classes in permission entries (a path like `[id].ts`
+/// should keep working), and `glob::Pattern` would otherwise interpret them.
+///
+/// This is a single pass so the two escapes can't interfere: a naive
+/// `.replace('[', "[[]").replace(']', "[]]")` corrupts the `]` introduced by
+/// the first replacement. (`deno_config` gets away with the naive form only
+/// because its brackets always land in the literal base it strips before
+/// matching, never in the glob itself.)
+fn escape_glob_brackets(pattern: &str) -> String {
+  let mut out = String::with_capacity(pattern.len());
+  for c in pattern.chars() {
+    match c {
+      '[' => out.push_str("[[]"),
+      ']' => out.push_str("[]]"),
+      _ => out.push(c),
+    }
+  }
+  out
+}
+
+/// Split a normalized (forward-slash) glob pattern into its literal directory
+/// prefix (everything before the first segment containing a glob character) and
+/// the remaining pattern. The prefix anchors the entry in the specificity
+/// ordering used by the permission list.
+fn split_glob_base(pattern: &str) -> PathBuf {
+  let mut base_parts = Vec::new();
+  for part in pattern.split('/') {
+    if is_glob_pattern_entry(part) {
+      break;
+    }
+    base_parts.push(part);
+  }
+  PathBuf::from(base_parts.join(std::path::MAIN_SEPARATOR_STR))
+}
+
+/// Match options used when testing a concrete path against a permission glob.
+fn glob_match_options() -> glob::MatchOptions {
+  glob::MatchOptions {
+    // Mirror the permission system's path comparison: case-sensitive on Linux,
+    // case-insensitive on Windows and macOS (see `comparison_path`).
+    case_sensitive: cfg!(not(any(windows, target_os = "macos"))),
+    // `*` stays within a path segment; `**` is required to cross directories.
+    require_literal_separator: true,
+    // `*` matches dotfiles too, so `--allow-read=/dir/*` grants everything in
+    // the directory as users expect.
+    require_literal_leading_dot: false,
+  }
+}
+
+/// A glob pattern entry in a read/write allow/deny list, e.g.
+/// `/home/user/*.ts` or `/data/**/*.json`.
+///
+/// Unlike a literal path entry (which grants a whole subtree by prefix), a glob
+/// only grants the concrete paths it matches. It is anchored in the list's
+/// specificity ordering by its literal `base_path` (the directory prefix before
+/// the first glob character).
+///
+/// Equality, hashing and ordering are based on the canonical (normalized,
+/// absolute) textual form of the pattern.
+#[derive(Clone)]
+pub struct PathPattern {
+  pattern: glob::Pattern,
+  /// Literal absolute directory prefix before the first glob character, used to
+  /// anchor the entry in the specificity ordering (stored as the descriptor's
+  /// `cmp_path`).
+  base_path: PathBuf,
+  /// Canonical (normalized, absolute) textual form, used for display, equality,
+  /// hashing and ordering.
+  canonical: String,
+}
+
+impl PathPattern {
+  /// Parse a list entry such as `/data/**/*.ts` (or a relative `src/*.ts`,
+  /// resolved against `cwd`) into a glob pattern.
+  fn parse(entry: &str, cwd: &Path) -> Result<Self, PathResolveError> {
+    if let Some(stripped) = entry.strip_prefix('!') {
+      // Negated globs aren't supported: the deny list is the way to exclude
+      // paths. Reject rather than silently treat `!` as a literal.
+      let _ = stripped;
+      return Err(PathResolveError::GlobPattern {
+        pattern: entry.to_string(),
+        message:
+          "negated glob patterns ('!') are not supported; use --deny-* instead"
+            .to_string(),
+      });
+    }
+
+    let joined = if Path::new(entry).is_absolute() {
+      Cow::Borrowed(Path::new(entry))
+    } else {
+      Cow::Owned(cwd.join(entry))
+    };
+    // Resolve `.`/`..` lexically; glob segments (`*`, `**`) are ordinary
+    // components and are preserved.
+    let normalized = normalize_path(joined);
+    let pattern_text = normalized.to_string_lossy().replace('\\', "/");
+    let escaped = escape_glob_brackets(&pattern_text);
+    let pattern = glob::Pattern::new(&escaped).map_err(|source| {
+      PathResolveError::GlobPattern {
+        pattern: entry.to_string(),
+        message: source.to_string(),
+      }
+    })?;
+    let base_path = split_glob_base(&pattern_text);
+    Ok(PathPattern {
+      pattern,
+      base_path,
+      canonical: pattern_text,
+    })
+  }
+
+  /// Test whether a concrete absolute path matches this pattern.
+  fn matches(&self, path: &Path) -> bool {
+    self.pattern.matches_path_with(path, glob_match_options())
+  }
+}
+
+impl PartialEq for PathPattern {
+  fn eq(&self, other: &Self) -> bool {
+    self.canonical == other.canonical
+  }
+}
+
+impl Eq for PathPattern {}
+
+impl Hash for PathPattern {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    self.canonical.hash(state);
+  }
+}
+
+impl fmt::Debug for PathPattern {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_tuple("PathPattern").field(&self.canonical).finish()
+  }
+}
+
 #[derive(Clone, Debug)]
 pub struct PathDescriptor {
   path: PathBuf,
   /// Lowercased on Windows for case-insensitive comparison; same as `path` on
-  /// other platforms. Used by PartialEq, Hash, starts_with, cmp_*.
+  /// other platforms. Used by PartialEq, Hash, starts_with, cmp_*. For a glob
+  /// entry this is the pattern's literal `base_path`, which anchors it in the
+  /// specificity ordering.
   cmp_path: PathBuf,
   /// Custom requested display name when differs from resolved.
   requested: Option<String>,
   is_windows_device_path: bool,
+  /// `Some` when this entry is a glob pattern (only ever set for allow/deny
+  /// list entries, never for a concrete query). Boxed to keep the common
+  /// literal-path descriptor small.
+  pattern: Option<Box<PathPattern>>,
 }
 
 impl PartialEq for PathDescriptor {
   fn eq(&self, other: &Self) -> bool {
     self.cmp_path == other.cmp_path
+      && self.pattern.as_deref() == other.pattern.as_deref()
   }
 }
 
@@ -1565,6 +1728,7 @@ impl Eq for PathDescriptor {}
 impl Hash for PathDescriptor {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
     self.cmp_path.hash(state);
+    self.pattern.as_deref().hash(state);
   }
 }
 
@@ -1574,6 +1738,39 @@ impl PathDescriptor {
     path: Cow<'_, Path>,
   ) -> Result<Self, PathResolveError> {
     PathQueryDescriptor::new(sys, path).map(|p| p.into_descriptor())
+  }
+
+  /// Parse a read/write list entry that may be a glob pattern (contains `*` or
+  /// `?`). Entries without glob characters are parsed as literal paths exactly
+  /// as before.
+  pub fn new_maybe_glob(
+    sys: &impl sys_traits::EnvCurrentDir,
+    text: &str,
+  ) -> Result<Self, PathResolveError> {
+    if is_glob_pattern_entry(text) {
+      let cwd = sys
+        .env_current_dir()
+        .map_err(PathResolveError::CwdResolve)?;
+      Self::from_glob(text, &cwd)
+    } else {
+      Self::new(sys, Cow::Borrowed(Path::new(text)))
+    }
+  }
+
+  /// Build a glob-pattern descriptor from a list entry, resolving a relative
+  /// pattern against `cwd`. The descriptor is anchored on the pattern's literal
+  /// `base_path` for ordering purposes.
+  pub fn from_glob(entry: &str, cwd: &Path) -> Result<Self, PathResolveError> {
+    let pattern = PathPattern::parse(entry, cwd)?;
+    let base_path = pattern.base_path.clone();
+    let cmp_path = comparison_path(&base_path);
+    Ok(Self {
+      path: base_path,
+      cmp_path,
+      requested: None,
+      is_windows_device_path: false,
+      pattern: Some(Box::new(pattern)),
+    })
   }
 
   pub fn new_known_cwd(path: Cow<'_, Path>, cwd: &Path) -> Self {
@@ -1600,6 +1797,7 @@ impl PathDescriptor {
       cmp_path,
       requested: display,
       is_windows_device_path,
+      pattern: None,
     }
   }
 
@@ -1608,10 +1806,19 @@ impl PathDescriptor {
   }
 
   pub fn starts_with(&self, base: &PathQueryDescriptor) -> bool {
+    // A glob entry has no prefix/subtree relationship to a concrete path, so it
+    // never yields the "partial" (ancestor-of-a-denied-path) states that the
+    // literal-path model relies on. Treat it as non-partial.
+    if self.pattern.is_some() {
+      return false;
+    }
     self.cmp_path.starts_with(&base.cmp_path)
   }
 
   pub fn display_name(&self) -> Cow<'_, str> {
+    if let Some(pattern) = &self.pattern {
+      return Cow::Borrowed(pattern.canonical.as_str());
+    }
     match &self.requested {
       Some(requested) => Cow::Borrowed(requested.as_str()),
       None => self.path.to_string_lossy(),
@@ -1643,9 +1850,17 @@ impl PathDescriptor {
     self.path
   }
 
+  /// Pattern key used to break ordering ties between entries that share the
+  /// same `cmp_path`. A literal path (`None`) sorts before a glob (`Some`) with
+  /// the same base, and two distinct globs are ordered by their canonical text
+  /// so they aren't collapsed into one entry.
+  fn pattern_key(&self) -> Option<&str> {
+    self.pattern.as_deref().map(|p| p.canonical.as_str())
+  }
+
   fn cmp_allow_allow(&self, other: &PathDescriptor) -> Ordering {
     if self.cmp_path == other.cmp_path {
-      Ordering::Equal
+      self.pattern_key().cmp(&other.pattern_key())
     } else if other.cmp_path.starts_with(&self.cmp_path) {
       Ordering::Greater
     } else if self.cmp_path.starts_with(&other.cmp_path) {
@@ -2563,6 +2778,9 @@ pub enum PathResolveError {
   #[class(generic)]
   #[error("Empty path is not allowed")]
   EmptyPath,
+  #[class(generic)]
+  #[error("invalid glob pattern '{pattern}': {message}")]
+  GlobPattern { pattern: String, message: String },
 }
 
 impl PathResolveError {
@@ -2571,14 +2789,16 @@ impl PathResolveError {
       Self::CwdResolve(e) | Self::Canonicalize(e) | Self::NotFound(e) => {
         e.kind()
       }
-      Self::EmptyPath => std::io::ErrorKind::InvalidData,
+      Self::EmptyPath | Self::GlobPattern { .. } => {
+        std::io::ErrorKind::InvalidData
+      }
     }
   }
 
   pub fn into_io_error(self) -> std::io::Error {
     match self {
       Self::CwdResolve(e) | Self::Canonicalize(e) | Self::NotFound(e) => e,
-      PathResolveError::EmptyPath => {
+      PathResolveError::EmptyPath | PathResolveError::GlobPattern { .. } => {
         std::io::Error::new(self.kind(), format!("{}", self))
       }
     }
@@ -5597,6 +5817,24 @@ mod tests {
         cmp_path,
         requested: None,
         is_windows_device_path: false,
+        pattern: None,
+      }
+    }
+
+    /// Like [`join_path_with_root`], but parses glob entries (for read/write).
+    fn join_path_or_glob_with_root(
+      &self,
+      path: &str,
+    ) -> Result<PathDescriptor, PathResolveError> {
+      if is_glob_pattern_entry(path) {
+        let root = if path.starts_with("C:\\") {
+          PathBuf::from("C:\\")
+        } else {
+          PathBuf::from("/")
+        };
+        PathDescriptor::from_glob(path, &root)
+      } else {
+        Ok(self.join_path_with_root(path))
       }
     }
   }
@@ -5606,14 +5844,14 @@ mod tests {
       &self,
       text: &str,
     ) -> Result<ReadDescriptor, PathResolveError> {
-      Ok(ReadDescriptor(self.join_path_with_root(text)))
+      Ok(ReadDescriptor(self.join_path_or_glob_with_root(text)?))
     }
 
     fn parse_write_descriptor(
       &self,
       text: &str,
     ) -> Result<WriteDescriptor, PathResolveError> {
-      Ok(WriteDescriptor(self.join_path_with_root(text)))
+      Ok(WriteDescriptor(self.join_path_or_glob_with_root(text)?))
     }
 
     fn parse_net_descriptor(
@@ -5776,6 +6014,97 @@ mod tests {
         is_ok
       );
     }
+  }
+
+  #[test]
+  fn test_check_read_write_glob() {
+    set_prompter(Box::new(TestPrompter));
+    let parser = TestPermissionDescriptorParser;
+    let perms = Permissions::from_options(
+      &parser,
+      &PermissionsOptions {
+        allow_read: Some(svec![
+          // single-segment wildcard: only direct children ending in .ts
+          "/project/src/*.ts",
+          // recursive wildcard across directories
+          "/project/data/**/*.json",
+          // brackets are matched literally, not as character classes
+          "/project/[id]/*.ts",
+          // a plain literal path entry kept working alongside globs
+          "/project/literal"
+        ]),
+        // a glob in the deny list blocks matching paths...
+        deny_read: Some(svec!["/project/src/secret*.ts"]),
+        allow_write: Some(svec!["/project/out/*.log"]),
+        ..Default::default()
+      },
+    )
+    .unwrap();
+    let perms = PermissionsContainer::new(Arc::new(parser), perms);
+
+    let read = |p: &str| {
+      perms
+        .check_open(
+          Cow::Borrowed(Path::new(p)),
+          OpenAccessKind::Read,
+          Some("api"),
+        )
+        .is_ok()
+    };
+    let write = |p: &str| {
+      perms
+        .check_open(
+          Cow::Borrowed(Path::new(p)),
+          OpenAccessKind::Write,
+          Some("api"),
+        )
+        .is_ok()
+    };
+
+    // `*.ts` matches direct children only, not nested dirs or other extensions.
+    assert!(read("/project/src/main.ts"));
+    assert!(!read("/project/src/main.js"));
+    assert!(!read("/project/src/nested/main.ts"));
+    // Deny glob wins over the allow glob for matching files.
+    assert!(!read("/project/src/secret.ts"));
+    assert!(!read("/project/src/secret_key.ts"));
+    // `**` crosses directories.
+    assert!(read("/project/data/a.json"));
+    assert!(read("/project/data/nested/deep/b.json"));
+    assert!(!read("/project/data/nested/b.txt"));
+    // Brackets in a glob entry match literally, not as a character class.
+    assert!(read("/project/[id]/main.ts"));
+    assert!(!read("/project/i/main.ts"));
+    // A literal entry still grants its whole subtree by prefix.
+    assert!(read("/project/literal"));
+    assert!(read("/project/literal/child/file.txt"));
+    // Paths outside every entry are denied.
+    assert!(!read("/project/other/x.ts"));
+    // Write globs are independent of read globs.
+    assert!(write("/project/out/run.log"));
+    assert!(!write("/project/out/run.txt"));
+    assert!(!write("/project/src/main.ts"));
+  }
+
+  #[test]
+  fn test_read_write_descriptor_glob_parse() {
+    let parser = TestPermissionDescriptorParser;
+    // Glob entries parse and are typed as patterns; the display form is the
+    // canonical (normalized, absolute) pattern text.
+    let d = parser.parse_read_descriptor("/a/b/*.ts").unwrap();
+    assert!(d.0.pattern.is_some());
+    assert_eq!(d.0.display_name(), "/a/b/*.ts");
+    // Entries without glob characters stay literal.
+    let d = parser.parse_read_descriptor("/a/b/c.ts").unwrap();
+    assert!(d.0.pattern.is_none());
+    // `.`/`..` are normalized inside a glob entry.
+    let d = parser.parse_write_descriptor("/a/./x/../*.log").unwrap();
+    assert_eq!(d.0.display_name(), "/a/*.log");
+    // Negated patterns are rejected.
+    assert!(parser.parse_read_descriptor("!/a/*.ts").is_err());
+    // Brackets are matched literally, not as character classes.
+    let d = parser.parse_read_descriptor("/pages/[id]/*.ts").unwrap();
+    assert!(d.0.pattern.is_some());
   }
 
   #[test]

--- a/runtime/permissions/runtime_descriptor_parser.rs
+++ b/runtime/permissions/runtime_descriptor_parser.rs
@@ -65,18 +65,18 @@ impl<TSys: RuntimePermissionDescriptorParserSys + std::fmt::Debug>
     &self,
     text: &str,
   ) -> Result<ReadDescriptor, PathResolveError> {
-    Ok(ReadDescriptor(
-      self.parse_path_descriptor(Cow::Borrowed(Path::new(text)))?,
-    ))
+    Ok(ReadDescriptor(PathDescriptor::new_maybe_glob(
+      &self.sys, text,
+    )?))
   }
 
   fn parse_write_descriptor(
     &self,
     text: &str,
   ) -> Result<WriteDescriptor, PathResolveError> {
-    Ok(WriteDescriptor(
-      self.parse_path_descriptor(Cow::Borrowed(Path::new(text)))?,
-    ))
+    Ok(WriteDescriptor(PathDescriptor::new_maybe_glob(
+      &self.sys, text,
+    )?))
   }
 
   fn parse_net_descriptor(
@@ -198,5 +198,16 @@ mod test {
     );
     assert!(parser.parse_net_query("").is_err());
     assert!(parser.parse_run_query("").is_err());
+  }
+
+  #[test]
+  fn parse_read_write_glob_descriptor() {
+    let parser =
+      RuntimePermissionDescriptorParser::new(sys_traits::impls::RealSys);
+    // Absolute glob entries parse as patterns.
+    assert!(parser.parse_read_descriptor("/a/b/*.ts").is_ok());
+    assert!(parser.parse_write_descriptor("/a/**/*.log").is_ok());
+    // Negated patterns are rejected.
+    assert!(parser.parse_read_descriptor("!/a/*.ts").is_err());
   }
 }

--- a/tests/specs/permission/allow_read_glob/__test__.jsonc
+++ b/tests/specs/permission/allow_read_glob/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "allow_read_glob": {
+      "args": "run --allow-read=sub/*.txt main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/permission/allow_read_glob/main.out
+++ b/tests/specs/permission/allow_read_glob/main.out
@@ -1,0 +1,4 @@
+sub/a.txt: allowed
+sub/nested/a.txt: denied
+sub/a.log: denied
+other/a.txt: denied

--- a/tests/specs/permission/allow_read_glob/main.ts
+++ b/tests/specs/permission/allow_read_glob/main.ts
@@ -1,0 +1,28 @@
+// Tests glob entries in --allow-read. The allow list grants `sub/*.txt`, which
+// matches only direct `.txt` children of `sub/`. We classify each access by
+// whether the permission layer rejects it (NotCapable) before touching the
+// filesystem. Allowed accesses instead fail with NotFound against the
+// (nonexistent) file, which is immediate and offline-safe.
+
+function isPermissionError(e: unknown): boolean {
+  return e instanceof Deno.errors.NotCapable ||
+    (e instanceof Error && e.name === "PermissionDenied");
+}
+
+function classifyRead(path: string): string {
+  try {
+    Deno.readTextFileSync(path);
+    return "allowed";
+  } catch (e) {
+    return isPermissionError(e) ? "denied" : "allowed";
+  }
+}
+
+// Matching direct child -> allowed.
+console.log("sub/a.txt:", classifyRead("sub/a.txt"));
+// `*` does not cross directory boundaries -> denied.
+console.log("sub/nested/a.txt:", classifyRead("sub/nested/a.txt"));
+// Wrong extension -> denied.
+console.log("sub/a.log:", classifyRead("sub/a.log"));
+// Outside the pattern's base directory -> denied.
+console.log("other/a.txt:", classifyRead("other/a.txt"));


### PR DESCRIPTION
This adds glob-pattern support to the filesystem read/write permission lists, addressing the long-standing request in #30740 (and the older #11277 / #10389).

## What

A `--allow-read` / `--allow-write` entry that contains a glob character (`*`, `**` or `?`) is now matched as a glob against the concrete path being accessed, instead of as a literal path prefix:

```sh
deno run --allow-read="/data/**/*.json"     main.ts
deno run --allow-write="/tmp/*.log"         main.ts
deno run --allow-read="src/*.ts"            main.ts   # relative, resolved against cwd
```

- `*` matches within a single path segment; `**` crosses directories (and matches zero directories, so `/data/**/*.json` also matches `/data/a.json`).
- `?` matches a single character.
- Patterns are compiled with the [`glob`](https://crates.io/crates/glob) crate — the same engine already used for `deno.json` include/exclude globs — so semantics match the rest of the toolchain.

## Not a breaking change

An entry is only treated as a glob when it contains `*` or `?`. Every entry that parsed before — absolute/relative literal paths, `unix:` sockets, etc. — parses and matches **exactly** as before (literal path, whole-subtree-by-prefix). Bracket characters (`[` / `]`) are matched **literally**, so a path like `pages/[id].ts` is unaffected. All existing permission tests are unchanged.

## Semantics & design notes for reviewers

- **Scope:** read/write only for now. FFI (which shares `PathDescriptor`) deliberately stays literal-path-only; `--allow-run`/`--allow-import` are out of scope.
- **Ordering / specificity:** the permission list resolves overlaps with a "most-specific-rule-wins" model keyed on path prefixes. A glob is anchored in that ordering by its literal **base path** (the directory prefix before the first glob character, e.g. `/data` for `/data/**/*.json`). This integrates cleanly for the common cases (a glob under a directory, a deny glob vs a host allow, etc.), but it's an approximation: a glob with a shallow base but a specific tail (e.g. a deny `**/*.secret`, base empty) sorts as very broad and is easily overridden by a narrower literal. Happy to refine if a stronger rule is wanted.
- **Non-partial:** a glob only grants the concrete paths it matches. Unlike a literal prefix it never produces the directory-descent "partial" grant states (used for e.g. `readDir` on a parent of a granted child). A glob deny therefore blocks matching file access but does not "partially deny" ancestor directories.
- **Negation:** `!pattern` entries are rejected — the deny list is the intended way to exclude paths.
- **Case sensitivity:** case-sensitive on Linux, case-insensitive on Windows/macOS, matching the existing literal-path comparison (`comparison_path`).
- Implementation is self-contained in `deno_permissions` (depends on `glob` directly, mirroring how the URLPattern net work took `urlpattern` directly) rather than depending on the heavier `deno_config` glob module. Unifying the two `GlobPattern` implementations would be a reasonable follow-up. One correctness note: `deno_config`'s bracket-escape (`.replace('[', "[[]").replace(']', "[]]")`) is subtly broken for a glob that both contains brackets and is glob-matched; it's safe there only because its brackets always land in the stripped literal base. This PR uses a correct single-pass escape.

## Tests

- `runtime/permissions`: `test_check_read_write_glob` (segment vs recursive wildcards, deny globs, literal brackets, literal entries alongside globs, read/write independence), `test_read_write_descriptor_glob_parse` and `parse_read_write_glob_descriptor` (parsing/typing/normalization/negation-rejection through both the test and real parsers). Full crate suite passes.
- `tests/specs/permission/allow_read_glob`: end-to-end spec test for segment matching and the directory/extension boundaries.

Closes #30740
