### PR TITLE
fix(ext/napi): cancel async sends after close

### DIFF
--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -140,6 +140,7 @@ struct uv_async_t {
   // private
   async_cb: uv_async_cb,
   work: napi_async_work,
+  state: *const UvAsyncState,
   refed: bool,
   _padding: [MaybeUninit<usize>; const {
     (UV_ASYNC_SIZE
@@ -148,6 +149,7 @@ struct uv_async_t {
       - size_of::<uv_handle_type>()
       - size_of::<uv_async_cb>()
       - size_of::<napi_async_work>()
+      - size_of::<*const UvAsyncState>()
       - size_of::<bool>()
       - size_of::<usize>())
       / size_of::<usize>()
@@ -166,6 +168,7 @@ struct uv_async_t {
   // private
   async_cb: uv_async_cb,
   work: napi_async_work,
+  state: *const UvAsyncState,
   refed: bool,
   _async_padding: [MaybeUninit<usize>; 2],
   _padding: [MaybeUninit<usize>; const {
@@ -173,13 +176,36 @@ struct uv_async_t {
       - 112
       - size_of::<uv_async_cb>()
       - size_of::<napi_async_work>()
+      - size_of::<*const UvAsyncState>()
       - size_of::<bool>())
       / size_of::<usize>()
   }],
 }
 
+struct UvAsyncState {
+  closing: AtomicBool,
+}
+
 type uv_loop_t = Env;
 type uv_async_cb = extern "C" fn(handle: *mut uv_async_t);
+
+unsafe fn clone_uv_async_state(
+  handle: *const uv_async_t,
+) -> Option<Arc<UvAsyncState>> {
+  unsafe {
+    if handle.is_null() {
+      return None;
+    }
+    let state = (*handle).state;
+    if state.is_null() {
+      return None;
+    }
+
+    Arc::increment_strong_count(state);
+    Some(Arc::from_raw(state))
+  }
+}
+
 #[unsafe(export_name = "uv_async_init")]
 unsafe extern "C" fn _napi_uv_async_init(
   r#loop: *mut uv_loop_t,
@@ -192,6 +218,11 @@ unsafe extern "C" fn _napi_uv_async_init(
     addr_of_mut!((*r#async).r#type).write(uv_handle_type::UV_ASYNC);
     addr_of_mut!((*r#async).async_cb).write(async_cb);
     addr_of_mut!((*r#async).refed).write(true);
+    addr_of_mut!((*r#async).state).write(Arc::into_raw(Arc::new(
+      UvAsyncState {
+        closing: AtomicBool::new(false),
+      },
+    )));
 
     let mut resource_name: MaybeUninit<napi_value> = MaybeUninit::uninit();
     assert_ok(napi_create_string_utf8(
@@ -227,9 +258,19 @@ unsafe extern "C" fn uv_async_send(handle: *mut uv_async_t) -> c_int {
   // runs `execute` on a worker thread), uv_async callbacks need V8 access so
   // they must run on the main thread.
   unsafe {
+    let Some(state) = clone_uv_async_state(handle) else {
+      return 0;
+    };
+    if state.closing.load(Ordering::Acquire) {
+      return 0;
+    }
+
     let env = &mut *(*handle).r#loop;
     let handle = SendPtr(handle as *const uv_async_t);
     env.async_work_sender.spawn(move |_| {
+      if state.closing.load(Ordering::Acquire) {
+        return;
+      }
       let handle = handle.take() as *mut uv_async_t;
       ((*handle).async_cb)(handle);
     });
@@ -254,13 +295,38 @@ unsafe extern "C" fn _napi_uv_close(
     match (*handle).r#type {
       uv_handle_type::UV_ASYNC => {
         let handle: *mut uv_async_t = handle.cast();
+        let Some(state) = clone_uv_async_state(handle) else {
+          return;
+        };
+        if state.closing.swap(true, Ordering::AcqRel) {
+          return;
+        }
+
         napi_delete_async_work((*handle).r#loop, (*handle).work);
-        // Unref the event loop to match the ref in uv_async_init.
+        // Unref the event loop to match the ref in uv_async_init, but keep a
+        // temporary ref for the deferred close callback below.
+        let env = &mut *(*handle).r#loop;
+        let tracker = env.external_ops_tracker.clone();
+        tracker.ref_op();
         if (*handle).refed {
-          let env = &mut *(*handle).r#loop;
-          env.external_ops_tracker.unref_op();
+          tracker.unref_op();
           (*handle).refed = false;
         }
+        let state_ptr = SendPtr((*handle).state);
+        let handle =
+          SendPtr(handle.cast::<uv_handle_t>() as *const uv_handle_t);
+        env.async_work_sender.spawn(move |_| {
+          let handle = handle.take() as *mut uv_handle_t;
+          if let Some(close) = close {
+            close(handle);
+          }
+          let state_ptr = state_ptr.take();
+          if !state_ptr.is_null() {
+            drop(Arc::from_raw(state_ptr));
+          }
+          tracker.unref_op();
+        });
+        return;
       }
       uv_handle_type::UV_TIMER => {
         let handle: *mut uv_timer_t = handle.cast();
@@ -982,8 +1048,21 @@ unsafe extern "C" fn uv_default_loop() -> *mut uv_loop_t {
 }
 
 #[unsafe(no_mangle)]
-unsafe extern "C" fn uv_is_closing(_handle: *const uv_handle_t) -> c_int {
-  0
+unsafe extern "C" fn uv_is_closing(handle: *const uv_handle_t) -> c_int {
+  if handle.is_null() {
+    return 0;
+  }
+  unsafe {
+    match (*handle).r#type {
+      uv_handle_type::UV_ASYNC => {
+        let Some(state) = clone_uv_async_state(handle.cast()) else {
+          return 0;
+        };
+        state.closing.load(Ordering::Acquire) as c_int
+      }
+      _ => 0,
+    }
+  }
 }
 
 #[unsafe(no_mangle)]
@@ -1548,6 +1627,12 @@ unsafe extern "C" fn uv_cond_timedwait(
 unsafe extern "C" fn async_exec_wrap(_env: napi_env, data: *mut c_void) {
   let data: *mut uv_async_t = data.cast();
   unsafe {
+    let Some(state) = clone_uv_async_state(data) else {
+      return;
+    };
+    if state.closing.load(Ordering::Acquire) {
+      return;
+    }
     ((*data).async_cb)(data);
   }
 }

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -276,6 +276,80 @@ extern "C" fn test_uv_async_ref(
   ptr::null_mut()
 }
 
+struct CloseAfterSendAsync {
+  env: napi_env,
+  callback: napi_ref,
+}
+
+unsafe extern "C" fn close_after_send_async_cb(_handle: *mut uv_async_t) {
+  // This callback must not run once uv_close has marked the handle closing.
+  // If it does, the queued callback retained and dereferenced a stale
+  // addon-owned uv_async_t after the close callback was allowed to free it.
+  std::process::abort();
+}
+
+unsafe extern "C" fn close_after_send_close_cb(handle: *mut uv_handle_t) {
+  unsafe {
+    let handle = handle.cast::<uv_async_t>();
+    let async_ = (*handle).data as *mut CloseAfterSendAsync;
+    let env = (*async_).env;
+    let mut js_cb = null_mut();
+    assert_napi_ok!(napi_get_reference_value(
+      env,
+      (*async_).callback,
+      &mut js_cb
+    ));
+    let mut global: napi_value = ptr::null_mut();
+    assert_napi_ok!(napi_get_global(env, &mut global));
+
+    let mut result: napi_value = ptr::null_mut();
+    assert_napi_ok!(napi_call_function(
+      env,
+      global,
+      js_cb,
+      0,
+      ptr::null(),
+      &mut result,
+    ));
+    assert_napi_ok!(napi_delete_reference(env, (*async_).callback));
+    let _ = Box::from_raw(async_);
+    let _ = Box::from_raw(handle);
+  }
+}
+
+#[allow(unused_unsafe, reason = "napi_sys safe fn in unsafe extern blocks")]
+extern "C" fn test_uv_async_close_after_send(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  let (args, argc, _) = napi_get_callback_info!(env, info, 1);
+  assert_eq!(argc, 1);
+
+  let mut loop_ = null_mut();
+  assert_napi_ok!(napi_get_uv_event_loop(env, &mut loop_));
+  let uv_async = new_raw(MaybeUninit::<uv_async_t>::uninit());
+  let uv_async = uv_async.cast::<uv_async_t>();
+  let mut js_cb = null_mut();
+  assert_napi_ok!(napi_create_reference(env, args[0], 1, &mut js_cb));
+
+  let data = new_raw(CloseAfterSendAsync {
+    env,
+    callback: js_cb,
+  });
+  unsafe {
+    addr_of_mut!((*uv_async).data).write(data.cast());
+    assert_napi_ok!(uv_async_init(
+      loop_.cast(),
+      uv_async,
+      Some(close_after_send_async_cb),
+    ));
+    assert_napi_ok!(libuv_sys_lite::uv_async_send(uv_async));
+    uv_close(uv_async.cast(), Some(close_after_send_close_cb));
+  }
+
+  ptr::null_mut()
+}
+
 // Smoke test for the new uv polyfills (uv_hrtime, uv_timer_*, uv_cpu_info,
 // uv_handle_*, uv_default_loop, uv_is_active/closing, uv_ref/unref). The
 // goal is to verify that the symbols are exported from the host binary and
@@ -937,6 +1011,11 @@ pub fn init(env: napi_env, exports: napi_value) {
   let properties = &[
     napi_new_property!(env, "test_uv_async", test_uv_async),
     napi_new_property!(env, "test_uv_async_ref", test_uv_async_ref),
+    napi_new_property!(
+      env,
+      "test_uv_async_close_after_send",
+      test_uv_async_close_after_send
+    ),
     napi_new_property!(env, "test_uv_polyfills", test_uv_polyfills),
     napi_new_property!(env, "test_uv_timer_fires", test_uv_timer_fires),
     napi_new_property!(env, "test_uv_loop_helpers", test_uv_loop_helpers),

--- a/tests/napi/uv_test.js
+++ b/tests/napi/uv_test.js
@@ -35,6 +35,21 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "napi uv async close cancels pending send",
+  fn: async () => {
+    let closed = false;
+    await new Promise((resolve) => {
+      uv.test_uv_async_close_after_send(() => {
+        closed = true;
+        resolve();
+      });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(closed, true);
+  },
+});
+
 // Exercises the uv polyfills added for native addons that link directly
 // against libuv (e.g. @sentry/profiling-node). The Rust side asserts that
 // uv_hrtime, uv_timer_*, uv_cpu_info, uv_handle_*, uv_default_loop,


### PR DESCRIPTION
## Summary

- track `uv_async_t` close state in its private ABI storage
- skip queued async callbacks once close has begun
- defer the close callback until pending runtime tasks can observe cancellation

## Problem

`uv_async_send()` queued a runtime callback that retained the addon-owned handle pointer. The `UV_ASYNC` close path then invoked the close callback synchronously, even though that callback is allowed to release the handle. A previously queued send could consequently run after close and access a handle that was no longer valid.

This change gives each async handle private ref-counted close state. Pending sends retain that state and check it before touching the handle, while the close callback runs from the runtime queue after close has marked the handle.

## Validation

- `./tools/format.js`
- `cargo test -p deno_napi sizes --lib`
- `cargo check -p test_napi`
- `cargo build -p test_napi`
- `cargo build --bin deno`
- focused async send/close regression
- complete `tests/napi/uv_test.js`
