### PR TITLE
perf: use FxHash for hot internal hash maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,6 +2810,7 @@ name = "deno_maybe_sync"
 version = "0.42.0"
 dependencies = [
  "dashmap",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -3314,6 +3315,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "phf 0.11.2",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sys_traits",
@@ -7042,6 +7044,7 @@ dependencies = [
  "percent-encoding",
  "pretty_assertions",
  "regex",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sys_traits",

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -3,7 +3,6 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::future::Future;
 use std::path::Path;
 use std::path::PathBuf;
@@ -84,6 +83,7 @@ use node_resolver::InNpmPackageChecker;
 use node_resolver::NodeResolutionKind;
 use node_resolver::ResolutionMode;
 use node_resolver::errors::PackageJsonLoadError;
+use rustc_hash::FxHashSet;
 use sys_traits::FsCanonicalize;
 use sys_traits::FsMetadata;
 use sys_traits::FsMetadataValue;
@@ -593,7 +593,7 @@ struct CliModuleLoaderInner<TGraphContainer: ModuleGraphContainer> {
   permissions: PermissionsContainer,
   shared: Arc<SharedCliModuleLoaderState>,
   graph_container: TGraphContainer,
-  loaded_files: RefCell<HashSet<ModuleSpecifier>>,
+  loaded_files: RefCell<FxHashSet<ModuleSpecifier>>,
   hook_registry: deno_runtime::deno_node::ops::module_hooks::LoaderHookRegistry,
   /// For blob/object-URL module workers, the captured root blob and its
   /// specifier. Captured synchronously at worker construction so that a

--- a/cli/type_checker.rs
+++ b/cli/type_checker.rs
@@ -28,6 +28,7 @@ use deno_terminal::colors;
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use rustc_hash::FxHashSet;
 
 use crate::args::CliOptions;
 use crate::args::CompilerOptions;
@@ -500,7 +501,7 @@ struct DiagnosticsByFolderRealIterator<'a> {
   current_group_index: usize,
   log_level: Option<log::Level>,
   npm_check_state_hash: Option<u64>,
-  seen_diagnotics: HashSet<String>,
+  seen_diagnotics: FxHashSet<String>,
   options: CheckOptions,
   code_cache: Option<Arc<crate::cache::CodeCache>>,
   initial_cwd: PathBuf,
@@ -880,7 +881,7 @@ struct GraphWalker<'a> {
   /// packages linked via the "links" field), used to enhance import errors.
   bare_importable_pkg_names: &'a [String],
   maybe_hasher: Option<FastInsecureHasher>,
-  seen: HashSet<&'a Url>,
+  seen: FxHashSet<&'a Url>,
   pending: VecDeque<PendingGraphWalkSpecifier<'a>>,
   has_seen_node_builtin: bool,
   roots: Vec<(ModuleSpecifier, MediaType)>,
@@ -927,8 +928,9 @@ impl<'a> GraphWalker<'a> {
       compiler_options_resolver,
       bare_importable_pkg_names,
       maybe_hasher,
-      seen: HashSet::with_capacity(
+      seen: FxHashSet::with_capacity_and_hasher(
         graph.imports.len() + graph.specifiers_count(),
+        Default::default(),
       ),
       pending: VecDeque::new(),
       has_seen_node_builtin: false,

--- a/libs/maybe_sync/Cargo.toml
+++ b/libs/maybe_sync/Cargo.toml
@@ -16,3 +16,4 @@ sync = ["dashmap"]
 
 [dependencies]
 dashmap = { workspace = true, optional = true }
+rustc-hash.workspace = true

--- a/libs/maybe_sync/lib.rs
+++ b/libs/maybe_sync/lib.rs
@@ -14,8 +14,10 @@ mod inner {
   pub use std::sync::Arc as MaybeArc;
   pub use std::sync::OnceLock as MaybeOnceLock;
 
-  pub use dashmap::DashMap as MaybeDashMap;
-  pub use dashmap::DashSet as MaybeDashSet;
+  pub type MaybeDashMap<K, V, S = rustc_hash::FxBuildHasher> =
+    dashmap::DashMap<K, V, S>;
+  pub type MaybeDashSet<T, S = rustc_hash::FxBuildHasher> =
+    dashmap::DashSet<T, S>;
 }
 
 #[cfg(not(feature = "sync"))]
@@ -26,8 +28,9 @@ mod inner {
   use std::collections::HashMap;
   use std::hash::BuildHasher;
   use std::hash::Hash;
-  use std::hash::RandomState;
   pub use std::rc::Rc as MaybeArc;
+
+  use rustc_hash::FxBuildHasher;
 
   pub trait MaybeSync {}
   impl<T> MaybeSync for T where T: ?Sized {}
@@ -35,8 +38,17 @@ mod inner {
   impl<T> MaybeSend for T where T: ?Sized {}
 
   // Wrapper struct that exposes a subset of `DashMap` API.
-  #[derive(Debug)]
-  pub struct MaybeDashMap<K, V, S = RandomState>(RefCell<HashMap<K, V, S>>);
+  pub struct MaybeDashMap<K, V, S = FxBuildHasher>(RefCell<HashMap<K, V, S>>);
+
+  // manual impl to avoid requiring `S: Debug` (ex. `FxBuildHasher`
+  // does not implement `Debug`)
+  impl<K: std::fmt::Debug, V: std::fmt::Debug, S> std::fmt::Debug
+    for MaybeDashMap<K, V, S>
+  {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+      std::fmt::Debug::fmt(&self.0, f)
+    }
+  }
 
   impl<K, V, S> Default for MaybeDashMap<K, V, S>
   where
@@ -79,10 +91,17 @@ mod inner {
   }
 
   // Wrapper struct that exposes a subset of `DashMap` API.
-  #[derive(Debug)]
-  pub struct MaybeDashSet<V, S = RandomState>(
+  pub struct MaybeDashSet<V, S = FxBuildHasher>(
     RefCell<std::collections::HashSet<V, S>>,
   );
+
+  // manual impl to avoid requiring `S: Debug` (ex. `FxBuildHasher`
+  // does not implement `Debug`)
+  impl<V: std::fmt::Debug, S> std::fmt::Debug for MaybeDashSet<V, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+      std::fmt::Debug::fmt(&self.0, f)
+    }
+  }
 
   impl<V, S> Default for MaybeDashSet<V, S>
   where

--- a/libs/node_resolver/Cargo.toml
+++ b/libs/node_resolver/Cargo.toml
@@ -37,6 +37,7 @@ path-clean.workspace = true
 percent-encoding.workspace = true
 pretty_assertions.workspace = true
 regex.workspace = true
+rustc-hash.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sys_traits.workspace = true

--- a/libs/node_resolver/cache.rs
+++ b/libs/node_resolver/cache.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 
+use rustc_hash::FxHashMap;
 use sys_traits::BaseFsCanonicalize;
 use sys_traits::BaseFsOpen;
 use sys_traits::BaseFsRead;
@@ -31,8 +31,8 @@ pub trait NodeResolutionCache:
 }
 
 thread_local! {
-  static CANONICALIZED_CACHE: RefCell<HashMap<PathBuf, Option<PathBuf>>> = RefCell::new(HashMap::new());
-  static FILE_TYPE_CACHE: RefCell<HashMap<PathBuf, Option<FileType>>> = RefCell::new(HashMap::new());
+  static CANONICALIZED_CACHE: RefCell<FxHashMap<PathBuf, Option<PathBuf>>> = RefCell::new(FxHashMap::default());
+  static FILE_TYPE_CACHE: RefCell<FxHashMap<PathBuf, Option<FileType>>> = RefCell::new(FxHashMap::default());
 }
 
 // We use thread local caches here because it's just more convenient

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -5,7 +5,6 @@ use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
@@ -26,6 +25,8 @@ use futures::stream::FuturesUnordered;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use log::debug;
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use thiserror::Error;
 
 use super::common::NpmPackageVersionResolutionError;
@@ -148,8 +149,8 @@ impl ResolvedId {
 /// at sharing nodes.
 #[derive(Default)]
 struct ResolvedNodeIds {
-  node_to_resolved_id: HashMap<NodeId, (ResolvedId, u64)>,
-  resolved_to_node_id: HashMap<u64, NodeId>,
+  node_to_resolved_id: FxHashMap<NodeId, (ResolvedId, u64)>,
+  resolved_to_node_id: FxHashMap<u64, NodeId>,
 }
 
 impl ResolvedNodeIds {
@@ -293,27 +294,27 @@ impl GraphPath {
 
 struct PackagesForSnapshot<'a> {
   packages: Vec<NpmResolutionPackage>,
-  packages_by_name: HashMap<PackageName, Vec<NpmPackageId>>,
-  traversed_ids: HashSet<&'a NpmPackageId>,
+  packages_by_name: FxHashMap<PackageName, Vec<NpmPackageId>>,
+  traversed_ids: FxHashSet<&'a NpmPackageId>,
 }
 
 /// Tarjan's strongly connected components algorithm.
 ///
 /// Returns SCCs in reverse topological order (leaf/sink SCCs first),
 /// which is the order we need for bottom-up ID computation.
-fn tarjan_scc(adj: &HashMap<NodeId, Vec<NodeId>>) -> Vec<Vec<NodeId>> {
+fn tarjan_scc(adj: &FxHashMap<NodeId, Vec<NodeId>>) -> Vec<Vec<NodeId>> {
   struct TarjanState {
     index_counter: usize,
     stack: Vec<NodeId>,
-    on_stack: HashSet<NodeId>,
-    indices: HashMap<NodeId, usize>,
-    lowlinks: HashMap<NodeId, usize>,
+    on_stack: FxHashSet<NodeId>,
+    indices: FxHashMap<NodeId, usize>,
+    lowlinks: FxHashMap<NodeId, usize>,
     result: Vec<Vec<NodeId>>,
   }
 
   fn strongconnect(
     node: NodeId,
-    adj: &HashMap<NodeId, Vec<NodeId>>,
+    adj: &FxHashMap<NodeId, Vec<NodeId>>,
     state: &mut TarjanState,
   ) {
     state.indices.insert(node, state.index_counter);
@@ -358,9 +359,9 @@ fn tarjan_scc(adj: &HashMap<NodeId, Vec<NodeId>>) -> Vec<Vec<NodeId>> {
   let mut state = TarjanState {
     index_counter: 0,
     stack: Vec::new(),
-    on_stack: HashSet::new(),
-    indices: HashMap::new(),
-    lowlinks: HashMap::new(),
+    on_stack: FxHashSet::default(),
+    indices: FxHashMap::default(),
+    lowlinks: FxHashMap::default(),
     result: Vec::new(),
   };
 
@@ -375,17 +376,17 @@ fn tarjan_scc(adj: &HashMap<NodeId, Vec<NodeId>>) -> Vec<Vec<NodeId>> {
 
 pub struct Graph {
   /// Each requirement is mapped to a specific name and version.
-  package_reqs: HashMap<PackageReq, Rc<PackageNv>>,
+  package_reqs: FxHashMap<PackageReq, Rc<PackageNv>>,
   /// Then each name and version is mapped to an exact node id.
   /// Note: Uses a BTreeMap in order to create some determinism
   /// when creating the snapshot.
   root_packages: BTreeMap<Rc<PackageNv>, NodeId>,
-  package_name_versions: HashMap<StackString, HashSet<Version>>,
-  nodes: HashMap<NodeId, Node>,
+  package_name_versions: FxHashMap<StackString, FxHashSet<Version>>,
+  nodes: FxHashMap<NodeId, Node>,
   resolved_node_ids: ResolvedNodeIds,
   // This will be set when creating from a snapshot, then
   // inform the final snapshot creation.
-  packages_to_copy_index: HashMap<NpmPackageId, u8>,
+  packages_to_copy_index: FxHashMap<NpmPackageId, u8>,
   moved_package_ids: IndexMap<NodeId, (ResolvedId, ResolvedId)>,
   #[cfg(feature = "tracing")]
   traces: Vec<super::tracing::TraceGraphSnapshot>,
@@ -396,8 +397,8 @@ impl Graph {
     fn get_or_create_graph_node<'a>(
       graph: &mut Graph,
       pkg_id: &NpmPackageId,
-      packages: &HashMap<NpmPackageId, NpmResolutionPackage>,
-      created_package_ids: &mut HashMap<NpmPackageId, NodeId>,
+      packages: &FxHashMap<NpmPackageId, NpmResolutionPackage>,
+      created_package_ids: &mut FxHashMap<NpmPackageId, NodeId>,
       ancestor_ids: &'a OneDirectionalLinkedList<'a, NpmPackageId>,
     ) -> NodeId {
       if let Some(id) = created_package_ids.get(pkg_id) {
@@ -504,8 +505,10 @@ impl Graph {
       #[cfg(feature = "tracing")]
       traces: Default::default(),
     };
-    let mut created_package_ids =
-      HashMap::with_capacity(snapshot.packages.len());
+    let mut created_package_ids = FxHashMap::with_capacity_and_hasher(
+      snapshot.packages.len(),
+      Default::default(),
+    );
     for (id, resolved_id) in snapshot.root_packages {
       let node_id = get_or_create_graph_node(
         &mut graph,
@@ -535,7 +538,7 @@ impl Graph {
   ///
   /// Each node's ID is computed exactly ONCE, avoiding the O(n²) expansion
   /// that occurred with the previous per-path computing HashSet approach.
-  fn compute_all_npm_pkg_ids(&self) -> HashMap<NodeId, NpmPackageId> {
+  fn compute_all_npm_pkg_ids(&self) -> FxHashMap<NodeId, NpmPackageId> {
     // Step 1: Build per-node peer info and NV-level adjacency graph.
     //
     // We need TWO levels of analysis:
@@ -545,17 +548,17 @@ impl Graph {
     //   even if the specific NodeIds involved are different.
     // - Node-level (NodeId): for computation ordering. We process nodes
     //   in topological order so non-cyclic peers are cached before use.
-    let mut node_peers: HashMap<NodeId, Vec<(NodeId, Rc<PackageNv>)>> =
-      HashMap::new();
-    let mut nv_peer_adj: HashMap<Rc<PackageNv>, HashSet<Rc<PackageNv>>> =
-      HashMap::new();
-    let mut node_adj: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+    let mut node_peers: FxHashMap<NodeId, Vec<(NodeId, Rc<PackageNv>)>> =
+      FxHashMap::default();
+    let mut nv_peer_adj: FxHashMap<Rc<PackageNv>, FxHashSet<Rc<PackageNv>>> =
+      FxHashMap::default();
+    let mut node_adj: FxHashMap<NodeId, Vec<NodeId>> = FxHashMap::default();
 
     for (&node_id, (resolved_id, _)) in
       &self.resolved_node_ids.node_to_resolved_id
     {
       let nv_entry = nv_peer_adj.entry(resolved_id.nv.clone()).or_default();
-      let mut seen_nvs = HashSet::new();
+      let mut seen_nvs = FxHashSet::default();
       let mut peers = Vec::new();
       let mut adj = Vec::new();
 
@@ -578,13 +581,13 @@ impl Graph {
     // Map each unique NV to a pseudo NodeId for Tarjan's, which operates
     // on HashMap<NodeId, Vec<NodeId>>.
     let all_nvs: Vec<Rc<PackageNv>> = nv_peer_adj.keys().cloned().collect();
-    let nv_to_idx: HashMap<&PackageNv, usize> = all_nvs
+    let nv_to_idx: FxHashMap<&PackageNv, usize> = all_nvs
       .iter()
       .enumerate()
       .map(|(i, nv)| (nv.as_ref(), i))
       .collect();
 
-    let nv_adj_for_tarjan: HashMap<NodeId, Vec<NodeId>> = all_nvs
+    let nv_adj_for_tarjan: FxHashMap<NodeId, Vec<NodeId>> = all_nvs
       .iter()
       .enumerate()
       .map(|(i, nv)| {
@@ -606,8 +609,8 @@ impl Graph {
     let nv_sccs = tarjan_scc(&nv_adj_for_tarjan);
 
     // Build: for each NV, which SCC index is it in? And which NVs are cyclic?
-    let mut nv_scc_idx: HashMap<&PackageNv, usize> = HashMap::new();
-    let mut cyclic_nvs: HashSet<&PackageNv> = HashSet::new();
+    let mut nv_scc_idx: FxHashMap<&PackageNv, usize> = FxHashMap::default();
+    let mut cyclic_nvs: FxHashSet<&PackageNv> = FxHashSet::default();
     for (scc_idx, scc) in nv_sccs.iter().enumerate() {
       let is_cycle = scc.len() > 1
         || (scc.len() == 1
@@ -631,8 +634,8 @@ impl Graph {
     // For each node's peer deps, check if the peer's NV forms a cycle
     // with the node's own NV. If so, use flat name@version. Otherwise
     // use the cached (already computed) full ID.
-    let mut cache: HashMap<NodeId, NpmPackageId> =
-      HashMap::with_capacity(self.nodes.len());
+    let mut cache: FxHashMap<NodeId, NpmPackageId> =
+      FxHashMap::with_capacity_and_hasher(self.nodes.len(), Default::default());
 
     for scc in &node_sccs {
       for &node_id in scc {
@@ -700,7 +703,7 @@ impl Graph {
   fn get_npm_pkg_id_from_resolved_id_using_cache(
     &self,
     resolved_id: &ResolvedId,
-    cache: &HashMap<NodeId, NpmPackageId>,
+    cache: &FxHashMap<NodeId, NpmPackageId>,
   ) -> NpmPackageId {
     if let Some(node_id) = self.resolved_node_ids.get_node_id(resolved_id)
       && let Some(pkg_id) = cache.get(&node_id)
@@ -803,9 +806,10 @@ impl Graph {
     &self,
     api: &TNpmRegistryApi,
     link_packages: &HashMap<PackageName, Vec<NpmPackageVersionInfo>>,
-    packages_to_pkg_ids: &'ids HashMap<NodeId, NpmPackageId>,
+    packages_to_pkg_ids: &'ids FxHashMap<NodeId, NpmPackageId>,
   ) -> Result<Option<PackagesForSnapshot<'ids>>, NpmResolutionError> {
-    let mut traversed_ids = HashSet::with_capacity(self.nodes.len());
+    let mut traversed_ids =
+      FxHashSet::with_capacity_and_hasher(self.nodes.len(), Default::default());
     let mut pending = VecDeque::with_capacity(self.nodes.len());
     for root_id in self.root_packages.values().copied() {
       let pkg_id = packages_to_pkg_ids.get(&root_id).unwrap();
@@ -839,8 +843,8 @@ impl Graph {
       });
     }
 
-    let mut packages_by_name: HashMap<PackageName, Vec<_>> =
-      HashMap::with_capacity(self.nodes.len());
+    let mut packages_by_name: FxHashMap<PackageName, Vec<_>> =
+      FxHashMap::with_capacity_and_hasher(self.nodes.len(), Default::default());
     let mut packages: Vec<NpmResolutionPackage> =
       Vec::with_capacity(self.nodes.len());
     while let Some(result) = pending_futures.next().await {
@@ -906,7 +910,7 @@ impl Graph {
 
   fn into_snapshot_from_packages(
     mut self,
-    packages_to_pkg_ids: &HashMap<NodeId, NpmPackageId>,
+    packages_to_pkg_ids: &FxHashMap<NodeId, NpmPackageId>,
     pkgs_for_snapshot: PackagesForSnapshot<'_>,
   ) -> Result<NpmResolutionSnapshot, NpmResolutionError> {
     let PackagesForSnapshot {
@@ -1014,8 +1018,8 @@ impl Graph {
   #[cfg(debug_assertions)]
   #[allow(unused, clippy::print_stderr, reason = "debug utility")]
   fn output_node_with_ids(
-    nodes: &HashMap<NodeId, Node>,
-    pkg_ids: &HashMap<NodeId, NpmPackageId>,
+    nodes: &FxHashMap<NodeId, Node>,
+    pkg_ids: &FxHashMap<NodeId, NpmPackageId>,
     node_id: NodeId,
     show_children: bool,
   ) {
@@ -1051,7 +1055,7 @@ impl Graph {
 }
 
 #[derive(Default)]
-struct DepEntryCache(HashMap<Rc<PackageNv>, Rc<Vec<NpmDependencyEntry>>>);
+struct DepEntryCache(FxHashMap<Rc<PackageNv>, Rc<Vec<NpmDependencyEntry>>>);
 
 impl DepEntryCache {
   pub fn store(
@@ -1097,20 +1101,20 @@ pub struct GraphDependencyResolver<'a, TNpmRegistryApi: NpmRegistryApi> {
   /// that have already been re-queued for processing. Uses canonical node IDs
   /// (via `node_id_mappings`) so that node copies from `add_peer_deps_to_path`
   /// share the same dedup entries as their originals.
-  visited_requeue: HashSet<(NodeId, NodeId)>,
+  visited_requeue: FxHashSet<(NodeId, NodeId)>,
   /// Maps old NodeId → new NodeId when `add_peer_deps_to_path` creates a copy.
   /// Used to canonicalize node IDs for `visited_requeue` dedup, so that copies
   /// don't bypass the dedup check.
-  node_id_mappings: HashMap<NodeId, NodeId>,
+  node_id_mappings: FxHashMap<NodeId, NodeId>,
   // --- Phase 2: Peer resolution with caching ---
   /// Packages whose entire subtree has no externally resolved peer deps.
   /// Once marked pure, subsequent encounters skip the entire subtree.
-  pure_pkgs: HashSet<Rc<PackageNv>>,
+  pure_pkgs: FxHashSet<Rc<PackageNv>>,
   /// Cache of peer resolution results per package version.
   /// Each entry records which peers were resolved and to what NodeId.
   /// `find_peers_cache_hit` checks if the current parent context
   /// matches a cached entry.
-  peers_cache: HashMap<Rc<PackageNv>, Vec<PeersResolution>>,
+  peers_cache: FxHashMap<Rc<PackageNv>, Vec<PeersResolution>>,
   /// Auto-installed peer deps as fallback, not in root_packages so they
   /// don't pollute the root scope. Phase 2 uses these when a required
   /// peer isn't found in scope.
@@ -1137,10 +1141,10 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       reporter,
       should_dedup: options.should_dedup,
       initial_overrides: Rc::new((*version_resolver.overrides).clone()),
-      visited_requeue: HashSet::new(),
-      node_id_mappings: HashMap::new(),
-      pure_pkgs: HashSet::new(),
-      peers_cache: HashMap::new(),
+      visited_requeue: FxHashSet::default(),
+      node_id_mappings: FxHashMap::default(),
+      pure_pkgs: FxHashSet::default(),
+      peers_cache: FxHashMap::default(),
       peer_fallbacks: BTreeMap::new(),
     }
   }
@@ -1580,7 +1584,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       .collect();
 
     for (_nv, node_id) in &roots {
-      let mut visiting = HashSet::new();
+      let mut visiting = FxHashSet::default();
       let result = self.resolve_peers_of_node(
         *node_id,
         &root_scope,
@@ -1603,7 +1607,8 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
   fn dedup_peer_dependents(&mut self) {
     // Group NodeIds by PackageNv (name@version). Only groups with 2+
     // entries are candidates for dedup.
-    let mut nv_to_nodes: HashMap<Rc<PackageNv>, Vec<NodeId>> = HashMap::new();
+    let mut nv_to_nodes: FxHashMap<Rc<PackageNv>, Vec<NodeId>> =
+      FxHashMap::default();
     for (&node_id, (resolved_id, _)) in
       &self.graph.resolved_node_ids.node_to_resolved_id
     {
@@ -1647,8 +1652,8 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
   fn dedup_dep_paths(
     &self,
     duplicates: &[Vec<NodeId>],
-  ) -> (HashMap<NodeId, NodeId>, Vec<Vec<NodeId>>) {
-    let mut dep_paths_map: HashMap<NodeId, NodeId> = HashMap::new();
+  ) -> (FxHashMap<NodeId, NodeId>, Vec<Vec<NodeId>>) {
+    let mut dep_paths_map: FxHashMap<NodeId, NodeId> = FxHashMap::default();
     let mut remaining: Vec<Vec<NodeId>> = Vec::new();
 
     for node_ids in duplicates {
@@ -1768,7 +1773,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
 
   /// Apply dedup mappings to the entire graph.
   /// Replace all references to subset NodeIds with their superset NodeIds.
-  fn apply_dedup_mappings(&mut self, mappings: &HashMap<NodeId, NodeId>) {
+  fn apply_dedup_mappings(&mut self, mappings: &FxHashMap<NodeId, NodeId>) {
     // Update node children
     let all_node_ids: Vec<NodeId> = self.graph.nodes.keys().copied().collect();
     for node_id in &all_node_ids {
@@ -1842,7 +1847,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     &mut self,
     node_id: NodeId,
     parent_pkgs: &BTreeMap<StackString, NodeId>,
-    visiting: &mut HashSet<NodeId>,
+    visiting: &mut FxHashSet<NodeId>,
     ancestors: &[Rc<PackageNv>],
   ) -> Result<PeersResolution, NpmResolutionError> {
     let nv = self
@@ -2055,7 +2060,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     // When siblings are peers of each other, copies initially reference
     // the ORIGINAL nodes. Update them to reference copies.
     {
-      let original_to_copy: HashMap<NodeId, NodeId> = all_deps_to_recurse
+      let original_to_copy: FxHashMap<NodeId, NodeId> = all_deps_to_recurse
         .iter()
         .filter_map(|(spec, orig_id)| {
           let copy_id = resolved_children.get(spec)?;
@@ -2102,7 +2107,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
 
     // Check if there are transitive peers that would be added to identity.
     // These are peers from children that are NOT own children or own peers.
-    let original_child_names_set: HashSet<&StackString> =
+    let original_child_names_set: FxHashSet<&StackString> =
       children.iter().map(|(s, _)| s).collect();
     let has_transitive_peers = all_resolved_peers.keys().any(|name| {
       !original_child_names_set.contains(name)
@@ -2123,7 +2128,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
         let old_resolved_id =
           self.graph.resolved_node_ids.get(node_id).unwrap().clone();
         let mut new_peer_deps: Vec<NodeId> = Vec::new();
-        let mut seen_nvs: HashSet<Rc<PackageNv>> = HashSet::new();
+        let mut seen_nvs: FxHashSet<Rc<PackageNv>> = FxHashSet::default();
 
         // Add own peer deps first
         for (spec, _orig_peer_id) in &own_peer_deps {
@@ -2244,7 +2249,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     // regular deps are "consumed" here and don't bubble further up.
     // We use the original `children` vec (Phase 1 regular deps), NOT the
     // copy node's children (which includes newly-added peer deps).
-    let original_child_names: HashSet<&StackString> =
+    let original_child_names: FxHashSet<&StackString> =
       children.iter().map(|(s, _)| s).collect();
     let should_bubble = |name: &StackString| {
       !original_child_names.contains(name) && name.as_str() != nv.name.as_str()
@@ -2312,7 +2317,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     nv: &Rc<PackageNv>,
     parent_pkgs: &BTreeMap<StackString, NodeId>,
   ) -> Option<PeersResolution> {
-    let mut checking = HashSet::new();
+    let mut checking = FxHashSet::default();
     // Memoize recursive equivalence checks within this call.
     // `parent_pkgs` is constant throughout, so the result of
     // "does nv X have a matching cache entry?" is the same every
@@ -2320,7 +2325,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     // (like the AWS CDK v1 suite) cause combinatorial explosion:
     // each cache entry re-checks the same peers, each of which
     // re-checks their peers, leading to millions of redundant calls.
-    let mut memo = HashMap::new();
+    let mut memo = FxHashMap::default();
     self.find_peers_cache_hit_inner(nv, parent_pkgs, &mut checking, &mut memo)
   }
 
@@ -2328,8 +2333,8 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     &self,
     nv: &Rc<PackageNv>,
     parent_pkgs: &BTreeMap<StackString, NodeId>,
-    checking: &mut HashSet<Rc<PackageNv>>,
-    memo: &mut HashMap<Rc<PackageNv>, Option<PeersResolution>>,
+    checking: &mut FxHashSet<Rc<PackageNv>>,
+    memo: &mut FxHashMap<Rc<PackageNv>, Option<PeersResolution>>,
   ) -> Option<PeersResolution> {
     // Return memoized result if we've already fully evaluated this nv.
     if let Some(result) = memo.get(nv) {
@@ -2933,7 +2938,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
           .get(*node_id)
           .map(|r| r.nv.clone())
       })
-      .collect::<HashSet<_>>();
+      .collect::<FxHashSet<_>>();
     for (peer_dep, nv) in peer_deps {
       if *nv == new_resolved_id.nv {
         continue;
@@ -3013,12 +3018,17 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
   async fn run_dedup_pass(&mut self) -> Result<(), NpmResolutionError> {
     debug!("Running npm dedup pass.");
     type VersionReqsByVersion = BTreeMap<Version, Vec<VersionReq>>;
-    let mut package_version_reqs_by_version: HashMap<
+    let mut package_version_reqs_by_version: FxHashMap<
       PackageName,
       VersionReqsByVersion,
-    > = HashMap::with_capacity(self.graph.nodes.len());
-    let mut seen_nodes: HashSet<NodeId> =
-      HashSet::with_capacity(self.graph.nodes.len());
+    > = FxHashMap::with_capacity_and_hasher(
+      self.graph.nodes.len(),
+      Default::default(),
+    );
+    let mut seen_nodes: FxHashSet<NodeId> = FxHashSet::with_capacity_and_hasher(
+      self.graph.nodes.len(),
+      Default::default(),
+    );
     let mut pending_nodes: VecDeque<NodeId> = Default::default();
 
     for (req, pkg_nv) in &self.graph.package_reqs {
@@ -3143,7 +3153,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
 
     let mut consolidated_versions: BTreeMap<
       PackageName,
-      HashMap<VersionReq, Version>,
+      FxHashMap<VersionReq, Version>,
     > = Default::default();
 
     for (package_name, reqs_by_version) in package_version_reqs_by_version {
@@ -3229,7 +3239,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       else {
         continue;
       };
-      let target_versions: HashSet<&Version> =
+      let target_versions: FxHashSet<&Version> =
         versions_by_req.values().collect();
       if target_versions.contains(&current_nv.version) {
         continue; // already at a target version
@@ -3306,7 +3316,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     &self,
     package_name: &PackageName,
     by_version: &BTreeMap<Version, Vec<VersionReq>>,
-  ) -> HashMap<VersionReq, Version> {
+  ) -> FxHashMap<VersionReq, Version> {
     // this should already be cached
     let package_info = package_info_or_link_fallback(
       self.api,
@@ -3321,7 +3331,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     let reqs = by_version
       .values()
       .flat_map(|rs| rs.iter())
-      .collect::<HashSet<_>>();
+      .collect::<FxHashSet<_>>();
 
     // candidate versions = keys of by_version, highest -> lowest
     let mut candidates: Vec<Version> = by_version.keys().cloned().collect();
@@ -3344,8 +3354,8 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
 
     // otherwise, use highest-first per-range
     let mut unassigned = reqs;
-    let mut assigned: HashMap<VersionReq, Version> =
-      HashMap::with_capacity(unassigned.len());
+    let mut assigned: FxHashMap<VersionReq, Version> =
+      FxHashMap::with_capacity_and_hasher(unassigned.len(), Default::default());
 
     for v in candidates.into_iter() {
       // assign all still-unassigned reqs that accept this version
@@ -3454,6 +3464,7 @@ fn build_trace_graph_snapshot(
 #[cfg(test)]
 mod test {
   use std::collections::BTreeSet;
+  use std::collections::HashSet;
   use std::sync::Arc;
 
   use pretty_assertions::assert_eq;

--- a/libs/npm/resolution/snapshot.rs
+++ b/libs/npm/resolution/snapshot.rs
@@ -17,6 +17,8 @@ use deno_semver::package::PackageNv;
 use deno_semver::package::PackageReq;
 use futures::StreamExt;
 use futures::stream::FuturesOrdered;
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
@@ -146,13 +148,19 @@ impl SerializedNpmResolutionSnapshot {
   pub fn into_valid(
     self,
   ) -> Result<ValidSerializedNpmResolutionSnapshot, PackageIdNotFoundError> {
-    let mut verify_ids = HashSet::with_capacity(self.packages.len());
+    let mut verify_ids = FxHashSet::with_capacity_and_hasher(
+      self.packages.len(),
+      Default::default(),
+    );
 
     // collect the specifiers to version mappings
     verify_ids.extend(self.root_packages.values());
 
     // then the packages
-    let mut package_ids = HashSet::with_capacity(self.packages.len());
+    let mut package_ids = FxHashSet::with_capacity_and_hasher(
+      self.packages.len(),
+      Default::default(),
+    );
     for package in &self.packages {
       package_ids.insert(&package.id);
       verify_ids.extend(package.dependencies.values());
@@ -216,14 +224,16 @@ impl SerializedNpmResolutionSnapshot {
 
     loop {
       // Group packages by nv.
-      let mut nv_to_indices: HashMap<PackageNv, Vec<usize>> = HashMap::new();
+      let mut nv_to_indices: FxHashMap<PackageNv, Vec<usize>> =
+        FxHashMap::default();
       for (i, p) in self.packages.iter().enumerate() {
         nv_to_indices.entry(p.id.nv.clone()).or_default().push(i);
       }
 
       // For each nv group, partition packages by their dep signature and
       // emit (subset → canonical) mappings for equivalent partitions.
-      let mut mappings: HashMap<NpmPackageId, NpmPackageId> = HashMap::new();
+      let mut mappings: FxHashMap<NpmPackageId, NpmPackageId> =
+        FxHashMap::default();
       for indices in nv_to_indices.values() {
         if indices.len() < 2 {
           continue;
@@ -345,29 +355,35 @@ impl AddPkgReqsResult {
 #[derive(Debug, Default, Clone)]
 pub struct NpmResolutionSnapshot {
   /// The unique package requirements map to a single npm package name and version.
-  pub(super) package_reqs: HashMap<PackageReq, PackageNv>,
+  pub(super) package_reqs: FxHashMap<PackageReq, PackageNv>,
   // Each root level npm package name and version maps to an exact npm package node id.
-  pub(super) root_packages: HashMap<PackageNv, NpmPackageId>,
-  pub(super) packages_by_name: HashMap<StackString, Vec<NpmPackageId>>,
-  pub(super) packages: HashMap<NpmPackageId, NpmResolutionPackage>,
+  pub(super) root_packages: FxHashMap<PackageNv, NpmPackageId>,
+  pub(super) packages_by_name: FxHashMap<StackString, Vec<NpmPackageId>>,
+  pub(super) packages: FxHashMap<NpmPackageId, NpmResolutionPackage>,
 }
 
 impl NpmResolutionSnapshot {
   pub fn new(snapshot: ValidSerializedNpmResolutionSnapshot) -> Self {
     let snapshot = snapshot.0;
-    let mut package_reqs = HashMap::<PackageReq, PackageNv>::with_capacity(
-      snapshot.root_packages.len(),
-    );
-    let mut root_packages = HashMap::<PackageNv, NpmPackageId>::with_capacity(
-      snapshot.root_packages.len(),
-    );
+    let mut package_reqs =
+      FxHashMap::<PackageReq, PackageNv>::with_capacity_and_hasher(
+        snapshot.root_packages.len(),
+        Default::default(),
+      );
+    let mut root_packages =
+      FxHashMap::<PackageNv, NpmPackageId>::with_capacity_and_hasher(
+        snapshot.root_packages.len(),
+        Default::default(),
+      );
     let mut packages_by_name =
-      HashMap::<StackString, Vec<NpmPackageId>>::with_capacity(
+      FxHashMap::<StackString, Vec<NpmPackageId>>::with_capacity_and_hasher(
         snapshot.packages.len(),
+        Default::default(),
       ); // close enough
     let mut packages =
-      HashMap::<NpmPackageId, NpmResolutionPackage>::with_capacity(
+      FxHashMap::<NpmPackageId, NpmResolutionPackage>::with_capacity_and_hasher(
         snapshot.packages.len(),
+        Default::default(),
       );
     let mut copy_index_resolver =
       SnapshotPackageCopyIndexResolver::with_capacity(snapshot.packages.len());
@@ -510,13 +526,26 @@ impl NpmResolutionSnapshot {
   /// Returns a new snapshot made from a subset of this snapshot's package reqs.
   /// Requirements not present in this snapshot will be ignored.
   pub fn subset(&self, package_reqs: &[PackageReq]) -> Self {
-    let mut new_package_reqs = HashMap::with_capacity(package_reqs.len());
-    let mut packages = HashMap::with_capacity(package_reqs.len() * 2);
-    let mut packages_by_name: HashMap<StackString, Vec<NpmPackageId>> =
-      HashMap::with_capacity(package_reqs.len());
-    let mut root_packages = HashMap::with_capacity(package_reqs.len());
+    let mut new_package_reqs = FxHashMap::with_capacity_and_hasher(
+      package_reqs.len(),
+      Default::default(),
+    );
+    let mut packages = FxHashMap::with_capacity_and_hasher(
+      package_reqs.len() * 2,
+      Default::default(),
+    );
+    let mut packages_by_name: FxHashMap<StackString, Vec<NpmPackageId>> =
+      FxHashMap::with_capacity_and_hasher(
+        package_reqs.len(),
+        Default::default(),
+      );
+    let mut root_packages = FxHashMap::with_capacity_and_hasher(
+      package_reqs.len(),
+      Default::default(),
+    );
 
-    let mut visited = HashSet::with_capacity(packages.len());
+    let mut visited =
+      FxHashSet::with_capacity_and_hasher(packages.len(), Default::default());
 
     let mut stack = Vec::new();
     for req in package_reqs {
@@ -587,7 +616,10 @@ impl NpmResolutionSnapshot {
   ) -> ValidSerializedNpmResolutionSnapshot {
     let mut final_packages = Vec::with_capacity(self.packages.len());
     let mut pending = VecDeque::with_capacity(self.packages.len());
-    let mut visited_nvs = HashSet::with_capacity(self.packages.len());
+    let mut visited_nvs = FxHashSet::with_capacity_and_hasher(
+      self.packages.len(),
+      Default::default(),
+    );
 
     // add the root packages
     for pkg_id in self.root_packages.values() {
@@ -744,7 +776,7 @@ impl NpmResolutionSnapshot {
     self.root_packages.values()
   }
 
-  pub fn package_reqs(&self) -> &HashMap<PackageReq, PackageNv> {
+  pub fn package_reqs(&self) -> &FxHashMap<PackageReq, PackageNv> {
     &self.package_reqs
   }
 
@@ -822,7 +854,10 @@ impl NpmResolutionSnapshot {
   ) -> Vec<NpmResolutionPackage> {
     let mut packages = Vec::with_capacity(self.packages.len());
     let mut pending = VecDeque::with_capacity(self.packages.len());
-    let mut visited_nvs = HashSet::with_capacity(self.packages.len());
+    let mut visited_nvs = FxHashSet::with_capacity_and_hasher(
+      self.packages.len(),
+      Default::default(),
+    );
 
     for pkg_id in self.root_packages.values() {
       if visited_nvs.insert(&pkg_id.nv) {
@@ -864,7 +899,7 @@ impl NpmResolutionSnapshot {
         .iter()
         .filter(|p| p.copy_index == 0)
         .map(|p| p.id.nv.clone())
-        .collect::<HashSet<_>>();
+        .collect::<FxHashSet<_>>();
 
       // partition out any packages that are "copy" packages
       for i in (0..packages.len()).rev() {
@@ -925,24 +960,30 @@ impl NpmResolutionSnapshot {
 }
 
 pub struct SnapshotPackageCopyIndexResolver {
-  packages_to_copy_index: HashMap<NpmPackageId, u8>,
-  package_name_version_to_copy_count: HashMap<PackageNv, u8>,
+  packages_to_copy_index: FxHashMap<NpmPackageId, u8>,
+  package_name_version_to_copy_count: FxHashMap<PackageNv, u8>,
 }
 
 impl SnapshotPackageCopyIndexResolver {
   pub fn with_capacity(capacity: usize) -> Self {
     Self {
-      packages_to_copy_index: HashMap::with_capacity(capacity),
-      package_name_version_to_copy_count: HashMap::with_capacity(capacity), // close enough
+      packages_to_copy_index: FxHashMap::with_capacity_and_hasher(
+        capacity,
+        Default::default(),
+      ),
+      package_name_version_to_copy_count: FxHashMap::with_capacity_and_hasher(
+        capacity,
+        Default::default(),
+      ), // close enough
     }
   }
 
   pub fn from_map_with_capacity(
-    mut packages_to_copy_index: HashMap<NpmPackageId, u8>,
+    mut packages_to_copy_index: FxHashMap<NpmPackageId, u8>,
     capacity: usize,
   ) -> Self {
     let mut package_name_version_to_copy_count =
-      HashMap::with_capacity(capacity); // close enough
+      FxHashMap::with_capacity_and_hasher(capacity, Default::default()); // close enough
     if capacity > packages_to_copy_index.len() {
       packages_to_copy_index.reserve(capacity - packages_to_copy_index.len());
     }
@@ -1096,7 +1137,7 @@ pub fn snapshot_from_lockfile(
         version: info.version.clone(),
       })
     })
-    .collect::<HashSet<_>>();
+    .collect::<FxHashSet<_>>();
   // collect the specifiers to version mappings
   for (key, value) in &lockfile.content.packages.specifiers {
     match key.kind {

--- a/libs/resolver/Cargo.toml
+++ b/libs/resolver/Cargo.toml
@@ -60,6 +60,7 @@ node_resolver.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 phf = { workspace = true, features = ["macros"] }
+rustc-hash.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sys_traits.workspace = true

--- a/libs/resolver/cjs/mod.rs
+++ b/libs/resolver/cjs/mod.rs
@@ -6,6 +6,7 @@ use node_resolver::InNpmPackageChecker;
 use node_resolver::PackageJsonResolverRc;
 use node_resolver::ResolutionMode;
 use node_resolver::errors::PackageJsonLoadError;
+use rustc_hash::FxHashSet;
 use sys_traits::FsMetadata;
 use sys_traits::FsRead;
 use url::Url;
@@ -28,7 +29,7 @@ pub struct CjsTracker<
 > {
   is_cjs_resolver: IsCjsResolver<TInNpmPackageChecker, TSys>,
   known: MaybeDashMap<Url, ResolutionMode>,
-  require_modules: Vec<Url>,
+  require_modules: FxHashSet<Url>,
 }
 
 impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: FsRead + FsMetadata>
@@ -47,7 +48,7 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: FsRead + FsMetadata>
         mode,
       ),
       known: Default::default(),
-      require_modules,
+      require_modules: require_modules.into_iter().collect(),
     }
   }
 


### PR DESCRIPTION
An allocation-pattern review showed several hot internal hash maps still use
the default SipHash hasher: the npm resolution solver keys many of its maps
and sets on NodeId(u32), the node resolver's thread-local path caches hash
full PathBufs on every path segment lookup, and MaybeDashMap defaulted to
RandomState for every user (parsed source cache, CjsTracker, npm caches).
DoS-resistant hashing buys nothing for these internal, trusted-key maps, so
this switches them to rustc-hash, which is already a workspace dependency.

Also converts CjsTracker's require_modules from a linearly scanned Vec to a
set, since it is only used for membership checks. Maps that are part of
public crate APIs (serialized snapshot fields, link_packages parameters,
file content override options) are intentionally left on std HashMap.