### PR TITLE
fix(ext/web): handle failed webtransport datagram setup

### DIFF
--- a/ext/web/webtransport.js
+++ b/ext/web/webtransport.js
@@ -695,7 +695,13 @@ class WebTransportDatagramDuplexStream {
   }
 
   async #receiveDatagrams() {
-    const { conn, sessionIdBuf } = await this.#promise;
+    let conn;
+    let sessionIdBuf;
+    try {
+      ({ conn, sessionIdBuf } = await this.#promise);
+    } catch {
+      return;
+    }
     while (true) {
       const queue = this.#incomingDatagramsQueue;
       const duration = this.#incomingMaxAge ?? Infinity;
@@ -741,9 +747,21 @@ class WebTransportDatagramDuplexStream {
   async #sendDatagrams() {
     if (this.#sending) return;
     this.#sending = true;
-    const { conn, sessionIdBuf } = await this.#promise;
 
     const queue = this.#outgoingDatagramsQueue;
+    let conn;
+    let sessionIdBuf;
+    try {
+      ({ conn, sessionIdBuf } = await this.#promise);
+    } catch (error) {
+      while (queue.length > 0) {
+        const { promise } = ArrayPrototypeShift(queue);
+        promise.reject(error);
+      }
+      this.#sending = false;
+      return;
+    }
+
     const duration = this.#outgoingMaxAge ?? Infinity;
     while (queue.length > 0) {
       const { bytes, timestamp, promise } = ArrayPrototypeShift(queue);
@@ -856,6 +874,13 @@ class WebTransportDatagramDuplexStream {
         start: (controller) => {
           PromisePrototypeThen(
             PromisePrototypeThen(this.#promise, ({ conn }) => conn.closed),
+            () => {
+              try {
+                controller.close();
+              } catch {
+                // nothing
+              }
+            },
             () => {
               try {
                 controller.close();

--- a/tests/specs/run/webtransport_failed_datagrams/__test__.jsonc
+++ b/tests/specs/run/webtransport_failed_datagrams/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run --quiet --unstable-net --allow-net main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/run/webtransport_failed_datagrams/main.out
+++ b/tests/specs/run/webtransport_failed_datagrams/main.out
@@ -1,0 +1,4 @@
+ready rejected WebTransportError
+read done true
+write rejected true
+survived

--- a/tests/specs/run/webtransport_failed_datagrams/main.ts
+++ b/tests/specs/run/webtransport_failed_datagrams/main.ts
@@ -1,0 +1,30 @@
+// Copyright 2018-2026 the Deno authors. All rights reserved. MIT license.
+
+const wt = new WebTransport("https://127.0.0.1:65535");
+
+const reader = wt.datagrams.readable.getReader();
+const read = reader.read();
+
+const writer = wt.datagrams.writable.getWriter();
+const writes = [];
+for (let i = 0; i < 5; i++) {
+  writes.push(writer.write(new Uint8Array([i])));
+}
+const writesSettled = Promise.allSettled(writes);
+
+await wt.ready.then(
+  () => console.log("ready unexpectedly resolved"),
+  (err) => console.log("ready rejected", err.name),
+);
+
+const readResult = await read;
+console.log("read done", readResult.done);
+
+const writeResults = await writesSettled;
+console.log(
+  "write rejected",
+  writeResults.some((result) => result.status === "rejected"),
+);
+
+await wt.closed;
+console.log("survived");


### PR DESCRIPTION
## Summary

- handle WebTransport connection failure in the internal datagram receive and send loops
- settle pending datagram reads and writes when setup does not complete
- add a regression covering handled setup failure and queued datagram operations

## Bug

WebTransport setup is shared by the public readiness promises and the internal datagram tasks. When setup failed, the receive loop, sender, and readable startup also observed the rejected connection promise without completing all of their own paths. An application could handle the public failure while internal rejections remained unhandled and pending datagram operations did not settle.

The datagram paths now close the readable side, reject queued writes, reset sender state, and return cleanly when connection setup fails.

## Validation

- `./tools/format.js`
- `cargo fmt --check --package deno_net`
- `cargo build --bin deno`
- `cargo test -p specs_tests --test specs run::webtransport_failed_datagrams -- --nocapture`
