### PR TITLE
fix(core): root slow op string coercions

### DIFF
--- a/libs/core/runtime/ops.rs
+++ b/libs/core/runtime/ops.rs
@@ -1153,6 +1153,22 @@ mod tests {
       }
     }
 
+    for op in ["op_test_string_cow", "op_test_string_ref"] {
+      run_test2(
+        JIT_SLOW_ITERATIONS,
+        op,
+        &format!(
+          r"
+          const arg = {{
+            toString() {{
+              return 'a'.repeat(1000) + 'b'.repeat(1000);
+            }},
+          }};
+          assert({op}(arg) == 2000);"
+        ),
+      )?;
+    }
+
     // Ensure that we're correctly encoding UTF-8
     run_test2(
       JIT_SLOW_ITERATIONS,

--- a/libs/ops/op2/dispatch_slow.rs
+++ b/libs/ops/op2/dispatch_slow.rs
@@ -514,8 +514,10 @@ pub fn from_arg(
       }
     }
     Arg::String(Strings::RefStr) | Arg::String(Strings::CowStr) => {
-      // Only requires isolate, not a full scope
-      *needs_isolate = true;
+      // Non-string values may be coerced to strings in the slow path. Keep the
+      // converted string handle rooted for the whole argument conversion and
+      // op call instead of creating a temporary inner CallbackScope.
+      *needs_scope = true;
       let maybe_scope = if *needs_scope {
         quote!()
       } else {

--- a/libs/ops/op2/test_cases/sync/string_cow.out
+++ b/libs/ops/op2/test_cases/sync/string_cow.out
@@ -118,31 +118,21 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
                 &<Self as deno_core::_ops::Op>::DECL,
             );
             let parts: deno_core::v8::FunctionCallbackInfoParts<'s> = info.get_parts();
+            let scope = ::std::pin::pin!(
+                unsafe { deno_core::v8::CallbackScope::new(info) }
+            );
+            let mut scope = scope.init();
             let mut rv = parts.return_value;
             let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info_parts(
                 info,
                 &parts,
             );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            let mut scope = unsafe {
-                deno_core::v8::Isolate::from_raw_isolate_ptr(opctx.isolate)
-            };
-            let mut scope = &mut scope;
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp: [::std::mem::MaybeUninit<
                     u8,
                 >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
                 let arg0 = if !arg0.is_string() {
-                    let scope = ::std::pin::pin!(
-                        unsafe { deno_core::v8::CallbackScope::new(info) }
-                    );
-                    let mut scope = scope.init();
                     let tc = ::std::pin::pin!(deno_core::v8::TryCatch::new(& mut scope));
                     let mut tc = tc.init();
                     match arg0.to_string(&mut tc) {

--- a/libs/ops/op2/test_cases/sync/string_ref.out
+++ b/libs/ops/op2/test_cases/sync/string_ref.out
@@ -118,31 +118,21 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
                 &<Self as deno_core::_ops::Op>::DECL,
             );
             let parts: deno_core::v8::FunctionCallbackInfoParts<'s> = info.get_parts();
+            let scope = ::std::pin::pin!(
+                unsafe { deno_core::v8::CallbackScope::new(info) }
+            );
+            let mut scope = scope.init();
             let mut rv = parts.return_value;
             let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info_parts(
                 info,
                 &parts,
             );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            let mut scope = unsafe {
-                deno_core::v8::Isolate::from_raw_isolate_ptr(opctx.isolate)
-            };
-            let mut scope = &mut scope;
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp: [::std::mem::MaybeUninit<
                     u8,
                 >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
                 let arg0 = if !arg0.is_string() {
-                    let scope = ::std::pin::pin!(
-                        unsafe { deno_core::v8::CallbackScope::new(info) }
-                    );
-                    let mut scope = scope.init();
                     let tc = ::std::pin::pin!(deno_core::v8::TryCatch::new(& mut scope));
                     let mut tc = tc.init();
                     match arg0.to_string(&mut tc) {


### PR DESCRIPTION
Fixes slow op string argument handling so converted V8 string values stay rooted through the full conversion path and op call.

The generated slow dispatch code now uses one callback scope across conversion and the op call instead of returning handles from a shorter-lived scope.

Validation:
- `CARGO_TARGET_DIR=/Users/nathanwhit/Documents/Code/deno5/target cargo test -p deno_ops test_proc_macro_sync -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nathanwhit/Documents/Code/deno5/target cargo test -p deno_core test_op_strings -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nathanwhit/Documents/Code/deno5/target cargo fmt --check`
