### PR TITLE
fix(add): support --minimum-dependency-age flag in deno add/remove

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1714,6 +1714,7 @@ Or multiple dependencies at once:
       )
       .arg(package_json_arg())
       .arg(env_file_arg())
+      .arg(min_dep_age_arg())
   })
 }
 
@@ -1910,6 +1911,7 @@ removes a globally installed executable script:
       .args(lock_args())
       .arg(lockfile_only_arg().conflicts_with("global"))
       .arg(package_json_arg().conflicts_with("global"))
+      .arg(min_dep_age_arg().conflicts_with("global"))
   })
 }
 
@@ -6555,6 +6557,7 @@ fn add_parse(
   allow_and_deny_import_parse(flags, matches)?;
   lock_args_parse(flags, matches);
   env_file_arg_parse(flags, matches);
+  min_dep_age_arg_parse(flags, matches);
   flags.subcommand = DenoSubcommand::Add(add_parse_inner(matches, None));
   Ok(())
 }
@@ -6593,6 +6596,7 @@ fn remove_parse(
   matches: &mut ArgMatches,
 ) -> clap::error::Result<()> {
   lock_args_parse(flags, matches);
+  min_dep_age_arg_parse(flags, matches);
   let packages = matches.remove_many::<String>("packages").unwrap();
 
   // `deno remove --global <name>...` is an alias for `deno uninstall --global
@@ -12098,6 +12102,26 @@ mod tests {
       assert_eq!(
         flags.minimum_dependency_age,
         Some(NewestDependencyDate::Disabled)
+      );
+    }
+  }
+
+  #[test]
+  fn minimum_dependency_age_pm_subcommands() {
+    // The package management subcommands that resolve versions must accept the
+    // flag so users can act on the "blocked by minimum dependency age" hint.
+    let cases = [
+      svec!["deno", "add", "--min-dep-age=0", "jsr:@std/path"],
+      svec!["deno", "add", "--minimum-dependency-age=0", "jsr:@std/path"],
+      svec!["deno", "remove", "--min-dep-age=0", "@std/path"],
+    ];
+    for args in cases {
+      let flags = flags_from_vec(args.clone())
+        .unwrap_or_else(|e| panic!("failed to parse {args:?}: {e}"));
+      assert_eq!(
+        flags.minimum_dependency_age,
+        Some(NewestDependencyDate::Disabled),
+        "{args:?}"
       );
     }
   }

--- a/tests/specs/add/min_dep_age_flag/__test__.jsonc
+++ b/tests/specs/add/min_dep_age_flag/__test__.jsonc
@@ -1,0 +1,11 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": ["add", "jsr:@denotest/add@^1.0.0"],
+    "output": "blocked.out",
+    "exitCode": 1
+  }, {
+    "args": ["add", "jsr:@denotest/add@^1.0.0", "--min-dep-age=0"],
+    "output": "disabled.out"
+  }]
+}

--- a/tests/specs/add/min_dep_age_flag/blocked.out
+++ b/tests/specs/add/min_dep_age_flag/blocked.out
@@ -1,0 +1,6 @@
+error: Could not find version of '@denotest/add' that matches specified version constraint '^1.0.0'
+
+A newer matching version was found, but it was not used because it was newer than the specified minimum dependency date of 2025-05-15 00:00:00 UTC
+
+hint: This version is blocked by the minimum dependency age policy, which avoids installing recently published versions to reduce supply chain risk (the default is 24 hours). To use this version now, pass the --minimum-dependency-age (or --min-dep-age) flag (for example 0 to disable it, or a shorter duration like 60 minutes) or set "minimumDependencyAge" in your deno.json, or wait until the version is old enough.
+docs: https://docs.deno.com/go/minimum-dependency-age

--- a/tests/specs/add/min_dep_age_flag/deno.json
+++ b/tests/specs/add/min_dep_age_flag/deno.json
@@ -1,0 +1,3 @@
+{
+  "minimumDependencyAge": "2025-05-15T00:00:00.000Z"
+}

--- a/tests/specs/add/min_dep_age_flag/disabled.out
+++ b/tests/specs/add/min_dep_age_flag/disabled.out
@@ -1,0 +1,2 @@
+Add jsr:@denotest/add@1.0.0
+[WILDCARD]


### PR DESCRIPTION
When a package can not be resolved because the only matching version is
newer than the configured minimum dependency age, Deno prints a hint that
tells the user to override the policy by passing the
`--minimum-dependency-age` (or `--min-dep-age`) flag, for example
`--min-dep-age=0` to disable it.

The problem is that `deno add` and `deno remove` never registered that
flag, so following the hint failed:

    $ deno add jsr:@mirage/core@^0.1.1 --minimum-dependency-age=0
    error: unexpected argument '--minimum-dependency-age' found

The flag was only wired into `run`, `cache`, `install`, `check`,
`compile`, `bundle`, `info`, `outdated` and `update`, even though
`deno add` is the command most likely to hit the minimum dependency age
policy since it resolves and selects versions directly. This left users
with no way to act on the hint short of editing `deno.json`.

This registers `--minimum-dependency-age` (with the `--min-dep-age`
alias) on `deno add` and `deno remove` and wires up parsing so the value
flows into the resolver the same way it does for the other subcommands.
On `deno remove` the flag conflicts with `--global`, which routes to the
uninstaller and does not resolve versions.

A spec test covers both directions: `deno add` of a version blocked by
the configured minimum dependency age prints the hint and exits non-zero,
and re-running with `--min-dep-age=0` installs it. The existing
`minimum_dependency_age_alias` unit test is extended to cover `add` and
`remove`.

Closes https://github.com/denoland/deno/issues/36095