### PR TITLE
fix(napi): synchronize external string finalizers

### DIFF
--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -1454,8 +1454,16 @@ fn queue_external_string_finalizer(key: ExternalStringKey) {
 }
 
 /// Stop delivering non-null Env pointers for an environment being torn down.
-/// Resources already disposed by V8 are finalized immediately; still-live
-/// resources receive a null Env when V8 disposes them later.
+/// Resources already disposed by V8 are finalized immediately with the Env
+/// they were registered with; still-live resources receive a null Env when V8
+/// disposes them later.
+///
+/// Non-ready entries stay in the registry rather than being swept: their
+/// buffers still back a live V8 string, so calling their finalizers here would
+/// free memory V8 is still reading. They are reclaimed when the isolate is
+/// disposed, which fires the destructors that drain them through
+/// `queue_external_string_finalizer`. If the isolate is never disposed the
+/// entries last until the process exits.
 pub(crate) fn detach_external_string_env(env: *mut Env) {
   let ready = {
     let mut finalizers = EXTERNAL_STRING_FINALIZERS.lock().unwrap();
@@ -1464,10 +1472,17 @@ pub(crate) fn detach_external_string_env(env: *mut Env) {
       .entries
       .iter_mut()
       .filter_map(|(id, finalizer)| {
-        if finalizer.env == Some(env) {
-          finalizer.env = None;
-          finalizer.ready.then_some(*id)
+        if finalizer.env != Some(env) {
+          return None;
+        }
+        if finalizer.ready {
+          // V8 disposed this resource while the Env was still alive and its
+          // deferred completion has not drained yet. Keep the Env so this
+          // delivers what that task would have; it is removed below, so the
+          // task no-ops.
+          Some(*id)
         } else {
+          finalizer.env = None;
           None
         }
       })
@@ -1507,10 +1522,126 @@ unsafe extern "C" fn external_twobyte_destructor(data: *mut u16, len: usize) {
   });
 }
 
-#[napi_sym]
-fn node_api_create_external_string_latin1(
+/// The encoding-specific pieces of `node_api_create_external_string_*`. The
+/// finalizer handoff around them is shared, so the two encodings cannot drift
+/// apart.
+trait ExternalStringChar: Sized {
+  const ENCODING: ExternalStringEncoding;
+
+  /// Resolve `NAPI_AUTO_LENGTH` by finding the null terminator.
+  ///
+  /// # Safety
+  ///
+  /// `data` must point to a null-terminated sequence of `Self`.
+  unsafe fn auto_len(data: *const Self) -> usize;
+
+  /// Create a V8 string backed by `data` itself. V8 calls the encoding's
+  /// destructor once it collects the string.
+  ///
+  /// # Safety
+  ///
+  /// `data` must be valid for `len` code units and stay valid until the
+  /// destructor runs.
+  unsafe fn new_external<'s>(
+    scope: &v8::PinScope<'s, '_, ()>,
+    data: *mut Self,
+    len: usize,
+  ) -> Option<v8::Local<'s, v8::String>>;
+
+  /// Copy `data` into a V8-owned string.
+  ///
+  /// # Safety
+  ///
+  /// `data` must be valid for `length` code units and `result` must be
+  /// writable.
+  unsafe fn copy(
+    env: *mut Env,
+    data: *const Self,
+    length: usize,
+    result: *mut napi_value,
+  ) -> napi_status;
+}
+
+impl ExternalStringChar for c_char {
+  const ENCODING: ExternalStringEncoding = ExternalStringEncoding::OneByte;
+
+  unsafe fn auto_len(data: *const Self) -> usize {
+    unsafe { std::ffi::CStr::from_ptr(data).to_bytes().len() }
+  }
+
+  unsafe fn new_external<'s>(
+    scope: &v8::PinScope<'s, '_, ()>,
+    data: *mut Self,
+    len: usize,
+  ) -> Option<v8::Local<'s, v8::String>> {
+    unsafe {
+      v8::String::new_external_onebyte_raw(
+        scope,
+        data,
+        len,
+        external_onebyte_destructor,
+      )
+    }
+  }
+
+  unsafe fn copy(
+    env: *mut Env,
+    data: *const Self,
+    length: usize,
+    result: *mut napi_value,
+  ) -> napi_status {
+    unsafe { napi_create_string_latin1(env, data, length, result) }
+  }
+}
+
+impl ExternalStringChar for u16 {
+  const ENCODING: ExternalStringEncoding = ExternalStringEncoding::TwoByte;
+
+  unsafe fn auto_len(data: *const Self) -> usize {
+    let mut p = data;
+    unsafe {
+      while *p != 0 {
+        p = p.add(1);
+      }
+      p.offset_from(data) as usize
+    }
+  }
+
+  unsafe fn new_external<'s>(
+    scope: &v8::PinScope<'s, '_, ()>,
+    data: *mut Self,
+    len: usize,
+  ) -> Option<v8::Local<'s, v8::String>> {
+    unsafe {
+      v8::String::new_external_twobyte_raw(
+        scope,
+        data,
+        len,
+        external_twobyte_destructor,
+      )
+    }
+  }
+
+  unsafe fn copy(
+    env: *mut Env,
+    data: *const Self,
+    length: usize,
+    result: *mut napi_value,
+  ) -> napi_status {
+    unsafe { napi_create_string_utf16(env, data, length, result) }
+  }
+}
+
+/// Shared implementation of `node_api_create_external_string_latin1` and
+/// `node_api_create_external_string_utf16`.
+///
+/// # Safety
+///
+/// `string` must be valid for `length` code units, and `result` and `copied`
+/// must be writable or null.
+unsafe fn create_external_string<T: ExternalStringChar>(
   env_ptr: *mut Env,
-  string: *const c_char,
+  string: *const T,
   length: usize,
   nogc_finalize_callback: Option<napi_finalize>,
   finalize_hint: *mut c_void,
@@ -1521,9 +1652,8 @@ fn node_api_create_external_string_latin1(
   check_arg!(env, string);
   check_arg!(env, result);
 
-  let len = if length == usize::MAX {
-    // NAPI_AUTO_LENGTH: find null terminator
-    unsafe { std::ffi::CStr::from_ptr(string).to_bytes().len() }
+  let len = if length == NAPI_AUTO_LENGTH {
+    unsafe { T::auto_len(string) }
   } else {
     length
   };
@@ -1535,7 +1665,7 @@ fn node_api_create_external_string_latin1(
     let key = ExternalStringKey {
       data: string as usize,
       len,
-      encoding: ExternalStringEncoding::OneByte,
+      encoding: T::ENCODING,
     };
     let finalizer_id = register_external_string_finalizer(
       key,
@@ -1551,14 +1681,7 @@ fn node_api_create_external_string_latin1(
     if let Some(finalizer_id) = finalizer_id {
       let v8_str = {
         v8::callback_scope!(unsafe scope, env.context());
-        unsafe {
-          v8::String::new_external_onebyte_raw(
-            scope,
-            string as *mut std::ffi::c_char,
-            len,
-            external_onebyte_destructor,
-          )
-        }
+        unsafe { T::new_external(scope, string as *mut T, len) }
       };
       if let Some(v8_str) = v8_str {
         unsafe {
@@ -1576,8 +1699,7 @@ fn node_api_create_external_string_latin1(
   }
 
   // Fallback: copy the string and call finalize immediately
-  let status =
-    unsafe { napi_create_string_latin1(env_ptr, string, length, result) };
+  let status = unsafe { T::copy(env_ptr, string, length, result) };
   if status == napi_ok {
     unsafe {
       if !copied.is_null() {
@@ -1594,6 +1716,29 @@ fn node_api_create_external_string_latin1(
 }
 
 #[napi_sym]
+fn node_api_create_external_string_latin1(
+  env_ptr: *mut Env,
+  string: *const c_char,
+  length: usize,
+  nogc_finalize_callback: Option<napi_finalize>,
+  finalize_hint: *mut c_void,
+  result: *mut napi_value,
+  copied: *mut bool,
+) -> napi_status {
+  unsafe {
+    create_external_string(
+      env_ptr,
+      string,
+      length,
+      nogc_finalize_callback,
+      finalize_hint,
+      result,
+      copied,
+    )
+  }
+}
+
+#[napi_sym]
 fn node_api_create_external_string_utf16(
   env_ptr: *mut Env,
   string: *const u16,
@@ -1603,86 +1748,17 @@ fn node_api_create_external_string_utf16(
   result: *mut napi_value,
   copied: *mut bool,
 ) -> napi_status {
-  let env = check_env!(env_ptr);
-  check_arg!(env, string);
-  check_arg!(env, result);
-
-  let len = if length == usize::MAX {
-    // NAPI_AUTO_LENGTH: find null terminator
-    let mut p = string;
-    unsafe {
-      while *p != 0 {
-        p = p.add(1);
-      }
-      p.offset_from(string) as usize
-    }
-  } else {
-    length
-  };
-
-  let mut finalize_on_copy = true;
-  if let Some(finalize) = nogc_finalize_callback
-    && len > 0
-  {
-    let key = ExternalStringKey {
-      data: string as usize,
-      len,
-      encoding: ExternalStringEncoding::TwoByte,
-    };
-    let finalizer_id = register_external_string_finalizer(
-      key,
+  unsafe {
+    create_external_string(
       env_ptr,
-      finalize,
-      string as *mut c_void,
+      string,
+      length,
+      nogc_finalize_callback,
       finalize_hint,
-    );
-
-    // Try zero-copy: create a V8 external string backed by the
-    // caller's buffer. V8 will call our destructor when the string
-    // is GC'd, which in turn calls the NAPI finalize callback.
-    if let Some(finalizer_id) = finalizer_id {
-      let v8_str = {
-        v8::callback_scope!(unsafe scope, env.context());
-        unsafe {
-          v8::String::new_external_twobyte_raw(
-            scope,
-            string as *mut u16,
-            len,
-            external_twobyte_destructor,
-          )
-        }
-      };
-      if let Some(v8_str) = v8_str {
-        unsafe {
-          *result = v8::Local::<v8::Value>::from(v8_str).into();
-          if !copied.is_null() {
-            *copied = false;
-          }
-        }
-        return napi_clear_last_error(check_env!(env_ptr));
-      }
-      finalize_on_copy = cancel_external_string_finalizer(key, finalizer_id);
-    }
-    // V8 rejected the external string or an indistinguishable resource is
-    // already live. Fall through to the copy path.
+      result,
+      copied,
+    )
   }
-
-  // Fallback: copy the string and call finalize immediately
-  let status =
-    unsafe { napi_create_string_utf16(env_ptr, string, length, result) };
-  if status == napi_ok {
-    unsafe {
-      if !copied.is_null() {
-        *copied = true;
-      }
-    }
-    if finalize_on_copy && let Some(finalize) = nogc_finalize_callback {
-      unsafe {
-        finalize(env_ptr as napi_env, string as *mut c_void, finalize_hint);
-      }
-    }
-  }
-  status
 }
 
 #[napi_sym]

--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -1322,56 +1322,189 @@ fn napi_create_string_utf16(
   return napi_clear_last_error(env_ptr);
 }
 
-/// Metadata for an external one-byte string's finalize callback.
-/// Maps buffer address to the Env that owns its finalize callback.
-/// V8 external string destructors only receive (ptr, len), so this
-/// thin global index lets the destructor find the right Env.
-/// The actual callback + hint live on `Env::external_string_finalizers`.
-static EXTERNAL_STRING_ENVS: std::sync::LazyLock<
-  std::sync::Mutex<std::collections::HashMap<usize, usize>>,
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+enum ExternalStringEncoding {
+  OneByte,
+  TwoByte,
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+struct ExternalStringKey {
+  data: usize,
+  len: usize,
+  encoding: ExternalStringEncoding,
+}
+
+struct ExternalStringFinalizer {
+  env: Option<usize>,
+  callback: napi_finalize,
+  data: usize,
+  hint: usize,
+  sender: deno_core::V8CrossThreadTaskSpawner,
+  ready: bool,
+}
+
+#[derive(Default)]
+struct ExternalStringFinalizers {
+  next_id: u64,
+  active: std::collections::HashMap<ExternalStringKey, u64>,
+  entries: std::collections::HashMap<u64, ExternalStringFinalizer>,
+}
+
+static EXTERNAL_STRING_FINALIZERS: std::sync::LazyLock<
+  std::sync::Mutex<ExternalStringFinalizers>,
 > = std::sync::LazyLock::new(|| {
-  std::sync::Mutex::new(std::collections::HashMap::new())
+  std::sync::Mutex::new(ExternalStringFinalizers::default())
 });
 
-/// Remove an entry from the global env map. Called during Env teardown
-/// to prevent stale pointer dereferences.
-pub fn remove_external_string_env_entry(key: usize) {
-  EXTERNAL_STRING_ENVS.lock().unwrap().remove(&key);
+fn register_external_string_finalizer(
+  key: ExternalStringKey,
+  env: *mut Env,
+  callback: napi_finalize,
+  data: *mut c_void,
+  hint: *mut c_void,
+) -> Option<u64> {
+  let mut finalizers = EXTERNAL_STRING_FINALIZERS.lock().unwrap();
+
+  // rusty_v8's raw destructor callback only identifies a resource by its
+  // data pointer and length. Copy an indistinguishable second string instead
+  // of risking delivery of the wrong callback or hint.
+  if finalizers.active.contains_key(&key) {
+    return None;
+  }
+
+  let id = finalizers.next_id;
+  finalizers.next_id = finalizers
+    .next_id
+    .checked_add(1)
+    .expect("external string finalizer id overflow");
+  finalizers.active.insert(key, id);
+  finalizers.entries.insert(
+    id,
+    ExternalStringFinalizer {
+      env: Some(env as usize),
+      callback,
+      data: data as usize,
+      hint: hint as usize,
+      sender: unsafe { &*env }.async_work_sender.clone(),
+      ready: false,
+    },
+  );
+  Some(id)
 }
 
-/// V8 destructor for external one-byte strings. Looks up the Env from
-/// the global index, then retrieves and invokes the NAPI finalize callback.
+fn cancel_external_string_finalizer(key: ExternalStringKey, id: u64) -> bool {
+  let mut finalizers = EXTERNAL_STRING_FINALIZERS.lock().unwrap();
+  if finalizers.active.get(&key) == Some(&id) {
+    finalizers.active.remove(&key);
+    finalizers.entries.remove(&id);
+    true
+  } else {
+    false
+  }
+}
+
+fn call_external_string_finalizer(finalizer: ExternalStringFinalizer) {
+  let env = finalizer
+    .env
+    .map_or(std::ptr::null_mut(), |env| env as *mut Env as napi_env);
+  unsafe {
+    (finalizer.callback)(
+      env,
+      finalizer.data as *mut c_void,
+      finalizer.hint as *mut c_void,
+    );
+  }
+}
+
+fn complete_external_string_finalizer(id: u64) {
+  let finalizer = EXTERNAL_STRING_FINALIZERS
+    .lock()
+    .unwrap()
+    .entries
+    .remove(&id);
+  if let Some(finalizer) = finalizer {
+    call_external_string_finalizer(finalizer);
+  }
+}
+
+fn queue_external_string_finalizer(key: ExternalStringKey) {
+  let (id, sender, direct) = {
+    let mut finalizers = EXTERNAL_STRING_FINALIZERS.lock().unwrap();
+    let Some(id) = finalizers.active.remove(&key) else {
+      return;
+    };
+    let Some(finalizer) = finalizers.entries.get_mut(&id) else {
+      return;
+    };
+    finalizer.ready = true;
+    if finalizer.env.is_some() {
+      (id, Some(finalizer.sender.clone()), None)
+    } else {
+      let finalizer = finalizers.entries.remove(&id).unwrap();
+      (id, None, Some(finalizer))
+    }
+  };
+
+  if let Some(finalizer) = direct {
+    call_external_string_finalizer(finalizer);
+  } else if let Some(sender) = sender {
+    sender.spawn(move |_| complete_external_string_finalizer(id));
+  }
+}
+
+/// Stop delivering non-null Env pointers for an environment being torn down.
+/// Resources already disposed by V8 are finalized immediately; still-live
+/// resources receive a null Env when V8 disposes them later.
+pub(crate) fn detach_external_string_env(env: *mut Env) {
+  let ready = {
+    let mut finalizers = EXTERNAL_STRING_FINALIZERS.lock().unwrap();
+    let env = env as usize;
+    let ready: Vec<u64> = finalizers
+      .entries
+      .iter_mut()
+      .filter_map(|(id, finalizer)| {
+        if finalizer.env == Some(env) {
+          finalizer.env = None;
+          finalizer.ready.then_some(*id)
+        } else {
+          None
+        }
+      })
+      .collect();
+    ready
+      .into_iter()
+      .filter_map(|id| finalizers.entries.remove(&id))
+      .collect::<Vec<_>>()
+  };
+
+  for finalizer in ready {
+    call_external_string_finalizer(finalizer);
+  }
+}
+
+/// V8 destructor for external one-byte strings. V8 may call this away from
+/// the runtime thread, so it only updates synchronized metadata and queues the
+/// addon callback onto the runtime task queue.
 unsafe extern "C" fn external_onebyte_destructor(
   data: *mut std::ffi::c_char,
-  _len: usize,
+  len: usize,
 ) {
-  let key = data as usize;
-  if let Some(env_addr) = EXTERNAL_STRING_ENVS.lock().unwrap().remove(&key) {
-    let env_ptr = env_addr as *mut Env;
-    let env = unsafe { &mut *env_ptr };
-    if let Some((callback, hint)) = env.external_string_finalizers.remove(&key)
-    {
-      unsafe {
-        callback(env_ptr as napi_env, data as *mut c_void, hint);
-      }
-    }
-  }
+  queue_external_string_finalizer(ExternalStringKey {
+    data: data as usize,
+    len,
+    encoding: ExternalStringEncoding::OneByte,
+  });
 }
 
-/// V8 destructor for external two-byte strings. Looks up the Env from
-/// the global index, then retrieves and invokes the NAPI finalize callback.
-unsafe extern "C" fn external_twobyte_destructor(data: *mut u16, _len: usize) {
-  let key = data as usize;
-  if let Some(env_addr) = EXTERNAL_STRING_ENVS.lock().unwrap().remove(&key) {
-    let env_ptr = env_addr as *mut Env;
-    let env = unsafe { &mut *env_ptr };
-    if let Some((callback, hint)) = env.external_string_finalizers.remove(&key)
-    {
-      unsafe {
-        callback(env_ptr as napi_env, data as *mut c_void, hint);
-      }
-    }
-  }
+/// V8 destructor for external two-byte strings. This follows the same
+/// synchronized handoff as the one-byte destructor.
+unsafe extern "C" fn external_twobyte_destructor(data: *mut u16, len: usize) {
+  queue_external_string_finalizer(ExternalStringKey {
+    data: data as usize,
+    len,
+    encoding: ExternalStringEncoding::TwoByte,
+  });
 }
 
 #[napi_sym]
@@ -1395,42 +1528,51 @@ fn node_api_create_external_string_latin1(
     length
   };
 
-  if let Some(finalize) = nogc_finalize_callback {
+  let mut finalize_on_copy = true;
+  if let Some(finalize) = nogc_finalize_callback
+    && len > 0
+  {
+    let key = ExternalStringKey {
+      data: string as usize,
+      len,
+      encoding: ExternalStringEncoding::OneByte,
+    };
+    let finalizer_id = register_external_string_finalizer(
+      key,
+      env_ptr,
+      finalize,
+      string as *mut c_void,
+      finalize_hint,
+    );
+
     // Try zero-copy: create a V8 external string backed by the
     // caller's buffer. V8 will call our destructor when the string
     // is GC'd, which in turn calls the NAPI finalize callback.
-    let v8_str = {
-      v8::callback_scope!(unsafe scope, env.context());
-      unsafe {
-        v8::String::new_external_onebyte_raw(
-          scope,
-          string as *mut std::ffi::c_char,
-          len,
-          external_onebyte_destructor,
-        )
-      }
-    };
-    if let Some(v8_str) = v8_str {
-      let key = string as usize;
-      // SAFETY: env_ptr is valid and we need a separate mutable access
-      // to external_string_finalizers while v8_str borrows the scope.
-      unsafe { &mut *env_ptr }
-        .external_string_finalizers
-        .insert(key, (finalize, finalize_hint));
-      EXTERNAL_STRING_ENVS
-        .lock()
-        .unwrap()
-        .insert(key, env_ptr as usize);
-      unsafe {
-        *result = v8::Local::<v8::Value>::from(v8_str).into();
-        if !copied.is_null() {
-          *copied = false;
+    if let Some(finalizer_id) = finalizer_id {
+      let v8_str = {
+        v8::callback_scope!(unsafe scope, env.context());
+        unsafe {
+          v8::String::new_external_onebyte_raw(
+            scope,
+            string as *mut std::ffi::c_char,
+            len,
+            external_onebyte_destructor,
+          )
         }
+      };
+      if let Some(v8_str) = v8_str {
+        unsafe {
+          *result = v8::Local::<v8::Value>::from(v8_str).into();
+          if !copied.is_null() {
+            *copied = false;
+          }
+        }
+        return napi_clear_last_error(check_env!(env_ptr));
       }
-      return napi_clear_last_error(check_env!(env_ptr));
+      finalize_on_copy = cancel_external_string_finalizer(key, finalizer_id);
     }
-    // V8 rejected the external string (e.g. too short), fall through
-    // to copy path
+    // V8 rejected the external string or an indistinguishable resource is
+    // already live. Fall through to the copy path.
   }
 
   // Fallback: copy the string and call finalize immediately
@@ -1442,7 +1584,7 @@ fn node_api_create_external_string_latin1(
         *copied = true;
       }
     }
-    if let Some(finalize) = nogc_finalize_callback {
+    if finalize_on_copy && let Some(finalize) = nogc_finalize_callback {
       unsafe {
         finalize(env_ptr as napi_env, string as *mut c_void, finalize_hint);
       }
@@ -1478,42 +1620,51 @@ fn node_api_create_external_string_utf16(
     length
   };
 
-  if let Some(finalize) = nogc_finalize_callback {
+  let mut finalize_on_copy = true;
+  if let Some(finalize) = nogc_finalize_callback
+    && len > 0
+  {
+    let key = ExternalStringKey {
+      data: string as usize,
+      len,
+      encoding: ExternalStringEncoding::TwoByte,
+    };
+    let finalizer_id = register_external_string_finalizer(
+      key,
+      env_ptr,
+      finalize,
+      string as *mut c_void,
+      finalize_hint,
+    );
+
     // Try zero-copy: create a V8 external string backed by the
     // caller's buffer. V8 will call our destructor when the string
     // is GC'd, which in turn calls the NAPI finalize callback.
-    let v8_str = {
-      v8::callback_scope!(unsafe scope, env.context());
-      unsafe {
-        v8::String::new_external_twobyte_raw(
-          scope,
-          string as *mut u16,
-          len,
-          external_twobyte_destructor,
-        )
-      }
-    };
-    if let Some(v8_str) = v8_str {
-      let key = string as usize;
-      // SAFETY: env_ptr is valid and we need a separate mutable access
-      // to external_string_finalizers while v8_str borrows the scope.
-      unsafe { &mut *env_ptr }
-        .external_string_finalizers
-        .insert(key, (finalize, finalize_hint));
-      EXTERNAL_STRING_ENVS
-        .lock()
-        .unwrap()
-        .insert(key, env_ptr as usize);
-      unsafe {
-        *result = v8::Local::<v8::Value>::from(v8_str).into();
-        if !copied.is_null() {
-          *copied = false;
+    if let Some(finalizer_id) = finalizer_id {
+      let v8_str = {
+        v8::callback_scope!(unsafe scope, env.context());
+        unsafe {
+          v8::String::new_external_twobyte_raw(
+            scope,
+            string as *mut u16,
+            len,
+            external_twobyte_destructor,
+          )
         }
+      };
+      if let Some(v8_str) = v8_str {
+        unsafe {
+          *result = v8::Local::<v8::Value>::from(v8_str).into();
+          if !copied.is_null() {
+            *copied = false;
+          }
+        }
+        return napi_clear_last_error(check_env!(env_ptr));
       }
-      return napi_clear_last_error(check_env!(env_ptr));
+      finalize_on_copy = cancel_external_string_finalizer(key, finalizer_id);
     }
-    // V8 rejected the external string (e.g. too short), fall through
-    // to copy path
+    // V8 rejected the external string or an indistinguishable resource is
+    // already live. Fall through to the copy path.
   }
 
   // Fallback: copy the string and call finalize immediately
@@ -1525,7 +1676,7 @@ fn node_api_create_external_string_utf16(
         *copied = true;
       }
     }
-    if let Some(finalize) = nogc_finalize_callback {
+    if finalize_on_copy && let Some(finalize) = nogc_finalize_callback {
       unsafe {
         finalize(env_ptr as napi_env, string as *mut c_void, finalize_hint);
       }

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -372,18 +372,11 @@ unsafe impl Send for NapiState {}
 
 impl Drop for NapiState {
   fn drop(&mut self) {
-    // Drain external string finalizers from all tracked Envs and remove
-    // their entries from the global EXTERNAL_STRING_ENVS map. This
-    // prevents stale Env pointer dereferences if V8 GCs the external
-    // string after the Env is gone.
+    // External string resources can outlive their Env until V8 disposes the
+    // isolate. Stop exposing each Env to those eventual callbacks; callbacks
+    // whose V8 resource was already disposed are completed with a null Env.
     for env_ptr in &self.env_ptrs {
-      let env = unsafe { &mut **env_ptr };
-      let keys: Vec<usize> =
-        env.external_string_finalizers.keys().copied().collect();
-      for key in keys {
-        crate::js_native_api::remove_external_string_env_entry(key);
-      }
-      env.external_string_finalizers.clear();
+      crate::js_native_api::detach_external_string_env(*env_ptr);
     }
 
     let hooks = {
@@ -506,7 +499,6 @@ pub struct Env {
   pub async_hooks_after: v8::Global<v8::Function>,
   pub async_hooks_destroy: v8::Global<v8::Function>,
   pub next_async_id: i64,
-  pub external_string_finalizers: HashMap<usize, (napi_finalize, *mut c_void)>,
 }
 
 unsafe impl Send for Env {}
@@ -554,7 +546,6 @@ impl Env {
         error_code: Cell::new(napi_ok),
       },
       last_exception: None,
-      external_string_finalizers: HashMap::new(),
     }
   }
 

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -373,8 +373,11 @@ unsafe impl Send for NapiState {}
 impl Drop for NapiState {
   fn drop(&mut self) {
     // External string resources can outlive their Env until V8 disposes the
-    // isolate. Stop exposing each Env to those eventual callbacks; callbacks
-    // whose V8 resource was already disposed are completed with a null Env.
+    // isolate. Stop exposing each Env to those eventual callbacks. Callbacks
+    // whose V8 resource was already disposed are completed here with their
+    // original Env; the rest keep their registry entry, which the isolate's
+    // disposal reclaims by firing the V8 destructor with a null Env. They
+    // cannot be swept here because V8 still reads their buffers.
     for env_ptr in &self.env_ptrs {
       crate::js_native_api::detach_external_string_env(*env_ptr);
     }

--- a/tests/napi/src/strings.rs
+++ b/tests/napi/src/strings.rs
@@ -2,6 +2,8 @@
 
 use std::ffi::c_char;
 use std::ffi::c_void;
+use std::sync::LazyLock;
+use std::sync::Mutex;
 
 use napi_sys::ValueType::napi_string;
 use napi_sys::*;
@@ -409,6 +411,180 @@ extern "C" fn test_external_utf16(
   ret
 }
 
+const SHARED_EXTERNAL_STRING_LEN: usize = 4096;
+static SHARED_EXTERNAL_LATIN1: [u8; SHARED_EXTERNAL_STRING_LEN] =
+  [b'x'; SHARED_EXTERNAL_STRING_LEN];
+static SHARED_EXTERNAL_UTF16: [u16; SHARED_EXTERNAL_STRING_LEN] =
+  [b'y' as u16; SHARED_EXTERNAL_STRING_LEN];
+
+#[derive(Default)]
+struct ExternalStringFinalizerProbe {
+  creator_thread: Option<std::thread::ThreadId>,
+  called: u32,
+  hints: u32,
+  wrong_thread: bool,
+  null_env: bool,
+}
+
+static EXTERNAL_STRING_FINALIZER_PROBE: LazyLock<
+  Mutex<ExternalStringFinalizerProbe>,
+> = LazyLock::new(|| Mutex::new(ExternalStringFinalizerProbe::default()));
+
+unsafe extern "C" fn record_external_string_finalizer(
+  env: napi_env,
+  _data: *mut c_void,
+  hint: *mut c_void,
+) {
+  let mut probe = EXTERNAL_STRING_FINALIZER_PROBE.lock().unwrap();
+  probe.called += 1;
+  probe.hints |= 1 << hint as usize;
+  probe.wrong_thread |=
+    probe.creator_thread.as_ref() != Some(&std::thread::current().id());
+  probe.null_env |= env.is_null();
+}
+
+extern "C" fn test_external_string_finalizer_reset(
+  env: napi_env,
+  _info: napi_callback_info,
+) -> napi_value {
+  *EXTERNAL_STRING_FINALIZER_PROBE.lock().unwrap() =
+    ExternalStringFinalizerProbe {
+      creator_thread: Some(std::thread::current().id()),
+      ..Default::default()
+    };
+
+  let mut result = std::ptr::null_mut();
+  assert_napi_ok!(napi_get_undefined(env, &mut result));
+  result
+}
+
+/// Create two one-byte and two two-byte strings from identical backing-store
+/// addresses. The second string of each encoding must use the copy path so
+/// every resource keeps the correct finalizer identity.
+extern "C" fn test_external_string_finalizer_collisions(
+  env: napi_env,
+  _info: napi_callback_info,
+) -> napi_value {
+  let mut strings = [std::ptr::null_mut(); 4];
+  let mut copied = [true; 4];
+
+  for index in 0..2 {
+    let status = unsafe {
+      node_api_create_external_string_latin1(
+        env,
+        SHARED_EXTERNAL_LATIN1.as_ptr() as *const c_char,
+        SHARED_EXTERNAL_LATIN1.len(),
+        Some(record_external_string_finalizer),
+        index as *mut c_void,
+        &mut strings[index],
+        &mut copied[index],
+      )
+    };
+    assert_eq!(status, 0);
+  }
+
+  for index in 2..4 {
+    let status = unsafe {
+      node_api_create_external_string_utf16(
+        env,
+        SHARED_EXTERNAL_UTF16.as_ptr(),
+        SHARED_EXTERNAL_UTF16.len(),
+        Some(record_external_string_finalizer),
+        index as *mut c_void,
+        &mut strings[index],
+        &mut copied[index],
+      )
+    };
+    assert_eq!(status, 0);
+  }
+
+  let mut result = std::ptr::null_mut();
+  assert_napi_ok!(napi_create_array_with_length(env, 8, &mut result));
+  for (index, string) in strings.into_iter().enumerate() {
+    assert_napi_ok!(napi_set_element(env, result, index as u32, string));
+  }
+  for (index, copied) in copied.into_iter().enumerate() {
+    let mut value = std::ptr::null_mut();
+    assert_napi_ok!(napi_get_boolean(env, !copied, &mut value));
+    assert_napi_ok!(napi_set_element(env, result, (index + 4) as u32, value));
+  }
+  result
+}
+
+/// V8 disposes zero-length external resources synchronously. Keep these on
+/// the copy path so their callbacks run exactly once before the API returns.
+extern "C" fn test_empty_external_string_finalizers(
+  env: napi_env,
+  _info: napi_callback_info,
+) -> napi_value {
+  let mut strings = [std::ptr::null_mut(); 2];
+  let mut copied = [false; 2];
+
+  let latin1_status = unsafe {
+    node_api_create_external_string_latin1(
+      env,
+      SHARED_EXTERNAL_LATIN1.as_ptr() as *const c_char,
+      0,
+      Some(record_external_string_finalizer),
+      4 as *mut c_void,
+      &mut strings[0],
+      &mut copied[0],
+    )
+  };
+  assert_eq!(latin1_status, 0);
+
+  let utf16_status = unsafe {
+    node_api_create_external_string_utf16(
+      env,
+      SHARED_EXTERNAL_UTF16.as_ptr(),
+      0,
+      Some(record_external_string_finalizer),
+      5 as *mut c_void,
+      &mut strings[1],
+      &mut copied[1],
+    )
+  };
+  assert_eq!(utf16_status, 0);
+
+  let mut result = std::ptr::null_mut();
+  assert_napi_ok!(napi_create_array_with_length(env, 4, &mut result));
+  for (index, string) in strings.into_iter().enumerate() {
+    assert_napi_ok!(napi_set_element(env, result, index as u32, string));
+  }
+  for (index, copied) in copied.into_iter().enumerate() {
+    let mut value = std::ptr::null_mut();
+    assert_napi_ok!(napi_get_boolean(env, !copied, &mut value));
+    assert_napi_ok!(napi_set_element(env, result, (index + 2) as u32, value));
+  }
+  result
+}
+
+extern "C" fn test_external_string_finalizer_status(
+  env: napi_env,
+  _info: napi_callback_info,
+) -> napi_value {
+  let probe = EXTERNAL_STRING_FINALIZER_PROBE.lock().unwrap();
+  let mut result = std::ptr::null_mut();
+  assert_napi_ok!(napi_create_array_with_length(env, 4, &mut result));
+
+  let mut called = std::ptr::null_mut();
+  assert_napi_ok!(napi_create_uint32(env, probe.called, &mut called));
+  assert_napi_ok!(napi_set_element(env, result, 0, called));
+
+  let mut wrong_thread = std::ptr::null_mut();
+  assert_napi_ok!(napi_get_boolean(env, probe.wrong_thread, &mut wrong_thread));
+  assert_napi_ok!(napi_set_element(env, result, 1, wrong_thread));
+
+  let mut null_env = std::ptr::null_mut();
+  assert_napi_ok!(napi_get_boolean(env, probe.null_env, &mut null_env));
+  assert_napi_ok!(napi_set_element(env, result, 2, null_env));
+
+  let mut hints = std::ptr::null_mut();
+  assert_napi_ok!(napi_create_uint32(env, probe.hints, &mut hints));
+  assert_napi_ok!(napi_set_element(env, result, 3, hints));
+  result
+}
+
 pub fn init(env: napi_env, exports: napi_value) {
   let properties = &[
     napi_new_property!(env, "test_utf8", test_utf8),
@@ -425,6 +601,26 @@ pub fn init(env: napi_env, exports: napi_value) {
     napi_new_property!(env, "test_utf16_roundtrip", test_utf16_roundtrip),
     napi_new_property!(env, "test_external_latin1", test_external_latin1),
     napi_new_property!(env, "test_external_utf16", test_external_utf16),
+    napi_new_property!(
+      env,
+      "test_external_string_finalizer_reset",
+      test_external_string_finalizer_reset
+    ),
+    napi_new_property!(
+      env,
+      "test_external_string_finalizer_collisions",
+      test_external_string_finalizer_collisions
+    ),
+    napi_new_property!(
+      env,
+      "test_empty_external_string_finalizers",
+      test_empty_external_string_finalizers
+    ),
+    napi_new_property!(
+      env,
+      "test_external_string_finalizer_status",
+      test_external_string_finalizer_status
+    ),
   ];
 
   assert_napi_ok!(napi_define_properties(

--- a/tests/napi/strings_test.js
+++ b/tests/napi/strings_test.js
@@ -55,3 +55,47 @@ Deno.test("napi external string utf16", function () {
   // Either outcome is valid -- zero-copy is preferred but copy is acceptable
   assertEquals(typeof zeroCopy, "boolean");
 });
+
+Deno.test("napi external string finalizers keep per-resource state", async () => {
+  if (typeof globalThis.gc !== "function") {
+    return;
+  }
+
+  strings.test_external_string_finalizer_reset();
+  let values = strings.test_external_string_finalizer_collisions();
+
+  assertEquals(values[0].length, 4096);
+  assertEquals(values[1].length, 4096);
+  assertEquals(values[2].length, 4096);
+  assertEquals(values[3].length, 4096);
+  // rusty_v8 cannot distinguish two live resources with the same address,
+  // length, and encoding. The first remains external and the second is copied.
+  assertEquals(values.slice(4), [true, false, true, false]);
+
+  const empty = strings.test_empty_external_string_finalizers();
+  assertEquals(empty[0], "");
+  assertEquals(empty[1], "");
+  assertEquals(empty.slice(2), [false, false]);
+  assertEquals(strings.test_external_string_finalizer_status(), [
+    4,
+    false,
+    false,
+    0b111010,
+  ]);
+
+  values = null;
+  for (let i = 0; i < 100; i++) {
+    globalThis.gc();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (strings.test_external_string_finalizer_status()[0] === 6) {
+      break;
+    }
+  }
+
+  assertEquals(strings.test_external_string_finalizer_status(), [
+    6,
+    false,
+    false,
+    0b111111,
+  ]);
+});


### PR DESCRIPTION
## Summary

- keep external-string finalizer metadata in one synchronized registry
- preserve callback and hint identity for each distinguishable V8 resource
- deliver a null environment when a resource outlives N-API teardown
- use the copy path for zero-length or otherwise indistinguishable resources

## Problem

External-string finalizer metadata was split between a global buffer-to-environment map and a per-environment `HashMap`. V8 resource disposal could access the per-environment map concurrently with runtime operations. The buffer-only lookup also could not distinguish two live strings backed by the same address, allowing one registration to replace another, while teardown discarded callbacks for resources that V8 had not yet disposed.

This change moves registration and disposal into a synchronized registry. Destructor callbacks hand completed entries to the runtime task queue, teardown changes remaining entries to null-environment delivery, and a second resource with an indistinguishable address, length, and encoding takes the API's supported copy path.

## Validation

- `./tools/format.js`
- `cargo check -p deno_napi`
- `cargo check -p test_napi`
- `cargo build -p test_napi`
- `cargo build --bin deno`
- focused finalizer identity and zero-length regression
- complete `tests/napi/strings_test.js`
