### PR TITLE
fix(ext/node_crypto): validate RSA JWK modulus (n == p * q)

### DIFF
--- a/ext/node/polyfills/internal/crypto/keys.ts
+++ b/ext/node/polyfills/internal/crypto/keys.ts
@@ -312,22 +312,26 @@ function getKeyObjectHandleFromJwk(key, ctx) {
     e: key.e,
   };
 
-  if (!isPublic) {
-    validateString(key.d, "key.d");
-    validateString(key.p, "key.p");
-    validateString(key.q, "key.q");
-    validateString(key.dp, "key.dp");
-    validateString(key.dq, "key.dq");
-    validateString(key.qi, "key.qi");
-    jwk.d = key.d;
-    jwk.p = key.p;
-    jwk.q = key.q;
-    jwk.dp = key.dp;
-    jwk.dq = key.dq;
-    jwk.qi = key.qi;
-  }
+  try {
+    if (!isPublic) {
+      validateString(key.d, "key.d");
+      validateString(key.p, "key.p");
+      validateString(key.q, "key.q");
+      validateString(key.dp, "key.dp");
+      validateString(key.dq, "key.dq");
+      validateString(key.qi, "key.qi");
+      jwk.d = key.d;
+      jwk.p = key.p;
+      jwk.q = key.q;
+      jwk.dp = key.dp;
+      jwk.dq = key.dq;
+      jwk.qi = key.qi;
+    }
 
-  return op_node_create_rsa_jwk(jwk, isPublic);
+    return op_node_create_rsa_jwk(jwk, isPublic);
+  } catch {
+    throw new ERR_CRYPTO_INVALID_JWK();
+  }
 }
 
 function isStringOrBuffer(val: unknown): boolean {

--- a/ext/node_crypto/keys.rs
+++ b/ext/node_crypto/keys.rs
@@ -593,6 +593,9 @@ pub enum RsaJwkError {
   #[class(type)]
   #[error("missing RSA private component")]
   MissingRsaPrivateComponent,
+  #[class(type)]
+  #[error("Invalid JWK RSA key")]
+  InvalidJwk,
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
@@ -1370,47 +1373,49 @@ impl KeyObjectHandle {
   ) -> Result<KeyObjectHandle, RsaJwkError> {
     use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 
-    let n = BASE64_URL_SAFE_NO_PAD.decode(jwk.n.as_bytes())?;
-    let e = BASE64_URL_SAFE_NO_PAD.decode(jwk.e.as_bytes())?;
+    let n_bytes = BASE64_URL_SAFE_NO_PAD.decode(jwk.n.as_bytes())?;
+    let e_bytes = BASE64_URL_SAFE_NO_PAD.decode(jwk.e.as_bytes())?;
+
+    let n = rsa::BigUint::from_bytes_be(&n_bytes);
+    let e = rsa::BigUint::from_bytes_be(&e_bytes);
 
     if is_public {
-      let public_key = RsaPublicKey::new(
-        rsa::BigUint::from_bytes_be(&n),
-        rsa::BigUint::from_bytes_be(&e),
-      )?;
+      let public_key = RsaPublicKey::new(n, e)?;
 
       Ok(KeyObjectHandle::AsymmetricPublic(AsymmetricPublicKey::Rsa(
         public_key,
       )))
     } else {
-      let d = BASE64_URL_SAFE_NO_PAD.decode(
+      let d_bytes = BASE64_URL_SAFE_NO_PAD.decode(
         jwk
           .d
           .ok_or(RsaJwkError::MissingRsaPrivateComponent)?
           .as_bytes(),
       )?;
-      let p = BASE64_URL_SAFE_NO_PAD.decode(
+      let p_bytes = BASE64_URL_SAFE_NO_PAD.decode(
         jwk
           .p
           .ok_or(RsaJwkError::MissingRsaPrivateComponent)?
           .as_bytes(),
       )?;
-      let q = BASE64_URL_SAFE_NO_PAD.decode(
+      let q_bytes = BASE64_URL_SAFE_NO_PAD.decode(
         jwk
           .q
           .ok_or(RsaJwkError::MissingRsaPrivateComponent)?
           .as_bytes(),
       )?;
 
-      let mut private_key = RsaPrivateKey::from_components(
-        rsa::BigUint::from_bytes_be(&n),
-        rsa::BigUint::from_bytes_be(&e),
-        rsa::BigUint::from_bytes_be(&d),
-        vec![
-          rsa::BigUint::from_bytes_be(&p),
-          rsa::BigUint::from_bytes_be(&q),
-        ],
-      )?;
+      let d = rsa::BigUint::from_bytes_be(&d_bytes);
+      let p = rsa::BigUint::from_bytes_be(&p_bytes);
+      let q = rsa::BigUint::from_bytes_be(&q_bytes);
+
+      if &p * &q != n {
+        return Err(RsaJwkError::InvalidJwk);
+      }
+
+      let mut private_key =
+        RsaPrivateKey::from_components(n, e, d, vec![p, q])?;
+
       private_key.precompute()?; // precompute CRT params
 
       Ok(KeyObjectHandle::AsymmetricPrivate(

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -770,10 +770,7 @@
     "parallel/test-crypto-keygen-rfc8017-a-2-3.js": {},
     "parallel/test-crypto-keygen-rsa-pss.js": {},
     "parallel/test-crypto-keygen-sync.js": {},
-    "parallel/test-crypto-key-objects.js": {
-      "ignore": true,
-      "reason": "Deno does not validate RSA JWK modulus consistency (n == p*q) on import"
-    },
+    "parallel/test-crypto-key-objects.js": {},
     "parallel/test-crypto-scrypt.js": {},
     "parallel/test-crypto-key-objects-messageport.js": {},
     "parallel/test-crypto-key-objects-to-crypto-key.js": {


### PR DESCRIPTION
Fixes part of #35293 - RSA JWK modulus consistency validation (`n == p * q`).

* Added validation for private RSA JWK imports to ensure the modulus (`n`) matches the product of the prime factors (`p * q`).
* Added a new `InvalidJwk` error to return `ERR_CRYPTO_INVALID_JWK`, matching Node.js behavior for invalid RSA JWKs.

### Tests

* Added a test covering RSA private JWKs with a mismatched modulus.

### AI Disclosure

I used ChatGPT to help locate the relevant implementation in the Deno and Node.js codebases, understand Node.js's implementation, and verify my approach before implementing the fix.
