### PR TITLE
fix(ext/process): don't double-close extra stdio pipe handles on Windows

### DIFF
--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -885,7 +885,13 @@ fn create_command(
               continue;
             }
           };
-          handles_to_close.push(fd2);
+          // Ownership of `fd2` transfers to the command: the spawn
+          // machinery (`uv_stdio_create`) duplicates it into the child's
+          // stdio buffer and closes this original handle itself. Do NOT
+          // also push it onto `handles_to_close` - closing it a second
+          // time races with handle-value reuse on Windows and
+          // intermittently fails a concurrent spawn with
+          // `ERROR_INVALID_HANDLE` (os error 6). See issue #35994.
           command.extra_handle(Some(fd2));
           // `fd1` is a raw Windows HANDLE, but the JS side treats the
           // value it receives as a CRT file descriptor (it calls

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -670,6 +670,49 @@ Deno.test({
 
 Deno.test({
   name:
+    "[node/child_process spawn] concurrent spawns with extra pipe fds keep handles valid (#35994)",
+  async fn() {
+    // Playwright launches Firefox/WebKit with two extra pipe fds (3 and 4)
+    // for its "pipe" browser-protocol transport. On Windows the child end of
+    // each extra pipe used to be closed twice, which - under concurrent
+    // spawns - raced with handle-value reuse and intermittently failed a
+    // sibling spawn with "The handle is invalid. (os error 6)". Spawn a batch
+    // concurrently to stress handle reuse and assert none of them fail.
+    const isWindows = Deno.build.os === "windows";
+    const command = isWindows ? "cmd.exe" : "/bin/sh";
+    const args = isWindows ? ["/c", "exit 0"] : ["-c", "exit 0"];
+
+    const spawnOne = () =>
+      new Promise<void>((resolve, reject) => {
+        const cp = spawn(command, args, {
+          stdio: ["ignore", "pipe", "pipe", "pipe", "pipe"],
+        });
+        cp.on("error", reject);
+        // Drain every piped stream so the child's exit is observed promptly
+        // and no pipe keeps the process from closing.
+        for (const stream of cp.stdio) {
+          // deno-lint-ignore no-explicit-any
+          const s = stream as any;
+          if (s && typeof s.resume === "function") {
+            s.resume();
+          }
+        }
+        cp.on("close", (code) => {
+          if (code !== 0) {
+            reject(new Error(`child exited with code ${code}`));
+          } else {
+            resolve();
+          }
+        });
+      });
+
+    const BATCH = 24;
+    await Promise.all(Array.from({ length: BATCH }, () => spawnOne()));
+  },
+});
+
+Deno.test({
+  name:
     "[node/child_process spawn] Deno child fd 3 stays claimable by net.Socket",
   ignore: Deno.build.os === "windows",
   async fn() {


### PR DESCRIPTION
On Windows, `deno compile`d binaries (and `deno run`) could intermittently
fail `node:child_process.spawn()` with `Error: The handle is invalid.
(os error 6)` when the child was spawned with extra stdio pipe file
descriptors (fds 3, 4, ...). This is the configuration Playwright uses to
launch Firefox and WebKit via its "pipe" browser-protocol transport, so
those launches would flake, while Chromium (driven over a TCP socket with
only standard stdio) was unaffected.

The cause is a double close of a Windows `HANDLE`. For each extra piped
fd, `create_command` created a pipe pair and then referenced the child
end (`fd2`) from two places: it pushed `fd2` onto `handles_to_close` and
also handed `fd2` to `command.extra_handle`. On Windows the spawn
machinery (`uv_stdio_create`) already takes ownership of every handle
passed via `extra_handle`: it duplicates the handle into the child's CRT
stdio buffer and closes the original itself. The subsequent
`handles_to_close` pass then closed the same handle a second time.

Closing an already-closed handle is not benign on Windows because the
kernel recycles handle values immediately. Under concurrent spawns the
second close could land on a value that another in-flight spawn had just
been handed, so its `DuplicateHandle` failed with `ERROR_INVALID_HANDLE`.
That explains why the failure was intermittent, why only the extra-pipe
case broke (standard fds 0/1/2 are closed exactly once, by
`uv_stdio_create`, and are never added to `handles_to_close`), and why it
surfaced under `deno compile` on CI, where heavier handle-table churn
makes the reuse race far more likely to hit.

The fix removes the redundant `handles_to_close.push(fd2)`: ownership of
the child end transfers to the command and is closed once by the spawn
machinery. The IPC and npm-process-state handles are left as-is because
they are inherited via env-var fd numbers rather than `extra_handle`, so
closing them through `handles_to_close` remains correct.

Added a regression test that spawns a batch of children concurrently,
each with two extra pipe fds, and asserts none fail. Existing extra-stdio
tests are all skipped on Windows, so this also fills a coverage gap; the
new test runs on all platforms.

One related item left for a follow-up: the sibling `StdioOrFd::Fd(fd)`
arm hands a borrowed handle from `get_osfhandle(fd)` to `extra_handle`,
which `uv_stdio_create` will then close, closing the caller's fd out from
under it. That path is not exercised by the Playwright scenario in this
issue and warrants its own change.

Fixes #35994.
