### PR TITLE
feat(lint): graph-aware (cross-file) lint rules — prototype / RFC

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -512,6 +512,12 @@ function installPlugin(plugin, specifier) {
   return {
     name: plugin.name,
     ruleNames: Object.keys(plugin.rules),
+    // Names of rules that declare a graph-aware hook. Declaring
+    // `createGraphRule` is what opts the `deno lint` run into building and
+    // handing over the module graph.
+    graphRuleNames: Object.keys(plugin.rules).filter(
+      (name) => typeof plugin.rules[name].createGraphRule === "function",
+    ),
   };
 }
 
@@ -1245,6 +1251,11 @@ export function runPluginsForFile(fileName, serializedAst) {
         continue;
       }
 
+      // Graph-only rules (no per-file `create`) are handled in the graph phase.
+      if (typeof rule.create !== "function") {
+        continue;
+      }
+
       const ruleCtx = new Context(ctx, id, fileName);
       const visitor = rule.create(ruleCtx);
 
@@ -1590,10 +1601,118 @@ function _dump(ctx) {
   }
 }
 
+/**
+ * Read-only view of a resolved module, handed to a graph rule.
+ * @implements {Deno.lint.LintModule}
+ */
+class GraphModule {
+  /** @param {*} raw */
+  constructor(raw) {
+    this.specifier = raw.specifier;
+    this.mediaType = raw.mediaType;
+    this.dependencies = raw.dependencies;
+    this.exports = raw.exports;
+  }
+}
+
+/**
+ * Read-only view of the resolved module graph, handed to a graph rule.
+ * @implements {Deno.lint.LintModuleGraph}
+ */
+class GraphView {
+  /** @param {*} raw */
+  constructor(raw) {
+    this.roots = raw.roots;
+    /** @type {GraphModule[]} */
+    this.modules = raw.modules.map((m) => new GraphModule(m));
+    /** @type {Map<string, GraphModule>} */
+    this.#bySpecifier = new Map();
+    for (const m of this.modules) {
+      this.#bySpecifier.set(m.specifier, m);
+    }
+  }
+
+  #bySpecifier;
+
+  /** @param {string} specifier */
+  module(specifier) {
+    return this.#bySpecifier.get(specifier);
+  }
+}
+
+/**
+ * The context handed to a `createGraphRule` hook.
+ * @implements {Deno.lint.GraphRuleContext}
+ */
+class GraphRuleContext {
+  /**
+   * @param {GraphView} graph
+   * @param {string} id
+   * @param {any[]} sink Collected reports, drained by Rust.
+   */
+  constructor(graph, id, sink) {
+    this.graph = graph;
+    this.id = id;
+    this.#sink = sink;
+  }
+
+  #sink;
+
+  /** @param {Deno.lint.GraphDiagnostic} data */
+  report(data) {
+    if (typeof data.specifier !== "string") {
+      throw new Error("`specifier` must be provided when a graph rule reports");
+    }
+    const range = data.range ? data.range : [0, 0];
+    this.#sink.push({
+      specifier: data.specifier,
+      id: this.id,
+      message: data.message,
+      hint: data.hint ?? "",
+      start: range[0],
+      end: range[1],
+    });
+  }
+}
+
+/**
+ * Runs the graph-aware phase: for every enabled rule that declares a
+ * `createGraphRule` hook, invoke it once with a read-only graph view.
+ * Called by Rust after the per-file phase (see plugins.rs).
+ * @param {string} graphJson JSON-serialized `LintModuleGraph`.
+ * @returns {any[]} Collected reports, converted to diagnostics by Rust.
+ */
+export function runGraphRules(graphJson) {
+  const raw = JSON.parse(graphJson);
+  const graph = new GraphView(raw);
+  const sink = [];
+
+  for (let i = 0; i < state.plugins.length; i++) {
+    const plugin = state.plugins[i];
+    for (const name of Object.keys(plugin.rules)) {
+      const rule = plugin.rules[name];
+      if (typeof rule.createGraphRule !== "function") continue;
+
+      const id = `${plugin.name}/${name}`;
+      if (state.ignoredRules.has(id)) continue;
+
+      const ctx = new GraphRuleContext(graph, id, sink);
+      try {
+        rule.createGraphRule(ctx);
+      } catch (err) {
+        throw new Error(`Graph rule "${id}" errored`, { cause: err });
+      }
+    }
+  }
+
+  return sink;
+}
+
 // These are captured by Rust and called when plugins need to be loaded
 // or run.
 internals.installPlugins = installPlugins;
 internals.runPluginsForFile = runPluginsForFile;
+internals.runGraphRules = runGraphRules;
 internals.resetState = resetState;
 
 /**

--- a/cli/ops/lint.rs
+++ b/cli/ops/lint.rs
@@ -16,6 +16,7 @@ use deno_lint::diagnostic::LintDiagnosticRange;
 use deno_lint::diagnostic::LintDocsUrl;
 use deno_lint::diagnostic::LintFix;
 use deno_lint::diagnostic::LintFixChange;
+use std::collections::HashMap;
 use tokio_util::sync::CancellationToken;
 
 use crate::tools::lint;
@@ -60,6 +61,38 @@ pub struct LintPluginContainer {
   pub utf_16_map: Option<Utf16Map>,
   pub specifier: Option<ModuleSpecifier>,
   pub token: CancellationToken,
+  /// Per-module source info for the graph phase, keyed by specifier. A graph
+  /// rule reports against an arbitrary module (not the "current" file), so we
+  /// need each module's text info + utf16 map to attribute the diagnostic.
+  pub graph_files: HashMap<ModuleSpecifier, (SourceTextInfo, Utf16Map)>,
+}
+
+/// Convert a [start, end) UTF-16 range into a UTF-8 `SourceRange` within the
+/// given source, shared by the per-file and graph report paths.
+fn utf16_to_utf8_range(
+  utf16_map: &Utf16Map,
+  source_text_info: &SourceTextInfo,
+  start_utf16: usize,
+  end_utf16: usize,
+) -> Result<SourceRange, LintReportError> {
+  let out_of_range = || LintReportError::IncorrectRange {
+    start: start_utf16,
+    end: end_utf16,
+    source_end: utf16_map.text_content_length_utf16().into(),
+  };
+  let Some(start) = utf16_map.utf16_to_utf8_offset((start_utf16 as u32).into())
+  else {
+    return Err(out_of_range());
+  };
+  let Some(end) = utf16_map.utf16_to_utf8_offset((end_utf16 as u32).into())
+  else {
+    return Err(out_of_range());
+  };
+  let start_pos = source_text_info.start_pos();
+  Ok(SourceRange::new(
+    start_pos + start.into(),
+    start_pos + end.into(),
+  ))
 }
 
 impl LintPluginContainer {
@@ -77,6 +110,57 @@ impl LintPluginContainer {
     self.token = maybe_token.unwrap_or_default();
   }
 
+  /// Set the per-module source info used by the graph phase.
+  pub fn set_graph_files(
+    &mut self,
+    graph_files: HashMap<ModuleSpecifier, (SourceTextInfo, Utf16Map)>,
+  ) {
+    self.diagnostics.clear();
+    self.graph_files = graph_files;
+  }
+
+  /// Report a diagnostic from a graph rule, attributed to an arbitrary module
+  /// `specifier` (not the "current" file). The range is UTF-16 offsets within
+  /// that module's source. Called from the plugin host after reading the
+  /// reports returned by the JS `runGraphRules` function.
+  pub fn report_graph(
+    &mut self,
+    specifier: String,
+    id: String,
+    message: String,
+    hint: Option<String>,
+    start_utf16: usize,
+    end_utf16: usize,
+  ) -> Result<(), LintReportError> {
+    let specifier = ModuleSpecifier::parse(&specifier)
+      .map_err(|_| LintReportError::UnknownSpecifier(specifier.clone()))?;
+    let Some((source_text_info, utf16_map)) = self.graph_files.get(&specifier)
+    else {
+      return Err(LintReportError::UnknownSpecifier(specifier.to_string()));
+    };
+    let diagnostic_range =
+      utf16_to_utf8_range(utf16_map, source_text_info, start_utf16, end_utf16)?;
+    let range = LintDiagnosticRange {
+      range: diagnostic_range,
+      description: None,
+      text_info: source_text_info.clone(),
+    };
+    let lint_diagnostic = LintDiagnostic {
+      specifier,
+      range: Some(range),
+      details: LintDiagnosticDetails {
+        message,
+        code: id,
+        hint,
+        fixes: vec![],
+        custom_docs_url: LintDocsUrl::None,
+        info: vec![],
+      },
+    };
+    self.diagnostics.push(lint_diagnostic);
+    Ok(())
+  }
+
   fn report(
     &mut self,
     id: String,
@@ -86,40 +170,6 @@ impl LintPluginContainer {
     end_utf16: usize,
     raw_fixes: Vec<LintReportFix>,
   ) -> Result<(), LintReportError> {
-    fn out_of_range_err(
-      map: &Utf16Map,
-      start_utf16: usize,
-      end_utf16: usize,
-    ) -> LintReportError {
-      LintReportError::IncorrectRange {
-        start: start_utf16,
-        end: end_utf16,
-        source_end: map.text_content_length_utf16().into(),
-      }
-    }
-
-    fn utf16_to_utf8_range(
-      utf16_map: &Utf16Map,
-      source_text_info: &SourceTextInfo,
-      start_utf16: usize,
-      end_utf16: usize,
-    ) -> Result<SourceRange, LintReportError> {
-      let Some(start) =
-        utf16_map.utf16_to_utf8_offset((start_utf16 as u32).into())
-      else {
-        return Err(out_of_range_err(utf16_map, start_utf16, end_utf16));
-      };
-      let Some(end) = utf16_map.utf16_to_utf8_offset((end_utf16 as u32).into())
-      else {
-        return Err(out_of_range_err(utf16_map, start_utf16, end_utf16));
-      };
-      let start_pos = source_text_info.start_pos();
-      Ok(SourceRange::new(
-        start_pos + start.into(),
-        start_pos + end.into(),
-      ))
-    }
-
     let source_text_info = self.source_text_info.as_ref().unwrap();
     let utf16_map = self.utf_16_map.as_ref().unwrap();
     let specifier = self.specifier.clone().unwrap();
@@ -248,6 +298,9 @@ pub enum LintReportError {
     end: usize,
     source_end: u32,
   },
+  #[class(type)]
+  #[error("Unknown specifier reported by graph rule: {0}")]
+  UnknownSpecifier(String),
 }
 
 #[op2]
@@ -263,6 +316,21 @@ fn op_lint_report(
   let container = state.borrow_mut::<LintPluginContainer>();
   container.report(id, message, hint, start_utf16, end_utf16, fix)?;
   Ok(())
+}
+
+/// A single report emitted by a graph rule, decoded from the array returned by
+/// the JS `runGraphRules` function. Using a return value (rather than an op)
+/// avoids depending on op-table binding for `40_lint.js`, which is baked into
+/// the startup snapshot.
+#[derive(Debug, FromV8)]
+pub struct GraphReport {
+  pub specifier: String,
+  pub id: String,
+  pub message: String,
+  /// Empty string means "no hint".
+  pub hint: String,
+  pub start: usize,
+  pub end: usize,
 }
 
 #[op2]

--- a/cli/tools/lint/graph.rs
+++ b/cli/tools/lint/graph.rs
@@ -1,0 +1,204 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Graph-aware (cross-file) lint support.
+//!
+//! This builds a compact, read-only view of a `deno_graph::ModuleGraph` that
+//! is handed to opt-in `createGraphRule` plugin hooks. It runs once per
+//! `deno lint` invocation, after the per-file phase, and only when an enabled
+//! plugin rule declares a graph hook.
+//!
+//! v1 is graph-only (no type checker). Per module we expose: the resolved
+//! specifier, media type, resolved import edges, and resolved re-export edges
+//! (`export * from` / `export { x } from`). Re-export edges are extracted from
+//! each module's retained `ParsedSource` (via the CLI's `ParsedSourceCache`),
+//! because `deno_graph` folds imports and re-exports into a single
+//! `dependencies` map and does not distinguish them at the `Module` level.
+
+use std::collections::HashMap;
+
+use deno_ast::ModuleSpecifier;
+use deno_ast::ParsedSource;
+use deno_ast::SourceTextInfo;
+use deno_ast::swc::ast::ModuleDecl;
+use deno_ast::swc::ast::ModuleItem;
+use deno_ast::swc::ast::Program;
+use deno_ast::swc::common::Span;
+use deno_core::serde_json;
+use deno_graph::Module;
+use deno_graph::ModuleGraph;
+use deno_resolver::cache::ParsedSourceCache;
+use serde::Serialize;
+
+use crate::util::text_encoding::Utf16Map;
+
+pub struct SerializedGraph {
+  /// JSON payload handed to the JS runtime (see `LintModuleGraph` in
+  /// `lib.deno.unstable.d.ts`).
+  pub json: String,
+  /// Per-module `(SourceTextInfo, Utf16Map)` keyed by specifier, so that a
+  /// graph rule's `context.report({ specifier, range })` can be attributed
+  /// back to a concrete file + span even though the report targets a module
+  /// other than any single "current" file.
+  pub files: HashMap<ModuleSpecifier, (SourceTextInfo, Utf16Map)>,
+}
+
+#[derive(Serialize)]
+struct JsonGraph {
+  roots: Vec<String>,
+  modules: Vec<JsonModule>,
+}
+
+#[derive(Serialize)]
+struct JsonModule {
+  specifier: String,
+  #[serde(rename = "mediaType")]
+  media_type: String,
+  dependencies: Vec<JsonDependency>,
+  exports: Vec<JsonExport>,
+}
+
+#[derive(Serialize)]
+struct JsonDependency {
+  specifier: String,
+  resolved: Option<String>,
+  kind: &'static str,
+  range: [u32; 2],
+}
+
+#[derive(Serialize)]
+struct JsonExport {
+  name: String,
+  kind: &'static str,
+  from: Option<String>,
+  range: [u32; 2],
+}
+
+/// swc stores spans 1-indexed; convert to 0-based UTF-16 offsets within the
+/// module (matching the convention used by the per-file AST serializer).
+fn span_to_utf16(span: &Span, utf16_map: &Utf16Map) -> [u32; 2] {
+  if span.lo.0 == 0 && span.hi.0 == 0 {
+    return [0, 0];
+  }
+  let lo = span.lo.0.saturating_sub(1);
+  let hi = span.hi.0.saturating_sub(1);
+  let to16 = |v: u32| -> u32 {
+    utf16_map
+      .utf8_to_utf16_offset(v.into())
+      .map(|t| u32::from(t))
+      .unwrap_or(v)
+  };
+  [to16(lo), to16(hi)]
+}
+
+/// Extract resolved re-export edges from a module's parsed AST. Returns
+/// `(exports, ())`. Each `export * from "x"` / `export { a } from "x"` yields
+/// one entry whose `from` is the resolved target specifier (looked up in the
+/// module's `deno_graph` dependency map keyed by the raw specifier string).
+fn collect_exports(
+  parsed_source: &ParsedSource,
+  js_module: &deno_graph::JsModule,
+  utf16_map: &Utf16Map,
+) -> Vec<JsonExport> {
+  let mut exports = Vec::new();
+  let program = parsed_source.program();
+  let Program::Module(module) = program.as_ref() else {
+    return exports;
+  };
+
+  let resolve = |raw: &str| -> Option<String> {
+    js_module
+      .dependencies
+      .get(raw)
+      .and_then(|dep| dep.get_code())
+      .map(|s| s.to_string())
+  };
+
+  for item in &module.body {
+    let ModuleItem::ModuleDecl(decl) = item else {
+      continue;
+    };
+    match decl {
+      // `export * from "..."`
+      ModuleDecl::ExportAll(node) => {
+        let raw = node.src.value.to_string_lossy().into_owned();
+        exports.push(JsonExport {
+          name: "*".to_string(),
+          kind: "reexport",
+          from: resolve(&raw),
+          range: span_to_utf16(&node.span, utf16_map),
+        });
+      }
+      // `export { a, b } from "..."` (and `export * as ns from "..."`)
+      ModuleDecl::ExportNamed(node) => {
+        if let Some(src) = &node.src {
+          let raw = src.value.to_string_lossy().into_owned();
+          exports.push(JsonExport {
+            name: "*".to_string(),
+            kind: "reexport",
+            from: resolve(&raw),
+            range: span_to_utf16(&node.span, utf16_map),
+          });
+        }
+      }
+      _ => {}
+    }
+  }
+
+  exports
+}
+
+/// Build a serialized, read-only view of `graph` plus the per-module source
+/// info needed to attribute reported diagnostics.
+pub fn serialize_graph(
+  graph: &ModuleGraph,
+  parsed_source_cache: &ParsedSourceCache,
+) -> SerializedGraph {
+  let mut modules = Vec::new();
+  let mut files = HashMap::new();
+
+  for module in graph.modules() {
+    let Module::Js(js_module) = module else {
+      continue;
+    };
+
+    let parsed_source =
+      match parsed_source_cache.get_parsed_source_from_js_module(js_module) {
+        Ok(ps) => ps,
+        Err(_) => continue,
+      };
+    let source_text_info = parsed_source.text_info_lazy().clone();
+    let utf16_map = Utf16Map::new(parsed_source.text().as_ref());
+
+    let dependencies = js_module
+      .dependencies
+      .iter()
+      .map(|(raw, dep)| JsonDependency {
+        specifier: raw.clone(),
+        resolved: dep.get_code().map(|s| s.to_string()),
+        kind: if dep.is_dynamic { "dynamic" } else { "static" },
+        // Dependency source ranges are line/col in deno_graph; for the v1
+        // slice we leave them as whole-file. Rules attribute to export ranges
+        // (below), which carry real spans.
+        range: [0, 0],
+      })
+      .collect();
+
+    let exports = collect_exports(&parsed_source, js_module, &utf16_map);
+
+    modules.push(JsonModule {
+      specifier: js_module.specifier.to_string(),
+      media_type: js_module.media_type.to_string(),
+      dependencies,
+      exports,
+    });
+
+    files.insert(js_module.specifier.clone(), (source_text_info, utf16_map));
+  }
+
+  let roots = graph.roots.iter().map(|r| r.to_string()).collect();
+  let json_graph = JsonGraph { roots, modules };
+  let json = serde_json::to_string(&json_graph)
+    .unwrap_or_else(|_| "{\"roots\":[],\"modules\":[]}".to_string());
+
+  SerializedGraph { json, files }
+}

--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -58,6 +58,7 @@ use crate::util::path::is_script_ext;
 use crate::util::sync::AtomicFlag;
 
 mod ast_buffer;
+mod graph;
 mod linter;
 mod plugins;
 mod reporters;
@@ -110,6 +111,7 @@ pub async fn lint(
       factory.caches()?.clone(),
       lint_rule_provider,
       factory.module_graph_creator().await?.clone(),
+      factory.parsed_source_cache()?.clone(),
       compiler_options_resolver.clone(),
       cli_options.start_dir.clone(),
       &workspace_lint_options,
@@ -174,6 +176,7 @@ async fn lint_with_watch_inner(
     factory.caches()?.clone(),
     factory.lint_rule_provider().await?,
     factory.module_graph_creator().await?.clone(),
+    factory.parsed_source_cache()?.clone(),
     factory.compiler_options_resolver()?.clone(),
     cli_options.start_dir.clone(),
     &cli_options.resolve_workspace_lint_options(&lint_flags)?,
@@ -257,6 +260,7 @@ struct WorkspaceLinter {
   caches: Arc<Caches>,
   lint_rule_provider: LintRuleProvider,
   module_graph_creator: Arc<ModuleGraphCreator>,
+  parsed_source_cache: Arc<deno_resolver::cache::ParsedSourceCache>,
   compiler_options_resolver: Arc<CompilerOptionsResolver>,
   workspace_dir: Arc<WorkspaceDirectory>,
   reporter_lock: Arc<Mutex<Box<dyn LintReporter + Send>>>,
@@ -266,10 +270,12 @@ struct WorkspaceLinter {
 }
 
 impl WorkspaceLinter {
+  #[allow(clippy::too_many_arguments)]
   pub fn new(
     caches: Arc<Caches>,
     lint_rule_provider: LintRuleProvider,
     module_graph_creator: Arc<ModuleGraphCreator>,
+    parsed_source_cache: Arc<deno_resolver::cache::ParsedSourceCache>,
     compiler_options_resolver: Arc<CompilerOptionsResolver>,
     workspace_dir: Arc<WorkspaceDirectory>,
     workspace_options: &WorkspaceLintOptions,
@@ -280,6 +286,7 @@ impl WorkspaceLinter {
       caches,
       lint_rule_provider,
       module_graph_creator,
+      parsed_source_cache,
       compiler_options_resolver,
       workspace_dir,
       reporter_lock,
@@ -355,11 +362,16 @@ impl WorkspaceLinter {
         &self.compiler_options_resolver,
         member_dir.dir_url(),
       )?,
-      maybe_plugin_runner: plugin_runner,
+      maybe_plugin_runner: plugin_runner.clone(),
     }));
 
     let has_error = self.has_error.clone();
     let reporter_lock = self.reporter_lock.clone();
+
+    // Clones retained for the graph phase, which runs after `paths` and
+    // `cli_options` are moved into the per-file future below.
+    let graph_paths = paths.clone();
+    let graph_cli_options = cli_options.clone();
 
     let mut futures = Vec::with_capacity(2);
     if linter.has_package_rules()
@@ -428,6 +440,57 @@ impl WorkspaceLinter {
 
     if let Some(incremental_cache) = &maybe_incremental_cache {
       incremental_cache.wait_completion().await;
+    }
+
+    // Graph-aware (cross-file) lint phase. Opt-in: only runs when an enabled
+    // plugin rule declares a `createGraphRule` hook, in which case we build the
+    // module graph once (over the lint roots) and hand a read-only view to the
+    // graph rules. This is deferred until after the per-file phase.
+    if let Some(runner) = &plugin_runner
+      && runner.has_graph_rules()
+    {
+      self
+        .run_graph_rules(runner, graph_cli_options, &graph_paths)
+        .await?;
+    }
+
+    Ok(())
+  }
+
+  async fn run_graph_rules(
+    &self,
+    runner: &Arc<PluginHostProxy>,
+    cli_options: Arc<CliOptions>,
+    paths: &[PathBuf],
+  ) -> Result<(), AnyError> {
+    let roots = paths
+      .iter()
+      .filter_map(|p| ModuleSpecifier::from_file_path(p).ok())
+      .collect::<Vec<_>>();
+    if roots.is_empty() {
+      return Ok(());
+    }
+
+    let graph = self
+      .module_graph_creator
+      .create_graph(
+        deno_graph::GraphKind::CodeOnly,
+        roots,
+        cli_options.default_npm_caching_strategy(),
+      )
+      .await?;
+
+    let serialized = graph::serialize_graph(&graph, &self.parsed_source_cache);
+    let diagnostics = runner
+      .run_graph_rules(serialized.json, serialized.files)
+      .await?;
+
+    if !diagnostics.is_empty() {
+      self.has_error.raise();
+      let mut reporter = self.reporter_lock.lock();
+      for diagnostic in &diagnostics {
+        reporter.visit_diagnostic(diagnostic);
+      }
     }
 
     Ok(())

--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -49,12 +49,19 @@ pub enum PluginHostRequest {
     maybe_token: Option<CancellationToken>,
     tx: oneshot::Sender<PluginHostResponse>,
   },
+  RunGraph {
+    graph_json: String,
+    graph_files:
+      std::collections::HashMap<ModuleSpecifier, (SourceTextInfo, Utf16Map)>,
+    tx: oneshot::Sender<PluginHostResponse>,
+  },
 }
 
 pub enum PluginHostResponse {
   // TODO: write to structs
   LoadPlugin(Result<Vec<PluginInfo>, AnyError>),
   Run(Result<Vec<LintDiagnostic>, AnyError>),
+  RunGraph(Result<Vec<LintDiagnostic>, AnyError>),
 }
 
 impl std::fmt::Debug for PluginHostResponse {
@@ -62,6 +69,7 @@ impl std::fmt::Debug for PluginHostResponse {
     match self {
       Self::LoadPlugin(_arg0) => f.debug_tuple("LoadPlugin").finish(),
       Self::Run(_arg0) => f.debug_tuple("Run").finish(),
+      Self::RunGraph(_arg0) => f.debug_tuple("RunGraph").finish(),
     }
   }
 }
@@ -97,6 +105,7 @@ v8_static_strings! {
   DEFAULT = "default",
   INSTALL_PLUGINS = "installPlugins",
   RUN_PLUGINS_FOR_FILE = "runPluginsForFile",
+  RUN_GRAPH_RULES = "runGraphRules",
 }
 
 #[derive(Debug)]
@@ -117,12 +126,23 @@ impl PluginHostProxy {
 
     all_names
   }
+
+  /// Whether any loaded plugin declares a graph-aware rule (`createGraphRule`).
+  /// This is what opts the `deno lint` run into building the module graph.
+  pub fn has_graph_rules(&self) -> bool {
+    self
+      .plugin_info
+      .lock()
+      .iter()
+      .any(|info| !info.graph_rule_names.is_empty())
+  }
 }
 
 pub struct PluginHost {
   worker: MainWorker,
   install_plugins_fn: v8::Global<v8::Function>,
   run_plugins_for_file_fn: v8::Global<v8::Function>,
+  run_graph_rules_fn: v8::Global<v8::Function>,
   rx: mpsc::Receiver<PluginHostRequest>,
 }
 
@@ -173,7 +193,7 @@ async fn create_plugin_runner_inner(
   let obj = runtime.execute_script("lint.js", "Deno[Deno.internal]")?;
 
   log::debug!("Lint plugins loaded, capturing default exports");
-  let (install_plugins_fn, run_plugins_for_file_fn) = {
+  let (install_plugins_fn, run_plugins_for_file_fn, run_graph_rules_fn) = {
     deno_core::scope!(scope, runtime);
     let module_exports: v8::Local<v8::Object> =
       v8::Local::new(scope, obj).try_into().unwrap();
@@ -193,9 +213,17 @@ async fn create_plugin_runner_inner(
     let run_plugins_for_file_fn: v8::Local<v8::Function> =
       run_plugins_for_file_fn_val.try_into().unwrap();
 
+    let run_graph_rules_fn_name = RUN_GRAPH_RULES.v8_string(scope).unwrap();
+    let run_graph_rules_fn_val = module_exports
+      .get(scope, run_graph_rules_fn_name.into())
+      .unwrap();
+    let run_graph_rules_fn: v8::Local<v8::Function> =
+      run_graph_rules_fn_val.try_into().unwrap();
+
     (
       v8::Global::new(scope, install_plugins_fn),
       v8::Global::new(scope, run_plugins_for_file_fn),
+      v8::Global::new(scope, run_graph_rules_fn),
     )
   };
 
@@ -203,6 +231,7 @@ async fn create_plugin_runner_inner(
     worker,
     install_plugins_fn,
     run_plugins_for_file_fn,
+    run_graph_rules_fn,
     rx: rx_req,
   })
 }
@@ -211,6 +240,8 @@ async fn create_plugin_runner_inner(
 pub struct PluginInfo {
   pub name: String,
   pub rule_names: Vec<String>,
+  /// Names of rules in this plugin that declare a `createGraphRule` hook.
+  pub graph_rule_names: Vec<String>,
 }
 
 impl PluginInfo {
@@ -296,6 +327,22 @@ impl PluginHost {
           );
           let _ = tx.send(PluginHostResponse::Run(r));
         }
+        PluginHostRequest::RunGraph {
+          graph_json,
+          graph_files,
+          tx,
+        } => {
+          let start = std::time::Instant::now();
+          let r = match self.run_graph_rules(graph_json, graph_files) {
+            Ok(()) => Ok(self.take_diagnostics()),
+            Err(err) => Err(err),
+          };
+          log::debug!(
+            "Running graph lint rules took {:?}",
+            std::time::Instant::now() - start
+          );
+          let _ = tx.send(PluginHostResponse::RunGraph(r));
+        }
       }
     }
     log::debug!("Lint PluginHost run loop finished");
@@ -360,6 +407,64 @@ impl PluginHost {
       }
       _run_plugins_result
     };
+    Ok(())
+  }
+
+  fn run_graph_rules(
+    &mut self,
+    graph_json: String,
+    graph_files: std::collections::HashMap<
+      ModuleSpecifier,
+      (SourceTextInfo, Utf16Map),
+    >,
+  ) -> Result<(), AnyError> {
+    {
+      let state = self.worker.js_runtime.op_state();
+      let mut state = state.borrow_mut();
+      let container = state.borrow_mut::<LintPluginContainer>();
+      container.set_graph_files(graph_files);
+    }
+
+    let reports: Vec<crate::ops::lint::GraphReport> = {
+      deno_core::scope!(scope, &mut self.worker.js_runtime);
+      let graph_json_v8: v8::Local<v8::Value> =
+        v8::String::new(scope, &graph_json).unwrap().into();
+      let run_graph_rules = v8::Local::new(scope, &self.run_graph_rules_fn);
+      let undefined = v8::undefined(scope);
+
+      let result = {
+        v8::tc_scope!(tc_scope, scope);
+        let result =
+          run_graph_rules.call(tc_scope, undefined.into(), &[graph_json_v8]);
+        if let Some(exception) = tc_scope.exception() {
+          let error = JsError::from_v8_exception(tc_scope, exception);
+          return Err(error.into());
+        }
+        result.unwrap()
+      };
+      <Vec<crate::ops::lint::GraphReport> as FromV8>::from_v8(scope, result)?
+    };
+
+    // Convert the collected reports into diagnostics attributed to each
+    // module's real file + span.
+    let op_state = self.worker.js_runtime.op_state();
+    let mut op_state = op_state.borrow_mut();
+    let container = op_state.borrow_mut::<LintPluginContainer>();
+    for report in reports {
+      let hint = if report.hint.is_empty() {
+        None
+      } else {
+        Some(report.hint)
+      };
+      container.report_graph(
+        report.specifier,
+        report.id,
+        report.message,
+        hint,
+        report.start,
+        report.end,
+      )?;
+    }
     Ok(())
   }
 
@@ -506,6 +611,30 @@ impl PluginHostProxy {
       .await?;
 
     if let Ok(PluginHostResponse::Run(diagnostics_result)) = rx.await {
+      return diagnostics_result;
+    }
+    bail!("Plugin host has closed")
+  }
+
+  pub async fn run_graph_rules(
+    &self,
+    graph_json: String,
+    graph_files: std::collections::HashMap<
+      ModuleSpecifier,
+      (SourceTextInfo, Utf16Map),
+    >,
+  ) -> Result<Vec<LintDiagnostic>, AnyError> {
+    let (tx, rx) = oneshot::channel();
+    self
+      .tx
+      .send(PluginHostRequest::RunGraph {
+        graph_json,
+        graph_files,
+        tx,
+      })
+      .await?;
+
+    if let Ok(PluginHostResponse::RunGraph(diagnostics_result)) = rx.await {
       return diagnostics_result;
     }
     bail!("Plugin host has closed")

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1663,8 +1663,95 @@ declare namespace Deno {
      * @experimental
      */
     export interface Rule {
-      create(ctx: RuleContext): LintVisitor;
+      create?(ctx: RuleContext): LintVisitor;
       destroy?(ctx: RuleContext): void;
+      /**
+       * Graph-aware hook. Runs **once** per `deno lint` invocation, after all
+       * per-file passes, with a read-only view of the resolved module graph.
+       * Declaring this hook is what opts the run into building the graph.
+       * Synchronous — the graph is already resolved.
+       *
+       * @experimental
+       */
+      createGraphRule?(ctx: GraphRuleContext): void;
+    }
+
+    /**
+     * The context handed to a {@linkcode Rule.createGraphRule} hook.
+     * @category Linter
+     * @experimental
+     */
+    export interface GraphRuleContext {
+      /** Read-only view of the resolved module graph. */
+      graph: LintModuleGraph;
+      /** Attribute a finding to a concrete file + span. */
+      report(data: GraphDiagnostic): void;
+    }
+
+    /**
+     * Read-only, already-resolved module graph handed to a graph rule.
+     * @category Linter
+     * @experimental
+     */
+    export interface LintModuleGraph {
+      /** All modules reachable from the lint roots, plus the roots themselves. */
+      readonly modules: ReadonlyArray<LintModule>;
+      /** Root specifiers of the graph. */
+      readonly roots: ReadonlyArray<string>;
+      /** Look up a module by its fully-resolved specifier. */
+      module(specifier: string): LintModule | undefined;
+    }
+
+    /**
+     * @category Linter
+     * @experimental
+     */
+    export interface LintModule {
+      /** Fully-resolved specifier, e.g. `"file:///…/v4.ts"`. */
+      readonly specifier: string;
+      readonly mediaType: string;
+      /** Resolved outgoing dependency edges (imports + re-exports). */
+      readonly dependencies: ReadonlyArray<LintDependency>;
+      /** Resolved static re-export edges (`export * from` / `export { x } from`). */
+      readonly exports: ReadonlyArray<LintExport>;
+    }
+
+    /**
+     * @category Linter
+     * @experimental
+     */
+    export interface LintDependency {
+      /** Specifier text as written, e.g. `"./v4.ts"`. */
+      readonly specifier: string;
+      /** Resolved target specifier, or `null` if it failed to resolve. */
+      readonly resolved: string | null;
+      readonly kind: "static" | "dynamic";
+      readonly range: Range;
+    }
+
+    /**
+     * @category Linter
+     * @experimental
+     */
+    export interface LintExport {
+      readonly name: string;
+      readonly kind: "reexport";
+      /** For a re-export, the resolved source module (or `null`). */
+      readonly from: string | null;
+      readonly range: Range;
+    }
+
+    /**
+     * @category Linter
+     * @experimental
+     */
+    export interface GraphDiagnostic {
+      /** The file the diagnostic is attributed to (required). */
+      specifier: string;
+      /** Span within that file. Omit for a whole-file finding. */
+      range?: Range;
+      message: string;
+      hint?: string;
     }
 
     /**


### PR DESCRIPTION
> **Draft / RFC — not for merge.** This is a working vertical-slice
> prototype that accompanies a design proposal, opened to get feedback on
> the API shape. It builds and passes a hand-written acceptance test, but
> is deliberately narrow and has many known gaps (listed below).

## Motivation

Deno's lint plugin API is strictly **per-file**: a rule's only lifecycle
is `create(context)` / `destroy()`, with visitors over one file's AST.
This makes an entire class of genuinely useful checks inexpressible as
lint rules — anything that needs the whole module graph, or that must
detect the *absence* of something across files (unused exports, import
cycles, "every public module is re-exported from `mod.ts`", API-surface
consistency). Today these live as ad-hoc scripts that walk the filesystem
and re-parse with the TypeScript compiler, outside `deno lint` entirely.

The key lever: **Deno already builds a full module graph** (`deno_graph`)
for `deno info` / `check` / the LSP, and `CapturingModuleAnalyzer` already
retains each module's parsed source. The graph exists — this exposes it to
lint rules.

## What this prototype does

Adds an **opt-in `createGraphRule(context)` plugin hook** that runs **once,
after the per-file phase**, and only when an enabled rule declares it.
It receives a read-only `LintModuleGraph` (modules + resolved
re-export/import edges), and `context.report({ specifier, range, message,
hint })` emits a normal lint diagnostic attributed to a real file + span —
so it appears in both text output and `--json` like any other diagnostic.

Acceptance test (reimplements the existing `check_mod_exports` tooling
script as a graph rule): flags a package `mod.ts` that omits a sibling
re-export — **including catching a module that nothing imports**, the
"detect absence" case per-file linting structurally cannot see — and
passes clean when all siblings are re-exported.

## Scope of the change

Confined to the CLI; **no changes to `deno_lint` / `deno_graph` /
`deno_ast`** (only their public crate APIs were needed):

- `cli/tools/lint/graph.rs` *(new)* — builds the `LintModuleGraph`, runs
  graph rules, converts their reports to diagnostics.
- `cli/tools/lint/{mod,plugins}.rs`, `cli/ops/lint.rs`,
  `cli/js/40_lint.js`, `cli/tsc/dts/lib.deno.unstable.d.ts` — wire the
  hook, the JS-side surface, and the unstable type declarations.

`cargo build -p deno --bin deno` succeeds; the acceptance test runs
against the locally-built binary.

## Implementation note / deviation

The design originally called for a `context.report` **op**
(`op_lint_report_graph`). That failed at runtime: `40_lint.js`'s
`core.ops` table is baked into the startup snapshot, so a freshly-inserted
op won't bind. Instead, `runGraphRules` **returns** its reports through the
same `FromV8` return-value path `installPlugins` already uses, and Rust
converts them to diagnostics. No new op; robust. This is the one place the
implementation diverges from the written design.

## Known shortcomings (current prototype)

- **Reporting via return-value, not a snapshot-registered op** — works,
  but a proper op registered in the snapshot would be the cleaner
  long-term protocol.
- **Dependency-edge ranges are `[0,0]` placeholders** — export ranges
  carry real spans; import/dependency edges don't expose real source
  ranges yet.
- **No per-module AST exposed** — `LintModuleGraph` currently gives
  specifier + resolved export/import edges only; `deno_graph`'s retained
  `ParsedSource` is not surfaced to JS yet.
- **Opt-in is coarse** — the graph is built whenever *any* graph rule is
  registered; it does not yet skip the build when those rules are
  `exclude`d / disabled.
- **No `--fix`** — `GraphDiagnostic.fix` is unwired.
- **No `deno-lint-ignore` integration** — graph-rule diagnostics can't be
  suppressed inline yet.
- **No caching / `--watch` integration** — the incremental lint cache
  doesn't account for graph rules; every run rebuilds the graph.
- **No type information** — graph-only by design; type-aware rules
  (à la typescript-eslint typed linting) are out of scope here.
- **Perf unmeasured** — the cost of building the graph for lint is
  unquantified; no benchmarks.
- **Provisional, unstable API** — names (`createGraphRule`,
  `LintModuleGraph`, `GraphDiagnostic`) are placeholders under
  `lib.deno.unstable.d.ts` and have had no API review.
- **Thin tests** — only a manual acceptance fixture; no spec/unit tests in
  the suite yet.
- **Cross-file attribution semantics undesigned** — works for a single
  reported specifier+span; which file "owns" a genuinely cross-module
  finding needs design.

## Follow-ups to productionize

- [ ] Formalize the report protocol (snapshot-registered op, or bless the
      return-value path).
- [ ] Expose real dependency-edge ranges and per-module `ast` from the
      retained `ParsedSource`.
- [ ] Tighten opt-in to gate the graph build on *enabled* graph rules only.
- [ ] Wire `--fix` and `deno-lint-ignore` for graph diagnostics.
- [ ] Integrate with the lint cache and `--watch`.
- [ ] Add spec tests + unit coverage.
- [ ] Benchmark graph-build cost; consider a lazy / partial graph.
- [ ] Design the type-aware (v2) extension.
- [ ] API review of the `Deno.lint` graph-rule surface before stabilization.

## Design doc

A fuller written proposal (motivation, prior art — rustc
`Early`/`LateLintPass`, typescript-eslint typed linting, Biome v2 scanner,
oxlint — the API design, and a worked `check_mod_exports` reimplementation)
accompanies this; happy to share/attach it in the thread.