### PR TITLE
fix(upgrade): emit canonical Windows release checksums and parse both formats

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -2863,13 +2863,13 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         shell: pwsh
         run: |-
-          Get-FileHash target/release/deno.exe -Algorithm SHA256 | Format-List > target/release/deno-x86_64-pc-windows-msvc.sha256sum
+          "$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe" | Out-File -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
-          Get-FileHash target/release/deno-x86_64-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-x86_64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/deno-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-x86_64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-x86_64-pc-windows-msvc.zip
-          Get-FileHash target/release/denort-x86_64-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-x86_64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/denort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-x86_64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/denort-x86_64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-x86_64-pc-windows-msvc.zip
-          Get-FileHash target/release/libdenort-x86_64-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/libdenort-x86_64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/libdenort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-x86_64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/libdenort-x86_64-pc-windows-msvc.zip.sha256sum
           target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-x86_64-pc-windows-msvc.symcache
       - name: Build bsdiff helper
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
@@ -2886,7 +2886,7 @@ jobs:
           Remove-Item -Recurse -Force prev -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path prev | Out-Null
           Expand-Archive -Force -Path prev.zip -DestinationPath prev
           & .\target\release\bsdiff_helper.exe "prev\deno.exe" "target\release\deno.exe" "target\release\deno-$Target.from-$PrevVersion.bsdiff"
-          Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256 | Format-List > "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
+          "$((Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff" | Out-File -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
       - name: Upload canary to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
         env:
@@ -3728,13 +3728,13 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         shell: pwsh
         run: |-
-          Get-FileHash target/release/deno.exe -Algorithm SHA256 | Format-List > target/release/deno-aarch64-pc-windows-msvc.sha256sum
+          "$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe" | Out-File -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-aarch64-pc-windows-msvc.zip
-          Get-FileHash target/release/deno-aarch64-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-aarch64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/deno-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-aarch64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-aarch64-pc-windows-msvc.zip
-          Get-FileHash target/release/denort-aarch64-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-aarch64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/denort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-aarch64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/denort-aarch64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-aarch64-pc-windows-msvc.zip
-          Get-FileHash target/release/libdenort-aarch64-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/libdenort-aarch64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/libdenort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-aarch64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/libdenort-aarch64-pc-windows-msvc.zip.sha256sum
           target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-aarch64-pc-windows-msvc.symcache
       - name: Build bsdiff helper
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
@@ -3751,7 +3751,7 @@ jobs:
           Remove-Item -Recurse -Force prev -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path prev | Out-Null
           Expand-Archive -Force -Path prev.zip -DestinationPath prev
           & .\target\release\bsdiff_helper.exe "prev\deno.exe" "target\release\deno.exe" "target\release\deno-$Target.from-$PrevVersion.bsdiff"
-          Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256 | Format-List > "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
+          "$((Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff" | Out-File -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
       - name: Upload canary to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
         env:

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -2863,13 +2863,13 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         shell: pwsh
         run: |-
-          "$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe" | Out-File -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.sha256sum
+          "$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe`n" | Out-File -NoNewline -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/deno-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-x86_64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/deno-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-x86_64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-x86_64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/denort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-x86_64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/denort-x86_64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/denort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-x86_64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/denort-x86_64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-x86_64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/libdenort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-x86_64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/libdenort-x86_64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/libdenort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-x86_64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/libdenort-x86_64-pc-windows-msvc.zip.sha256sum
           target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-x86_64-pc-windows-msvc.symcache
       - name: Build bsdiff helper
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
@@ -2886,7 +2886,7 @@ jobs:
           Remove-Item -Recurse -Force prev -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path prev | Out-Null
           Expand-Archive -Force -Path prev.zip -DestinationPath prev
           & .\target\release\bsdiff_helper.exe "prev\deno.exe" "target\release\deno.exe" "target\release\deno-$Target.from-$PrevVersion.bsdiff"
-          "$((Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff" | Out-File -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
+          "$((Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff`n" | Out-File -NoNewline -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
       - name: Upload canary to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
         env:
@@ -3728,13 +3728,13 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         shell: pwsh
         run: |-
-          "$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe" | Out-File -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.sha256sum
+          "$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe`n" | Out-File -NoNewline -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-aarch64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/deno-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-aarch64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/deno-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-aarch64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-aarch64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/denort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-aarch64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/denort-aarch64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/denort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-aarch64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/denort-aarch64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-aarch64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/libdenort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-aarch64-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/libdenort-aarch64-pc-windows-msvc.zip.sha256sum
+          "$((Get-FileHash target/release/libdenort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-aarch64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/libdenort-aarch64-pc-windows-msvc.zip.sha256sum
           target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-aarch64-pc-windows-msvc.symcache
       - name: Build bsdiff helper
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
@@ -3751,7 +3751,7 @@ jobs:
           Remove-Item -Recurse -Force prev -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path prev | Out-Null
           Expand-Archive -Force -Path prev.zip -DestinationPath prev
           & .\target\release\bsdiff_helper.exe "prev\deno.exe" "target\release\deno.exe" "target\release\deno-$Target.from-$PrevVersion.bsdiff"
-          "$((Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff" | Out-File -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
+          "$((Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff`n" | Out-File -NoNewline -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
       - name: Upload canary to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
         env:

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -2863,13 +2863,17 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         shell: pwsh
         run: |-
-          "$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe`n" | Out-File -NoNewline -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.sha256sum
+          $Sha256 = (Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  deno.exe`n" | Out-File -NoNewline -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/deno-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-x86_64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.zip.sha256sum
+          $Sha256 = (Get-FileHash target/release/deno-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  deno-x86_64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/deno-x86_64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-x86_64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/denort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-x86_64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/denort-x86_64-pc-windows-msvc.zip.sha256sum
+          $Sha256 = (Get-FileHash target/release/denort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  denort-x86_64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/denort-x86_64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-x86_64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/libdenort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-x86_64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/libdenort-x86_64-pc-windows-msvc.zip.sha256sum
+          $Sha256 = (Get-FileHash target/release/libdenort-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  libdenort-x86_64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/libdenort-x86_64-pc-windows-msvc.zip.sha256sum
           target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-x86_64-pc-windows-msvc.symcache
       - name: Build bsdiff helper
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
@@ -2886,7 +2890,8 @@ jobs:
           Remove-Item -Recurse -Force prev -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path prev | Out-Null
           Expand-Archive -Force -Path prev.zip -DestinationPath prev
           & .\target\release\bsdiff_helper.exe "prev\deno.exe" "target\release\deno.exe" "target\release\deno-$Target.from-$PrevVersion.bsdiff"
-          "$((Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff`n" | Out-File -NoNewline -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
+          $Sha256 = (Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  deno-$Target.from-$PrevVersion.bsdiff`n" | Out-File -NoNewline -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
       - name: Upload canary to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
         env:
@@ -3728,13 +3733,17 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
         shell: pwsh
         run: |-
-          "$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe`n" | Out-File -NoNewline -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.sha256sum
+          $Sha256 = (Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  deno.exe`n" | Out-File -NoNewline -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-aarch64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/deno-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-aarch64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.zip.sha256sum
+          $Sha256 = (Get-FileHash target/release/deno-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  deno-aarch64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/deno-aarch64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-aarch64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/denort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-aarch64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/denort-aarch64-pc-windows-msvc.zip.sha256sum
+          $Sha256 = (Get-FileHash target/release/denort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  denort-aarch64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/denort-aarch64-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-aarch64-pc-windows-msvc.zip
-          "$((Get-FileHash target/release/libdenort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-aarch64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/libdenort-aarch64-pc-windows-msvc.zip.sha256sum
+          $Sha256 = (Get-FileHash target/release/libdenort-aarch64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  libdenort-aarch64-pc-windows-msvc.zip`n" | Out-File -NoNewline -Encoding ascii target/release/libdenort-aarch64-pc-windows-msvc.zip.sha256sum
           target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-aarch64-pc-windows-msvc.symcache
       - name: Build bsdiff helper
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
@@ -3751,7 +3760,8 @@ jobs:
           Remove-Item -Recurse -Force prev -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path prev | Out-Null
           Expand-Archive -Force -Path prev.zip -DestinationPath prev
           & .\target\release\bsdiff_helper.exe "prev\deno.exe" "target\release\deno.exe" "target\release\deno-$Target.from-$PrevVersion.bsdiff"
-          "$((Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff`n" | Out-File -NoNewline -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
+          $Sha256 = (Get-FileHash "target\release\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower()
+          "$Sha256  deno-$Target.from-$PrevVersion.bsdiff`n" | Out-File -NoNewline -Encoding ascii "target\release\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"
       - name: Upload canary to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
         env:

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -820,13 +820,17 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             if: isWindows.and(isDenoland),
             shell: "pwsh",
             run: [
-              `Get-FileHash target/release/deno.exe -Algorithm SHA256 | Format-List > target/release/deno-${buildItem.arch}-pc-windows-msvc.sha256sum`,
+              // Emit canonical GNU `sha256sum`-style files ("<hash>  <file>")
+              // so `deno upgrade`/`deno_install` verification can consume them.
+              // PowerShell `Get-FileHash | Format-List` output is NOT canonical
+              // and cannot be parsed by GNU-style checksum readers.
+              `"$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe" | Out-File -Encoding ascii target/release/deno-${buildItem.arch}-pc-windows-msvc.sha256sum`,
               `Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-${buildItem.arch}-pc-windows-msvc.zip`,
-              `Get-FileHash target/release/deno-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
+              `"$((Get-FileHash target/release/deno-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-${buildItem.arch}-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/deno-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
               `Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-${buildItem.arch}-pc-windows-msvc.zip`,
-              `Get-FileHash target/release/denort-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
+              `"$((Get-FileHash target/release/denort-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-${buildItem.arch}-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/denort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
               `Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip`,
-              `Get-FileHash target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
+              `"$((Get-FileHash target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-${buildItem.arch}-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
               `target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-${buildItem.arch}-pc-windows-msvc.symcache`,
             ],
           },
@@ -878,7 +882,7 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               "Remove-Item -Recurse -Force prev -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path prev | Out-Null",
               "Expand-Archive -Force -Path prev.zip -DestinationPath prev",
               '& .\\target\\release\\bsdiff_helper.exe "prev\\deno.exe" "target\\release\\deno.exe" "target\\release\\deno-$Target.from-$PrevVersion.bsdiff"',
-              'Get-FileHash "target\\release\\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256 | Format-List > "target\\release\\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"',
+              '"$((Get-FileHash "target\\release\\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff" | Out-File -Encoding ascii "target\\release\\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"',
             ],
           },
           step({

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -286,6 +286,16 @@ const cloneSubmodule = (path: string) =>
     name: `Clone submodule ${path}`,
     run: `git submodule update --init --recursive --depth=1 -- ${path}`,
   });
+// Emit a canonical GNU `sha256sum`-style file ("<hash>  <name>\n") for a
+// Windows release asset so `deno upgrade`/`deno_install` verification can
+// consume it, matching what the Unix jobs produce via `shasum -a 256`.
+// PowerShell's `Out-File` defaults to a CRLF line ending, which GNU checksum
+// readers fold into the filename ("No such file or directory"), so we append
+// an explicit LF and pass `-NoNewline`. `file`/`out` are inserted verbatim
+// (callers may pass quoted paths); `name` is the bare filename recorded in the
+// checksum file, matching the Unix jobs' convention.
+const winSha256sum = (file: string, name: string, out: string) =>
+  `"$((Get-FileHash ${file} -Algorithm SHA256).Hash.ToLower())  ${name}\`n" | Out-File -NoNewline -Encoding ascii ${out}`;
 const cloneStdSubmoduleStep = cloneSubmodule("./tests/util/std");
 const installDenoStep = step({
   name: "Install Deno",
@@ -820,17 +830,29 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             if: isWindows.and(isDenoland),
             shell: "pwsh",
             run: [
-              // Emit canonical GNU `sha256sum`-style files ("<hash>  <file>")
-              // so `deno upgrade`/`deno_install` verification can consume them.
-              // PowerShell `Get-FileHash | Format-List` output is NOT canonical
-              // and cannot be parsed by GNU-style checksum readers.
-              `"$((Get-FileHash target/release/deno.exe -Algorithm SHA256).Hash.ToLower())  deno.exe" | Out-File -Encoding ascii target/release/deno-${buildItem.arch}-pc-windows-msvc.sha256sum`,
+              winSha256sum(
+                "target/release/deno.exe",
+                "deno.exe",
+                `target/release/deno-${buildItem.arch}-pc-windows-msvc.sha256sum`,
+              ),
               `Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-${buildItem.arch}-pc-windows-msvc.zip`,
-              `"$((Get-FileHash target/release/deno-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  deno-${buildItem.arch}-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/deno-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
+              winSha256sum(
+                `target/release/deno-${buildItem.arch}-pc-windows-msvc.zip`,
+                `deno-${buildItem.arch}-pc-windows-msvc.zip`,
+                `target/release/deno-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
+              ),
               `Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-${buildItem.arch}-pc-windows-msvc.zip`,
-              `"$((Get-FileHash target/release/denort-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  denort-${buildItem.arch}-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/denort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
+              winSha256sum(
+                `target/release/denort-${buildItem.arch}-pc-windows-msvc.zip`,
+                `denort-${buildItem.arch}-pc-windows-msvc.zip`,
+                `target/release/denort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
+              ),
               `Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip`,
-              `"$((Get-FileHash target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower())  libdenort-${buildItem.arch}-pc-windows-msvc.zip" | Out-File -Encoding ascii target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
+              winSha256sum(
+                `target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip`,
+                `libdenort-${buildItem.arch}-pc-windows-msvc.zip`,
+                `target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
+              ),
               `target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-${buildItem.arch}-pc-windows-msvc.symcache`,
             ],
           },
@@ -882,7 +904,11 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               "Remove-Item -Recurse -Force prev -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path prev | Out-Null",
               "Expand-Archive -Force -Path prev.zip -DestinationPath prev",
               '& .\\target\\release\\bsdiff_helper.exe "prev\\deno.exe" "target\\release\\deno.exe" "target\\release\\deno-$Target.from-$PrevVersion.bsdiff"',
-              '"$((Get-FileHash "target\\release\\deno-$Target.from-$PrevVersion.bsdiff" -Algorithm SHA256).Hash.ToLower())  deno-$Target.from-$PrevVersion.bsdiff" | Out-File -Encoding ascii "target\\release\\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"',
+              winSha256sum(
+                '"target\\release\\deno-$Target.from-$PrevVersion.bsdiff"',
+                "deno-$Target.from-$PrevVersion.bsdiff",
+                '"target\\release\\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"',
+              ),
             ],
           },
           step({

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -291,11 +291,23 @@ const cloneSubmodule = (path: string) =>
 // consume it, matching what the Unix jobs produce via `shasum -a 256`.
 // PowerShell's `Out-File` defaults to a CRLF line ending, which GNU checksum
 // readers fold into the filename ("No such file or directory"), so we append
-// an explicit LF and pass `-NoNewline`. `file`/`out` are inserted verbatim
-// (callers may pass quoted paths); `name` is the bare filename recorded in the
-// checksum file, matching the Unix jobs' convention.
-const winSha256sum = (file: string, name: string, out: string) =>
-  `"$((Get-FileHash ${file} -Algorithm SHA256).Hash.ToLower())  ${name}\`n" | Out-File -NoNewline -Encoding ascii ${out}`;
+// an explicit LF and pass `-NoNewline`.
+//
+// The hash is computed into `$Sha256` on a line of its own rather than inlined
+// as a `"$(...)"` subexpression: `file` may be a quoted path, and nesting
+// quotes inside an interpolated subexpression is legal PowerShell but easy to
+// get subtly wrong — and the delta step that needs the quoting only runs on tag
+// builds, so a mistake there would first surface during a release.
+//
+// `file`/`out` are inserted verbatim (callers may pass quoted paths). `name` is
+// the bare filename recorded in the checksum file, matching the Unix jobs'
+// convention; it is interpolated into a PowerShell double-quoted string, so
+// callers may reference `$Var` (as the delta step does) but must not pass `"`,
+// `$(` or a backtick.
+const winSha256sum = (file: string, name: string, out: string) => [
+  `$Sha256 = (Get-FileHash ${file} -Algorithm SHA256).Hash.ToLower()`,
+  `"$Sha256  ${name}\`n" | Out-File -NoNewline -Encoding ascii ${out}`,
+];
 const cloneStdSubmoduleStep = cloneSubmodule("./tests/util/std");
 const installDenoStep = step({
   name: "Install Deno",
@@ -830,25 +842,25 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             if: isWindows.and(isDenoland),
             shell: "pwsh",
             run: [
-              winSha256sum(
+              ...winSha256sum(
                 "target/release/deno.exe",
                 "deno.exe",
                 `target/release/deno-${buildItem.arch}-pc-windows-msvc.sha256sum`,
               ),
               `Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-${buildItem.arch}-pc-windows-msvc.zip`,
-              winSha256sum(
+              ...winSha256sum(
                 `target/release/deno-${buildItem.arch}-pc-windows-msvc.zip`,
                 `deno-${buildItem.arch}-pc-windows-msvc.zip`,
                 `target/release/deno-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
               ),
               `Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-${buildItem.arch}-pc-windows-msvc.zip`,
-              winSha256sum(
+              ...winSha256sum(
                 `target/release/denort-${buildItem.arch}-pc-windows-msvc.zip`,
                 `denort-${buildItem.arch}-pc-windows-msvc.zip`,
                 `target/release/denort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
               ),
               `Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip`,
-              winSha256sum(
+              ...winSha256sum(
                 `target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip`,
                 `libdenort-${buildItem.arch}-pc-windows-msvc.zip`,
                 `target/release/libdenort-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
@@ -904,7 +916,7 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               "Remove-Item -Recurse -Force prev -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path prev | Out-Null",
               "Expand-Archive -Force -Path prev.zip -DestinationPath prev",
               '& .\\target\\release\\bsdiff_helper.exe "prev\\deno.exe" "target\\release\\deno.exe" "target\\release\\deno-$Target.from-$PrevVersion.bsdiff"',
-              winSha256sum(
+              ...winSha256sum(
                 '"target\\release\\deno-$Target.from-$PrevVersion.bsdiff"',
                 "deno-$Target.from-$PrevVersion.bsdiff",
                 '"target\\release\\deno-$Target.from-$PrevVersion.bsdiff.sha256sum"',

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -1626,20 +1626,42 @@ fn get_binary_checksum_url(target_version: &str) -> Result<Url, AnyError> {
     .with_context(|| format!("Failed to parse binary checksum URL: {}", url))
 }
 
+/// Parse a SHA-256 hash out of a checksum file's contents.
+///
+/// Handles both the canonical GNU `sha256sum` layout published for Unix
+/// assets (and now for Windows assets):
+///
+/// ```text
+/// <hex_hash>  <filename>
+/// ```
+///
+/// and the PowerShell `Get-FileHash | Format-List` layout historically
+/// published for Windows release assets (e.g. Deno v2.9.x):
+///
+/// ```text
+/// Algorithm       : SHA256
+/// Hash            : ABCDEF0123...
+/// Path            : C:\path\to\deno.exe
+/// ```
+///
+/// In both layouts the only 64-character hex token is the hash itself, so we
+/// return the first such token (lowercased). Returns `None` if none is found.
+fn parse_sha256sum(text: &str) -> Option<String> {
+  text
+    .split_whitespace()
+    .find(|token| {
+      token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit())
+    })
+    .map(|hash| hash.to_lowercase())
+}
+
 /// Fetch a SHA-256 hash from a .sha256sum file hosted as a release asset.
-/// The file format is expected to be: `<hex_hash>  <filename>\n`
 async fn fetch_sha256_from_url(
   client: &HttpClient,
   url: Url,
 ) -> Option<String> {
   let text = client.download_text(url).await.ok()?;
-  // sha256sum files are formatted as "<hash>  <filename>" or just "<hash>"
-  let hash = text.split_whitespace().next()?;
-  if hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
-    Some(hash.to_lowercase())
-  } else {
-    None
-  }
+  parse_sha256sum(&text)
 }
 
 /// Compute the SHA-256 hash of the given data, returning it as a lowercase
@@ -3554,6 +3576,52 @@ mod test {
     assert!(
       url_step2.to_string().contains("/download/v2.7.12/"),
       "step 2 should fetch from v2.7.12 release"
+    );
+  }
+
+  #[test]
+  fn test_parse_sha256sum_canonical() {
+    // Canonical GNU `sha256sum` output, as emitted by `shasum`/`sha256sum`
+    // and now by the Windows release jobs.
+    let text = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c  deno-aarch64-pc-windows-msvc.zip\n";
+    assert_eq!(
+      parse_sha256sum(text).as_deref(),
+      Some("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")
+    );
+  }
+
+  #[test]
+  fn test_parse_sha256sum_hash_only() {
+    let text =
+      "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c\n";
+    assert_eq!(
+      parse_sha256sum(text).as_deref(),
+      Some("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")
+    );
+  }
+
+  #[test]
+  fn test_parse_sha256sum_powershell_format_list() {
+    // Historical Windows release assets (e.g. Deno v2.9.x) published
+    // `Get-FileHash | Format-List` output, which is not GNU-canonical.
+    // Hash is uppercase and preceded by "Algorithm"/"Hash" labels.
+    let text = "\r\nAlgorithm       : SHA256\r\nHash            : B5BB9D8014A0F9B1D61E21E796D78DCCDF1352F23CD32812F4850B878AE4944C\r\nPath            : C:\\deno\\target\\release\\deno.exe\r\n\r\n";
+    assert_eq!(
+      parse_sha256sum(text).as_deref(),
+      Some("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")
+    );
+  }
+
+  #[test]
+  fn test_parse_sha256sum_no_hash() {
+    assert_eq!(parse_sha256sum(""), None);
+    assert_eq!(parse_sha256sum("not a checksum file"), None);
+    // 63 hex chars (one short) must not be accepted.
+    assert_eq!(
+      parse_sha256sum(
+        "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944"
+      ),
+      None
     );
   }
 }

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -1654,15 +1654,17 @@ fn is_sha256_hex(token: &str) -> bool {
 /// Rather than accept a 64-hex token from anywhere in the body (which would
 /// misread an HTML/XML error page served with HTTP 200 as a valid checksum and
 /// surface later as a spurious "checksum mismatch"), only these two shapes are
-/// recognized: the first whitespace-delimited token, or the value of a `Hash`
-/// label. Returns the hash lowercased, or `None` if neither matches.
+/// recognized: the leading whitespace-delimited token, or the value of a
+/// `Hash:` label on some line. Returns the hash lowercased, or `None` if
+/// neither matches.
 ///
 /// Note: distinct from the same-named `parse_sha256sum` in `desktop.rs`, which
 /// parses strict multi-line GNU checksum manifests; this lenient variant exists
 /// only to bridge the legacy Windows format and can be deleted once those
 /// releases age out.
 fn parse_sha256sum_lenient(text: &str) -> Option<String> {
-  // Canonical GNU layout: the hash is the first token on the first line.
+  // Canonical GNU layout: the hash is the leading token (any leading blank
+  // lines or indentation are skipped by `split_whitespace`).
   if let Some(token) = text.split_whitespace().next()
     && is_sha256_hex(token)
   {
@@ -3611,6 +3613,17 @@ mod test {
     // Canonical GNU `sha256sum` output, as emitted by `shasum`/`sha256sum`
     // and now by the Windows release jobs.
     let text = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c  deno-aarch64-pc-windows-msvc.zip\n";
+    assert_eq!(
+      parse_sha256sum_lenient(text).as_deref(),
+      Some("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")
+    );
+  }
+
+  #[test]
+  fn test_parse_sha256sum_canonical_uppercase() {
+    // A canonical-layout file whose hash is uppercase must still normalize,
+    // since `verify_checksum` compares against a lowercase hex digest.
+    let text = "B5BB9D8014A0F9B1D61E21E796D78DCCDF1352F23CD32812F4850B878AE4944C  deno.exe\n";
     assert_eq!(
       parse_sha256sum_lenient(text).as_deref(),
       Some("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -1626,17 +1626,24 @@ fn get_binary_checksum_url(target_version: &str) -> Result<Url, AnyError> {
     .with_context(|| format!("Failed to parse binary checksum URL: {}", url))
 }
 
-/// Parse a SHA-256 hash out of a checksum file's contents.
+/// Whether `token` is exactly a 64-character SHA-256 hex digest.
+fn is_sha256_hex(token: &str) -> bool {
+  token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Parse a SHA-256 hash out of a checksum file's contents, tolerating both the
+/// checksum layouts Deno release assets have been published with.
 ///
-/// Handles both the canonical GNU `sha256sum` layout published for Unix
-/// assets (and now for Windows assets):
+/// The canonical GNU `sha256sum` layout published for Unix assets (and now for
+/// Windows assets) leads with the hash:
 ///
 /// ```text
 /// <hex_hash>  <filename>
 /// ```
 ///
-/// and the PowerShell `Get-FileHash | Format-List` layout historically
-/// published for Windows release assets (e.g. Deno v2.9.x):
+/// Windows release assets historically (e.g. Deno v2.9.x) published PowerShell
+/// `Get-FileHash | Format-List` output instead, where the hash follows a
+/// `Hash` label:
 ///
 /// ```text
 /// Algorithm       : SHA256
@@ -1644,15 +1651,35 @@ fn get_binary_checksum_url(target_version: &str) -> Result<Url, AnyError> {
 /// Path            : C:\path\to\deno.exe
 /// ```
 ///
-/// In both layouts the only 64-character hex token is the hash itself, so we
-/// return the first such token (lowercased). Returns `None` if none is found.
-fn parse_sha256sum(text: &str) -> Option<String> {
-  text
-    .split_whitespace()
-    .find(|token| {
-      token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit())
-    })
-    .map(|hash| hash.to_lowercase())
+/// Rather than accept a 64-hex token from anywhere in the body (which would
+/// misread an HTML/XML error page served with HTTP 200 as a valid checksum and
+/// surface later as a spurious "checksum mismatch"), only these two shapes are
+/// recognized: the first whitespace-delimited token, or the value of a `Hash`
+/// label. Returns the hash lowercased, or `None` if neither matches.
+///
+/// Note: distinct from the same-named `parse_sha256sum` in `desktop.rs`, which
+/// parses strict multi-line GNU checksum manifests; this lenient variant exists
+/// only to bridge the legacy Windows format and can be deleted once those
+/// releases age out.
+fn parse_sha256sum_lenient(text: &str) -> Option<String> {
+  // Canonical GNU layout: the hash is the first token on the first line.
+  if let Some(token) = text.split_whitespace().next()
+    && is_sha256_hex(token)
+  {
+    return Some(token.to_lowercase());
+  }
+  // Legacy PowerShell `Format-List` layout: `Hash            : <hex>`.
+  for line in text.lines() {
+    if let Some((label, value)) = line.split_once(':')
+      && label.trim().eq_ignore_ascii_case("Hash")
+    {
+      let value = value.trim();
+      if is_sha256_hex(value) {
+        return Some(value.to_lowercase());
+      }
+    }
+  }
+  None
 }
 
 /// Fetch a SHA-256 hash from a .sha256sum file hosted as a release asset.
@@ -1661,7 +1688,7 @@ async fn fetch_sha256_from_url(
   url: Url,
 ) -> Option<String> {
   let text = client.download_text(url).await.ok()?;
-  parse_sha256sum(&text)
+  parse_sha256sum_lenient(&text)
 }
 
 /// Compute the SHA-256 hash of the given data, returning it as a lowercase
@@ -1930,7 +1957,7 @@ fn verify_checksum(
   let expected_checksum = expected_checksum.trim().to_lowercase();
   if computed_hex != expected_checksum {
     bail!(
-      "Checksum verification failed.\n  Actual:   {}\n  Expected: {}",
+      "Checksum verification failed.\n  Expected: {}\n  Actual:   {}",
       expected_checksum,
       computed_hex
     );
@@ -3585,7 +3612,7 @@ mod test {
     // and now by the Windows release jobs.
     let text = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c  deno-aarch64-pc-windows-msvc.zip\n";
     assert_eq!(
-      parse_sha256sum(text).as_deref(),
+      parse_sha256sum_lenient(text).as_deref(),
       Some("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")
     );
   }
@@ -3595,7 +3622,7 @@ mod test {
     let text =
       "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c\n";
     assert_eq!(
-      parse_sha256sum(text).as_deref(),
+      parse_sha256sum_lenient(text).as_deref(),
       Some("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")
     );
   }
@@ -3607,21 +3634,34 @@ mod test {
     // Hash is uppercase and preceded by "Algorithm"/"Hash" labels.
     let text = "\r\nAlgorithm       : SHA256\r\nHash            : B5BB9D8014A0F9B1D61E21E796D78DCCDF1352F23CD32812F4850B878AE4944C\r\nPath            : C:\\deno\\target\\release\\deno.exe\r\n\r\n";
     assert_eq!(
-      parse_sha256sum(text).as_deref(),
+      parse_sha256sum_lenient(text).as_deref(),
       Some("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")
     );
   }
 
   #[test]
   fn test_parse_sha256sum_no_hash() {
-    assert_eq!(parse_sha256sum(""), None);
-    assert_eq!(parse_sha256sum("not a checksum file"), None);
+    assert_eq!(parse_sha256sum_lenient(""), None);
+    assert_eq!(parse_sha256sum_lenient("not a checksum file"), None);
     // 63 hex chars (one short) must not be accepted.
     assert_eq!(
-      parse_sha256sum(
+      parse_sha256sum_lenient(
         "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944"
       ),
       None
     );
+  }
+
+  #[test]
+  fn test_parse_sha256sum_rejects_embedded_hex() {
+    // An HTML/XML error body served with HTTP 200 (proxy, captive portal, CDN)
+    // may embed a 64-hex request id/digest that is not a checksum. It must not
+    // be mistaken for a valid hash, else it surfaces as a spurious mismatch.
+    let text = concat!(
+      "<html><body><p>Request blocked</p>",
+      "<!-- trace: b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c -->",
+      "</body></html>\n"
+    );
+    assert_eq!(parse_sha256sum_lenient(text), None);
   }
 }


### PR DESCRIPTION
## Summary

First piece of #36045 (§1 "Correct Windows release checksums").

Windows release jobs write `.sha256sum` files with `Get-FileHash | Format-List`, which produces PowerShell block output:

```
Algorithm       : SHA256
Hash            : ABCDEF0123...
Path            : C:\...\deno.exe
```

Deno's upgrade checksum parser expects GNU-style output beginning with a 64-character hash, so Windows delta verification cannot consume the published files and silently falls back to a full-archive download.

## Changes

- **Emit canonical checksums** (`ci.ts`): the Windows "Pre-release" and "Generate delta patch" jobs now write canonical GNU-style `"<hash>  <filename>"` files (lowercased hash, explicit LF) for the uncompressed binary, the `deno`/`denort`/`libdenort` zips, and the bsdiff delta, matching what Linux/macOS already produce via `shasum -a 256`. The digest is computed into `$Sha256` on a line of its own rather than inlined as a `"$(...)"` subexpression: the delta step passes a quoted path, and nested quoting inside an interpolated subexpression only runs on tag builds, so a mistake there would first surface during a release instead of in PR CI.
- **Tolerant client parser** (`cli/tools/upgrade.rs`): extracted `parse_sha256sum_lenient()`, which accepts both the canonical form and historical PowerShell `Format-List` files. It deliberately recognizes only two shapes — the leading whitespace-delimited token, or the value of a `Hash:` label — rather than any 64-hex token in the body, so an HTML/XML error page served with HTTP 200 can't be misread as a checksum and surface as a spurious mismatch. `fetch_sha256_from_url` now delegates to it, so both newly-published and already-published (e.g. v2.9.x) Windows assets verify.
- **Drive-by**: `verify_checksum`'s error message had its `Actual:`/`Expected:` labels swapped relative to the format arguments; this corrects the ordering. Unrelated to the checksum format, but a one-line fix to a message this PR's paths can emit.
- **Tests**: unit tests for canonical, uppercase canonical, hash-only, PowerShell `Format-List`, no-hash, and embedded-hex-in-HTML inputs.

`ci.generated.yml` is regenerated from `ci.ts`; the regen touches only the intended lines and `tools/lint.js`'s workflow-freshness check passes.

## Notes

- `deno_install` archive verification (the fourth checkbox in §1) lives in the `denoland/deno_install` repo and is handled by a separate PR there.
- The two PowerShell steps aren't exercised by PR CI (`Pre-release` requires `denoland/deno`; the delta step additionally requires a tag), so they've been reviewed by inspection rather than executed.

Towards #36045.
