### PR TITLE
feat: add x86_64 and aarch64 linux musl builds

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -7041,6 +7041,7 @@ jobs:
             build-base musl-dev clang lld llvm cmake make perl \
             python3 protobuf protobuf-dev rustup \
             libstdc++ libgcc gcompat nodejs npm
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Configure git
         run: |-
           git config --global core.symlinks true
@@ -7375,6 +7376,7 @@ jobs:
             build-base musl-dev clang lld llvm cmake make perl \
             python3 protobuf protobuf-dev rustup \
             libstdc++ libgcc gcompat nodejs npm
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Configure git
         run: |-
           git config --global core.symlinks true

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -7299,8 +7299,8 @@ jobs:
         run: |-
           apk add --no-cache \
             bash git curl wget xz zip unzip tar coreutils \
-            build-base musl-dev clang lld llvm cmake make perl \
-            python3 protobuf protobuf-dev rustup \
+            build-base musl-dev clang clang-dev lld llvm llvm-dev \
+            cmake make perl python3 protobuf protobuf-dev rustup \
             libstdc++ libgcc gcompat nodejs npm
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Configure git
@@ -7408,6 +7408,7 @@ jobs:
           echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
+          echo "LIBCLANG_PATH=/usr/lib" >> $GITHUB_ENV
       - name: Configure canary build
         if: 'github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
@@ -7731,14 +7732,14 @@ jobs:
       - name: Set up musl build environment
         if: github.repository == 'denoland/deno'
         run: |-
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends musl-tools musl-dev
           rustup target add aarch64-unknown-linux-musl
+          pip3 install --break-system-packages ziglang==0.13.0
+          cargo install --locked cargo-zigbuild@0.19.8
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl
           echo "CARGO_BUILD_TARGET=aarch64-unknown-linux-musl" >> $GITHUB_ENV
           echo "RUSTFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV
           echo "RUSTDOCFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV
-          echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV
       - name: Configure canary build
         if: 'github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
@@ -7754,8 +7755,8 @@ jobs:
             grep -n fuse-ld .cargo/config.toml
           fi
           df -h
-          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
-          cargo build --release --locked -p denort_desktop
+          cargo zigbuild --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
+          cargo zigbuild --release --locked -p denort_desktop
           df -h
       - name: Relocate cross-build artifacts
         if: github.repository == 'denoland/deno'

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -7406,8 +7406,8 @@ jobs:
         run: |-
           echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
           echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
       - name: Configure canary build
         if: 'github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
@@ -7744,8 +7744,8 @@ jobs:
         run: |-
           echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
           echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
       - name: Configure canary build
         if: 'github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -7625,8 +7625,6 @@ jobs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true' && needs.pre_build.outputs.docs_only != 'true'
     runs-on: ubuntu-24.04-arm
-    container:
-      image: 'alpine:3.22'
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240
@@ -7638,15 +7636,6 @@ jobs:
       RUST_BACKTRACE: full
       RUST_LIB_BACKTRACE: 0
     steps:
-      - name: Install musl build dependencies
-        shell: sh
-        run: |-
-          apk add --no-cache \
-            bash git curl wget xz zip unzip tar coreutils \
-            build-base musl-dev clang lld llvm cmake make perl \
-            python3 protobuf protobuf-dev rustup \
-            libstdc++ libgcc gcompat nodejs npm
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Configure git
         run: |-
           git config --global core.symlinks true
@@ -7742,10 +7731,14 @@ jobs:
       - name: Set up musl build environment
         if: github.repository == 'denoland/deno'
         run: |-
-          echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
-          echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
-          echo "CC=gcc" >> $GITHUB_ENV
-          echo "CXX=g++" >> $GITHUB_ENV
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools musl-dev
+          rustup target add aarch64-unknown-linux-musl
+          echo "CARGO_BUILD_TARGET=aarch64-unknown-linux-musl" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV
+          echo "RUSTDOCFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV
+          echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV
       - name: Configure canary build
         if: 'github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
@@ -7764,6 +7757,9 @@ jobs:
           cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
           cargo build --release --locked -p denort_desktop
           df -h
+      - name: Relocate cross-build artifacts
+        if: github.repository == 'denoland/deno'
+        run: cp -a target/aarch64-unknown-linux-musl/release/. target/release/
       - name: Check release snapshot flags
         if: github.repository == 'denoland/deno'
         run: |-

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -952,6 +952,20 @@ jobs:
             target/release/denort-aarch64-unknown-linux-gnu.zip.sha256sum
             target/release/libdenort-aarch64-unknown-linux-gnu.zip
             target/release/libdenort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.zip
+            target/release/deno-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.sha256sum
+            target/release/denort-x86_64-unknown-linux-musl.zip
+            target/release/denort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-musl.zip
+            target/release/libdenort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.zip
+            target/release/deno-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.sha256sum
+            target/release/denort-aarch64-unknown-linux-musl.zip
+            target/release/denort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-musl.zip
+            target/release/libdenort-aarch64-unknown-linux-musl.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.zip
             target/release/deno-aarch64-apple-darwin.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.sha256sum
@@ -2028,6 +2042,20 @@ jobs:
             target/release/denort-aarch64-unknown-linux-gnu.zip.sha256sum
             target/release/libdenort-aarch64-unknown-linux-gnu.zip
             target/release/libdenort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.zip
+            target/release/deno-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.sha256sum
+            target/release/denort-x86_64-unknown-linux-musl.zip
+            target/release/denort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-musl.zip
+            target/release/libdenort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.zip
+            target/release/deno-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.sha256sum
+            target/release/denort-aarch64-unknown-linux-musl.zip
+            target/release/denort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-musl.zip
+            target/release/libdenort-aarch64-unknown-linux-musl.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.zip
             target/release/deno-aarch64-apple-darwin.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.sha256sum
@@ -3063,6 +3091,20 @@ jobs:
             target/release/denort-aarch64-unknown-linux-gnu.zip.sha256sum
             target/release/libdenort-aarch64-unknown-linux-gnu.zip
             target/release/libdenort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.zip
+            target/release/deno-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.sha256sum
+            target/release/denort-x86_64-unknown-linux-musl.zip
+            target/release/denort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-musl.zip
+            target/release/libdenort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.zip
+            target/release/deno-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.sha256sum
+            target/release/denort-aarch64-unknown-linux-musl.zip
+            target/release/denort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-musl.zip
+            target/release/libdenort-aarch64-unknown-linux-musl.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.zip
             target/release/deno-aarch64-apple-darwin.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.sha256sum
@@ -3956,6 +3998,20 @@ jobs:
             target/release/denort-aarch64-unknown-linux-gnu.zip.sha256sum
             target/release/libdenort-aarch64-unknown-linux-gnu.zip
             target/release/libdenort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.zip
+            target/release/deno-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.sha256sum
+            target/release/denort-x86_64-unknown-linux-musl.zip
+            target/release/denort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-musl.zip
+            target/release/libdenort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.zip
+            target/release/deno-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.sha256sum
+            target/release/denort-aarch64-unknown-linux-musl.zip
+            target/release/denort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-musl.zip
+            target/release/libdenort-aarch64-unknown-linux-musl.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.zip
             target/release/deno-aarch64-apple-darwin.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.sha256sum
@@ -4544,6 +4600,20 @@ jobs:
             target/release/denort-aarch64-unknown-linux-gnu.zip.sha256sum
             target/release/libdenort-aarch64-unknown-linux-gnu.zip
             target/release/libdenort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.zip
+            target/release/deno-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.sha256sum
+            target/release/denort-x86_64-unknown-linux-musl.zip
+            target/release/denort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-musl.zip
+            target/release/libdenort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.zip
+            target/release/deno-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.sha256sum
+            target/release/denort-aarch64-unknown-linux-musl.zip
+            target/release/denort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-musl.zip
+            target/release/libdenort-aarch64-unknown-linux-musl.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.zip
             target/release/deno-aarch64-apple-darwin.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.sha256sum
@@ -6603,6 +6673,20 @@ jobs:
             target/release/denort-aarch64-unknown-linux-gnu.zip.sha256sum
             target/release/libdenort-aarch64-unknown-linux-gnu.zip
             target/release/libdenort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.zip
+            target/release/deno-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.sha256sum
+            target/release/denort-x86_64-unknown-linux-musl.zip
+            target/release/denort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-musl.zip
+            target/release/libdenort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.zip
+            target/release/deno-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.sha256sum
+            target/release/denort-aarch64-unknown-linux-musl.zip
+            target/release/denort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-musl.zip
+            target/release/libdenort-aarch64-unknown-linux-musl.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.zip
             target/release/deno-aarch64-apple-darwin.zip.sha256sum
             target/release/deno-aarch64-apple-darwin.sha256sum
@@ -6930,6 +7014,646 @@ jobs:
         with:
           name: 'test-results-linux-aarch64-release-${{ matrix.test_crate }}${{ matrix.shard_total > 1 && format(''-shard-{0}'', matrix.shard_index) || '''' }}.json'
           path: 'target/test_results_${{ matrix.test_crate }}.json'
+  build-release-linux-x86_64-musl:
+    name: build release linux-x86_64-musl
+    needs:
+      - pre_build
+    if: needs.pre_build.outputs.skip_build != 'true' && needs.pre_build.outputs.docs_only != 'true'
+    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || ''ubuntu-24.04'' }}'
+    container:
+      image: 'alpine:3.22'
+    environment:
+      name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
+    timeout-minutes: 240
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      RUST_LIB_BACKTRACE: 0
+    steps:
+      - name: Install musl build dependencies
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        shell: sh
+        run: |-
+          apk add --no-cache \
+            bash git curl wget xz zip unzip tar coreutils \
+            build-base musl-dev clang lld llvm cmake make perl \
+            python3 protobuf protobuf-dev rustup \
+            libstdc++ libgcc gcompat nodejs npm
+      - name: Configure git
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        run: |-
+          git config --global core.symlinks true
+          git config --global fetch.parallel 32
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          fetch-depth: 5
+          submodules: false
+      - name: Clone submodule ./tests/util/std
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
+      - name: 'Create source tarballs (release, linux)'
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          mkdir -p target/release
+          tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \
+              -czvf target/release/deno_src.tar.gz -C .. deno
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        with:
+          deno-version: v2.x
+      - name: Restore cache cargo home
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && !startsWith(github.ref, ''refs/tags/'')'
+        with:
+          path: |-
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: never_saved
+          restore-keys: 121-cargo-home-linux-x86_64-build-main-musl-
+      - name: Restore cache build output
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        with:
+          path: |-
+            ./target
+            !./target/*/gn_out
+            !./target/*/gn_root
+            !./target/*/*.zip
+            !./target/*/*.tar.gz
+          key: never_saved
+          restore-keys: 121-cargo-target-linux-x86_64-release-build-main-musl-
+      - name: Apply and update mtime cache
+        uses: ./.github/mtime_cache
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          cache-path: ./target
+      - name: Pre-install rustup 1.28.2 (workaround broken 1.29.0)
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        shell: bash
+        run: |-
+          if command -v rustup >/dev/null 2>&1; then
+            if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
+            echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
+            Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
+            macOS-X64)     target=x86_64-apple-darwin; ext= ;;
+            macOS-ARM64)   target=aarch64-apple-darwin; ext= ;;
+            Windows-X64)   target=x86_64-pc-windows-msvc; ext=.exe ;;
+            Windows-ARM64) target=aarch64-pc-windows-msvc; ext=.exe ;;
+            *) echo "Unsupported: ${RUNNER_OS}-${RUNNER_ARCH}"; exit 1 ;;
+          esac
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL \
+            "https://static.rust-lang.org/rustup/archive/1.28.2/${target}/rustup-init${ext}" \
+            -o "rustup-init${ext}"
+          chmod +x "rustup-init${ext}"
+          "./rustup-init${ext}" -y --default-toolchain none --no-modify-path
+          rm "rustup-init${ext}"
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+      - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+      - name: Log versions
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        run: |-
+          echo '*** Python'
+          command -v python && python --version || echo 'No python found or bad executable'
+          echo '*** Rust'
+          command -v rustc && rustc --version || echo 'No rustc found or bad executable'
+          echo '*** Cargo'
+          command -v cargo && cargo --version || echo 'No cargo found or bad executable'
+          echo '*** Deno'
+          command -v deno && deno --version || echo 'No deno found or bad executable'
+          echo '*** Node'
+          command -v node && node --version || echo 'No node found or bad executable'
+          echo '*** Installed packages'
+          command -v dpkg && dpkg -l || echo 'No dpkg found or bad executable'
+      - name: Set up musl build environment
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        run: |-
+          echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
+          echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+      - name: Configure canary build
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
+        run: echo "DENO_CANARY=true" >> $GITHUB_ENV
+      - name: Build release
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        env:
+          DENO_SNAPSHOT_MINIFY_SOURCES: '1'
+        run: |-
+          if [ "$(uname -s)" = Darwin ] && [ "$(uname -m)" = arm64 ]; then
+            git submodule update --init tools/lzld
+            make -C tools/lzld
+            sed -i '' "s#-fuse-ld=lld #-fuse-ld=$GITHUB_WORKSPACE/tools/lzld/lzld -L$GITHUB_WORKSPACE/tools/lzld -llzld_arm64 #" .cargo/config.toml
+            grep -n fuse-ld .cargo/config.toml
+          fi
+          df -h
+          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
+          cargo build --release --locked -p denort_desktop
+          df -h
+      - name: Check release snapshot flags
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        run: |-
+          if strings target/release/deno | grep -F -- '--no-lazy --no-lazy-eval --no-lazy-streaming'; then
+            echo "release deno binary contains eager snapshot flags"
+            exit 1
+          fi
+      - name: 'Check eager bootstrap does not static-import node:'
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        run: |-
+          if grep -rEn '^import .* from "node:' runtime/js/; then
+            echo "eager bootstrap statically imports a node: module — use core.createLazyLoader so it stays out of the startup snapshot"
+            exit 1
+          fi
+      - name: Generate symcache
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        env:
+          NO_COLOR: 1
+        run: |-
+          target/release/deno -A tools/release/create_symcache.ts ./deno.symcache
+          du -h deno.symcache
+          du -h target/release/deno
+      - name: Pre-release (linux)
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        run: |-
+          cd target/release
+          ./deno -A ../../tools/release/create_symcache.ts deno-x86_64-unknown-linux-musl.symcache
+          strip ./deno
+          shasum -a 256 deno > deno-x86_64-unknown-linux-musl.sha256sum
+          zip -r deno-x86_64-unknown-linux-musl.zip deno
+          shasum -a 256 deno-x86_64-unknown-linux-musl.zip > deno-x86_64-unknown-linux-musl.zip.sha256sum
+          strip --strip-debug ./denort
+          zip -r denort-x86_64-unknown-linux-musl.zip denort
+          shasum -a 256 denort-x86_64-unknown-linux-musl.zip > denort-x86_64-unknown-linux-musl.zip.sha256sum
+          strip ./libdenort.so
+          zip -r libdenort-x86_64-unknown-linux-musl.zip libdenort.so
+          shasum -a 256 libdenort-x86_64-unknown-linux-musl.zip > libdenort-x86_64-unknown-linux-musl.zip.sha256sum
+          ./deno types > lib.deno.d.ts
+      - name: Build bsdiff helper
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        run: cargo build --release -p bsdiff_helper
+      - name: Upload canary to dl.deno.land
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
+        env:
+          AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
+          AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
+          AWS_ENDPOINT_URL_S3: '${{ vars.S3_ENDPOINT }}'
+          AWS_DEFAULT_REGION: '${{ vars.S3_REGION }}'
+        run: |-
+          aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.zip"
+          aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.sha256sum"
+          aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.symcache"
+          echo ${{ github.sha }} > canary-latest.txt
+          aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
+          rm canary-latest.txt
+      - name: Build product size info
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
+        run: |-
+          du -hd1 "./target/release"
+          du -ha  "./target/release/deno"
+          du -ha  "./target/release/denort"
+      - name: Check deno binary
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        env:
+          NO_COLOR: 1
+        run: target/release/deno eval "console.log(1+2)" | grep 3
+      - name: Upload artifact release-linux-x86_64-musl-deno
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          name: release-linux-x86_64-musl-deno
+          path: target/release/deno
+          retention-days: 3
+      - name: Upload artifact release-linux-x86_64-musl-denort
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          name: release-linux-x86_64-musl-denort
+          path: target/release/denort
+          retention-days: 3
+      - name: Upload artifact release-linux-x86_64-musl-test-server
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          name: release-linux-x86_64-musl-test-server
+          path: target/release/test_server
+          retention-days: 3
+      - name: Upload release to dl.deno.land (unix)
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        env:
+          AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
+          AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
+          AWS_ENDPOINT_URL_S3: '${{ vars.S3_ENDPOINT }}'
+          AWS_DEFAULT_REGION: '${{ vars.S3_REGION }}'
+        run: |-
+          aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.zip"
+          aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.sha256sum"
+          aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.symcache"
+          aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.bsdiff"
+      - name: Create release notes
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          export PATH=$PATH:$(pwd)/target/release
+          ./tools/release/05_create_release_notes.ts
+      - name: Upload release to GitHub
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        with:
+          files: |-
+            target/release/deno-x86_64-pc-windows-msvc.zip
+            target/release/deno-x86_64-pc-windows-msvc.zip.sha256sum
+            target/release/deno-x86_64-pc-windows-msvc.sha256sum
+            target/release/denort-x86_64-pc-windows-msvc.zip
+            target/release/denort-x86_64-pc-windows-msvc.zip.sha256sum
+            target/release/libdenort-x86_64-pc-windows-msvc.zip
+            target/release/libdenort-x86_64-pc-windows-msvc.zip.sha256sum
+            target/release/deno-aarch64-pc-windows-msvc.zip
+            target/release/deno-aarch64-pc-windows-msvc.zip.sha256sum
+            target/release/deno-aarch64-pc-windows-msvc.sha256sum
+            target/release/denort-aarch64-pc-windows-msvc.zip
+            target/release/denort-aarch64-pc-windows-msvc.zip.sha256sum
+            target/release/libdenort-aarch64-pc-windows-msvc.zip
+            target/release/libdenort-aarch64-pc-windows-msvc.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-gnu.zip
+            target/release/deno-x86_64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-gnu.sha256sum
+            target/release/denort-x86_64-unknown-linux-gnu.zip
+            target/release/denort-x86_64-unknown-linux-gnu.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-gnu.zip
+            target/release/libdenort-x86_64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-apple-darwin.zip
+            target/release/deno-x86_64-apple-darwin.zip.sha256sum
+            target/release/deno-x86_64-apple-darwin.sha256sum
+            target/release/denort-x86_64-apple-darwin.zip
+            target/release/denort-x86_64-apple-darwin.zip.sha256sum
+            target/release/libdenort-x86_64-apple-darwin.zip
+            target/release/libdenort-x86_64-apple-darwin.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-gnu.zip
+            target/release/deno-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-gnu.sha256sum
+            target/release/denort-aarch64-unknown-linux-gnu.zip
+            target/release/denort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-gnu.zip
+            target/release/libdenort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.zip
+            target/release/deno-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.sha256sum
+            target/release/denort-x86_64-unknown-linux-musl.zip
+            target/release/denort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-musl.zip
+            target/release/libdenort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.zip
+            target/release/deno-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.sha256sum
+            target/release/denort-aarch64-unknown-linux-musl.zip
+            target/release/denort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-musl.zip
+            target/release/libdenort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-apple-darwin.zip
+            target/release/deno-aarch64-apple-darwin.zip.sha256sum
+            target/release/deno-aarch64-apple-darwin.sha256sum
+            target/release/denort-aarch64-apple-darwin.zip
+            target/release/denort-aarch64-apple-darwin.zip.sha256sum
+            target/release/libdenort-aarch64-apple-darwin.zip
+            target/release/libdenort-aarch64-apple-darwin.zip.sha256sum
+            target/release/deno_src.tar.gz
+            target/release/lib.deno.d.ts
+            target/release/deno-*.bsdiff
+            target/release/deno-*.bsdiff.sha256sum
+          body_path: target/release/release-notes.md
+          draft: true
+          prerelease: '${{ contains(github.ref_name, ''-'') }}'
+  build-release-linux-aarch64-musl:
+    name: build release linux-aarch64-musl
+    needs:
+      - pre_build
+    if: needs.pre_build.outputs.skip_build != 'true' && needs.pre_build.outputs.docs_only != 'true'
+    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || ''ubuntu-24.04-arm'' }}'
+    container:
+      image: 'alpine:3.22'
+    environment:
+      name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
+    timeout-minutes: 240
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      RUST_LIB_BACKTRACE: 0
+    steps:
+      - name: Install musl build dependencies
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        shell: sh
+        run: |-
+          apk add --no-cache \
+            bash git curl wget xz zip unzip tar coreutils \
+            build-base musl-dev clang lld llvm cmake make perl \
+            python3 protobuf protobuf-dev rustup \
+            libstdc++ libgcc gcompat nodejs npm
+      - name: Configure git
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        run: |-
+          git config --global core.symlinks true
+          git config --global fetch.parallel 32
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          fetch-depth: 5
+          submodules: false
+      - name: Clone submodule ./tests/util/std
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        with:
+          deno-version: v2.x
+      - name: Restore cache cargo home
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && !startsWith(github.ref, ''refs/tags/'')'
+        with:
+          path: |-
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: never_saved
+          restore-keys: 121-cargo-home-linux-aarch64-build-main-musl-
+      - name: Restore cache build output
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        with:
+          path: |-
+            ./target
+            !./target/*/gn_out
+            !./target/*/gn_root
+            !./target/*/*.zip
+            !./target/*/*.tar.gz
+          key: never_saved
+          restore-keys: 121-cargo-target-linux-aarch64-release-build-main-musl-
+      - name: Apply and update mtime cache
+        uses: ./.github/mtime_cache
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          cache-path: ./target
+      - name: Pre-install rustup 1.28.2 (workaround broken 1.29.0)
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        shell: bash
+        run: |-
+          if command -v rustup >/dev/null 2>&1; then
+            if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
+            echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
+            Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
+            macOS-X64)     target=x86_64-apple-darwin; ext= ;;
+            macOS-ARM64)   target=aarch64-apple-darwin; ext= ;;
+            Windows-X64)   target=x86_64-pc-windows-msvc; ext=.exe ;;
+            Windows-ARM64) target=aarch64-pc-windows-msvc; ext=.exe ;;
+            *) echo "Unsupported: ${RUNNER_OS}-${RUNNER_ARCH}"; exit 1 ;;
+          esac
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL \
+            "https://static.rust-lang.org/rustup/archive/1.28.2/${target}/rustup-init${ext}" \
+            -o "rustup-init${ext}"
+          chmod +x "rustup-init${ext}"
+          "./rustup-init${ext}" -y --default-toolchain none --no-modify-path
+          rm "rustup-init${ext}"
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+      - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+      - name: Log versions
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        run: |-
+          echo '*** Python'
+          command -v python && python --version || echo 'No python found or bad executable'
+          echo '*** Rust'
+          command -v rustc && rustc --version || echo 'No rustc found or bad executable'
+          echo '*** Cargo'
+          command -v cargo && cargo --version || echo 'No cargo found or bad executable'
+          echo '*** Deno'
+          command -v deno && deno --version || echo 'No deno found or bad executable'
+          echo '*** Node'
+          command -v node && node --version || echo 'No node found or bad executable'
+          echo '*** Installed packages'
+          command -v dpkg && dpkg -l || echo 'No dpkg found or bad executable'
+      - name: Set up musl build environment
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        run: |-
+          echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
+          echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+      - name: Configure canary build
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
+        run: echo "DENO_CANARY=true" >> $GITHUB_ENV
+      - name: Build release
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        env:
+          DENO_SNAPSHOT_MINIFY_SOURCES: '1'
+        run: |-
+          if [ "$(uname -s)" = Darwin ] && [ "$(uname -m)" = arm64 ]; then
+            git submodule update --init tools/lzld
+            make -C tools/lzld
+            sed -i '' "s#-fuse-ld=lld #-fuse-ld=$GITHUB_WORKSPACE/tools/lzld/lzld -L$GITHUB_WORKSPACE/tools/lzld -llzld_arm64 #" .cargo/config.toml
+            grep -n fuse-ld .cargo/config.toml
+          fi
+          df -h
+          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
+          cargo build --release --locked -p denort_desktop
+          df -h
+      - name: Check release snapshot flags
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        run: |-
+          if strings target/release/deno | grep -F -- '--no-lazy --no-lazy-eval --no-lazy-streaming'; then
+            echo "release deno binary contains eager snapshot flags"
+            exit 1
+          fi
+      - name: 'Check eager bootstrap does not static-import node:'
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        run: |-
+          if grep -rEn '^import .* from "node:' runtime/js/; then
+            echo "eager bootstrap statically imports a node: module — use core.createLazyLoader so it stays out of the startup snapshot"
+            exit 1
+          fi
+      - name: Generate symcache
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        env:
+          NO_COLOR: 1
+        run: |-
+          target/release/deno -A tools/release/create_symcache.ts ./deno.symcache
+          du -h deno.symcache
+          du -h target/release/deno
+      - name: Pre-release (linux)
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        run: |-
+          cd target/release
+          ./deno -A ../../tools/release/create_symcache.ts deno-aarch64-unknown-linux-musl.symcache
+          strip ./deno
+          shasum -a 256 deno > deno-aarch64-unknown-linux-musl.sha256sum
+          zip -r deno-aarch64-unknown-linux-musl.zip deno
+          shasum -a 256 deno-aarch64-unknown-linux-musl.zip > deno-aarch64-unknown-linux-musl.zip.sha256sum
+          strip --strip-debug ./denort
+          zip -r denort-aarch64-unknown-linux-musl.zip denort
+          shasum -a 256 denort-aarch64-unknown-linux-musl.zip > denort-aarch64-unknown-linux-musl.zip.sha256sum
+          strip ./libdenort.so
+          zip -r libdenort-aarch64-unknown-linux-musl.zip libdenort.so
+          shasum -a 256 libdenort-aarch64-unknown-linux-musl.zip > libdenort-aarch64-unknown-linux-musl.zip.sha256sum
+          ./deno types > lib.deno.d.ts
+      - name: Build bsdiff helper
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        run: cargo build --release -p bsdiff_helper
+      - name: Upload canary to dl.deno.land
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
+        env:
+          AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
+          AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
+          AWS_ENDPOINT_URL_S3: '${{ vars.S3_ENDPOINT }}'
+          AWS_DEFAULT_REGION: '${{ vars.S3_REGION }}'
+        run: |-
+          aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.zip"
+          aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.sha256sum"
+          aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.symcache"
+          echo ${{ github.sha }} > canary-latest.txt
+          aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
+          rm canary-latest.txt
+      - name: Build product size info
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
+        run: |-
+          du -hd1 "./target/release"
+          du -ha  "./target/release/deno"
+          du -ha  "./target/release/denort"
+      - name: Check deno binary
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        env:
+          NO_COLOR: 1
+        run: target/release/deno eval "console.log(1+2)" | grep 3
+      - name: Upload artifact release-linux-aarch64-musl-deno
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          name: release-linux-aarch64-musl-deno
+          path: target/release/deno
+          retention-days: 3
+      - name: Upload artifact release-linux-aarch64-musl-denort
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          name: release-linux-aarch64-musl-denort
+          path: target/release/denort
+          retention-days: 3
+      - name: Upload artifact release-linux-aarch64-musl-test-server
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        with:
+          name: release-linux-aarch64-musl-test-server
+          path: target/release/test_server
+          retention-days: 3
+      - name: Upload release to dl.deno.land (unix)
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        env:
+          AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
+          AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
+          AWS_ENDPOINT_URL_S3: '${{ vars.S3_ENDPOINT }}'
+          AWS_DEFAULT_REGION: '${{ vars.S3_REGION }}'
+        run: |-
+          aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.zip"
+          aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.sha256sum"
+          aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.symcache"
+          aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.bsdiff"
+      - name: Create release notes
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        run: |-
+          export PATH=$PATH:$(pwd)/target/release
+          ./tools/release/05_create_release_notes.ts
+      - name: Upload release to GitHub
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
+        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        with:
+          files: |-
+            target/release/deno-x86_64-pc-windows-msvc.zip
+            target/release/deno-x86_64-pc-windows-msvc.zip.sha256sum
+            target/release/deno-x86_64-pc-windows-msvc.sha256sum
+            target/release/denort-x86_64-pc-windows-msvc.zip
+            target/release/denort-x86_64-pc-windows-msvc.zip.sha256sum
+            target/release/libdenort-x86_64-pc-windows-msvc.zip
+            target/release/libdenort-x86_64-pc-windows-msvc.zip.sha256sum
+            target/release/deno-aarch64-pc-windows-msvc.zip
+            target/release/deno-aarch64-pc-windows-msvc.zip.sha256sum
+            target/release/deno-aarch64-pc-windows-msvc.sha256sum
+            target/release/denort-aarch64-pc-windows-msvc.zip
+            target/release/denort-aarch64-pc-windows-msvc.zip.sha256sum
+            target/release/libdenort-aarch64-pc-windows-msvc.zip
+            target/release/libdenort-aarch64-pc-windows-msvc.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-gnu.zip
+            target/release/deno-x86_64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-gnu.sha256sum
+            target/release/denort-x86_64-unknown-linux-gnu.zip
+            target/release/denort-x86_64-unknown-linux-gnu.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-gnu.zip
+            target/release/libdenort-x86_64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-apple-darwin.zip
+            target/release/deno-x86_64-apple-darwin.zip.sha256sum
+            target/release/deno-x86_64-apple-darwin.sha256sum
+            target/release/denort-x86_64-apple-darwin.zip
+            target/release/denort-x86_64-apple-darwin.zip.sha256sum
+            target/release/libdenort-x86_64-apple-darwin.zip
+            target/release/libdenort-x86_64-apple-darwin.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-gnu.zip
+            target/release/deno-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-gnu.sha256sum
+            target/release/denort-aarch64-unknown-linux-gnu.zip
+            target/release/denort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-gnu.zip
+            target/release/libdenort-aarch64-unknown-linux-gnu.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.zip
+            target/release/deno-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-x86_64-unknown-linux-musl.sha256sum
+            target/release/denort-x86_64-unknown-linux-musl.zip
+            target/release/denort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-x86_64-unknown-linux-musl.zip
+            target/release/libdenort-x86_64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.zip
+            target/release/deno-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-unknown-linux-musl.sha256sum
+            target/release/denort-aarch64-unknown-linux-musl.zip
+            target/release/denort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/libdenort-aarch64-unknown-linux-musl.zip
+            target/release/libdenort-aarch64-unknown-linux-musl.zip.sha256sum
+            target/release/deno-aarch64-apple-darwin.zip
+            target/release/deno-aarch64-apple-darwin.zip.sha256sum
+            target/release/deno-aarch64-apple-darwin.sha256sum
+            target/release/denort-aarch64-apple-darwin.zip
+            target/release/denort-aarch64-apple-darwin.zip.sha256sum
+            target/release/libdenort-aarch64-apple-darwin.zip
+            target/release/libdenort-aarch64-apple-darwin.zip.sha256sum
+            target/release/deno_src.tar.gz
+            target/release/lib.deno.d.ts
+            target/release/deno-*.bsdiff
+            target/release/deno-*.bsdiff.sha256sum
+          body_path: target/release/release-notes.md
+          draft: true
+          prerelease: '${{ contains(github.ref_name, ''-'') }}'
   lint:
     name: 'lint ${{ matrix.profile }} ${{ matrix.os }}-${{ matrix.arch }}'
     needs:
@@ -7359,6 +8083,8 @@ jobs:
       - test-libs-debug-linux-aarch64
       - build-release-linux-aarch64
       - test-release-linux-aarch64
+      - build-release-linux-x86_64-musl
+      - build-release-linux-aarch64-musl
       - lint
       - deno-core-test
       - deno-core-miri
@@ -7387,6 +8113,8 @@ jobs:
       - build-debug-linux-x86_64
       - build-debug-linux-aarch64
       - build-release-linux-aarch64
+      - build-release-linux-x86_64-musl
+      - build-release-linux-aarch64-musl
     if: github.repository == 'denoland/deno' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -7019,7 +7019,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true' && needs.pre_build.outputs.docs_only != 'true'
-    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || ''ubuntu-24.04'' }}'
+    runs-on: ubuntu-24.04
     container:
       image: 'alpine:3.22'
     environment:
@@ -7034,7 +7034,6 @@ jobs:
       RUST_LIB_BACKTRACE: 0
     steps:
       - name: Install musl build dependencies
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         shell: sh
         run: |-
           apk add --no-cache \
@@ -7043,33 +7042,30 @@ jobs:
             python3 protobuf protobuf-dev rustup \
             libstdc++ libgcc gcompat nodejs npm
       - name: Configure git
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: |-
           git config --global core.symlinks true
           git config --global fetch.parallel 32
       - name: Clone repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           fetch-depth: 5
           submodules: false
       - name: Clone submodule ./tests/util/std
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: 'Create source tarballs (release, linux)'
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           mkdir -p target/release
           tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \
               -czvf target/release/deno_src.tar.gz -C .. deno
       - name: Install Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         with:
           deno-version: v2.x
       - name: Restore cache cargo home
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && !startsWith(github.ref, ''refs/tags/'')'
+        if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
             ~/.cargo/.crates.toml
@@ -7082,7 +7078,7 @@ jobs:
           restore-keys: 121-cargo-home-linux-x86_64-build-main-musl-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
             ./target
@@ -7094,11 +7090,9 @@ jobs:
           restore-keys: 121-cargo-target-linux-x86_64-release-build-main-musl-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           cache-path: ./target
       - name: Pre-install rustup 1.28.2 (workaround broken 1.29.0)
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         shell: bash
         run: |-
           if command -v rustup >/dev/null 2>&1; then
@@ -7122,9 +7116,7 @@ jobs:
           rm "rustup-init${ext}"
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
       - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
       - name: Log versions
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: |-
           echo '*** Python'
           command -v python && python --version || echo 'No python found or bad executable'
@@ -7139,17 +7131,17 @@ jobs:
           echo '*** Installed packages'
           command -v dpkg && dpkg -l || echo 'No dpkg found or bad executable'
       - name: Set up musl build environment
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         run: |-
           echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
           echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
       - name: Configure canary build
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
       - name: Build release
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         env:
           DENO_SNAPSHOT_MINIFY_SOURCES: '1'
         run: |-
@@ -7164,21 +7156,21 @@ jobs:
           cargo build --release --locked -p denort_desktop
           df -h
       - name: Check release snapshot flags
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         run: |-
           if strings target/release/deno | grep -F -- '--no-lazy --no-lazy-eval --no-lazy-streaming'; then
             echo "release deno binary contains eager snapshot flags"
             exit 1
           fi
       - name: 'Check eager bootstrap does not static-import node:'
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         run: |-
           if grep -rEn '^import .* from "node:' runtime/js/; then
             echo "eager bootstrap statically imports a node: module — use core.createLazyLoader so it stays out of the startup snapshot"
             exit 1
           fi
       - name: Generate symcache
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         env:
           NO_COLOR: 1
         run: |-
@@ -7186,7 +7178,7 @@ jobs:
           du -h deno.symcache
           du -h target/release/deno
       - name: Pre-release (linux)
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         run: |-
           cd target/release
           ./deno -A ../../tools/release/create_symcache.ts deno-x86_64-unknown-linux-musl.symcache
@@ -7202,10 +7194,10 @@ jobs:
           shasum -a 256 libdenort-x86_64-unknown-linux-musl.zip > libdenort-x86_64-unknown-linux-musl.zip.sha256sum
           ./deno types > lib.deno.d.ts
       - name: Build bsdiff helper
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         run: cargo build --release -p bsdiff_helper
       - name: Upload canary to dl.deno.land
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
+        if: github.repository == 'denoland/deno' && github.ref == 'refs/heads/main'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
           AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
@@ -7219,39 +7211,35 @@ jobs:
           aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
           rm canary-latest.txt
       - name: Build product size info
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
+        if: 'github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
         run: |-
           du -hd1 "./target/release"
           du -ha  "./target/release/deno"
           du -ha  "./target/release/denort"
       - name: Check deno binary
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         env:
           NO_COLOR: 1
         run: target/release/deno eval "console.log(1+2)" | grep 3
       - name: Upload artifact release-linux-x86_64-musl-deno
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           name: release-linux-x86_64-musl-deno
           path: target/release/deno
           retention-days: 3
       - name: Upload artifact release-linux-x86_64-musl-denort
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           name: release-linux-x86_64-musl-denort
           path: target/release/denort
           retention-days: 3
       - name: Upload artifact release-linux-x86_64-musl-test-server
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           name: release-linux-x86_64-musl-test-server
           path: target/release/test_server
           retention-days: 3
       - name: Upload release to dl.deno.land (unix)
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
           AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
@@ -7263,13 +7251,13 @@ jobs:
           aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.symcache"
           aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.bsdiff"
       - name: Create release notes
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           export PATH=$PATH:$(pwd)/target/release
           ./tools/release/05_create_release_notes.ts
       - name: Upload release to GitHub
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
@@ -7337,12 +7325,35 @@ jobs:
           body_path: target/release/release-notes.md
           draft: true
           prerelease: '${{ contains(github.ref_name, ''-'') }}'
+      - name: Cache cargo home
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        with:
+          path: |-
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: '121-cargo-home-linux-x86_64-build-main-musl-${{ github.sha }}'
+      - name: Cache build output
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        with:
+          path: |-
+            ./target
+            !./target/*/gn_out
+            !./target/*/gn_root
+            !./target/*/*.zip
+            !./target/*/*.tar.gz
+          key: '121-cargo-target-linux-x86_64-release-build-main-musl-${{ github.sha }}'
   build-release-linux-aarch64-musl:
     name: build release linux-aarch64-musl
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true' && needs.pre_build.outputs.docs_only != 'true'
-    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || ''ubuntu-24.04-arm'' }}'
+    runs-on: ubuntu-24.04-arm
     container:
       image: 'alpine:3.22'
     environment:
@@ -7357,7 +7368,6 @@ jobs:
       RUST_LIB_BACKTRACE: 0
     steps:
       - name: Install musl build dependencies
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         shell: sh
         run: |-
           apk add --no-cache \
@@ -7366,27 +7376,24 @@ jobs:
             python3 protobuf protobuf-dev rustup \
             libstdc++ libgcc gcompat nodejs npm
       - name: Configure git
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: |-
           git config --global core.symlinks true
           git config --global fetch.parallel 32
       - name: Clone repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           fetch-depth: 5
           submodules: false
       - name: Clone submodule ./tests/util/std
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Install Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         with:
           deno-version: v2.x
       - name: Restore cache cargo home
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && !startsWith(github.ref, ''refs/tags/'')'
+        if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
             ~/.cargo/.crates.toml
@@ -7399,7 +7406,7 @@ jobs:
           restore-keys: 121-cargo-home-linux-aarch64-build-main-musl-
       - name: Restore cache build output
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
             ./target
@@ -7411,11 +7418,9 @@ jobs:
           restore-keys: 121-cargo-target-linux-aarch64-release-build-main-musl-
       - name: Apply and update mtime cache
         uses: ./.github/mtime_cache
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           cache-path: ./target
       - name: Pre-install rustup 1.28.2 (workaround broken 1.29.0)
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         shell: bash
         run: |-
           if command -v rustup >/dev/null 2>&1; then
@@ -7439,9 +7444,7 @@ jobs:
           rm "rustup-init${ext}"
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
       - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
       - name: Log versions
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: |-
           echo '*** Python'
           command -v python && python --version || echo 'No python found or bad executable'
@@ -7456,17 +7459,17 @@ jobs:
           echo '*** Installed packages'
           command -v dpkg && dpkg -l || echo 'No dpkg found or bad executable'
       - name: Set up musl build environment
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         run: |-
           echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
           echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
       - name: Configure canary build
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
       - name: Build release
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         env:
           DENO_SNAPSHOT_MINIFY_SOURCES: '1'
         run: |-
@@ -7481,21 +7484,21 @@ jobs:
           cargo build --release --locked -p denort_desktop
           df -h
       - name: Check release snapshot flags
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         run: |-
           if strings target/release/deno | grep -F -- '--no-lazy --no-lazy-eval --no-lazy-streaming'; then
             echo "release deno binary contains eager snapshot flags"
             exit 1
           fi
       - name: 'Check eager bootstrap does not static-import node:'
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         run: |-
           if grep -rEn '^import .* from "node:' runtime/js/; then
             echo "eager bootstrap statically imports a node: module — use core.createLazyLoader so it stays out of the startup snapshot"
             exit 1
           fi
       - name: Generate symcache
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         env:
           NO_COLOR: 1
         run: |-
@@ -7503,7 +7506,7 @@ jobs:
           du -h deno.symcache
           du -h target/release/deno
       - name: Pre-release (linux)
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'''
+        if: github.repository == 'denoland/deno'
         run: |-
           cd target/release
           ./deno -A ../../tools/release/create_symcache.ts deno-aarch64-unknown-linux-musl.symcache
@@ -7519,10 +7522,10 @@ jobs:
           shasum -a 256 libdenort-aarch64-unknown-linux-musl.zip > libdenort-aarch64-unknown-linux-musl.zip.sha256sum
           ./deno types > lib.deno.d.ts
       - name: Build bsdiff helper
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         run: cargo build --release -p bsdiff_helper
       - name: Upload canary to dl.deno.land
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && github.ref == ''refs/heads/main'''
+        if: github.repository == 'denoland/deno' && github.ref == 'refs/heads/main'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
           AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
@@ -7536,39 +7539,35 @@ jobs:
           aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
           rm canary-latest.txt
       - name: Build product size info
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
+        if: 'github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
         run: |-
           du -hd1 "./target/release"
           du -ha  "./target/release/deno"
           du -ha  "./target/release/denort"
       - name: Check deno binary
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         env:
           NO_COLOR: 1
         run: target/release/deno eval "console.log(1+2)" | grep 3
       - name: Upload artifact release-linux-aarch64-musl-deno
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           name: release-linux-aarch64-musl-deno
           path: target/release/deno
           retention-days: 3
       - name: Upload artifact release-linux-aarch64-musl-denort
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           name: release-linux-aarch64-musl-denort
           path: target/release/denort
           retention-days: 3
       - name: Upload artifact release-linux-aarch64-musl-test-server
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         with:
           name: release-linux-aarch64-musl-test-server
           path: target/release/test_server
           retention-days: 3
       - name: Upload release to dl.deno.land (unix)
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
           AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
@@ -7580,13 +7579,13 @@ jobs:
           aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.symcache"
           aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.bsdiff"
       - name: Create release notes
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         run: |-
           export PATH=$PATH:$(pwd)/target/release
           ./tools/release/05_create_release_notes.ts
       - name: Upload release to GitHub
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
-        if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
+        if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
@@ -7654,6 +7653,29 @@ jobs:
           body_path: target/release/release-notes.md
           draft: true
           prerelease: '${{ contains(github.ref_name, ''-'') }}'
+      - name: Cache cargo home
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        with:
+          path: |-
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: '121-cargo-home-linux-aarch64-build-main-musl-${{ github.sha }}'
+      - name: Cache build output
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        with:
+          path: |-
+            ./target
+            !./target/*/gn_out
+            !./target/*/gn_root
+            !./target/*/*.zip
+            !./target/*/*.tar.gz
+          key: '121-cargo-target-linux-aarch64-release-build-main-musl-${{ github.sha }}'
   lint:
     name: 'lint ${{ matrix.profile }} ${{ matrix.os }}-${{ matrix.arch }}'
     needs:

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -106,6 +106,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -346,6 +355,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -549,6 +567,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -748,6 +775,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -1103,6 +1139,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -1274,6 +1319,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -1478,6 +1532,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -1668,6 +1731,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -1838,6 +1910,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -2193,6 +2274,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -2361,6 +2451,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -2565,6 +2664,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -2732,6 +2840,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -2863,6 +2980,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -3242,6 +3368,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -3387,6 +3522,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -3591,6 +3735,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -3770,6 +3923,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -4149,6 +4311,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -4304,6 +4475,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -4774,6 +4954,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -5155,6 +5344,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -5455,6 +5653,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -5693,6 +5900,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -5845,6 +6061,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -6049,6 +6274,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -6228,6 +6462,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -6365,6 +6608,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -6824,6 +7076,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -7099,6 +7360,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
@@ -7429,6 +7699,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -7754,6 +8033,15 @@ jobs:
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
           fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;
             Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;
@@ -7871,6 +8159,15 @@ jobs:
           if command -v rustup >/dev/null 2>&1; then
             if ! rustup --version 2>&1 | grep -q '1\.29\.0'; then exit 0; fi
             echo "Detected broken rustup 1.29.0, replacing with 1.28.2"
+          fi
+          # On the Alpine/musl runner the glibc rustup-init from
+          # static.rust-lang.org cannot run (missing __res_init), but apk
+          # installs a native musl rustup-init that is not the broken 1.29.0.
+          # Use it directly instead of downloading.
+          if command -v rustup-init >/dev/null 2>&1; then
+            rustup-init -y --default-toolchain none --no-modify-path
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+            exit 0
           fi
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -7733,13 +7733,24 @@ jobs:
         if: github.repository == 'denoland/deno'
         run: |-
           rustup target add aarch64-unknown-linux-musl
-          pip3 install --break-system-packages ziglang==0.13.0
-          cargo install --locked cargo-zigbuild@0.19.8
+          TOOLCHAIN="$RUNNER_TEMP/aarch64-linux-musl-native"
+          curl --proto '=https' --tlsv1.2 \
+            --retry 10 --retry-all-errors --retry-delay 5 -fSL \
+            https://musl.cc/aarch64-linux-musl-native.tgz \
+            -o "$RUNNER_TEMP/musl-toolchain.tgz"
+          tar -xzf "$RUNNER_TEMP/musl-toolchain.tgz" -C "$RUNNER_TEMP"
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends musl
+          echo "$TOOLCHAIN/bin" >> $GITHUB_PATH
           echo "CARGO_BUILD_TARGET=aarch64-unknown-linux-musl" >> $GITHUB_ENV
           echo "RUSTFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV
           echo "RUSTDOCFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV
+          echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc" >> $GITHUB_ENV
+          echo "CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++" >> $GITHUB_ENV
+          echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc" >> $GITHUB_ENV
+          echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl=--sysroot=$TOOLCHAIN/aarch64-linux-musl" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$TOOLCHAIN/aarch64-linux-musl/lib" >> $GITHUB_ENV
       - name: Configure canary build
         if: 'github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
@@ -7755,8 +7766,8 @@ jobs:
             grep -n fuse-ld .cargo/config.toml
           fi
           df -h
-          cargo zigbuild --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
-          cargo zigbuild --release --locked -p denort_desktop
+          cargo build --release --locked -p deno -p denort -p test_server --bin deno --bin denort --bin test_server --features=deno/panic-trace
+          cargo build --release --locked -p denort_desktop
           df -h
       - name: Relocate cross-build artifacts
         if: github.repository == 'denoland/deno'

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -7414,8 +7414,7 @@ jobs:
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
       - name: Build release
         if: github.repository == 'denoland/deno'
-        env:
-          DENO_SNAPSHOT_MINIFY_SOURCES: '1'
+        env: {}
         run: |-
           if [ "$(uname -s)" = Darwin ] && [ "$(uname -m)" = arm64 ]; then
             git submodule update --init tools/lzld
@@ -7733,31 +7732,24 @@ jobs:
         if: github.repository == 'denoland/deno'
         run: |-
           rustup target add aarch64-unknown-linux-musl
-          TOOLCHAIN="$RUNNER_TEMP/aarch64-linux-musl-native"
-          curl --proto '=https' --tlsv1.2 \
-            --retry 10 --retry-all-errors --retry-delay 5 -fSL \
-            https://musl.cc/aarch64-linux-musl-native.tgz \
-            -o "$RUNNER_TEMP/musl-toolchain.tgz"
-          tar -xzf "$RUNNER_TEMP/musl-toolchain.tgz" -C "$RUNNER_TEMP"
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends musl
-          echo "$TOOLCHAIN/bin" >> $GITHUB_PATH
+          sudo apt-get install -y --no-install-recommends musl-tools musl-dev musl
+          LIBGCC="$RUNNER_TEMP/musl-libgcc"
+          mkdir -p "$LIBGCC"
+          docker run --rm alpine:3.22 sh -c 'apk add --no-cache libgcc >/dev/null 2>&1 && cat /usr/lib/libgcc_s.so.1' > "$LIBGCC/libgcc_s.so.1"
+          ln -sf libgcc_s.so.1 "$LIBGCC/libgcc_s.so"
           echo "CARGO_BUILD_TARGET=aarch64-unknown-linux-musl" >> $GITHUB_ENV
-          echo "RUSTFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV
-          echo "RUSTDOCFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV
-          echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc" >> $GITHUB_ENV
-          echo "CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++" >> $GITHUB_ENV
-          echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc" >> $GITHUB_ENV
-          echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl=--sysroot=$TOOLCHAIN/aarch64-linux-musl" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=$TOOLCHAIN/aarch64-linux-musl/lib" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-C target-feature=-crt-static -C link-arg=-L$LIBGCC --cfg tokio_unstable" >> $GITHUB_ENV
+          echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C link-arg=-L$LIBGCC --cfg tokio_unstable" >> $GITHUB_ENV
+          echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LIBGCC" >> $GITHUB_ENV
       - name: Configure canary build
         if: 'github.repository == ''denoland/deno'' && !startsWith(github.ref, ''refs/tags/'')'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
       - name: Build release
         if: github.repository == 'denoland/deno'
-        env:
-          DENO_SNAPSHOT_MINIFY_SOURCES: '1'
+        env: {}
         run: |-
           if [ "$(uname -s)" = Darwin ] && [ "$(uname -m)" = arm64 ]; then
             git submodule update --init tools/lzld

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -1215,6 +1215,12 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             "  build-base musl-dev clang lld llvm cmake make perl \\",
             "  python3 protobuf protobuf-dev rustup \\",
             "  libstdc++ libgcc gcompat nodejs npm",
+            // The workspace is created by the host runner under a different
+            // uid than the container root user, so git refuses to operate on
+            // it. actions/checkout works around this with a temporary HOME,
+            // but that does not persist for later steps (e.g. submodule
+            // clones), so mark the workspace as a safe directory globally.
+            "git config --global --add safe.directory \"$GITHUB_WORKSPACE\"",
           ],
         });
 

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -963,9 +963,6 @@ const buildJobs = buildItems.map((rawBuildItem) => {
           .map((name) => `-p ${name}`).join(" ");
         const binsToBuild = ["deno", "denort", "test_server"]
           .map((name) => `--bin ${name}`).join(" ");
-        // aarch64 musl cross-compiles via cargo-zigbuild (see the musl build
-        // environment step); all other builds use plain cargo.
-        const cargoBuild = isCrossMuslBuild ? "cargo zigbuild" : "cargo build";
         const cargoBuildReleaseStep = step
           .if(
             isRelease.and(isDenoland.or(buildItem.use_sysroot)),
@@ -983,32 +980,46 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             // re-add `--cfg tokio_unstable` (required to compile) here.
             isCrossMuslBuild
               ? {
-                // Cross-compile to musl from the arm64 glibc runner. musl-gcc
-                // (musl-tools) compiles C deps and links against musl; the
-                // prebuilt rusty_v8 for the musl triple is downloaded, so V8 is
-                // not built from source. Outputs land in
-                // target/<triple>/release and are relocated to target/release
+                // Cross-compile to musl from the arm64 glibc runner. A real
+                // aarch64-linux-musl gcc toolchain compiles the C/C++ deps and
+                // links against musl; the prebuilt rusty_v8 for the musl triple
+                // is downloaded, so V8 is not built from source. Outputs land
+                // in target/<triple>/release and are relocated to target/release
                 // after the build so downstream steps find them.
                 name: "Set up musl build environment",
                 run: [
-                  // Cross-compiling to musl with dynamic linking (crt-static
-                  // off, needed for FFI/dlopen) requires a musl libgcc_s, which
-                  // Ubuntu's musl-tools does not provide. cargo-zigbuild uses
-                  // Zig's bundled musl toolchain + compiler-rt, which supplies
-                  // libgcc_s and compiles the C/C++ deps (aws-lc-sys etc.)
-                  // against musl. Zig is provided via the `ziglang` PyPI
-                  // package and found automatically by cargo-zigbuild.
                   "rustup target add aarch64-unknown-linux-musl",
-                  "pip3 install --break-system-packages ziglang==0.13.0",
-                  "cargo install --locked cargo-zigbuild@0.19.8",
+                  // The runner is arm64, so use a native (arm64-hosted) gcc
+                  // toolchain that targets aarch64-linux-musl. Unlike Ubuntu's
+                  // musl-tools it ships a musl-built libgcc_s.so.1, which
+                  // dynamic linking (crt-static off, needed for FFI/dlopen)
+                  // requires. Real gcc also avoids the codegen bugs Zig's
+                  // bundled clang hit on aarch64 crypto intrinsics.
+                  'TOOLCHAIN="$RUNNER_TEMP/aarch64-linux-musl-native"',
+                  "curl --proto '=https' --tlsv1.2 \\",
+                  "  --retry 10 --retry-all-errors --retry-delay 5 -fSL \\",
+                  "  https://musl.cc/aarch64-linux-musl-native.tgz \\",
+                  '  -o "$RUNNER_TEMP/musl-toolchain.tgz"',
+                  'tar -xzf "$RUNNER_TEMP/musl-toolchain.tgz" -C "$RUNNER_TEMP"',
                   // The musl runtime loader (/lib/ld-musl-aarch64.so.1) lets the
                   // dynamically linked binary run on this glibc host (e.g. for
-                  // the symcache step).
+                  // the symcache step); libgcc_s.so.1 comes from the toolchain.
                   "sudo apt-get update",
                   "sudo apt-get install -y --no-install-recommends musl",
+                  'echo "$TOOLCHAIN/bin" >> $GITHUB_PATH',
                   'echo "CARGO_BUILD_TARGET=aarch64-unknown-linux-musl" >> $GITHUB_ENV',
                   'echo "RUSTFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV',
                   'echo "RUSTDOCFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV',
+                  'echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc" >> $GITHUB_ENV',
+                  'echo "CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++" >> $GITHUB_ENV',
+                  'echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar" >> $GITHUB_ENV',
+                  'echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc" >> $GITHUB_ENV',
+                  // bindgen (libsqlite3-sys) parses headers for the target;
+                  // point it at the musl sysroot.
+                  'echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl=--sysroot=$TOOLCHAIN/aarch64-linux-musl" >> $GITHUB_ENV',
+                  // The built binary loads musl libgcc_s.so.1 at runtime; make
+                  // the toolchain-provided copy discoverable for the run steps.
+                  'echo "LD_LIBRARY_PATH=$TOOLCHAIN/aarch64-linux-musl/lib" >> $GITHUB_ENV',
                 ],
               }
               : {
@@ -1058,11 +1069,11 @@ const buildJobs = buildItems.map((rawBuildItem) => {
                 "fi",
                 // output fs space before and after building
                 "df -h",
-                `${cargoBuild} --release --locked ${packagesToBuild} ${binsToBuild} --features=deno/panic-trace`,
+                `cargo build --release --locked ${packagesToBuild} ${binsToBuild} --features=deno/panic-trace`,
                 // Build the desktop runtime shared library (libdenort cdylib) for
                 // laufey-based desktop apps. Separate invocation because the
                 // panic-trace feature only applies to the deno/denort binaries.
-                `${cargoBuild} --release --locked -p denort_desktop`,
+                "cargo build --release --locked -p denort_desktop",
                 "df -h",
               ],
             },

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -63,6 +63,16 @@ const Runners = {
     ),
     testRunner: ubuntuARMRunner,
   },
+  linuxX86Musl: {
+    os: "linux",
+    arch: "x86_64",
+    runner: ubuntuX86Runner,
+  },
+  linuxArmMusl: {
+    os: "linux",
+    arch: "aarch64",
+    runner: ubuntuARMRunner,
+  },
   macosX86: {
     os: "macos",
     arch: "x86_64",
@@ -232,12 +242,17 @@ function handleBuildItems(items: {
   use_sysroot?: boolean;
   testRunner?: string | ExpressionValue;
   wpt?: Condition | boolean;
+  // C library variant of the target. Defaults to "gnu". "musl" builds run
+  // inside an Alpine container on the native runner (host == target) and
+  // produce dynamically linked musl binaries.
+  libc?: "gnu" | "musl";
 }[]) {
   return items.map(({ skip_pr, ...rest }) => {
     const defaultValues = {
       skip: false,
       "use_sysroot": false,
       wpt: false,
+      libc: "gnu",
     };
     if (skip_pr == null) {
       return {
@@ -598,6 +613,19 @@ const buildItems = handleBuildItems([{
   profile: "release",
   use_sysroot: true,
   skip_pr: true,
+}, {
+  ...Runners.linuxX86Musl,
+  profile: "release",
+  libc: "musl",
+  // The glibc sysroot is not usable for musl builds.
+  use_sysroot: false,
+  skip_pr: true,
+}, {
+  ...Runners.linuxArmMusl,
+  profile: "release",
+  libc: "musl",
+  use_sysroot: false,
+  skip_pr: true,
 }]);
 
 const buildJobs = buildItems.map((rawBuildItem) => {
@@ -605,10 +633,30 @@ const buildJobs = buildItems.map((rawBuildItem) => {
   const isLinux = buildItem.os.equals("linux");
   const isWindows = buildItem.os.equals("windows");
   const isMacos = buildItem.os.equals("macos");
-  const profileName = `${buildItem.profile}-${buildItem.os}-${buildItem.arch}`;
+  const isMusl = buildItem.libc.equals("musl");
+  // Statically-known variant of the above, used for decisions that must be made
+  // at generation time (job id, container image, which jobs to emit).
+  const isMuslBuild = rawBuildItem.libc === "musl";
+  const linuxLibc = rawBuildItem.libc ?? "gnu";
+  // e.g. `x86_64-unknown-linux-gnu` or `x86_64-unknown-linux-musl`.
+  const linuxTriple = `${buildItem.arch}-unknown-linux-${linuxLibc}`;
+  // musl builds run inside an Alpine container on the native runner so that
+  // host == target (no cross-compile, no qemu); glibc builds run bare.
+  const muslContainer = isMuslBuild
+    ? {
+      image: "alpine:3.22",
+    }
+    : undefined;
+  // Append `-musl` to the job id so musl items don't collide with the gnu
+  // items that share the same os/arch/profile.
+  const profileName = `${buildItem.profile}-${buildItem.os}-${buildItem.arch}${
+    isMuslBuild ? "-musl" : ""
+  }`;
   const jobIdForJob = (name: string) => `${name}-${profileName}`;
   const jobNameForJob = (name: string) =>
-    `${name} ${buildItem.profile} ${buildItem.os}-${buildItem.arch}`;
+    `${name} ${buildItem.profile} ${buildItem.os}-${buildItem.arch}${
+      isMuslBuild ? "-musl" : ""
+    }`;
   const createBinaryArtifact = (name: string) => {
     const directory = `target/${buildItem.profile}`;
     const exeExt = rawBuildItem.os === "windows" ? ".exe" : "";
@@ -680,6 +728,7 @@ const buildJobs = buildItems.map((rawBuildItem) => {
       needs: [preBuildJob],
       if: preBuildJob.outputs.skip_build.notEquals("true").and(notDocsOnly),
       runsOn: buildItem.runner,
+      container: muslContainer,
       // This is required to successfully authenticate with Azure using OIDC for
       // code signing.
       environment: {
@@ -694,7 +743,8 @@ const buildJobs = buildItems.map((rawBuildItem) => {
           saveCacheStep,
         } = createCacheSteps({
           ...buildItem,
-          cachePrefix: "build-main",
+          // Keep musl caches separate from gnu; they share os/arch/profile.
+          cachePrefix: isMuslBuild ? "build-main-musl" : "build-main",
         });
         const tarSourcePublishStep = step({
           name: "Create source tarballs (release, linux)",
@@ -713,11 +763,11 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             if: isLinux.and(isDenoland),
             run: [
               "cd target/release",
-              `./deno -A ../../tools/release/create_symcache.ts deno-${buildItem.arch}-unknown-linux-gnu.symcache`,
+              `./deno -A ../../tools/release/create_symcache.ts deno-${linuxTriple}.symcache`,
               "strip ./deno",
-              `shasum -a 256 deno > deno-${buildItem.arch}-unknown-linux-gnu.sha256sum`,
-              `zip -r deno-${buildItem.arch}-unknown-linux-gnu.zip deno`,
-              `shasum -a 256 deno-${buildItem.arch}-unknown-linux-gnu.zip > deno-${buildItem.arch}-unknown-linux-gnu.zip.sha256sum`,
+              `shasum -a 256 deno > deno-${linuxTriple}.sha256sum`,
+              `zip -r deno-${linuxTriple}.zip deno`,
+              `shasum -a 256 deno-${linuxTriple}.zip > deno-${linuxTriple}.zip.sha256sum`,
               // denort is the `deno compile` base binary: libsui rewrites its
               // ELF to embed user code, and that rewrite drops `.relr.dyn`
               // relative relocations when the symbol table is gone, producing a
@@ -725,11 +775,11 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               // (`__cxa_guard_acquire failed to acquire mutex`). Keep .symtab
               // (strip only debug info) so the relocations survive.
               "strip --strip-debug ./denort",
-              `zip -r denort-${buildItem.arch}-unknown-linux-gnu.zip denort`,
-              `shasum -a 256 denort-${buildItem.arch}-unknown-linux-gnu.zip > denort-${buildItem.arch}-unknown-linux-gnu.zip.sha256sum`,
+              `zip -r denort-${linuxTriple}.zip denort`,
+              `shasum -a 256 denort-${linuxTriple}.zip > denort-${linuxTriple}.zip.sha256sum`,
               "strip ./libdenort.so",
-              `zip -r libdenort-${buildItem.arch}-unknown-linux-gnu.zip libdenort.so`,
-              `shasum -a 256 libdenort-${buildItem.arch}-unknown-linux-gnu.zip > libdenort-${buildItem.arch}-unknown-linux-gnu.zip.sha256sum`,
+              `zip -r libdenort-${linuxTriple}.zip libdenort.so`,
+              `shasum -a 256 libdenort-${linuxTriple}.zip > libdenort-${linuxTriple}.zip.sha256sum`,
               "./deno types > lib.deno.d.ts",
             ],
           },
@@ -839,7 +889,8 @@ const buildJobs = buildItems.map((rawBuildItem) => {
           },
           {
             name: "Generate delta patch (linux)",
-            if: isLinux.and(isDenoland).and(isTag),
+            // Skip musl for now: there is no prior musl release to diff against.
+            if: isLinux.and(isDenoland).and(isTag).and(isMusl.not()),
             run: [
               `TARGET="${buildItem.arch}-unknown-linux-gnu"`,
               'PREV_VERSION=$(curl -sf https://dl.deno.land/release-latest.txt | tr -d "v\\n") || true',
@@ -910,6 +961,20 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             installRustStep,
             sysRootStep,
           )(
+            {
+              // rustc defaults musl targets to `+crt-static`; force dynamic
+              // linking so `Deno.dlopen`/FFI/native-addon loading works. The
+              // config-file rustflags are ignored once RUSTFLAGS is set, so
+              // re-add `--cfg tokio_unstable` (required to compile) here.
+              name: "Set up musl build environment",
+              if: isMusl,
+              run: [
+                'echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV',
+                'echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV',
+                'echo "CC=clang" >> $GITHUB_ENV',
+                'echo "CXX=clang++" >> $GITHUB_ENV',
+              ],
+            },
             {
               // do this on PRs as well as main so that PRs can use the cargo build cache from main
               name: "Configure canary build",
@@ -1102,6 +1167,20 @@ const buildJobs = buildItems.map((rawBuildItem) => {
                 "target/release/denort-aarch64-unknown-linux-gnu.zip.sha256sum",
                 "target/release/libdenort-aarch64-unknown-linux-gnu.zip",
                 "target/release/libdenort-aarch64-unknown-linux-gnu.zip.sha256sum",
+                "target/release/deno-x86_64-unknown-linux-musl.zip",
+                "target/release/deno-x86_64-unknown-linux-musl.zip.sha256sum",
+                "target/release/deno-x86_64-unknown-linux-musl.sha256sum",
+                "target/release/denort-x86_64-unknown-linux-musl.zip",
+                "target/release/denort-x86_64-unknown-linux-musl.zip.sha256sum",
+                "target/release/libdenort-x86_64-unknown-linux-musl.zip",
+                "target/release/libdenort-x86_64-unknown-linux-musl.zip.sha256sum",
+                "target/release/deno-aarch64-unknown-linux-musl.zip",
+                "target/release/deno-aarch64-unknown-linux-musl.zip.sha256sum",
+                "target/release/deno-aarch64-unknown-linux-musl.sha256sum",
+                "target/release/denort-aarch64-unknown-linux-musl.zip",
+                "target/release/denort-aarch64-unknown-linux-musl.zip.sha256sum",
+                "target/release/libdenort-aarch64-unknown-linux-musl.zip",
+                "target/release/libdenort-aarch64-unknown-linux-musl.zip.sha256sum",
                 "target/release/deno-aarch64-apple-darwin.zip",
                 "target/release/deno-aarch64-apple-darwin.zip.sha256sum",
                 "target/release/deno-aarch64-apple-darwin.sha256sum",
@@ -1123,7 +1202,26 @@ const buildJobs = buildItems.map((rawBuildItem) => {
           },
         );
 
+        // Provision the Alpine/musl container before anything else runs. The
+        // job default shell is bash, which Alpine lacks until this installs it,
+        // so this step must use `sh`. gcompat/libstdc++ let GitHub's glibc node
+        // (used by JS actions like checkout) run; rustup lets installRustStep
+        // install the pinned toolchain (musl host, no cross-compile).
+        const muslSetupStep = step({
+          name: "Install musl build dependencies",
+          if: isMusl,
+          shell: "sh",
+          run: [
+            "apk add --no-cache \\",
+            "  bash git curl wget xz zip unzip tar coreutils \\",
+            "  build-base musl-dev clang lld llvm cmake make perl \\",
+            "  python3 protobuf protobuf-dev rustup \\",
+            "  libstdc++ libgcc gcompat nodejs npm",
+          ],
+        });
+
         return step.if(buildItem.skip.not())(
+          muslSetupStep,
           cloneRepoStep,
           cloneStdSubmoduleStep,
           // ensure this happens right after cloning
@@ -1171,7 +1269,9 @@ const buildJobs = buildItems.map((rawBuildItem) => {
 
   const additionalJobs = [];
 
-  {
+  // musl builds are release-only and produce artifacts that cannot run on the
+  // glibc test runners, so don't emit the per-item test job for them.
+  if (!isMuslBuild) {
     const shardedCrates = new Map([
       ["specs", 2],
       ["integration", 2],

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -644,12 +644,18 @@ const buildJobs = buildItems.map((rawBuildItem) => {
   // Statically-known variant of the above, used for decisions that must be made
   // at generation time (job id, container image, which jobs to emit).
   const isMuslBuild = rawBuildItem.libc === "musl";
+  // aarch64 musl cannot use the Alpine-container approach: GitHub only supports
+  // JavaScript actions (checkout, cache, setup-deno) in Alpine containers on x64
+  // runners, not arm64. So aarch64 musl builds run bare on the native arm64
+  // glibc runner and cross-compile to the musl target instead.
+  const isCrossMuslBuild = isMuslBuild && rawBuildItem.arch === "aarch64";
+  const isContainerMuslBuild = isMuslBuild && !isCrossMuslBuild;
   const linuxLibc = rawBuildItem.libc ?? "gnu";
   // e.g. `x86_64-unknown-linux-gnu` or `x86_64-unknown-linux-musl`.
   const linuxTriple = `${buildItem.arch}-unknown-linux-${linuxLibc}`;
-  // musl builds run inside an Alpine container on the native runner so that
-  // host == target (no cross-compile, no qemu); glibc builds run bare.
-  const muslContainer = isMuslBuild
+  // x86_64 musl builds run inside an Alpine container on the native runner so
+  // that host == target (no cross-compile, no qemu); glibc builds run bare.
+  const muslContainer = isContainerMuslBuild
     ? {
       image: "alpine:3.22",
     }
@@ -968,28 +974,52 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             installRustStep,
             sysRootStep,
           )(
-            {
-              // rustc defaults musl targets to `+crt-static`; force dynamic
-              // linking so `Deno.dlopen`/FFI/native-addon loading works. The
-              // config-file rustflags are ignored once RUSTFLAGS is set, so
-              // re-add `--cfg tokio_unstable` (required to compile) here.
-              name: "Set up musl build environment",
-              if: isMusl,
-              run: [
-                'echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV',
-                'echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV',
-                // Use Alpine's native gcc/g++ for C/C++ dependencies (e.g.
-                // aws-lc-sys). They target musl directly and know where their
-                // crt objects and libgcc live; clang, invoked by the cc crate
-                // with `--target=x86_64-unknown-linux-musl`, fails to locate
-                // Alpine's `x86_64-alpine-linux-musl` gcc install and cannot
-                // find crtbeginS.o/-lgcc. The Rust link still uses clang+lld
-                // above, which works because rustc's musl target is
-                // self-contained.
-                'echo "CC=gcc" >> $GITHUB_ENV',
-                'echo "CXX=g++" >> $GITHUB_ENV',
-              ],
-            },
+            // rustc defaults musl targets to `+crt-static`; force dynamic
+            // linking so `Deno.dlopen`/FFI/native-addon loading works. The
+            // config-file rustflags are ignored once RUSTFLAGS is set, so
+            // re-add `--cfg tokio_unstable` (required to compile) here.
+            isCrossMuslBuild
+              ? {
+                // Cross-compile to musl from the arm64 glibc runner. musl-gcc
+                // (musl-tools) compiles C deps and links against musl; the
+                // prebuilt rusty_v8 for the musl triple is downloaded, so V8 is
+                // not built from source. Outputs land in
+                // target/<triple>/release and are relocated to target/release
+                // after the build so downstream steps find them.
+                name: "Set up musl build environment",
+                run: [
+                  // musl-tools provides musl-gcc and pulls in musl-dev and the
+                  // musl runtime loader (/lib/ld-musl-aarch64.so.1), which the
+                  // dynamically linked musl binary needs to run on this glibc
+                  // host (e.g. for the symcache step).
+                  "sudo apt-get update",
+                  "sudo apt-get install -y --no-install-recommends musl-tools musl-dev",
+                  "rustup target add aarch64-unknown-linux-musl",
+                  'echo "CARGO_BUILD_TARGET=aarch64-unknown-linux-musl" >> $GITHUB_ENV',
+                  'echo "RUSTFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV',
+                  'echo "RUSTDOCFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV',
+                  'echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV',
+                  'echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV',
+                ],
+              }
+              : {
+                name: "Set up musl build environment",
+                if: isMusl,
+                run: [
+                  'echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV',
+                  'echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV',
+                  // Use Alpine's native gcc/g++ for C/C++ dependencies (e.g.
+                  // aws-lc-sys). They target musl directly and know where their
+                  // crt objects and libgcc live; clang, invoked by the cc crate
+                  // with `--target=x86_64-unknown-linux-musl`, fails to locate
+                  // Alpine's `x86_64-alpine-linux-musl` gcc install and cannot
+                  // find crtbeginS.o/-lgcc. The Rust link still uses clang+lld
+                  // above, which works because rustc's musl target is
+                  // self-contained.
+                  'echo "CC=gcc" >> $GITHUB_ENV',
+                  'echo "CXX=g++" >> $GITHUB_ENV',
+                ],
+              },
             {
               // do this on PRs as well as main so that PRs can use the cargo build cache from main
               name: "Configure canary build",
@@ -1024,6 +1054,19 @@ const buildJobs = buildItems.map((rawBuildItem) => {
                 "df -h",
               ],
             },
+            ...(isCrossMuslBuild
+              ? [{
+                // Cross builds set CARGO_BUILD_TARGET, so cargo writes the musl
+                // artifacts to target/<triple>/release. Relocate them into
+                // target/release so the many downstream steps that assume that
+                // path (snapshot check, symcache, pre-release, artifact upload)
+                // work unchanged.
+                name: "Relocate cross-build artifacts",
+                run: [
+                  "cp -a target/aarch64-unknown-linux-musl/release/. target/release/",
+                ],
+              }]
+              : []),
             {
               name: "Check release snapshot flags",
               if: isLinux,
@@ -1242,7 +1285,7 @@ const buildJobs = buildItems.map((rawBuildItem) => {
         });
 
         return step.if(buildItem.skip.not())(
-          muslSetupStep,
+          ...(isContainerMuslBuild ? [muslSetupStep] : []),
           cloneRepoStep,
           cloneStdSubmoduleStep,
           // ensure this happens right after cloning

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -619,13 +619,11 @@ const buildItems = handleBuildItems([{
   libc: "musl",
   // The glibc sysroot is not usable for musl builds.
   use_sysroot: false,
-  skip_pr: true,
 }, {
   ...Runners.linuxArmMusl,
   profile: "release",
   libc: "musl",
   use_sysroot: false,
-  skip_pr: true,
 }]);
 
 const buildJobs = buildItems.map((rawBuildItem) => {

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -978,8 +978,16 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               run: [
                 'echo "RUSTFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV',
                 'echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C linker=clang -C link-arg=-fuse-ld=lld --cfg tokio_unstable" >> $GITHUB_ENV',
-                'echo "CC=clang" >> $GITHUB_ENV',
-                'echo "CXX=clang++" >> $GITHUB_ENV',
+                // Use Alpine's native gcc/g++ for C/C++ dependencies (e.g.
+                // aws-lc-sys). They target musl directly and know where their
+                // crt objects and libgcc live; clang, invoked by the cc crate
+                // with `--target=x86_64-unknown-linux-musl`, fails to locate
+                // Alpine's `x86_64-alpine-linux-musl` gcc install and cannot
+                // find crtbeginS.o/-lgcc. The Rust link still uses clang+lld
+                // above, which works because rustc's musl target is
+                // self-contained.
+                'echo "CC=gcc" >> $GITHUB_ENV',
+                'echo "CXX=g++" >> $GITHUB_ENV',
               ],
             },
             {

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -963,6 +963,9 @@ const buildJobs = buildItems.map((rawBuildItem) => {
           .map((name) => `-p ${name}`).join(" ");
         const binsToBuild = ["deno", "denort", "test_server"]
           .map((name) => `--bin ${name}`).join(" ");
+        // aarch64 musl cross-compiles via cargo-zigbuild (see the musl build
+        // environment step); all other builds use plain cargo.
+        const cargoBuild = isCrossMuslBuild ? "cargo zigbuild" : "cargo build";
         const cargoBuildReleaseStep = step
           .if(
             isRelease.and(isDenoland.or(buildItem.use_sysroot)),
@@ -988,18 +991,24 @@ const buildJobs = buildItems.map((rawBuildItem) => {
                 // after the build so downstream steps find them.
                 name: "Set up musl build environment",
                 run: [
-                  // musl-tools provides musl-gcc and pulls in musl-dev and the
-                  // musl runtime loader (/lib/ld-musl-aarch64.so.1), which the
-                  // dynamically linked musl binary needs to run on this glibc
-                  // host (e.g. for the symcache step).
-                  "sudo apt-get update",
-                  "sudo apt-get install -y --no-install-recommends musl-tools musl-dev",
+                  // Cross-compiling to musl with dynamic linking (crt-static
+                  // off, needed for FFI/dlopen) requires a musl libgcc_s, which
+                  // Ubuntu's musl-tools does not provide. cargo-zigbuild uses
+                  // Zig's bundled musl toolchain + compiler-rt, which supplies
+                  // libgcc_s and compiles the C/C++ deps (aws-lc-sys etc.)
+                  // against musl. Zig is provided via the `ziglang` PyPI
+                  // package and found automatically by cargo-zigbuild.
                   "rustup target add aarch64-unknown-linux-musl",
+                  "pip3 install --break-system-packages ziglang==0.13.0",
+                  "cargo install --locked cargo-zigbuild@0.19.8",
+                  // The musl runtime loader (/lib/ld-musl-aarch64.so.1) lets the
+                  // dynamically linked binary run on this glibc host (e.g. for
+                  // the symcache step).
+                  "sudo apt-get update",
+                  "sudo apt-get install -y --no-install-recommends musl",
                   'echo "CARGO_BUILD_TARGET=aarch64-unknown-linux-musl" >> $GITHUB_ENV',
                   'echo "RUSTFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV',
                   'echo "RUSTDOCFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV',
-                  'echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV',
-                  'echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV',
                 ],
               }
               : {
@@ -1018,6 +1027,9 @@ const buildJobs = buildItems.map((rawBuildItem) => {
                   // self-contained.
                   'echo "CC=gcc" >> $GITHUB_ENV',
                   'echo "CXX=g++" >> $GITHUB_ENV',
+                  // bindgen (libsqlite3-sys) dlopens libclang at build time;
+                  // point it at Alpine's clang-dev/llvm-dev shared library.
+                  'echo "LIBCLANG_PATH=/usr/lib" >> $GITHUB_ENV',
                 ],
               },
             {
@@ -1046,11 +1058,11 @@ const buildJobs = buildItems.map((rawBuildItem) => {
                 "fi",
                 // output fs space before and after building
                 "df -h",
-                `cargo build --release --locked ${packagesToBuild} ${binsToBuild} --features=deno/panic-trace`,
+                `${cargoBuild} --release --locked ${packagesToBuild} ${binsToBuild} --features=deno/panic-trace`,
                 // Build the desktop runtime shared library (libdenort cdylib) for
                 // laufey-based desktop apps. Separate invocation because the
                 // panic-trace feature only applies to the deno/denort binaries.
-                "cargo build --release --locked -p denort_desktop",
+                `${cargoBuild} --release --locked -p denort_desktop`,
                 "df -h",
               ],
             },
@@ -1272,8 +1284,8 @@ const buildJobs = buildItems.map((rawBuildItem) => {
           run: [
             "apk add --no-cache \\",
             "  bash git curl wget xz zip unzip tar coreutils \\",
-            "  build-base musl-dev clang lld llvm cmake make perl \\",
-            "  python3 protobuf protobuf-dev rustup \\",
+            "  build-base musl-dev clang clang-dev lld llvm llvm-dev \\",
+            "  cmake make perl python3 protobuf protobuf-dev rustup \\",
             "  libstdc++ libgcc gcompat nodejs npm",
             // The workspace is created by the host runner under a different
             // uid than the container root user, so git refuses to operate on

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -427,6 +427,15 @@ const installRustStep = step(
       "  if ! rustup --version 2>&1 | grep -q '1\\.29\\.0'; then exit 0; fi",
       '  echo "Detected broken rustup 1.29.0, replacing with 1.28.2"',
       "fi",
+      "# On the Alpine/musl runner the glibc rustup-init from",
+      "# static.rust-lang.org cannot run (missing __res_init), but apk",
+      "# installs a native musl rustup-init that is not the broken 1.29.0.",
+      "# Use it directly instead of downloading.",
+      "if command -v rustup-init >/dev/null 2>&1; then",
+      "  rustup-init -y --default-toolchain none --no-modify-path",
+      '  echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"',
+      "  exit 0",
+      "fi",
       'case "${RUNNER_OS}-${RUNNER_ARCH}" in',
       "  Linux-X64)     target=x86_64-unknown-linux-gnu; ext= ;;",
       "  Linux-ARM64)   target=aarch64-unknown-linux-gnu; ext= ;;",
@@ -1220,7 +1229,7 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             // it. actions/checkout works around this with a temporary HOME,
             // but that does not persist for later steps (e.g. submodule
             // clones), so mark the workspace as a safe directory globally.
-            "git config --global --add safe.directory \"$GITHUB_WORKSPACE\"",
+            'git config --global --add safe.directory "$GITHUB_WORKSPACE"',
           ],
         });
 

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -989,37 +989,33 @@ const buildJobs = buildItems.map((rawBuildItem) => {
                 name: "Set up musl build environment",
                 run: [
                   "rustup target add aarch64-unknown-linux-musl",
-                  // The runner is arm64, so use a native (arm64-hosted) gcc
-                  // toolchain that targets aarch64-linux-musl. Unlike Ubuntu's
-                  // musl-tools it ships a musl-built libgcc_s.so.1, which
-                  // dynamic linking (crt-static off, needed for FFI/dlopen)
-                  // requires. Real gcc also avoids the codegen bugs Zig's
-                  // bundled clang hit on aarch64 crypto intrinsics.
-                  'TOOLCHAIN="$RUNNER_TEMP/aarch64-linux-musl-native"',
-                  "curl --proto '=https' --tlsv1.2 \\",
-                  "  --retry 10 --retry-all-errors --retry-delay 5 -fSL \\",
-                  "  https://musl.cc/aarch64-linux-musl-native.tgz \\",
-                  '  -o "$RUNNER_TEMP/musl-toolchain.tgz"',
-                  'tar -xzf "$RUNNER_TEMP/musl-toolchain.tgz" -C "$RUNNER_TEMP"',
-                  // The musl runtime loader (/lib/ld-musl-aarch64.so.1) lets the
-                  // dynamically linked binary run on this glibc host (e.g. for
-                  // the symcache step); libgcc_s.so.1 comes from the toolchain.
+                  // musl-tools provides a real musl-targeting gcc (musl-gcc)
+                  // plus musl-dev headers/libs; `musl` provides the runtime
+                  // loader so the dynamically linked binary can run on this
+                  // glibc host (e.g. the symcache step).
                   "sudo apt-get update",
-                  "sudo apt-get install -y --no-install-recommends musl",
-                  'echo "$TOOLCHAIN/bin" >> $GITHUB_PATH',
+                  "sudo apt-get install -y --no-install-recommends musl-tools musl-dev musl",
+                  // The one thing musl-tools lacks is a musl-built
+                  // libgcc_s.so.1, which dynamic linking (crt-static off,
+                  // needed for FFI/dlopen) requires. Take it from the arm64
+                  // Alpine image -- the same real musl libgcc the shipped
+                  // binary loads on Alpine at runtime -- because musl.cc is not
+                  // reliably reachable from CI. Alpine is already pulled
+                  // reliably for the x86_64 musl container.
+                  'LIBGCC="$RUNNER_TEMP/musl-libgcc"',
+                  'mkdir -p "$LIBGCC"',
+                  "docker run --rm alpine:3.22 sh -c " +
+                  "'apk add --no-cache libgcc >/dev/null 2>&1 && cat /usr/lib/libgcc_s.so.1' " +
+                  '> "$LIBGCC/libgcc_s.so.1"',
+                  'ln -sf libgcc_s.so.1 "$LIBGCC/libgcc_s.so"',
                   'echo "CARGO_BUILD_TARGET=aarch64-unknown-linux-musl" >> $GITHUB_ENV',
-                  'echo "RUSTFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV',
-                  'echo "RUSTDOCFLAGS=-C target-feature=-crt-static --cfg tokio_unstable" >> $GITHUB_ENV',
-                  'echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc" >> $GITHUB_ENV',
-                  'echo "CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++" >> $GITHUB_ENV',
-                  'echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar" >> $GITHUB_ENV',
-                  'echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc" >> $GITHUB_ENV',
-                  // bindgen (libsqlite3-sys) parses headers for the target;
-                  // point it at the musl sysroot.
-                  'echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl=--sysroot=$TOOLCHAIN/aarch64-linux-musl" >> $GITHUB_ENV',
+                  'echo "RUSTFLAGS=-C target-feature=-crt-static -C link-arg=-L$LIBGCC --cfg tokio_unstable" >> $GITHUB_ENV',
+                  'echo "RUSTDOCFLAGS=-C target-feature=-crt-static -C link-arg=-L$LIBGCC --cfg tokio_unstable" >> $GITHUB_ENV',
+                  'echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV',
+                  'echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV',
                   // The built binary loads musl libgcc_s.so.1 at runtime; make
-                  // the toolchain-provided copy discoverable for the run steps.
-                  'echo "LD_LIBRARY_PATH=$TOOLCHAIN/aarch64-linux-musl/lib" >> $GITHUB_ENV',
+                  // the extracted copy discoverable for the run steps.
+                  'echo "LD_LIBRARY_PATH=$LIBGCC" >> $GITHUB_ENV',
                 ],
               }
               : {
@@ -1051,7 +1047,13 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             },
             {
               name: "Build release",
-              env: {
+              // Snapshot source minification shells out to a `deno` binary
+              // (runtime/transpile.rs). musl builds have no runnable deno at
+              // build time: the setup-deno one is glibc (fails in the Alpine
+              // container / on the musl target) and no musl deno is published
+              // yet. Skip minification for musl; the only cost is a slightly
+              // larger snapshot.
+              env: isMuslBuild ? {} : {
                 DENO_SNAPSHOT_MINIFY_SOURCES: "1",
               },
               run: [

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -222,6 +222,14 @@ impl DenoSubcommandExt for DenoSubcommand {
             os: "linux".into(),
             cpu: "x64".into(),
           },
+          "aarch64-unknown-linux-musl" => NpmSystemInfo {
+            os: "linux".into(),
+            cpu: "arm64".into(),
+          },
+          "x86_64-unknown-linux-musl" => NpmSystemInfo {
+            os: "linux".into(),
+            cpu: "x64".into(),
+          },
           "x86_64-pc-windows-msvc" => NpmSystemInfo {
             os: "win32".into(),
             cpu: "x64".into(),
@@ -2337,9 +2345,11 @@ Unless --reload is specified, this command will not re-download already cached d
     )
 }
 
-const SUPPORTED_OS: [&str; 6] = [
+const SUPPORTED_OS: [&str; 8] = [
   "x86_64-unknown-linux-gnu",
   "aarch64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+  "aarch64-unknown-linux-musl",
   "x86_64-pc-windows-msvc",
   "aarch64-pc-windows-msvc",
   "x86_64-apple-darwin",
@@ -14392,6 +14402,20 @@ mod tests {
       ])
       .is_err()
     );
+  }
+
+  #[test]
+  fn compile_target_linux_musl() {
+    // denort for linux musl is built and published by CI, so both musl triples
+    // must be accepted by the SUPPORTED_OS value parser.
+    for target in ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"] {
+      let r =
+        flags_from_vec(svec!["deno", "compile", "--target", target, "main.ts"]);
+      let DenoSubcommand::Compile(c) = r.unwrap().subcommand else {
+        unreachable!()
+      };
+      assert_eq!(c.target, Some(target.to_string()));
+    }
   }
 
   #[test]

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -384,7 +384,9 @@ fn op_create_worker(
     // OS. Without this, glibc in particular holds onto the fragmented heap
     // pages, causing RSS to remain high after many workers are created and
     // destroyed (https://github.com/denoland/deno/issues/26058).
-    #[cfg(target_os = "linux")]
+    // `malloc_trim` is a glibc extension, so gate it on the gnu env (musl has
+    // no such function).
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     {
       // SAFETY: calling libc function with no preconditions.
       unsafe {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -80,6 +80,8 @@ pub(crate) static SIGUSR2_RX: LazyLock<tokio::sync::watch::Receiver<()>> =
         sigusr2.recv().await;
 
         // SAFETY: calling into libc, nothing relevant on the Rust side.
+        // `malloc_trim` is a glibc extension; musl has no such function.
+        #[cfg(target_env = "gnu")]
         unsafe {
           libc::malloc_trim(0);
         }

--- a/tools/release/npm/build.ts
+++ b/tools/release/npm/build.ts
@@ -43,6 +43,16 @@ const packages: Package[] = [{
   os: "linux",
   cpu: "arm64",
   libc: "glibc",
+}, {
+  zipFileName: "deno-x86_64-unknown-linux-musl.zip",
+  os: "linux",
+  cpu: "x64",
+  libc: "musl",
+}, {
+  zipFileName: "deno-aarch64-unknown-linux-musl.zip",
+  os: "linux",
+  cpu: "arm64",
+  libc: "musl",
 }];
 
 const markdownText = `# Deno

--- a/tools/release/promote_to_release.ts
+++ b/tools/release/promote_to_release.ts
@@ -10,9 +10,11 @@ import { patchver } from "jsr:@deno/patchver@0.5.1";
 const SUPPORTED_TARGETS = [
   "aarch64-apple-darwin",
   "aarch64-unknown-linux-gnu",
+  "aarch64-unknown-linux-musl",
   "x86_64-apple-darwin",
   "x86_64-pc-windows-msvc",
   "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
 ];
 
 const DENO_BINARIES = [


### PR DESCRIPTION
Adds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` as release
targets, and makes both accepted by `deno compile --target`. This lights up
Alpine/musl for both the `deno` and `denort` binaries, building on the musl
prebuilt libs shipped in rusty_v8 150.2.0 (already on `main` via #36098).

## Two design decisions worth calling out

**Dynamic linking, not static.** rustc defaults musl targets to
`+crt-static`, which would produce a fully static binary — but a static musl
binary substitutes a non-functional stub for `dlopen()`, which breaks
`Deno.dlopen`/FFI and native `.node` addon loading. That would defeat the
purpose for the main audience here (Alpine users running FFI / native addons).
So the musl builds explicitly force dynamic linking with
`-C target-feature=-crt-static`, matching how the community Alpine `deno`
package is linked (dynamic musl + libffi). The resulting binaries depend on
the musl loader being present (normal on Alpine/musl hosts).

**Container build on native runners, not cross-compile.** Deno builds each
arch on a native runner today (no `--target` anywhere). Rather than
introduce cross-compilation, the musl jobs run inside an `alpine:3.22`
container on the existing `ubuntu-24.04` / `ubuntu-24.04-arm` runners, so
`host == target`. This keeps `target/release` paths, the `create_symcache`
step, `deno types`, and snapshot generation working without qemu.

## What's here

- `cli/args/flags.rs` — both triples added to `SUPPORTED_OS` (the
  `deno compile --target` allowlist), matching `npm_system_info` arms, and an
  acceptance test. Everything downstream of the allowlist (the
  `denort-<triple>.zip` download name, the ELF writer, `.exe` handling) is
  substring-based on `linux`/`windows`/`darwin`, so no other compile-path
  edits are needed — `--target *-linux-musl` resolves to
  `denort-*-unknown-linux-musl.zip` automatically once CI publishes it.
- `.github/workflows/ci.ts` — a `libc` discriminator on build items; two
  `release` + `skip_pr` musl build items; the linux packaging step
  parameterised on `<arch>-unknown-linux-<libc>` (gnu output is byte-identical);
  an Alpine provisioning step; the dynamic-linking RUSTFLAGS step; musl entries
  in the GitHub-release file list. Delta patches are gnu-only for now (no prior
  musl release to diff against), and musl items don't spawn the glibc test jobs.
  `ci.generated.yml` is regenerated.
- `tools/release/promote_to_release.ts` and `tools/release/npm/build.ts` —
  musl added to the release/promotion set and the npm platform packages
  (`@deno/deno-linux-{x64,arm64}-musl`, carried with `libc: "musl"` so
  npm/pnpm/bun/yarn select them correctly on musl hosts).

## Verified locally

- `cargo check --bin deno` passes with the 150.2.0 bump.
- `ci.ts` regenerates idempotently and passes the `--lint` staleness check;
  the gnu jobs are unchanged.
- `deno compile --target` unit tests cover the two new triples.

## Needs a real CI run to validate (hence draft)

The container build itself can only be exercised on CI. Open questions I'd
like reviewers' eyes on:

- Alpine provisioning: JS actions (checkout, etc.) run on GitHub's glibc node
  inside the container — `gcompat`+`libstdc++`+`libgcc` are installed as the
  usual workaround, and `setup-deno` downloads a glibc `deno` it may try to
  exec. These are the most likely failure points.
- `rustup` from apk satisfying `rust-toolchain-file` with the pinned toolchain.
- Linker choice is `clang` + `-fuse-ld=lld`; falling back to `build-base`
  gcc/ld is a lower-risk option if lld misbehaves.
- Confirm libsui / `deno compile`'s ELF rewrite works on the dynamically
  linked musl `denort`.

## Follow-up (out of scope)

`NpmSystemInfo` (Rust) carries only `os`/`cpu`, not `libc`, so
`deno compile --target *-musl` can't yet distinguish musl-specific native npm
deps (e.g. `@parcel/watcher-linux-x64-musl`) from the glibc variant. That
libc-aware selection is tracked in #35041; I'll leave a note there referencing
this PR as a motivating case.
