### PR TITLE
fix(webtransport): avoid url parse panic

### DIFF
--- a/ext/net/quic.rs
+++ b/ext/net/quic.rs
@@ -119,6 +119,9 @@ pub enum QuicError {
   #[class(generic)]
   #[error("{0}")]
   WebTransportConnectError(#[from] web_transport_proto::ConnectError),
+  #[class(type)]
+  #[error("Invalid WebTransport URL: {0}")]
+  WebTransportUrlParse(#[from] url::ParseError),
   #[class(inherit)]
   #[error(transparent)]
   Other(#[from] JsErrorBox),
@@ -1173,7 +1176,7 @@ pub(crate) mod webtransport {
     use web_transport_proto::ConnectResponse;
 
     let conn = connection_resource.0.clone();
-    let url = url::Url::parse(&url).unwrap();
+    let url = url::Url::parse(&url)?;
 
     let (settings_tx_rid, settings_rx_rid) =
       exchange_settings(state.clone(), conn.clone()).await?;

--- a/ext/web/webtransport.js
+++ b/ext/web/webtransport.js
@@ -9,6 +9,7 @@ import {
 } from "ext:deno_net/03_quic.js";
 const { assert } = core.loadExtScript("ext:deno_web/00_infra.js");
 const { DOMException } = core.loadExtScript("ext:deno_web/01_dom_exception.js");
+const { URLPrototype } = core.loadExtScript("ext:deno_web/00_url.js");
 const {
   getReadableStreamResourceBacking,
   getWritableStreamResourceBacking,
@@ -36,6 +37,7 @@ const {
   DataViewPrototypeSetUint32,
   DataViewPrototypeSetBigUint64,
   DateNow,
+  FunctionPrototypeCall,
   BigInt,
   Number,
   ObjectPrototypeIsPrototypeOf,
@@ -53,6 +55,7 @@ const {
   TypeError,
   Uint8Array,
 } = primordials;
+const URLPrototypeToString = URLPrototype.toString;
 
 const MAX_PRIORITY = 2_147_483_647;
 const BI_WEBTRANSPORT = 0x41n;
@@ -225,8 +228,7 @@ class WebTransport {
         async (conn) => {
           const { connect, settingsTx, settingsRx } = await webtransportConnect(
             conn,
-            // deno-lint-ignore prefer-primordials
-            parsedURL.toString(),
+            FunctionPrototypeCall(URLPrototypeToString, parsedURL),
           );
 
           return {

--- a/tests/specs/run/webtransport/main.out
+++ b/tests/specs/run/webtransport/main.out
@@ -1,5 +1,6 @@
-running 1 test from ./main.ts
+running 2 tests from ./main.ts
 WebTransport ... ok ([WILDCARD])
+WebTransport ignores overridden URL toString ... ok ([WILDCARD])
 
-ok | 1 passed | 0 failed ([WILDCARD])
+ok | 2 passed | 0 failed ([WILDCARD])
 

--- a/tests/specs/run/webtransport/main.ts
+++ b/tests/specs/run/webtransport/main.ts
@@ -104,3 +104,43 @@ Deno.test("WebTransport", async () => {
     server.close();
   });
 });
+
+Deno.test("WebTransport ignores overridden URL toString", async () => {
+  const server = new Deno.QuicEndpoint({
+    hostname: "localhost",
+    port: 0,
+  });
+  const listener = server.listen({
+    cert,
+    key: Deno.readTextFileSync("../../../testdata/tls/localhost.key"),
+    alpnProtocols: ["h3"],
+  });
+  const expectedUrl = `https://localhost:${server.addr.port}/path`;
+
+  const serverDone = (async () => {
+    for await (const incoming of listener) {
+      const conn = await incoming.accept();
+      const wt = await Deno.upgradeWebTransport(conn);
+      await wt.ready;
+      assertEquals(wt.url, expectedUrl);
+      return;
+    }
+  })();
+
+  const originalToString = URL.prototype.toString;
+  URL.prototype.toString = () => "not a url";
+  try {
+    const client = new WebTransport(expectedUrl, {
+      serverCertificateHashes: [{
+        algorithm: "sha-256",
+        value: certHash,
+      }],
+    });
+    await client.ready;
+    client.close();
+    await serverDone;
+  } finally {
+    URL.prototype.toString = originalToString;
+    server.close();
+  }
+});


### PR DESCRIPTION
## Summary

- serialize parsed WebTransport URLs with the captured URL prototype method
- return a typed error if the native URL conversion receives an invalid value
- add a regression covering an overridden `URL.prototype.toString`

## Bug

The WebTransport constructor parses its URL up front, but the connection path later serialized that object through mutable prototype dispatch. An override could replace the serialized value with an invalid string, while the native connection op assumed parsing was infallible and unwrapped the result. Using the captured method preserves the parsed URL, and the native boundary now handles conversion failure without a process panic.

## Validation

- `./tools/format.js`
- `cargo fmt --check --package deno_net`
- `cargo check -p deno_net`
- `cargo build --bin deno`
- `cargo test -p specs_tests --test specs run::webtransport -- --nocapture`
