### PR TITLE
fix(ext/node): keep header validation enabled in node:http2

### DIFF
--- a/ext/node/ops/http2/session.rs
+++ b/ext/node/ops/http2/session.rs
@@ -369,10 +369,11 @@ unsafe extern "C" fn h2_read_cb(
 
 // Http2Options
 
-const OPTIONS_FLAG_NO_RECV_CLIENT_MAGIC: u32 = 0x2;
-const OPTIONS_FLAG_NO_HTTP_MESSAGING: u32 = 0x4;
-
 const DEFAULT_MAX_HEADER_LIST_PAIRS: u32 = 128;
+
+fn option_present(flags: u32, index: OptionsIndex) -> bool {
+  flags & (1 << index as u32) != 0
+}
 
 struct Http2Options {
   options: *mut ffi::nghttp2_option,
@@ -393,7 +394,7 @@ impl Http2Options {
     let padding_strategy = with_options(|buffer| {
       let flags = buffer[OptionsIndex::Flags as usize];
 
-      if flags & (1 << OptionsIndex::MaxHeaderListPairs as u32) != 0 {
+      if option_present(flags, OptionsIndex::MaxHeaderListPairs) {
         max_header_pairs = buffer[OptionsIndex::MaxHeaderListPairs as usize];
       }
 
@@ -410,17 +411,11 @@ impl Http2Options {
         // sends exceed the advertised initial window.
         ffi::nghttp2_option_set_no_auto_window_update(options, 1);
 
-        if flags & OPTIONS_FLAG_NO_RECV_CLIENT_MAGIC != 0 {
-          ffi::nghttp2_option_set_no_recv_client_magic(options, 1);
-        }
-
-        if flags & OPTIONS_FLAG_NO_HTTP_MESSAGING != 0 {
-          ffi::nghttp2_option_set_no_http_messaging(options, 1);
-        }
-
         let max_deflate =
           buffer[OptionsIndex::MaxDeflateDynamicTableSize as usize];
-        if max_deflate > 0 {
+        if option_present(flags, OptionsIndex::MaxDeflateDynamicTableSize)
+          && max_deflate > 0
+        {
           ffi::nghttp2_option_set_max_deflate_dynamic_table_size(
             options,
             max_deflate as usize,
@@ -429,7 +424,9 @@ impl Http2Options {
 
         let max_reserved =
           buffer[OptionsIndex::MaxReservedRemoteStreams as usize];
-        if max_reserved > 0 {
+        if option_present(flags, OptionsIndex::MaxReservedRemoteStreams)
+          && max_reserved > 0
+        {
           ffi::nghttp2_option_set_max_reserved_remote_streams(
             options,
             max_reserved,
@@ -438,7 +435,9 @@ impl Http2Options {
 
         let max_send_header =
           buffer[OptionsIndex::MaxSendHeaderBlockLength as usize];
-        if max_send_header > 0 {
+        if option_present(flags, OptionsIndex::MaxSendHeaderBlockLength)
+          && max_send_header > 0
+        {
           ffi::nghttp2_option_set_max_send_header_block_length(
             options,
             max_send_header as usize,
@@ -447,7 +446,9 @@ impl Http2Options {
 
         let peer_max_concurrent =
           buffer[OptionsIndex::PeerMaxConcurrentStreams as usize];
-        if peer_max_concurrent > 0 {
+        if option_present(flags, OptionsIndex::PeerMaxConcurrentStreams)
+          && peer_max_concurrent > 0
+        {
           ffi::nghttp2_option_set_peer_max_concurrent_streams(
             options,
             peer_max_concurrent,
@@ -462,7 +463,7 @@ impl Http2Options {
         // didn't pass the option and could lower nghttp2's max_outbound_ack
         // (e.g. to 1), making a legitimate second concurrent ping trip
         // NGHTTP2_ERR_FLOODED.
-        if flags & (1 << OptionsIndex::MaxOutstandingPings as u32) != 0 {
+        if option_present(flags, OptionsIndex::MaxOutstandingPings) {
           let max_outstanding_pings =
             buffer[OptionsIndex::MaxOutstandingPings as usize];
           if max_outstanding_pings > 0 {
@@ -480,7 +481,8 @@ impl Http2Options {
         // on inbound SETTINGS *entries* per frame — handled below).
 
         let max_settings = buffer[OptionsIndex::MaxSettings as usize];
-        if max_settings > 0 {
+        if option_present(flags, OptionsIndex::MaxSettings) && max_settings > 0
+        {
           ffi::nghttp2_option_set_max_settings(options, max_settings as usize);
         }
 
@@ -506,7 +508,11 @@ impl Http2Options {
         }
       }
 
-      let padding = buffer[OptionsIndex::PaddingStrategy as usize];
+      let padding = if option_present(flags, OptionsIndex::PaddingStrategy) {
+        buffer[OptionsIndex::PaddingStrategy as usize]
+      } else {
+        0
+      };
       match padding {
         1 => PaddingStrategy::Aligned,
         2 => PaddingStrategy::Max,

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -229,6 +229,54 @@ Deno.test("[node/http2.createServer()]", {
   await new Promise<void>((resolve) => server.on("close", resolve));
 });
 
+Deno.test(
+  "[node/http2.createServer()] maxSendHeaderBlockLength keeps header validation enabled",
+  {
+    ignore: Deno.build.os === "windows",
+  },
+  async () => {
+    const server = http2.createServer({ maxSendHeaderBlockLength: 10000 });
+    const portDeferred = Promise.withResolvers<number>();
+    const streamDeferred = Promise.withResolvers<void>();
+
+    server.on("stream", (stream, headers) => {
+      try {
+        assertEquals(headers["x-inject"], undefined);
+        stream.respond({ ":status": 204 });
+        stream.end();
+        streamDeferred.resolve();
+      } catch (err) {
+        streamDeferred.reject(err);
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as net.AddressInfo;
+      portDeferred.resolve(address.port);
+    });
+
+    const port = await portDeferred.promise;
+    const conn = await Deno.connect({ hostname: "127.0.0.1", port });
+    try {
+      await writeHttp2ClientPreface(conn);
+      await writeHttp2Headers(
+        conn,
+        [
+          [":method", "GET"],
+          [":path", "/"],
+          [":authority", `127.0.0.1:${port}`],
+          [":scheme", "http"],
+          ["x-inject", "injected\r\nset-cookie: session=hacked"],
+        ],
+        true,
+      );
+      await streamDeferred.promise;
+    } finally {
+      conn.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  },
+);
+
 Deno.test("[node/http2 client] write image buffer on request stream works", {
   // TODO(littledivy): h2 over TLS is not yet implemented
   ignore: true,
@@ -539,6 +587,67 @@ Deno.test("[node/http2] createSecureServer with allowHTTP1", {
 
   await promise;
 });
+
+async function writeAll(conn: Deno.Conn, bytes: Uint8Array): Promise<void> {
+  let written = 0;
+  while (written < bytes.length) {
+    written += await conn.write(bytes.subarray(written));
+  }
+}
+
+function http2LiteralHeader(name: string, value: string): number[] {
+  const encoder = new TextEncoder();
+  const encodedName = encoder.encode(name);
+  const encodedValue = encoder.encode(value);
+  return [
+    0x00,
+    encodedName.length,
+    ...encodedName,
+    encodedValue.length,
+    ...encodedValue,
+  ];
+}
+
+function http2Frame(
+  type: number,
+  flags: number,
+  streamId: number,
+  payload: number[] | Uint8Array,
+): Uint8Array {
+  const length = payload.length;
+  return new Uint8Array([
+    (length >> 16) & 0xff,
+    (length >> 8) & 0xff,
+    length & 0xff,
+    type,
+    flags,
+    (streamId >> 24) & 0x7f,
+    (streamId >> 16) & 0xff,
+    (streamId >> 8) & 0xff,
+    streamId & 0xff,
+    ...payload,
+  ]);
+}
+
+async function writeHttp2ClientPreface(conn: Deno.Conn): Promise<void> {
+  const encoder = new TextEncoder();
+  await writeAll(conn, encoder.encode("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"));
+  await writeAll(conn, http2Frame(0x04, 0, 0, []));
+}
+
+async function writeHttp2Headers(
+  conn: Deno.Conn,
+  headers: [string, string][],
+  endStream: boolean,
+): Promise<void> {
+  const block = headers.flatMap(([name, value]) =>
+    http2LiteralHeader(name, value)
+  );
+  await writeAll(
+    conn,
+    http2Frame(0x01, endStream ? 0x05 : 0x04, 1, block),
+  );
+}
 
 Deno.test("[node/http2] createSecureServer responds to client", {
   ignore: Deno.build.os === "windows",


### PR DESCRIPTION
## Summary

- treat the shared HTTP/2 option flags as option-presence bits only
- apply native option values only when their corresponding presence bit is set
- keep nghttp2 HTTP messaging validation enabled for ordinary session options
- add raw-client coverage for the option-buffer behavior

The JavaScript side records which numeric options are present in a shared flags field. The native side previously also interpreted two of those bits as unrelated nghttp2 behavior flags. This change separates those meanings and prevents stale shared-buffer values from affecting sessions that did not set the corresponding option.

## Testing

- `cargo build --bin deno`
- `target/debug/deno test -A --config tests/config/deno.json tests/unit_node/http2_test.ts`
- `./tools/format.js`
- `cargo fmt --check --package deno_node`
