### PR TITLE
test: deflake parallel serve watcher test

### DIFF
--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -162,6 +162,41 @@ where
   })
 }
 
+async fn wait_for_server_and_watcher<R>(
+  file_name: &str,
+  stderr_lines: &mut LoggingLines<R>,
+) -> String
+where
+  R: tokio::io::AsyncBufRead + Unpin,
+{
+  let timeout = tokio::time::Duration::from_secs(60);
+
+  tokio::time::timeout(timeout, async {
+    let mut listening_line = None;
+    let mut watcher_ready = false;
+    while let Some(line) = stderr_lines.next_line().await.unwrap() {
+      if line.contains("Listening on") {
+        listening_line = Some(line.clone());
+      }
+      if line.contains("Watching paths") && line.contains(file_name) {
+        watcher_ready = true;
+      }
+      if watcher_ready && let Some(line) = listening_line.take() {
+        return line;
+      }
+    }
+    panic!("Output ended before the server and watcher were ready")
+  })
+  .await
+  .unwrap_or_else(|_| {
+    panic!(
+      "Server and watcher were not ready for file \"{}\" after {} seconds",
+      file_name,
+      timeout.as_secs()
+    )
+  })
+}
+
 fn check_alive_then_kill(mut child: DenoChild) {
   assert!(child.try_wait().unwrap().is_none());
   child.kill().unwrap();
@@ -941,6 +976,8 @@ async fn serve_watch_parallel_stops_old_workers() {
     .arg("--watch")
     .arg("--port")
     .arg("0")
+    .arg("-L")
+    .arg("debug")
     .arg(&file_to_watch)
     .env("NO_COLOR", "1")
     .env("DENO_JOBS", "4")
@@ -976,7 +1013,14 @@ async fn serve_watch_parallel_stops_old_workers_inner(
   let port_regex =
     regex::Regex::new(r"Listening on https?:[^:]+:(\d+)/").unwrap();
 
-  let line = wait_contains("Listening on", &mut stderr_lines).await;
+  // "Listening on" only means that the HTTP listener is ready. Watch paths
+  // are delivered to the notify task asynchronously, so wait until the entry
+  // point is actually watched before doing the one-shot rewrite below. The
+  // readiness lines are produced by separate tasks and may arrive either way
+  // around.
+  let line =
+    wait_for_server_and_watcher("server_file_to_watch.js", &mut stderr_lines)
+      .await;
   let old_port = port_regex.captures(&line).unwrap()[1].to_string();
 
   let client = reqwest::Client::builder()


### PR DESCRIPTION
## Summary

- wait for both the parallel serve HTTP listener and its file watch to be ready before rewriting the test entrypoint
- preserve the listener line regardless of which asynchronous readiness message arrives first
- keep the existing old-worker shutdown assertions unchanged

## Root cause

The test treated `deno serve`'s `Listening` message as file-watcher readiness. The module graph sends watch paths to the notify task asynchronously, so on slower CI workers the test's one-shot rewrite could happen before the OS watch was armed. That event was then lost and the test timed out waiting for `Restarting`.

This enables debug watcher output and waits for both `Listening` and the matching `Watching paths` message before performing the rewrite.

Closes #35352.

## Validation

- `CARGO_INCREMENTAL=0 cargo test -p integration_tests --test integration integration::watcher::serve_watch_parallel_stops_old_workers -- --nocapture`
- 20/20 repeated focused test runs
- `./tools/format.js --check`
- `./tools/lint.js --rs`
