### PR TITLE
chore: use standard executable permissions for promoted binaries

### DIFF
--- a/tools/release/promote_to_release.ts
+++ b/tools/release/promote_to_release.ts
@@ -224,7 +224,7 @@ async function promoteBinaryToRc(
   await runRcodesign(target, unzippedName, commitHash);
   // Set executable permission
   if (!target.includes("windows")) {
-    Deno.chmod(unzippedName, 0o777);
+    await Deno.chmod(unzippedName, 0o755);
   }
 
   await createArchive(unzippedName, archiveName);


### PR DESCRIPTION
## Summary

- set promoted non-Windows binaries to mode 0o755 before archiving
- wait for the permission change to finish before invoking zip

## Details

The release promotion script used 0o777 while restoring executable permissions and started archive creation without waiting for chmod. This could make the archived mode depend on operation timing and leave extracted binaries writable by more users than intended.

Using 0o755 matches conventional executable permissions and makes archive creation deterministic.

## Validation

- ./tools/format.js
- deno check --no-lock tools/release/promote_to_release.ts
- repeated archive and extraction smoke check; all 20 archives preserved mode 0o755