### PR TITLE
fix(bundle): preserve raw imports in watch mode

### DIFF
--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -1918,12 +1918,30 @@ impl DenoPluginHandler {
     let mut specifiers_vec = Vec::with_capacity(specifiers.len());
     for specifier in specifiers {
       let specifier = deno_path_util::url_from_file_path(specifier)?;
+      // Raw imports are represented as external assets in the module graph.
+      // Their contents are fetched by `bundle_load` instead of being stored
+      // in the graph, so reloading them as ordinary graph roots loses their
+      // requested module type (for example, `type: "css"`). Esbuild will call
+      // `on_load` again for the changed file and fetch its current contents.
+      if matches!(
+        graph.get(&specifier),
+        Some(deno_graph::Module::External(module)) if module.was_asset_load
+      ) {
+        continue;
+      }
       specifiers_vec.push(specifier);
     }
-    self
-      .module_load_preparer
-      .reload_specifiers(graph, specifiers_vec, false, self.permissions.clone())
-      .await?;
+    if !specifiers_vec.is_empty() {
+      self
+        .module_load_preparer
+        .reload_specifiers(
+          graph,
+          specifiers_vec,
+          false,
+          self.permissions.clone(),
+        )
+        .await?;
+    }
     graph_permit.commit();
     Ok(())
   }

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -3359,6 +3359,63 @@ async fn bundle_watch() {
 }
 
 #[test(flaky)]
+async fn bundle_watch_raw_css_import() {
+  let _server = http_server();
+
+  let t = TempDir::new();
+  let main_ts = t.path().join("main.ts");
+  main_ts.write(
+    r#"import styles from "./styles.css" with { type: "css" };
+console.log(styles);
+"#,
+  );
+  let styles_css = t.path().join("styles.css");
+  styles_css.write("div { color: red; }\n");
+  let output = t.path().join("output.js");
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("bundle")
+    .arg("--watch")
+    .arg("--unstable-raw-imports")
+    .arg("--platform=browser")
+    .arg("-L")
+    .arg("debug")
+    .arg("--output")
+    .arg(&output)
+    .arg(&main_ts)
+    .env("NO_COLOR", "1")
+    .envs(env_vars_for_npm_tests())
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (_, mut stderr_lines) = child_lines(&mut child);
+
+  wait_contains("Bundled 2 modules in", &mut stderr_lines).await;
+  assert_contains!(output.read_to_string(), "div { color: red; }");
+  wait_for_watcher("styles.css", &mut stderr_lines).await;
+
+  styles_css.write("div { color: blue; }\n");
+  wait_contains("File change detected", &mut stderr_lines).await;
+  wait_contains("Bundled 2 modules in", &mut stderr_lines).await;
+  let contents = output.read_to_string();
+  assert_contains!(contents, "div { color: blue; }");
+  assert_not_contains!(contents, "div { color: red; }");
+
+  wait_for_watcher("main.ts", &mut stderr_lines).await;
+  main_ts.write(
+    r#"import styles from "./styles.css" with { type: "css" };
+console.log("watch still works", styles);
+"#,
+  );
+  wait_contains("File change detected", &mut stderr_lines).await;
+  wait_contains("Bundled 2 modules in", &mut stderr_lines).await;
+  assert_contains!(output.read_to_string(), "watch still works");
+
+  check_alive_then_kill(child);
+}
+
+#[test(flaky)]
 async fn bundle_watch_html_entry() {
   let _server = http_server();
 


### PR DESCRIPTION
## Summary

- avoid reloading raw import assets as ordinary module graph roots in bundle watch mode
- add regression coverage for rebuilding after CSS and TypeScript changes

## Root cause

Raw imports are represented as external assets in the module graph, and their contents are fetched by the bundle loader. Watch invalidation passed a changed CSS asset to `ModuleGraph::reload()`, which reloaded the URL as an ordinary root without its `type: "css"` import context. That poisoned the graph and caused every subsequent rebuild to reject the CSS import.

External asset entries do not contain source that needs to be refreshed. Esbuild calls the bundle loader again for the changed input, which fetches the current contents, so watch mode now excludes those entries from graph reload while retaining normal reload behavior for source modules.

Fixes #36036.

## Validation

- `cargo build --bin deno`
- `cargo test -p integration_tests --test integration -- watcher::bundle_watch` (3 passed)
- `./tools/lint.js`
- `./tools/format.js --check`
- reproduced the reported HTML/`--outdir` workflow and verified CSS and subsequent TypeScript changes both rebuilt successfully
