### PR TITLE
fix(desktop): preserve binding wrappers after lazy op upgrade

### DIFF
--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -35,6 +35,8 @@ pub const DESKTOP_JS: &str = r#"
   } = internals.core.ops;
   const BrowserWindowPrototype = BrowserWindow.prototype;
   Object.setPrototypeOf(BrowserWindowPrototype, EventTarget.prototype);
+  const privateDesktopBind = Symbol.for("Deno_privateDesktopBind");
+  const privateDesktopUnbind = Symbol.for("Deno_privateDesktopUnbind");
 
   class UIEvent extends Event {
     #detail = 0;
@@ -225,14 +227,13 @@ pub const DESKTOP_JS: &str = r#"
     // No env access — fine, we just don't trace binding calls.
   }
 
-  const nativeBind = BrowserWindowPrototype.bind;
   BrowserWindowPrototype.bind = function(name, fn) {
     const windowId = this.windowId;
     if (!windowBindCallbacks.has(windowId)) {
       windowBindCallbacks.set(windowId, new Map());
     }
     windowBindCallbacks.get(windowId).set(name, fn.bind(this));
-    nativeBind.call(this, name);
+    BrowserWindowPrototype[privateDesktopBind].call(this, name);
 
     // Inject a renderer-side wrapper that emits console.debug around
     // every binding call. The wrapper waits for the native binding to
@@ -276,12 +277,11 @@ pub const DESKTOP_JS: &str = r#"
     }
   };
 
-  const nativeUnbind = BrowserWindowPrototype.unbind;
   BrowserWindowPrototype.unbind = function(name) {
     const windowId = this.windowId;
     const callbacks = windowBindCallbacks.get(windowId);
     if (callbacks) callbacks.delete(name);
-    nativeUnbind.call(this, name);
+    BrowserWindowPrototype[privateDesktopUnbind].call(this, name);
   };
 
   function alert(message = "Alert") {
@@ -330,6 +330,9 @@ pub const DESKTOP_JS: &str = r#"
 
   const TrayPrototype = Tray.prototype;
   Object.setPrototypeOf(TrayPrototype, EventTarget.prototype);
+  const privateDesktopTrayDestroy = Symbol.for(
+    "Deno_privateDesktopTrayDestroy",
+  );
 
   const trays = new Map();
   const nativeTrayConstructor = Tray;
@@ -342,10 +345,9 @@ pub const DESKTOP_JS: &str = r#"
   Object.setPrototypeOf(OrigTray.prototype, nativeTrayConstructor.prototype);
   Deno.Tray = OrigTray;
 
-  const nativeTrayDestroy = TrayPrototype.destroy;
   TrayPrototype.destroy = function() {
     trays.delete(this.trayId);
-    nativeTrayDestroy.call(this);
+    TrayPrototype[privateDesktopTrayDestroy].call(this);
   };
   TrayPrototype[Symbol.dispose] = function() {
     this.destroy();
@@ -1290,6 +1292,36 @@ mod tests {
     // The original BrowserWindow is wrapped so per-window state is
     // recorded.
     assert!(DESKTOP_JS.contains("windows.set"));
+  }
+
+  #[test]
+  fn desktop_js_interposes_on_native_registry_methods() {
+    assert!(
+      DESKTOP_JS.contains("BrowserWindowPrototype.bind = function(name, fn)")
+    );
+    assert!(
+      DESKTOP_JS.contains("BrowserWindowPrototype.unbind = function(name)")
+    );
+    assert!(DESKTOP_JS.contains("TrayPrototype.destroy = function()"));
+    assert!(DESKTOP_JS.contains(
+      "const privateDesktopBind = Symbol.for(\"Deno_privateDesktopBind\")"
+    ));
+    assert!(DESKTOP_JS.contains(
+      "const privateDesktopUnbind = Symbol.for(\"Deno_privateDesktopUnbind\")"
+    ));
+    assert!(
+      DESKTOP_JS.contains(
+        "BrowserWindowPrototype[privateDesktopBind].call(this, name)"
+      )
+    );
+    assert!(DESKTOP_JS.contains(
+      "BrowserWindowPrototype[privateDesktopUnbind].call(this, name)"
+    ));
+    assert!(DESKTOP_JS.contains("Deno_privateDesktopTrayDestroy"));
+    assert!(
+      DESKTOP_JS
+        .contains("TrayPrototype[privateDesktopTrayDestroy].call(this)")
+    );
   }
 
   // --- desktop_auto_update_js ---

--- a/runtime/ops/desktop.rs
+++ b/runtime/ops/desktop.rs
@@ -645,12 +645,17 @@ impl BrowserWindow {
     self.window_id
   }
 
+  // Keep the native primitive separate from DESKTOP_JS's public `bind`
+  // wrapper. The deferred fast-call upgrade may replace this symbol-backed
+  // method without overwriting the wrapper.
   #[fast]
+  #[symbol("Deno_privateDesktopBind")]
   fn bind(&self, #[string] name: &str) {
     self.api.bind(self.window_id, name);
   }
 
   #[fast]
+  #[symbol("Deno_privateDesktopUnbind")]
   fn unbind(&self, #[string] name: &str) {
     self.api.unbind(self.window_id, name);
   }
@@ -1529,7 +1534,10 @@ impl Tray {
       })
   }
 
+  // DESKTOP_JS exposes the public `destroy` wrapper that also updates its tray
+  // registry. Keep the native primitive on a distinct symbol-backed slot.
   #[fast]
+  #[symbol("Deno_privateDesktopTrayDestroy")]
   fn destroy(&self) {
     self.api.destroy_tray(self.tray_id);
   }
@@ -1758,9 +1766,11 @@ mod tests {
   use deno_core::serde_json;
   use deno_core::serde_json::json;
 
+  use super::BrowserWindow;
   use super::DesktopEvent;
   use super::PendingBindResponses;
   use super::PermissionState;
+  use super::Tray;
   use super::dylib_magic_ok;
   use super::permission_state_to_web_string;
   use super::register_bind_call;
@@ -1772,6 +1782,42 @@ mod tests {
   // fail if you change a field name or remove a `#[serde(rename_all =
   // "camelCase")]` so you find out at test time, not at runtime in the
   // packaged app.
+
+  #[test]
+  fn js_wrapped_desktop_methods_use_private_symbols() {
+    for (object, methods) in [
+      (
+        BrowserWindow::DECL,
+        &["Deno_privateDesktopBind", "Deno_privateDesktopUnbind"][..],
+      ),
+      (Tray::DECL, &["Deno_privateDesktopTrayDestroy"][..]),
+    ] {
+      for name in methods {
+        let method = object
+          .methods
+          .iter()
+          .find(|method| method.name == *name)
+          .unwrap_or_else(|| panic!("missing method {name}"));
+        assert!(
+          method.symbol_for,
+          "{name} must not share a string property with its DESKTOP_JS wrapper"
+        );
+        let _ = method.fast_fn();
+      }
+    }
+
+    for (object, public_names) in [
+      (BrowserWindow::DECL, &["bind", "unbind"][..]),
+      (Tray::DECL, &["destroy"][..]),
+    ] {
+      for name in public_names {
+        assert!(
+          object.methods.iter().all(|method| method.name != *name),
+          "native method must not collide with the public {name} wrapper"
+        );
+      }
+    }
+  }
 
   #[test]
   fn app_menu_click_wire_shape() {


### PR DESCRIPTION
Closes #36033.

## Problem

`DESKTOP_JS` wraps `BrowserWindow.prototype.bind`, `unbind`, and `Tray.prototype.destroy` to maintain JavaScript-side callback and object registries.

Fast-call op installation is deferred until the first residual extension module is loaded. `Deno.serve()` triggers that upgrade, which unconditionally replaced the cppgc prototype methods and overwrote the JavaScript wrappers. The native binding name still reached the desktop backend, but the callback was no longer recorded in `windowBindCallbacks`, so renderer calls failed with `No callback bound for: ping`.

## Fix

- Register the native bind, unbind, and tray-destroy primitives on internal `Symbol.for(...)` slots.
- Keep the public string-named methods as JavaScript wrappers.
- Resolve the symbol-backed primitive dynamically when forwarding, so calls use the original slow op before deferred installation and the upgraded fast op afterward.
- Add tests pinning the separation between public wrapper names and fast symbol-backed native methods.

This avoids disabling fast calls and does not force the whole deferred fast-op pass to run eagerly during desktop startup.

## Validation

- `cargo test -p deno_runtime ops::desktop::tests`
- `cargo test -p denort desktop::tests`
- `./tools/format.js --check`
- `cargo build -p deno -p denort_desktop`
- Reproduced the issue with matched debug `target/debug/deno` and `target/debug/libdenort.dylib` using `deno desktop --hmr -RN bug.ts`: the handler logged `handler invoked` and the desktop window rendered `pong`.
