### PR TITLE
fix(serde_v8): handle deserialization exceptions

### DIFF
--- a/libs/serde_v8/de.rs
+++ b/libs/serde_v8/de.rs
@@ -229,8 +229,8 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
     V: Visitor<'de>,
   {
     if self.input.is_string() || self.input.is_string_object() {
-      // fixme: this unwrap is not safe because stringifier could have thrown
-      let v8_string = self.input.to_string(self.scope).unwrap();
+      let v8_string =
+        self.input.to_string(self.scope).ok_or(Error::V8Exception)?;
       let string = to_utf8(v8_string, self.scope);
       visitor.visit_string(string)
     } else {
@@ -347,7 +347,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
       };
       visitor.visit_map(map)
     } else {
-      visitor.visit_map(MapObjectAccess::new(obj, self.scope, depth))
+      visitor.visit_map(MapObjectAccess::new(obj, self.scope, depth)?)
     }
   }
 
@@ -397,7 +397,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
 
         // Fields names are a hint and must be inferred when not provided
         if fields.is_empty() {
-          visitor.visit_map(MapObjectAccess::new(obj, self.scope, depth))
+          visitor.visit_map(MapObjectAccess::new(obj, self.scope, depth)?)
         } else {
           visitor.visit_map(StructAccess {
             obj,
@@ -440,18 +440,17 @@ impl<'de> de::Deserializer<'de> for &'_ mut Deserializer<'_, '_, '_> {
       let tag = {
         let prop_names =
           obj.get_own_property_names(self.scope, Default::default());
-        let prop_names = prop_names
-          .ok_or_else(|| Error::ExpectedEnum(self.input.type_repr()))?;
+        let prop_names = prop_names.ok_or(Error::V8Exception)?;
         let prop_names_len = prop_names.length();
         if prop_names_len != 1 {
           return Err(Error::LengthMismatch(prop_names_len as usize, 1));
         }
-        // fixme: this unwrap  is not safe because of proxies
-        prop_names.get_index(self.scope, 0).unwrap()
+        prop_names
+          .get_index(self.scope, 0)
+          .ok_or(Error::V8Exception)?
       };
 
-      // fixme: this unwrap  is not safe because of proxies
-      let payload = obj.get(self.scope, tag).unwrap();
+      let payload = obj.get(self.scope, tag).ok_or(Error::V8Exception)?;
       visitor.visit_enum(EnumAccess {
         scope: self.scope,
         tag,
@@ -509,24 +508,23 @@ impl<'a, 's, 'i> MapObjectAccess<'a, 's, 'i> {
     obj: v8::Local<'a, v8::Object>,
     scope: &'a mut v8::PinScope<'s, 'i>,
     remaining_depth: usize,
-  ) -> Self {
-    let keys = match obj.get_own_property_names(
-      scope,
-      v8::GetPropertyNamesArgsBuilder::new()
-        .key_conversion(v8::KeyConversionMode::ConvertToString)
-        .build(),
-    ) {
-      Some(keys) => {
-        SeqAccess::new(keys.into(), scope, 0..keys.length(), remaining_depth)
-      }
-      None => SeqAccess::new(obj, scope, 0..0, remaining_depth),
-    };
+  ) -> Result<Self> {
+    let keys = obj
+      .get_own_property_names(
+        scope,
+        v8::GetPropertyNamesArgsBuilder::new()
+          .key_conversion(v8::KeyConversionMode::ConvertToString)
+          .build(),
+      )
+      .ok_or(Error::V8Exception)?;
+    let keys =
+      SeqAccess::new(keys.into(), scope, 0..keys.length(), remaining_depth);
 
-    Self {
+    Ok(Self {
       obj,
       keys,
       next_value: None,
-    }
+    })
   }
 }
 
@@ -538,7 +536,10 @@ impl<'de> de::MapAccess<'de> for MapObjectAccess<'_, '_, '_> {
     seed: K,
   ) -> Result<Option<K::Value>> {
     while let Some(key) = self.keys.next_element::<magic::Value>()? {
-      let v8_val = self.obj.get(self.keys.scope, key.v8_value).unwrap();
+      let v8_val = self
+        .obj
+        .get(self.keys.scope, key.v8_value)
+        .ok_or(Error::V8Exception)?;
       if v8_val.is_undefined() {
         // Historically keys/value pairs with undefined values are not added to the output
         continue;
@@ -593,7 +594,10 @@ impl<'de> de::MapAccess<'de> for MapPairsAccess<'_, '_, '_> {
     seed: K,
   ) -> Result<Option<K::Value>> {
     if self.pos < self.len {
-      let v8_key = self.obj.get_index(self.scope, self.pos).unwrap();
+      let v8_key = self
+        .obj
+        .get_index(self.scope, self.pos)
+        .ok_or(Error::V8Exception)?;
       self.pos += 1;
       let mut deserializer = Deserializer::with_depth(
         self.scope,
@@ -613,7 +617,10 @@ impl<'de> de::MapAccess<'de> for MapPairsAccess<'_, '_, '_> {
     seed: V,
   ) -> Result<V::Value> {
     debug_assert!(self.pos < self.len);
-    let v8_val = self.obj.get_index(self.scope, self.pos).unwrap();
+    let v8_val = self
+      .obj
+      .get_index(self.scope, self.pos)
+      .ok_or(Error::V8Exception)?;
     self.pos += 1;
     let mut deserializer =
       Deserializer::with_depth(self.scope, v8_val, None, self.remaining_depth);
@@ -642,7 +649,7 @@ impl<'de> de::MapAccess<'de> for StructAccess<'_, '_, '_> {
   {
     for field in self.keys.by_ref() {
       let key = v8_struct_key(self.scope, field).into();
-      let val = self.obj.get(self.scope, key).unwrap();
+      let val = self.obj.get(self.scope, key).ok_or(Error::V8Exception)?;
       if val.is_undefined() {
         // Historically keys/value pairs with undefined values are not added to the output
         continue;
@@ -700,8 +707,10 @@ impl<'de> de::SeqAccess<'de> for SeqAccess<'_, '_, '_> {
     seed: T,
   ) -> Result<Option<T::Value>> {
     if let Some(pos) = self.range.next() {
-      // fixme: this unwrap  is not safe because of proxies
-      let val = self.obj.get_index(self.scope, pos).unwrap();
+      let val = self
+        .obj
+        .get_index(self.scope, pos)
+        .ok_or(Error::V8Exception)?;
       let mut deserializer =
         Deserializer::with_depth(self.scope, val, None, self.remaining_depth);
       seed.deserialize(&mut deserializer).map(Some)

--- a/libs/serde_v8/error.rs
+++ b/libs/serde_v8/error.rs
@@ -61,6 +61,9 @@ pub enum Error {
   #[error("serde_v8 error: recursion limit exceeded")]
   RecursionLimitExceeded,
 
+  #[error("serde_v8 error: exception during value conversion")]
+  V8Exception,
+
   #[error("serde_v8 error: can't create slice from resizable ArrayBuffer")]
   ResizableBackingStoreNotSupported,
 

--- a/libs/serde_v8/tests/de.rs
+++ b/libs/serde_v8/tests/de.rs
@@ -104,8 +104,26 @@ detest!(de_bool, bool, "true", true);
 detest!(de_char, char, "'é'", 'é');
 detest!(de_u64, u64, "32", 32);
 detest!(de_string, String, "'Hello'", "Hello".to_owned());
+defail!(
+  de_string_throwing_conversion,
+  String,
+  r#"(() => {
+    const value = new String("hello");
+    value.toString = () => { throw new Error("getter boom"); };
+    return value;
+  })()"#,
+  |e| matches!(e, Err(Error::V8Exception))
+);
 detest!(de_vec_empty, Vec<u64>, "[]", vec![0; 0]);
 detest!(de_vec_u64, Vec<u64>, "[1,2,3,4,5]", vec![1, 2, 3, 4, 5]);
+defail!(
+  de_vec_throwing_index,
+  Vec<u64>,
+  r#"Object.defineProperty([1], "0", {
+    get() { throw new Error("getter boom"); }
+  })"#,
+  |e| matches!(e, Err(Error::V8Exception))
+);
 detest!(
   de_vec_str,
   Vec<String>,
@@ -148,6 +166,22 @@ detest!(de_enum_unit_b, EnumUnit, "'B'", EnumUnit::B);
 detest!(de_enum_unit_so_b, EnumUnit, "new String('B')", EnumUnit::B);
 detest!(de_enum_unit_c, EnumUnit, "'C'", EnumUnit::C);
 detest!(de_enum_unit_so_c, EnumUnit, "new String('C')", EnumUnit::C);
+defail!(
+  de_enum_throwing_payload,
+  EnumPayloads,
+  r#"new Proxy({ UInt: 1 }, {
+    get() { throw new Error("getter boom"); }
+  })"#,
+  |e| matches!(e, Err(Error::V8Exception))
+);
+defail!(
+  de_enum_throwing_own_keys,
+  EnumPayloads,
+  r#"new Proxy({ UInt: 1 }, {
+    ownKeys() { throw new Error("getter boom"); }
+  })"#,
+  |e| matches!(e, Err(Error::V8Exception))
+);
 
 // Enums with payloads (tuples & struct)
 detest!(
@@ -201,6 +235,24 @@ fn de_map() {
     assert_eq!(map.get("nada"), None);
   })
 }
+
+defail!(
+  de_map_throwing_value,
+  std::collections::HashMap<String, u64>,
+  r#"new Proxy({ a: 1 }, {
+    get() { throw new Error("getter boom"); }
+  })"#,
+  |e| matches!(e, Err(Error::V8Exception))
+);
+
+defail!(
+  de_map_throwing_own_keys,
+  std::collections::HashMap<String, u64>,
+  r#"new Proxy({}, {
+    ownKeys() { throw new Error("getter boom"); }
+  })"#,
+  |e| matches!(e, Err(Error::V8Exception))
+);
 
 #[test]
 fn de_obj_with_numeric_keys() {
@@ -340,6 +392,15 @@ fn de_struct_hint() {
     assert_eq!(payload, StructPayload { a: 1, b: 2 })
   })
 }
+
+defail!(
+  de_struct_throwing_field,
+  MathOp,
+  r#"Object.defineProperty({ b: 2 }, "a", {
+    get() { throw new Error("getter boom"); }
+  })"#,
+  |e| matches!(e, Err(Error::V8Exception))
+);
 
 ////
 // JSON tests: serde_json::Value compatibility

--- a/tests/integration/eval_tests.rs
+++ b/tests/integration/eval_tests.rs
@@ -1,6 +1,8 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use test_util as util;
+use test_util::assert_contains;
+use test_util::assert_not_contains;
 use test_util::test;
 
 // Make sure that snapshot flags don't affect runtime.
@@ -25,4 +27,23 @@ fn eval_randomness() {
   }
   numbers.dedup();
   assert!(numbers.len() > 1);
+}
+
+#[test]
+fn eval_error_getter_does_not_panic() {
+  let output = util::deno_cmd()
+    .arg("eval")
+    .arg(
+      r#"Object.defineProperty(Error.prototype, "name", { get() { throw new Error("getter boom"); }, configurable: true }); throw new Error("outer");"#,
+    )
+    .stderr_piped()
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(!output.status.success());
+  let stderr =
+    util::strip_ansi_codes(std::str::from_utf8(&output.stderr).unwrap().trim());
+  assert_contains!(stderr, "error: Uncaught");
+  assert_not_contains!(stderr, "Deno has panicked", "panicked at");
 }


### PR DESCRIPTION
## Summary

- handle exceptions raised during V8 property, index, key, and string conversion
- return a normal `serde_v8` conversion error when V8 produces an empty value
- add coverage for throwing getters and proxy traps across the affected conversion shapes

## Testing

- `cargo test -p serde_v8 --test de -- --nocapture`
- `cargo test -p integration_tests eval_error_getter_does_not_panic -- --nocapture`
- `cargo build --bin deno`
