### PR TITLE
fix(worker): remove imported ops during bootstrap

### DIFF
--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -923,6 +923,11 @@ mod impl_ {
     use deno_core::RuntimeOptions;
     use deno_core::v8;
 
+    deno_core::extension!(
+      test_ipc_ops,
+      ops = [super::op_node_ipc_ref, super::op_node_ipc_unref],
+    );
+
     fn wrap_expr(s: &str) -> String {
       format!("(function () {{ return {s}; }})()")
     }
@@ -975,6 +980,34 @@ mod impl_ {
         let actual = serialize_js_to_json(&mut runtime, js);
         assert_eq!(actual, expect);
       }
+    }
+
+    #[test]
+    fn ipc_ref_unref_invalid_resource() {
+      let mut runtime = JsRuntime::new(RuntimeOptions {
+        extensions: vec![test_ipc_ops::init()],
+        ..Default::default()
+      });
+
+      runtime
+        .execute_script(
+          "ipc_ref_unref_invalid_resource.js",
+          r#"
+            for (const opName of ["op_node_ipc_ref", "op_node_ipc_unref"]) {
+              for (const serializationJson of [true, false]) {
+                try {
+                  Deno.core.ops[opName](0, serializationJson);
+                  throw new Error(`${opName} did not throw`);
+                } catch (error) {
+                  if (error.name !== "BadResource") {
+                    throw error;
+                  }
+                }
+              }
+            }
+          "#,
+        )
+        .unwrap();
     }
   }
 }

--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -888,20 +888,16 @@ mod impl_ {
     state: &mut OpState,
     #[smi] rid: ResourceId,
     serialization_json: bool,
-  ) {
+  ) -> Result<(), deno_core::error::ResourceError> {
     if serialization_json {
-      let stream = state
-        .resource_table
-        .get::<IpcJsonStreamResource>(rid)
-        .expect("Invalid resource ID");
+      let stream = state.resource_table.get::<IpcJsonStreamResource>(rid)?;
       stream.ref_tracker.ref_();
     } else {
-      let stream = state
-        .resource_table
-        .get::<IpcAdvancedStreamResource>(rid)
-        .expect("Invalid resource ID");
+      let stream =
+        state.resource_table.get::<IpcAdvancedStreamResource>(rid)?;
       stream.ref_tracker.ref_();
     }
+    Ok(())
   }
 
   #[op2(fast)]
@@ -909,20 +905,16 @@ mod impl_ {
     state: &mut OpState,
     #[smi] rid: ResourceId,
     serialization_json: bool,
-  ) {
+  ) -> Result<(), deno_core::error::ResourceError> {
     if serialization_json {
-      let stream = state
-        .resource_table
-        .get::<IpcJsonStreamResource>(rid)
-        .expect("Invalid resource ID");
+      let stream = state.resource_table.get::<IpcJsonStreamResource>(rid)?;
       stream.ref_tracker.unref();
     } else {
-      let stream = state
-        .resource_table
-        .get::<IpcAdvancedStreamResource>(rid)
-        .expect("Invalid resource ID");
+      let stream =
+        state.resource_table.get::<IpcAdvancedStreamResource>(rid)?;
       stream.ref_tracker.unref();
     }
+    Ok(())
   }
 
   #[cfg(test)]

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -1153,6 +1153,8 @@ function bootstrapWorkerRuntime(
 
     closeOnIdle = runtimeOptions[14];
 
+    removeImportedOps();
+
     performance.setTimeOrigin();
     globalThis_ = globalThis;
 

--- a/tests/unit/ops_test.ts
+++ b/tests/unit/ops_test.ts
@@ -1,11 +1,16 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 const EXPECTED_OP_COUNT = 41;
+const EXPECTED_WORKER_OP_COUNT = 19;
 
-Deno.test(function checkExposedOps() {
+function getExposedOpNames(): string[] {
   // @ts-ignore TS doesn't allow to index with symbol
   const core = Deno[Deno.internal].core;
-  const opNames = Object.keys(core.ops);
+  return Object.keys(core.ops);
+}
+
+Deno.test(function checkExposedOps() {
+  const opNames = getExposedOpNames();
 
   if (opNames.length !== EXPECTED_OP_COUNT) {
     throw new Error(
@@ -16,22 +21,32 @@ Deno.test(function checkExposedOps() {
   }
 });
 Deno.test(async function workerDoesNotExposeImportedOps() {
+  const mainOpNames = getExposedOpNames();
   const worker = new Worker(
     `data:application/javascript,${
       encodeURIComponent(`
         // @ts-ignore TS doesn't allow to index with symbol
         const core = Deno[Deno.internal].core;
-        postMessage(typeof core.ops.op_node_ipc_ref);
+        postMessage(Object.keys(core.ops));
       `)
     }`,
     { type: "module" },
   );
-  const result = await new Promise((resolve, reject) => {
-    worker.onmessage = (event) => resolve(event.data);
-    worker.onerror = (event) => reject(event.error);
-  });
-  worker.terminate();
-  if (result !== "undefined") {
-    throw new Error(`op_node_ipc_ref unexpectedly exposed: ${result}`);
+  let actualOpNames: string[];
+  try {
+    actualOpNames = await new Promise((resolve, reject) => {
+      worker.onmessage = (event) => resolve(event.data);
+      worker.onerror = (event) => reject(event.error);
+    });
+  } finally {
+    worker.terminate();
+  }
+  if (
+    actualOpNames.length !== EXPECTED_WORKER_OP_COUNT ||
+    actualOpNames.some((opName) => !mainOpNames.includes(opName))
+  ) {
+    throw new Error(
+      `Unexpected worker ops:\n${actualOpNames.join("\n")}`,
+    );
   }
 });

--- a/tests/unit/ops_test.ts
+++ b/tests/unit/ops_test.ts
@@ -15,3 +15,23 @@ Deno.test(function checkExposedOps() {
     );
   }
 });
+Deno.test(async function workerDoesNotExposeImportedOps() {
+  const worker = new Worker(
+    `data:application/javascript,${
+      encodeURIComponent(`
+        // @ts-ignore TS doesn't allow to index with symbol
+        const core = Deno[Deno.internal].core;
+        postMessage(typeof core.ops.op_node_ipc_ref);
+      `)
+    }`,
+    { type: "module" },
+  );
+  const result = await new Promise((resolve, reject) => {
+    worker.onmessage = (event) => resolve(event.data);
+    worker.onerror = (event) => reject(event.error);
+  });
+  worker.terminate();
+  if (result !== "undefined") {
+    throw new Error(`op_node_ipc_ref unexpectedly exposed: ${result}`);
+  }
+});


### PR DESCRIPTION
Worker bootstrap should clean up imported ops consistently with the main runtime bootstrap.

This calls `removeImportedOps()` during worker startup before user code runs. The IPC ref/unref ops also now return normal resource errors for invalid resource ids instead of panicking.

Tests:
- `cargo build --bin deno`
- `/Users/nathanwhit/Documents/Code/deno5/target/debug/deno test -A --config tests/config/deno.json --no-lock tests/unit/ops_test.ts`
- `cargo fmt --check`
