### PR TITLE
chore: promote to LTS by re-stamping published release binaries

### DIFF
--- a/.github/workflows/promote_to_release.generated.yml
+++ b/.github/workflows/promote_to_release.generated.yml
@@ -12,7 +12,7 @@ on:
           - lts
         required: true
       commitHash:
-        description: Commit to promote to release
+        description: 'rc: canary commit hash to promote. lts: release version to re-stamp, e.g. v2.9.3'
         required: true
 jobs:
   promote-to-release-windows:
@@ -42,9 +42,17 @@ jobs:
           deno-version: v2.x
       - name: Download Windows binaries
         run: |-
-          $CANARY_URL="https://dl.deno.land/canary/${{github.event.inputs.commitHash}}"
-          Invoke-WebRequest -Uri "$CANARY_URL/deno-${{ matrix.target }}.zip" -OutFile "deno-windows.zip"
-          Invoke-WebRequest -Uri "$CANARY_URL/denort-${{ matrix.target }}.zip" -OutFile "denort-windows.zip"
+          # LTS is cut from a release branch with no canary build, so re-stamp
+          # the already-published stable release binaries. RC still promotes
+          # canary binaries by commit hash.
+          if ("${{github.event.inputs.releaseKind}}" -eq "lts") {
+            $Version = "${{github.event.inputs.commitHash}}" -replace "^v", ""
+            $SrcUrl = "https://dl.deno.land/release/v$Version"
+          } else {
+            $SrcUrl = "https://dl.deno.land/canary/${{github.event.inputs.commitHash}}"
+          }
+          Invoke-WebRequest -Uri "$SrcUrl/deno-${{ matrix.target }}.zip" -OutFile "deno-windows.zip"
+          Invoke-WebRequest -Uri "$SrcUrl/denort-${{ matrix.target }}.zip" -OutFile "denort-windows.zip"
           Expand-Archive -Path "deno-windows.zip" -DestinationPath "."
           Expand-Archive -Path "denort-windows.zip" -DestinationPath "."
       - name: Run patchver for Windows

--- a/.github/workflows/promote_to_release.ts
+++ b/.github/workflows/promote_to_release.ts
@@ -36,9 +36,17 @@ const windowsJob = job("promote-to-release-windows", {
     step({
       name: "Download Windows binaries",
       run: [
-        '$CANARY_URL="https://dl.deno.land/canary/${{github.event.inputs.commitHash}}"',
-        'Invoke-WebRequest -Uri "$CANARY_URL/deno-${{ matrix.target }}.zip" -OutFile "deno-windows.zip"',
-        'Invoke-WebRequest -Uri "$CANARY_URL/denort-${{ matrix.target }}.zip" -OutFile "denort-windows.zip"',
+        "# LTS is cut from a release branch with no canary build, so re-stamp",
+        "# the already-published stable release binaries. RC still promotes",
+        "# canary binaries by commit hash.",
+        'if ("${{github.event.inputs.releaseKind}}" -eq "lts") {',
+        '  $Version = "${{github.event.inputs.commitHash}}" -replace "^v", ""',
+        '  $SrcUrl = "https://dl.deno.land/release/v$Version"',
+        "} else {",
+        '  $SrcUrl = "https://dl.deno.land/canary/${{github.event.inputs.commitHash}}"',
+        "}",
+        'Invoke-WebRequest -Uri "$SrcUrl/deno-${{ matrix.target }}.zip" -OutFile "deno-windows.zip"',
+        'Invoke-WebRequest -Uri "$SrcUrl/denort-${{ matrix.target }}.zip" -OutFile "denort-windows.zip"',
         'Expand-Archive -Path "deno-windows.zip" -DestinationPath "."',
         'Expand-Archive -Path "denort-windows.zip" -DestinationPath "."',
       ],
@@ -120,7 +128,8 @@ const workflow = createWorkflow({
           required: true,
         },
         commitHash: {
-          description: "Commit to promote to release",
+          description:
+            "rc: canary commit hash to promote. lts: release version to re-stamp, e.g. v2.9.3",
           required: true,
         },
       },

--- a/tools/release/promote_to_release.ts
+++ b/tools/release/promote_to_release.ts
@@ -30,14 +30,20 @@ if (CHANNEL !== "rc" && CHANNEL !== "lts") {
   throw new Error(`Invalid channel: ${CHANNEL}`);
 }
 
-const CANARY_URL = "https://dl.deno.land";
+const DL_URL = "https://dl.deno.land";
 
-function getCanaryBinaryUrl(
-  version: string,
+function getSourceBinaryUrl(
+  versionOrHash: string,
   binary: string,
   target: string,
 ): string {
-  return `${CANARY_URL}/canary/${version}/${binary}-${target}.zip`;
+  if (CHANNEL === "lts") {
+    // LTS is cut from a release branch that has no canary build, so re-stamp
+    // the already-published stable release binaries instead of canary ones.
+    const version = versionOrHash.replace(/^v/, "");
+    return `${DL_URL}/release/v${version}/${binary}-${target}.zip`;
+  }
+  return `${DL_URL}/canary/${versionOrHash}/${binary}-${target}.zip`;
 }
 
 function getUnzippedFilename(binary: string, target: string) {
@@ -73,20 +79,20 @@ async function remove(filePath: string) {
   }
 }
 
-async function fetchLatestCanaryBinary(
-  version: string,
+async function fetchSourceBinary(
+  versionOrHash: string,
   binary: string,
   target: string,
 ) {
-  const url = getCanaryBinaryUrl(version, binary, target);
+  const url = getSourceBinaryUrl(versionOrHash, binary, target);
   await $.request(url).showProgress().pipeToPath();
 }
 
-async function fetchLatestCanaryBinaries(canaryVersion: string) {
+async function fetchSourceBinaries(versionOrHash: string) {
   for (const binary of DENO_BINARIES) {
     for (const target of NON_WINDOWS_TARGETS) {
       $.logStep("Download", binary, gray("target:"), target);
-      await fetchLatestCanaryBinary(canaryVersion, binary, target);
+      await fetchSourceBinary(versionOrHash, binary, target);
     }
   }
 }
@@ -273,12 +279,15 @@ async function dumpRcVersion() {
 async function main() {
   const commitHash = Deno.args[1];
   if (!commitHash) {
-    throw new Error("Commit hash needs to be provided as an argument");
+    throw new Error(
+      "A canary commit hash (rc) or release version (lts) needs to be provided as an argument",
+    );
   }
-  $.logStep("Download canary binaries...");
-  await fetchLatestCanaryBinaries(commitHash);
-  console.log("All canary binaries ready");
-  $.logStep(`Promote canary binaries to ${CHANNEL}...`);
+  const sourceKind = CHANNEL === "lts" ? "release" : "canary";
+  $.logStep(`Download ${sourceKind} binaries...`);
+  await fetchSourceBinaries(commitHash);
+  console.log(`All ${sourceKind} binaries ready`);
+  $.logStep(`Promote ${sourceKind} binaries to ${CHANNEL}...`);
   await promoteBinariesToRc(commitHash);
 
   // Finally dump the version name to a `release.txt` file for uploading to GCP


### PR DESCRIPTION
The promote_to_release workflow sourced its input binaries from
dl.deno.land/canary/<commitHash>/. That works for RC, which is promoted
from a canary build produced on main, but not for LTS. An LTS version is
cut from a release branch that never produces a canary build, so the
canary URLs 404 and the promote dies at its first download step.

For releaseKind=lts this instead pulls the already-published stable
release binaries from dl.deno.land/release/v<version>/ and re-stamps them
to the lts channel with patchver, so the same v2.9.3 build that ships as
stable on GitHub becomes the lts binary served from dl.deno.land. RC
keeps sourcing canary binaries by commit hash. For lts the workflow's
commitHash input takes the release version (e.g. v2.9.3) rather than a
hash.

Verified locally against the real release/v2.9.3 binaries: patchver
injects the lts channel section into the signed macOS binaries, and the
result self-identifies as lts at runtime (its background upgrade check
polls release-lts-latest.txt rather than release-latest.txt).