### PR TITLE
fix(canvas): don't hold SurfaceData mut borrow over window resize

### DIFF
--- a/ext/canvas/byow.rs
+++ b/ext/canvas/byow.rs
@@ -141,11 +141,7 @@ impl UnsafeWindowSurface {
     scope: &mut v8::PinScope<'_, '_>,
     value: u32,
   ) -> Result<(), JsErrorBox> {
-    {
-      // We need to be sure to drop the borrow before using the context below
-      let mut data = self.data.borrow_mut();
-      data.height = value;
-    }
+    self.data.borrow_mut().height = value;
 
     if let Some((id, active_context)) = self.active_context.get() {
       let active_context = v8::Local::new(scope, active_context);

--- a/ext/canvas/byow.rs
+++ b/ext/canvas/byow.rs
@@ -113,11 +113,7 @@ impl UnsafeWindowSurface {
     scope: &mut v8::PinScope<'_, '_>,
     value: u32,
   ) -> Result<(), JsErrorBox> {
-    {
-      // We need to be sure to drop the borrow before using the context below
-      let mut data = self.data.borrow_mut();
-      data.width = value;
-    }
+    self.data.borrow_mut().width = value;
 
     if let Some((id, active_context)) = self.active_context.get() {
       let active_context = v8::Local::new(scope, active_context);

--- a/ext/canvas/byow.rs
+++ b/ext/canvas/byow.rs
@@ -113,8 +113,11 @@ impl UnsafeWindowSurface {
     scope: &mut v8::PinScope<'_, '_>,
     value: u32,
   ) -> Result<(), JsErrorBox> {
-    let mut data = self.data.borrow_mut();
-    data.width = value;
+    {
+      // We need to be sure to drop the borrow before using the context below
+      let mut data = self.data.borrow_mut();
+      data.width = value;
+    }
 
     if let Some((id, active_context)) = self.active_context.get() {
       let active_context = v8::Local::new(scope, active_context);
@@ -138,8 +141,11 @@ impl UnsafeWindowSurface {
     scope: &mut v8::PinScope<'_, '_>,
     value: u32,
   ) -> Result<(), JsErrorBox> {
-    let mut data = self.data.borrow_mut();
-    data.height = value;
+    {
+      // We need to be sure to drop the borrow before using the context below
+      let mut data = self.data.borrow_mut();
+      data.height = value;
+    }
 
     if let Some((id, active_context)) = self.active_context.get() {
       let active_context = v8::Local::new(scope, active_context);

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -103,6 +103,10 @@ fn run_test(test: &CollectedTest) -> TestResult {
     deno = deno.arg("--unstable-kv");
   }
 
+  if test.name.ends_with("::webgpu_test") {
+    deno = deno.arg("--unstable-webgpu");
+  }
+
   if test.name.ends_with("::worker_permissions_test")
     || test.name.ends_with("::worker_test")
   {

--- a/tests/unit/webgpu_test.ts
+++ b/tests/unit/webgpu_test.ts
@@ -15,6 +15,43 @@ const isCIWithoutGPU = (Deno.build.os === "linux" ||
   (Deno.build.os === "darwin" && Deno.build.arch === "x86_64")) && isCI;
 // Skip these tests in WSL because it doesn't have good GPU support.
 const isWsl = await checkIsWsl();
+// Skip the window surface tests when there is no windowing system available
+// (e.g. headless or Wayland-only). Checked up front so those tests are
+// reported as ignored rather than silently passing.
+const hasWindowingSystem = checkWindowingSystem();
+
+function checkWindowingSystem(): boolean {
+  if (Deno.build.os === "windows") {
+    // Window creation is asserted in the test itself.
+    return true;
+  }
+  if (Deno.build.os !== "linux") {
+    return false;
+  }
+  try {
+    const x11 = Deno.dlopen(
+      "libX11.so.6",
+      {
+        XOpenDisplay: { parameters: ["pointer"], result: "pointer" },
+        XCloseDisplay: { parameters: ["pointer"], result: "i32" },
+      } as const,
+    );
+    try {
+      const display = x11.symbols.XOpenDisplay(null);
+      if (display === null) {
+        return false;
+      }
+      // Safe to close: this probe connection never backs a wgpu surface.
+      x11.symbols.XCloseDisplay(display);
+      return true;
+    } finally {
+      x11.close();
+    }
+  } catch {
+    // libX11 is not present
+    return false;
+  }
+}
 
 Deno.test({
   permissions: { read: true, env: true },
@@ -301,8 +338,7 @@ Deno.test(function webgpuWindowSurfaceNoWidthHeight() {
 
 Deno.test({
   permissions: { ffi: true },
-  ignore: isWsl || isCIWithoutGPU ||
-    (Deno.build.os !== "windows" && Deno.build.os !== "linux"),
+  ignore: isWsl || isCIWithoutGPU || !hasWindowingSystem,
 }, async function webgpuWindowSurfaceResizeAfterConfigure() {
   // Regression test for the RefCell double-borrow panic where the
   // UnsafeWindowSurface width/height setters held the SurfaceData borrow
@@ -310,10 +346,6 @@ Deno.test({
   const nativeWindow = Deno.build.os === "windows"
     ? createWin32Window()
     : createX11Window();
-  if (nativeWindow === null) {
-    // No windowing system available (e.g. headless or Wayland-only).
-    return;
-  }
   try {
     const adapter = await navigator.gpu.requestAdapter();
     assert(adapter);
@@ -359,7 +391,7 @@ interface NativeWindow {
   close(): void;
 }
 
-function createWin32Window(): NativeWindow | null {
+function createWin32Window(): NativeWindow {
   const user32 = Deno.dlopen(
     "user32.dll",
     {
@@ -420,7 +452,7 @@ function createWin32Window(): NativeWindow | null {
   };
 }
 
-function createX11Window(): NativeWindow | null {
+function createX11Window(): NativeWindow {
   const symbols = {
     XOpenDisplay: { parameters: ["pointer"], result: "pointer" },
     XDefaultRootWindow: { parameters: ["pointer"], result: "u64" },
@@ -442,17 +474,11 @@ function createX11Window(): NativeWindow | null {
     },
     XFlush: { parameters: ["pointer"], result: "i32" },
   } as const;
-  let x11: Deno.DynamicLibrary<typeof symbols>;
-  try {
-    x11 = Deno.dlopen("libX11.so.6", symbols);
-  } catch {
-    return null;
-  }
+  // The top-level windowing system check already dlopened libX11 and opened a
+  // display, so any failure here is a real error rather than a reason to skip.
+  const x11 = Deno.dlopen("libX11.so.6", symbols);
   const display = x11.symbols.XOpenDisplay(null);
-  if (display === null) {
-    x11.close();
-    return null;
-  }
+  assert(display !== null, "XOpenDisplay failed");
   const root = x11.symbols.XDefaultRootWindow(display);
   const win = x11.symbols.XCreateSimpleWindow(
     display,

--- a/tests/unit/webgpu_test.ts
+++ b/tests/unit/webgpu_test.ts
@@ -263,6 +263,8 @@ Deno.test({
   const device = await adapter.requestDevice();
   assert(device);
 
+  const msgIncludes = "Invalid parameters";
+
   assertThrows(
     () => {
       new Deno.UnsafeWindowSurface({
@@ -273,12 +275,16 @@ Deno.test({
         height: 0,
       });
     },
+    TypeError,
+    msgIncludes,
   );
 
   device.destroy();
 });
 
 Deno.test(function webgpuWindowSurfaceNoWidthHeight() {
+  const msgIncludes = "expected type `v8::data::Number`, got `v8::data::Value`";
+
   assertThrows(
     () => {
       // @ts-expect-error width and height are required
@@ -288,6 +294,8 @@ Deno.test(function webgpuWindowSurfaceNoWidthHeight() {
         displayHandle: null,
       });
     },
+    TypeError,
+    msgIncludes,
   );
 });
 

--- a/tests/unit/webgpu_test.ts
+++ b/tests/unit/webgpu_test.ts
@@ -291,6 +291,184 @@ Deno.test(function webgpuWindowSurfaceNoWidthHeight() {
   );
 });
 
+Deno.test({
+  permissions: { ffi: true },
+  ignore: isWsl || isCIWithoutGPU ||
+    (Deno.build.os !== "windows" && Deno.build.os !== "linux"),
+}, async function webgpuWindowSurfaceResizeAfterConfigure() {
+  // Regression test for the RefCell double-borrow panic where the
+  // UnsafeWindowSurface width/height setters held the SurfaceData borrow
+  // across the canvas context resize.
+  const nativeWindow = Deno.build.os === "windows"
+    ? createWin32Window()
+    : createX11Window();
+  if (nativeWindow === null) {
+    // No windowing system available (e.g. headless or Wayland-only).
+    return;
+  }
+  try {
+    const adapter = await navigator.gpu.requestAdapter();
+    assert(adapter);
+    const device = await adapter.requestDevice();
+    assert(device);
+    try {
+      const surface = new Deno.UnsafeWindowSurface({
+        system: nativeWindow.system,
+        windowHandle: nativeWindow.windowHandle,
+        displayHandle: nativeWindow.displayHandle,
+        width: 320,
+        height: 240,
+      });
+      const context = surface.getContext("webgpu") as GPUCanvasContext;
+      context.configure({
+        device,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+      });
+      // Each assignment triggers a resize of the configured context, which
+      // reads the same SurfaceData the setter just mutated. The getter reads
+      // prove the setters released their borrows.
+      surface.width = 640;
+      surface.height = 480;
+      assertEquals(surface.width, 640);
+      assertEquals(surface.height, 480);
+    } finally {
+      device.destroy();
+    }
+  } finally {
+    nativeWindow.close();
+  }
+});
+
+// The native window and display are deliberately leaked: the wgpu surface
+// held by UnsafeWindowSurface is a GC-managed object that is dropped at
+// isolate teardown, after the test body has finished. Destroying the window
+// or display connection earlier makes that surface drop a use-after-free in
+// the driver. close() only releases the dlopen handle.
+interface NativeWindow {
+  system: "win32" | "x11";
+  windowHandle: Deno.PointerValue;
+  displayHandle: Deno.PointerValue;
+  close(): void;
+}
+
+function createWin32Window(): NativeWindow | null {
+  const user32 = Deno.dlopen(
+    "user32.dll",
+    {
+      CreateWindowExW: {
+        parameters: [
+          "u32", // dwExStyle
+          "buffer", // lpClassName
+          "buffer", // lpWindowName
+          "u32", // dwStyle
+          "i32", // X
+          "i32", // Y
+          "i32", // nWidth
+          "i32", // nHeight
+          "pointer", // hWndParent
+          "pointer", // hMenu
+          "pointer", // hInstance
+          "pointer", // lpParam
+        ],
+        result: "pointer",
+      },
+    } as const,
+  );
+
+  function wide(s: string): Uint16Array {
+    const buf = new Uint16Array(s.length + 1);
+    for (let i = 0; i < s.length; i++) {
+      buf[i] = s.charCodeAt(i);
+    }
+    return buf;
+  }
+
+  const WS_OVERLAPPEDWINDOW = 0x00CF0000;
+  // The predefined "STATIC" window class avoids needing RegisterClassW. The
+  // window is deliberately not WS_VISIBLE; surface creation works on hidden
+  // windows.
+  const hwnd = user32.symbols.CreateWindowExW(
+    0,
+    wide("STATIC"),
+    wide("deno webgpu test"),
+    WS_OVERLAPPEDWINDOW,
+    0,
+    0,
+    320,
+    240,
+    null,
+    null,
+    null,
+    null,
+  );
+  assert(hwnd !== null, "CreateWindowExW failed");
+  return {
+    system: "win32",
+    windowHandle: hwnd,
+    displayHandle: null,
+    close() {
+      user32.close();
+    },
+  };
+}
+
+function createX11Window(): NativeWindow | null {
+  const symbols = {
+    XOpenDisplay: { parameters: ["pointer"], result: "pointer" },
+    XDefaultRootWindow: { parameters: ["pointer"], result: "u64" },
+    XCreateSimpleWindow: {
+      // (display, parent, x, y, width, height, border_width, border,
+      // background)
+      parameters: [
+        "pointer",
+        "u64",
+        "i32",
+        "i32",
+        "u32",
+        "u32",
+        "u32",
+        "u64",
+        "u64",
+      ],
+      result: "u64",
+    },
+    XFlush: { parameters: ["pointer"], result: "i32" },
+  } as const;
+  let x11: Deno.DynamicLibrary<typeof symbols>;
+  try {
+    x11 = Deno.dlopen("libX11.so.6", symbols);
+  } catch {
+    return null;
+  }
+  const display = x11.symbols.XOpenDisplay(null);
+  if (display === null) {
+    x11.close();
+    return null;
+  }
+  const root = x11.symbols.XDefaultRootWindow(display);
+  const win = x11.symbols.XCreateSimpleWindow(
+    display,
+    root,
+    0,
+    0,
+    320,
+    240,
+    0,
+    0n,
+    0n,
+  );
+  x11.symbols.XFlush(display);
+  return {
+    system: "x11",
+    // The windowHandle external's value is the X11 window XID itself.
+    windowHandle: Deno.UnsafePointer.create(BigInt(win)),
+    displayHandle: display,
+    close() {
+      x11.close();
+    },
+  };
+}
+
 Deno.test(function getPreferredCanvasFormat() {
   const preferredFormat = navigator.gpu.getPreferredCanvasFormat();
   assert(preferredFormat === "bgra8unorm" || preferredFormat === "rgba8unorm");


### PR DESCRIPTION
Fixes #35992. I've used Claude Code while working on this PR.

The original issue was a panic when resizing a window when using the `raw` webgpu desktop backend. This change addresses that by explicitly dropping the `RefMut` used to modify the width/height.

The added test opens a real FFI window. If that's undesirable, then we could potentially remove it. But, I think the alternative test would be a more invasive change to set up mockable traits for windowing, which might be even less desirable.\
The intent is that the X11 version of the test is optional, and that the Windows version is required for CI. I'm not able to try out the Windows version locally right now, though. We'll need to check the PR's CI run.

One broader change that might be a better alternative than this fix would be to change width and height into plain `Cell<u32>` properties, with no runtime borrow-checking. There's already no atomicity between width and height, and it seems like the other properties are intended to be read-only. That would make the test redundant, because the panic would no longer be possible.

<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
