### PR TITLE
fix(ext/napi): don't resurrect a released threadsafe function in acquire

### DIFF
--- a/ext/napi/node_api.rs
+++ b/ext/napi/node_api.rs
@@ -966,7 +966,24 @@ impl TsFn {
     if self.is_closing.load(Ordering::SeqCst) {
       return napi_closing;
     }
-    self.thread_count.fetch_add(1, Ordering::Relaxed);
+    // Refuse to resurrect a tsfn whose `thread_count` already reached zero.
+    // Once at zero the tsfn is terminal (freed, or about to be by the release
+    // that observed the 1->0 transition). A plain `fetch_add` here races that
+    // final release: if `acquire` increments 0->1 after the release read zero,
+    // both this acquire's eventual release and the original one observe
+    // `Ok(1)` and each spawn a drop of the same box — a double free (the assert
+    // in TsFn::drop). A CAS that fails from zero closes that window: zero is a
+    // one-way state, so exactly one release ever sees the 1->0 transition.
+    let result = self.thread_count.fetch_update(
+      Ordering::Relaxed,
+      Ordering::Relaxed,
+      |x| {
+        if x == 0 { None } else { Some(x + 1) }
+      },
+    );
+    if result.is_err() {
+      return napi_closing;
+    }
     napi_ok
   }
 

--- a/tests/napi/async_test.js
+++ b/tests/napi/async_test.js
@@ -72,6 +72,23 @@ Deno.test("napi tsfn acquire and release", async function () {
   });
 });
 
+Deno.test("napi tsfn acquire racing final release does not double free", async () => {
+  // A previous version of `acquire` did a plain `fetch_add` after a non-atomic
+  // `is_closing` check, so it could resurrect a tsfn whose thread_count had
+  // already reached zero (racing the final release). The resurrecting thread's
+  // later release then spawned a second drop of the same box — a use-after-free
+  // and double free (assert in TsFn::drop). Each call runs one acquire-vs-final
+  // -release race; loop it to hit the narrow window. The finalizer must run
+  // exactly once per iteration, so every promise resolves and none double free.
+  for (let i = 0; i < 500; i++) {
+    await new Promise((resolve) => {
+      asyncTask.test_tsfn_acquire_release_race(() => {
+        resolve();
+      });
+    });
+  }
+});
+
 Deno.test("napi tsfn get context", function () {
   assertEquals(asyncTask.test_tsfn_get_context(), true);
 });

--- a/tests/napi/src/async.rs
+++ b/tests/napi/src/async.rs
@@ -529,6 +529,95 @@ extern "C" fn test_tsfn_abort_outstanding(
   ptr::null_mut()
 }
 
+// Reproduces a double free when napi_acquire_threadsafe_function races the
+// final napi_release_threadsafe_function. A previous version of `acquire` did a
+// plain `fetch_add` after a non-atomic `is_closing` check, so it could increment
+// `thread_count` from 0 back to 1 in the window after the final release read
+// zero but before it marked the tsfn closing. That resurrected a tsfn that was
+// already being freed: the resurrecting thread's own later release then observed
+// `Ok(1)` a second time and spawned a second drop of the same box (use-after-free
+// + double free, tripping the assert in TsFn::drop).
+//
+// The tsfn starts with initial_thread_count = 1. Thread A performs the single
+// owning release (1 -> 0); Thread B races an acquire against it. With the fix,
+// acquire refuses to increment from zero (returns napi_closing), so the count
+// reaches zero exactly once and the finalizer runs exactly once. The JS side
+// loops this many times to hit the narrow window.
+extern "C" fn test_tsfn_acquire_release_race(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  let (args, argc, _) = napi_get_callback_info!(env, info, 1);
+  assert_eq!(argc, 1);
+
+  let mut resource_name: napi_value = ptr::null_mut();
+  assert_napi_ok!(napi_create_string_utf8(
+    env,
+    c"tsfn_acquire_release_race".as_ptr(),
+    usize::MAX,
+    &mut resource_name,
+  ));
+
+  let mut func: napi_ref = ptr::null_mut();
+  assert_napi_ok!(napi_create_reference(env, args[0], 1, &mut func));
+
+  let mut tsfn: napi_threadsafe_function = ptr::null_mut();
+  assert_napi_ok!(napi_create_threadsafe_function(
+    env,
+    ptr::null_mut(),
+    ptr::null_mut(),
+    resource_name,
+    0,
+    1, // initial_thread_count: a single owning release drops the count to zero
+    func as *mut c_void,
+    Some(tsfn_race_finalize),
+    ptr::null_mut(),
+    Some(tsfn_race_call_js),
+    &mut tsfn,
+  ));
+
+  let tsfn_addr = tsfn as usize;
+
+  // Thread A: the sole owning reference. This release takes the count 1 -> 0
+  // and is the one that must free the tsfn exactly once.
+  let tsfn_a = tsfn_addr;
+  let handle_a = std::thread::spawn(move || {
+    let tsfn = tsfn_a as napi_threadsafe_function;
+    unsafe {
+      napi_release_threadsafe_function(
+        tsfn,
+        ThreadsafeFunctionReleaseMode::release,
+      );
+    }
+  });
+
+  // Thread B: races an acquire against Thread A's final release. If the acquire
+  // succeeds it took a real reference (count was still >= 1) and must balance it
+  // with a release; if it fails (napi_closing) the tsfn was already closing and
+  // must be left untouched. The buggy `acquire` could instead resurrect a zeroed
+  // count here, leading to a second drop.
+  let tsfn_b = tsfn_addr;
+  let handle_b = std::thread::spawn(move || {
+    let tsfn = tsfn_b as napi_threadsafe_function;
+    let status = unsafe { napi_acquire_threadsafe_function(tsfn) };
+    if status == napi_ok {
+      unsafe {
+        napi_release_threadsafe_function(
+          tsfn,
+          ThreadsafeFunctionReleaseMode::release,
+        );
+      }
+    }
+  });
+
+  // Join here so the tsfn pointer is not touched by these threads after this
+  // native call returns (the queued drop runs later on the main thread).
+  handle_a.join().unwrap();
+  handle_b.join().unwrap();
+
+  ptr::null_mut()
+}
+
 // Test napi_acquire_threadsafe_function and napi_release_threadsafe_function.
 // Creates a tsfn with initial_thread_count=1, acquires it (count=2),
 // releases twice (count drops to 1 then 0, triggering close).
@@ -789,6 +878,11 @@ pub fn init(env: napi_env, exports: napi_value) {
       env,
       "test_tsfn_acquire_release",
       test_tsfn_acquire_release
+    ),
+    napi_new_property!(
+      env,
+      "test_tsfn_acquire_release_race",
+      test_tsfn_acquire_release_race
     ),
     napi_new_property!(env, "test_tsfn_get_context", test_tsfn_get_context),
     napi_new_property!(env, "test_cancel_async_work", test_cancel_async_work),


### PR DESCRIPTION
## Problem

The Windows panic reported in #35990 / #36047 still reproduces on canaries **after** the fix in #36032:

```
thread 'tokio-runtime-worker' panicked at ext/napi/node_api.rs:947:5:
assertion failed: self.is_closed.compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed).is_ok()
```

#36032 closed the *abort-frees-early* path, but left a second way to double-free that it didn't cover: **`napi_acquire_threadsafe_function`**.

`acquire` did a plain `fetch_add` on `thread_count` after a non-atomic `is_closing` check:

```rust
pub fn acquire(&self) -> napi_status {
    if self.is_closing.load(Ordering::SeqCst) {
        return napi_closing;
    }
    self.thread_count.fetch_add(1, Ordering::Relaxed);
    napi_ok
}
```

This races the final `release`:

1. `thread_count == 1`. Thread R calls `release`: `fetch_update` does `1 -> 0` (`result == Ok(1)`, will free), but hasn't set `is_closing` yet.
2. Thread Q calls `acquire`: `is_closing` still `false` (R sets it only *after* the `fetch_update`), so Q does `fetch_add`: `0 -> 1` and believes it holds a live ref.
3. R sets `is_closing`, spawns the drop → **box freed**.
4. Q later calls `release`: `fetch_update` `1 -> 0`, `result == Ok(1)` → spawns a **second drop of the already-freed box** → use-after-free + double free → the `is_closed` assert panics.

This shows up under heavy concurrent addons — notably napi-rs's `ThreadsafeFunction`, which calls `acquire` on every clone — during teardown, exactly matching the reporter's "deno teardown crash after pass" logs.

## Fix

`acquire` now uses a `fetch_update` CAS that refuses to increment `thread_count` from zero, returning `napi_closing` instead. Zero becomes a one-way terminal state, so exactly one release ever observes the `1 -> 0` transition and the box is freed exactly once. This matches Node.js, where acquiring a closing tsfn fails.

## Test

`test_tsfn_acquire_release_race` races an `acquire` against the sole owning `release` (looped from JS to hit the narrow window). Verified locally:

- **Before the fix**: `deno test async_test.js` crashes with **SIGSEGV (exit 139)** on this test.
- **After the fix**: all 9 async tests pass, repeatedly.

Refs #35990
Closes #36047