### PR TITLE
fix(bundle): respect runtime file permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,6 +2148,7 @@ dependencies = [
  "async-trait",
  "deno_core",
  "deno_error",
+ "deno_permissions",
  "regex",
  "serde",
 ]

--- a/cli/graph_container.rs
+++ b/cli/graph_container.rs
@@ -92,6 +92,7 @@ impl MainModuleGraphContainer {
           is_dynamic: false,
           lib: self.cli_options.ts_type_lib_window(),
           permissions: self.root_permissions.clone(),
+          file_permission_api_name: None,
           ext_overwrite: options.ext_overwrite,
           allow_unknown_media_types: options.allow_unknown_media_types,
           skip_graph_roots_validation: false,

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -1178,12 +1178,14 @@ impl ModuleGraphBuilder {
   ) -> CliDenoGraphLoader {
     self.create_graph_loader_with_permissions(
       self.root_permissions_container.clone(),
+      None,
     )
   }
 
   pub fn create_graph_loader_with_permissions(
     &self,
     permissions: PermissionsContainer,
+    file_permission_api_name: Option<&'static str>,
   ) -> CliDenoGraphLoader {
     CliDenoGraphLoader::new(
       self.file_fetcher.clone(),
@@ -1193,6 +1195,7 @@ impl ModuleGraphBuilder {
       deno_resolver::file_fetcher::DenoGraphLoaderOptions {
         file_header_overrides: self.cli_options.resolve_file_header_overrides(),
         permissions: Some(permissions),
+        file_permission_api_name,
         reporter: self.load_reporter.clone(),
         include_npm_sources: self.analyze_npm_sources(),
       },

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -150,6 +150,7 @@ pub struct PrepareModuleLoadOptions<'a> {
   pub is_dynamic: bool,
   pub lib: TsTypeLib,
   pub permissions: PermissionsContainer,
+  pub file_permission_api_name: Option<&'static str>,
   pub ext_overwrite: Option<&'a String>,
   pub allow_unknown_media_types: bool,
   /// Whether to skip validating the graph roots. This is useful
@@ -196,6 +197,7 @@ impl ModuleLoadPreparer {
       is_dynamic,
       lib,
       permissions,
+      file_permission_api_name,
       ext_overwrite,
       allow_unknown_media_types,
       skip_graph_roots_validation,
@@ -206,7 +208,10 @@ impl ModuleLoadPreparer {
 
     let mut loader = self
       .module_graph_builder
-      .create_graph_loader_with_permissions(permissions);
+      .create_graph_loader_with_permissions(
+        permissions,
+        file_permission_api_name,
+      );
     if !file_content_overrides.is_empty() {
       loader.set_file_content_overrides(file_content_overrides);
     }
@@ -302,7 +307,7 @@ impl ModuleLoadPreparer {
 
     let loader = self
       .module_graph_builder
-      .create_graph_loader_with_permissions(permissions);
+      .create_graph_loader_with_permissions(permissions, None);
     self
       .module_graph_builder
       .build_graph_with_npm_resolution(
@@ -702,6 +707,7 @@ impl<TGraphContainer: ModuleGraphContainer>
           is_dynamic,
           lib: self.lib,
           permissions: permissions.clone(),
+          file_permission_api_name: None,
           ext_overwrite: None,
           allow_unknown_media_types: false,
           skip_graph_roots_validation: true,
@@ -1672,6 +1678,7 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
               is_dynamic,
               lib,
               permissions: permissions.clone(),
+              file_permission_api_name: None,
               ext_overwrite: None,
               allow_unknown_media_types: false,
               skip_graph_roots_validation: is_dynamic,

--- a/cli/tools/bundle/html.rs
+++ b/cli/tools/bundle/html.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 use capacity_builder::StringBuilder;
 use deno_core::anyhow;
 use deno_core::error::AnyError;
+use deno_runtime::deno_permissions::OpenAccessKind;
+use deno_runtime::deno_permissions::PermissionsContainer;
 
 use crate::tools::bundle::OutputFile;
 
@@ -374,9 +376,15 @@ fn parse_html_entrypoint(
 pub fn load_html_entrypoint(
   cwd: &Path,
   path: &Path,
+  permissions: &PermissionsContainer,
 ) -> anyhow::Result<HtmlEntrypoint> {
-  let contents = std::fs::read_to_string(path)?;
-  let canonical_path = crate::util::fs::canonicalize_path(path)?;
+  let checked_path = permissions.check_open(
+    Cow::Borrowed(path),
+    OpenAccessKind::Read,
+    Some("Deno.bundle()"),
+  )?;
+  let contents = std::fs::read_to_string(&checked_path)?;
+  let canonical_path = crate::util::fs::canonicalize_path(&checked_path)?;
   parse_html_entrypoint(cwd, path, canonical_path, contents)
 }
 
@@ -703,7 +711,63 @@ fn inject_scripts_and_css(
 
 #[cfg(test)]
 mod tests {
+  use std::sync::Arc;
+
+  use deno_runtime::deno_permissions::Permissions;
+  use deno_runtime::permissions::RuntimePermissionDescriptorParser;
+
   use super::*;
+
+  fn no_prompt_permissions() -> PermissionsContainer {
+    PermissionsContainer::new(
+      Arc::new(RuntimePermissionDescriptorParser::new(
+        crate::sys::CliSys::default(),
+      )),
+      Permissions::none_without_prompt(),
+    )
+  }
+
+  fn allow_all_permissions() -> PermissionsContainer {
+    PermissionsContainer::allow_all(Arc::new(
+      RuntimePermissionDescriptorParser::new(crate::sys::CliSys::default()),
+    ))
+  }
+
+  #[test]
+  fn load_html_entrypoint_requires_read_permission() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let html_path = temp_dir.path().join("index.html");
+    std::fs::write(&html_path, "<p>blocked</p>").unwrap();
+
+    let err = load_html_entrypoint(
+      temp_dir.path(),
+      &html_path,
+      &no_prompt_permissions(),
+    )
+    .unwrap_err();
+
+    assert!(
+      err.to_string().contains("Requires read access"),
+      "unexpected error: {err}"
+    );
+  }
+
+  #[test]
+  fn load_html_entrypoint_allows_read_permission() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let html_path = temp_dir.path().join("index.html");
+    std::fs::write(&html_path, "<p>allowed</p>").unwrap();
+
+    let entry = load_html_entrypoint(
+      temp_dir.path(),
+      &html_path,
+      &allow_all_permissions(),
+    )
+    .unwrap();
+
+    assert_eq!(entry.path, html_path);
+    assert_eq!(entry.contents, "<p>allowed</p>");
+  }
 
   fn script(src: &str) -> Script {
     Script {

--- a/cli/tools/bundle/html.rs
+++ b/cli/tools/bundle/html.rs
@@ -376,15 +376,20 @@ fn parse_html_entrypoint(
 pub fn load_html_entrypoint(
   cwd: &Path,
   path: &Path,
-  permissions: &PermissionsContainer,
+  permissions: Option<&PermissionsContainer>,
 ) -> anyhow::Result<HtmlEntrypoint> {
-  let checked_path = permissions.check_open(
-    Cow::Borrowed(path),
-    OpenAccessKind::Read,
-    Some("Deno.bundle()"),
-  )?;
-  let contents = std::fs::read_to_string(&checked_path)?;
-  let canonical_path = crate::util::fs::canonicalize_path(&checked_path)?;
+  let checked_path = permissions
+    .map(|permissions| {
+      permissions.check_open(
+        Cow::Borrowed(path),
+        OpenAccessKind::Read,
+        Some("Deno.bundle()"),
+      )
+    })
+    .transpose()?;
+  let open_path = checked_path.as_deref().unwrap_or(path);
+  let contents = std::fs::read_to_string(open_path)?;
+  let canonical_path = crate::util::fs::canonicalize_path(open_path)?;
   parse_html_entrypoint(cwd, path, canonical_path, contents)
 }
 
@@ -742,7 +747,7 @@ mod tests {
     let err = load_html_entrypoint(
       temp_dir.path(),
       &html_path,
-      &no_prompt_permissions(),
+      Some(&no_prompt_permissions()),
     )
     .unwrap_err();
 
@@ -761,12 +766,24 @@ mod tests {
     let entry = load_html_entrypoint(
       temp_dir.path(),
       &html_path,
-      &allow_all_permissions(),
+      Some(&allow_all_permissions()),
     )
     .unwrap();
 
     assert_eq!(entry.path, html_path);
     assert_eq!(entry.contents, "<p>allowed</p>");
+  }
+
+  #[test]
+  fn load_html_entrypoint_without_permissions_skips_check() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let html_path = temp_dir.path().join("index.html");
+    std::fs::write(&html_path, "<p>cli</p>").unwrap();
+
+    let entry =
+      load_html_entrypoint(temp_dir.path(), &html_path, None).unwrap();
+
+    assert_eq!(entry.contents, "<p>cli</p>");
   }
 
   fn script(src: &str) -> Script {

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -50,6 +50,7 @@ use deno_resolver::loader::LoadedModuleOrAsset;
 use deno_resolver::loader::LoadedModuleSource;
 use deno_resolver::loader::RequestedModuleType;
 use deno_resolver::npm::managed::ResolvePkgFolderFromDenoModuleError;
+use deno_runtime::deno_permissions::OpenAccessKind;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_semver::npm::NpmPackageReqReference;
 use esbuild_client::EsbuildFlagsBuilder;
@@ -105,7 +106,7 @@ pub async fn prepare_inputs(
   let mut html_paths = Vec::new();
   let mut script_entry_urls = Vec::new();
   for url in &resolved_entrypoints {
-    if url.as_str().to_lowercase().ends_with(".html") {
+    if is_html_entrypoint(url) {
       html_paths.push(url.to_file_path().unwrap());
     } else {
       script_entry_urls.push(url.clone());
@@ -154,7 +155,11 @@ pub async fn prepare_inputs(
     let virtual_modules = Arc::new(VirtualModules::new());
 
     for html_path in &html_paths {
-      let entry = html::load_html_entrypoint(init_cwd, html_path)?;
+      let entry = html::load_html_entrypoint(
+        init_cwd,
+        html_path,
+        &plugin_handler.permissions,
+      )?;
 
       let virtual_module_path =
         deno_path_util::url_from_file_path(&entry.virtual_module_path)?;
@@ -209,6 +214,7 @@ pub async fn prepare_inputs(
 pub async fn bundle_init(
   mut flags: Arc<Flags>,
   bundle_flags: &BundleFlags,
+  caller_permissions: Option<PermissionsContainer>,
 ) -> Result<EsbuildBundler, AnyError> {
   {
     let flags_mut = Arc::make_mut(&mut flags);
@@ -220,7 +226,12 @@ pub async fn bundle_init(
 
   let resolver = factory.resolver().await?.clone();
   let module_load_preparer = factory.module_load_preparer().await?.clone();
-  let root_permissions = factory.root_permissions_container()?;
+  let permissions = match caller_permissions {
+    Some(permissions) => permissions,
+    None => {
+      PermissionsContainer::allow_all(factory.permission_desc_parser()?.clone())
+    }
+  };
   let npm_resolver = factory.npm_resolver().await?;
   let node_resolver = factory.node_resolver().await?;
   let cli_options = factory.cli_options()?;
@@ -240,7 +251,7 @@ pub async fn bundle_init(
     module_load_preparer,
     resolved_roots: Arc::new(RwLock::new(Arc::new(IndexSet::new()))),
     module_graph_container,
-    permissions: root_permissions.clone(),
+    permissions,
     module_loader: module_loader.clone(),
     externals_matcher: if bundle_flags.external.is_empty() {
       None
@@ -334,7 +345,7 @@ pub async fn bundle(
       )
       .await?;
   }
-  let bundler = bundle_init(flags.clone(), &bundle_flags).await?;
+  let bundler = bundle_init(flags.clone(), &bundle_flags, None).await?;
   let init_cwd = bundler.cwd.clone();
   let start = std::time::Instant::now();
   let response = bundler.build().await?;
@@ -377,6 +388,7 @@ pub async fn bundle(
       bundle_flags.minify,
       bundler.input.clone(),
       bundle_flags.output_dir.as_ref().map(Path::new),
+      None,
     )?;
 
     if bundle_flags.declaration {
@@ -877,7 +889,7 @@ pub async fn bundle_for_compile(
     flags_mut.internal.force_bundle_mode = true;
   }
 
-  let bundler = bundle_init(flags, &bundle_flags).await?;
+  let bundler = bundle_init(flags, &bundle_flags, None).await?;
   let response = bundler.build().await?;
 
   handle_esbuild_errors_and_warnings(
@@ -1001,6 +1013,7 @@ async fn bundle_watch(
             minified,
             input,
             output_dir,
+            None,
           )?;
           print_finished_message(&metafile, &output_infos, start.elapsed())?;
 
@@ -1197,7 +1210,11 @@ impl EsbuildBundler {
         continue;
       }
 
-      let updated = html::load_html_entrypoint(&self.cwd, &page.path)?;
+      let updated = html::load_html_entrypoint(
+        &self.cwd,
+        &page.path,
+        &self.plugin_handler.permissions,
+      )?;
       let virtual_module_url =
         deno_path_util::url_from_file_path(&updated.virtual_module_path)?
           .to_string();
@@ -2523,6 +2540,10 @@ fn resolve_entrypoints(
   Ok(resolved)
 }
 
+fn is_html_entrypoint(url: &Url) -> bool {
+  url.path().to_ascii_lowercase().ends_with(".html")
+}
+
 fn resolve_roots(
   entrypoints: Vec<Url>,
   cwd: &Path,
@@ -2832,6 +2853,7 @@ pub fn process_result(
   minified: bool,
   input: BundlerInput,
   outdir: Option<&Path>,
+  write_permissions: Option<&PermissionsContainer>,
 ) -> Result<Vec<OutputFileInfo>, AnyError> {
   let output_files =
     collect_output_files(response.output_files.as_deref(), cwd, input, outdir)?;
@@ -2854,11 +2876,31 @@ pub fn process_result(
       continue;
     }
 
+    let checked_path = write_permissions
+      .map(|permissions| {
+        permissions.check_open(
+          Cow::Owned(path.to_path_buf()),
+          OpenAccessKind::Write,
+          Some("Deno.bundle()"),
+        )
+      })
+      .transpose()?;
+    let path = checked_path.as_deref().unwrap_or(path);
+
     if let Some(parent) = path.parent()
       && !exists_cache.contains(parent)
     {
       if !parent.exists() {
-        std::fs::create_dir_all(parent)?;
+        let checked_parent = write_permissions
+          .map(|permissions| {
+            permissions.check_open(
+              Cow::Owned(parent.to_path_buf()),
+              OpenAccessKind::WriteNoFollow,
+              Some("Deno.bundle()"),
+            )
+          })
+          .transpose()?;
+        std::fs::create_dir_all(checked_parent.as_deref().unwrap_or(parent))?;
       }
       exists_cache.insert(parent.to_path_buf());
     }
@@ -2916,6 +2958,26 @@ fn print_finished_message(
   log::info!("{}", output);
 
   Ok(())
+}
+
+#[cfg(test)]
+mod entrypoint_tests {
+  use deno_core::url::Url;
+
+  use super::is_html_entrypoint;
+
+  #[test]
+  fn html_entrypoint_detection_ignores_fragment() {
+    assert!(is_html_entrypoint(
+      &Url::parse("file:///tmp/index.html").unwrap()
+    ));
+    assert!(is_html_entrypoint(
+      &Url::parse("file:///tmp/INDEX.HTML").unwrap()
+    ));
+    assert!(!is_html_entrypoint(
+      &Url::parse("file:///tmp/secret.txt#.html").unwrap()
+    ));
+  }
 }
 
 #[cfg(test)]

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -158,7 +158,7 @@ pub async fn prepare_inputs(
       let entry = html::load_html_entrypoint(
         init_cwd,
         html_path,
-        &plugin_handler.permissions,
+        plugin_handler.file_permissions.as_ref(),
       )?;
 
       let virtual_module_path =
@@ -226,11 +226,12 @@ pub async fn bundle_init(
 
   let resolver = factory.resolver().await?.clone();
   let module_load_preparer = factory.module_load_preparer().await?.clone();
-  let permissions = match caller_permissions {
-    Some(permissions) => permissions,
-    None => {
-      PermissionsContainer::allow_all(factory.permission_desc_parser()?.clone())
-    }
+  // Module loads (including remote imports) are checked against the caller's
+  // permissions when invoked via `Deno.bundle()`, and against the CLI's own
+  // permissions when invoked via `deno bundle`.
+  let permissions = match &caller_permissions {
+    Some(permissions) => permissions.clone(),
+    None => factory.root_permissions_container()?.clone(),
   };
   let npm_resolver = factory.npm_resolver().await?;
   let node_resolver = factory.node_resolver().await?;
@@ -252,6 +253,7 @@ pub async fn bundle_init(
     resolved_roots: Arc::new(RwLock::new(Arc::new(IndexSet::new()))),
     module_graph_container,
     permissions,
+    file_permissions: caller_permissions,
     module_loader: module_loader.clone(),
     externals_matcher: if bundle_flags.external.is_empty() {
       None
@@ -1213,7 +1215,7 @@ impl EsbuildBundler {
       let updated = html::load_html_entrypoint(
         &self.cwd,
         &page.path,
-        &self.plugin_handler.permissions,
+        self.plugin_handler.file_permissions.as_ref(),
       )?;
       let virtual_module_url =
         deno_path_util::url_from_file_path(&updated.virtual_module_path)?
@@ -1469,6 +1471,11 @@ pub struct DenoPluginHandler {
   resolved_roots: Arc<RwLock<Arc<IndexSet<ModuleSpecifier>>>>,
   module_graph_container: Arc<MainModuleGraphContainer>,
   permissions: PermissionsContainer,
+  /// Only set when bundling via `Deno.bundle()`, where reads and writes of
+  /// local files must respect the calling program's permissions. `deno bundle`
+  /// reads and writes its entrypoints and output without a check, like the
+  /// other CLI subcommands.
+  file_permissions: Option<PermissionsContainer>,
   module_loader: Arc<CliDenoResolverModuleLoader>,
   externals_matcher: Option<ExternalsMatcher>,
   on_end_tx: tokio::sync::mpsc::Sender<esbuild_client::OnEndArgs>,

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -50,6 +50,7 @@ use deno_resolver::loader::LoadedModuleOrAsset;
 use deno_resolver::loader::LoadedModuleSource;
 use deno_resolver::loader::RequestedModuleType;
 use deno_resolver::npm::managed::ResolvePkgFolderFromDenoModuleError;
+use deno_runtime::deno_permissions::CheckSpecifierKind;
 use deno_runtime::deno_permissions::OpenAccessKind;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_semver::npm::NpmPackageReqReference;
@@ -1808,6 +1809,9 @@ pub enum BundleLoadErrorKind {
   ResolveUrlOrPath(#[from] deno_path_util::ResolveUrlOrPathError),
   #[class(inherit)]
   #[error(transparent)]
+  Permission(#[from] deno_runtime::deno_permissions::PermissionCheckError),
+  #[class(inherit)]
+  #[error(transparent)]
   ResolveWithGraph(#[from] ResolveWithGraphError),
   #[class(generic)]
   #[error("Failed to parse Wasm module: {0}")]
@@ -2110,6 +2114,28 @@ impl DenoPluginHandler {
     Ok(())
   }
 
+  /// When bundling via `Deno.bundle()`, reading a module returns its
+  /// (transpiled) source to the calling program, so it must be gated on the
+  /// caller's permissions. `deno bundle` reads its inputs unchecked like the
+  /// other CLI subcommands, in which case `file_permissions` is `None` and this
+  /// is a no-op.
+  ///
+  /// This mirrors how dynamic `import()` is gated: `check_specifier` applies a
+  /// read check to `file:` specifiers and an import check to remote ones. The
+  /// file fetcher only gates the latter for the bundler (module reads use
+  /// `Static` semantics, which exempt `file:`), so this closes the local-read
+  /// gap without canonicalizing paths in a way that would break reads scoped to
+  /// a symlinked directory (e.g. a `/var` -> `/private/var` temp dir on macOS).
+  fn check_read_permission(
+    &self,
+    specifier: &Url,
+  ) -> Result<(), BundleLoadError> {
+    if let Some(permissions) = &self.file_permissions {
+      permissions.check_specifier(specifier, CheckSpecifierKind::Dynamic)?;
+    }
+    Ok(())
+  }
+
   async fn bundle_load(
     &self,
     specifier: &str,
@@ -2155,6 +2181,11 @@ impl DenoPluginHandler {
         }
         (specifier, media_type)
       };
+
+    // `specifier` is now the concrete module we're about to read the source of
+    // (a `file:` path for local modules, including npm packages resolved into
+    // `node_modules`). Gate the read on the caller's permissions.
+    self.check_read_permission(&specifier)?;
 
     let graph = self.module_graph_container.graph();
     let module_or_asset = self
@@ -2228,13 +2259,16 @@ impl DenoPluginHandler {
       LoadedModuleOrAsset::ExternalAsset {
         specifier,
         statically_analyzable: _,
-      } => LoadedModuleSource::ArcBytes(
-        self
-          .file_fetcher
-          .fetch(&specifier, &self.permissions)
-          .await?
-          .source,
-      ),
+      } => {
+        self.check_read_permission(&specifier)?;
+        LoadedModuleSource::ArcBytes(
+          self
+            .file_fetcher
+            .fetch(&specifier, &self.permissions)
+            .await?
+            .source,
+        )
+      }
     };
 
     Ok(Some(

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -100,8 +100,12 @@ pub async fn prepare_inputs(
   bundle_flags: &BundleFlags,
   plugin_handler: &mut DenoPluginHandler,
 ) -> Result<BundlerInput, AnyError> {
-  let resolved_entrypoints =
-    resolve_entrypoints(resolver, init_cwd, &bundle_flags.entrypoints)?;
+  let resolved_entrypoints = resolve_entrypoints(
+    resolver,
+    init_cwd,
+    &bundle_flags.entrypoints,
+    !plugin_handler.is_runtime_api,
+  )?;
 
   // Partition into HTML and non-HTML entrypoints
   let mut html_paths = Vec::new();
@@ -425,7 +429,7 @@ async fn emit_bundle_declarations(
   // Resolve entrypoints to specifiers
   let resolver = factory.resolver().await?;
   let entrypoint_specifiers =
-    resolve_entrypoints(resolver, init_cwd, &bundle_flags.entrypoints)?;
+    resolve_entrypoints(resolver, init_cwd, &bundle_flags.entrypoints, true)?;
 
   // Determine root names with media types
   let root_names: Vec<(ModuleSpecifier, MediaType)> = entrypoint_specifiers
@@ -2210,7 +2214,7 @@ impl DenoPluginHandler {
     // `specifier` is now the concrete module we're about to read the source of
     // (a `file:` path for local modules, including npm packages resolved into
     // `node_modules`). Gate the read on the caller's permissions.
-    let specifier = self.check_read_permission(&specifier)?;
+    let checked_specifier = self.check_read_permission(&specifier)?;
 
     let graph = self.module_graph_container.graph();
     let module_or_asset = self
@@ -2223,7 +2227,7 @@ impl DenoPluginHandler {
         LoadCodeSourceErrorKind::LoadUnpreparedModule(_) => {
           let file = self
             .file_fetcher
-            .fetch(&specifier, &self.permissions)
+            .fetch(&checked_specifier, &self.permissions)
             .await?;
           let media_type = MediaType::from_specifier_and_headers(
             &specifier,
@@ -2249,12 +2253,12 @@ impl DenoPluginHandler {
                 let str = String::from_utf8_lossy(&file.source);
                 let value = str.into();
                 let source = self
-                  .maybe_transpile(&file.url, media_type, &value, None)
+                  .maybe_transpile(&specifier, media_type, &value, None)
                   .await?;
                 return self
                   .create_module_response(
                     &graph,
-                    &file.url,
+                    &specifier,
                     media_type,
                     source.as_bytes(),
                     Some(requested_type),
@@ -2265,7 +2269,7 @@ impl DenoPluginHandler {
                 return self
                   .create_module_response(
                     &graph,
-                    &file.url,
+                    &specifier,
                     media_type,
                     &file.source,
                     Some(requested_type),
@@ -2285,11 +2289,11 @@ impl DenoPluginHandler {
         specifier,
         statically_analyzable: _,
       } => {
-        let specifier = self.check_read_permission(&specifier)?;
+        let checked_specifier = self.check_read_permission(&specifier)?;
         LoadedModuleSource::ArcBytes(
           self
             .file_fetcher
-            .fetch(&specifier, &self.permissions)
+            .fetch(&checked_specifier, &self.permissions)
             .await?
             .source,
         )
@@ -2568,13 +2572,23 @@ fn media_type_to_loader(
 fn resolve_url_or_path_absolute(
   specifier: &str,
   current_dir: &Path,
+  canonicalize: bool,
 ) -> Result<Url, AnyError> {
   if deno_path_util::specifier_has_uri_scheme(specifier) {
     Ok(Url::parse(specifier)?)
   } else {
     let path = current_dir.join(specifier);
     let path = deno_path_util::normalize_path(Cow::Owned(path));
-    let path = canonicalize_path(&path)?;
+    // Runtime permission checks must see the caller's path spelling before
+    // following aliases. `check_open` then returns the canonical path used for
+    // the actual read. The trusted CLI path retains its historical eager
+    // canonicalization.
+    let canonicalized_path = canonicalize_path(&path)?;
+    let path = if canonicalize {
+      Cow::Owned(canonicalized_path)
+    } else {
+      path
+    };
     Ok(deno_path_util::url_from_file_path(&path)?)
   }
 }
@@ -2583,10 +2597,13 @@ fn resolve_entrypoints(
   resolver: &CliResolver,
   init_cwd: &Path,
   entrypoints: &[String],
+  canonicalize_entrypoints: bool,
 ) -> Result<Vec<Url>, AnyError> {
   let entrypoints = entrypoints
     .iter()
-    .map(|e| resolve_url_or_path_absolute(e, init_cwd))
+    .map(|e| {
+      resolve_url_or_path_absolute(e, init_cwd, canonicalize_entrypoints)
+    })
     .collect::<Result<Vec<_>, _>>()?;
 
   let init_cwd_url = Url::from_directory_path(init_cwd).unwrap();

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -108,7 +108,7 @@ pub async fn prepare_inputs(
   let mut script_entry_urls = Vec::new();
   for url in &resolved_entrypoints {
     if is_html_entrypoint(url) {
-      html_paths.push(url.to_file_path().unwrap());
+      html_paths.push(deno_path_util::url_to_file_path(url)?);
     } else {
       script_entry_urls.push(url.clone());
     }
@@ -159,7 +159,9 @@ pub async fn prepare_inputs(
       let entry = html::load_html_entrypoint(
         init_cwd,
         html_path,
-        plugin_handler.file_permissions.as_ref(),
+        plugin_handler
+          .is_runtime_api
+          .then_some(&plugin_handler.permissions),
       )?;
 
       let virtual_module_path =
@@ -230,9 +232,9 @@ pub async fn bundle_init(
   // Module loads (including remote imports) are checked against the caller's
   // permissions when invoked via `Deno.bundle()`, and against the CLI's own
   // permissions when invoked via `deno bundle`.
-  let permissions = match &caller_permissions {
-    Some(permissions) => permissions.clone(),
-    None => factory.root_permissions_container()?.clone(),
+  let (permissions, is_runtime_api) = match caller_permissions {
+    Some(permissions) => (permissions, true),
+    None => (factory.root_permissions_container()?.clone(), false),
   };
   let npm_resolver = factory.npm_resolver().await?;
   let node_resolver = factory.node_resolver().await?;
@@ -254,7 +256,7 @@ pub async fn bundle_init(
     resolved_roots: Arc::new(RwLock::new(Arc::new(IndexSet::new()))),
     module_graph_container,
     permissions,
-    file_permissions: caller_permissions,
+    is_runtime_api,
     module_loader: module_loader.clone(),
     externals_matcher: if bundle_flags.external.is_empty() {
       None
@@ -1216,7 +1218,10 @@ impl EsbuildBundler {
       let updated = html::load_html_entrypoint(
         &self.cwd,
         &page.path,
-        self.plugin_handler.file_permissions.as_ref(),
+        self
+          .plugin_handler
+          .is_runtime_api
+          .then_some(&self.plugin_handler.permissions),
       )?;
       let virtual_module_url =
         deno_path_util::url_from_file_path(&updated.virtual_module_path)?
@@ -1472,11 +1477,9 @@ pub struct DenoPluginHandler {
   resolved_roots: Arc<RwLock<Arc<IndexSet<ModuleSpecifier>>>>,
   module_graph_container: Arc<MainModuleGraphContainer>,
   permissions: PermissionsContainer,
-  /// Only set when bundling via `Deno.bundle()`, where reads and writes of
-  /// local files must respect the calling program's permissions. `deno bundle`
-  /// reads and writes its entrypoints and output without a check, like the
-  /// other CLI subcommands.
-  file_permissions: Option<PermissionsContainer>,
+  /// Whether reads and writes must respect the calling program's permissions.
+  /// The directly invoked `deno bundle` command is a trusted CLI path.
+  is_runtime_api: bool,
   module_loader: Arc<CliDenoResolverModuleLoader>,
   externals_matcher: Option<ExternalsMatcher>,
   on_end_tx: tokio::sync::mpsc::Sender<esbuild_client::OnEndArgs>,
@@ -2099,9 +2102,12 @@ impl DenoPluginHandler {
         graph,
         specifiers,
         PrepareModuleLoadOptions {
-          is_dynamic: false,
+          is_dynamic: self.is_runtime_api,
           lib: TsTypeLib::default(),
           permissions: self.permissions.clone(),
+          file_permission_api_name: self
+            .is_runtime_api
+            .then_some("Deno.bundle()"),
           ext_overwrite: None,
           allow_unknown_media_types: true,
           skip_graph_roots_validation: true,
@@ -2117,23 +2123,42 @@ impl DenoPluginHandler {
   /// When bundling via `Deno.bundle()`, reading a module returns its
   /// (transpiled) source to the calling program, so it must be gated on the
   /// caller's permissions. `deno bundle` reads its inputs unchecked like the
-  /// other CLI subcommands, in which case `file_permissions` is `None` and this
-  /// is a no-op.
+  /// other CLI subcommands, in which case this is a no-op.
   ///
-  /// This mirrors how dynamic `import()` is gated: `check_specifier` applies a
-  /// read check to `file:` specifiers and an import check to remote ones. The
-  /// file fetcher only gates the latter for the bundler (module reads use
-  /// `Static` semantics, which exempt `file:`), so this closes the local-read
-  /// gap without canonicalizing paths in a way that would break reads scoped to
-  /// a symlinked directory (e.g. a `/var` -> `/private/var` temp dir on macOS).
-  fn check_read_permission(
+  /// Graph preparation already performs the check before reading source. This
+  /// second boundary covers later esbuild loads and direct asset fetches.
+  fn check_read_permission<'a>(
     &self,
-    specifier: &Url,
-  ) -> Result<(), BundleLoadError> {
-    if let Some(permissions) = &self.file_permissions {
-      permissions.check_specifier(specifier, CheckSpecifierKind::Dynamic)?;
+    specifier: &'a Url,
+  ) -> Result<Cow<'a, Url>, BundleLoadError> {
+    if self.is_runtime_api {
+      if specifier.scheme() == "file" {
+        let path = deno_path_util::url_to_file_path(specifier).map_err(|_| {
+          deno_runtime::deno_permissions::PermissionCheckError::InvalidFilePath(
+            specifier.clone(),
+          )
+        })?;
+        let checked_path = self.permissions.check_open(
+          Cow::Owned(path),
+          OpenAccessKind::Read,
+          Some("Deno.bundle()"),
+        )?;
+        let checked_specifier = deno_path_util::url_from_file_path(
+          &checked_path,
+        )
+        .map_err(|_| {
+          deno_runtime::deno_permissions::PermissionCheckError::InvalidFilePath(
+            specifier.clone(),
+          )
+        })?;
+        return Ok(Cow::Owned(checked_specifier));
+      } else {
+        self
+          .permissions
+          .check_specifier(specifier, CheckSpecifierKind::Dynamic)?;
+      }
     }
-    Ok(())
+    Ok(Cow::Borrowed(specifier))
   }
 
   async fn bundle_load(
@@ -2185,7 +2210,7 @@ impl DenoPluginHandler {
     // `specifier` is now the concrete module we're about to read the source of
     // (a `file:` path for local modules, including npm packages resolved into
     // `node_modules`). Gate the read on the caller's permissions.
-    self.check_read_permission(&specifier)?;
+    let specifier = self.check_read_permission(&specifier)?;
 
     let graph = self.module_graph_container.graph();
     let module_or_asset = self
@@ -2260,7 +2285,7 @@ impl DenoPluginHandler {
         specifier,
         statically_analyzable: _,
       } => {
-        self.check_read_permission(&specifier)?;
+        let specifier = self.check_read_permission(&specifier)?;
         LoadedModuleSource::ArcBytes(
           self
             .file_fetcher
@@ -2582,7 +2607,7 @@ fn resolve_entrypoints(
 }
 
 fn is_html_entrypoint(url: &Url) -> bool {
-  url.path().to_ascii_lowercase().ends_with(".html")
+  url.scheme() == "file" && url.path().to_ascii_lowercase().ends_with(".html")
 }
 
 fn resolve_roots(
@@ -3017,6 +3042,9 @@ mod entrypoint_tests {
     ));
     assert!(!is_html_entrypoint(
       &Url::parse("file:///tmp/secret.txt#.html").unwrap()
+    ));
+    assert!(!is_html_entrypoint(
+      &Url::parse("https://example.com/index.html").unwrap()
     ));
   }
 }

--- a/cli/tools/bundle/provider.rs
+++ b/cli/tools/bundle/provider.rs
@@ -121,6 +121,7 @@ impl BundleProvider for CliBundleProvider {
   async fn bundle(
     &self,
     options: RtBundleOptions,
+    permissions: deno_runtime::deno_permissions::PermissionsContainer,
   ) -> Result<rt_bundle::BuildResponse, AnyError> {
     let mut flags_clone = (*self.flags).clone();
     flags_clone.type_check_mode = crate::args::TypeCheckMode::None;
@@ -132,7 +133,13 @@ impl BundleProvider for CliBundleProvider {
     std::thread::spawn(move || {
       deno_runtime::tokio_util::create_and_run_current_thread(async move {
         let flags = Arc::new(flags_clone);
-        let bundler = match super::bundle_init(flags, &bundle_flags).await {
+        let bundler = match super::bundle_init(
+          flags,
+          &bundle_flags,
+          Some(permissions.clone()),
+        )
+        .await
+        {
           Ok(bundler) => bundler,
           Err(e) => {
             log::trace!("bundle_init error: {e:?}");
@@ -150,7 +157,7 @@ impl BundleProvider for CliBundleProvider {
           }
         };
         log::trace!("process_result");
-        if write_output {
+        let process_result_result = if write_output {
           super::process_result(
             &result,
             &bundler.cwd,
@@ -160,15 +167,23 @@ impl BundleProvider for CliBundleProvider {
             bundle_flags.minify,
             bundler.input,
             bundle_flags.output_dir.as_ref().map(Path::new),
-          )?;
-          result.output_files = None;
+            Some(&permissions),
+          )
+          .map(|_| {
+            result.output_files = None;
+          })
         } else {
           process_output_files(
             &bundle_flags,
             &mut result,
             &bundler.cwd,
             bundler.input,
-          )?;
+          )
+        };
+        if let Err(e) = process_result_result {
+          log::trace!("process_result error: {e:?}");
+          let _ = tx.send(Err(e));
+          return Ok(());
         }
         log::trace!("convert_build_response");
         let result = convert_build_response(result);

--- a/cli/tools/bundle/provider.rs
+++ b/cli/tools/bundle/provider.rs
@@ -158,7 +158,7 @@ impl BundleProvider for CliBundleProvider {
         };
         log::trace!("process_result");
         let process_result_result = if write_output {
-          super::process_result(
+          match super::process_result(
             &result,
             &bundler.cwd,
             crate::tools::bundle::should_replace_require_shim(
@@ -168,10 +168,13 @@ impl BundleProvider for CliBundleProvider {
             bundler.input,
             bundle_flags.output_dir.as_ref().map(Path::new),
             Some(&permissions),
-          )
-          .map(|_| {
-            result.output_files = None;
-          })
+          ) {
+            Ok(_) => {
+              result.output_files = None;
+              Ok(())
+            }
+            Err(err) => Err(err),
+          }
         } else {
           process_output_files(
             &bundle_flags,

--- a/cli/tools/pm/deps.rs
+++ b/cli/tools/pm/deps.rs
@@ -830,6 +830,7 @@ impl DepManager {
           is_dynamic: false,
           lib: deno_config::workspace::TsTypeLib::DenoWindow,
           permissions: self.permissions_container.clone(),
+          file_permission_api_name: None,
           ext_overwrite: None,
           allow_unknown_media_types: true,
           skip_graph_roots_validation: false,

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -191,6 +191,10 @@ declare namespace Deno {
    * }
    * ```
    *
+   * Requires read access to local entrypoints and their dependency trees,
+   * import access to remote modules, and write access when output is written
+   * to the filesystem.
+   *
    * @category Bundler
    * @experimental
    */

--- a/ext/bundle/Cargo.toml
+++ b/ext/bundle/Cargo.toml
@@ -13,5 +13,6 @@ description = "Bundle runtime API for Deno"
 async-trait.workspace = true
 deno_core.workspace = true
 deno_error.workspace = true
+deno_permissions.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/ext/bundle/src/lib.rs
+++ b/ext/bundle/src/lib.rs
@@ -12,6 +12,7 @@ use deno_core::convert::Uint8Array;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_error::JsErrorBox;
+use deno_permissions::PermissionsContainer;
 
 deno_core::extension!(
   deno_bundle_runtime,
@@ -41,6 +42,7 @@ impl BundleProvider for () {
   async fn bundle(
     &self,
     _options: BundleOptions,
+    _permissions: PermissionsContainer,
   ) -> Result<BuildResponse, AnyError> {
     // Embedders that don't wire up a real provider (notably `denort`, used
     // by `deno compile` outputs) fall through to this no-op implementation.
@@ -59,6 +61,7 @@ pub trait BundleProvider: Send + Sync {
   async fn bundle(
     &self,
     options: BundleOptions,
+    permissions: PermissionsContainer,
   ) -> Result<BuildResponse, AnyError>;
 }
 
@@ -226,13 +229,24 @@ pub async fn op_bundle(
   #[scoped] options: BundleOptions,
 ) -> Result<BuildResponse, JsErrorBox> {
   // eprintln!("op_bundle: {:?}", options);
-  let provider = {
+  let (provider, permissions) = {
     let state = state.borrow();
-    state.borrow::<Arc<dyn BundleProvider>>().clone()
+    let permissions = state
+      .try_borrow::<PermissionsContainer>()
+      .cloned()
+      .ok_or_else(|| {
+        JsErrorBox::generic(
+          "Deno.bundle() requires a runtime permissions context",
+        )
+      })?;
+    (
+      state.borrow::<Arc<dyn BundleProvider>>().clone(),
+      permissions,
+    )
   };
 
   provider
-    .bundle(options)
+    .bundle(options, permissions)
     .await
     .map_err(|e| JsErrorBox::generic(e.to_string()))
 }

--- a/libs/resolver/file_fetcher.rs
+++ b/libs/resolver/file_fetcher.rs
@@ -328,12 +328,24 @@ impl<
     permissions: FetchPermissionsOptionRef<'_>,
     options: FetchNoFollowOptions<'_>,
   ) -> Result<FileOrRedirect, FetchNoFollowError> {
-    let specifier = self.validate_fetch(specifier, permissions)?;
-    self
+    let checked_specifier = self.validate_fetch(specifier, permissions)?;
+    let restore_original_url =
+      specifier.scheme() == "file" && checked_specifier.as_ref() != specifier;
+    let mut result = self
       .file_fetcher
-      .fetch_no_follow(&specifier, options.into_deno_cache_dir_options())
+      .fetch_no_follow(
+        &checked_specifier,
+        options.into_deno_cache_dir_options(),
+      )
       .await
-      .map_err(|err| FetchNoFollowErrorKind::FetchNoFollow(err).into_box())
+      .map_err(|err| FetchNoFollowErrorKind::FetchNoFollow(err).into_box())?;
+    if restore_original_url && let FileOrRedirect::File(file) = &mut result {
+      // `check_open` may canonicalize an allowed path before it is read. Keep
+      // the requested URL as the module identity so short paths and symlink
+      // aliases do not become graph redirects to paths outside the allowlist.
+      file.url = specifier.clone();
+    }
+    Ok(result)
   }
 
   fn validate_fetch<'a>(
@@ -348,11 +360,9 @@ impl<
       FetchPermissionsOptionRef::AllowAll => {}
       FetchPermissionsOptionRef::RestrictedWithFileApiName(
         permissions,
-        kind,
+        _,
         file_api_name,
-      ) if specifier.scheme() == "file"
-        && kind == CheckSpecifierKind::Dynamic =>
-      {
+      ) if specifier.scheme() == "file" => {
         let path =
           deno_path_util::url_to_file_path(specifier).map_err(|_| {
             PermissionCheckError::InvalidFilePath(specifier.clone())

--- a/libs/resolver/file_fetcher.rs
+++ b/libs/resolver/file_fetcher.rs
@@ -85,6 +85,11 @@ pub enum GetCachedSourceOrLocalErrorKind {
 pub enum FetchPermissionsOptionRef<'a> {
   AllowAll,
   Restricted(&'a PermissionsContainer, CheckSpecifierKind),
+  RestrictedWithFileApiName(
+    &'a PermissionsContainer,
+    CheckSpecifierKind,
+    &'a str,
+  ),
 }
 
 #[derive(Debug, Default)]
@@ -305,10 +310,13 @@ impl<
     permissions: FetchPermissionsOptionRef<'_>,
     options: FetchNoFollowOptions<'_>,
   ) -> Result<CachedOrRedirect, FetchNoFollowError> {
-    self.validate_fetch(specifier, permissions)?;
+    let specifier = self.validate_fetch(specifier, permissions)?;
     self
       .file_fetcher
-      .ensure_cached_no_follow(specifier, options.into_deno_cache_dir_options())
+      .ensure_cached_no_follow(
+        &specifier,
+        options.into_deno_cache_dir_options(),
+      )
       .await
       .map_err(|err| FetchNoFollowErrorKind::FetchNoFollow(err).into_box())
   }
@@ -320,31 +328,56 @@ impl<
     permissions: FetchPermissionsOptionRef<'_>,
     options: FetchNoFollowOptions<'_>,
   ) -> Result<FileOrRedirect, FetchNoFollowError> {
-    self.validate_fetch(specifier, permissions)?;
+    let specifier = self.validate_fetch(specifier, permissions)?;
     self
       .file_fetcher
-      .fetch_no_follow(specifier, options.into_deno_cache_dir_options())
+      .fetch_no_follow(&specifier, options.into_deno_cache_dir_options())
       .await
       .map_err(|err| FetchNoFollowErrorKind::FetchNoFollow(err).into_box())
   }
 
-  fn validate_fetch(
+  fn validate_fetch<'a>(
     &self,
-    specifier: &Url,
+    specifier: &'a Url,
     permissions: FetchPermissionsOptionRef<'_>,
-  ) -> Result<(), FetchNoFollowError> {
+  ) -> Result<Cow<'a, Url>, FetchNoFollowError> {
     validate_scheme(specifier).map_err(|err| {
       FetchNoFollowErrorKind::FetchNoFollow(err.into()).into_box()
     })?;
     match permissions {
-      FetchPermissionsOptionRef::AllowAll => {
-        // allow
+      FetchPermissionsOptionRef::AllowAll => {}
+      FetchPermissionsOptionRef::RestrictedWithFileApiName(
+        permissions,
+        kind,
+        file_api_name,
+      ) if specifier.scheme() == "file"
+        && kind == CheckSpecifierKind::Dynamic =>
+      {
+        let path =
+          deno_path_util::url_to_file_path(specifier).map_err(|_| {
+            PermissionCheckError::InvalidFilePath(specifier.clone())
+          })?;
+        let checked_path = permissions.check_open(
+          Cow::Owned(path),
+          deno_permissions::OpenAccessKind::Read,
+          Some(file_api_name),
+        )?;
+        let checked_specifier =
+          deno_path_util::url_from_file_path(&checked_path).map_err(|_| {
+            PermissionCheckError::InvalidFilePath(specifier.clone())
+          })?;
+        return Ok(Cow::Owned(checked_specifier));
       }
-      FetchPermissionsOptionRef::Restricted(permissions, kind) => {
+      FetchPermissionsOptionRef::Restricted(permissions, kind)
+      | FetchPermissionsOptionRef::RestrictedWithFileApiName(
+        permissions,
+        kind,
+        _,
+      ) => {
         permissions.check_specifier(specifier, kind)?;
       }
     }
-    Ok(())
+    Ok(Cow::Borrowed(specifier))
   }
 
   /// A synchronous way to retrieve a source file, where if the file has already
@@ -408,6 +441,8 @@ pub struct DenoGraphLoaderOptions {
   /// don't need to pre-analyze npm sources for https specifiers.
   pub include_npm_sources: bool,
   pub permissions: Option<PermissionsContainer>,
+  /// Uses `check_open` with this API name for dynamic local-file loads.
+  pub file_permission_api_name: Option<&'static str>,
   pub reporter: Option<GraphLoaderReporterRc>,
 }
 
@@ -434,6 +469,7 @@ pub struct DenoGraphLoader<
   global_http_cache: GlobalHttpCacheRc<TSys>,
   in_npm_pkg_checker: DenoInNpmPackageChecker,
   permissions: Option<PermissionsContainer>,
+  file_permission_api_name: Option<&'static str>,
   sys: TSys,
   cache_info_enabled: bool,
   include_npm_sources: bool,
@@ -460,6 +496,7 @@ impl<
       sys,
       file_header_overrides: options.file_header_overrides,
       permissions: options.permissions,
+      file_permission_api_name: options.file_permission_api_name,
       cache_info_enabled: false,
       include_npm_sources: options.include_npm_sources,
       reporter: options.reporter,
@@ -516,6 +553,7 @@ impl<
   > {
     let file_fetcher = self.file_fetcher.clone();
     let permissions = self.permissions.clone();
+    let file_permission_api_name = self.file_permission_api_name;
     let is_statically_analyzable = !options.was_dynamic_root;
 
     async move {
@@ -535,16 +573,27 @@ impl<
       let result = strategy
         .handle_fetch_or_cache_no_follow(
           &specifier,
-          match &permissions {
-            Some(permissions) => FetchPermissionsOptionRef::Restricted(
-              permissions,
-              if is_statically_analyzable {
+          match (&permissions, file_permission_api_name) {
+            (Some(permissions), file_permission_api_name) => {
+              let kind = if is_statically_analyzable {
                 CheckSpecifierKind::Static
               } else {
                 CheckSpecifierKind::Dynamic
-              },
-            ),
-            None => FetchPermissionsOptionRef::AllowAll,
+              };
+              match file_permission_api_name {
+                Some(api_name) => {
+                  FetchPermissionsOptionRef::RestrictedWithFileApiName(
+                    permissions,
+                    kind,
+                    api_name,
+                  )
+                }
+                None => {
+                  FetchPermissionsOptionRef::Restricted(permissions, kind)
+                }
+              }
+            }
+            (None, _) => FetchPermissionsOptionRef::AllowAll,
           },
           FetchNoFollowOptions {
             local: FetchLocalOptions {
@@ -915,6 +964,7 @@ mod test {
       DenoGraphLoaderOptions {
         file_header_overrides: HashMap::new(),
         permissions: None,
+        file_permission_api_name: None,
         reporter: None,
         include_npm_sources: false,
       },

--- a/tests/specs/bundle/require_browser/__test__.jsonc
+++ b/tests/specs/bundle/require_browser/__test__.jsonc
@@ -4,7 +4,7 @@
     "api": {
       "steps": [
         {
-          "args": "run --unstable-bundle bundle.ts",
+          "args": "run -A --unstable-bundle bundle.ts",
           "output": "[WILDCARD]"
         },
         {

--- a/tests/specs/bundle/worker/main.ts.out
+++ b/tests/specs/bundle/worker/main.ts.out
@@ -1,2 +1,3 @@
 Worker: bundling module
-Worker: bundle result.success: true
+Worker: bundle result.success: false
+Worker: read denied: true

--- a/tests/specs/bundle/worker/main.ts.out
+++ b/tests/specs/bundle/worker/main.ts.out
@@ -1,3 +1,3 @@
 Worker: bundling module
-Worker: bundle result.success: false
+Worker: allowed bundle result.success: true
 Worker: read denied: true

--- a/tests/specs/bundle/worker/worker.ts
+++ b/tests/specs/bundle/worker/worker.ts
@@ -1,10 +1,16 @@
 // deno-lint-ignore-file no-console
 console.log("Worker: bundling module");
+// Only `./worker.ts` is readable, so bundling `./main.ts` is denied: the
+// bundle reads (and would return) module source, which requires read access.
 const result = await Deno.bundle({
   entrypoints: ["./main.ts"],
   write: false,
   outputDir: "/",
 });
 console.log("Worker: bundle result.success:", result.success);
+console.log(
+  "Worker: read denied:",
+  result.errors.some((e) => e.text.includes("Requires read access")),
+);
 
 postMessage("done");

--- a/tests/specs/bundle/worker/worker.ts
+++ b/tests/specs/bundle/worker/worker.ts
@@ -1,16 +1,26 @@
 // deno-lint-ignore-file no-console
 console.log("Worker: bundling module");
-// Only `./worker.ts` is readable, so bundling `./main.ts` is denied: the
-// bundle reads (and would return) module source, which requires read access.
-const result = await Deno.bundle({
-  entrypoints: ["./main.ts"],
+const allowed = await Deno.bundle({
+  entrypoints: ["./worker.ts"],
   write: false,
   outputDir: "/",
 });
-console.log("Worker: bundle result.success:", result.success);
-console.log(
-  "Worker: read denied:",
-  result.errors.some((e) => e.text.includes("Requires read access")),
-);
+console.log("Worker: allowed bundle result.success:", allowed.success);
+
+// Only `./worker.ts` is readable, so bundling `./main.ts` is denied: the
+// bundle reads (and would return) module source, which requires read access.
+let readDenied = false;
+try {
+  const denied = await Deno.bundle({
+    entrypoints: ["./main.ts"],
+    write: false,
+    outputDir: "/",
+  });
+  readDenied = !denied.success &&
+    denied.errors.some((error) => error.text.includes("Requires read access"));
+} catch (err) {
+  readDenied = String(err).includes("Requires read access");
+}
+console.log("Worker: read denied:", readDenied);
 
 postMessage("done");

--- a/tests/specs/bundle/worker/worker.ts
+++ b/tests/specs/bundle/worker/worker.ts
@@ -3,7 +3,6 @@ console.log("Worker: bundling module");
 const allowed = await Deno.bundle({
   entrypoints: ["./worker.ts"],
   write: false,
-  outputDir: "/",
 });
 console.log("Worker: allowed bundle result.success:", allowed.success);
 
@@ -14,7 +13,6 @@ try {
   const denied = await Deno.bundle({
     entrypoints: ["./main.ts"],
     write: false,
-    outputDir: "/",
   });
   readDenied = !denied.success &&
     denied.errors.some((error) => error.text.includes("Requires read access"));

--- a/tests/unit/bundle_test.ts
+++ b/tests/unit/bundle_test.ts
@@ -14,7 +14,11 @@ import { basename, join, toFileUrl } from "@std/path";
 class TempDir implements AsyncDisposable, Disposable {
   #path: string;
   constructor(options?: Deno.MakeTempOptions) {
-    this.#path = Deno.makeTempDirSync(options);
+    // Resolve symlinks (e.g. macOS `/var` -> `/private/var`) up front. The
+    // bundler canonicalizes module paths, and Deno matches read/write grants
+    // by literal path, so tests that scope permissions to this directory must
+    // grant the canonical path the bundler will actually check against.
+    this.#path = Deno.realPathSync(Deno.makeTempDirSync(options));
   }
 
   async [Symbol.asyncDispose]() {
@@ -193,6 +197,66 @@ Deno.test("bundle: write requires caller permission", async () => {
   assertStringIncludes(stderrText, "--allow-write");
   await assertPathNotFound(blockedDir);
   await assertPathNotFound(output);
+});
+
+Deno.test("bundle: module read requires caller permission", async () => {
+  using dir = new TempDir();
+  const secret = dir.join("secret.ts");
+  const runner = dir.join("runner.ts");
+
+  await Deno.writeTextFile(
+    secret,
+    'export const TOKEN = "super-secret-value";\n',
+  );
+  await Deno.writeTextFile(
+    runner,
+    unindent`
+      const result = await Deno.bundle({
+        entrypoints: [${JSON.stringify(secret)}],
+        write: false,
+      });
+      const text = result.outputFiles
+        ?.map((f) => new TextDecoder().decode(f.contents))
+        .join("") ?? "";
+      console.log(JSON.stringify({
+        success: result.success,
+        leaked: text.includes("super-secret-value"),
+        outputs: result.outputFiles?.length ?? 0,
+        errors: result.errors?.map((e) => e.text) ?? [],
+      }));
+    `,
+  );
+
+  // Read access to the runner only, so reading the bundled module is denied
+  // and its (transpiled) source is never returned to the caller.
+  const { success, stdout } = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--no-config",
+      "--no-lock",
+      "--no-prompt",
+      "--quiet",
+      "--unstable-bundle",
+      `--allow-read=${runner}`,
+      runner,
+    ],
+    stdout: "piped",
+  }).output();
+
+  assert(success);
+  const result = JSON.parse(new TextDecoder().decode(stdout)) as {
+    success: boolean;
+    leaked: boolean;
+    outputs: number;
+    errors: string[];
+  };
+  assertFalse(result.success);
+  assertFalse(result.leaked);
+  assertEquals(result.outputs, 0);
+  assert(
+    result.errors.some((e) => e.includes("Requires read access")),
+    `expected a read-access error, got: ${JSON.stringify(result.errors)}`,
+  );
 });
 
 Deno.test("bundle: html entrypoint read requires caller permission", async () => {

--- a/tests/unit/bundle_test.ts
+++ b/tests/unit/bundle_test.ts
@@ -195,6 +195,59 @@ Deno.test("bundle: write requires caller permission", async () => {
   await assertPathNotFound(output);
 });
 
+Deno.test("bundle: html entrypoint read requires caller permission", async () => {
+  using dir = new TempDir();
+  const secretDir = dir.join("secret");
+  const secretHtml = join(secretDir, "index.html");
+  const outDir = dir.join("dist");
+  const runner = dir.join("runner.ts");
+
+  await Deno.mkdir(secretDir, { recursive: true });
+  await Deno.writeTextFile(
+    secretHtml,
+    unindent`
+      <html>
+        <body><script type="module" src="./main.ts"></script></body>
+      </html>
+    `,
+  );
+  await Deno.writeTextFile(
+    join(secretDir, "main.ts"),
+    "console.log('secret');\n",
+  );
+  await Deno.writeTextFile(
+    runner,
+    unindent`
+      await Deno.bundle({
+        entrypoints: [${JSON.stringify(toFileUrl(secretHtml).href)}],
+        outputDir: ${JSON.stringify(outDir)},
+        write: false,
+      });
+    `,
+  );
+
+  // Read access to the runner only, so loading the HTML entrypoint is denied.
+  const { success, stderr } = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--no-config",
+      "--no-lock",
+      "--no-prompt",
+      "--quiet",
+      "--unstable-bundle",
+      `--allow-read=${runner}`,
+      runner,
+    ],
+    stderr: "piped",
+  }).output();
+
+  assertFalse(success);
+  const stderrText = new TextDecoder().decode(stderr);
+  assertStringIncludes(stderrText, "Requires read access");
+  assertStringIncludes(stderrText, "--allow-read");
+  await assertPathNotFound(outDir);
+});
+
 Deno.test("bundle: worker permissions override parent permissions", async () => {
   using dir = new TempDir();
   const sourceDir = dir.join("source");

--- a/tests/unit/bundle_test.ts
+++ b/tests/unit/bundle_test.ts
@@ -12,21 +12,25 @@ import {
 import { basename, join, toFileUrl } from "@std/path";
 
 class TempDir implements AsyncDisposable, Disposable {
-  private path: string;
+  #path: string;
   constructor(options?: Deno.MakeTempOptions) {
-    this.path = Deno.makeTempDirSync(options);
+    this.#path = Deno.makeTempDirSync(options);
   }
 
   async [Symbol.asyncDispose]() {
-    await Deno.remove(this.path, { recursive: true });
+    await Deno.remove(this.#path, { recursive: true });
   }
 
   [Symbol.dispose]() {
-    Deno.removeSync(this.path, { recursive: true });
+    Deno.removeSync(this.#path, { recursive: true });
+  }
+
+  get path() {
+    return this.#path;
   }
 
   join(path: string) {
-    return join(this.path, path);
+    return join(this.#path, path);
   }
 }
 
@@ -46,6 +50,17 @@ class TempFile implements AsyncDisposable, Disposable {
 
   get path() {
     return this.#path;
+  }
+}
+
+async function assertPathNotFound(path: string) {
+  try {
+    await Deno.lstat(path);
+    throw new Error(`expected path not to exist: ${path}`);
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) {
+      throw err;
+    }
   }
 }
 
@@ -137,6 +152,156 @@ Deno.test("bundle: write to outputDir omits outputFiles and writes files", async
   const outJsPath = join(outDir, files[0]);
   const outContent = await Deno.readTextFile(outJsPath);
   assertStringIncludes(outContent, "Hello bundle write");
+});
+
+Deno.test("bundle: write requires caller permission", async () => {
+  using dir = new TempDir();
+  const entry = dir.join("main.ts");
+  const runner = dir.join("runner.ts");
+  const blockedDir = dir.join("blocked");
+  const output = join(blockedDir, "dist", "main.js");
+
+  await Deno.writeTextFile(entry, "export const value = 42;\n");
+  await Deno.writeTextFile(
+    runner,
+    unindent`
+      await Deno.bundle({
+        entrypoints: [${JSON.stringify(entry)}],
+        outputPath: ${JSON.stringify(output)},
+        write: true,
+      });
+    `,
+  );
+
+  const { success, stderr } = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--no-config",
+      "--no-lock",
+      "--no-prompt",
+      "--quiet",
+      "--unstable-bundle",
+      `--allow-read=${dir.path}`,
+      runner,
+    ],
+    stderr: "piped",
+  }).output();
+
+  assertFalse(success);
+  const stderrText = new TextDecoder().decode(stderr);
+  assertStringIncludes(stderrText, "Requires write access");
+  assertStringIncludes(stderrText, "--allow-write");
+  await assertPathNotFound(blockedDir);
+  await assertPathNotFound(output);
+});
+
+Deno.test("bundle: worker permissions override parent permissions", async () => {
+  using dir = new TempDir();
+  const sourceDir = dir.join("source");
+  const secretDir = dir.join("secret");
+  const blockedDir = dir.join("blocked");
+  const entry = join(sourceDir, "main.ts");
+  const secretHtml = join(secretDir, "secret.html");
+  const output = join(blockedDir, "main.js");
+  const runner = dir.join("worker_runner.ts");
+
+  await Deno.mkdir(sourceDir, { recursive: true });
+  await Deno.mkdir(secretDir, { recursive: true });
+  await Deno.writeTextFile(entry, "export const value = 42;\n");
+  await Deno.writeTextFile(secretHtml, "<p>blocked</p>\n");
+
+  await Deno.writeTextFile(
+    runner,
+    unindent`
+      const workerSource = ${
+      JSON.stringify(unindent`
+        self.onmessage = async ({ data }) => {
+          const result = {};
+
+          try {
+            await Deno.bundle({
+              entrypoints: [data.secretHtml],
+              outputDir: data.outputDir,
+              write: false,
+            });
+            result.htmlRead = "allowed";
+          } catch (err) {
+            result.htmlRead = String(err);
+          }
+
+          try {
+            await Deno.bundle({
+              entrypoints: [data.entry],
+              outputPath: data.output,
+              write: true,
+            });
+            result.write = "allowed";
+          } catch (err) {
+            result.write = String(err);
+          }
+
+          self.postMessage(result);
+        };
+      `)
+    };
+      const workerUrl = URL.createObjectURL(
+        new Blob([workerSource], { type: "text/javascript" }),
+      );
+      const worker = new Worker(workerUrl, {
+        type: "module",
+        deno: {
+          permissions: {
+            read: [${JSON.stringify(sourceDir)}],
+            write: false,
+          },
+        },
+      });
+      const result = await new Promise((resolve, reject) => {
+        worker.onmessage = (event) => resolve(event.data);
+        worker.onerror = (event) => reject(event.error ?? event.message);
+        worker.postMessage({
+          entry: ${JSON.stringify(entry)},
+          secretHtml: ${JSON.stringify(toFileUrl(secretHtml).href)},
+          outputDir: ${JSON.stringify(blockedDir)},
+          output: ${JSON.stringify(output)},
+        });
+      });
+      worker.terminate();
+      console.log(JSON.stringify(result));
+    `,
+  );
+
+  const { success, stdout, stderr } = await new Deno.Command(
+    Deno.execPath(),
+    {
+      args: [
+        "run",
+        "--no-config",
+        "--no-lock",
+        "--no-prompt",
+        "--quiet",
+        "--unstable-bundle",
+        "--unstable-worker-options",
+        `--allow-read=${dir.path}`,
+        `--allow-write=${dir.path}`,
+        runner,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    },
+  ).output();
+
+  const stdoutText = new TextDecoder().decode(stdout);
+  const stderrText = new TextDecoder().decode(stderr);
+  assert(success, stderrText);
+  const result = JSON.parse(stdoutText) as {
+    htmlRead: string;
+    write: string;
+  };
+  assertStringIncludes(result.htmlRead, "Requires read access");
+  assertStringIncludes(result.write, "Requires write access");
+  await assertPathNotFound(blockedDir);
+  await assertPathNotFound(output);
 });
 
 Deno.test("bundle: minify produces smaller output", async () => {

--- a/tests/unit/bundle_test.ts
+++ b/tests/unit/bundle_test.ts
@@ -5,6 +5,7 @@ import {
   assertEquals,
   assertFalse,
   assertMatch,
+  assertRejects,
   assertStringIncludes,
   unindent,
 } from "./test_util.ts";
@@ -58,14 +59,7 @@ class TempFile implements AsyncDisposable, Disposable {
 }
 
 async function assertPathNotFound(path: string) {
-  try {
-    await Deno.lstat(path);
-    throw new Error(`expected path not to exist: ${path}`);
-  } catch (err) {
-    if (!(err instanceof Deno.errors.NotFound)) {
-      throw err;
-    }
-  }
+  await assertRejects(() => Deno.lstat(path), Deno.errors.NotFound);
 }
 
 Deno.test("bundle: basic in-memory bundle succeeds and returns content", async () => {
@@ -215,20 +209,16 @@ Deno.test("bundle: module read requires caller permission", async () => {
         entrypoints: [${JSON.stringify(secret)}],
         write: false,
       });
-      const text = result.outputFiles
-        ?.map((f) => new TextDecoder().decode(f.contents))
-        .join("") ?? "";
       console.log(JSON.stringify({
         success: result.success,
-        leaked: text.includes("super-secret-value"),
         outputs: result.outputFiles?.length ?? 0,
-        errors: result.errors?.map((e) => e.text) ?? [],
+        errors: result.errors.map((error) => error.text),
       }));
     `,
   );
 
   // Read access to the runner only, so reading the bundled module is denied
-  // and its (transpiled) source is never returned to the caller.
+  // before graph preparation reads its source.
   const { success, stdout } = await new Deno.Command(Deno.execPath(), {
     args: [
       "run",
@@ -246,16 +236,21 @@ Deno.test("bundle: module read requires caller permission", async () => {
   assert(success);
   const result = JSON.parse(new TextDecoder().decode(stdout)) as {
     success: boolean;
-    leaked: boolean;
     outputs: number;
     errors: string[];
   };
   assertFalse(result.success);
-  assertFalse(result.leaked);
   assertEquals(result.outputs, 0);
   assert(
-    result.errors.some((e) => e.includes("Requires read access")),
-    `expected a read-access error, got: ${JSON.stringify(result.errors)}`,
+    result.errors.some((error) => error.includes("Requires read access")),
+  );
+  assert(
+    result.errors.some((error) => error.includes("--allow-read")),
+    JSON.stringify(result.errors),
+  );
+  assertFalse(
+    result.errors.some((error) => error.includes("import()")),
+    JSON.stringify(result.errors),
   );
 });
 

--- a/tests/unit/bundle_test.ts
+++ b/tests/unit/bundle_test.ts
@@ -254,6 +254,60 @@ Deno.test("bundle: module read requires caller permission", async () => {
   );
 });
 
+Deno.test("bundle: permitted path alias preserves module identity", async () => {
+  using dir = new TempDir();
+  const realDir = dir.join("real");
+  const aliasDir = dir.join("alias");
+  const entry = join(realDir, "entry.ts");
+  const aliasEntry = join(aliasDir, "entry.ts");
+  const runner = dir.join("runner.ts");
+
+  await Deno.mkdir(realDir);
+  await Deno.writeTextFile(entry, "export const value = 42;\n");
+  await Deno.symlink(realDir, aliasDir, {
+    type: Deno.build.os === "windows" ? "junction" : "dir",
+  });
+  await Deno.writeTextFile(
+    runner,
+    unindent`
+      const result = await Deno.bundle({
+        entrypoints: [${JSON.stringify(aliasEntry)}],
+        write: false,
+      });
+      console.log(JSON.stringify({
+        success: result.success,
+        errors: result.errors.map((error) => error.text),
+      }));
+    `,
+  );
+
+  const { success, stdout, stderr } = await new Deno.Command(
+    Deno.execPath(),
+    {
+      args: [
+        "run",
+        "--no-config",
+        "--no-lock",
+        "--no-prompt",
+        "--quiet",
+        "--unstable-bundle",
+        `--allow-read=${runner},${aliasEntry}`,
+        runner,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    },
+  ).output();
+
+  const stderrText = new TextDecoder().decode(stderr);
+  assert(success, stderrText);
+  const result = JSON.parse(new TextDecoder().decode(stdout)) as {
+    success: boolean;
+    errors: string[];
+  };
+  assert(result.success, JSON.stringify(result.errors));
+});
+
 Deno.test("bundle: html entrypoint read requires caller permission", async () => {
   using dir = new TempDir();
   const secretDir = dir.join("secret");


### PR DESCRIPTION
## Summary

`Deno.bundle()` reuses the CLI bundling pipeline, but its HTML loading and
output-writing paths did not carry the calling isolate's filesystem
permissions. This made the JavaScript API behave differently from other
runtime file operations.

- carry the caller's current permissions through the runtime bundle provider
- check HTML entrypoint reads and output writes before filesystem access
- classify HTML entrypoints from the URL path instead of fragment text
- preserve the trusted behavior of the directly invoked `deno bundle` command

## Testing

- `./tools/format.js`
- `./tools/lint.js`
- `cargo check -p deno_bundle_runtime -p deno --lib`
- `cargo test -p deno --lib html_entrypoint -- --nocapture`
- `cargo build --bin deno`
- `cargo test -p unit_tests --test unit -- bundle_test --nocapture`
- `cargo test -p specs_tests --test specs -- specs::bundle::html --nocapture`

## Permission behavior

When called through the JavaScript API, `Deno.bundle()` now checks the
calling isolate’s permissions before filesystem access:

- local entrypoints and every local dependency require read access
- remote modules require import access
- filesystem output requires write access

The local dependency tree includes packages resolved into `node_modules`.
Restricted runs may therefore prompt for multiple previously ungranted paths.
This is an intentional change to the unstable API; the directly invoked
`deno bundle` command remains a trusted CLI path and is unaffected.
