### PR TITLE
fix(core): block user ext imports after resolution

### DIFF
--- a/ext/node/ops/vm.rs
+++ b/ext/node/ops/vm.rs
@@ -41,42 +41,6 @@ fn vm_host_defined_options<'s>(
   }
 }
 
-fn sanitize_internal_scheme_resource_name(
-  resource_name: &str,
-) -> Option<String> {
-  let (scheme, _) = resource_name.split_once(':')?;
-  if !scheme.eq_ignore_ascii_case("ext")
-    && !scheme.eq_ignore_ascii_case("node")
-    && !scheme.eq_ignore_ascii_case("checkin")
-  {
-    return None;
-  }
-  Some(format!("deno-vm:{resource_name}"))
-}
-
-fn sanitize_vm_resource_name<'s>(
-  scope: &mut v8::PinScope<'s, '_>,
-  resource_name: v8::Local<'s, v8::Value>,
-) -> Option<v8::Local<'s, v8::Value>> {
-  let resource_name_string = resource_name.to_string(scope)?;
-  let resource_name_rust = resource_name_string.to_rust_string_lossy(scope);
-  let Some(sanitized) =
-    sanitize_internal_scheme_resource_name(&resource_name_rust)
-  else {
-    return Some(resource_name);
-  };
-  Some(v8::String::new(scope, &sanitized)?.into())
-}
-
-fn vm_resource_name_from_str<'s>(
-  scope: &mut v8::PinScope<'s, '_>,
-  resource_name: &str,
-) -> Option<v8::Local<'s, v8::Value>> {
-  let resource_name = sanitize_internal_scheme_resource_name(resource_name)
-    .unwrap_or_else(|| resource_name.to_string());
-  Some(v8::String::new(scope, &resource_name)?.into())
-}
-
 #[op2(fast)]
 pub fn op_vm_dynamic_import_callback_register(
   scope: &mut v8::PinScope<'_, '_>,
@@ -144,7 +108,6 @@ impl ContextifyScript {
     let scope = &mut v8::ContextScope::new(scope, context);
     let host_defined_options =
       vm_host_defined_options(scope, import_module_dynamically_id);
-    let filename = sanitize_vm_resource_name(scope, filename)?;
     let origin = v8::ScriptOrigin::new(
       scope,
       filename,
@@ -1553,7 +1516,6 @@ pub fn op_vm_compile_function<'s>(
   let scope = &mut v8::ContextScope::new(scope, context);
   let host_defined_options =
     vm_host_defined_options(scope, import_module_dynamically_id);
-  let filename = sanitize_vm_resource_name(scope, filename)?;
   let origin = v8::ScriptOrigin::new(
     scope,
     filename,
@@ -1823,10 +1785,10 @@ pub fn op_vm_module_create_source_text_module<'a>(
   let scope = &mut v8::ContextScope::new(scope, context);
   let host_defined_options =
     vm_host_defined_options(scope, import_module_dynamically_id);
-  let filename = vm_resource_name_from_str(scope, &identifier)?;
+  let filename = v8::String::new(scope, &identifier)?;
   let origin = v8::ScriptOrigin::new(
     scope,
-    filename,
+    filename.into(),
     line_offset,
     column_offset,
     true,

--- a/ext/node/ops/vm.rs
+++ b/ext/node/ops/vm.rs
@@ -41,6 +41,42 @@ fn vm_host_defined_options<'s>(
   }
 }
 
+fn sanitize_internal_scheme_resource_name(
+  resource_name: &str,
+) -> Option<String> {
+  let (scheme, _) = resource_name.split_once(':')?;
+  if !scheme.eq_ignore_ascii_case("ext")
+    && !scheme.eq_ignore_ascii_case("node")
+    && !scheme.eq_ignore_ascii_case("checkin")
+  {
+    return None;
+  }
+  Some(format!("deno-vm:{resource_name}"))
+}
+
+fn sanitize_vm_resource_name<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  resource_name: v8::Local<'s, v8::Value>,
+) -> Option<v8::Local<'s, v8::Value>> {
+  let resource_name_string = resource_name.to_string(scope)?;
+  let resource_name_rust = resource_name_string.to_rust_string_lossy(scope);
+  let Some(sanitized) =
+    sanitize_internal_scheme_resource_name(&resource_name_rust)
+  else {
+    return Some(resource_name);
+  };
+  Some(v8::String::new(scope, &sanitized)?.into())
+}
+
+fn vm_resource_name_from_str<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  resource_name: &str,
+) -> Option<v8::Local<'s, v8::Value>> {
+  let resource_name = sanitize_internal_scheme_resource_name(resource_name)
+    .unwrap_or_else(|| resource_name.to_string());
+  Some(v8::String::new(scope, &resource_name)?.into())
+}
+
 #[op2(fast)]
 pub fn op_vm_dynamic_import_callback_register(
   scope: &mut v8::PinScope<'_, '_>,
@@ -108,6 +144,7 @@ impl ContextifyScript {
     let scope = &mut v8::ContextScope::new(scope, context);
     let host_defined_options =
       vm_host_defined_options(scope, import_module_dynamically_id);
+    let filename = sanitize_vm_resource_name(scope, filename)?;
     let origin = v8::ScriptOrigin::new(
       scope,
       filename,
@@ -1516,6 +1553,7 @@ pub fn op_vm_compile_function<'s>(
   let scope = &mut v8::ContextScope::new(scope, context);
   let host_defined_options =
     vm_host_defined_options(scope, import_module_dynamically_id);
+  let filename = sanitize_vm_resource_name(scope, filename)?;
   let origin = v8::ScriptOrigin::new(
     scope,
     filename,
@@ -1785,10 +1823,10 @@ pub fn op_vm_module_create_source_text_module<'a>(
   let scope = &mut v8::ContextScope::new(scope, context);
   let host_defined_options =
     vm_host_defined_options(scope, import_module_dynamically_id);
-  let filename = v8::String::new(scope, &identifier)?;
+  let filename = vm_resource_name_from_str(scope, &identifier)?;
   let origin = v8::ScriptOrigin::new(
     scope,
-    filename.into(),
+    filename,
     line_offset,
     column_offset,
     true,

--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -76,6 +76,13 @@ use crate::source_map::SourceMapper;
 
 const DATA_PREFIX: &str = "data:";
 
+fn is_internal_module_specifier(specifier: &str) -> bool {
+  let Ok(specifier) = ModuleSpecifier::parse(specifier) else {
+    return false;
+  };
+  matches!(specifier.scheme(), "ext" | "node" | "checkin")
+}
+
 fn residual_source_from_static_table(
   entries: &'static [(&'static str, &'static str)],
   specifier: &str,
@@ -282,6 +289,7 @@ pub(crate) struct ModuleMap {
   module_waker: AtomicWaker,
   data: RefCell<ModuleMapData>,
   will_snapshot: bool,
+  loading_internal_modules: Cell<bool>,
 
   /// A counter used to delay our dynamic import deadlock detection by one spin
   /// of the event loop.
@@ -290,6 +298,26 @@ pub(crate) struct ModuleMap {
   /// Tracks module IDs currently being evaluated via `op_import_sync` to
   /// detect require() cycles that V8's module status alone cannot catch.
   pub(crate) import_sync_eval_stack: RefCell<Vec<ModuleId>>,
+}
+
+struct LoadingInternalModulesGuard<'a> {
+  module_map: &'a ModuleMap,
+  previous: bool,
+}
+
+impl<'a> LoadingInternalModulesGuard<'a> {
+  fn new(module_map: &'a ModuleMap) -> Self {
+    Self {
+      module_map,
+      previous: module_map.loading_internal_modules.replace(true),
+    }
+  }
+}
+
+impl Drop for LoadingInternalModulesGuard<'_> {
+  fn drop(&mut self) {
+    self.module_map.loading_internal_modules.set(self.previous);
+  }
 }
 
 /// Outcome of compiling a module's source.
@@ -382,8 +410,13 @@ impl ModuleMap {
       code_cache_ready_futs: Default::default(),
       module_waker: Default::default(),
       data: Default::default(),
+      loading_internal_modules: Default::default(),
       import_sync_eval_stack: Default::default(),
     }
+  }
+
+  pub(crate) fn set_loading_internal_modules(&self, value: bool) {
+    self.loading_internal_modules.set(value);
   }
 
   pub(crate) fn update_with_snapshotted_data(
@@ -936,6 +969,10 @@ impl ModuleMap {
       }
     }
 
+    let _loading_internal_modules_guard =
+      is_internal_module_specifier(name.as_str())
+        .then(|| LoadingInternalModulesGuard::new(self));
+
     let name_str = name.v8_string(scope).unwrap();
     let source_str = source.v8_string(scope).unwrap();
     let host_defined_options = self
@@ -1355,6 +1392,13 @@ impl ModuleMap {
       return Ok(());
     }
 
+    let _loading_internal_modules_guard = self
+      .data
+      .borrow()
+      .get_name_by_id(id)
+      .filter(|name| is_internal_module_specifier(name))
+      .map(|_| LoadingInternalModulesGuard::new(self));
+
     tc_scope.set_slot(self as *const _);
     let instantiate_result = module.instantiate_module2(
       tc_scope,
@@ -1505,26 +1549,10 @@ impl ModuleMap {
     referrer: &str,
     kind: ResolutionKind,
   ) -> ModuleResolveResponse {
-    if specifier.starts_with("ext:")
-      && !referrer.starts_with("ext:")
-      && !referrer.starts_with("node:")
-      && !referrer.starts_with("checkin:")
-      && referrer != "."
-      && kind != ResolutionKind::MainModule
-    {
-      let referrer = if referrer.is_empty() {
-        "(no referrer)"
-      } else {
-        referrer
-      };
-      let msg = format!(
-        "Importing ext: modules is only allowed from ext: and node: modules. Tried to import {} from {}",
-        specifier, referrer
-      );
-      return Err(JsErrorBox::type_error(msg));
-    }
-
-    self.loader.borrow().resolve(specifier, referrer, kind)
+    let resolved_specifier =
+      self.loader.borrow().resolve(specifier, referrer, kind)?;
+    self.validate_ext_module_import(&resolved_specifier, referrer)?;
+    Ok(resolved_specifier)
   }
 
   pub fn resolve_with_scope(
@@ -1535,32 +1563,53 @@ impl ModuleMap {
     kind: ResolutionKind,
     import_attributes: &HashMap<String, String>,
   ) -> ModuleResolveResponse {
-    if specifier.starts_with("ext:")
-      && !referrer.starts_with("ext:")
-      && !referrer.starts_with("node:")
-      && !referrer.starts_with("checkin:")
-      && referrer != "."
-      && kind != ResolutionKind::MainModule
-    {
-      let referrer = if referrer.is_empty() {
-        "(no referrer)"
-      } else {
-        referrer
-      };
-      let msg = format!(
-        "Importing ext: modules is only allowed from ext: and node: modules. Tried to import {} from {}",
-        specifier, referrer
-      );
-      return Err(JsErrorBox::type_error(msg));
-    }
-
-    self.loader.borrow().resolve_with_scope(
+    let resolved_specifier = self.loader.borrow().resolve_with_scope(
       scope,
       specifier,
       referrer,
       kind,
       import_attributes,
-    )
+    )?;
+    self.validate_ext_module_import(&resolved_specifier, referrer)?;
+    Ok(resolved_specifier)
+  }
+
+  fn validate_ext_module_import(
+    &self,
+    resolved_specifier: &ModuleSpecifier,
+    referrer: &str,
+  ) -> Result<(), JsErrorBox> {
+    if resolved_specifier.scheme() != "ext" {
+      return Ok(());
+    }
+
+    if (self.will_snapshot || self.loading_internal_modules.get())
+      && referrer == "."
+    {
+      return Ok(());
+    }
+
+    if self.is_internal_referrer(referrer) {
+      return Ok(());
+    }
+
+    let referrer = if referrer.is_empty() {
+      "(no referrer)"
+    } else {
+      referrer
+    };
+    let msg = format!(
+      "Importing ext: modules is only allowed from ext: and node: modules. Tried to import {} from {}",
+      resolved_specifier, referrer
+    );
+    Err(JsErrorBox::type_error(msg))
+  }
+
+  fn is_internal_referrer(&self, referrer: &str) -> bool {
+    if !is_internal_module_specifier(referrer) {
+      return false;
+    }
+    self.will_snapshot || self.loading_internal_modules.get()
   }
 
   /// Called by `module_resolve_callback` during module instantiation.
@@ -2735,6 +2784,28 @@ impl ModuleMap {
     code_cache_info: Option<CodeCacheInfo>,
   ) -> Result<v8::Global<v8::Value>, CoreError> {
     let specifier = ModuleSpecifier::parse(module_specifier)?;
+    let previous_loading_internal_modules =
+      matches!(specifier.scheme(), "ext" | "node" | "checkin")
+        .then(|| self.loading_internal_modules.replace(true));
+    let result = self.lazy_load_es_module_with_code_inner(
+      scope,
+      specifier,
+      source_code,
+      code_cache_info,
+    );
+    if let Some(previous) = previous_loading_internal_modules {
+      self.loading_internal_modules.set(previous);
+    }
+    result
+  }
+
+  fn lazy_load_es_module_with_code_inner(
+    &self,
+    scope: &mut v8::PinScope,
+    specifier: ModuleSpecifier,
+    source_code: ModuleCodeString,
+    code_cache_info: Option<CodeCacheInfo>,
+  ) -> Result<v8::Global<v8::Value>, CoreError> {
     let mod_id = self
       .new_es_module(
         scope,

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -2160,6 +2160,7 @@ fn builtin_core_module() {
     module_loader: Some(Rc::new(loader)),
     ..Default::default()
   });
+  runtime.module_map().set_loading_internal_modules(true);
 
   let main_id_fut = runtime.load_main_es_module(&main_specifier).boxed_local();
   let main_id = futures::executor::block_on(main_id_fut).unwrap();
@@ -2168,6 +2169,7 @@ fn builtin_core_module() {
   let _ = runtime.mod_evaluate(main_id);
   futures::executor::block_on(runtime.run_event_loop(Default::default()))
     .unwrap();
+  runtime.module_map().set_loading_internal_modules(false);
 }
 
 #[test]
@@ -2425,6 +2427,54 @@ fn ext_module_loader_relative() {
       .resolve(specifier, referrer, ResolutionKind::Import)
       .unwrap();
     assert_eq!(result.as_str(), expected);
+  }
+}
+
+#[test]
+fn module_map_rejects_user_ext_imports_after_resolution() {
+  struct ExtResolvingLoader;
+
+  impl ModuleLoader for ExtResolvingLoader {
+    fn resolve(
+      &self,
+      specifier: &str,
+      referrer: &str,
+      _kind: ResolutionKind,
+    ) -> ModuleResolveResponse {
+      if specifier == "mapped" {
+        return Ok(ModuleSpecifier::parse("ext:core/ops").unwrap());
+      }
+      let referrer = if referrer == "." {
+        "file:///"
+      } else {
+        referrer
+      };
+      resolve_import(specifier, referrer).map_err(JsErrorBox::from_err)
+    }
+
+    fn load(
+      &self,
+      _module_specifier: &ModuleSpecifier,
+      _maybe_referrer: Option<&ModuleLoadReferrer>,
+      _options: ModuleLoadOptions,
+    ) -> ModuleLoadResponse {
+      unreachable!()
+    }
+  }
+
+  let runtime = JsRuntime::new(RuntimeOptions {
+    module_loader: Some(Rc::new(ExtResolvingLoader)),
+    ..Default::default()
+  });
+  let module_map = runtime.module_map();
+
+  for specifier in ["Ext:core/ops", "mapped"] {
+    let error = module_map
+      .resolve(specifier, "file:///main.js", ResolutionKind::DynamicImport)
+      .unwrap_err();
+    let message = error.to_string();
+    assert!(message.contains("Importing ext: modules is only allowed"));
+    assert!(message.contains("ext:core/ops"));
   }
 }
 

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -1579,6 +1579,7 @@ impl JsRuntime {
     let ext_loader =
       Rc::new(ExtModuleLoader::new(sources, ext_code_cache.clone()));
     *module_map.loader.borrow_mut() = ext_loader.clone();
+    module_map.set_loading_internal_modules(true);
 
     // Next, load the extension modules as side modules (but do not execute them)
     for module in modules {
@@ -1642,6 +1643,7 @@ impl JsRuntime {
     }
 
     let module_map = realm.0.module_map();
+    module_map.set_loading_internal_modules(false);
     *module_map.loader.borrow_mut() = loader;
     ext_loader.finalize()?;
 

--- a/tests/unit_node/vm_test.ts
+++ b/tests/unit_node/vm_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import vm, {
   compileFunction,
   createContext,
@@ -178,6 +178,52 @@ Deno.test({
     assertEquals(
       result.message,
       "A dynamic import callback was not specified.",
+    );
+  },
+});
+
+Deno.test({
+  name: "vm default loader does not trust internal scheme filenames",
+  async fn() {
+    await assertRejects(
+      async () => {
+        await runInThisContext('import("ext:core/ops")', {
+          filename: "node:vm",
+          importModuleDynamically: vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+        });
+      },
+      TypeError,
+      "Importing ext: modules is only allowed",
+    );
+
+    const fn = compileFunction('return import("ext:core/ops")', [], {
+      filename: "node:vm",
+      importModuleDynamically: vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+    await assertRejects(
+      () => fn(),
+      TypeError,
+      "Importing ext: modules is only allowed",
+    );
+
+    const mod = new SourceTextModule(
+      'export const p = import("ext:core/ops");',
+      {
+        identifier: "node:vm",
+        importModuleDynamically: vm.constants
+          .USE_MAIN_CONTEXT_DEFAULT_LOADER as never,
+      },
+    );
+    await mod.link(() => {
+      throw new Error("unexpected static import");
+    });
+    await mod.evaluate();
+    assertEquals(mod.identifier, "node:vm");
+    const namespace = mod.namespace as { p: Promise<unknown> };
+    await assertRejects(
+      () => namespace.p,
+      TypeError,
+      "Importing ext: modules is only allowed",
     );
   },
 });


### PR DESCRIPTION
This keeps internal `ext:` module loading tied to the resolved module context.

The module map now rejects resolved internal module specifiers when they are requested from ordinary file modules, including after loader resolution. This also covers `node:vm` default-loader paths where filenames can be caller-controlled.

Tests:
- `cargo test -p deno_core module_map_rejects_user_ext_imports_after_resolution -- --nocapture`
- `cargo test -p unit_node_tests --test unit_node -- unit_node::vm_test --nocapture`
- `cargo fmt --check`
