### PR TITLE
fix(node): handle sqlite conversion failures

### DIFF
--- a/ext/node_sqlite/database.rs
+++ b/ext/node_sqlite/database.rs
@@ -377,20 +377,24 @@ impl<'a> AggregateFunctionOption<'a> {
       INVERSE_STRING = "inverse",
     }
 
+    let object = v8::Local::<v8::Object>::try_from(value).map_err(|_| {
+      Error::InvalidArgType(
+        "The \"options\" argument must be an object.".into(),
+      )
+    })?;
+
     let start_key = START_STRING.v8_string(scope).unwrap();
-    let start_value = v8::Local::<v8::Object>::try_from(value)
-      .unwrap()
+    let start_value = object
       .get(scope, start_key.into())
-      .unwrap();
+      .ok_or(Error::V8Exception)?;
     if start_value.is_undefined() {
       return Err(Error::InvalidArgType("The \"options.start\" argument must be a function or a primitive value.".into()));
     }
 
     let step_key = STEP_STRING.v8_string(scope).unwrap();
-    let step_value = v8::Local::<v8::Object>::try_from(value)
-      .unwrap()
+    let step_value = object
       .get(scope, step_key.into())
-      .unwrap();
+      .ok_or(Error::V8Exception)?;
     let step_function = v8::Local::<v8::Function>::try_from(step_value)
       .map_err(|_| {
         Error::InvalidArgType(
@@ -399,10 +403,9 @@ impl<'a> AggregateFunctionOption<'a> {
       })?;
 
     let result_key = RESULT_STRING.v8_string(scope).unwrap();
-    let result_value = v8::Local::<v8::Object>::try_from(value)
-      .unwrap()
+    let result_value = object
       .get(scope, result_key.into())
-      .unwrap();
+      .ok_or(Error::V8Exception)?;
     let result_function = if result_value.is_undefined() {
       None
     } else {
@@ -421,10 +424,9 @@ impl<'a> AggregateFunctionOption<'a> {
     let mut direct_only = false;
 
     let deterministic_key = DETERMINISTIC_STRING.v8_string(scope).unwrap();
-    let deterministic_value = v8::Local::<v8::Object>::try_from(value)
-      .unwrap()
+    let deterministic_value = object
       .get(scope, deterministic_key.into())
-      .unwrap();
+      .ok_or(Error::V8Exception)?;
     if !deterministic_value.is_undefined() {
       if !deterministic_value.is_boolean() {
         return Err(Error::InvalidArgType(
@@ -435,10 +437,9 @@ impl<'a> AggregateFunctionOption<'a> {
     }
 
     let use_bigint_key = USE_BIG_INT_ARGUMENTS_STRING.v8_string(scope).unwrap();
-    let bigint_value = v8::Local::<v8::Object>::try_from(value)
-      .unwrap()
+    let bigint_value = object
       .get(scope, use_bigint_key.into())
-      .unwrap();
+      .ok_or(Error::V8Exception)?;
     if !bigint_value.is_undefined() {
       if !bigint_value.is_boolean() {
         return Err(Error::InvalidArgType(
@@ -450,10 +451,9 @@ impl<'a> AggregateFunctionOption<'a> {
     }
 
     let varargs_key = VARARGS_STRING.v8_string(scope).unwrap();
-    let varargs_value = v8::Local::<v8::Object>::try_from(value)
-      .unwrap()
+    let varargs_value = object
       .get(scope, varargs_key.into())
-      .unwrap();
+      .ok_or(Error::V8Exception)?;
     if !varargs_value.is_undefined() {
       if !varargs_value.is_boolean() {
         return Err(Error::InvalidArgType(
@@ -464,10 +464,9 @@ impl<'a> AggregateFunctionOption<'a> {
     }
 
     let direct_only_key = DIRECT_ONLY_STRING.v8_string(scope).unwrap();
-    let direct_only_value = v8::Local::<v8::Object>::try_from(value)
-      .unwrap()
+    let direct_only_value = object
       .get(scope, direct_only_key.into())
-      .unwrap();
+      .ok_or(Error::V8Exception)?;
     if !direct_only_value.is_undefined() {
       if !direct_only_value.is_boolean() {
         return Err(Error::InvalidArgType(
@@ -478,10 +477,9 @@ impl<'a> AggregateFunctionOption<'a> {
     }
 
     let inverse_key = INVERSE_STRING.v8_string(scope).unwrap();
-    let inverse_value = v8::Local::<v8::Object>::try_from(value)
-      .unwrap()
+    let inverse_value = object
       .get(scope, inverse_key.into())
-      .unwrap();
+      .ok_or(Error::V8Exception)?;
     let inverse_function = if inverse_value.is_undefined() {
       None
     } else {
@@ -1181,7 +1179,9 @@ impl DatabaseSync {
       }
 
       let use_bigint_key = USE_BIG_INT_ARGUMENTS.v8_string(scope).unwrap();
-      let bigint_value = options.get(scope, use_bigint_key.into()).unwrap();
+      let bigint_value = options
+        .get(scope, use_bigint_key.into())
+        .ok_or(validators::Error::V8Exception)?;
       if !bigint_value.is_undefined() {
         if !bigint_value.is_boolean() {
           return Err(
@@ -1196,7 +1196,9 @@ impl DatabaseSync {
       }
 
       let varargs_key = VARARGS.v8_string(scope).unwrap();
-      let varargs_value = options.get(scope, varargs_key.into()).unwrap();
+      let varargs_value = options
+        .get(scope, varargs_key.into())
+        .ok_or(validators::Error::V8Exception)?;
       if !varargs_value.is_undefined() {
         if !varargs_value.is_boolean() {
           return Err(
@@ -1210,8 +1212,9 @@ impl DatabaseSync {
       }
 
       let deterministic_key = DETERMINISTIC.v8_string(scope).unwrap();
-      let deterministic_value =
-        options.get(scope, deterministic_key.into()).unwrap();
+      let deterministic_value = options
+        .get(scope, deterministic_key.into())
+        .ok_or(validators::Error::V8Exception)?;
       if !deterministic_value.is_undefined() {
         if !deterministic_value.is_boolean() {
           return Err(
@@ -1226,8 +1229,9 @@ impl DatabaseSync {
       }
 
       let direct_only_key = DIRECT_ONLY.v8_string(scope).unwrap();
-      let direct_only_value =
-        options.get(scope, direct_only_key.into()).unwrap();
+      let direct_only_value = options
+        .get(scope, direct_only_key.into())
+        .ok_or(validators::Error::V8Exception)?;
       if !direct_only_value.is_undefined() {
         if !direct_only_value.is_boolean() {
           return Err(
@@ -1249,8 +1253,12 @@ impl DatabaseSync {
       -1
     } else {
       let length_key = LENGTH.v8_string(scope).unwrap();
-      let length = function.get(scope, length_key.into()).unwrap();
-      length.int32_value(scope).unwrap_or(0)
+      let length = function
+        .get(scope, length_key.into())
+        .ok_or(validators::Error::V8Exception)?;
+      length
+        .int32_value(scope)
+        .ok_or(validators::Error::V8Exception)?
     };
 
     let db = self.conn.borrow();
@@ -1559,14 +1567,21 @@ impl DatabaseSync {
     // counting.
     let raw_handle = unsafe { db.handle() };
 
-    let mut raw_session = std::ptr::null_mut();
     let mut options = options;
 
     let z_db = options
       .as_mut()
       .and_then(|options| options.db.take())
-      .map(|db| CString::new(db).unwrap())
-      .unwrap_or_else(|| CString::new("main").unwrap());
+      .map(CString::new)
+      .transpose()?
+      .unwrap_or_else(|| c"main".to_owned());
+    let table = options
+      .as_mut()
+      .and_then(|options| options.table.take())
+      .map(CString::new)
+      .transpose()?;
+
+    let mut raw_session = std::ptr::null_mut();
     // SAFETY: `z_db` points to a valid c-string.
     let r = unsafe {
       libsqlite3_sys::sqlite3session_create(
@@ -1580,10 +1595,6 @@ impl DatabaseSync {
       return Err(SqliteError::SessionCreateFailed);
     }
 
-    let table = options
-      .as_mut()
-      .and_then(|options| options.table.take())
-      .map(|table| CString::new(table).unwrap());
     let z_table = table.as_ref().map(|table| table.as_ptr()).unwrap_or(null());
     let r =
       // SAFETY: `z_table` points to a valid c-string and `raw_session`
@@ -1803,9 +1814,9 @@ impl DatabaseSync {
       let step_fn_length = options
         .step
         .get(scope, length_key.into())
-        .unwrap()
+        .ok_or(validators::Error::V8Exception)?
         .int32_value(scope)
-        .unwrap();
+        .ok_or(validators::Error::V8Exception)?;
 
       // Subtract 1 because the first argument is the aggregate value.
       argc = step_fn_length - 1;
@@ -1813,9 +1824,9 @@ impl DatabaseSync {
       let inverse_fn_length = if let Some(inverse_fn) = &options.inverse {
         inverse_fn
           .get(scope, length_key.into())
-          .unwrap()
+          .ok_or(validators::Error::V8Exception)?
           .int32_value(scope)
-          .unwrap()
+          .ok_or(validators::Error::V8Exception)?
       } else {
         0
       };
@@ -2930,7 +2941,7 @@ fn throw_range_error(scope: &mut v8::PinScope<'_, '_>, message: &str) {
   let code_value = ERR_OUT_OF_RANGE.v8_string(scope).unwrap();
   let error_obj: v8::Local<v8::Object> = error.try_into().unwrap();
   error_obj
-    .set(scope, code_key.into(), code_value.into())
+    .create_data_property(scope, code_key.into(), code_value.into())
     .unwrap();
 
   scope.throw_exception(error);
@@ -2949,7 +2960,7 @@ fn throw_type_error_with_code(
   let code_value = v8::String::new(scope, code).unwrap();
   let error_obj: v8::Local<v8::Object> = error.try_into().unwrap();
   error_obj
-    .set(scope, code_key.into(), code_value.into())
+    .create_data_property(scope, code_key.into(), code_value.into())
     .unwrap();
 
   scope.throw_exception(error);
@@ -2970,7 +2981,7 @@ fn throw_error_with_code(
   let code_value = v8::String::new(scope, code).unwrap();
   let error_obj: v8::Local<v8::Object> = error.try_into().unwrap();
   error_obj
-    .set(scope, code_key.into(), code_value.into())
+    .create_data_property(scope, code_key.into(), code_value.into())
     .unwrap();
 
   scope.throw_exception(error);

--- a/ext/node_sqlite/lib.rs
+++ b/ext/node_sqlite/lib.rs
@@ -122,7 +122,7 @@ pub enum SqliteError {
   #[property("code" = self.code())]
   InvalidCallback(&'static str),
   #[class(type)]
-  #[error("FromUtf8Error: {0}")]
+  #[error("String contains a null byte: {0}")]
   #[property("code" = self.code())]
   FromNullError(#[from] std::ffi::NulError),
   #[class(type)]
@@ -201,7 +201,9 @@ impl SqliteError {
     match self {
       Self::InvalidConstructor => ErrorCode::ERR_ILLEGAL_CONSTRUCTOR,
       Self::InvalidBindType(_) => ErrorCode::ERR_INVALID_ARG_TYPE,
-      Self::InvalidBindValue(_) => ErrorCode::ERR_INVALID_ARG_VALUE,
+      Self::InvalidBindValue(_) | Self::FromNullError(_) => {
+        ErrorCode::ERR_INVALID_ARG_VALUE
+      }
       Self::FailedBind(_)
       | Self::UnknownNamedParameter(_)
       | Self::DuplicateNamedParameter(..)

--- a/ext/node_sqlite/sql_tag_store.rs
+++ b/ext/node_sqlite/sql_tag_store.rs
@@ -230,7 +230,9 @@ impl SQLTagStore {
 
     let mut sql = String::new();
     for i in 0..n_strings {
-      let str_val = strings.get_index(scope, i).unwrap();
+      let str_val = strings
+        .get_index(scope, i)
+        .ok_or(super::validators::Error::V8Exception)?;
       if !str_val.is_string() {
         return Err(SqliteError::Validation(
           super::validators::Error::InvalidArgType(
@@ -388,7 +390,11 @@ impl SQLTagStore {
     };
 
     obj
-      .set(scope, last_insert_row_id_str.into(), last_insert_row_id_val)
+      .create_data_property(
+        scope,
+        last_insert_row_id_str.into(),
+        last_insert_row_id_val,
+      )
       .unwrap();
 
     let changes_str = CHANGES.v8_string(scope).unwrap();
@@ -399,7 +405,9 @@ impl SQLTagStore {
       v8::Number::new(scope, changes as f64).into()
     };
 
-    obj.set(scope, changes_str.into(), changes_val).unwrap();
+    obj
+      .create_data_property(scope, changes_str.into(), changes_val)
+      .unwrap();
 
     Ok(obj.into())
   }
@@ -642,16 +650,28 @@ impl SQLTagStore {
 
     let global = scope.get_current_context().global(scope);
     let iter_str = ITERATOR.v8_string(scope).unwrap();
-    let js_iterator: v8::Local<v8::Object> = {
-      global
-        .get(scope, iter_str.into())
-        .unwrap()
-        .try_into()
-        .unwrap()
-    };
+    let js_iterator = global
+      .get(scope, iter_str.into())
+      .ok_or(super::validators::Error::V8Exception)?;
+    let js_iterator =
+      v8::Local::<v8::Object>::try_from(js_iterator).map_err(|_| {
+        super::validators::Error::InvalidArgType(
+          "Iterator must be an object.".into(),
+        )
+      })?;
 
     let proto_str = PROTOTYPE.v8_string(scope).unwrap();
-    let js_iterator_proto = js_iterator.get(scope, proto_str.into()).unwrap();
+    let js_iterator_proto = js_iterator
+      .get(scope, proto_str.into())
+      .ok_or(super::validators::Error::V8Exception)?;
+    if !js_iterator_proto.is_object() && !js_iterator_proto.is_null() {
+      return Err(
+        super::validators::Error::InvalidArgType(
+          "Iterator.prototype must be an object or null.".into(),
+        )
+        .into(),
+      );
+    }
 
     let names = &[
       NEXT.v8_string(scope).unwrap().into(),

--- a/ext/node_sqlite/statement.rs
+++ b/ext/node_sqlite/statement.rs
@@ -514,7 +514,7 @@ impl StatementSync {
         let obj = v8::Local::<v8::Object>::try_from(param0).unwrap();
         let keys = obj
           .get_property_names(scope, GetPropertyNamesArgs::default())
-          .unwrap();
+          .ok_or(validators::Error::V8Exception)?;
 
         // Allow specifying named parameters without the SQLite prefix character to improve
         // ergonomics. This can be disabled with `StatementSync#setAllowBareNamedParams`.
@@ -557,9 +557,11 @@ impl StatementSync {
 
         let len = keys.length();
         for j in 0..len {
-          let key = keys.get_index(scope, j).unwrap();
+          let key = keys
+            .get_index(scope, j)
+            .ok_or(validators::Error::V8Exception)?;
           let key_str = key.to_rust_string_lossy(scope);
-          let key_c = std::ffi::CString::new(key_str).unwrap();
+          let key_c = std::ffi::CString::new(key_str.as_bytes())?;
 
           // SAFETY: `raw` is a valid pointer to a sqlite3_stmt.
           let mut r = unsafe {
@@ -576,13 +578,12 @@ impl StatementSync {
                 continue;
               }
 
-              return Err(SqliteError::UnknownNamedParameter(
-                key_c.into_string().unwrap(),
-              ));
+              return Err(SqliteError::UnknownNamedParameter(key_str));
             }
           }
 
-          let value = obj.get(scope, key).unwrap();
+          let value =
+            obj.get(scope, key).ok_or(validators::Error::V8Exception)?;
           self.bind_value(scope, value, r)?;
         }
 
@@ -932,16 +933,26 @@ impl StatementSync {
 
     let global = scope.get_current_context().global(scope);
     let iter_str = ITERATOR.v8_string(scope).unwrap();
-    let js_iterator: v8::Local<v8::Object> = {
-      global
-        .get(scope, iter_str.into())
-        .unwrap()
-        .try_into()
-        .unwrap()
-    };
+    let js_iterator = global
+      .get(scope, iter_str.into())
+      .ok_or(validators::Error::V8Exception)?;
+    let js_iterator =
+      v8::Local::<v8::Object>::try_from(js_iterator).map_err(|_| {
+        validators::Error::InvalidArgType("Iterator must be an object.".into())
+      })?;
 
     let proto_str = PROTOTYPE.v8_string(scope).unwrap();
-    let js_iterator_proto = js_iterator.get(scope, proto_str.into()).unwrap();
+    let js_iterator_proto = js_iterator
+      .get(scope, proto_str.into())
+      .ok_or(validators::Error::V8Exception)?;
+    if !js_iterator_proto.is_object() && !js_iterator_proto.is_null() {
+      return Err(
+        validators::Error::InvalidArgType(
+          "Iterator.prototype must be an object or null.".into(),
+        )
+        .into(),
+      );
+    }
 
     let names = &[
       NEXT.v8_string(scope).unwrap().into(),

--- a/ext/node_sqlite/validators.rs
+++ b/ext/node_sqlite/validators.rs
@@ -13,6 +13,9 @@ pub enum Error {
   #[class(range)]
   #[error("{0}")]
   OutOfRange(Cow<'static, str>),
+  #[class(type)]
+  #[error("Exception during property access")]
+  V8Exception,
 }
 
 impl Error {
@@ -20,6 +23,7 @@ impl Error {
     match self {
       Self::InvalidArgType(_) => ErrorCode::ERR_INVALID_ARG_TYPE,
       Self::OutOfRange(_) => ErrorCode::ERR_OUT_OF_RANGE,
+      Self::V8Exception => ErrorCode::ERR_INVALID_ARG_TYPE,
     }
   }
 }

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -136,6 +136,21 @@ Deno.test("[node/sqlite] createSession and changesets", () => {
   assertThrows(() => session.close(), Error, "database is not open");
 });
 
+Deno.test("[node/sqlite] createSession rejects null bytes in options", () => {
+  using db = new DatabaseSync(":memory:");
+
+  nodeAssert.throws(() => db.createSession({ db: "main\0" }), {
+    code: "ERR_INVALID_ARG_VALUE",
+  });
+  nodeAssert.throws(() => db.createSession({ table: "data\0" }), {
+    code: "ERR_INVALID_ARG_VALUE",
+  });
+
+  const session = db.createSession();
+  assert(session.changeset() instanceof Uint8Array);
+  session.close();
+});
+
 Deno.test("[node/sqlite] StatementSync integer too large", () => {
   const db = new DatabaseSync(":memory:");
   db.exec("CREATE TABLE data(key INTEGER PRIMARY KEY);");
@@ -279,6 +294,38 @@ Deno.test("[node/sqlite] query should handle mixed positional and named paramete
   db.close();
 });
 
+Deno.test("[node/sqlite] StatementSync handles named parameter access failures", () => {
+  using db = new DatabaseSync(":memory:");
+  const statement = db.prepare("SELECT :value AS value");
+
+  assertThrows(
+    () =>
+      statement.get(
+        new Proxy({}, {
+          ownKeys() {
+            throw new Error("ownKeys failed");
+          },
+        }),
+      ),
+    Error,
+  );
+  assertThrows(
+    () =>
+      statement.get({
+        get value(): number {
+          throw new Error("getter failed");
+        },
+      }),
+    Error,
+  );
+  assertThrows(() => statement.get({ "value\0suffix": 1 }), TypeError);
+
+  assertEquals(statement.get({ value: 1 }), {
+    value: 1,
+    __proto__: null,
+  });
+});
+
 Deno.test("[node/sqlite] StatementSync unknown named parameters should throw", () => {
   const db = new DatabaseSync(":memory:");
   db.exec(
@@ -335,6 +382,29 @@ Deno.test("[node/sqlite] StatementSync#iterate", () => {
   assertEquals(value, null);
 
   db.close();
+});
+
+Deno.test("[node/sqlite] iterator creation handles accessor failures", () => {
+  using db = new DatabaseSync(":memory:");
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "Iterator");
+  assert(descriptor);
+
+  try {
+    Object.defineProperty(globalThis, "Iterator", {
+      configurable: true,
+      get() {
+        throw new Error("Iterator getter failed");
+      },
+    });
+    assertThrows(() => db.prepare("SELECT 1").iterate(), Error);
+  } finally {
+    Object.defineProperty(globalThis, "Iterator", descriptor);
+  }
+
+  assertEquals([...db.prepare("SELECT 1 AS value").iterate()], [{
+    value: 1,
+    __proto__: null,
+  }]);
 });
 
 // https://github.com/denoland/deno/issues/28187
@@ -719,6 +789,60 @@ Deno.test("[node/sqlite] DatabaseSync.aggregate input validation", () => {
   }, {
     code: "ERR_INVALID_ARG_TYPE",
     message: /The "options\.directOnly" argument must be a boolean/,
+  });
+});
+
+Deno.test("[node/sqlite] function option access failures remain catchable", () => {
+  using db = new DatabaseSync(":memory:");
+
+  assertThrows(
+    () =>
+      db.function(
+        "scalar_option",
+        {
+          get varargs(): boolean {
+            throw new Error("option getter failed");
+          },
+        },
+        () => 0,
+      ),
+    Error,
+  );
+
+  const scalar = () => 0;
+  Object.defineProperty(scalar, "length", {
+    get() {
+      throw new Error("length getter failed");
+    },
+  });
+  assertThrows(() => db.function("scalar_length", scalar), Error);
+
+  const step = () => 0;
+  Object.defineProperty(step, "length", {
+    get() {
+      throw new Error("length getter failed");
+    },
+  });
+  assertThrows(
+    () => db.aggregate("aggregate_length", { start: 0, step }),
+    Error,
+  );
+
+  assertThrows(
+    () =>
+      db.aggregate("aggregate_option", {
+        get start(): number {
+          throw new Error("option getter failed");
+        },
+        step: () => 0,
+      }),
+    Error,
+  );
+
+  db.function("scalar", () => 1);
+  assertEquals(db.prepare("SELECT scalar() AS value").get(), {
+    value: 1,
+    __proto__: null,
   });
 });
 
@@ -1270,6 +1394,27 @@ Deno.test("sql.get retrieves a single row", () => {
   assertStrictEquals(first.text, "bob");
   assertStrictEquals(first.id, 1);
   assertStrictEquals(Object.getPrototypeOf(first), null);
+});
+
+Deno.test("SQLTagStore handles template access failures", () => {
+  using db = new DatabaseSync(":memory:");
+  // @ts-expect-error createTagStore is a valid method
+  const sql = db.createTagStore(10);
+  const strings = new Array(1) as unknown as TemplateStringsArray;
+  Object.defineProperty(strings, 0, {
+    get() {
+      throw new Error("template getter failed");
+    },
+  });
+
+  assertThrows(
+    () => sql.get(strings),
+    Error,
+  );
+  assertEquals(sql.get`SELECT 1 AS value`, {
+    value: 1,
+    __proto__: null,
+  });
 });
 
 Deno.test("sql.all retrieves all rows", () => {


### PR DESCRIPTION
This makes `node:sqlite` treat JavaScript conversion failures as normal, catchable errors.

V8 property and index access can execute JavaScript and fail, while C string conversion rejects embedded null bytes. The affected statement binding, tag store, function and aggregate option, iterator setup, and session option paths now propagate those failures instead of assuming conversion always succeeds. Result and error properties are also defined directly to avoid invoking inherited setters.

After a failed conversion, the database remains usable by subsequent operations.

Validation:

- `./tools/format.js`
- `cargo fmt --check --package deno_node_sqlite`
- `cargo build --bin deno`
- full `tests/unit_node/sqlite_test.ts` suite (82 tests)
