### PR TITLE
fix(config): reject out-of-range minimum dependency ages

### DIFF
--- a/libs/config/deno_json/mod.rs
+++ b/libs/config/deno_json/mod.rs
@@ -2640,10 +2640,7 @@ impl ConfigFile {
     ) -> Result<chrono::DateTime<chrono::Utc>, MinimumDependencyAgeParseError>
     {
       match minutes.as_i64() {
-        Some(minutes) => {
-          let now = chrono::DateTime::<chrono::Utc>::from(sys.sys_time_now());
-          Ok(now - chrono::Duration::minutes(minutes))
-        }
+        Some(minutes) => Ok(crate::util::date_from_minutes(sys, minutes)?),
         None => Err(MinimumDependencyAgeParseError::InvalidNumber),
       }
     }
@@ -3309,6 +3306,21 @@ mod tests {
     assert!(matches!(
       err,
       MinimumDependencyAgeParseError::UnsupportedObject(_)
+    ));
+
+    // Out-of-range numeric values should return an error instead of panicking.
+    let specifier = Url::parse("file:///deno/deno.json").unwrap();
+    let config_file =
+      ConfigFile::new(r#"{ "minimumDependencyAge": 138939752218 }"#, specifier)
+        .unwrap();
+    let err = config_file
+      .to_minimum_dependency_age_config(&TestEnv)
+      .unwrap_err();
+    assert!(matches!(
+      err,
+      MinimumDependencyAgeParseError::ParseDateOrDuration(
+        crate::ParseDateOrDurationError::OutOfRange
+      )
     ));
   }
 

--- a/libs/config/util.rs
+++ b/libs/config/util.rs
@@ -33,6 +33,9 @@ pub enum ParseDateOrDurationError {
 
   #[error("expected minutes, RFC3339 datetime, or ISO-8601 duration")]
   InvalidDuration(#[source] ParseIso8601DurationError),
+
+  #[error("date or duration is out of range")]
+  OutOfRange,
 }
 
 /// Parses a string that could be an integer for number of minutes,
@@ -56,11 +59,10 @@ fn parse_enabled_minutes_duration_or_date(
   s: &str,
 ) -> Result<chrono::DateTime<chrono::Utc>, ParseDateOrDurationError> {
   if s.chars().all(|c| c.is_ascii_digit()) {
-    let now = chrono::DateTime::<chrono::Utc>::from(sys.sys_time_now());
     let minutes: i64 = s
       .parse()
       .map_err(ParseDateOrDurationError::InvalidMinutes)?;
-    return Ok(now - chrono::Duration::minutes(minutes));
+    return date_from_minutes(sys, minutes);
   }
 
   let datetime_parse_err = match DateTime::parse_from_rfc3339(s) {
@@ -79,15 +81,31 @@ fn parse_enabled_minutes_duration_or_date(
   }
   // try duration
   match parse_iso8601_duration(s) {
-    Ok(duration) => {
-      let now = chrono::DateTime::<chrono::Utc>::from(sys.sys_time_now());
-      Ok(now - duration)
-    }
+    Ok(duration) => date_from_duration(sys, duration),
     Err(ParseIso8601DurationError::MissingP) => Err(
       ParseDateOrDurationError::InvalidDateTime(datetime_parse_err),
     ),
     Err(err) => Err(ParseDateOrDurationError::InvalidDuration(err)),
   }
+}
+
+pub(crate) fn date_from_minutes(
+  sys: &impl sys_traits::SystemTimeNow,
+  minutes: i64,
+) -> Result<chrono::DateTime<chrono::Utc>, ParseDateOrDurationError> {
+  let duration = chrono::Duration::try_minutes(minutes)
+    .ok_or(ParseDateOrDurationError::OutOfRange)?;
+  date_from_duration(sys, duration)
+}
+
+fn date_from_duration(
+  sys: &impl sys_traits::SystemTimeNow,
+  duration: chrono::Duration,
+) -> Result<chrono::DateTime<chrono::Utc>, ParseDateOrDurationError> {
+  let now = chrono::DateTime::<chrono::Utc>::from(sys.sys_time_now());
+  now
+    .checked_sub_signed(duration)
+    .ok_or(ParseDateOrDurationError::OutOfRange)
 }
 
 #[derive(Debug, Error)]
@@ -173,11 +191,15 @@ fn parse_iso8601_duration(
     let weeks: i64 = num
       .parse()
       .map_err(|_| ParseIso8601DurationError::InvalidNumber)?;
-    let days = weeks
-      .checked_mul(7)
-      .ok_or(ParseIso8601DurationError::Overflow)?;
-    let d = Duration::days(days);
-    return Ok(if neg { -d } else { d });
+    let d =
+      Duration::try_weeks(weeks).ok_or(ParseIso8601DurationError::Overflow)?;
+    return if neg {
+      Duration::zero()
+        .checked_sub(&d)
+        .ok_or(ParseIso8601DurationError::Overflow)
+    } else {
+      Ok(d)
+    };
   }
 
   let bytes = s.as_bytes();
@@ -238,7 +260,8 @@ fn parse_iso8601_duration(
 
     // add to total
     let add = match (in_time, unit, frac_len) {
-      (false, 'D', 0) => Duration::days(int_val),
+      (false, 'D', 0) => Duration::try_days(int_val)
+        .ok_or(ParseIso8601DurationError::Overflow)?,
       (false, 'M', _) => {
         return Err(ParseIso8601DurationError::MonthsNotSupported);
       }
@@ -249,12 +272,15 @@ fn parse_iso8601_duration(
         return Err(ParseIso8601DurationError::WeeksMustBeAlone);
       }
 
-      (true, 'H', 0) => Duration::hours(int_val),
-      (true, 'M', 0) => Duration::minutes(int_val),
+      (true, 'H', 0) => Duration::try_hours(int_val)
+        .ok_or(ParseIso8601DurationError::Overflow)?,
+      (true, 'M', 0) => Duration::try_minutes(int_val)
+        .ok_or(ParseIso8601DurationError::Overflow)?,
 
       // Seconds may be fractional: PT1.5S
       (true, 'S', _) => {
-        let mut d = Duration::seconds(int_val);
+        let mut d = Duration::try_seconds(int_val)
+          .ok_or(ParseIso8601DurationError::Overflow)?;
         if frac_len > 0 {
           let frac_str = &s[frac_start..(frac_start + frac_len)];
           // take up to 9 digits for nanoseconds, right-pad with zeros
@@ -289,7 +315,13 @@ fn parse_iso8601_duration(
       .ok_or(ParseIso8601DurationError::Overflow)?;
   }
 
-  Ok(if neg { -total } else { total })
+  if neg {
+    Duration::zero()
+      .checked_sub(&total)
+      .ok_or(ParseIso8601DurationError::Overflow)
+  } else {
+    Ok(total)
+  }
 }
 
 #[cfg(test)]
@@ -377,6 +409,10 @@ mod tests {
     assert!(parse_iso8601_duration("PT").is_err());
     assert!(parse_iso8601_duration("PT1.2M").is_err()); // fractional minutes rejected
     assert!(parse_iso8601_duration("P1WT1H").is_err()); // W must be alone
+    assert!(matches!(
+      parse_iso8601_duration("PT153722867280913M"),
+      Err(ParseIso8601DurationError::Overflow)
+    ));
   }
 
   #[test]
@@ -431,5 +467,17 @@ mod tests {
         Utc.with_ymd_and_hms(2025, 5, 30, 0, 0, 0).unwrap()
       )
     );
+
+    for value in [
+      "138939752218",
+      "153722867280913",
+      "9223372036854775807",
+      "P100000000D",
+    ] {
+      assert!(matches!(
+        parse_minutes_duration_or_date(&TestEnv, value),
+        Err(ParseDateOrDurationError::OutOfRange)
+      ));
+    }
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Use fallible chrono duration constructors and checked date arithmetic to prevent invalid minimum dependency ages from panicking.

Fixes #35996
