### PR TITLE
feat(release): add DENO_LTS build flag and lts version-file routing

### DIFF
--- a/cli/lib/version.rs
+++ b/cli/lib/version.rs
@@ -29,6 +29,10 @@ pub use deno_node::NODE_VERSION;
 const IS_CANARY: bool = option_env!("DENO_CANARY").is_some();
 // TODO(bartlomieju): this is temporary, to allow Homebrew to cut RC releases as well
 const IS_RC: bool = option_env!("DENO_RC").is_some();
+// Set when building an LTS release (e.g. from the `2.9` branch). Like
+// DENO_CANARY/DENO_RC, this is read from the build environment and only used as
+// a fallback when the binary has no `denover` section.
+const IS_LTS: bool = option_env!("DENO_LTS").is_some();
 
 pub static DENO_VERSION_INFO: std::sync::LazyLock<DenoVersionInfo> =
   std::sync::LazyLock::new(|| {
@@ -47,6 +51,8 @@ pub static DENO_VERSION_INFO: std::sync::LazyLock<DenoVersionInfo> =
           ReleaseChannel::Canary
         } else if IS_RC {
           ReleaseChannel::Rc
+        } else if IS_LTS {
+          ReleaseChannel::Lts
         } else {
           release_channel_from_version_string(DENO_VERSION)
         }
@@ -57,6 +63,8 @@ pub static DENO_VERSION_INFO: std::sync::LazyLock<DenoVersionInfo> =
       ReleaseChannel::Canary
     } else if IS_RC {
       ReleaseChannel::Rc
+    } else if IS_LTS {
+      ReleaseChannel::Lts
     } else {
       release_channel_from_version_string(DENO_VERSION)
     };

--- a/tools/release/upload_version_file.ts
+++ b/tools/release/upload_version_file.ts
@@ -4,19 +4,30 @@
 
 // Determines the correct latest-version file for a given release tag,
 // writes the version into it, and prints the file name to stdout.
-// For stable releases, exits with code 1 if the version is not greater
-// than the current published latest (to skip the upload).
+//
+// Pass `--lts` (or set DENO_LTS) for an LTS release: it targets
+// `release-lts-latest.txt` and never touches the stable pointer, so an LTS
+// patch (a plain version like 2.9.4) can't be mistaken for the latest stable.
+//
+// For stable and LTS releases, exits with code 1 if the version is not greater
+// than the currently published latest for that channel (to skip the upload).
 
 import { greaterThan, parse } from "jsr:@std/semver@1";
 
-const version = Deno.args[0];
+const isLts = Deno.args.includes("--lts") ||
+  Boolean(Deno.env.get("DENO_LTS"));
+const version = Deno.args.find((a) => !a.startsWith("--"));
 if (!version) {
-  console.error("Usage: upload_version_file.ts <version-tag>");
+  console.error("Usage: upload_version_file.ts <version-tag> [--lts]");
   Deno.exit(1);
 }
 
 let latestFile: string;
-if (version.includes("-alpha.")) {
+if (isLts) {
+  // LTS versions are plain semver, so this must take precedence over the
+  // suffix checks below and never fall through to `release-latest.txt`.
+  latestFile = "release-lts-latest.txt";
+} else if (version.includes("-alpha.")) {
   latestFile = "release-alpha-latest.txt";
 } else if (version.includes("-beta.")) {
   latestFile = "release-beta-latest.txt";
@@ -29,22 +40,27 @@ console.error("Latest file:", latestFile);
 
 Deno.writeTextFileSync(latestFile, version + "\n");
 
-// For stable releases, check that this version is actually newer
-if (latestFile === "release-latest.txt") {
-  const response = await fetch("https://dl.deno.land/release-latest.txt");
-  if (!response.ok) {
-    throw new Error(`Failed to fetch: ${response.statusText}`);
-  }
-  const latestVersionText = (await response.text()).trim();
-  console.error("Currently published latest:", latestVersionText);
+// Stable and LTS pointers must never regress.
+if (
+  latestFile === "release-latest.txt" ||
+  latestFile === "release-lts-latest.txt"
+) {
+  const response = await fetch(`https://dl.deno.land/${latestFile}`);
+  if (response.ok) {
+    const latestVersionText = (await response.text()).trim();
+    console.error("Currently published latest:", latestVersionText);
 
-  const latestVersion = parse(latestVersionText);
-  const currentVersion = parse(version);
-  if (!greaterThan(currentVersion, latestVersion)) {
-    console.error(
-      "Skipping upload because this version is not greater than the latest.",
-    );
-    Deno.exit(1);
+    const latestVersion = parse(latestVersionText);
+    const currentVersion = parse(version);
+    if (!greaterThan(currentVersion, latestVersion)) {
+      console.error(
+        "Skipping upload because this version is not greater than the latest.",
+      );
+      Deno.exit(1);
+    }
+  } else if (response.status !== 404) {
+    // 404 means the channel has no pointer yet (first release) -> allow.
+    throw new Error(`Failed to fetch: ${response.statusText}`);
   }
 }
 


### PR DESCRIPTION
Inert plumbing for cutting LTS releases (e.g. from a future 2.9 branch).
No behavior change until an LTS build sets the flag, so this is safe to
land on main ahead of the branch.

cli/lib/version.rs: add a DENO_LTS compile flag mirroring
DENO_CANARY/DENO_RC. When a binary has no denover section and DENO_LTS is
set at build time, the release channel resolves to Lts. The reported
version stays plain (only canary appends the git hash), so
`deno --version` shows e.g. 2.9.4, not a prerelease.

tools/release/upload_version_file.ts: add an lts mode via `--lts` or the
DENO_LTS env. LTS versions are plain semver, so without this a 2.9.4 LTS
release would be written to release-latest.txt and mistaken for the
latest stable (moving stable users backward off, say, 3.0.0). In lts mode
it writes release-lts-latest.txt, applies the same "must be newer than
the current pointer" guard (generalized to both stable and lts, with 404
handling for a channel's first release), and never touches the stable
pointer.

Part of the Deno 2.9 LTS work; the lts build/publish workflow that sets
the flag is a follow-up.