### PR TITLE
feat(release): promote aarch64-pc-windows-msvc in promote_to_release

### DIFF
--- a/.github/workflows/promote_to_release.generated.yml
+++ b/.github/workflows/promote_to_release.generated.yml
@@ -24,6 +24,12 @@ jobs:
       id-token: write
     environment:
       name: build
+    strategy:
+      matrix:
+        target:
+          - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
+      fail-fast: false
     steps:
       - name: Clone repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -37,8 +43,8 @@ jobs:
       - name: Download Windows binaries
         run: |-
           $CANARY_URL="https://dl.deno.land/canary/${{github.event.inputs.commitHash}}"
-          Invoke-WebRequest -Uri "$CANARY_URL/deno-x86_64-pc-windows-msvc.zip" -OutFile "deno-windows.zip"
-          Invoke-WebRequest -Uri "$CANARY_URL/denort-x86_64-pc-windows-msvc.zip" -OutFile "denort-windows.zip"
+          Invoke-WebRequest -Uri "$CANARY_URL/deno-${{ matrix.target }}.zip" -OutFile "deno-windows.zip"
+          Invoke-WebRequest -Uri "$CANARY_URL/denort-${{ matrix.target }}.zip" -OutFile "denort-windows.zip"
           Expand-Archive -Path "deno-windows.zip" -DestinationPath "."
           Expand-Archive -Path "denort-windows.zip" -DestinationPath "."
       - name: Run patchver for Windows
@@ -78,15 +84,15 @@ jobs:
           & $SignToolPath verify /pa /v "deno.exe"
       - name: Create archives
         run: |-
-          Compress-Archive -Path "deno.exe" -DestinationPath "deno-x86_64-pc-windows-msvc.zip" -Force
-          Compress-Archive -Path "denort.exe" -DestinationPath "denort-x86_64-pc-windows-msvc.zip" -Force
+          Compress-Archive -Path "deno.exe" -DestinationPath "deno-${{ matrix.target }}.zip" -Force
+          Compress-Archive -Path "denort.exe" -DestinationPath "denort-${{ matrix.target }}.zip" -Force
       - name: Upload Windows archives
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
-          name: windows-binaries
+          name: 'windows-binaries-${{ matrix.target }}'
           path: |-
-            deno-x86_64-pc-windows-msvc.zip
-            denort-x86_64-pc-windows-msvc.zip
+            deno-${{ matrix.target }}.zip
+            denort-${{ matrix.target }}.zip
   promote-to-release:
     name: Promote to Release
     needs:
@@ -115,7 +121,8 @@ jobs:
       - name: Download Windows binaries
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
-          name: windows-binaries
+          pattern: windows-binaries-*
+          merge-multiple: true
           path: .
       - name: Create version file
         run: |-

--- a/.github/workflows/promote_to_release.ts
+++ b/.github/workflows/promote_to_release.ts
@@ -102,8 +102,7 @@ const windowsJob = job("promote-to-release-windows", {
       uses: "actions/upload-artifact@v6",
       with: {
         name: "windows-binaries-${{ matrix.target }}",
-        path:
-          "deno-${{ matrix.target }}.zip\ndenort-${{ matrix.target }}.zip",
+        path: "deno-${{ matrix.target }}.zip\ndenort-${{ matrix.target }}.zip",
       },
     }),
   ],

--- a/.github/workflows/promote_to_release.ts
+++ b/.github/workflows/promote_to_release.ts
@@ -8,6 +8,12 @@ const windowsJob = job("promote-to-release-windows", {
   name: "Promote Windows to Release",
   runsOn: "windows-2022",
   if: isDenoland,
+  strategy: {
+    matrix: {
+      target: ["x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc"],
+    },
+    failFast: false,
+  },
   permissions: {
     contents: "write",
     "id-token": "write",
@@ -31,8 +37,8 @@ const windowsJob = job("promote-to-release-windows", {
       name: "Download Windows binaries",
       run: [
         '$CANARY_URL="https://dl.deno.land/canary/${{github.event.inputs.commitHash}}"',
-        'Invoke-WebRequest -Uri "$CANARY_URL/deno-x86_64-pc-windows-msvc.zip" -OutFile "deno-windows.zip"',
-        'Invoke-WebRequest -Uri "$CANARY_URL/denort-x86_64-pc-windows-msvc.zip" -OutFile "denort-windows.zip"',
+        'Invoke-WebRequest -Uri "$CANARY_URL/deno-${{ matrix.target }}.zip" -OutFile "deno-windows.zip"',
+        'Invoke-WebRequest -Uri "$CANARY_URL/denort-${{ matrix.target }}.zip" -OutFile "denort-windows.zip"',
         'Expand-Archive -Path "deno-windows.zip" -DestinationPath "."',
         'Expand-Archive -Path "denort-windows.zip" -DestinationPath "."',
       ],
@@ -87,17 +93,17 @@ const windowsJob = job("promote-to-release-windows", {
     step({
       name: "Create archives",
       run: [
-        'Compress-Archive -Path "deno.exe" -DestinationPath "deno-x86_64-pc-windows-msvc.zip" -Force',
-        'Compress-Archive -Path "denort.exe" -DestinationPath "denort-x86_64-pc-windows-msvc.zip" -Force',
+        'Compress-Archive -Path "deno.exe" -DestinationPath "deno-${{ matrix.target }}.zip" -Force',
+        'Compress-Archive -Path "denort.exe" -DestinationPath "denort-${{ matrix.target }}.zip" -Force',
       ],
     }),
     step({
       name: "Upload Windows archives",
       uses: "actions/upload-artifact@v6",
       with: {
-        name: "windows-binaries",
+        name: "windows-binaries-${{ matrix.target }}",
         path:
-          "deno-x86_64-pc-windows-msvc.zip\ndenort-x86_64-pc-windows-msvc.zip",
+          "deno-${{ matrix.target }}.zip\ndenort-${{ matrix.target }}.zip",
       },
     }),
   ],
@@ -163,7 +169,8 @@ const workflow = createWorkflow({
           name: "Download Windows binaries",
           uses: "actions/download-artifact@v7",
           with: {
-            name: "windows-binaries",
+            pattern: "windows-binaries-*",
+            "merge-multiple": true,
             path: ".",
           },
         }),


### PR DESCRIPTION
The Windows promote job only handled `x86_64-pc-windows-msvc`, so rc/lts
promotions were missing the aarch64 Windows binaries — `deno upgrade` on
that target had no build on those channels.

Matrix the Windows job over both windows targets: each matrix run does
the same download -> patchver -> Azure code-sign -> archive flow once
(unchanged, just parameterized by `matrix.target`) and uploads a
per-target artifact `windows-binaries-<target>`. The non-Windows job
downloads both via `pattern: windows-binaries-*` + `merge-multiple`, and
the existing `deno-*.zip`/`denort-*.zip` upload loop picks up the aarch64
zips.

The aarch64 canary binaries are built alongside x86_64 (both present on
release commits, e.g. the v2.9.2 commit), so no upstream change is
needed. Note: the Azure signing leg can't be exercised outside CI, so the
first rc/lts run should be watched for the aarch64 sign/verify steps.