### PR TITLE
fix(node/child_process): don't synchronously disconnect IPC on kill() (#36075)

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -873,11 +873,6 @@ class ChildProcess extends EventEmitter {
       }
     }
 
-    /* Cancel any pending IPC I/O */
-    if (this[kCanDisconnect]) {
-      this.disconnect?.();
-    }
-
     this.killed = true;
     this.signalCode = signalName;
     return true;

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1399,8 +1399,9 @@ Deno.test(async function killMultipleTimesNoError() {
   child.kill();
   child.kill();
 
-  // explicitly calling disconnect after kill should throw
-  assertThrows(() => child.disconnect());
+  // kill() should not synchronously disconnect — connected stays true
+  // until the pipe closes asynchronously.
+  assert(child.connected);
 
   await timeout.promise;
 });


### PR DESCRIPTION
Remove the synchronous IPC disconnect from ChildProcess.kill(). In Node.js, kill() only delivers a signal and the IPC channel remains up until the child's pipe reaches EOF, at which point 'disconnect' fires asynchronously. Deno was calling this.disconnect?.() synchronously inside kill(), which immediately flipped child.connected to false and emitted 'disconnect' early.

This fix removes the synchronous disconnect from kill(), letting the existing asynchronous readLoop handle disconnection when the pipe closes (NODE_CLOSE internal message or BadResource/ConnectionReset error), matching Node.js behavior.

Closes #36075