### PR TITLE
fix(publish): hint how to create a config file when none is found

### DIFF
--- a/cli/tools/publish/mod.rs
+++ b/cli/tools/publish/mod.rs
@@ -103,8 +103,9 @@ pub async fn publish(
       }
       None => {
         bail!(
-          "Couldn't find a deno.json, deno.jsonc, jsr.json or jsr.jsonc configuration file in {}.",
-          directory_path.display()
+          "Couldn't find a deno.json, deno.jsonc, jsr.json or jsr.jsonc configuration file in {}. {}",
+          directory_path.display(),
+          colors::italic_gray("Run `deno init` to create one.")
         );
       }
     }

--- a/tests/specs/publish/missing_deno_json/missing_deno_json.out
+++ b/tests/specs/publish/missing_deno_json/missing_deno_json.out
@@ -1,1 +1,1 @@
-error: Couldn't find a deno.json, deno.jsonc, jsr.json or jsr.jsonc configuration file in [WILDCARD]
+error: Couldn't find a deno.json, deno.jsonc, jsr.json or jsr.jsonc configuration file in [WILDCARD]. Run `deno init` to create one.


### PR DESCRIPTION
## Summary

`deno publish` fails when no `deno.json`, `deno.jsonc`, `jsr.json`, or `jsr.jsonc` is found, but the error message doesn't tell the user what to do about it:

```
error: Couldn't find a deno.json, deno.jsonc, jsr.json or jsr.jsonc configuration file in /path/to/project.
```

This is a common source of confusion, especially for users landing on `deno publish` via the `jsr` npm package wrapper, since they have no other context for what config file `deno` expects or how to create one.

This PR appends a hint pointing to `deno init`, which scaffolds a `deno.json`:

```
error: Couldn't find a deno.json, deno.jsonc, jsr.json or jsr.jsonc configuration file in /path/to/project. Run `deno init` to create one.
```

The hint styling (`colors::italic_gray`) matches the existing convention used for actionable hints elsewhere in the CLI, e.g. in `cli/tools/upgrade.rs`:

```rust
colors::italic_gray("Run `deno upgrade` to install it.")
```

## Test plan

- [x] `cargo check -p deno`
- [x] `cargo fmt -p deno -- --check`
- [x] `cargo clippy -p deno --no-deps`
- [x] `./x lint` (full repo lint, Rust + JS/TS)
- [x] Updated `tests/specs/publish/missing_deno_json/missing_deno_json.out` and verified it passes: `cargo test -p specs_tests missing_deno_json`
- [x] Manually reproduced with a local build in an empty directory and confirmed the new message