### PR TITLE
fix(fetch): bound multipart part headers

### DIFF
--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -20,6 +20,7 @@ const {
   ObjectFreeze,
   ObjectFromEntries,
   ObjectPrototypeIsPrototypeOf,
+  ReflectApply,
   SafeMap,
   SafeRegExp,
   Symbol,
@@ -387,6 +388,16 @@ const CRLF = "\r\n";
 const LF = StringPrototypeCodePointAt(CRLF, 1);
 const CR = StringPrototypeCodePointAt(CRLF, 0);
 const DASH = StringPrototypeCodePointAt("-", 0);
+const MAX_MULTIPART_PART_HEADER_SIZE = 16 * 1024;
+const MAX_MULTIPART_PART_HEADER_COUNT = 128;
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+function decodeLatin1Bytes(bytes) {
+  return ReflectApply(StringFromCharCode, null, bytes);
+}
 
 class MultipartParser {
   /**
@@ -412,11 +423,16 @@ class MultipartParser {
   #parseHeaders(headersText) {
     const headers = new Headers();
     const rawHeaders = StringPrototypeSplit(headersText, "\r\n");
+    let headerCount = 0;
     for (let i = 0; i < rawHeaders.length; ++i) {
       const rawHeader = rawHeaders[i];
       const sepIndex = StringPrototypeIndexOf(rawHeader, ":");
       if (sepIndex < 0) {
         continue; // Skip this header
+      }
+      headerCount++;
+      if (headerCount > MAX_MULTIPART_PART_HEADER_COUNT) {
+        throw new TypeError("Multipart part has too many headers");
       }
       const key = StringPrototypeSlice(rawHeader, 0, sepIndex);
       const value = StringPrototypeSlice(rawHeader, sepIndex + 1);
@@ -476,6 +492,7 @@ class MultipartParser {
 
     const formData = new FormData();
     let headerText = "";
+    let headerStart = 0;
     let state = 0;
     let fileStart = 0;
 
@@ -484,20 +501,24 @@ class MultipartParser {
       const prevByte = this.body[i - 1];
       const isNewLine = byte === LF && prevByte === CR;
 
-      if (state === 1) {
-        headerText += StringFromCharCode(byte);
-      }
-
       if (state === 0 && isNewLine) {
         state = 1;
+        headerStart = i + 1;
       } else if (
         state === 1
       ) {
+        const headerByteLength = i - headerStart + 1;
+        if (headerByteLength > MAX_MULTIPART_PART_HEADER_SIZE) {
+          throw new TypeError("Multipart part headers are too large");
+        }
         if (
           isNewLine && this.body[i + 1] === CR &&
           this.body[i + 2] === LF
         ) {
           // end of the headers section
+          headerText = decodeLatin1Bytes(
+            TypedArrayPrototypeSubarray(this.body, headerStart, i + 1),
+          );
           state = 2;
           fileStart = i + 3; // After \r\n
         }
@@ -547,6 +568,7 @@ class MultipartParser {
 
           state = 1;
           i += this.boundaryChars.length + 2; // Skip boundary + trailing \r\n
+          headerStart = i + 1;
         }
       }
     }

--- a/tests/unit/body_test.ts
+++ b/tests/unit/body_test.ts
@@ -257,6 +257,61 @@ Deno.test(
   },
 );
 
+Deno.test(async function bodyMultipartFormDataRejectsTooManyPartHeaders() {
+  const boundary = "AaB03x";
+  const partHeaders = [
+    'Content-Disposition: form-data; name="field"',
+  ];
+  for (let i = 0; i < 128; i++) {
+    partHeaders.push(`X-Deno-Test-${i}: ${i}`);
+  }
+  const payload = [
+    `--${boundary}`,
+    ...partHeaders,
+    "",
+    "value",
+    `--${boundary}--`,
+  ].join("\r\n");
+
+  const body = buildBody(
+    new TextEncoder().encode(payload),
+    new Headers({
+      "Content-Type": `multipart/form-data; boundary=${boundary}`,
+    }),
+  );
+
+  await assertRejects(
+    () => body.formData(),
+    TypeError,
+    "too many headers",
+  );
+});
+
+Deno.test(async function bodyMultipartFormDataRejectsLargePartHeaders() {
+  const boundary = "AaB03x";
+  const payload = [
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="field"',
+    `X-Deno-Large: ${"a".repeat(16 * 1024)}`,
+    "",
+    "value",
+    `--${boundary}--`,
+  ].join("\r\n");
+
+  const body = buildBody(
+    new TextEncoder().encode(payload),
+    new Headers({
+      "Content-Type": `multipart/form-data; boundary=${boundary}`,
+    }),
+  );
+
+  await assertRejects(
+    () => body.formData(),
+    TypeError,
+    "headers are too large",
+  );
+});
+
 Deno.test(
   async function bodyMultipartFormDataEmbeddedBoundaryTextInFileContent() {
     const boundary = "AaB03x";


### PR DESCRIPTION
## Summary

- limit each multipart part's header block to 16 KiB
- reject parts with more than 128 parsed headers
- decode the bounded header byte range once instead of appending one byte at a time

## Context

Multipart form parsing previously accepted an unbounded header block and an
unbounded number of headers for each part. Large or malformed parts could
therefore require disproportionate processing before the form-data parser
returned.

Inputs that exceed either limit now fail with a `TypeError` at the point the
limit is reached. Ordinary multipart parsing and its existing Latin-1 header
handling remain unchanged.

## Validation

- `./tools/format.js`
- `./tools/lint.js`
- `cargo build --bin deno --bin test_server`
- `cargo test -p unit_tests --test unit unit::body_test`
- large multipart-header smoke test rejects promptly with the expected error
