### PR TITLE
fix(web): guard encodeInto fallback result buffer

### DIFF
--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -744,6 +744,19 @@ fn pack_encode_into_result(read: usize, written: usize) -> f64 {
   (read as f64) * ENCODE_INTO_PACKED_MULTIPLIER + written as f64
 }
 
+fn write_encode_into_result(
+  out_buf: &mut [u32],
+  read: usize,
+  written: usize,
+) -> Result<(), WebError> {
+  if out_buf.len() < 2 {
+    return Err(WebError::BufferTooSmall);
+  }
+  out_buf[1] = written as u32;
+  out_buf[0] = read as u32;
+  Ok(())
+}
+
 #[op2(fast(op_encoding_encode_into_fast))]
 fn op_encoding_encode_into(
   scope: &mut v8::PinScope<'_, '_>,
@@ -787,9 +800,7 @@ fn op_encoding_encode_into_fallback(
     v8::WriteFlags::kReplaceInvalidUtf8,
     Some(&mut nchars),
   );
-  out_buf[1] = len as u32;
-  out_buf[0] = nchars as u32;
-  Ok(())
+  write_encode_into_result(out_buf, nchars, len)
 }
 
 #[op2(fast)]
@@ -833,6 +844,35 @@ fn op_encoding_encode_into_fast(
   buffer[..boundary].copy_from_slice(input[..boundary].as_bytes());
 
   pack_encode_into_result(read, boundary)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::WebError;
+  use super::write_encode_into_result;
+
+  #[test]
+  fn encode_into_result_rejects_undersized_output_buffer() {
+    let mut empty: [u32; 0] = [];
+    assert!(matches!(
+      write_encode_into_result(&mut empty, 1, 1),
+      Err(WebError::BufferTooSmall)
+    ));
+
+    let mut one = [0];
+    assert!(matches!(
+      write_encode_into_result(&mut one, 1, 1),
+      Err(WebError::BufferTooSmall)
+    ));
+    assert_eq!(one, [0]);
+  }
+
+  #[test]
+  fn encode_into_result_writes_read_and_written_counts() {
+    let mut out = [0, 0];
+    write_encode_into_result(&mut out, 3, 7).unwrap();
+    assert_eq!(out, [3, 7]);
+  }
 }
 
 pub struct Location(pub Url);

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -846,6 +846,8 @@ fn op_encoding_encode_into_fast(
   pack_encode_into_result(read, boundary)
 }
 
+pub struct Location(pub Url);
+
 #[cfg(test)]
 mod tests {
   use super::WebError;
@@ -874,5 +876,3 @@ mod tests {
     assert_eq!(out, [3, 7]);
   }
 }
-
-pub struct Location(pub Url);


### PR DESCRIPTION
Reject undersized fallback encoding result buffers before writing `read` and `written` counts.

The fallback `encodeInto` path now writes through a small helper with focused unit coverage for both short-buffer rejection and normal result writes.

Validation:
- `CARGO_TARGET_DIR=/Users/nathanwhit/Documents/Code/deno5/target cargo test -p deno_web encode_into_result -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nathanwhit/Documents/Code/deno5/target cargo fmt --check`
