### PR TITLE
fix(ext/napi): scope callback info per invocation

### DIFF
--- a/ext/napi/function.rs
+++ b/ext/napi/function.rs
@@ -7,6 +7,12 @@ pub struct CallbackInfo {
   pub env: *mut Env,
   pub cb: napi_callback,
   pub data: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct CallbackInfoScope {
+  pub function_info: *const CallbackInfo,
   pub args: *const c_void,
 }
 
@@ -17,20 +23,16 @@ impl CallbackInfo {
     cb: napi_callback,
     data: *mut c_void,
   ) -> *mut Self {
-    Box::into_raw(Box::new(Self {
-      env,
-      cb,
-      data,
-      args: std::ptr::null(),
-    }))
+    Box::into_raw(Box::new(Self { env, cb, data }))
   }
 }
 
 extern "C" fn call_fn(info: *const v8::FunctionCallbackInfo) {
-  let callback_info = unsafe { &*info };
-  let args =
-    v8::FunctionCallbackArguments::from_function_callback_info(callback_info);
-  let mut rv = v8::ReturnValue::from_function_callback_info(callback_info);
+  let v8_callback_info = unsafe { &*info };
+  let args = v8::FunctionCallbackArguments::from_function_callback_info(
+    v8_callback_info,
+  );
+  let mut rv = v8::ReturnValue::from_function_callback_info(v8_callback_info);
   // SAFETY: create_function guarantees that the data is a CallbackInfo external.
   let info_ptr: *mut CallbackInfo = unsafe {
     let external_value = v8::Local::<v8::External>::cast_unchecked(args.data());
@@ -38,13 +40,21 @@ extern "C" fn call_fn(info: *const v8::FunctionCallbackInfo) {
   };
 
   // SAFETY: pointer from Box::into_raw.
-  let info = unsafe { &mut *info_ptr };
-  info.args = &args as *const _ as *const c_void;
+  let info = unsafe { &*info_ptr };
+  let mut callback_info_scope = CallbackInfoScope {
+    function_info: info_ptr,
+    args: &args as *const _ as *const c_void,
+  };
 
   // SAFETY: calling user provided function pointer.
-  let value = unsafe { (info.cb)(info.env as napi_env, info_ptr as *mut _) };
+  let value = unsafe {
+    (info.cb)(
+      info.env as napi_env,
+      &mut callback_info_scope as *mut _ as *mut c_void,
+    )
+  };
   if let Some(exc) = unsafe { &mut *info.env }.last_exception.take() {
-    v8::callback_scope!(unsafe scope, callback_info);
+    v8::callback_scope!(unsafe scope, v8_callback_info);
     let exc = v8::Local::new(scope, exc);
     scope.throw_exception(exc);
   }

--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -21,6 +21,7 @@ use super::util::v8_name_from_property_descriptor;
 use crate::check_arg;
 use crate::check_env;
 use crate::function::CallbackInfo;
+use crate::function::CallbackInfoScope;
 use crate::function::create_function;
 use crate::function::create_function_template;
 use crate::*;
@@ -2047,7 +2048,9 @@ fn napi_get_cb_info(
   let env = check_env!(env);
   check_arg!(env, cbinfo);
 
-  let cbinfo: &CallbackInfo = unsafe { &*(cbinfo as *const CallbackInfo) };
+  let cbinfo: &CallbackInfoScope =
+    unsafe { &*(cbinfo as *const CallbackInfoScope) };
+  let function_info: &CallbackInfo = unsafe { &*cbinfo.function_info };
   let args = unsafe { &*(cbinfo.args as *const v8::FunctionCallbackArguments) };
 
   if !argv.is_null() {
@@ -2075,7 +2078,7 @@ fn napi_get_cb_info(
 
   if !data.is_null() {
     unsafe {
-      *data = cbinfo.data;
+      *data = function_info.data;
     }
   }
 
@@ -2093,7 +2096,8 @@ fn napi_get_new_target(
   check_arg!(env, cbinfo);
   check_arg!(env, result);
 
-  let cbinfo: &CallbackInfo = unsafe { &*(cbinfo as *const CallbackInfo) };
+  let cbinfo: &CallbackInfoScope =
+    unsafe { &*(cbinfo as *const CallbackInfoScope) };
   let args = unsafe { &*(cbinfo.args as *const v8::FunctionCallbackArguments) };
 
   unsafe {

--- a/tests/napi/callback_test.js
+++ b/tests/napi/callback_test.js
@@ -45,3 +45,19 @@ Deno.test("napi callback handles errors correctly", function () {
     });
   }, e);
 });
+
+Deno.test("napi callback info remains scoped during reentrant calls", function () {
+  let reentered = false;
+  const result = callback.test_callback_info_reentrant(() => {
+    if (!reentered) {
+      reentered = true;
+      assertEquals(
+        callback.test_callback_info_reentrant(() => {}, "inner"),
+        true,
+      );
+    }
+  }, "outer");
+
+  assertEquals(result, true);
+  assertEquals(reentered, true);
+});

--- a/tests/napi/src/callback.rs
+++ b/tests/napi/src/callback.rs
@@ -129,6 +129,49 @@ extern "C" fn test_callback_throws(
   result
 }
 
+extern "C" fn test_callback_info_reentrant(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  let (args, argc, _) = napi_get_callback_info!(env, info, 2);
+  assert_eq!(argc, 2);
+
+  let mut ty = -1;
+  assert_napi_ok!(napi_typeof(env, args[0], &mut ty));
+  assert_eq!(ty, napi_function);
+
+  let outer_marker = args[1];
+
+  let mut global: napi_value = ptr::null_mut();
+  assert_napi_ok!(napi_get_global(env, &mut global));
+
+  let mut result: napi_value = ptr::null_mut();
+  assert_napi_ok!(napi_call_function(
+    env,
+    global,
+    args[0],
+    0,
+    ptr::null(),
+    &mut result,
+  ));
+
+  let (args_after_reentry, argc_after_reentry, _) =
+    napi_get_callback_info!(env, info, 2);
+  assert_eq!(argc_after_reentry, 2);
+
+  let mut same_marker = false;
+  assert_napi_ok!(napi_strict_equals(
+    env,
+    outer_marker,
+    args_after_reentry[1],
+    &mut same_marker,
+  ));
+
+  let mut result: napi_value = ptr::null_mut();
+  assert_napi_ok!(napi_get_boolean(env, same_marker, &mut result));
+  result
+}
+
 pub fn init(env: napi_env, exports: napi_value) {
   let properties = &[
     napi_new_property!(env, "test_callback_run", test_callback_run),
@@ -138,6 +181,11 @@ pub fn init(env: napi_env, exports: napi_value) {
       test_callback_run_with_recv
     ),
     napi_new_property!(env, "test_callback_throws", test_callback_throws),
+    napi_new_property!(
+      env,
+      "test_callback_info_reentrant",
+      test_callback_info_reentrant
+    ),
   ];
 
   assert_napi_ok!(napi_define_properties(


### PR DESCRIPTION
## Summary

- keep N-API function metadata immutable across callback invocations
- store V8 callback arguments in invocation-local state
- cover synchronous re-entry into the same exported callback

## Problem

N-API functions stored the current V8 callback arguments in metadata shared by every invocation of that function. If a callback synchronously re-entered the same exported function, the inner call replaced that pointer. The outer callback could then observe the inner call's arguments or state from an invocation that had already returned.

This change passes a separate callback-info object to each invocation while retaining the function's environment, callback, and user data in stable metadata.

## Validation

- `./tools/format.js`
- `cargo check -p deno_napi`
- `cargo build -p test_napi`
- `cargo build --bin deno`
- focused re-entrant callback-info test
- complete `tests/napi/callback_test.js`
