### PR TITLE
fix(core): bound error graph conversion

### DIFF
--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -1032,12 +1032,6 @@ impl JsError {
     // handles below.
     v8::scope!(let scope, scope);
 
-    if let Ok(exception_object) = exception.try_cast::<v8::Object>()
-      && seen.contains(&exception_object)
-    {
-      return Some(Self::circular_error_reference());
-    }
-
     let msg = v8::Exception::create_message(scope, exception);
 
     let mut exception_message = None;
@@ -1077,8 +1071,15 @@ impl JsError {
           "Uncaught".to_string()
         }
       });
+      // A cycle terminates by converting the repeated error one final time and
+      // dropping its `cause` and aggregate members. Formatters rely on that
+      // repeat: `find_recursive_cause` matches it against the earlier
+      // occurrence by value to label a cycle `<ref *n>` / `[Circular *n]`, so
+      // it cannot be replaced with a placeholder. `seen` is path-local, so an
+      // error reachable by several distinct paths is not mistaken for a cycle.
+      let is_repeat = seen.contains(&exception);
       let cause = cause.and_then(|cause| {
-        if cause.is_undefined() {
+        if cause.is_undefined() || is_repeat {
           None
         } else {
           let mut seen = seen.clone();
@@ -1193,7 +1194,7 @@ impl JsError {
       }
 
       let mut aggregated: Option<Vec<JsError>> = None;
-      if is_aggregate_error(scope, v8_exception) {
+      if is_aggregate_error(scope, v8_exception) && !is_repeat {
         // Read an array of stored errors, this is only defined for `AggregateError`
         let (aggregated_errors, errors_getter_failed) = {
           v8::tc_scope!(let tc_scope, scope);
@@ -1329,10 +1330,6 @@ impl JsError {
         stack_is_custom: false,
       })
     }
-  }
-
-  fn circular_error_reference() -> Self {
-    Self::conversion_placeholder("[Circular]")
   }
 
   fn error_conversion_limit() -> Self {
@@ -2601,7 +2598,10 @@ mod tests {
     let error = JsError::from_v8_exception(scope, exception.into());
     let aggregated = error.aggregated.as_ref().expect("aggregate errors");
     assert_eq!(aggregated.len(), 1);
-    assert_eq!(aggregated[0].exception_message, "Uncaught [Circular]");
+    // The cycle terminates by repeating the error once with its own members
+    // dropped, rather than recursing into itself forever.
+    assert_eq!(aggregated[0].exception_message, error.exception_message);
+    assert!(aggregated[0].aggregated.is_none());
   }
 
   #[cfg(not(miri))]
@@ -2624,7 +2624,8 @@ mod tests {
     let error = JsError::from_v8_exception(scope, exception.into());
     let second = &error.aggregated.as_ref().unwrap()[0];
     let repeated_first = &second.aggregated.as_ref().unwrap()[0];
-    assert_eq!(repeated_first.exception_message, "Uncaught [Circular]");
+    assert_eq!(repeated_first.exception_message, error.exception_message);
+    assert!(repeated_first.aggregated.is_none());
   }
 
   #[cfg(not(miri))]

--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -511,6 +511,51 @@ pub struct JsError {
   pub stack_is_custom: bool,
 }
 
+const MAX_ERROR_CONVERSION_DEPTH: usize = 32;
+const MAX_ERROR_CONVERSION_NODES: usize = 256;
+
+struct ErrorConversionState {
+  remaining_nodes: usize,
+  limit_marker_emitted: bool,
+}
+
+enum ErrorConversionStep {
+  Convert,
+  Truncate,
+  Omit,
+}
+
+impl ErrorConversionState {
+  fn new() -> Self {
+    Self {
+      remaining_nodes: MAX_ERROR_CONVERSION_NODES,
+      limit_marker_emitted: false,
+    }
+  }
+
+  fn enter(&mut self, depth: usize) -> ErrorConversionStep {
+    if depth < MAX_ERROR_CONVERSION_DEPTH && self.remaining_nodes > 0 {
+      self.remaining_nodes -= 1;
+      ErrorConversionStep::Convert
+    } else {
+      self.truncate()
+    }
+  }
+
+  fn is_exhausted(&self) -> bool {
+    self.remaining_nodes == 0
+  }
+
+  fn truncate(&mut self) -> ErrorConversionStep {
+    if !self.limit_marker_emitted {
+      self.limit_marker_emitted = true;
+      ErrorConversionStep::Truncate
+    } else {
+      ErrorConversionStep::Omit
+    }
+  }
+}
+
 impl JsErrorClass for JsError {
   fn get_class(&self) -> Cow<'static, str> {
     if let Some(name) = &self.name {
@@ -906,11 +951,17 @@ impl JsError {
     scope: &mut v8::PinScope<'s, 'i>,
     exception: v8::Local<'s, v8::Value>,
   ) -> Box<Self> {
-    Box::new(Self::inner_from_v8_exception(
-      scope,
-      exception,
-      Default::default(),
-    ))
+    let mut state = ErrorConversionState::new();
+    Box::new(
+      Self::inner_from_v8_exception(
+        scope,
+        exception,
+        Default::default(),
+        0,
+        &mut state,
+      )
+      .expect("the conversion budget includes the root exception"),
+    )
   }
 
   pub fn from_v8_message<'s, 'i>(
@@ -965,11 +1016,27 @@ impl JsError {
   fn inner_from_v8_exception<'s, 'i>(
     scope: &mut v8::PinScope<'s, 'i>,
     exception: v8::Local<'s, v8::Value>,
-    mut seen: HashSet<v8::Local<'s, v8::Object>>,
-  ) -> Self {
+    seen: HashSet<v8::Local<'s, v8::Object>>,
+    depth: usize,
+    state: &mut ErrorConversionState,
+  ) -> Option<Self> {
+    match state.enter(depth) {
+      ErrorConversionStep::Convert => {}
+      ErrorConversionStep::Truncate => {
+        return Some(Self::error_conversion_limit());
+      }
+      ErrorConversionStep::Omit => return None,
+    }
+
     // Create a new HandleScope because we're creating a lot of new local
     // handles below.
     v8::scope!(let scope, scope);
+
+    if let Ok(exception_object) = exception.try_cast::<v8::Object>()
+      && seen.contains(&exception_object)
+    {
+      return Some(Self::circular_error_reference());
+    }
 
     let msg = v8::Exception::create_message(scope, exception);
 
@@ -1011,13 +1078,13 @@ impl JsError {
         }
       });
       let cause = cause.and_then(|cause| {
-        if cause.is_undefined() || seen.contains(&exception) {
+        if cause.is_undefined() {
           None
         } else {
+          let mut seen = seen.clone();
           seen.insert(exception);
-          Some(Box::new(JsError::inner_from_v8_exception(
-            scope, cause, seen,
-          )))
+          JsError::inner_from_v8_exception(scope, cause, seen, depth + 1, state)
+            .map(Box::new)
         }
       });
 
@@ -1128,21 +1195,68 @@ impl JsError {
       let mut aggregated: Option<Vec<JsError>> = None;
       if is_aggregate_error(scope, v8_exception) {
         // Read an array of stored errors, this is only defined for `AggregateError`
-        let aggregated_errors =
-          get_property(scope, exception, v8_static_strings::ERRORS);
-        let aggregated_errors: Option<v8::Local<v8::Array>> =
-          aggregated_errors.and_then(|a| a.try_into().ok());
-
-        if let Some(errors) = aggregated_errors
-          && errors.length() > 0
-        {
-          let mut agg = vec![];
-          for i in 0..errors.length() {
-            let error = errors.get_index(scope, i).unwrap();
-            let js_error = Self::from_v8_exception(scope, error);
-            agg.push(*js_error);
+        let (aggregated_errors, errors_getter_failed) = {
+          v8::tc_scope!(let tc_scope, scope);
+          let aggregated_errors =
+            get_property(tc_scope, exception, v8_static_strings::ERRORS)
+              .and_then(|value| value.try_cast::<v8::Array>().ok())
+              .map(|errors| v8::Global::new(tc_scope, errors));
+          let errors_getter_failed = tc_scope.has_caught();
+          if errors_getter_failed {
+            tc_scope.reset();
           }
-          aggregated = Some(agg);
+          (aggregated_errors, errors_getter_failed)
+        };
+
+        if errors_getter_failed {
+          aggregated = Some(vec![Self::aggregate_element_unavailable()]);
+        } else if let Some(errors) = aggregated_errors {
+          let errors = v8::Local::new(scope, errors);
+          if errors.length() > 0 {
+            let mut seen = seen.clone();
+            seen.insert(exception);
+            let mut agg = vec![];
+            for i in 0..errors.length() {
+              if state.is_exhausted() {
+                if matches!(state.truncate(), ErrorConversionStep::Truncate) {
+                  agg.push(Self::error_conversion_limit());
+                }
+                break;
+              }
+
+              let (error, element_getter_failed) = {
+                v8::tc_scope!(let tc_scope, scope);
+                let error = errors
+                  .get_index(tc_scope, i)
+                  .map(|error| v8::Global::new(tc_scope, error));
+                let element_getter_failed = tc_scope.has_caught();
+                if element_getter_failed {
+                  tc_scope.reset();
+                }
+                (error, element_getter_failed)
+              };
+              if element_getter_failed {
+                agg.push(Self::aggregate_element_unavailable());
+                break;
+              }
+              let Some(error) = error else {
+                agg.push(Self::aggregate_element_unavailable());
+                break;
+              };
+              let error = v8::Local::new(scope, error);
+              let Some(js_error) = Self::inner_from_v8_exception(
+                scope,
+                error,
+                seen.clone(),
+                depth + 1,
+                state,
+              ) else {
+                break;
+              };
+              agg.push(js_error);
+            }
+            aggregated = Some(agg);
+          }
         }
       };
 
@@ -1182,7 +1296,7 @@ impl JsError {
         vec![]
       };
 
-      Self {
+      Some(Self {
         name: e.name,
         message: e.message,
         exception_message,
@@ -1194,14 +1308,14 @@ impl JsError {
         aggregated,
         additional_properties,
         stack_is_custom,
-      }
+      })
     } else {
       let exception_message = exception_message
         .unwrap_or_else(|| v8_to_rust_string(&msg.get(scope), scope));
       // The exception is not a JS Error object.
       // Get the message given by V8::Exception::create_message(), and provide
       // empty frames.
-      Self {
+      Some(Self {
         name: None,
         message: None,
         exception_message,
@@ -1213,7 +1327,35 @@ impl JsError {
         aggregated: None,
         additional_properties: vec![],
         stack_is_custom: false,
-      }
+      })
+    }
+  }
+
+  fn circular_error_reference() -> Self {
+    Self::conversion_placeholder("[Circular]")
+  }
+
+  fn error_conversion_limit() -> Self {
+    Self::conversion_placeholder("[Error details truncated]")
+  }
+
+  fn aggregate_element_unavailable() -> Self {
+    Self::conversion_placeholder("[Error details unavailable]")
+  }
+
+  fn conversion_placeholder(message: &str) -> Self {
+    Self {
+      name: None,
+      message: Some(message.to_string()),
+      exception_message: format!("Uncaught {message}"),
+      cause: None,
+      source_line: None,
+      source_line_frame_index: None,
+      frames: vec![],
+      stack: None,
+      aggregated: None,
+      additional_properties: vec![],
+      stack_is_custom: false,
     }
   }
 }
@@ -2439,6 +2581,207 @@ pub fn throw_invalid_this_error_one_byte<'s, 'i>(
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[cfg(not(miri))]
+  #[test]
+  fn test_js_error_from_v8_exception_handles_cyclic_aggregate_error() {
+    let mut runtime = JsRuntime::new(Default::default());
+    deno_core::scope!(scope, runtime);
+
+    let exception: v8::Local<v8::Object> = JsRuntime::eval(
+      scope,
+      r#"(() => {
+        const error = new AggregateError([], "boom");
+        error.errors.push(error);
+        return error;
+      })()"#,
+    )
+    .unwrap();
+
+    let error = JsError::from_v8_exception(scope, exception.into());
+    let aggregated = error.aggregated.as_ref().expect("aggregate errors");
+    assert_eq!(aggregated.len(), 1);
+    assert_eq!(aggregated[0].exception_message, "Uncaught [Circular]");
+  }
+
+  #[cfg(not(miri))]
+  #[test]
+  fn test_js_error_from_v8_exception_handles_crossed_aggregate_cycle() {
+    let mut runtime = JsRuntime::new(Default::default());
+    deno_core::scope!(scope, runtime);
+
+    let exception: v8::Local<v8::Object> = JsRuntime::eval(
+      scope,
+      r#"(() => {
+        const first = new AggregateError([], "first");
+        const second = new AggregateError([first], "second");
+        first.errors.push(second);
+        return first;
+      })()"#,
+    )
+    .unwrap();
+
+    let error = JsError::from_v8_exception(scope, exception.into());
+    let second = &error.aggregated.as_ref().unwrap()[0];
+    let repeated_first = &second.aggregated.as_ref().unwrap()[0];
+    assert_eq!(repeated_first.exception_message, "Uncaught [Circular]");
+  }
+
+  #[cfg(not(miri))]
+  #[test]
+  fn test_js_error_from_v8_exception_truncates_deep_cause_chain() {
+    let mut runtime = JsRuntime::new(Default::default());
+    deno_core::scope!(scope, runtime);
+
+    let exception: v8::Local<v8::Object> = JsRuntime::eval(
+      scope,
+      r#"(() => {
+        let error = new Error("0");
+        for (let i = 1; i < 100; i++) {
+          error = new Error(String(i), { cause: error });
+        }
+        return error;
+      })()"#,
+    )
+    .unwrap();
+
+    let error = JsError::from_v8_exception(scope, exception.into());
+    let mut current = Some(error.as_ref());
+    let mut found_truncated = false;
+    while let Some(error) = current {
+      if error.exception_message == "Uncaught [Error details truncated]" {
+        found_truncated = true;
+        break;
+      }
+      current = error.cause.as_deref();
+    }
+    assert!(found_truncated);
+  }
+
+  #[cfg(not(miri))]
+  #[test]
+  fn test_js_error_from_v8_exception_bounds_shared_aggregate_graph() {
+    let mut runtime = JsRuntime::new(Default::default());
+    deno_core::scope!(scope, runtime);
+
+    let exception: v8::Local<v8::Object> = JsRuntime::eval(
+      scope,
+      r#"(() => {
+        globalThis.aggregateElementReads = 0;
+        let error = new Error("leaf");
+        for (let i = 0; i < 20; i++) {
+          error = new AggregateError([error, error], String(i));
+          const child = error.errors[0];
+          Object.defineProperties(error.errors, {
+            0: {
+              get() {
+                globalThis.aggregateElementReads++;
+                return child;
+              },
+            },
+            1: {
+              get() {
+                globalThis.aggregateElementReads++;
+                return child;
+              },
+            },
+          });
+        }
+        return error;
+      })()"#,
+    )
+    .unwrap();
+
+    let error = JsError::from_v8_exception(scope, exception.into());
+    let mut pending = vec![error.as_ref()];
+    let mut converted_nodes = 0;
+    let mut truncated_nodes = 0;
+    while let Some(error) = pending.pop() {
+      converted_nodes += 1;
+      if error.exception_message == "Uncaught [Error details truncated]" {
+        truncated_nodes += 1;
+      }
+      if let Some(cause) = error.cause.as_deref() {
+        pending.push(cause);
+      }
+      if let Some(aggregated) = &error.aggregated {
+        pending.extend(aggregated);
+      }
+    }
+
+    assert_eq!(truncated_nodes, 1);
+    assert!(converted_nodes <= MAX_ERROR_CONVERSION_NODES + 1);
+    let element_reads: v8::Local<v8::Integer> =
+      JsRuntime::eval(scope, "globalThis.aggregateElementReads").unwrap();
+    assert!(element_reads.value() as usize <= MAX_ERROR_CONVERSION_NODES);
+  }
+
+  #[cfg(not(miri))]
+  #[test]
+  fn test_js_error_from_v8_exception_handles_throwing_aggregate_element() {
+    let mut runtime = JsRuntime::new(Default::default());
+    deno_core::scope!(scope, runtime);
+
+    let exception: v8::Local<v8::Object> = JsRuntime::eval(
+      scope,
+      r#"(() => {
+        const error = new AggregateError([new Error("inner")], "outer");
+        Object.defineProperty(error.errors, 0, {
+          get() {
+            throw new Error("element getter failed");
+          },
+        });
+        return error;
+      })()"#,
+    )
+    .unwrap();
+
+    let error = JsError::from_v8_exception(scope, exception.into());
+    let aggregated = error.aggregated.as_ref().expect("aggregate errors");
+    assert_eq!(aggregated.len(), 1);
+    assert_eq!(
+      aggregated[0].exception_message,
+      "Uncaught [Error details unavailable]"
+    );
+
+    let result: v8::Local<v8::Integer> =
+      JsRuntime::eval(scope, "1 + 1").expect("exception was contained");
+    assert_eq!(result.value(), 2);
+  }
+
+  #[cfg(not(miri))]
+  #[test]
+  fn test_js_error_from_v8_exception_handles_throwing_aggregate_errors_getter()
+  {
+    let mut runtime = JsRuntime::new(Default::default());
+    deno_core::scope!(scope, runtime);
+
+    let exception: v8::Local<v8::Object> = JsRuntime::eval(
+      scope,
+      r#"(() => {
+        const error = new AggregateError([], "outer");
+        Object.defineProperty(error, "errors", {
+          get() {
+            throw new Error("errors getter failed");
+          },
+        });
+        return error;
+      })()"#,
+    )
+    .unwrap();
+
+    let error = JsError::from_v8_exception(scope, exception.into());
+    let aggregated = error.aggregated.as_ref().expect("aggregate errors");
+    assert_eq!(aggregated.len(), 1);
+    assert_eq!(
+      aggregated[0].exception_message,
+      "Uncaught [Error details unavailable]"
+    );
+
+    let result: v8::Local<v8::Integer> =
+      JsRuntime::eval(scope, "1 + 1").expect("exception was contained");
+    assert_eq!(result.value(), 2);
+  }
 
   #[test]
   fn test_format_file_name() {

--- a/runtime/fmt_errors.rs
+++ b/runtime/fmt_errors.rs
@@ -31,6 +31,8 @@ pub static PROTO_SET_ATTEMPTED: AtomicBool = AtomicBool::new(false);
 /// Written by `op_proto_get_attempted`, read by `get_suggestions_for_terminal_errors`.
 pub static PROTO_GET_ATTEMPTED: AtomicBool = AtomicBool::new(false);
 
+const MAX_FORMAT_ERROR_DEPTH: usize = 64;
+
 #[derive(Debug, Clone)]
 struct ErrorReference<'a> {
   from: &'a JsError,
@@ -176,11 +178,13 @@ fn format_maybe_source_line(
 }
 
 fn find_recursive_cause(js_error: &JsError) -> Option<ErrorReference<'_>> {
-  let mut history = Vec::<&JsError>::new();
+  let mut history = Vec::<&JsError>::with_capacity(MAX_FORMAT_ERROR_DEPTH);
 
   let mut current_error: &JsError = js_error;
 
-  while let Some(cause) = &current_error.cause {
+  while history.len() < MAX_FORMAT_ERROR_DEPTH
+    && let Some(cause) = &current_error.cause
+  {
     history.push(current_error);
 
     if let Some(seen) = history.iter().find(|&el| cause.is_same_error(el)) {
@@ -201,6 +205,7 @@ fn format_aggregated_error(
   circular_reference_index: usize,
   initial_cwd: Option<&Url>,
   filter_frames: bool,
+  depth: usize,
 ) -> String {
   let mut s = String::new();
   let mut nested_circular_reference_index = circular_reference_index;
@@ -220,6 +225,7 @@ fn format_aggregated_error(
       filter_frames,
       vec![],
       initial_cwd,
+      depth + 1,
     );
 
     for line in error_string.trim_start_matches("Uncaught ").lines() {
@@ -247,7 +253,12 @@ fn format_js_error_inner(
   filter_frames: bool,
   suggestions: Vec<FixSuggestion>,
   initial_cwd: Option<&Url>,
+  depth: usize,
 ) -> String {
+  if depth >= MAX_FORMAT_ERROR_DEPTH {
+    return colors::cyan("[Error details truncated]").to_string();
+  }
+
   let mut s = String::new();
 
   s.push_str(&js_error.exception_message);
@@ -268,6 +279,7 @@ fn format_js_error_inner(
         .unwrap_or(0),
       initial_cwd,
       filter_frames,
+      depth,
     );
     s.push_str(&aggregated_message);
   }
@@ -330,7 +342,15 @@ fn format_js_error_inner(
       colors::cyan(format!("[Circular *{}]", circular.unwrap().index))
         .to_string()
     } else {
-      format_js_error_inner(cause, circular, false, false, vec![], initial_cwd)
+      format_js_error_inner(
+        cause,
+        circular,
+        false,
+        false,
+        vec![],
+        initial_cwd,
+        depth + 1,
+      )
     };
 
     write!(
@@ -424,6 +444,17 @@ fn error_mentions_proto(e: &JsError) -> bool {
 }
 
 fn get_message_suggestions(e: &JsError) -> Vec<FixSuggestion<'_>> {
+  get_message_suggestions_inner(e, 0)
+}
+
+fn get_message_suggestions_inner(
+  e: &JsError,
+  depth: usize,
+) -> Vec<FixSuggestion<'_>> {
+  if depth >= MAX_FORMAT_ERROR_DEPTH {
+    return vec![];
+  }
+
   if let Some(msg) = &e.message {
     if msg.contains("module is not defined")
       || msg.contains("exports is not defined")
@@ -652,7 +683,7 @@ fn get_message_suggestions(e: &JsError) -> Vec<FixSuggestion<'_>> {
   // `TypeError: fetch failed` with the underlying error (such as a TLS
   // certificate failure) in `.cause`.
   if let Some(cause) = &e.cause {
-    return get_message_suggestions(cause);
+    return get_message_suggestions_inner(cause, depth + 1);
   }
 
   vec![]
@@ -679,6 +710,7 @@ pub fn format_js_error(
     *SHOULD_FILTER_FRAMES,
     suggestions,
     initial_cwd,
+    0,
   )
 }
 
@@ -687,6 +719,22 @@ mod tests {
   use test_util::strip_ansi_codes;
 
   use super::*;
+
+  fn js_error_with_cause(message: String, cause: Option<JsError>) -> JsError {
+    JsError {
+      name: Some("Error".to_string()),
+      message: Some(message.clone()),
+      stack: None,
+      cause: cause.map(Box::new),
+      exception_message: format!("Uncaught Error: {message}"),
+      frames: vec![],
+      source_line: None,
+      source_line_frame_index: None,
+      aggregated: None,
+      additional_properties: vec![],
+      stack_is_custom: false,
+    }
+  }
 
   #[test]
   fn test_format_none_source_line() {
@@ -702,5 +750,17 @@ mod tests {
       strip_ansi_codes(&actual),
       "\nconsole.log(\'foo\');\n        ^"
     );
+  }
+
+  #[test]
+  fn test_format_js_error_truncates_deep_cause_chain() {
+    let mut error = js_error_with_cause("0".to_string(), None);
+    for i in 1..(MAX_FORMAT_ERROR_DEPTH + 5) {
+      error = js_error_with_cause(i.to_string(), Some(error));
+    }
+
+    let formatted = format_js_error(&error, None);
+    let formatted = strip_ansi_codes(&formatted);
+    assert!(formatted.contains("[Error details truncated]"));
   }
 }

--- a/tests/specs/run/error_cause_recursive_aggregate_self/__test__.jsonc
+++ b/tests/specs/run/error_cause_recursive_aggregate_self/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run error_cause_recursive_aggregate_self.ts",
+  "output": "error_cause_recursive_aggregate_self.ts.out",
+  "exitCode": 1
+}

--- a/tests/specs/run/error_cause_recursive_aggregate_self/error_cause_recursive_aggregate_self.ts
+++ b/tests/specs/run/error_cause_recursive_aggregate_self/error_cause_recursive_aggregate_self.ts
@@ -1,0 +1,5 @@
+// An `AggregateError` listed among its own `errors` used to make error
+// conversion recurse until the stack overflowed.
+const error = new AggregateError([], "boom");
+error.errors.push(error);
+throw error;

--- a/tests/specs/run/error_cause_recursive_aggregate_self/error_cause_recursive_aggregate_self.ts.out
+++ b/tests/specs/run/error_cause_recursive_aggregate_self/error_cause_recursive_aggregate_self.ts.out
@@ -1,0 +1,6 @@
+error: Uncaught (in promise) AggregateError: boom
+    AggregateError: boom
+        at file:///[WILDCARD]/error_cause_recursive_aggregate_self.ts:3:15
+const error = new AggregateError([], "boom");
+              ^
+    at file:///[WILDCARD]/error_cause_recursive_aggregate_self.ts:3:15


### PR DESCRIPTION
## Summary

- preserve cycle tracking while converting nested error causes and aggregate members
- cap error conversion by both path depth and a shared node budget
- contain failed aggregate property reads and bound recursive terminal formatting
- add regressions for cycles, deep chains, shared graphs, and throwing getters

## Bug

Deno converts JavaScript exceptions into a native `JsError` tree before formatting them. Aggregate members previously restarted conversion with a fresh cycle set, so a self-reference could recurse indefinitely. Deep cause chains also had no native recursion bound, and compact graphs containing the same child on multiple branches could cause conversion work to grow much faster than the input graph.

The converter now retains path-local cycle state, limits each path to 32 levels, and shares a 256-node budget across the complete conversion. It emits a single truncation marker when either limit is reached. Reads of `AggregateError.errors` and its elements are contained so a throwing getter produces an unavailable-details marker instead of disrupting conversion. The terminal formatter and its cause-chain prepasses have their own depth bound for manually constructed `JsError` values.

## Validation

- `./tools/format.js`
- `cargo fmt --check --package deno_core --package deno_runtime`
- 6 focused `deno_core` error-conversion tests
- `cargo test -p deno_runtime test_format_js_error_truncates_deep_cause_chain --lib`
- `cargo check -p deno_core -p deno_runtime`
- `cargo build --bin deno`
- behavior smokes for a cyclic aggregate, a throwing `errors` getter, and a 100-level cause chain
