### PR TITLE
fix(ext/http): don't panic recycling cancelled record on native response

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -166,9 +166,14 @@ impl HttpRecordExternal {
     }
   }
 
-  fn complete(&self) {
+  fn complete(self) {
     match self {
-      Self::Hyper(record) => record.clone().complete(),
+      // Move the record into `complete()` so that when the request was
+      // cancelled (`been_dropped`) this is the last strong reference and the
+      // record can be recycled. Cloning here would leave this enum's own
+      // reference alive, breaking `HttpRecord::recycle`'s sole-ownership
+      // invariant (see #36046).
+      Self::Hyper(record) => record.complete(),
       Self::Raw(record) => record.complete(),
     }
   }

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -4099,6 +4099,76 @@ Deno.test(
   },
 );
 
+// Regression test for #36046: cancelling an HTTP/2 stream while the handler is
+// still pending used to panic in HttpRecord::recycle when the handler later
+// committed a native (fast-path) response, because the record was no longer the
+// sole strong reference. Requires the hyper HTTP/2 path, which is only used over
+// TLS with ALPN h2.
+Deno.test(
+  { permissions: { net: true, read: true } },
+  async function httpServerHttp2CancelBeforeNativeResponse() {
+    const listeningDeferred = Promise.withResolvers<void>();
+    const ac = new AbortController();
+    const cert = Deno.readTextFileSync("tests/testdata/tls/localhost.crt");
+    const key = Deno.readTextFileSync("tests/testdata/tls/localhost.key");
+
+    await using server = Deno.serve({
+      handler: async () => {
+        // Slow enough that the client cancels before we commit the response.
+        await new Promise((r) => setTimeout(r, 50));
+        // Native (fast-path) empty response reaches op_http_set_response_native.
+        return new Response();
+      },
+      port: servePort,
+      cert,
+      key,
+      signal: ac.signal,
+      onListen: onListen(listeningDeferred.resolve),
+      onError: createOnErrorCb(ac),
+    });
+
+    await listeningDeferred.promise;
+
+    const client = http2.connect(`https://localhost:${servePort}`, {
+      ca: cert,
+      rejectUnauthorized: false,
+    });
+    client.on("error", () => {});
+    try {
+      for (let i = 0; i < 50; i++) {
+        const req = client.request({ ":path": "/", ":method": "GET" });
+        req.on("error", () => {});
+        req.end();
+        // Cancel the stream while the handler is still pending.
+        await new Promise((r) => setTimeout(r, 2 + (i % 5)));
+        req.close(http2.constants.NGHTTP2_CANCEL);
+      }
+
+      // Give the pending handlers time to commit their (now orphaned)
+      // responses; without the fix the server would have panicked by now.
+      await new Promise((r) => setTimeout(r, 200));
+
+      // The server must still be healthy and able to serve a normal request.
+      const req = client.request({ ":path": "/", ":method": "GET" });
+      let status: number | undefined;
+      req.on("response", (headers) => {
+        status = Number(headers[":status"]);
+      });
+      req.on("data", () => {});
+      req.end();
+      await new Promise<void>((resolve, reject) => {
+        req.on("end", resolve);
+        req.on("error", reject);
+      });
+      assertEquals(status, 200);
+    } finally {
+      client.close();
+      ac.abort();
+      await server.finished;
+    }
+  },
+);
+
 Deno.test(
   { permissions: { net: true, write: true, read: true } },
   async function httpServerPostFile() {


### PR DESCRIPTION
Fixes #36046, a panic in `HttpRecord::recycle` reported on Windows over
HTTP/2. It triggers when a client cancels a request while its handler is
still running and the handler then returns a native fast-path response
(such as `new Response()`). Depending on timing it surfaced as either
`HTTP state error: Expected to be last strong reference` or a `RefCell`
borrow error at `ext/http/service.rs`.

`recycle()` pools the record's allocation and takes the inner value, so it
requires sole ownership of the `Rc<HttpRecord>`. Every correct caller of
`complete()` moves the last reference in (for example `set_response` owns
`http: Rc<HttpRecord>` and calls `http.complete()`). The native-response
path added in #34446 routes through the `HttpRecordExternal` enum, whose
`complete` method took `&self` and therefore had to clone the `Rc`. That
clone left the enum's own reference alive, so on the cancelled
(`been_dropped`) path `complete()` reached `finish` and `recycle` while an
extra reference was still outstanding, violating the invariant.

The fix makes `HttpRecordExternal::complete` consume `self`, moving the
record into `HttpRecord::complete` rather than cloning it. All call sites
were already using the value for the last time, so no other changes were
needed.

The added unit test reproduces the crash: it cancels HTTP/2 streams (over
TLS, which is where the hyper record path is used) while the handler is
still pending, then confirms the server stays healthy. It panics the
pre-fix binary and passes after the change.