### PR TITLE
perf(ext/http,ext/fetch): trim two small per-request allocations

### DIFF
--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -663,7 +663,7 @@ pub async fn op_fetch_send(
 
   let status = res.status();
   let url = request.url.into();
-  let mut res_headers = Vec::new();
+  let mut res_headers = Vec::with_capacity(res.headers().len());
   for (key, val) in res.headers().iter() {
     res_headers.push((key.as_str().into(), val.as_bytes().into()));
   }

--- a/ext/http/request_body.rs
+++ b/ext/http/request_body.rs
@@ -67,7 +67,7 @@ impl BufferedIncoming {
     let mut cx = Context::from_waker(&waker);
     loop {
       if self.done {
-        return Some(std::mem::take(&mut self.pending).to_vec());
+        return Some(std::mem::take(&mut self.pending).into());
       }
       match Pin::new(&mut self.inner).poll_frame(&mut cx) {
         Poll::Ready(Some(Ok(frame))) => {
@@ -80,7 +80,7 @@ impl BufferedIncoming {
         Poll::Ready(Some(Err(_))) => return None,
         Poll::Ready(None) => {
           self.done = true;
-          return Some(std::mem::take(&mut self.pending).to_vec());
+          return Some(std::mem::take(&mut self.pending).into());
         }
         Poll::Pending => return None,
       }


### PR DESCRIPTION
## Summary

Two small, contained allocation trims on the request/response hot paths:

1. **`ext/http/request_body.rs`** — `BufferedIncoming::try_take_full` (the
   buffered fast path for reading a full request body) drained its `BytesMut`
   with `.to_vec()`, which allocates a fresh `Vec` and copies the entire body.
   Switch to `Vec::from(BytesMut)`, which for the common `KIND_VEC` case (a
   buffer built via `BytesMut::new()` + `extend_from_slice`, exactly what this
   code does) **reuses the existing allocation** — no copy, no second alloc.

2. **`ext/fetch/lib.rs`** — `op_fetch_send` built the response-header `Vec` from
   empty and grew it; preallocate with `HeaderMap::len()` (which equals the
   number of `iter()` items) to avoid reallocations.

## Correctness

Behavior-preserving. Request bodies verified to round-trip correctly (empty,
4 KiB, 32 KiB POST bodies echo the right length).

## Performance

Both are small allocation reductions rather than throughput changes. Isolated
server user-CPU for a fixed 200k-request h2c POST load (4 KiB bodies) was within
noise vs baseline — the copy avoided is small relative to h2 framing and body
marshaling — with no regression. The changes are idiomatic and zero-risk; the
`Vec::from` change also scales better for larger buffered bodies where the
avoided copy is proportionally bigger.

## Tests

- `cargo test -p deno_http -p deno_fetch` — all pass.
- `cargo clippy -p deno_http -p deno_fetch` — clean.