### PR TITLE
fix(publish): constrain generated source rewrites

### DIFF
--- a/cli/tools/pack/unfurl.rs
+++ b/cli/tools/pack/unfurl.rs
@@ -14,7 +14,9 @@ use deno_graph::analysis::TypeScriptReference;
 use deno_semver::jsr::JsrPackageReqReference;
 use deno_semver::npm::NpmPackageReqReference;
 
+use crate::tools::unfurl_utils::SpecifierTextContext;
 use crate::tools::unfurl_utils::dynamic_argument_prefix_range;
+use crate::tools::unfurl_utils::specifier_text_change;
 use crate::tools::unfurl_utils::to_range;
 
 /// Result of unfurling a module's specifiers for npm compatibility.
@@ -85,6 +87,7 @@ pub fn unfurl_specifiers(
       &specifier_with_range.text,
       &specifier_with_range.range,
       text_info,
+      SpecifierTextContext::QuotedComment,
       &mut text_changes,
       &mut dependencies,
     );
@@ -96,6 +99,7 @@ pub fn unfurl_specifiers(
       &jsdoc.specifier.text,
       &jsdoc.specifier.range,
       text_info,
+      SpecifierTextContext::QuotedComment,
       &mut text_changes,
       &mut dependencies,
     );
@@ -107,6 +111,7 @@ pub fn unfurl_specifiers(
       &specifier_with_range.text,
       &specifier_with_range.range,
       text_info,
+      SpecifierTextContext::UnquotedComment,
       &mut text_changes,
       &mut dependencies,
     );
@@ -118,6 +123,7 @@ pub fn unfurl_specifiers(
       &specifier_with_range.text,
       &specifier_with_range.range,
       text_info,
+      SpecifierTextContext::UnquotedComment,
       &mut text_changes,
       &mut dependencies,
     );
@@ -140,10 +146,14 @@ pub fn unfurl_specifiers(
         }
 
         let byte_range = range.as_byte_range(text_info.range().start);
-        text_changes.push(TextChange {
-          range: byte_range,
-          new_text: rewritten,
-        });
+        if let Some(text_change) = specifier_text_change(
+          text_info,
+          byte_range,
+          &rewritten,
+          SpecifierTextContext::JavaScript,
+        ) {
+          text_changes.push(text_change);
+        }
       }
     }
   }
@@ -159,6 +169,7 @@ fn unfurl_specifier_with_range(
   spec: &str,
   range: &deno_graph::PositionRange,
   text_info: &SourceTextInfo,
+  context: SpecifierTextContext,
   text_changes: &mut Vec<TextChange>,
   dependencies: &mut BTreeMap<String, String>,
 ) {
@@ -168,10 +179,11 @@ fn unfurl_specifier_with_range(
 
   if let Some(rewritten) = rewrite_specifier(spec) {
     let byte_range = to_range(text_info, range);
-    text_changes.push(TextChange {
-      range: byte_range,
-      new_text: rewritten,
-    });
+    if let Some(text_change) =
+      specifier_text_change(text_info, byte_range, &rewritten, context)
+    {
+      text_changes.push(text_change);
+    }
   }
 }
 
@@ -196,10 +208,14 @@ fn unfurl_static_specifier(
 
   if let Some(rewritten) = rewrite_specifier(spec) {
     let byte_range = to_range(text_info, range);
-    text_changes.push(TextChange {
-      range: byte_range,
-      new_text: rewritten,
-    });
+    if let Some(text_change) = specifier_text_change(
+      text_info,
+      byte_range,
+      &rewritten,
+      SpecifierTextContext::JavaScript,
+    ) {
+      text_changes.push(text_change);
+    }
   }
 }
 
@@ -223,17 +239,20 @@ fn unfurl_dynamic_specifier(
         dependencies.insert(name, version);
       }
 
-      if let Some(rewritten) = rewrite_specifier(specifier) {
-        if let Some(range) = dynamic_argument_prefix_range(
+      if let Some(rewritten) = rewrite_specifier(specifier)
+        && let Some(range) = dynamic_argument_prefix_range(
           text_info,
           &dep.argument_range,
           specifier,
-        ) {
-          text_changes.push(TextChange {
-            range,
-            new_text: rewritten,
-          });
-        }
+        )
+        && let Some(text_change) = specifier_text_change(
+          text_info,
+          range,
+          &rewritten,
+          SpecifierTextContext::JavaScript,
+        )
+      {
+        text_changes.push(text_change);
       }
     }
     DynamicArgument::Template(parts) => {
@@ -256,11 +275,13 @@ fn unfurl_dynamic_specifier(
               text_info,
               &dep.argument_range,
               specifier,
+            ) && let Some(text_change) = specifier_text_change(
+              text_info,
+              range,
+              &rewritten,
+              SpecifierTextContext::JavaScript,
             ) {
-              text_changes.push(TextChange {
-                range,
-                new_text: rewritten,
-              });
+              text_changes.push(text_change);
             }
           }
           return;
@@ -270,17 +291,20 @@ fn unfurl_dynamic_specifier(
           if let Some((name, version)) = extract_package_dependency(specifier) {
             dependencies.insert(name, version);
           }
-          if let Some(rewritten) = rewrite_specifier(specifier) {
-            if let Some(range) = dynamic_argument_prefix_range(
+          if let Some(rewritten) = rewrite_specifier(specifier)
+            && let Some(range) = dynamic_argument_prefix_range(
               text_info,
               &dep.argument_range,
               specifier,
-            ) {
-              text_changes.push(TextChange {
-                range,
-                new_text: rewritten,
-              });
-            }
+            )
+            && let Some(text_change) = specifier_text_change(
+              text_info,
+              range,
+              &rewritten,
+              SpecifierTextContext::JavaScript,
+            )
+          {
+            text_changes.push(text_change);
           }
         }
       }
@@ -494,6 +518,47 @@ const validConcatenation = import("express/lib/" + name);
 const laterUnrelatedText = "npm:express@4/lib/";
 "#
     );
+  }
+
+  #[test]
+  fn test_generated_specifiers_remain_valid_literals() {
+    let specifier = ModuleSpecifier::parse("file:///mod.ts").unwrap();
+    let source = r#"import value from "npm:package/path\"double";
+export * from 'npm:package/path\'single';
+import.meta.resolve("npm:package/path\"double");
+"#;
+    let parsed_source = deno_ast::parse_module(deno_ast::ParseParams {
+      specifier: specifier.clone(),
+      text: source.into(),
+      media_type: deno_ast::MediaType::TypeScript,
+      capture_tokens: false,
+      scope_analysis: false,
+      maybe_syntax: None,
+    })
+    .unwrap();
+    let result = unfurl_specifiers(
+      &parsed_source,
+      &specifier,
+      &ModuleGraph::new(deno_graph::GraphKind::All),
+    );
+    let output = deno_ast::apply_text_changes(source, result.text_changes);
+
+    assert_eq!(
+      output,
+      r#"import value from "package/path\"double";
+export * from 'package/path\'single';
+import.meta.resolve("package/path\"double");
+"#
+    );
+    deno_ast::parse_module(deno_ast::ParseParams {
+      specifier,
+      text: output.into(),
+      media_type: deno_ast::MediaType::TypeScript,
+      capture_tokens: false,
+      scope_analysis: false,
+      maybe_syntax: None,
+    })
+    .unwrap();
   }
 
   #[test]

--- a/cli/tools/pack/unfurl.rs
+++ b/cli/tools/pack/unfurl.rs
@@ -14,6 +14,7 @@ use deno_graph::analysis::TypeScriptReference;
 use deno_semver::jsr::JsrPackageReqReference;
 use deno_semver::npm::NpmPackageReqReference;
 
+use crate::tools::unfurl_utils::dynamic_argument_prefix_range;
 use crate::tools::unfurl_utils::to_range;
 
 /// Result of unfurling a module's specifiers for npm compatibility.
@@ -223,13 +224,13 @@ fn unfurl_dynamic_specifier(
       }
 
       if let Some(rewritten) = rewrite_specifier(specifier) {
-        let range = to_range(text_info, &dep.argument_range);
-        // Find the specifier within the range (it may be surrounded by quotes)
-        let text_in_range = &text_info.text_str()[range.clone()];
-        if let Some(relative_index) = text_in_range.find(specifier.as_str()) {
-          let start = range.start + relative_index;
+        if let Some(range) = dynamic_argument_prefix_range(
+          text_info,
+          &dep.argument_range,
+          specifier,
+        ) {
           text_changes.push(TextChange {
-            range: start..start + specifier.len(),
+            range,
             new_text: rewritten,
           });
         }
@@ -251,13 +252,13 @@ fn unfurl_dynamic_specifier(
             {
               dependencies.insert(name, version);
             }
-            let range = to_range(text_info, &dep.argument_range);
-            let text_in_range = &text_info.text_str()[range.clone()];
-            if let Some(relative_index) = text_in_range.find(specifier.as_str())
-            {
-              let start = range.start + relative_index;
+            if let Some(range) = dynamic_argument_prefix_range(
+              text_info,
+              &dep.argument_range,
+              specifier,
+            ) {
               text_changes.push(TextChange {
-                range: start..start + specifier.len(),
+                range,
                 new_text: rewritten,
               });
             }
@@ -270,13 +271,13 @@ fn unfurl_dynamic_specifier(
             dependencies.insert(name, version);
           }
           if let Some(rewritten) = rewrite_specifier(specifier) {
-            let range = to_range(text_info, &dep.argument_range);
-            let text_in_range = &text_info.text_str()[range.start..];
-            if let Some(relative_index) = text_in_range.find(specifier.as_str())
-            {
-              let start = range.start + relative_index;
+            if let Some(range) = dynamic_argument_prefix_range(
+              text_info,
+              &dep.argument_range,
+              specifier,
+            ) {
               text_changes.push(TextChange {
-                range: start..start + specifier.len(),
+                range,
                 new_text: rewritten,
               });
             }
@@ -452,6 +453,48 @@ fn normalize_version(version: &str) -> String {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn test_dynamic_prefix_rewrites_exact_source_part() {
+    let specifier = ModuleSpecifier::parse("file:///mod.ts").unwrap();
+    let source = r#"const escapedTemplate = import(`npm:\x65xpress@4/lib/${name}`);
+const interpolationDecoy = import(`npm:\x65xpress@4/lib/${"npm:express@4/lib/"}${name}`);
+const concatenationDecoy = import("npm:\x65xpress@4/lib/" + "npm:express@4/lib/" + name);
+const validTemplate = import(`npm:express@4/lib/${name}`);
+const validConcatenation = import("npm:express@4/lib/" + name);
+const laterUnrelatedText = "npm:express@4/lib/";
+"#;
+    let parsed_source = deno_ast::parse_module(deno_ast::ParseParams {
+      specifier: specifier.clone(),
+      text: source.into(),
+      media_type: deno_ast::MediaType::TypeScript,
+      capture_tokens: false,
+      scope_analysis: false,
+      maybe_syntax: None,
+    })
+    .unwrap();
+    let result = unfurl_specifiers(
+      &parsed_source,
+      &specifier,
+      &ModuleGraph::new(deno_graph::GraphKind::All),
+    );
+    assert_eq!(
+      result.dependencies.get("express").map(String::as_str),
+      Some("^4")
+    );
+    let output = deno_ast::apply_text_changes(source, result.text_changes);
+
+    assert_eq!(
+      output,
+      r#"const escapedTemplate = import(`npm:\x65xpress@4/lib/${name}`);
+const interpolationDecoy = import(`npm:\x65xpress@4/lib/${"npm:express@4/lib/"}${name}`);
+const concatenationDecoy = import("npm:\x65xpress@4/lib/" + "npm:express@4/lib/" + name);
+const validTemplate = import(`express/lib/${name}`);
+const validConcatenation = import("express/lib/" + name);
+const laterUnrelatedText = "npm:express@4/lib/";
+"#
+    );
+  }
 
   #[test]
   fn test_rewrite_file_extension() {

--- a/cli/tools/publish/module_content.rs
+++ b/cli/tools/publish/module_content.rs
@@ -25,6 +25,16 @@ use super::unfurl::SpecifierUnfurler;
 use super::unfurl::SpecifierUnfurlerDiagnostic;
 use super::unfurl::SpecifierUnfurlerSys;
 use crate::sys::CliSys;
+use crate::tools::unfurl_utils::is_safe_unquoted_comment_value;
+
+fn jsx_pragma(name: &str, value: &str) -> Result<String, AnyError> {
+  if !is_safe_unquoted_comment_value(value) {
+    return Err(deno_core::anyhow::anyhow!(
+      "Cannot represent compiler option '{name}' as a generated JSX pragma."
+    ));
+  }
+  Ok(format!("/** @{name} {value} */"))
+}
 
 struct JsxFolderOptions<'a> {
   jsx_runtime: &'static str,
@@ -236,28 +246,22 @@ impl<TSys: ModuleContentProviderSys> ModuleContentProvider<TSys> {
     if module_info.jsx_import_source.is_none()
       && let Some(import_source) = jsx_options.jsx_import_source
     {
-      add_text_change(format!("/** @jsxImportSource {} */", import_source));
+      add_text_change(jsx_pragma("jsxImportSource", &import_source)?);
     }
     if module_info.jsx_import_source_types.is_none()
       && let Some(import_source) = jsx_options.jsx_import_source_types
     {
-      add_text_change(format!(
-        "/** @jsxImportSourceTypes {} */",
-        import_source
-      ));
+      add_text_change(jsx_pragma("jsxImportSourceTypes", &import_source)?);
     }
     if let Some(classic_options) = &jsx_options.jsx_classic {
       if !leading_comments_has_re(&JSX_FACTORY_RE) {
-        add_text_change(format!(
-          "/** @jsxFactory {} */",
-          classic_options.factory,
-        ));
+        add_text_change(jsx_pragma("jsxFactory", &classic_options.factory)?);
       }
       if !leading_comments_has_re(&JSX_FRAGMENT_FACTORY_RE) {
-        add_text_change(format!(
-          "/** @jsxFragmentFactory {} */",
-          classic_options.fragment_factory,
-        ));
+        add_text_change(jsx_pragma(
+          "jsxFragmentFactory",
+          &classic_options.fragment_factory,
+        )?);
       }
     }
     Ok(())
@@ -348,6 +352,22 @@ mod test {
   use sys_traits::impls::InMemorySys;
 
   use super::*;
+
+  #[test]
+  fn test_jsx_pragma_safety() {
+    assert_eq!(
+      jsx_pragma("jsxImportSource", "npm:react").unwrap(),
+      "/** @jsxImportSource npm:react */"
+    );
+    for value in [
+      "",
+      "npm:package/sub*/path",
+      "npm:package/with space",
+      "line\nbreak",
+    ] {
+      assert!(jsx_pragma("jsxImportSource", value).is_err());
+    }
+  }
 
   #[tokio::test]
   async fn test_module_content_jsx() {
@@ -454,6 +474,45 @@ mod test {
         ),
       ),
     ]).await;
+  }
+
+  #[tokio::test]
+  async fn test_module_content_rejects_unrepresentable_jsx_pragma() {
+    let in_memory_sys = InMemorySys::default();
+    in_memory_sys.fs_create_dir_all(get_path("/")).unwrap();
+    in_memory_sys
+      .fs_write(
+        get_path("/deno.json"),
+        r#"{
+          "compilerOptions": {
+            "jsx": "react-jsx",
+            "jsxImportSource": "npm:package/sub*/path"
+          }
+        }"#,
+      )
+      .unwrap();
+    in_memory_sys
+      .fs_write(
+        get_path("/main.tsx"),
+        "export const component = <div></div>;",
+      )
+      .unwrap();
+
+    let provider = module_content_provider(in_memory_sys).await;
+    let path = get_path("/main.tsx");
+    let error = provider
+      .resolve_content_maybe_unfurling(
+        &ModuleGraph::new(deno_graph::GraphKind::All),
+        &Default::default(),
+        &path,
+        &url_from_file_path(&path).unwrap(),
+      )
+      .unwrap_err();
+    assert!(
+      error
+        .to_string()
+        .contains("Cannot represent compiler option 'jsxImportSource'")
+    );
   }
 
   #[tokio::test]
@@ -605,7 +664,10 @@ mod test {
     let workspace_factory = Arc::new(WorkspaceFactory::new(
       sys.clone(),
       cwd.to_path_buf(),
-      WorkspaceFactoryOptions::default(),
+      WorkspaceFactoryOptions {
+        maybe_custom_deno_dir_root: Some(cwd.join("deno_dir")),
+        ..Default::default()
+      },
     ));
     let resolver_factory = ResolverFactory::new(
       workspace_factory,

--- a/cli/tools/publish/unfurl.rs
+++ b/cli/tools/publish/unfurl.rs
@@ -49,6 +49,7 @@ use crate::node::CliPackageJsonResolver;
 use crate::resolver::CliNpmReqResolver;
 use crate::sys::CliSys;
 use crate::tools::unfurl_utils::ImportMetaResolveCollector;
+use crate::tools::unfurl_utils::dynamic_argument_prefix_range;
 use crate::tools::unfurl_utils::to_range;
 
 #[derive(Debug, Clone)]
@@ -818,12 +819,6 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
   ) -> bool {
     match &dep.argument {
       deno_graph::analysis::DynamicArgument::String(specifier) => {
-        let range = to_range(text_info, &dep.argument_range);
-        let maybe_relative_index =
-          text_info.text_str()[range.start..range.end].find(specifier);
-        let Some(relative_index) = maybe_relative_index else {
-          return true; // always say it's analyzable for a string
-        };
         let maybe_unfurled = self.unfurl_specifier_reporting_diagnostic(
           module_url,
           specifier,
@@ -833,9 +828,15 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
           diagnostic_reporter,
         );
         if let Some(unfurled) = maybe_unfurled {
-          let start = range.start + relative_index;
+          let Some(range) = dynamic_argument_prefix_range(
+            text_info,
+            &dep.argument_range,
+            specifier,
+          ) else {
+            return false;
+          };
           text_changes.push(deno_ast::TextChange {
-            range: start..start + specifier.len(),
+            range,
             new_text: unfurled,
           });
         }
@@ -862,15 +863,15 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
             let Some(unfurled) = unfurled else {
               return true; // nothing to unfurl
             };
-            let range = to_range(text_info, &dep.argument_range);
-            let maybe_relative_index =
-              text_info.text_str()[range.start..].find(specifier);
-            let Some(relative_index) = maybe_relative_index else {
+            let Some(range) = dynamic_argument_prefix_range(
+              text_info,
+              &dep.argument_range,
+              specifier,
+            ) else {
               return false;
             };
-            let start = range.start + relative_index;
             text_changes.push(deno_ast::TextChange {
-              range: start..start + specifier.len(),
+              range,
               new_text: unfurled,
             });
             true
@@ -1322,6 +1323,49 @@ export type * from "./c.d.ts";
   }
 
   #[tokio::test]
+  async fn test_unfurling_dynamic_prefix_source_ranges() {
+    let cwd = get_cwd();
+    let memory_sys = InMemorySys::new_with_cwd(&cwd);
+    memory_sys.fs_insert_json(
+      cwd.join("deno.json"),
+      json!({
+        "imports": {
+          "lib/": "./lib/",
+        }
+      }),
+    );
+    let unfurler = build_unfurler(memory_sys, &cwd).await;
+
+    let source_code = r#"const escapedTemplate = await import(`\x6cib/${name}`);
+const interpolationDecoy = await import(`\x6cib/${"lib/"}${name}`);
+const concatenationDecoy = await import("\x6cib/" + "lib/" + name);
+const unchangedEscaped = await import("\x6eode:fs");
+const validTemplate = await import(`lib/${name}`);
+const validConcatenation = await import("lib/" + name);
+const laterUnrelatedText = "lib/";
+"#;
+    let (unfurled_source, diagnostics) =
+      unfurl_text_with_diagnostics(&cwd.join("mod.ts"), source_code, &unfurler);
+
+    assert_eq!(diagnostics.len(), 3);
+    assert!(diagnostics.iter().all(|diagnostic| matches!(
+      diagnostic,
+      SpecifierUnfurlerDiagnostic::UnanalyzableDynamicImport { .. }
+    )));
+    assert_eq!(
+      unfurled_source,
+      r#"const escapedTemplate = await import(`\x6cib/${name}`);
+const interpolationDecoy = await import(`\x6cib/${"lib/"}${name}`);
+const concatenationDecoy = await import("\x6cib/" + "lib/" + name);
+const unchangedEscaped = await import("\x6eode:fs");
+const validTemplate = await import(`./lib/${name}`);
+const validConcatenation = await import("./lib/" + name);
+const laterUnrelatedText = "lib/";
+"#
+    );
+  }
+
+  #[tokio::test]
   async fn test_unfurling_npm_dep_workspace_specifier() {
     let cwd = get_cwd();
     let memory_sys = InMemorySys::new_with_cwd(&cwd);
@@ -1712,7 +1756,10 @@ export * from "jsr:@std/semver@1";
     let workspace_factory = Arc::new(WorkspaceFactory::new(
       sys,
       cwd.to_path_buf(),
-      WorkspaceFactoryOptions::default(),
+      WorkspaceFactoryOptions {
+        maybe_custom_deno_dir_root: Some(cwd.join("deno_dir")),
+        ..Default::default()
+      },
     ));
     let resolver_factory = ResolverFactory::new(
       workspace_factory,

--- a/cli/tools/publish/unfurl.rs
+++ b/cli/tools/publish/unfurl.rs
@@ -49,7 +49,9 @@ use crate::node::CliPackageJsonResolver;
 use crate::resolver::CliNpmReqResolver;
 use crate::sys::CliSys;
 use crate::tools::unfurl_utils::ImportMetaResolveCollector;
+use crate::tools::unfurl_utils::SpecifierTextContext;
 use crate::tools::unfurl_utils::dynamic_argument_prefix_range;
+use crate::tools::unfurl_utils::specifier_text_change;
 use crate::tools::unfurl_utils::to_range;
 
 #[derive(Debug, Clone)]
@@ -835,10 +837,15 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
           ) else {
             return false;
           };
-          text_changes.push(deno_ast::TextChange {
+          let Some(text_change) = specifier_text_change(
+            text_info,
             range,
-            new_text: unfurled,
-          });
+            &unfurled,
+            SpecifierTextContext::JavaScript,
+          ) else {
+            return false;
+          };
+          text_changes.push(text_change);
         }
         true
       }
@@ -870,10 +877,15 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
             ) else {
               return false;
             };
-            text_changes.push(deno_ast::TextChange {
+            let Some(text_change) = specifier_text_change(
+              text_info,
               range,
-              new_text: unfurled,
-            });
+              &unfurled,
+              SpecifierTextContext::JavaScript,
+            ) else {
+              return false;
+            };
+            text_changes.push(text_change);
             true
           }
           Some(DynamicTemplatePart::Expr) => {
@@ -903,6 +915,7 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
       |specifier: &str,
        range: PositionOrSourceRangeRef,
        resolution_kind: deno_resolver::workspace::ResolutionKind,
+       context: SpecifierTextContext,
        text_changes: &mut Vec<deno_ast::TextChange>,
        diagnostic_reporter: &mut dyn FnMut(SpecifierUnfurlerDiagnostic)| {
         if let Some(unfurled) = self.unfurl_specifier_reporting_diagnostic(
@@ -913,17 +926,19 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
           range,
           diagnostic_reporter,
         ) {
-          text_changes.push(deno_ast::TextChange {
-            range: match range {
-              PositionOrSourceRangeRef::PositionRange(position_range) => {
-                to_range(text_info, position_range)
-              }
-              PositionOrSourceRangeRef::SourceRange(source_range) => {
-                source_range.as_byte_range(parsed_source.start_pos())
-              }
-            },
-            new_text: unfurled,
-          });
+          let range = match range {
+            PositionOrSourceRangeRef::PositionRange(position_range) => {
+              to_range(text_info, position_range)
+            }
+            PositionOrSourceRangeRef::SourceRange(source_range) => {
+              source_range.as_byte_range(parsed_source.start_pos())
+            }
+          };
+          if let Some(text_change) =
+            specifier_text_change(text_info, range, &unfurled, context)
+          {
+            text_changes.push(text_change);
+          }
         }
       };
     // collect import declaration start positions to correctly insert @ts-types
@@ -977,17 +992,20 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
                   text_info.line_start(dep.specifier_range.start.line);
                 line_start.as_byte_index(text_info.range().start)
               });
-            // use block comment so it works even with multiple imports on one line
-            text_changes.push(deno_ast::TextChange {
-              range: decl_start_byte_index..decl_start_byte_index,
-              new_text: format!("/* @ts-types=\"{}\" */ ", types_specifier),
-            });
+            if let Some(comment) = ts_types_comment(&types_specifier) {
+              // use block comment so it works even with multiple imports on one line
+              text_changes.push(deno_ast::TextChange {
+                range: decl_start_byte_index..decl_start_byte_index,
+                new_text: comment,
+              });
+            }
           }
 
           analyze_specifier(
             &dep.specifier,
             PositionOrSourceRangeRef::PositionRange(&dep.specifier_range),
             resolution_kind,
+            SpecifierTextContext::JavaScript,
             text_changes,
             diagnostic_reporter,
           );
@@ -1026,6 +1044,7 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
         &specifier_with_range.text,
         PositionOrSourceRangeRef::PositionRange(&specifier_with_range.range),
         deno_resolver::workspace::ResolutionKind::Types,
+        SpecifierTextContext::QuotedComment,
         text_changes,
         diagnostic_reporter,
       );
@@ -1035,6 +1054,7 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
         &jsdoc.specifier.text,
         PositionOrSourceRangeRef::PositionRange(&jsdoc.specifier.range),
         deno_resolver::workspace::ResolutionKind::Types,
+        SpecifierTextContext::QuotedComment,
         text_changes,
         diagnostic_reporter,
       );
@@ -1044,6 +1064,7 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
         &specifier_with_range.text,
         PositionOrSourceRangeRef::PositionRange(&specifier_with_range.range),
         deno_resolver::workspace::ResolutionKind::Execution,
+        SpecifierTextContext::UnquotedComment,
         text_changes,
         diagnostic_reporter,
       );
@@ -1053,6 +1074,7 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
         &specifier_with_range.text,
         PositionOrSourceRangeRef::PositionRange(&specifier_with_range.range),
         deno_resolver::workspace::ResolutionKind::Types,
+        SpecifierTextContext::UnquotedComment,
         text_changes,
         diagnostic_reporter,
       );
@@ -1065,6 +1087,7 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
         &specifier,
         PositionOrSourceRangeRef::SourceRange(range),
         deno_resolver::workspace::ResolutionKind::Execution,
+        SpecifierTextContext::JavaScript,
         text_changes,
         diagnostic_reporter,
       );
@@ -1078,6 +1101,18 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
         },
       );
     }
+  }
+}
+
+fn ts_types_comment(types_specifier: &str) -> Option<String> {
+  let cannot_represent = types_specifier.contains("*/")
+    || types_specifier.chars().any(|c| {
+      matches!(c, '\'' | '"' | '\u{2028}' | '\u{2029}') || c.is_control()
+    });
+  if cannot_represent {
+    None
+  } else {
+    Some(format!("/* @ts-types=\"{}\" */ ", types_specifier))
   }
 }
 
@@ -1166,6 +1201,25 @@ mod tests {
       text: source_code.into(),
     })
     .unwrap()
+  }
+
+  #[test]
+  fn test_ts_types_comment_safety() {
+    assert_eq!(
+      ts_types_comment("npm:@types/package@^1/path`with\\backslash"),
+      Some(
+        "/* @ts-types=\"npm:@types/package@^1/path`with\\backslash\" */ "
+          .to_string()
+      )
+    );
+    for value in [
+      "npm:@types/package@^1/sub*/path",
+      "npm:@types/package@^1/single'quote",
+      "npm:@types/package@^1/double\"quote",
+      "npm:@types/package@^1/line\nbreak",
+    ] {
+      assert_eq!(ts_types_comment(value), None);
+    }
   }
 
   #[tokio::test]
@@ -1366,6 +1420,43 @@ const laterUnrelatedText = "lib/";
   }
 
   #[tokio::test]
+  async fn test_unfurling_escapes_generated_specifiers() {
+    let cwd = get_cwd();
+    let memory_sys = InMemorySys::new_with_cwd(&cwd);
+    memory_sys.fs_insert_json(
+      cwd.join("deno.json"),
+      json!({
+        "imports": {
+          "double": "npm:package/path\"double",
+          "single": "npm:package/path'single",
+          "templated": "npm:package/path`tick${literal}",
+        }
+      }),
+    );
+    let unfurler = build_unfurler(memory_sys, &cwd).await;
+
+    let source_code = r#"import double from "double";
+import single from 'single';
+const templated = await import(`templated`);
+import.meta.resolve("double");
+"#;
+    let unfurled_source =
+      unfurl_text(&cwd.join("mod.ts"), source_code, &unfurler);
+    assert_eq!(
+      unfurled_source,
+      r#"import double from "npm:package/path\"double";
+import single from 'npm:package/path\'single';
+const templated = await import(`npm:package/path\`tick\${literal}`);
+import.meta.resolve("npm:package/path\"double");
+"#
+    );
+    parse_ast(
+      &ModuleSpecifier::from_file_path(cwd.join("mod.ts")).unwrap(),
+      &unfurled_source,
+    );
+  }
+
+  #[tokio::test]
   async fn test_unfurling_npm_dep_workspace_specifier() {
     let cwd = get_cwd();
     let memory_sys = InMemorySys::new_with_cwd(&cwd);
@@ -1460,12 +1551,14 @@ const laterUnrelatedText = "lib/";
           "name": "package",
           "exports": {
             ".": "./index.js",
-            "./subpath": "./subpath.js"
+            "./subpath": "./subpath.js",
+            "./*": "./*.js"
           }
         }),
       );
       memory_sys.fs_insert(cwd.join("node_modules/package/index.js"), "");
       memory_sys.fs_insert(cwd.join("node_modules/package/subpath.js"), "");
+      memory_sys.fs_insert(cwd.join("node_modules/package/sub*/path.js"), "");
       memory_sys.fs_insert_json(
         cwd.join("node_modules/@types/package/package.json"),
         json!({
@@ -1473,7 +1566,8 @@ const laterUnrelatedText = "lib/";
           "types": "./index.d.ts",
           "exports": {
             ".": "./index.d.ts",
-            "./subpath": "./subpath.d.ts"
+            "./subpath": "./subpath.d.ts",
+            "./*": "./*.d.ts"
           }
         }),
       );
@@ -1481,13 +1575,16 @@ const laterUnrelatedText = "lib/";
         .fs_insert(cwd.join("node_modules/@types/package/index.d.ts"), "");
       memory_sys
         .fs_insert(cwd.join("node_modules/@types/package/subpath.d.ts"), "");
+      memory_sys
+        .fs_insert(cwd.join("node_modules/@types/package/sub*/path.d.ts"), "");
       let unfurler = build_unfurler(memory_sys, &cwd).await;
 
       let source_code = r#"import { data } from "package"; import { a } from "package";
 import { helper } from "package/subpath";
+import { unsafe } from "package/sub*/path";
 // @ts-types="npm:@types/package@^1.0"
 import { other } from "package";
-export { a, data, helper, other };
+export { a, data, helper, other, unsafe };
 export { b } from "package"; export { c } from "package";
 import type { d } from "package"; import type { e } from "package";
 import type { f } from "@types/package";
@@ -1497,9 +1594,10 @@ export { d, e, f };
         unfurl_text(&cwd.join("mod.ts"), source_code, &unfurler);
       let expected_source = r#"/* @ts-types="npm:@types/package@^1" */ import { data } from "npm:package@^1.2.3"; /* @ts-types="npm:@types/package@^1" */ import { a } from "npm:package@^1.2.3";
 /* @ts-types="npm:@types/package@^1/subpath" */ import { helper } from "npm:package@^1.2.3/subpath";
+import { unsafe } from "npm:package@^1.2.3/sub*/path";
 // @ts-types="npm:@types/package@^1.0"
 import { other } from "npm:package@^1.2.3";
-export { a, data, helper, other };
+export { a, data, helper, other, unsafe };
 /* @ts-types="npm:@types/package@^1" */ export { b } from "npm:package@^1.2.3"; /* @ts-types="npm:@types/package@^1" */ export { c } from "npm:package@^1.2.3";
 /* @ts-types="npm:@types/package@^1" */ import type { d } from "npm:package@^1.2.3"; /* @ts-types="npm:@types/package@^1" */ import type { e } from "npm:package@^1.2.3";
 import type { f } from "npm:@types/package@^1";
@@ -1509,6 +1607,10 @@ export { d, e, f };
       // start, which is harmless, so ignore that in order to normalize to the
       // expected source
       assert_eq!(unfurled_source.replace("npm:/", "npm:"), expected_source);
+      parse_ast(
+        &ModuleSpecifier::from_file_path(cwd.join("mod.ts")).unwrap(),
+        &unfurled_source,
+      );
     }
 
     // these different scenarios should all have the same outcome

--- a/cli/tools/unfurl_utils.rs
+++ b/cli/tools/unfurl_utils.rs
@@ -4,6 +4,7 @@ use deno_ast::SourcePos;
 use deno_ast::SourceRange;
 use deno_ast::SourceRangedForSpanned;
 use deno_ast::SourceTextInfo;
+use deno_ast::TextChange;
 use deno_ast::swc::ast::CallExpr;
 use deno_ast::swc::ast::Callee;
 use deno_ast::swc::ast::Expr;
@@ -12,6 +13,91 @@ use deno_ast::swc::ast::MemberProp;
 use deno_ast::swc::ast::MetaPropKind;
 use deno_ast::swc::ecma_visit::Visit;
 use deno_ast::swc::ecma_visit::noop_visit_type;
+
+#[derive(Clone, Copy)]
+pub enum SpecifierTextContext {
+  JavaScript,
+  QuotedComment,
+  UnquotedComment,
+}
+
+/// Creates a source edit for a cooked specifier in its original syntax
+/// context. Returns `None` when the value cannot be represented without
+/// changing how that context is parsed.
+pub fn specifier_text_change(
+  text_info: &SourceTextInfo,
+  range: std::ops::Range<usize>,
+  replacement: &str,
+  context: SpecifierTextContext,
+) -> Option<TextChange> {
+  let new_text = match context {
+    SpecifierTextContext::JavaScript => {
+      javascript_literal_content(text_info.text_str(), &range, replacement)?
+    }
+    SpecifierTextContext::QuotedComment => {
+      let source = text_info.text_str().as_bytes();
+      let delimiter = *source.get(range.start.checked_sub(1)?)?;
+      if !matches!(delimiter, b'\'' | b'"')
+        || source.get(range.end) != Some(&delimiter)
+        || !is_safe_quoted_comment_value(replacement)
+      {
+        return None;
+      }
+      replacement.to_string()
+    }
+    SpecifierTextContext::UnquotedComment => {
+      if !is_safe_unquoted_comment_value(replacement) {
+        return None;
+      }
+      replacement.to_string()
+    }
+  };
+  Some(TextChange { range, new_text })
+}
+
+fn javascript_literal_content(
+  source: &str,
+  range: &std::ops::Range<usize>,
+  replacement: &str,
+) -> Option<String> {
+  let delimiter = *source.as_bytes().get(range.start.checked_sub(1)?)?;
+  let remaining = source.as_bytes().get(range.end..)?;
+  let valid_boundary = match delimiter {
+    b'\'' | b'"' => remaining.first() == Some(&delimiter),
+    b'`' => remaining.starts_with(b"${") || remaining.first() == Some(&b'`'),
+    _ => false,
+  };
+  if !valid_boundary {
+    return None;
+  }
+
+  let serialized = deno_core::serde_json::to_string(replacement).ok()?;
+  let mut content = serialized
+    .get(1..serialized.len().checked_sub(1)?)?
+    .to_string();
+  content = content
+    .replace('\u{2028}', "\\u2028")
+    .replace('\u{2029}', "\\u2029");
+  match delimiter {
+    b'\'' => Some(content.replace('\'', "\\'")),
+    b'"' => Some(content),
+    b'`' => Some(content.replace('`', "\\`").replace("${", "\\${")),
+    _ => None,
+  }
+}
+
+fn is_safe_quoted_comment_value(value: &str) -> bool {
+  !value.contains("*/")
+    && !value.chars().any(|c| {
+      matches!(c, '\'' | '"' | '\u{2028}' | '\u{2029}') || c.is_control()
+    })
+}
+
+pub fn is_safe_unquoted_comment_value(value: &str) -> bool {
+  !value.is_empty()
+    && !value.contains("*/")
+    && !value.chars().any(|c| c.is_whitespace() || c.is_control())
+}
 
 /// Gets the exact source range for a cooked dynamic import prefix.
 ///
@@ -102,4 +188,114 @@ pub fn to_range(
     range.end -= 1;
   }
   range
+}
+
+#[cfg(test)]
+mod tests {
+  use deno_ast::MediaType;
+  use deno_ast::ModuleSpecifier;
+  use deno_graph::analysis::DependencyDescriptor;
+  use deno_graph::analysis::DynamicArgument;
+  use deno_graph::ast::ParserModuleAnalyzer;
+
+  use super::*;
+
+  #[test]
+  fn javascript_specifier_changes_preserve_cooked_values() {
+    let replacement = "double\" single' tick` slash\\${value} slash-tick\\`\n\r\u{2028}\u{2029}";
+    for source in [r#"import("old");"#, "import('old');", "import(`old`);"] {
+      let text_info = SourceTextInfo::from_string(source.to_string());
+      let start = source.find("old").unwrap();
+      let change = specifier_text_change(
+        &text_info,
+        start..start + 3,
+        replacement,
+        SpecifierTextContext::JavaScript,
+      )
+      .unwrap();
+      let output = deno_ast::apply_text_changes(source, vec![change]);
+      let specifier = ModuleSpecifier::parse("file:///mod.ts").unwrap();
+      let parsed_source = deno_ast::parse_module(deno_ast::ParseParams {
+        specifier,
+        text: output.into(),
+        media_type: MediaType::TypeScript,
+        capture_tokens: false,
+        scope_analysis: false,
+        maybe_syntax: None,
+      })
+      .unwrap();
+      let module_info = ParserModuleAnalyzer::module_info(&parsed_source);
+      let DependencyDescriptor::Dynamic(dependency) =
+        &module_info.dependencies[0]
+      else {
+        panic!("expected dynamic dependency");
+      };
+      let DynamicArgument::String(actual) = &dependency.argument else {
+        panic!("expected string argument");
+      };
+      assert_eq!(actual, replacement);
+      assert_eq!(module_info.dependencies.len(), 1);
+    }
+  }
+
+  #[test]
+  fn comment_specifier_changes_reject_unsafe_values() {
+    let quoted_source = r#"/// <reference types="old" />"#;
+    let quoted_text_info =
+      SourceTextInfo::from_string(quoted_source.to_string());
+    let quoted_start = quoted_source.find("old").unwrap();
+    let quoted_range = quoted_start..quoted_start + 3;
+    assert!(
+      specifier_text_change(
+        &quoted_text_info,
+        quoted_range.clone(),
+        "npm:package/path",
+        SpecifierTextContext::QuotedComment,
+      )
+      .is_some()
+    );
+    for unsafe_value in [
+      "npm:package/sub*/path",
+      "npm:package/single'quote",
+      "npm:package/double\"quote",
+      "npm:package/line\nbreak",
+    ] {
+      assert!(
+        specifier_text_change(
+          &quoted_text_info,
+          quoted_range.clone(),
+          unsafe_value,
+          SpecifierTextContext::QuotedComment,
+        )
+        .is_none()
+      );
+    }
+
+    let unquoted_source = "/** @jsxImportSource old */";
+    let unquoted_text_info =
+      SourceTextInfo::from_string(unquoted_source.to_string());
+    let unquoted_start = unquoted_source.find("old").unwrap();
+    let unquoted_range = unquoted_start..unquoted_start + 3;
+    assert!(
+      specifier_text_change(
+        &unquoted_text_info,
+        unquoted_range.clone(),
+        "npm:package/path",
+        SpecifierTextContext::UnquotedComment,
+      )
+      .is_some()
+    );
+    for unsafe_value in ["", "npm:package/sub*/path", "npm:package/with space"]
+    {
+      assert!(
+        specifier_text_change(
+          &unquoted_text_info,
+          unquoted_range.clone(),
+          unsafe_value,
+          SpecifierTextContext::UnquotedComment,
+        )
+        .is_none()
+      );
+    }
+  }
 }

--- a/cli/tools/unfurl_utils.rs
+++ b/cli/tools/unfurl_utils.rs
@@ -13,6 +13,40 @@ use deno_ast::swc::ast::MetaPropKind;
 use deno_ast::swc::ecma_visit::Visit;
 use deno_ast::swc::ecma_visit::noop_visit_type;
 
+/// Gets the exact source range for a cooked dynamic import prefix.
+///
+/// Dynamic dependency ranges may cover an entire concatenation or template
+/// expression. Only accept prefixes that occur immediately after the opening
+/// string or template delimiter so a cooked value cannot match unrelated text
+/// later in the expression.
+pub fn dynamic_argument_prefix_range(
+  text_info: &SourceTextInfo,
+  range: &deno_graph::PositionRange,
+  prefix: &str,
+) -> Option<std::ops::Range<usize>> {
+  let range = range
+    .as_source_range(text_info)
+    .as_byte_range(text_info.range().start);
+  let text = &text_info.text_str()[range.clone()];
+  let delimiter = match text.as_bytes().first() {
+    Some(delimiter @ (b'\'' | b'"' | b'`')) => *delimiter,
+    _ => return None,
+  };
+  let start = range.start + 1;
+  let end = start.checked_add(prefix.len())?;
+  if end > range.end || text_info.text_str().get(start..end) != Some(prefix) {
+    return None;
+  }
+
+  let remaining = text_info.text_str().as_bytes().get(end..range.end)?;
+  let has_exact_boundary = match delimiter {
+    b'\'' | b'"' => remaining.first() == Some(&delimiter),
+    b'`' => remaining.starts_with(b"${") || remaining.first() == Some(&b'`'),
+    _ => unreachable!(),
+  };
+  has_exact_boundary.then_some(start..end)
+}
+
 /// Collects `import.meta.resolve("...")` call sites from a parsed AST.
 ///
 /// Used by both publish and pack unfurlers to find specifiers passed to


### PR DESCRIPTION
This keeps publish and pack source transformations tied to the parsed source syntax.

- rewrite dynamic specifier prefixes only when the cooked value maps to the first raw literal or template segment
- escape rewritten specifiers for their original JavaScript delimiter
- validate generated type and JSX comment directives before emitting them
- cover the publish and pack paths with source-reparse regressions

Tests:
- `./tools/lint.js`
- `cargo check -p deno --lib`
- `cargo build --bin deno`
- `cargo test -p deno --lib tools::unfurl_utils::tests -- --nocapture`
- `cargo test -p deno --lib tools::publish::unfurl::tests -- --nocapture`
- `cargo test -p deno --lib tools::pack::unfurl::tests -- --nocapture`
- `cargo test -p deno --lib tools::publish::module_content::test -- --nocapture`
- `cargo test -p specs_tests --test specs -- specs::publish::unanalyzable_dynamic_import --nocapture`
- `cargo test -p specs_tests --test specs -- specs::pack::specifier_rewriting --nocapture`
