### PR TITLE
fix(ext/node): guard sqlite deserialize during callbacks

### DIFF
--- a/ext/node_sqlite/database.rs
+++ b/ext/node_sqlite/database.rs
@@ -2021,6 +2021,13 @@ impl DatabaseSync {
     buffer_value: v8::Local<'a, v8::Value>,
     options_value: v8::Local<'a, v8::Value>,
   ) -> Result<(), SqliteError> {
+    // Refuse to replace the database while SQLite is executing a
+    // user-defined callback. deserialize() finalizes existing statements,
+    // which would invalidate the currently executing statement.
+    if self.callback_depth.get() > 0 {
+      return Err(SqliteError::ActiveCallback);
+    }
+
     if !buffer_value.is_array_buffer_view() {
       return Err(SqliteError::Validation(validators::Error::InvalidArgType(
         "The \"serialized\" argument must be a TypedArray or a DataView."

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -600,6 +600,44 @@ Deno.test("[node/sqlite] DatabaseSync.deserialize corrupt header surfaces error 
   );
 });
 
+Deno.test("[node/sqlite] DatabaseSync.deserialize is blocked during user callback", () => {
+  using db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE test (id INTEGER)");
+  db.exec("INSERT INTO test VALUES (1), (2), (3)");
+
+  let blocked = false;
+
+  db.function("deserialize_in_callback", (id) => {
+    if (id === 2) {
+      nodeAssert.throws(
+        () => db.deserialize(new Uint8Array(0)),
+        {
+          code: "ERR_INVALID_STATE",
+          message:
+            "cannot close database while a user-defined callback is running",
+        },
+      );
+      blocked = true;
+    }
+
+    return id;
+  });
+
+  assertEquals(
+    db.prepare("SELECT deserialize_in_callback(id) AS id FROM test").all(),
+    [
+      { id: 1, __proto__: null },
+      { id: 2, __proto__: null },
+      { id: 3, __proto__: null },
+    ],
+  );
+  assertStrictEquals(blocked, true);
+  assertEquals(db.prepare("SELECT COUNT(*) AS count FROM test").get(), {
+    count: 3,
+    __proto__: null,
+  });
+});
+
 Deno.test("[node/sqlite] calling StatementSync and Session methods after connection has closed", () => {
   const errMessage = "statement has been finalized";
   const errMessageClosed = "database is not open";


### PR DESCRIPTION
This prevents `DatabaseSync.deserialize()` from replacing database contents while a user-defined SQLite callback is active.

`deserialize()` finalizes existing statements, so calling it reentrantly could invalidate the statement SQLite is currently executing. The method now uses the existing callback-depth guard and returns `ERR_INVALID_STATE`, matching `DatabaseSync.close()` behavior.

Validation:

- `./tools/format.js`
- `cargo build --bin deno`
- focused `DatabaseSync.deserialize` callback regression
- full `tests/unit_node/sqlite_test.ts` suite (78 tests)
