### PR TITLE
fix(runtime): guard usage op output buffers

### DIFF
--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -530,6 +530,10 @@ fn op_uid(state: &mut OpState) -> Result<Option<u32>, PermissionCheckError> {
 
 #[op2(fast)]
 fn op_runtime_cpu_usage(#[buffer] out: &mut [f64]) {
+  if out.len() < 2 {
+    return;
+  }
+
   let (sys, user) = get_cpu_usage();
 
   out[0] = sys.as_micros() as f64;
@@ -639,6 +643,10 @@ fn op_runtime_memory_usage(
   scope: &mut v8::PinScope<'_, '_>,
   #[buffer] out: &mut [f64],
 ) {
+  if out.len() < 4 {
+    return;
+  }
+
   let s = scope.get_heap_statistics();
 
   let (rss, heap_total, heap_used, external) = (

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -731,6 +731,10 @@ fn op_host_get_worker_cpu_usage(
   #[scoped] id: WorkerId,
   #[buffer] out: &mut [f64],
 ) {
+  if out.len() < 2 {
+    return;
+  }
+
   if let Some(worker_thread) = state.borrow::<WorkersTable>().get(&id) {
     let handle = worker_thread.cpu_thread_handle.load(Ordering::Acquire);
     if handle != 0 {
@@ -746,6 +750,10 @@ fn op_host_get_worker_cpu_usage(
 
 #[op2(fast)]
 fn op_current_thread_cpu_usage(#[buffer] out: &mut [f64]) {
+  if out.len() < 2 {
+    return;
+  }
+
   let handle = capture_current_thread_handle();
   let (user, system) = get_thread_cpu_usage_by_handle(handle);
   out[0] = user;


### PR DESCRIPTION
Reject undersized result buffers in runtime usage ops before writing usage values.

This makes the runtime usage helpers consistently return ordinary errors for invalid output buffers instead of indexing directly into caller-provided slices.

Validation:
- `CARGO_TARGET_DIR=/Users/nathanwhit/Documents/Code/deno5/target cargo build --bin deno`
- `CARGO_TARGET_DIR=/Users/nathanwhit/Documents/Code/deno5/target cargo fmt --check`
