### PR TITLE
fix(rt): isolate extracted native addons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,6 +3811,7 @@ version = "0.53.0"
 dependencies = [
  "deno_error",
  "deno_path_util",
+ "libc",
  "sys_traits",
  "tempfile",
  "thiserror 2.0.12",

--- a/ext/rt_helper/Cargo.toml
+++ b/ext/rt_helper/Cargo.toml
@@ -17,9 +17,9 @@ path = "lib.rs"
 deno_error.workspace = true
 deno_path_util.workspace = true
 sys_traits = { features = ["getrandom", "real"], workspace = true }
+tempfile.workspace = true
 thiserror.workspace = true
 twox-hash.workspace = true
 
-[dev-dependencies]
-sys_traits = { features = ["getrandom", "real", "memory"], workspace = true }
-tempfile.workspace = true
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true

--- a/ext/rt_helper/lib.rs
+++ b/ext/rt_helper/lib.rs
@@ -1,16 +1,21 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
+use std::fs;
 use std::fs::File;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::io::BufReader;
+use std::io::ErrorKind;
 use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use sys_traits::EnvTempDir;
+
+const NATIVE_ADDON_CACHE_DIR_NAME: &str = "deno-native-addons";
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum LoadError {
@@ -54,13 +59,15 @@ pub trait DenoRtNativeAddonLoader: Send + Sync {
           .and_then(|p| p.file_stem())
           .map(|s| s.to_string_lossy())
           .unwrap_or("denort".into());
-        let real_path = resolve_temp_file_name(
-          &sys_traits::impls::RealSys,
-          &exe_name,
-          path,
-          &bytes,
-        )
-        .map_err(LoadError::Io)?;
+        let cache_dir = native_addon_cache_dir().map_err(LoadError::Io)?;
+        let real_path =
+          resolve_temp_file_name(cache_dir, &exe_name, path, &bytes);
+        let cache_dir = real_path.parent().ok_or_else(|| {
+          LoadError::Io(std::io::Error::other(
+            "Native addon cache path had no parent",
+          ))
+        })?;
+        ensure_private_native_addon_dir(cache_dir).map_err(LoadError::Io)?;
         if let Err(err) = deno_path_util::fs::atomic_write_file(
           &sys_traits::impls::RealSys,
           &real_path,
@@ -92,6 +99,21 @@ pub trait DenoRtNativeAddonLoader: Send + Sync {
 }
 
 fn file_matches_bytes(path: &Path, expected_bytes: &[u8]) -> bool {
+  let path_metadata = match fs::symlink_metadata(path) {
+    Ok(metadata) => metadata,
+    Err(_) => return false,
+  };
+  if path_metadata.file_type().is_symlink() || !path_metadata.is_file() {
+    return false;
+  }
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::MetadataExt;
+    if path_metadata.uid() != current_uid() {
+      return false;
+    }
+  }
+
   let file = match File::open(path) {
     Ok(f) => f,
     Err(_) => return false,
@@ -127,12 +149,17 @@ fn file_matches_bytes(path: &Path, expected_bytes: &[u8]) -> bool {
   }
 }
 
+#[cfg(unix)]
+fn current_uid() -> u32 {
+  unsafe { libc::geteuid() }
+}
+
 fn resolve_temp_file_name(
-  sys: &impl EnvTempDir,
+  cache_dir: &Path,
   current_exe_name: &str,
   path: &Path,
   bytes: &[u8],
-) -> std::io::Result<PathBuf> {
+) -> PathBuf {
   // should be deterministic
   let path_hash = {
     let mut hasher = twox_hash::XxHash64::default();
@@ -150,16 +177,115 @@ fn resolve_temp_file_name(
     file_name.push('.');
     file_name.push_str(&ext.to_string_lossy());
   }
-  Ok(sys.env_temp_dir()?.join(&file_name))
+  cache_dir.join(&file_name)
+}
+
+fn native_addon_cache_dir() -> std::io::Result<&'static Path> {
+  static CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+  if let Some(cache_dir) = CACHE_DIR.get() {
+    return Ok(cache_dir);
+  }
+
+  let temp_dir = sys_traits::impls::RealSys.env_temp_dir()?;
+  let cache_dir = create_native_addon_cache_dir(&temp_dir)?;
+  Ok(CACHE_DIR.get_or_init(|| cache_dir))
+}
+
+fn create_native_addon_cache_dir(temp_dir: &Path) -> std::io::Result<PathBuf> {
+  let preferred = temp_dir.join(NATIVE_ADDON_CACHE_DIR_NAME);
+  if ensure_private_native_addon_dir(&preferred).is_ok() {
+    return Ok(preferred);
+  }
+
+  let mut builder = tempfile::Builder::new();
+  builder.prefix("deno-native-addons-");
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+    builder.permissions(fs::Permissions::from_mode(0o700));
+  }
+  let fallback = builder.tempdir_in(temp_dir)?;
+  let fallback = fallback.into_path();
+  validate_private_native_addon_dir(&fallback)?;
+  Ok(fallback)
+}
+
+#[cfg(unix)]
+fn create_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
+  use std::os::unix::fs::DirBuilderExt;
+
+  let mut builder = fs::DirBuilder::new();
+  builder.mode(0o700);
+  match builder.create(path) {
+    Ok(()) => Ok(()),
+    Err(err) if err.kind() == ErrorKind::AlreadyExists => Ok(()),
+    Err(err) => Err(err),
+  }
+}
+
+#[cfg(not(unix))]
+fn create_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
+  match fs::create_dir(path) {
+    Ok(()) => Ok(()),
+    Err(err) if err.kind() == ErrorKind::AlreadyExists => Ok(()),
+    Err(err) => Err(err),
+  }
+}
+
+fn ensure_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
+  create_private_native_addon_dir(path)?;
+  validate_private_native_addon_dir(path)
+}
+
+fn validate_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
+  let metadata = fs::symlink_metadata(path)?;
+  if metadata.file_type().is_symlink() || !metadata.is_dir() {
+    return Err(std::io::Error::new(
+      ErrorKind::PermissionDenied,
+      format!(
+        "Native addon cache path '{}' is not a private directory",
+        path.display()
+      ),
+    ));
+  }
+
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::MetadataExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    if metadata.uid() != current_uid() {
+      return Err(std::io::Error::new(
+        ErrorKind::PermissionDenied,
+        format!(
+          "Native addon cache directory '{}' is not owned by the current user",
+          path.display()
+        ),
+      ));
+    }
+
+    if metadata.permissions().mode() & 0o777 != 0o700 {
+      fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+      let metadata = fs::symlink_metadata(path)?;
+      if metadata.permissions().mode() & 0o777 != 0o700 {
+        return Err(std::io::Error::new(
+          ErrorKind::PermissionDenied,
+          format!(
+            "Native addon cache directory '{}' is not private",
+            path.display()
+          ),
+        ));
+      }
+    }
+  }
+
+  Ok(())
 }
 
 #[cfg(test)]
 mod test {
   #![allow(clippy::disallowed_methods, reason = "test code")]
-
-  use sys_traits::EnvTempDir;
-  use sys_traits::FsCreateDirAll;
-  use sys_traits::impls::InMemorySys;
 
   use super::*;
 
@@ -177,20 +303,103 @@ mod test {
     assert!(!file_matches_bytes(&path, &bytes));
   }
 
+  #[cfg(unix)]
+  #[test]
+  fn test_file_matches_bytes_rejects_symlink() {
+    let tempdir = tempfile::TempDir::new().unwrap();
+    let target = tempdir.path().join("target.node");
+    let link = tempdir.path().join("link.node");
+    let bytes = b"native addon";
+    std::fs::write(&target, bytes).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    assert!(!file_matches_bytes(&link, bytes));
+  }
+
   #[test]
   fn test_resolve_temp_file_name() {
-    let sys = InMemorySys::default();
-    sys.fs_create_dir_all("/").unwrap();
+    let cache_dir = PathBuf::from("/native-addons");
     let file_path = PathBuf::from("/test/test.node");
     let bytes: [u8; 3] = [1, 2, 3];
     let temp_file =
-      resolve_temp_file_name(&sys, "exe_name", &file_path, &bytes).unwrap();
+      resolve_temp_file_name(&cache_dir, "exe_name", &file_path, &bytes);
     assert_eq!(
       temp_file,
-      sys
-        .env_temp_dir()
-        .unwrap()
-        .join("exe_name1805603793990095570513255480333703631005.node")
+      cache_dir.join("exe_name1805603793990095570513255480333703631005.node")
     );
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn test_native_addon_cache_dir_falls_back_from_symlink() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tempdir = tempfile::TempDir::new().unwrap();
+    let target = tempdir.path().join("target");
+    let preferred = tempdir.path().join(NATIVE_ADDON_CACHE_DIR_NAME);
+    std::fs::create_dir(&target).unwrap();
+    std::os::unix::fs::symlink(&target, &preferred).unwrap();
+
+    let cache_dir = create_native_addon_cache_dir(tempdir.path()).unwrap();
+
+    assert_ne!(cache_dir, preferred);
+    assert_eq!(cache_dir.parent(), Some(tempdir.path()));
+    assert!(
+      cache_dir
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .starts_with("deno-native-addons-")
+    );
+    let metadata = std::fs::symlink_metadata(&cache_dir).unwrap();
+    assert!(metadata.is_dir());
+    assert!(!metadata.file_type().is_symlink());
+    assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
+    assert!(std::fs::symlink_metadata(&preferred).unwrap().is_symlink());
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn test_ensure_private_native_addon_dir_creates_private_dir() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tempdir = tempfile::TempDir::new().unwrap();
+    let path = tempdir.path().join("cache");
+
+    ensure_private_native_addon_dir(&path).unwrap();
+
+    let metadata = std::fs::symlink_metadata(&path).unwrap();
+    assert!(metadata.is_dir());
+    assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn test_ensure_private_native_addon_dir_repairs_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tempdir = tempfile::TempDir::new().unwrap();
+    let path = tempdir.path().join("cache");
+    std::fs::create_dir(&path).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o777))
+      .unwrap();
+
+    ensure_private_native_addon_dir(&path).unwrap();
+
+    let metadata = std::fs::symlink_metadata(&path).unwrap();
+    assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn test_ensure_private_native_addon_dir_rejects_symlink() {
+    let tempdir = tempfile::TempDir::new().unwrap();
+    let target = tempdir.path().join("target");
+    let link = tempdir.path().join("cache");
+    std::fs::create_dir(&target).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let err = ensure_private_native_addon_dir(&link).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::PermissionDenied);
   }
 }

--- a/ext/rt_helper/lib.rs
+++ b/ext/rt_helper/lib.rs
@@ -98,6 +98,7 @@ pub trait DenoRtNativeAddonLoader: Send + Sync {
   }
 }
 
+#[allow(clippy::disallowed_methods, reason = "requires real fs")]
 fn file_matches_bytes(path: &Path, expected_bytes: &[u8]) -> bool {
   let path_metadata = match fs::symlink_metadata(path) {
     Ok(metadata) => metadata,
@@ -151,6 +152,8 @@ fn file_matches_bytes(path: &Path, expected_bytes: &[u8]) -> bool {
 
 #[cfg(unix)]
 fn current_uid() -> u32 {
+  // SAFETY: `geteuid` takes no arguments and is always safe to call; it
+  // cannot fail and has no preconditions.
   unsafe { libc::geteuid() }
 }
 
@@ -212,6 +215,7 @@ fn create_native_addon_cache_dir(temp_dir: &Path) -> std::io::Result<PathBuf> {
 }
 
 #[cfg(unix)]
+#[allow(clippy::disallowed_methods, reason = "requires real fs")]
 fn create_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
   use std::os::unix::fs::DirBuilderExt;
 
@@ -225,6 +229,7 @@ fn create_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(not(unix))]
+#[allow(clippy::disallowed_methods, reason = "requires real fs")]
 fn create_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
   match fs::create_dir(path) {
     Ok(()) => Ok(()),
@@ -238,6 +243,7 @@ fn ensure_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
   validate_private_native_addon_dir(path)
 }
 
+#[allow(clippy::disallowed_methods, reason = "requires real fs")]
 fn validate_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
   let metadata = fs::symlink_metadata(path)?;
   if metadata.file_type().is_symlink() || !metadata.is_dir() {

--- a/ext/rt_helper/lib.rs
+++ b/ext/rt_helper/lib.rs
@@ -62,12 +62,6 @@ pub trait DenoRtNativeAddonLoader: Send + Sync {
         let cache_dir = native_addon_cache_dir().map_err(LoadError::Io)?;
         let real_path =
           resolve_temp_file_name(cache_dir, &exe_name, path, &bytes);
-        let cache_dir = real_path.parent().ok_or_else(|| {
-          LoadError::Io(std::io::Error::other(
-            "Native addon cache path had no parent",
-          ))
-        })?;
-        ensure_private_native_addon_dir(cache_dir).map_err(LoadError::Io)?;
         if let Err(err) = deno_path_util::fs::atomic_write_file(
           &sys_traits::impls::RealSys,
           &real_path,
@@ -256,6 +250,8 @@ fn validate_private_native_addon_dir(path: &Path) -> std::io::Result<()> {
     ));
   }
 
+  // Windows temp directories are normally per-user; Unix additionally
+  // enforces ownership and mode here.
   #[cfg(unix)]
   {
     use std::os::unix::fs::MetadataExt;


### PR DESCRIPTION
## Summary

- extract embedded native addons into a validated owner-only directory
- reject redirected or mismatched existing addon files before reuse
- use a randomized fallback when the preferred directory is unavailable

## Details

Compiled executables previously extracted embedded native addons directly into
the operating-system temporary directory using a deterministic filename. This
made addon loading depend on unrelated entries already present at that path.

The runtime now uses a dedicated directory, validates it before each write,
and checks an existing file's type and ownership before comparing its contents.
If the preferred directory cannot be used, the process creates a randomized
owner-only fallback directory.

## Validation

- `./tools/format.js --check`
- `cargo test -p denort_helper -- --nocapture`
- `cargo check -p denort`

AI assistance was used to help implement and test this change.
