### PR TITLE
fix(process): avoid collisions in Windows stdio pipe names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,10 +3438,10 @@ dependencies = [
 name = "deno_subprocess_windows"
 version = "0.50.0"
 dependencies = [
- "fastrand",
  "futures-channel",
  "libc",
  "pretty_assertions",
+ "rand 0.8.5",
  "windows-sys 0.59.0",
 ]
 

--- a/runtime/subprocess_windows/Cargo.toml
+++ b/runtime/subprocess_windows/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 description = "Subprocess API implementation for Windows"
 
 [dependencies]
-fastrand = "2.3.0"
 futures-channel = "0.3.31"
 libc = "0.2.172"
+rand.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_Security", "Win32_System_JobObjects", "Win32_System_Diagnostics_Debug", "Win32_Globalization", "Win32_System_Threading", "Win32_Storage_FileSystem", "Win32_System_Environment", "Win32_Foundation", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_UI_Shell", "Win32_System_Com", "Win32_System_WindowsProgramming", "Win32_UI_WindowsAndMessaging", "Win32_System_Pipes", "Win32_System_Console", "Win32_System_IO", "Win32_System_SystemInformation"] }

--- a/runtime/subprocess_windows/src/anon_pipe.rs
+++ b/runtime/subprocess_windows/src/anon_pipe.rs
@@ -34,9 +34,9 @@ use std::io;
 use std::mem;
 use std::os::windows::prelude::*;
 use std::ptr;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::Relaxed;
 
+use rand::RngCore;
+use rand::rngs::OsRng;
 use windows_sys::Win32::Foundation::BOOL;
 use windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED;
 use windows_sys::Win32::Foundation::ERROR_BROKEN_PIPE;
@@ -154,11 +154,7 @@ pub fn anon_pipe(
     let mut tries = 0;
     loop {
       tries += 1;
-      name = format!(
-        r"\\.\pipe\__rust_anonymous_pipe1__.{}.{}",
-        GetCurrentProcessId(),
-        random_number(),
-      );
+      name = pipe_name(GetCurrentProcessId());
       let wide_name = OsStr::new(&name)
         .encode_wide()
         .chain(Some(0))
@@ -241,6 +237,9 @@ pub fn anon_pipe(
       0,
       ptr::null_mut(),
     );
+    if handle2 == INVALID_HANDLE_VALUE {
+      return Err(io::Error::last_os_error());
+    }
     let theirs = Handle::from_raw_handle(handle2);
 
     Ok(Pipes {
@@ -250,14 +249,33 @@ pub fn anon_pipe(
   }
 }
 
-fn random_number() -> usize {
-  static N: std::sync::atomic::AtomicUsize = AtomicUsize::new(0);
-  loop {
-    if N.load(Relaxed) != 0 {
-      return N.fetch_add(1, Relaxed);
-    }
+fn pipe_name(process_id: u32) -> String {
+  let mut rng = OsRng;
+  format!(
+    r"\\.\pipe\__rust_anonymous_pipe1__.{}.{:016x}{:016x}",
+    process_id,
+    rng.next_u64(),
+    rng.next_u64(),
+  )
+}
 
-    N.store(fastrand::usize(..), Relaxed);
+#[cfg(test)]
+mod tests {
+  use super::pipe_name;
+
+  #[test]
+  fn pipe_name_uses_fresh_random_suffix() {
+    let first = pipe_name(1234);
+    let second = pipe_name(1234);
+
+    assert_ne!(first, second);
+
+    let prefix = r"\\.\pipe\__rust_anonymous_pipe1__.1234.";
+    let suffix = first
+      .strip_prefix(prefix)
+      .expect("pipe name should include the process id prefix");
+    assert_eq!(suffix.len(), 32);
+    assert!(suffix.chars().all(|c| c.is_ascii_hexdigit()));
   }
 }
 


### PR DESCRIPTION
## Summary

- generate a fresh 128-bit OS-random suffix for every Windows subprocess stdio pipe
- return the original `CreateFileW` error before constructing the client handle
- cover the generated pipe-name format and freshness in the Windows unit tests

## Context

Windows subprocess stdio uses named pipes to emulate anonymous pipes with
overlapped I/O. Pipe names previously used one random starting value followed
by an incrementing counter, making later names more susceptible to collisions
with existing pipe instances.

Using a fresh random suffix for each pipe avoids those collisions. Checking the
client open immediately also reports setup failures at their source instead of
surfacing them later during handle preparation.

## Validation

- `./tools/format.js`
- `cargo check -p deno_subprocess_windows`

The implementation and unit test are Windows-only and will be compiled and run
by Windows CI.
