### PR TITLE
fix(desktop): retain update signature verification op

### DIFF
--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -705,6 +705,7 @@ const NOT_IMPORTED_OPS = [
   "Notification",
   "op_desktop_apply_patch",
   "op_desktop_confirm_update",
+  "op_desktop_verify_ed25519",
   "op_desktop_init",
   "op_desktop_recv_event",
   "op_desktop_resolve_bind_call",

--- a/tests/unit/ops_test.ts
+++ b/tests/unit/ops_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-const EXPECTED_OP_COUNT = 41;
+const EXPECTED_OP_COUNT = 42;
 const EXPECTED_WORKER_OP_COUNT = 19;
 
 function getExposedOpNames(): string[] {
@@ -18,6 +18,10 @@ Deno.test(function checkExposedOps() {
         opNames.join("\n")
       }`,
     );
+  }
+
+  if (!opNames.includes("op_desktop_verify_ed25519")) {
+    throw new Error("Desktop update signature verification op is not exposed");
   }
 });
 Deno.test(function internalCoreOnlyHidesExtensionLoaders() {

--- a/tests/unit/ops_test.ts
+++ b/tests/unit/ops_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 const EXPECTED_OP_COUNT = 42;
-const EXPECTED_WORKER_OP_COUNT = 19;
+const EXPECTED_WORKER_OP_COUNT = 20;
 
 function getExposedOpNames(): string[] {
   // @ts-ignore TS doesn't allow to index with symbol


### PR DESCRIPTION
## Summary

- retain `op_desktop_verify_ed25519` when imported ops are removed during runtime bootstrap
- assert that the desktop update signature-verification op remains exposed

Without this entry, the desktop auto-update initializer receives `undefined` for the verification op and cannot stage signed updates.

Closes #36150

## Verification

- `./tools/format.js --check runtime/js/99_main.js tests/unit/ops_test.ts`
- `./tools/lint.js --js runtime/js/99_main.js tests/unit/ops_test.ts`
