### PR TITLE
fix(canvas): require FFI permission for native window handles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,7 @@ dependencies = [
  "deno_core",
  "deno_error",
  "deno_image",
+ "deno_permissions",
  "deno_webgpu",
  "raw-window-handle",
  "thiserror 2.0.12",

--- a/ext/canvas/Cargo.toml
+++ b/ext/canvas/Cargo.toml
@@ -18,6 +18,7 @@ bytemuck.workspace = true
 deno_core.workspace = true
 deno_error.workspace = true
 deno_image.workspace = true
+deno_permissions.workspace = true
 deno_webgpu.workspace = true
 raw-window-handle.workspace = true
 thiserror.workspace = true

--- a/ext/canvas/byow.rs
+++ b/ext/canvas/byow.rs
@@ -18,6 +18,7 @@ use deno_core::OpState;
 use deno_core::op2;
 use deno_core::v8;
 use deno_error::JsErrorBox;
+use deno_permissions::PermissionsContainer;
 use deno_webgpu::canvas::ContextData;
 use deno_webgpu::canvas::SurfaceData;
 
@@ -40,6 +41,9 @@ pub enum ByowError {
   #[class(type)]
   #[error("Invalid parameters")]
   InvalidParameters,
+  #[class(inherit)]
+  #[error(transparent)]
+  Permission(#[from] deno_permissions::PermissionCheckError),
   #[class(generic)]
   #[error(transparent)]
   CreateSurface(deno_webgpu::wgpu_core::instance::CreateSurfaceError),
@@ -156,6 +160,10 @@ impl UnsafeWindowSurface {
     state: &mut OpState,
     #[scoped] options: UnsafeWindowSurfaceOptions,
   ) -> Result<UnsafeWindowSurface, ByowError> {
+    state
+      .borrow_mut::<PermissionsContainer>()
+      .check_ffi_partial_no_path()?;
+
     let (_, instance) = deno_webgpu::get_or_init_instance(
       state,
       &deno_webgpu::adapter::GPURequestAdapterOptions {
@@ -166,19 +174,13 @@ impl UnsafeWindowSurface {
     )
     .ok_or(ByowError::NoWgpuInstance)?;
 
-    // Security note:
+    // SAFETY:
     //
     // The `window_handle` and `display_handle` options are pointers to
     // platform-specific window handles.
     //
-    // The code below works under the assumption that:
-    //
-    // - handles can only be created by the FFI interface which
-    // enforces --allow-ffi.
-    //
-    // - `*const c_void` deserizalizes null and v8::External.
-    //
-    // - Only FFI can export v8::External to user code.
+    // FFI permission is checked above, and `*const c_void` deserializes only
+    // null and v8::External values.
     if options.window_handle.is_null() {
       return Err(ByowError::InvalidParameters);
     }

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -443,10 +443,6 @@ class InnerRequest {
     return text;
   }
 
-  get external() {
-    return this.#external;
-  }
-
   onCancel(callback) {
     this.#signalAccessed = true;
     if (this.#external === null) {

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -137,6 +137,29 @@ Deno.test(
   },
 );
 
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerRequestDoesNotExposeExternal() {
+    let innerRequest: object | undefined;
+    await using server = await makeServer((req) => {
+      const requestSymbol = Object.getOwnPropertySymbols(req).find(
+        (symbol) => symbol.description === "request",
+      );
+      if (requestSymbol !== undefined) {
+        innerRequest = (req as unknown as Record<symbol, object>)[
+          requestSymbol
+        ];
+      }
+      return new Response("ok");
+    });
+    const resp = await fetch(`http://localhost:${servePort}/`);
+    await resp.text();
+    assert(innerRequest !== undefined);
+    assertEquals(Reflect.has(innerRequest, "external"), false);
+    await server.shutdown();
+  },
+);
+
 // When shutting down abruptly, we require that all in-progress connections are aborted,
 // no new connections are allowed, and no new transactions are allowed on existing connections.
 Deno.test(

--- a/tests/unit/webgpu_test.ts
+++ b/tests/unit/webgpu_test.ts
@@ -336,6 +336,37 @@ Deno.test(function webgpuWindowSurfaceNoWidthHeight() {
   );
 });
 
+Deno.test(
+  { permissions: { ffi: false } },
+  function webgpuWindowSurfaceFfiPermission() {
+    const response = new Response("ok", { status: 201 });
+    const nativeResponseSymbol = Object.getOwnPropertySymbols(response).find(
+      (symbol) => symbol.description === "serve native response",
+    );
+    assert(nativeResponseSymbol !== undefined);
+    const nativeResponse =
+      (response as unknown as Record<symbol, Deno.PointerValue>)[
+        nativeResponseSymbol
+      ];
+    assert(nativeResponse);
+    const system = Deno.build.os === "darwin" ? "x11" : "cocoa";
+
+    assertThrows(
+      () => {
+        new Deno.UnsafeWindowSurface({
+          system,
+          windowHandle: nativeResponse,
+          displayHandle: nativeResponse,
+          width: 1,
+          height: 1,
+        });
+      },
+      Deno.errors.NotCapable,
+      "Requires ffi access",
+    );
+  },
+);
+
 Deno.test({
   permissions: { ffi: true },
   ignore: isWsl || isCIWithoutGPU || !hasWindowingSystem,


### PR DESCRIPTION
## What

- Check FFI permission before initializing a native window surface.
- Keep `Deno.serve`'s native request handle private by removing an unused accessor.
- Add regressions for the permission behavior and request-wrapper shape.

## Why

`UnsafeWindowSurface` consumes raw native handles represented by FFI pointer values, but it relied on pointer-creation paths to enforce permission. Checking at the consumer makes every construction path follow the same permission contract and avoids starting graphics initialization for denied calls.

The request accessor was unused and unnecessarily made native request state part of the wrapper's observable shape.

## Impact

Construction without FFI access now throws `NotCapable`. Existing construction with FFI access remains unchanged.

## Checks

- `./tools/format.js`
- `cargo check -p deno_canvas`
- `cargo test -p unit_tests --test unit -- serve_test`
- `cargo test -p unit_tests --test unit -- webgpu_test`
