### PR TITLE
fix(loader): reject non-JSON modules for JSON imports

### DIFF
--- a/libs/resolver/loader/mod.rs
+++ b/libs/resolver/loader/mod.rs
@@ -16,6 +16,32 @@ pub use npm::*;
 use parking_lot::RwLock;
 use url::Url;
 
+fn media_type_name(media_type: MediaType) -> &'static str {
+  match media_type {
+    MediaType::JavaScript
+    | MediaType::Mjs
+    | MediaType::Cjs
+    | MediaType::Jsx => "JavaScript",
+    MediaType::TypeScript
+    | MediaType::Mts
+    | MediaType::Cts
+    | MediaType::Tsx
+    | MediaType::Dts
+    | MediaType::Dmts
+    | MediaType::Dcts => "TypeScript",
+    MediaType::Json => "Json",
+    MediaType::Jsonc => "JsonC",
+    MediaType::Json5 => "Json5",
+    MediaType::Wasm => "Wasm",
+    MediaType::Css => "Css",
+    MediaType::Html => "Html",
+    MediaType::Markdown => "Markdown",
+    MediaType::Sql => "Sql",
+    MediaType::SourceMap => "SourceMap",
+    MediaType::Unknown => "Unknown",
+  }
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub enum AllowJsonImports {
   Always,

--- a/libs/resolver/loader/module_loader.rs
+++ b/libs/resolver/loader/module_loader.rs
@@ -20,6 +20,7 @@ use super::LoadedModuleOrAsset;
 use super::LoadedModuleSource;
 use super::NpmModuleLoadError;
 use super::RequestedModuleType;
+use super::media_type_name;
 use crate::cache::ParsedSourceCacheRc;
 use crate::cjs::CjsTrackerRc;
 use crate::emit::EmitParsedSourceHelperError;
@@ -83,6 +84,14 @@ pub enum LoadCodeSourceErrorKind {
     "Attempted to load JSON module without specifying \"type\": \"json\" attribute in the import statement."
   )]
   MissingJsonAttribute,
+  #[class(type)]
+  #[error(
+    "Expected a JSON module, but identified a {actual} module.\n  Specifier: {specifier}"
+  )]
+  ExpectedJsonModule {
+    specifier: Url,
+    actual: &'static str,
+  },
   #[class(inherit)]
   #[error(transparent)]
   NpmModuleLoad(#[from] NpmModuleLoadError),
@@ -250,6 +259,16 @@ impl<TSys: ModuleLoaderSys> ModuleLoader<TSys> {
           && matches!(self.allow_json_imports, AllowJsonImports::WithAttribute)
         {
           Err(LoadCodeSourceErrorKind::MissingJsonAttribute.into_box())
+        } else if matches!(requested_module_type, RequestedModuleType::Json)
+          && loaded_module.media_type != MediaType::Json
+        {
+          Err(
+            LoadCodeSourceErrorKind::ExpectedJsonModule {
+              specifier: loaded_module.specifier.clone().into_owned(),
+              actual: media_type_name(loaded_module.media_type),
+            }
+            .into_box(),
+          )
         } else {
           Ok(source)
         }
@@ -281,6 +300,17 @@ impl<TSys: ModuleLoaderSys> ModuleLoader<TSys> {
       && matches!(self.allow_json_imports, AllowJsonImports::WithAttribute)
     {
       return Err(LoadCodeSourceErrorKind::MissingJsonAttribute.into_box());
+    }
+    if matches!(requested_module_type, RequestedModuleType::Json)
+      && loaded_module.media_type != MediaType::Json
+    {
+      return Err(
+        LoadCodeSourceErrorKind::ExpectedJsonModule {
+          specifier: loaded_module.specifier.clone().into_owned(),
+          actual: media_type_name(loaded_module.media_type),
+        }
+        .into_box(),
+      );
     }
 
     Ok(Some(loaded_module))

--- a/libs/resolver/loader/npm.rs
+++ b/libs/resolver/loader/npm.rs
@@ -16,6 +16,7 @@ use url::Url;
 use super::LoadedModule;
 use super::LoadedModuleSource;
 use super::RequestedModuleType;
+use super::media_type_name;
 use crate::cjs::CjsTrackerRc;
 
 #[derive(Debug, Error, deno_error::JsError)]
@@ -66,6 +67,14 @@ pub enum NpmModuleLoadError {
     #[source]
     #[inherit]
     source: std::io::Error,
+  },
+  #[class(type)]
+  #[error(
+    "Expected a JSON module, but identified a {actual} module.\n  Specifier: {specifier}"
+  )]
+  ExpectedJsonModule {
+    specifier: Url,
+    actual: &'static str,
   },
 }
 
@@ -186,6 +195,15 @@ impl<
     })?;
 
     let media_type = MediaType::from_specifier(&specifier);
+    if matches!(requested_module_type, RequestedModuleType::Json)
+      && media_type != MediaType::Json
+    {
+      return Err(NpmModuleLoadError::ExpectedJsonModule {
+        specifier: specifier.clone().into_owned(),
+        actual: media_type_name(media_type),
+      });
+    }
+
     match requested_module_type {
       RequestedModuleType::Text | RequestedModuleType::Bytes => {
         Ok(LoadedModule {

--- a/tests/specs/run/byonm_json_attribute_mismatch/__test__.jsonc
+++ b/tests/specs/run/byonm_json_attribute_mismatch/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "npm_js_rejected_when_json_requested": {
+      "args": "run -A main.ts",
+      "output": "true\ntrue\nexecuted false\n"
+    }
+  }
+}

--- a/tests/specs/run/byonm_json_attribute_mismatch/deno.json
+++ b/tests/specs/run/byonm_json_attribute_mismatch/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "manual"
+}

--- a/tests/specs/run/byonm_json_attribute_mismatch/main.ts
+++ b/tests/specs/run/byonm_json_attribute_mismatch/main.ts
@@ -1,0 +1,14 @@
+Object.defineProperty(globalThis, "packageExecuted", {
+  value: false,
+  writable: true,
+});
+
+try {
+  await import("npm:testpkg@1.0.0", { with: { type: "json" } });
+  console.log("unexpected success");
+  Deno.exit(1);
+} catch (err) {
+  console.log(err instanceof TypeError);
+  console.log(String(err).includes("Expected a JSON module"));
+  console.log("executed", globalThis.packageExecuted);
+}

--- a/tests/specs/run/byonm_json_attribute_mismatch/node_modules/testpkg/index.js
+++ b/tests/specs/run/byonm_json_attribute_mismatch/node_modules/testpkg/index.js
@@ -1,0 +1,3 @@
+globalThis.packageExecuted = true;
+console.log("PACKAGE_EXECUTED");
+export default { ok: true };

--- a/tests/specs/run/byonm_json_attribute_mismatch/node_modules/testpkg/package.json
+++ b/tests/specs/run/byonm_json_attribute_mismatch/node_modules/testpkg/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "testpkg",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module"
+}


### PR DESCRIPTION
## Summary

- require modules requested with `type: "json"` to resolve to JSON media
- apply the check to prepared modules and direct npm module loading
- add a BYONM regression covering a JavaScript package requested as JSON

## Details

The loader already rejected JSON modules imported without the JSON attribute, but it did not consistently enforce the reverse direction. In the npm/BYONM path, a non-JSON module requested as JSON could continue through JavaScript loading.

This change reports a module-type error before CJS translation or module evaluation when the requested and loaded types do not match.

## Validation

- `./tools/format.js`
- `cargo check -p deno_resolver --all-features`
- `cargo build --bin deno`
- `cargo test -p specs_tests --test specs run::byonm_json_attribute_mismatch -- --nocapture`
- `cargo test -p specs_tests --test specs run::npm_json_without_attribute_error -- --nocapture`
- `cargo test -p specs_tests --test specs run::byonm_exact_version -- --nocapture`
- `cargo test -p specs_tests --test specs run::import_attributes_dynamic_import -- --nocapture`
