### PR TITLE
fix(http): preserve trust proxy environment setting

### DIFF
--- a/ext/http/service.rs
+++ b/ext/http/service.rs
@@ -805,16 +805,9 @@ impl Drop for HttpRecord {
 pub(crate) fn trust_proxy_headers() -> bool {
   static TRUST_PROXY_HEADERS: OnceLock<bool> = OnceLock::new();
 
-  static VAR_NAME: &str = "DENO_TRUST_PROXY_HEADERS";
-
   *TRUST_PROXY_HEADERS.get_or_init(|| {
-    if let Some(v) = std::env::var_os(VAR_NAME) {
-      // SAFETY: called once during single-threaded init via OnceLock
-      unsafe { std::env::remove_var(VAR_NAME) };
-      v == "1"
-    } else {
-      false
-    }
+    std::env::var_os("DENO_TRUST_PROXY_HEADERS")
+      .is_some_and(|value| value == "1")
   })
 }
 

--- a/tests/specs/serve/trust_proxy_headers/main.out
+++ b/tests/specs/serve/trust_proxy_headers/main.out
@@ -1,4 +1,5 @@
 remoteAddr: {"transport":"tcp","hostname":"10.1.2.3","port":4567}
 header visible: false
+environment after first request: 1
 remoteAddr: {"transport":"tcp","hostname":"10.1.2.3","port":4567}
 header visible: false

--- a/tests/specs/serve/trust_proxy_headers/main.ts
+++ b/tests/specs/serve/trust_proxy_headers/main.ts
@@ -17,6 +17,10 @@ const res = await fetch(`http://127.0.0.1:${server.addr.port}/`, {
   headers: { "x-deno-client-address": "10.1.2.3:4567" },
 });
 await res.body?.cancel();
+console.log(
+  "environment after first request:",
+  Deno.env.get("DENO_TRUST_PROXY_HEADERS"),
+);
 
 // A request with a body exercises the streaming/prebuffered raw record
 // construction paths as well.


### PR DESCRIPTION
## Summary

- keep `DENO_TRUST_PROXY_HEADERS` in the process environment after caching its value
- extend the existing serve spec to cover the setting after the first request

## Details

`trust_proxy_headers()` initializes its cached configuration when the first request is handled. That initialization also removed the environment variable, so reading the configuration had an unexpected process-wide side effect after startup.

This keeps the existing cached behavior while leaving the process environment unchanged.

## Validation

- `./tools/format.js`
- `cargo check -p deno_http`
- `cargo build --bin deno`
- `cargo test -p specs_tests --test specs -- trust_proxy_headers`
