### PR TITLE
fix(cache): store Web Cache under origin data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,6 +2172,7 @@ dependencies = [
  "rusqlite",
  "sha2",
  "slab",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -141,13 +141,18 @@ impl StorageKeyResolver {
   }
 }
 
-pub fn get_cache_storage_dir() -> PathBuf {
-  #[allow(
-    clippy::disallowed_methods,
-    reason = "ok because this won't ever be used by the js runtime"
-  )]
-  // Note: we currently use temp_dir() to avoid managing storage size.
-  std::env::temp_dir().join("deno_cache")
+/// Returns the persistent Cache API storage root beneath Deno's origin data
+/// directory. Each storage key uses a hashed child directory of this root.
+pub fn get_cache_storage_dir(origin_data_folder_path: &Path) -> PathBuf {
+  origin_data_folder_path.join("web_cache")
+}
+
+fn get_cache_storage_dir_for_key(
+  origin_data_folder_path: &Path,
+  key: &str,
+) -> PathBuf {
+  get_cache_storage_dir(origin_data_folder_path)
+    .join(checksum::r#gen(&[key.as_bytes()]))
 }
 
 /// By default V8 uses 1.4Gb heap limit which is meant for browser tabs.
@@ -377,9 +382,12 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
       let maybe_storage_key = shared
         .storage_key_resolver
         .resolve_storage_key(&args.main_module);
-      let cache_storage_dir = maybe_storage_key.map(|key| {
+      let cache_storage_dir = maybe_storage_key.as_ref().map(|key| {
         // TODO(@satyarohith): storage quota management
-        get_cache_storage_dir().join(checksum::r#gen(&[key.as_bytes()]))
+        get_cache_storage_dir_for_key(
+          shared.options.origin_data_folder_path.as_ref().unwrap(), // must be set if storage key resolver returns a value
+          key,
+        )
       });
 
       // TODO(bartlomieju): this is cruft, update FeatureChecker to spit out
@@ -680,9 +688,12 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
           .unwrap() // must be set if storage key resolver returns a value
           .join(checksum::r#gen(&[key.as_bytes()]))
       });
-    let cache_storage_dir = maybe_storage_key.map(|key| {
+    let cache_storage_dir = maybe_storage_key.as_ref().map(|key| {
       // TODO(@satyarohith): storage quota management
-      get_cache_storage_dir().join(checksum::r#gen(&[key.as_bytes()]))
+      get_cache_storage_dir_for_key(
+        shared.options.origin_data_folder_path.as_ref().unwrap(), // must be set if storage key resolver returns a value
+        key,
+      )
     });
 
     let services = WorkerServiceOptions {
@@ -1080,5 +1091,22 @@ mod test {
     // test empty
     let resolver = StorageKeyResolver::empty();
     assert_eq!(resolver.resolve_storage_key(&specifier), None);
+  }
+
+  #[test]
+  fn cache_storage_dir_is_under_origin_data() {
+    let origin_data_dir = PathBuf::from("deno_dir").join("location_data");
+    let key = "file:///project/main.ts";
+
+    assert_eq!(
+      get_cache_storage_dir(&origin_data_dir),
+      origin_data_dir.join("web_cache")
+    );
+    assert_eq!(
+      get_cache_storage_dir_for_key(&origin_data_dir, key),
+      origin_data_dir
+        .join("web_cache")
+        .join(checksum::r#gen(&[key.as_bytes()]))
+    );
   }
 }

--- a/cli/tools/info.rs
+++ b/cli/tools/info.rs
@@ -236,7 +236,7 @@ fn print_cache_info(
   let registry_cache = dir.registries_folder_path();
   let mut origin_dir = dir.origin_data_folder_path();
   let deno_dir = dir.root_path_for_display().to_string();
-  let web_cache_dir = deno_lib::worker::get_cache_storage_dir();
+  let web_cache_dir = deno_lib::worker::get_cache_storage_dir(&origin_dir);
 
   if let Some(location) = &location {
     origin_dir =

--- a/ext/cache/Cargo.toml
+++ b/ext/cache/Cargo.toml
@@ -33,3 +33,6 @@ slab.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/ext/cache/sqlite.rs
+++ b/ext/cache/sqlite.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::future::poll_fn;
+use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -43,6 +44,49 @@ enum Mode {
   InMemory,
 }
 
+#[allow(
+  clippy::disallowed_methods,
+  reason = "cache storage manages its own directory"
+)]
+fn create_cache_storage_dir(
+  cache_storage_dir: &Path,
+) -> Result<(), CacheError> {
+  if let Ok(metadata) = std::fs::symlink_metadata(cache_storage_dir)
+    && metadata.file_type().is_symlink()
+  {
+    return Err(CacheError::CacheStorageDirectory {
+      dir: cache_storage_dir.to_path_buf(),
+      source: std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        "cache storage directory must not be a symlink",
+      ),
+    });
+  }
+
+  std::fs::create_dir_all(cache_storage_dir).map_err(|source| {
+    CacheError::CacheStorageDirectory {
+      dir: cache_storage_dir.to_path_buf(),
+      source,
+    }
+  })?;
+
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(
+      cache_storage_dir,
+      std::fs::Permissions::from_mode(0o700),
+    )
+    .map_err(|source| CacheError::CacheStorageDirectory {
+      dir: cache_storage_dir.to_path_buf(),
+      source,
+    })?;
+  }
+
+  Ok(())
+}
+
 impl SqliteBackedCache {
   pub fn new(cache_storage_dir: PathBuf) -> Result<Self, CacheError> {
     let mode = match std::env::var("DENO_CACHE_DB_MODE")
@@ -61,16 +105,7 @@ impl SqliteBackedCache {
       rusqlite::Connection::open_in_memory()
         .unwrap_or_else(|_| panic!("failed to open in-memory cache db"))
     } else {
-      #[allow(
-        clippy::disallowed_methods,
-        reason = "cache storage manages its own directory"
-      )]
-      std::fs::create_dir_all(&cache_storage_dir).map_err(|source| {
-        CacheError::CacheStorageDirectory {
-          dir: cache_storage_dir.clone(),
-          source,
-        }
-      })?;
+      create_cache_storage_dir(&cache_storage_dir)?;
 
       let path = cache_storage_dir.join("cache_metadata.db");
       let connection = rusqlite::Connection::open(&path).unwrap_or_else(|_| {
@@ -475,4 +510,52 @@ impl deno_core::Resource for SqliteBackedCache {
 pub fn hash(token: &str) -> String {
   use sha2::Digest;
   format!("{:x}", sha2::Sha256::digest(token.as_bytes()))
+}
+
+#[cfg(all(test, unix))]
+#[allow(
+  clippy::disallowed_methods,
+  reason = "tests control their own temporary filesystem state"
+)]
+mod tests {
+  use std::os::unix::fs::PermissionsExt;
+  use std::os::unix::fs::symlink;
+
+  use super::*;
+
+  #[test]
+  fn cache_storage_dir_rejects_symlink() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let target_dir = temp_dir.path().join("target");
+    let cache_storage_dir = temp_dir.path().join("cache");
+    std::fs::create_dir(&target_dir).unwrap();
+    symlink(&target_dir, &cache_storage_dir).unwrap();
+
+    let error = create_cache_storage_dir(&cache_storage_dir).unwrap_err();
+    let CacheError::CacheStorageDirectory { dir, source } = error else {
+      panic!("unexpected cache directory error");
+    };
+    assert_eq!(dir, cache_storage_dir);
+    assert_eq!(source.kind(), std::io::ErrorKind::InvalidInput);
+  }
+
+  #[test]
+  fn cache_storage_dir_has_private_permissions() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_storage_dir = temp_dir.path().join("cache");
+    std::fs::create_dir(&cache_storage_dir).unwrap();
+    std::fs::set_permissions(
+      &cache_storage_dir,
+      std::fs::Permissions::from_mode(0o777),
+    )
+    .unwrap();
+
+    create_cache_storage_dir(&cache_storage_dir).unwrap();
+
+    let mode = std::fs::metadata(&cache_storage_dir)
+      .unwrap()
+      .permissions()
+      .mode();
+    assert_eq!(mode & 0o777, 0o700);
+  }
 }

--- a/tests/integration/cache_tests.rs
+++ b/tests/integration/cache_tests.rs
@@ -103,6 +103,32 @@ fn cache_put_overwrite() {
 }
 
 #[test]
+fn web_cache_is_stored_under_deno_dir() {
+  let test_context = TestContextBuilder::new().use_temp_cwd().build();
+  test_context
+    .temp_dir()
+    .write("main.js", "await caches.open('test');");
+
+  test_context
+    .new_command()
+    .args("run main.js")
+    .run()
+    .assert_exit_code(0);
+
+  let web_cache_dir = test_context
+    .deno_dir()
+    .path()
+    .join("location_data")
+    .join("web_cache");
+  let storage_dirs = std::fs::read_dir(&web_cache_dir)
+    .unwrap()
+    .collect::<Result<Vec<_>, _>>()
+    .unwrap();
+  assert_eq!(storage_dirs.len(), 1);
+  assert!(storage_dirs[0].path().join("cache_metadata.db").is_file());
+}
+
+#[test]
 fn loads_type_graph() {
   let output = TestContext::default()
     .new_command()

--- a/tests/specs/info/flag/041_info_flag.out
+++ b/tests/specs/info/flag/041_info_flag.out
@@ -5,4 +5,4 @@ npm modules cache: [WILDCARD]npm
 Emitted modules cache: [WILDCARD]gen
 Language server registries cache: [WILDCARD]registries
 Origin storage: [WILDCARD]location_data
-Web cache storage: [WILDCARD]deno_cache
+Web cache storage: [WILDCARD]location_data[WILDCARD]web_cache

--- a/tests/specs/info/flag_location/041_info_flag_location.out
+++ b/tests/specs/info/flag_location/041_info_flag_location.out
@@ -5,5 +5,5 @@ npm modules cache: [WILDCARD]npm
 Emitted modules cache: [WILDCARD]gen
 Language server registries cache: [WILDCARD]registries
 Origin storage: [WILDCARD]location_data[WILDCARD]
-Web cache storage: [WILDCARD]deno_cache
+Web cache storage: [WILDCARD]location_data[WILDCARD]web_cache
 Local Storage: [WILDCARD]location_data[WILDCARD]local_storage

--- a/tests/specs/info/json/info_json.out
+++ b/tests/specs/info/json/info_json.out
@@ -7,5 +7,5 @@
   "typescriptCache": "[WILDCARD]gen",
   "registryCache": "[WILDCARD]registries",
   "originStorage": "[WILDCARD]location_data",
-  "webCacheStorage": [WILDCARD]deno_cache"
+  "webCacheStorage": [WILDCARD]location_data[WILDCARD]web_cache"
 }


### PR DESCRIPTION
## Summary

- store Cache API data beneath Deno's origin-data directory
- reject redirected final cache directories and use owner-only Unix modes
- update `deno info` output and cover the persisted location end to end

## Details

The Web Cache implementation stored its SQLite metadata and response bodies in
a system temporary directory, independently of the selected Deno cache and
origin-data location. This also made otherwise persistent Cache API state
subject to temporary-directory lifecycle.

Cache API state now lives under `<DENO_DIR>/location_data/web_cache`, with the
existing storage-key hash separating individual stores. Directory setup
validates the final path before opening the database.

## Validation

- `./tools/format.js --check`
- `cargo test -p deno_cache cache_storage_dir`
- `cargo test -p deno_lib cache_storage_dir_is_under_origin_data`
- `cargo test -p integration_tests --test integration -- web_cache_is_stored_under_deno_dir --nocapture`
- `cargo test -p integration_tests --test integration -- cache_put_overwrite --nocapture`
- `cargo test -p specs_tests --test specs -- info::flag --nocapture`
- `cargo test -p specs_tests --test specs -- info::json --nocapture`
- `cargo check -p deno_lib -p deno_cache`
- `cargo clippy -p deno_cache --tests -- -D warnings`

AI assistance was used to help implement and test this change.
