### PR TITLE
fix(ext/napi): don't free threadsafe function on abort while refs remain

### DIFF
--- a/ext/napi/node_api.rs
+++ b/ext/napi/node_api.rs
@@ -988,12 +988,24 @@ impl TsFn {
       return napi_invalid_arg;
     }
 
-    if (result == Ok(1) || mode == napi_tsfn_abort)
-      && tsfn
-        .is_closing
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_ok()
-    {
+    // In abort mode, reject any pending and future calls immediately and wake
+    // up callers that are blocked on a full queue. This only marks the tsfn as
+    // closing; it must NOT free it while other threads still hold a reference.
+    // Freeing here (as a previous version did, regardless of thread_count)
+    // leaves those threads with a dangling pointer, and a subsequent release
+    // from one of them can spawn a second drop of the same box, causing a
+    // use-after-free and a double free (the assert in TsFn::drop).
+    if mode == napi_tsfn_abort {
+      tsfn.is_closing.store(true, Ordering::SeqCst);
+      tsfn.queue_cond.notify_all();
+    }
+
+    // Free the tsfn exactly once, when the last thread has released it. The
+    // thread count reaching zero (`result == Ok(1)`) guarantees no other
+    // thread still holds the pointer, and it can only be observed by a single
+    // release, so the drop is spawned at most once.
+    if result == Ok(1) {
+      tsfn.is_closing.store(true, Ordering::SeqCst);
       tsfn.queue_cond.notify_all();
       let tsfnptr = SendPtr(tsfn);
       // drop must be queued in order to preserve ordering consistent

--- a/tests/napi/async_test.js
+++ b/tests/napi/async_test.js
@@ -52,6 +52,20 @@ Deno.test("napi tsfn call_js_cb receives valid env after abort race", async () =
   });
 });
 
+Deno.test("napi tsfn abort with outstanding thread does not double free", async () => {
+  // With napi_tsfn_abort, a previous version freed the tsfn regardless of
+  // thread_count, leaving other reference holders with a dangling pointer.
+  // A subsequent release could then spawn a second drop of the same box,
+  // causing a use-after-free and a double free (assert in TsFn::drop). Here
+  // the tsfn is created with initial_thread_count = 2 and both threads must
+  // release before it is freed; the finalizer must run exactly once.
+  await new Promise((resolve) => {
+    asyncTask.test_tsfn_abort_outstanding(() => {
+      resolve();
+    });
+  });
+});
+
 Deno.test("napi tsfn acquire and release", async function () {
   await new Promise((resolve) => {
     asyncTask.test_tsfn_acquire_release(resolve);

--- a/tests/napi/src/async.rs
+++ b/tests/napi/src/async.rs
@@ -434,6 +434,101 @@ extern "C" fn test_tsfn_abort_race(
   ptr::null_mut()
 }
 
+// Reproduces a double free when napi_tsfn_abort is used while more than one
+// thread still holds the tsfn. A previous version freed the tsfn on abort
+// regardless of thread_count, so the still-outstanding thread was left with a
+// dangling pointer; its later release could spawn a second drop of the same
+// box (use-after-free + double free, tripping the assert in TsFn::drop). The
+// tsfn here starts with initial_thread_count = 2, so both threads must release
+// before it is freed and the finalizer must run exactly once.
+extern "C" fn test_tsfn_abort_outstanding(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  let (args, argc, _) = napi_get_callback_info!(env, info, 1);
+  assert_eq!(argc, 1);
+
+  let mut resource_name: napi_value = ptr::null_mut();
+  assert_napi_ok!(napi_create_string_utf8(
+    env,
+    c"tsfn_abort_outstanding".as_ptr(),
+    usize::MAX,
+    &mut resource_name,
+  ));
+
+  let mut func: napi_ref = ptr::null_mut();
+  assert_napi_ok!(napi_create_reference(env, args[0], 1, &mut func));
+
+  let mut tsfn: napi_threadsafe_function = ptr::null_mut();
+  assert_napi_ok!(napi_create_threadsafe_function(
+    env,
+    ptr::null_mut(),
+    ptr::null_mut(),
+    resource_name,
+    0,
+    2, // initial_thread_count: two releases are owed
+    func as *mut c_void,
+    Some(tsfn_race_finalize),
+    ptr::null_mut(),
+    Some(tsfn_race_call_js),
+    &mut tsfn,
+  ));
+
+  let tsfn_addr = tsfn as usize;
+
+  // Thread A: calls the tsfn, then aborts. With thread_count still at 2 this
+  // must not free the tsfn out from under Thread B.
+  let tsfn_a = tsfn_addr;
+  std::thread::spawn(move || {
+    let tsfn = tsfn_a as napi_threadsafe_function;
+    for _ in 0..100 {
+      let status = unsafe {
+        napi_call_threadsafe_function(
+          tsfn,
+          ptr::null_mut(),
+          ThreadsafeFunctionCallMode::nonblocking,
+        )
+      };
+      if status != napi_ok {
+        break;
+      }
+    }
+    unsafe {
+      napi_release_threadsafe_function(
+        tsfn,
+        ThreadsafeFunctionReleaseMode::abort,
+      );
+    }
+  });
+
+  // Thread B: the second reference holder. Whichever release drops the count
+  // to zero frees the tsfn exactly once.
+  let tsfn_b = tsfn_addr;
+  std::thread::spawn(move || {
+    let tsfn = tsfn_b as napi_threadsafe_function;
+    for _ in 0..100 {
+      let status = unsafe {
+        napi_call_threadsafe_function(
+          tsfn,
+          ptr::null_mut(),
+          ThreadsafeFunctionCallMode::nonblocking,
+        )
+      };
+      if status != napi_ok {
+        break;
+      }
+    }
+    unsafe {
+      napi_release_threadsafe_function(
+        tsfn,
+        ThreadsafeFunctionReleaseMode::release,
+      );
+    }
+  });
+
+  ptr::null_mut()
+}
+
 // Test napi_acquire_threadsafe_function and napi_release_threadsafe_function.
 // Creates a tsfn with initial_thread_count=1, acquires it (count=2),
 // releases twice (count drops to 1 then 0, triggering close).
@@ -685,6 +780,11 @@ pub fn init(env: napi_env, exports: napi_value) {
     ),
     napi_new_property!(env, "test_tsfn_close_race", test_tsfn_close_race),
     napi_new_property!(env, "test_tsfn_abort_race", test_tsfn_abort_race),
+    napi_new_property!(
+      env,
+      "test_tsfn_abort_outstanding",
+      test_tsfn_abort_outstanding
+    ),
     napi_new_property!(
       env,
       "test_tsfn_acquire_release",


### PR DESCRIPTION
Fixes the Windows panic reported in #35990:

```
thread 'main' panicked at ext\napi\node_api.rs:947:5:
assertion failed: self.is_closed.compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed).is_ok()
```

`napi_release_threadsafe_function` with `napi_tsfn_abort` freed the `TsFn`
regardless of the remaining `thread_count`. When more than one thread still held
the function, aborting spawned the drop immediately, freeing the box out from
under the other reference holders. Those threads were left with a dangling
pointer, and a later `release` from one of them could deref the freed box and
spawn a second drop of the same allocation, producing a use-after-free and a
double free. On the second drop the `is_closed` compare-exchange in `TsFn::drop`
fails and the assertion panics.

Abort now only marks the function as closing (rejecting pending and future calls
and waking any callers blocked on a full queue). The box is freed exactly once,
when the last thread releases it and the thread count reaches zero. This matches
Node.js semantics, where abort stops further calls but destruction still waits
for every acquired thread to release. The non-abort path is unchanged: it
already only freed on the final release.

The reproduction is inherently timing and allocator dependent (the second drop
only trips the assert once the freed memory is observed as reusable), which is
why it surfaced on Windows under a real addon rather than deterministically. The
added regression test creates a tsfn with `initial_thread_count = 2`, aborts
from one thread while a second reference is still outstanding, and asserts the
finalizer runs exactly once.