### PR TITLE
fix(tls): resolve sni requests concurrently

### DIFF
--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -241,17 +241,19 @@ function createTlsKeyResolver(callback) {
       if (typeof sni !== "string") {
         break;
       }
-      try {
-        const key = await callback(sni);
-        if (!hasTlsKeyPairOptions(key)) {
-          op_tls_cert_resolver_resolve_error(lookup, sni, "Invalid key");
-        } else {
-          const resolved = loadTlsKeyPair("Deno.listenTls", key);
-          op_tls_cert_resolver_resolve(lookup, sni, resolved);
+      (async () => {
+        try {
+          const key = await callback(sni);
+          if (!hasTlsKeyPairOptions(key)) {
+            op_tls_cert_resolver_resolve_error(lookup, sni, "Invalid key");
+          } else {
+            const resolved = loadTlsKeyPair("Deno.listenTls", key);
+            op_tls_cert_resolver_resolve(lookup, sni, resolved);
+          }
+        } catch (e) {
+          op_tls_cert_resolver_resolve_error(lookup, sni, e.message);
         }
-      } catch (e) {
-        op_tls_cert_resolver_resolve_error(lookup, sni, e.message);
-      }
+      })();
     }
   })();
   return resolver;

--- a/ext/tls/tls_key.rs
+++ b/ext/tls/tls_key.rs
@@ -156,7 +156,11 @@ impl TlsKeyResolver {
     // to respond to the requests.
     spawn(async move {
       while let Some((sni, txr)) = rx.recv().await {
-        _ = txr.send(self.resolve_internal(sni, alpn.clone()).await);
+        let resolver = self.clone();
+        let alpn = alpn.clone();
+        spawn(async move {
+          _ = txr.send(resolver.resolve_internal(sni, alpn).await);
+        });
       }
     });
 

--- a/tests/unit/tls_sni_test.ts
+++ b/tests/unit/tls_sni_test.ts
@@ -5,8 +5,23 @@ const { resolverSymbol, serverNameSymbol } = Deno[Deno.internal];
 
 const cert = Deno.readTextFileSync("tests/testdata/tls/localhost.crt");
 const key = Deno.readTextFileSync("tests/testdata/tls/localhost.key");
+const caCert = Deno.readTextFileSync("tests/testdata/tls/RootCA.pem");
 const certEcc = Deno.readTextFileSync("tests/testdata/tls/localhost_ecc.crt");
 const keyEcc = Deno.readTextFileSync("tests/testdata/tls/localhost_ecc.key");
+
+async function resolvesWithin(promise: Promise<unknown>, ms: number) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => "resolved"),
+      new Promise<"blocked">((resolve) => {
+        timer = setTimeout(() => resolve("blocked"), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 Deno.test(
   { permissions: { net: true, read: true } },
@@ -55,5 +70,78 @@ Deno.test(
       "fail-server-4",
     ]);
     listener.close();
+  },
+);
+
+Deno.test(
+  { permissions: { net: true, read: true } },
+  async function listenResolverDoesNotBlockUnrelatedSni() {
+    const slowStarted = Promise.withResolvers<void>();
+    const releaseSlow = Promise.withResolvers<void>();
+    const handshakes: Promise<unknown>[] = [];
+    const connections: { close(): void }[] = [];
+
+    const opts: unknown = {
+      hostname: "localhost",
+      port: 0,
+      [resolverSymbol]: async (sni: string) => {
+        if (sni === "slow-server") {
+          slowStarted.resolve();
+          await releaseSlow.promise;
+        }
+        return { cert, key };
+      },
+    };
+    // @ts-ignore Trust me
+    const listener = Deno.listenTls(opts);
+
+    try {
+      const slowClient = await Deno.connectTls({
+        hostname: "localhost",
+        [serverNameSymbol]: "slow-server",
+        port: listener.addr.port,
+        caCerts: [caCert],
+        unsafelyDisableHostnameVerification: true,
+      });
+      const slowServer = await listener.accept();
+      connections.push(slowClient, slowServer);
+      handshakes.push(slowClient.handshake(), slowServer.handshake());
+
+      await slowStarted.promise;
+
+      const fastClient = await Deno.connectTls({
+        hostname: "localhost",
+        [serverNameSymbol]: "fast-server",
+        port: listener.addr.port,
+        caCerts: [caCert],
+        unsafelyDisableHostnameVerification: true,
+      });
+      const fastServer = await listener.accept();
+      connections.push(fastClient, fastServer);
+      const fastHandshake = Promise.all([
+        fastClient.handshake(),
+        fastServer.handshake(),
+      ]);
+      handshakes.push(fastHandshake);
+
+      assertEquals(
+        await resolvesWithin(fastHandshake, 1_000),
+        "resolved",
+      );
+
+      releaseSlow.resolve();
+      await Promise.all(handshakes);
+    } finally {
+      releaseSlow.resolve();
+      listener.close();
+      for (const conn of connections) {
+        try {
+          conn.close();
+        } catch {
+          // The connection may already have been closed by the handshake path.
+        }
+      }
+      await Promise.allSettled(handshakes);
+    }
   },
 );


### PR DESCRIPTION
## Summary

- dispatch independent dynamic SNI certificate resolutions concurrently in the Rust provider
- continue polling for SNI requests while an asynchronous JavaScript resolver callback is pending
- add a regression test covering a slow lookup alongside an unrelated fast lookup

## Motivation

The resolver pipeline currently awaits each request in both dispatcher layers. A slow callback therefore delays every later handshake on the same listener, even when the SNI names and key lookups are independent. Dispatching each resolution separately removes that cross-request coupling while the existing resolver cache continues to coalesce lookups for the same name.

## Validation

- `./tools/format.js`
- `cargo fmt --check --package deno_tls`
- `cargo build --bin deno`
- `cargo test -p deno_tls --lib`
- `cargo test -p unit_tests --test unit -- tls_sni_test`
