### PR TITLE
feat(compile): support aarch64-pc-windows-msvc target

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2308,10 +2308,11 @@ Unless --reload is specified, this command will not re-download already cached d
     )
 }
 
-const SUPPORTED_OS: [&str; 5] = [
+const SUPPORTED_OS: [&str; 6] = [
   "x86_64-unknown-linux-gnu",
   "aarch64-unknown-linux-gnu",
   "x86_64-pc-windows-msvc",
+  "aarch64-pc-windows-msvc",
   "x86_64-apple-darwin",
   "aarch64-apple-darwin",
 ];

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -14311,6 +14311,35 @@ mod tests {
   }
 
   #[test]
+  fn compile_target_aarch64_windows() {
+    // denort for Windows arm64 is built and published by CI, so
+    // `--target aarch64-pc-windows-msvc` must be accepted by the SUPPORTED_OS
+    // value parser (and an unsupported triple must still be rejected).
+    let r = flags_from_vec(svec![
+      "deno",
+      "compile",
+      "--target",
+      "aarch64-pc-windows-msvc",
+      "main.ts"
+    ]);
+    let DenoSubcommand::Compile(c) = r.unwrap().subcommand else {
+      unreachable!()
+    };
+    assert_eq!(c.target, Some("aarch64-pc-windows-msvc".to_string()));
+
+    assert!(
+      flags_from_vec(svec![
+        "deno",
+        "compile",
+        "--target",
+        "riscv64gc-unknown-linux-gnu",
+        "main.ts"
+      ])
+      .is_err()
+    );
+  }
+
+  #[test]
   fn coverage() {
     let r = flags_from_vec(svec!["deno", "coverage", "foo.json"]);
     assert_eq!(

--- a/libs/cli_parser/src/defs.rs
+++ b/libs/cli_parser/src/defs.rs
@@ -16,6 +16,7 @@ const SUPPORTED_OS: &[&str] = &[
   "x86_64-unknown-linux-gnu",
   "aarch64-unknown-linux-gnu",
   "x86_64-pc-windows-msvc",
+  "aarch64-pc-windows-msvc",
   "x86_64-apple-darwin",
   "aarch64-apple-darwin",
 ];

--- a/libs/cli_parser/src/tests_full.rs
+++ b/libs/cli_parser/src/tests_full.rs
@@ -5056,6 +5056,37 @@ fn compile() {
 }
 
 #[test]
+fn compile_target_aarch64_windows() {
+  // The denort runtime for Windows arm64 is built and published by CI, so
+  // `--target aarch64-pc-windows-msvc` must be accepted. This is the
+  // regression guard for the clap -> deno_cli_parser cutover: the new parser
+  // validates `--target` against its own SUPPORTED_OS list, so the triple has
+  // to be present here too (not just in clap's list).
+  let r = flags_from_vec(svec![
+    "deno",
+    "compile",
+    "--target=aarch64-pc-windows-msvc",
+    "main.ts"
+  ]);
+  let DenoSubcommand::Compile(c) = r.unwrap().subcommand else {
+    panic!("expected compile subcommand");
+  };
+  assert_eq!(c.target, Some("aarch64-pc-windows-msvc".to_string()));
+
+  // An unsupported triple is still rejected, proving the validator is active
+  // (and this test isn't passing just because validation was dropped).
+  assert!(
+    flags_from_vec(svec![
+      "deno",
+      "compile",
+      "--target=riscv64gc-unknown-linux-gnu",
+      "main.ts"
+    ])
+    .is_err()
+  );
+}
+
+#[test]
 fn desktop_backend_default() {
   let r = flags_from_vec(svec!["deno", "desktop", "main.tsx"]);
   let flags = r.unwrap();


### PR DESCRIPTION
`deno compile --target aarch64-pc-windows-msvc` was rejected at argument
parse time because `aarch64-pc-windows-msvc` was missing from the
`SUPPORTED_OS` allowlist in `cli/args/flags.rs`, even though the denort
runtime binary for Windows arm64 is already built and published by CI
(`denort-aarch64-pc-windows-msvc.zip`, see the `windows-11-arm` build in
`.github/workflows/ci.ts`).

This adds the triple to the allowlist so the flag is accepted. The
download logic in `cli/standalone/binary.rs` already resolves the base
binary name from the target (`denort-{target}.zip`) and the Windows
specific handling keys off `target.contains("windows")`, so no other
changes are required for cross-compilation to work.