### PR TITLE
chore: insert into versions.json in semver order during release

### DIFF
--- a/tools/release/update_versions_json.ts
+++ b/tools/release/update_versions_json.ts
@@ -2,9 +2,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // deno-lint-ignore-file no-console
 
-// Fetches the current versions.json from the bucket, prepends the given
-// release version to the "cli" list (if not already present), and writes the
-// result to versions.json.
+// Fetches the current versions.json from the bucket, inserts the given release
+// version into the "cli" list in descending (newest-first) order (if not
+// already present), and writes the result to versions.json.
+
+import { greaterThan, parse } from "jsr:@std/semver@1";
 
 const version = Deno.args[0];
 if (!version) {
@@ -30,9 +32,18 @@ if (response.ok) {
   await response.body?.cancel();
 }
 
-// The freshly published release is always the newest, so prepend it.
+// Insert in descending (newest-first) order rather than blindly prepending.
+// Releases are not always published newest-first: an LTS patch (e.g. v2.9.5)
+// can ship after a newer stable (e.g. v3.0.0), and a prepend would then list it
+// above the newer versions. Insert by semver so the ordering stays correct.
 if (!versions.cli.includes(version)) {
-  versions.cli.unshift(version);
+  const parsed = parse(version);
+  const idx = versions.cli.findIndex((v) => greaterThan(parsed, parse(v)));
+  if (idx === -1) {
+    versions.cli.push(version);
+  } else {
+    versions.cli.splice(idx, 0, version);
+  }
 }
 
 console.error("Adding version:", version);


### PR DESCRIPTION
update_versions_json.ts assumed the freshly published release is always
the newest and blindly prepended it to the cli list. That assumption
breaks once the LTS line diverges from stable: a 2.9.x patch published
after 3.0.0 has shipped would be prepended above the newer 3.x versions,
so anything treating the top of the list as newest would show the LTS
patch as the latest release.

Insert the version by semver in descending order instead. A newest
release still lands at the front, an older LTS patch lands in its correct
position, and prereleases keep their semver ordering.