### PR TITLE
fix(ext/node): respect base64 buffer ranges

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -1047,24 +1047,36 @@ Buffer.prototype.asciiWrite = function asciiWrite(string, offset, length) {
 
 Buffer.prototype.base64Slice = function base64Slice(
   offset,
-  length,
+  end,
 ) {
   if (offset === undefined) {
     offset = 0;
   }
 
-  if (length === undefined) {
-    length = this.length;
+  if (end === undefined) {
+    end = this.length;
+  }
+
+  // deno-lint-ignore prefer-primordials
+  if (offset < 0 || offset > this.byteLength) {
+    throw new codes.ERR_BUFFER_OUT_OF_BOUNDS("offset");
+  }
+  // deno-lint-ignore prefer-primordials
+  if (end < 0 || end > this.byteLength) {
+    throw new codes.ERR_BUFFER_OUT_OF_BOUNDS("end");
+  }
+  if (end <= offset) {
+    return "";
   }
 
   // Use op_base64_encode (#[string] return) for small buffers where
   // the lighter-weight op2 string path is faster.
   // Use op_base64_encode_from_buffer (v8::String::new_external_onebyte) for
   // large buffers where avoiding UTF-8 processing and copying matters.
-  if (offset === 0 && length === this.length && length <= 4096) {
+  if (offset === 0 && end === this.length && end <= 4096) {
     return op_base64_encode(this);
   }
-  return op_base64_encode_from_buffer(this, offset, length - offset);
+  return op_base64_encode_from_buffer(this, offset, end - offset);
 };
 
 Buffer.prototype.base64Write = function base64Write(
@@ -1072,9 +1084,26 @@ Buffer.prototype.base64Write = function base64Write(
   offset,
   length,
 ) {
+  if (offset === undefined) {
+    offset = 0;
+  }
+  // deno-lint-ignore prefer-primordials
+  if (offset < 0 || offset > this.byteLength) {
+    throw new codes.ERR_BUFFER_OUT_OF_BOUNDS("offset");
+  }
+
+  const remaining = this.byteLength - offset;
+  if (length === undefined || length > remaining) {
+    length = remaining;
+  } else if (length < 0) {
+    throw new codes.ERR_BUFFER_OUT_OF_BOUNDS("length");
+  }
+
+  const target = offset === 0 && length === this.byteLength
+    ? this
+    : TypedArrayPrototypeSubarray(this, 0, offset + length);
   try {
-    const written = op_base64_decode_into(string, this, offset);
-    return length !== undefined ? MathMin(written, length) : written;
+    return op_base64_decode_into(string, target, offset);
   } catch {
     // Fallback for strings with base64url chars or invalid chars
     return blitBuffer(base64ToBytes(string), this, offset, length);

--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -1049,20 +1049,19 @@ Buffer.prototype.base64Slice = function base64Slice(
   offset,
   end,
 ) {
+  const byteLength = TypedArrayPrototypeGetByteLength(this);
   if (offset === undefined) {
     offset = 0;
   }
 
   if (end === undefined) {
-    end = this.length;
+    end = byteLength;
   }
 
-  // deno-lint-ignore prefer-primordials
-  if (offset < 0 || offset > this.byteLength) {
+  if (offset < 0 || offset > byteLength) {
     throw new codes.ERR_BUFFER_OUT_OF_BOUNDS("offset");
   }
-  // deno-lint-ignore prefer-primordials
-  if (end < 0 || end > this.byteLength) {
+  if (end < 0 || end > byteLength) {
     throw new codes.ERR_BUFFER_OUT_OF_BOUNDS("end");
   }
   if (end <= offset) {
@@ -1073,7 +1072,7 @@ Buffer.prototype.base64Slice = function base64Slice(
   // the lighter-weight op2 string path is faster.
   // Use op_base64_encode_from_buffer (v8::String::new_external_onebyte) for
   // large buffers where avoiding UTF-8 processing and copying matters.
-  if (offset === 0 && end === this.length && end <= 4096) {
+  if (offset === 0 && end === byteLength && end <= 4096) {
     return op_base64_encode(this);
   }
   return op_base64_encode_from_buffer(this, offset, end - offset);
@@ -1084,22 +1083,22 @@ Buffer.prototype.base64Write = function base64Write(
   offset,
   length,
 ) {
+  const byteLength = TypedArrayPrototypeGetByteLength(this);
   if (offset === undefined) {
     offset = 0;
   }
-  // deno-lint-ignore prefer-primordials
-  if (offset < 0 || offset > this.byteLength) {
+  if (offset < 0 || offset > byteLength) {
     throw new codes.ERR_BUFFER_OUT_OF_BOUNDS("offset");
   }
 
-  const remaining = this.byteLength - offset;
+  const remaining = byteLength - offset;
   if (length === undefined || length > remaining) {
     length = remaining;
   } else if (length < 0) {
     throw new codes.ERR_BUFFER_OUT_OF_BOUNDS("length");
   }
 
-  const target = offset === 0 && length === this.byteLength
+  const target = offset === 0 && length === byteLength
     ? this
     : TypedArrayPrototypeSubarray(this, 0, offset + length);
   try {

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -385,7 +385,7 @@ fn op_base64_decode_into(
   #[smi] offset: u32,
 ) -> Result<u32, WebError> {
   let offset = offset as usize;
-  let target = &mut target[offset..];
+  let target = target.get_mut(offset..).ok_or(WebError::BufferTooSmall)?;
 
   // Fast path: try strict decode directly into target.
   // Works for clean padded base64 (the common case).
@@ -465,8 +465,9 @@ fn op_base64_encode_from_buffer<'a>(
 ) -> Result<v8::Local<'a, v8::String>, WebError> {
   let offset = offset as usize;
   let length = length as usize;
-  let end = (offset + length).min(s.len());
-  base64_encode_to_v8_string(scope, &s[offset..end])
+  let end = offset.checked_add(length).ok_or(WebError::BufferTooSmall)?;
+  let s = s.get(offset..end).ok_or(WebError::BufferTooSmall)?;
+  base64_encode_to_v8_string(scope, s)
 }
 
 /// Encode bytes to base64 and create a V8 one-byte string directly.

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -658,6 +658,55 @@ Deno.test({
 });
 
 Deno.test({
+  name: "[node/buffer] base64Slice validates its range",
+  fn() {
+    const buf = Buffer.alloc(10);
+    assertThrows(
+      () => {
+        // @ts-expect-error Buffer.prototype.base64Slice is undocumented
+        buf.base64Slice(20, 25);
+      },
+      RangeError,
+    );
+    assertThrows(
+      () => {
+        // @ts-expect-error Buffer.prototype.base64Slice is undocumented
+        buf.base64Slice(0, 20);
+      },
+      RangeError,
+    );
+    // @ts-expect-error Buffer.prototype.base64Slice is undocumented
+    assertEquals(buf.base64Slice(5, 4), "");
+  },
+});
+
+Deno.test({
+  name: "[node/buffer] base64Write validates its offset",
+  fn() {
+    const buf = Buffer.alloc(10);
+    assertThrows(
+      () => {
+        Buffer.prototype.base64Write.call(buf, "YmFzZTY0", 100);
+      },
+      RangeError,
+    );
+  },
+});
+
+Deno.test({
+  name: "[node/buffer] base64 write respects the length limit",
+  fn() {
+    const buf = Buffer.alloc(64);
+    buf.fill(0x61, 32);
+    const input = Buffer.from("B".repeat(48)).toString("base64");
+
+    assertEquals(buf.write(input, 0, 32, "base64"), 32);
+    assertEquals(buf.subarray(0, 32), Buffer.alloc(32, 0x42));
+    assertEquals(buf.subarray(32), Buffer.alloc(32, 0x61));
+  },
+});
+
+Deno.test({
   name: "[node/buffer] base64urlSlice allows omitting arguments",
   fn() {
     const buf = Buffer.of(1, 2, 3);

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -707,6 +707,18 @@ Deno.test({
 });
 
 Deno.test({
+  name: "[node/buffer] base64 operations use the actual buffer length",
+  fn() {
+    const buf = Buffer.from("abcdef");
+    Object.defineProperty(buf, "byteLength", { value: 0 });
+
+    assertEquals(buf.toString("base64", 1, 4), "YmNk");
+    assertEquals(buf.write("WFla", 1, 2, "base64"), 2);
+    assertEquals(buf.toString(), "aXYdef");
+  },
+});
+
+Deno.test({
   name: "[node/buffer] base64urlSlice allows omitting arguments",
   fn() {
     const buf = Buffer.of(1, 2, 3);


### PR DESCRIPTION
## Summary

- validate internal base64 slice and write ranges before invoking native operations
- limit base64 decoding to the caller-requested destination span
- make the underlying base64 operations reject invalid ranges consistently

The base64 write path previously decoded into the full remaining buffer and only clamped the returned byte count afterward. This change bounds the destination view before decoding and adds range checks at both the JavaScript adapter and native operation layers.

## Testing

- `cargo build --bin deno`
- `target/debug/deno test -A --config tests/config/deno.json tests/unit_node/buffer_test.ts`
- `./tools/format.js`
- `cargo fmt --check --package deno_web --package deno_node`
