### PR TITLE
fix(webtransport): validate certificate dates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ dependencies = [
  "tokio-vsock",
  "url",
  "web-transport-proto",
+ "x509-parser",
 ]
 
 [[package]]

--- a/ext/net/Cargo.toml
+++ b/ext/net/Cargo.toml
@@ -35,6 +35,7 @@ thiserror.workspace = true
 tokio.workspace = true
 url.workspace = true
 web-transport-proto.workspace = true
+x509-parser.workspace = true
 
 [target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))'.dependencies]
 tokio-vsock.workspace = true

--- a/ext/net/quic.rs
+++ b/ext/net/quic.rs
@@ -1096,6 +1096,8 @@ pub(crate) mod webtransport {
   use rustls::crypto::verify_tls13_signature;
   use sha2::Digest;
   use sha2::Sha256;
+  use x509_parser::prelude::FromDer;
+  use x509_parser::prelude::X509Certificate;
 
   use super::*;
 
@@ -1300,6 +1302,38 @@ pub(crate) mod webtransport {
     }
   }
 
+  fn verify_certificate_validity(
+    end_entity: &rustls::pki_types::CertificateDer<'_>,
+    now: rustls::pki_types::UnixTime,
+  ) -> Result<(), rustls::Error> {
+    let (remainder, certificate) =
+      X509Certificate::from_der(end_entity.as_ref()).map_err(|_| {
+        rustls::Error::InvalidCertificate(rustls::CertificateError::BadEncoding)
+      })?;
+    if !remainder.is_empty() {
+      return Err(rustls::Error::InvalidCertificate(
+        rustls::CertificateError::BadEncoding,
+      ));
+    }
+
+    let now = i64::try_from(now.as_secs()).map_err(|_| {
+      rustls::Error::InvalidCertificate(rustls::CertificateError::Expired)
+    })?;
+    let validity = certificate.validity();
+    if now < validity.not_before.timestamp() {
+      return Err(rustls::Error::InvalidCertificate(
+        rustls::CertificateError::NotValidYet,
+      ));
+    }
+    if now > validity.not_after.timestamp() {
+      return Err(rustls::Error::InvalidCertificate(
+        rustls::CertificateError::Expired,
+      ));
+    }
+
+    Ok(())
+  }
+
   impl ServerCertVerifier for ServerFingerprints {
     fn verify_server_cert(
       &self,
@@ -1307,7 +1341,7 @@ pub(crate) mod webtransport {
       _intermediates: &[rustls::pki_types::CertificateDer<'_>],
       _server_name: &rustls::pki_types::ServerName<'_>,
       _ocsp_response: &[u8],
-      _now: rustls::pki_types::UnixTime,
+      now: rustls::pki_types::UnixTime,
     ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
       let cert_hash = Sha256::digest(end_entity);
 
@@ -1316,6 +1350,7 @@ pub(crate) mod webtransport {
         .iter()
         .any(|fingerprint| fingerprint == cert_hash.as_slice())
       {
+        verify_certificate_validity(end_entity, now)?;
         return Ok(rustls::client::danger::ServerCertVerified::assertion());
       }
 
@@ -1359,6 +1394,52 @@ pub(crate) mod webtransport {
         .provider
         .signature_verification_algorithms
         .supported_schemes()
+    }
+  }
+
+  #[cfg(test)]
+  mod tests {
+    use rustls::client::danger::ServerCertVerifier;
+
+    use super::*;
+
+    static CERTIFICATE: &[u8] =
+      include_bytes!("../tls/testdata/example1_cert.der");
+
+    fn verify_at(
+      timestamp: i64,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+      let certificate = rustls::pki_types::CertificateDer::from(CERTIFICATE);
+      let fingerprint = Sha256::digest(CERTIFICATE).to_vec();
+      let verifier = ServerFingerprints::new(vec![fingerprint]);
+      let server_name =
+        rustls::pki_types::ServerName::try_from("example1.com").unwrap();
+      let now = rustls::pki_types::UnixTime::since_unix_epoch(
+        Duration::from_secs(timestamp.try_into().unwrap()),
+      );
+      verifier.verify_server_cert(&certificate, &[], &server_name, &[], now)
+    }
+
+    #[test]
+    fn fingerprint_certificate_must_be_currently_valid() {
+      let (_, certificate) = X509Certificate::from_der(CERTIFICATE).unwrap();
+      let validity = certificate.validity();
+      let not_before = validity.not_before.timestamp();
+      let not_after = validity.not_after.timestamp();
+
+      verify_at(not_before + (not_after - not_before) / 2).unwrap();
+      assert!(matches!(
+        verify_at(not_before - 1),
+        Err(rustls::Error::InvalidCertificate(
+          rustls::CertificateError::NotValidYet
+        ))
+      ));
+      assert!(matches!(
+        verify_at(not_after + 1),
+        Err(rustls::Error::InvalidCertificate(
+          rustls::CertificateError::Expired
+        ))
+      ));
     }
   }
 }


### PR DESCRIPTION
## Summary

- parse fingerprint-authenticated WebTransport certificates before accepting them
- reject matching certificates before `notBefore` or after `notAfter`
- add deterministic tests for valid, not-yet-valid, and expired certificate times

## Bug

The custom certificate verifier compared the configured SHA-256 fingerprints but ignored the verification time supplied by rustls. A certificate with a matching fingerprint was therefore accepted even when the current time was outside its encoded validity interval.

The verifier now parses the matching certificate and returns the corresponding rustls certificate error when its dates are not current.

## Validation

- `./tools/format.js`
- `cargo fmt --check --package deno_net`
- `cargo test -p deno_net fingerprint_certificate_must_be_currently_valid --lib`
- `cargo build --bin deno`
- existing fingerprint-authenticated WebTransport connection spec
