### PR TITLE
fix(ext/node): node:sqlite backup() and deserialize() argument validation

### DIFF
--- a/ext/node/polyfills/sqlite.ts
+++ b/ext/node/polyfills/sqlite.ts
@@ -14,7 +14,9 @@ const { isUint8Array } = core.loadExtScript(
 const { URLPrototype } = core.loadExtScript("ext:deno_web/00_url.js");
 
 const {
+  Error,
   FunctionPrototypeCall,
+  NumberIsInteger,
   ObjectDefineProperty,
   ObjectDefineProperties,
   ObjectGetOwnPropertyDescriptor,
@@ -114,6 +116,14 @@ class InvalidURLSchemeError extends TypeError {
   }
 }
 
+class InvalidStateError extends Error {
+  code;
+  constructor(message) {
+    super(message);
+    this.code = "ERR_INVALID_STATE";
+  }
+}
+
 const parsePath = (path) => {
   let parsedPath;
   if (typeof path === "string") {
@@ -158,8 +168,43 @@ function DatabaseSync(
 ObjectSetPrototypeOf(DatabaseSync.prototype, DatabaseSyncOp.prototype);
 ObjectSetPrototypeOf(DatabaseSync, DatabaseSyncOp);
 
-// deno-lint-ignore require-await
-async function backup(
+function validateBackupOptions(options) {
+  if (options === undefined) {
+    return;
+  }
+  if (typeof options !== "object" || options === null) {
+    throw new InvalidArgTypeError(
+      'The "options" argument must be an object.',
+    );
+  }
+  if (options.source !== undefined && typeof options.source !== "string") {
+    throw new InvalidArgTypeError(
+      'The "options.source" argument must be a string.',
+    );
+  }
+  if (options.target !== undefined && typeof options.target !== "string") {
+    throw new InvalidArgTypeError(
+      'The "options.target" argument must be a string.',
+    );
+  }
+  if (options.rate !== undefined && !NumberIsInteger(options.rate)) {
+    throw new InvalidArgTypeError(
+      'The "options.rate" argument must be an integer.',
+    );
+  }
+  if (
+    options.progress !== undefined && typeof options.progress !== "function"
+  ) {
+    throw new InvalidArgTypeError(
+      'The "options.progress" argument must be a function.',
+    );
+  }
+}
+
+// Argument validation happens synchronously (mirroring Node.js, where invalid
+// arguments throw rather than reject), while the backup itself is performed by
+// `backupExec` so that runtime failures reject the returned promise.
+function backup(
   sourceDb,
   path,
   options,
@@ -169,11 +214,21 @@ async function backup(
       'The "sourceDb" argument must be an object.',
     );
   }
+  const parsedPath = parsePath(path);
+  validateBackupOptions(options);
+  if (!sourceDb.isOpen) {
+    throw new InvalidStateError("database is not open");
+  }
 
+  return backupExec(sourceDb, parsedPath, options);
+}
+
+// deno-lint-ignore require-await
+async function backupExec(sourceDb, parsedPath, options) {
   // TODO(Tango992): Implement async op
   return op_node_database_backup(
     sourceDb,
-    parsePath(path),
+    parsedPath,
     options,
   );
 }

--- a/ext/node/polyfills/sqlite.ts
+++ b/ext/node/polyfills/sqlite.ts
@@ -177,6 +177,11 @@ function validateBackupOptions(options) {
       'The "options" argument must be an object.',
     );
   }
+  if (options.rate !== undefined && !NumberIsInteger(options.rate)) {
+    throw new InvalidArgTypeError(
+      'The "options.rate" argument must be an integer.',
+    );
+  }
   if (options.source !== undefined && typeof options.source !== "string") {
     throw new InvalidArgTypeError(
       'The "options.source" argument must be a string.',
@@ -185,11 +190,6 @@ function validateBackupOptions(options) {
   if (options.target !== undefined && typeof options.target !== "string") {
     throw new InvalidArgTypeError(
       'The "options.target" argument must be a string.',
-    );
-  }
-  if (options.rate !== undefined && !NumberIsInteger(options.rate)) {
-    throw new InvalidArgTypeError(
-      'The "options.rate" argument must be an integer.',
     );
   }
   if (
@@ -214,11 +214,11 @@ function backup(
       'The "sourceDb" argument must be an object.',
     );
   }
-  const parsedPath = parsePath(path);
-  validateBackupOptions(options);
   if (!sourceDb.isOpen) {
     throw new InvalidStateError("database is not open");
   }
+  const parsedPath = parsePath(path);
+  validateBackupOptions(options);
 
   return backupExec(sourceDb, parsedPath, options);
 }

--- a/ext/node_sqlite/database.rs
+++ b/ext/node_sqlite/database.rs
@@ -2039,10 +2039,17 @@ impl DatabaseSync {
       return Err(SqliteError::ActiveCallback);
     }
 
-    if !buffer_value.is_array_buffer_view() {
+    if !buffer_value.is_uint8_array() {
       return Err(SqliteError::Validation(validators::Error::InvalidArgType(
-        "The \"serialized\" argument must be a TypedArray or a DataView."
-          .into(),
+        "The \"buffer\" argument must be a Uint8Array.".into(),
+      )));
+    }
+
+    let view: v8::Local<v8::ArrayBufferView> = buffer_value.try_into().unwrap();
+    let byte_length = view.byte_length();
+    if byte_length == 0 {
+      return Err(SqliteError::Validation(validators::Error::InvalidArgValue(
+        "The \"buffer\" argument must not be empty.".into(),
       )));
     }
 
@@ -2094,8 +2101,6 @@ impl DatabaseSync {
       }
     }
 
-    let view: v8::Local<v8::ArrayBufferView> = buffer_value.try_into().unwrap();
-    let byte_length = view.byte_length();
     let name_cstring = CString::new(db_name)?;
 
     // Per Node's contract, existing prepared statements are finalized before

--- a/ext/node_sqlite/validators.rs
+++ b/ext/node_sqlite/validators.rs
@@ -10,6 +10,9 @@ pub enum Error {
   #[class(type)]
   #[error("{0}")]
   InvalidArgType(Cow<'static, str>),
+  #[class(type)]
+  #[error("{0}")]
+  InvalidArgValue(Cow<'static, str>),
   #[class(range)]
   #[error("{0}")]
   OutOfRange(Cow<'static, str>),
@@ -22,6 +25,7 @@ impl Error {
   pub fn code(&self) -> ErrorCode {
     match self {
       Self::InvalidArgType(_) => ErrorCode::ERR_INVALID_ARG_TYPE,
+      Self::InvalidArgValue(_) => ErrorCode::ERR_INVALID_ARG_VALUE,
       Self::OutOfRange(_) => ErrorCode::ERR_OUT_OF_RANGE,
       Self::V8Exception => ErrorCode::ERR_INVALID_ARG_TYPE,
     }
@@ -31,6 +35,7 @@ impl Error {
 #[allow(non_camel_case_types, reason = "matches Node.js error code naming")]
 pub enum ErrorCode {
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
   ERR_OUT_OF_RANGE,
 }
 
@@ -44,6 +49,7 @@ impl ErrorCode {
   pub fn as_str(&self) -> &str {
     match self {
       Self::ERR_INVALID_ARG_TYPE => "ERR_INVALID_ARG_TYPE",
+      Self::ERR_INVALID_ARG_VALUE => "ERR_INVALID_ARG_VALUE",
       Self::ERR_OUT_OF_RANGE => "ERR_OUT_OF_RANGE",
     }
   }

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3343,12 +3343,14 @@
     "parallel/test-socket-write-after-fin.js": {},
     "parallel/test-sqlite-aggregate-function.mjs": {},
     "parallel/test-sqlite-authz.js": {},
+    "parallel/test-sqlite-backup.mjs": {},
     "parallel/test-sqlite-config.js": {},
     "parallel/test-sqlite-custom-functions.js": {},
     "parallel/test-sqlite-data-types.js": {},
     "parallel/test-sqlite-database-sync.js": {},
     "parallel/test-sqlite-limits.js": {},
     "parallel/test-sqlite-named-parameters.js": {},
+    "parallel/test-sqlite-serialize.js": {},
     "parallel/test-sqlite-session.js": {
       "ignore": true,
       "reason": "malformed-changeset subtest crashes in the shared SQLite; Node skips it unless using its bundled SQLite session fix (node_shared_sqlite)"


### PR DESCRIPTION
Enables and fixes the `node:sqlite` `test-sqlite-backup` and `test-sqlite-serialize` Node.js compatibility tests. `backup()` was an `async function`, so argument-validation errors surfaced as promise rejections instead of the synchronous throws Node performs, so it is split into a synchronous validation phase (sourceDb type, path, options, and open-state checks) plus an async execution phase that runs the backup op so genuine runtime failures still reject; and `DatabaseSync.prototype.deserialize()` is corrected to accept only a `Uint8Array` (with Node's `The \"buffer\" argument must be a Uint8Array.` message) and to throw `ERR_INVALID_ARG_VALUE` for an empty buffer, backed by a new `InvalidArgValue` validator variant. Both tests are added to `tests/node_compat/config.jsonc` so they run in the suite.