### PR TITLE
fix(ext/node): validate serialized headers in node:http2

### DIFF
--- a/ext/node/ops/http2/stream.rs
+++ b/ext/node/ops/http2/stream.rs
@@ -64,7 +64,8 @@ impl Http2Headers {
         break;
       }
 
-      let flags = bytes.get(offset).copied().unwrap_or(0);
+      let flags =
+        sanitize_header_flags(bytes.get(offset).copied().unwrap_or(0));
       offset += 1;
 
       nva.push(ffi::nghttp2_nv {
@@ -120,6 +121,10 @@ impl Http2Headers {
 
 fn find_null(slice: &[u8]) -> Option<usize> {
   slice.iter().position(|&b| b == 0)
+}
+
+fn sanitize_header_flags(flags: u8) -> u8 {
+  flags & (ffi::NGHTTP2_NV_FLAG_NO_INDEX as u8)
 }
 
 // Http2Priority
@@ -398,6 +403,46 @@ impl Http2Stream {
   fn nghttp2_session(&self) -> *mut ffi::nghttp2_session {
     // SAFETY: session outlives the stream
     unsafe { (*self.session).session }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn http2_header_parse_preserves_no_index_flag() {
+    let headers = Http2Headers::parse(b"name\0value\0\x01".to_vec(), 1);
+
+    assert_eq!(headers.nva.len(), 1);
+    assert_eq!(headers.nva[0].flags, ffi::NGHTTP2_NV_FLAG_NO_INDEX as u8);
+  }
+
+  #[test]
+  fn http2_header_parse_strips_no_copy_flags() {
+    let injected_flags = (ffi::NGHTTP2_NV_FLAG_NO_INDEX
+      | ffi::NGHTTP2_NV_FLAG_NO_COPY_NAME
+      | ffi::NGHTTP2_NV_FLAG_NO_COPY_VALUE) as u8;
+    let headers = Http2Headers::parse(
+      vec![
+        b'n',
+        b'a',
+        b'm',
+        b'e',
+        0,
+        b'v',
+        b'a',
+        b'l',
+        b'u',
+        b'e',
+        0,
+        injected_flags,
+      ],
+      1,
+    );
+
+    assert_eq!(headers.nva.len(), 1);
+    assert_eq!(headers.nva[0].flags, ffi::NGHTTP2_NV_FLAG_NO_INDEX as u8);
   }
 }
 

--- a/ext/node/polyfills/internal/http2/util.ts
+++ b/ext/node/polyfills/internal/http2/util.ts
@@ -29,9 +29,11 @@ const {
 const { op_http2_error_string, op_http2_http_state } = core.ops;
 const lazyHttpCommon = core.createLazyLoader("node:_http_common");
 const lazyProcess = core.createLazyLoader("node:process");
-const { codes, hideStackFrames } = core.loadExtScript(
-  "ext:deno_node/internal/errors.ts",
-);
+const {
+  codes,
+  ERR_INVALID_CHAR,
+  hideStackFrames,
+} = core.loadExtScript("ext:deno_node/internal/errors.ts");
 const {
   HTTP2_HEADER_ACCESS_CONTROL_ALLOW_CREDENTIALS,
   HTTP2_HEADER_ACCESS_CONTROL_MAX_AGE,
@@ -791,6 +793,7 @@ function buildNgHeaderString(
   strictSingleValueFields?,
 ) {
   const checkIsHttpToken = lazyHttpCommon()._checkIsHttpToken;
+  const checkInvalidHeaderChar = lazyHttpCommon()._checkInvalidHeaderChar;
   let headers = "";
   let pseudoHeaders = "";
   let count = 0;
@@ -837,6 +840,9 @@ function buildNgHeaderString(
       if (err !== undefined) {
         throw err;
       }
+      if (checkInvalidHeaderChar(value)) {
+        throw new ERR_INVALID_CHAR("header content", key);
+      }
       pseudoHeaders += `${key}\0${value}\0${flags}`;
       count++;
       return;
@@ -850,10 +856,16 @@ function buildNgHeaderString(
     if (isArray) {
       for (let j = 0; j < value.length; ++j) {
         const val = String(value[j]);
+        if (checkInvalidHeaderChar(val)) {
+          throw new ERR_INVALID_CHAR("header content", key);
+        }
         headers += `${key}\0${val}\0${flags}`;
       }
       count += value.length;
       return;
+    }
+    if (checkInvalidHeaderChar(value)) {
+      throw new ERR_INVALID_CHAR("header content", key);
     }
     headers += `${key}\0${value}\0${flags}`;
     count++;

--- a/ext/node/polyfills/internal/http2/util.ts
+++ b/ext/node/polyfills/internal/http2/util.ts
@@ -21,6 +21,7 @@ const {
   SafeSet,
   String,
   StringFromCharCode,
+  StringPrototypeCharCodeAt,
   StringPrototypeSlice,
   StringPrototypeToLowerCase,
   Symbol,
@@ -29,11 +30,9 @@ const {
 const { op_http2_error_string, op_http2_http_state } = core.ops;
 const lazyHttpCommon = core.createLazyLoader("node:_http_common");
 const lazyProcess = core.createLazyLoader("node:process");
-const {
-  codes,
-  ERR_INVALID_CHAR,
-  hideStackFrames,
-} = core.loadExtScript("ext:deno_node/internal/errors.ts");
+const { codes, hideStackFrames } = core.loadExtScript(
+  "ext:deno_node/internal/errors.ts",
+);
 const {
   HTTP2_HEADER_ACCESS_CONTROL_ALLOW_CREDENTIALS,
   HTTP2_HEADER_ACCESS_CONTROL_MAX_AGE,
@@ -779,6 +778,28 @@ function prepareRequestHeadersObject(headers, session) {
 const emptyArray = [];
 const kNeverIndexFlag = StringFromCharCode(NGHTTP2_NV_FLAG_NO_INDEX);
 const kNoHeaderFlags = StringFromCharCode(NGHTTP2_NV_FLAG_NONE);
+const kInvalidHeaderValueByte = StringFromCharCode(1);
+
+// The native binding converts this serialized string to Latin-1 and uses a
+// zero byte as the field delimiter. Replace value code units whose low byte is
+// zero with another invalid HTTP/2 header byte so nghttp2 still rejects or
+// drops the header through its normal path without interpreting value data as
+// another serialized field.
+function escapeNgHeaderValueZeroBytes(value) {
+  let escaped = "";
+  let start = 0;
+  let changed = false;
+  for (let i = 0; i < value.length; ++i) {
+    if ((StringPrototypeCharCodeAt(value, i) & 0xff) !== 0) {
+      continue;
+    }
+    changed = true;
+    escaped += StringPrototypeSlice(value, start, i) +
+      kInvalidHeaderValueByte;
+    start = i + 1;
+  }
+  return changed ? escaped + StringPrototypeSlice(value, start) : value;
+}
 
 /**
  * Builds an NgHeader string + header count value, validating the header key
@@ -793,7 +814,6 @@ function buildNgHeaderString(
   strictSingleValueFields?,
 ) {
   const checkIsHttpToken = lazyHttpCommon()._checkIsHttpToken;
-  const checkInvalidHeaderChar = lazyHttpCommon()._checkInvalidHeaderChar;
   let headers = "";
   let pseudoHeaders = "";
   let count = 0;
@@ -840,9 +860,7 @@ function buildNgHeaderString(
       if (err !== undefined) {
         throw err;
       }
-      if (checkInvalidHeaderChar(value)) {
-        throw new ERR_INVALID_CHAR("header content", key);
-      }
+      value = escapeNgHeaderValueZeroBytes(value);
       pseudoHeaders += `${key}\0${value}\0${flags}`;
       count++;
       return;
@@ -855,18 +873,13 @@ function buildNgHeaderString(
     }
     if (isArray) {
       for (let j = 0; j < value.length; ++j) {
-        const val = String(value[j]);
-        if (checkInvalidHeaderChar(val)) {
-          throw new ERR_INVALID_CHAR("header content", key);
-        }
+        const val = escapeNgHeaderValueZeroBytes(String(value[j]));
         headers += `${key}\0${val}\0${flags}`;
       }
       count += value.length;
       return;
     }
-    if (checkInvalidHeaderChar(value)) {
-      throw new ERR_INVALID_CHAR("header content", key);
-    }
+    value = escapeNgHeaderValueZeroBytes(value);
     headers += `${key}\0${value}\0${flags}`;
     count++;
   }

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -9,7 +9,7 @@ import { Buffer } from "node:buffer";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import * as net from "node:net";
-import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { curlRequest } from "../unit/test_util.ts";
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
@@ -459,24 +459,34 @@ Deno.test("internal/http2/util exports", () => {
   assert(typeof util.kRequest === "symbol");
 });
 
-Deno.test("internal/http2/util rejects NUL header values", () => {
+Deno.test("internal/http2/util escapes NUL header value bytes", () => {
   const { assertValidPseudoHeader, buildNgHeaderString } = require(
     "internal/http2/util",
   );
-  for (
-    const headers of [
+  assertEquals(
+    buildNgHeaderString(
       { "user-agent": "good\0x-injected\0bad" },
-      { "x-custom": ["good", "bad\0x-injected\0bad"] },
+      assertValidPseudoHeader,
+      true,
+    ),
+    ["user-agent\0good\x01x-injected\x01bad\0\0", 1],
+  );
+  assertEquals(
+    buildNgHeaderString(
+      { "x-custom": ["good", "bad\u0100x-injected\u0100bad"] },
+      assertValidPseudoHeader,
+      true,
+    ),
+    ["x-custom\0good\0\0x-custom\0bad\x01x-injected\x01bad\0\0", 2],
+  );
+  assertEquals(
+    buildNgHeaderString(
       { ":path": "/ok\0x-injected\0bad" },
-    ]
-  ) {
-    const error = assertThrows(
-      () => buildNgHeaderString(headers, assertValidPseudoHeader, true),
-      TypeError,
-      "Invalid character in header content",
-    ) as Error & { code?: string };
-    assertEquals(error.code, "ERR_INVALID_CHAR");
-  }
+      assertValidPseudoHeader,
+      true,
+    ),
+    [":path\0/ok\x01x-injected\x01bad\0\0", 1],
+  );
 });
 
 Deno.test("[node/http2] Server.address() includes family property", async () => {

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -9,7 +9,7 @@ import { Buffer } from "node:buffer";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import * as net from "node:net";
-import { assert, assertEquals, assertRejects } from "@std/assert";
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { curlRequest } from "../unit/test_util.ts";
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
@@ -457,6 +457,26 @@ Deno.test("internal/http2/util exports", () => {
   assert(typeof util.kProtocol === "symbol");
   assert(typeof util.kProxySocket === "symbol");
   assert(typeof util.kRequest === "symbol");
+});
+
+Deno.test("internal/http2/util rejects NUL header values", () => {
+  const { assertValidPseudoHeader, buildNgHeaderString } = require(
+    "internal/http2/util",
+  );
+  for (
+    const headers of [
+      { "user-agent": "good\0x-injected\0bad" },
+      { "x-custom": ["good", "bad\0x-injected\0bad"] },
+      { ":path": "/ok\0x-injected\0bad" },
+    ]
+  ) {
+    const error = assertThrows(
+      () => buildNgHeaderString(headers, assertValidPseudoHeader, true),
+      TypeError,
+      "Invalid character in header content",
+    ) as Error & { code?: string };
+    assertEquals(error.code, "ERR_INVALID_CHAR");
+  }
 });
 
 Deno.test("[node/http2] Server.address() includes family property", async () => {


### PR DESCRIPTION
## Summary

- protect the compact NUL-delimited JavaScript-to-Rust header representation without changing Node's invalid-header behavior
- replace header-value code units that would become NUL after Latin-1 conversion with an invalid HTTP/2 byte for nghttp2 to reject or drop
- preserve only supported nghttp2 header flags in the native parser
- cover scalar, array, pseudo-header, non-ASCII low-byte, and native flag handling

## Testing

- `cargo build --bin deno`
- `cargo test -p deno_node http2_header_parse --lib -- --nocapture`
- `target/debug/deno test -A --config tests/config/deno.json tests/unit_node/http2_test.ts`
- `cargo test -p node_compat_tests --test node_compat test-http2-client-unescaped-path -- --nocapture`
- `cargo test -p node_compat_tests --test node_compat test-http2-response-splitting -- --nocapture`
- `cargo test -p node_compat_tests --test node_compat test-http2-util-headers-list -- --nocapture`
- `./tools/format.js`
- `./tools/lint.js`
