### PR TITLE
perf(core): drop the per-op .catch wrapper promise

### DIFF
--- a/libs/core/00_infra.js
+++ b/libs/core/00_infra.js
@@ -17,7 +17,6 @@
     Promise,
     PromiseReject,
     PromiseResolve,
-    PromisePrototypeCatch,
     RangeError,
     ReferenceError,
     SafeArrayIterator,
@@ -159,16 +158,8 @@
     const promise = new Promise((resolve, reject) => {
       promiseRing[idx] = [resolve, reject, promiseId];
     });
-    const wrappedPromise = PromisePrototypeCatch(
-      promise,
-      function __opRejectHandler(res) {
-        // recreate the stacktrace and strip internal event loop frames
-        ErrorCaptureStackTrace(res, __opRejectHandler);
-        throw res;
-      },
-    );
-    wrappedPromise[promiseIdSymbol] = promiseId;
-    return wrappedPromise;
+    promise[promiseIdSymbol] = promiseId;
+    return promise;
   }
 
   function __resolvePromise(promiseId, res, isOk) {

--- a/libs/core/runtime/tests/misc.rs
+++ b/libs/core/runtime/tests/misc.rs
@@ -1236,9 +1236,20 @@ async fn test_dynamic_import_module_error_stack() {
     error_str.contains("TypeError: foo"),
     "Expected error to contain 'TypeError: foo', got: {error_str}"
   );
+  // The rejection propagates out of the dynamically imported module and
+  // surfaces the `await import(...)` site in `main.js`.
+  //
+  // Note: this asserts on the `main.js` frame rather than the innermost
+  // `import.js` op-call site. `import.js` awaits a *bare* op stub directly;
+  // its await frame used to be materialized by an `ErrorCaptureStackTrace`
+  // recapture in a per-op `.catch` handler, which has been removed to avoid
+  // allocating a second promise for every pending async op. Every real Deno
+  // async API (`Deno.readFile`, `fetch`, ...) wraps the op in an `async`
+  // function, so V8's async stack traces still include the call site there —
+  // see the CLI `error_023_stack_async` / `fetch_async_error_stack` specs.
   assert!(
-    error_str.contains("at async file:///import.js:1:43"),
-    "Expected error to contain import.js stack frame, got: {error_str}"
+    error_str.contains("at async file:///main.js:1:1"),
+    "Expected error to contain main.js stack frame, got: {error_str}"
   );
 }
 


### PR DESCRIPTION
Every pending async op currently allocates **two** promises: the op promise created in `setPromise`, plus a second, derived promise from `PromisePrototypeCatch(promise, __opRejectHandler)` whose only purpose is to recapture the error stack (stripping internal event-loop frames) on the rare rejection path. This doubles the promise objects the GC sweeps per in-flight op and registers promise-reaction machinery on every op.

This PR returns the raw op promise (still carrying `promiseIdSymbol`, so `refOp`/`unrefOp` keep working) and drops the recapture.

## Impact

- **~6.5% faster** across all tick-path ops on the async op microbench (`libs/core/benches/ops/async.rs`), measured back-to-back:

  | bench (1000 ops/iter) | before | after | Δ |
  |---|---|---|---|
  | `op_async_void_deferred` | 429,487 | 401,318 | −6.6% |
  | `op_async_void_deferred_nofast` | 433,513 | 403,950 | −6.8% |
  | `op_async_void_lazy` | 425,649 | 394,058 | −7.4% |
  | `op_async_yield_deferred` | 423,214 | 396,355 | −6.3% |
  | `op_async_yield_lazy_nofast` | 535,074 | 498,536 | −6.8% |

- One fewer promise + reaction allocated per in-flight async op → less GC pressure on op-heavy servers.

## Stack traces

The recapture only ever affected a **bare op stub awaited directly** (no JS wrapper). Every real Deno async API (`Deno.readFile`, `fetch`, …) is an `async` function that awaits the op, so V8's async stack traces already include the call site without the recapture. Verified caught, uncaught, and dynamic-import error stacks via `deno run` are byte-identical to before.

The one raw-runtime test that exercised the bare-op pattern (`test_dynamic_import_module_error_stack`) is updated: it now asserts on the `await import(...)` site in `main.js` rather than the innermost bare-op frame. The user-facing #20034 guarantee stays covered by the CLI specs `error_023_stack_async` and `fetch_async_error_stack` (both pass).

## Tests

- `cargo test -p deno_core` (441/441 relevant, incl. updated dynamic-import stack test)
- spec: `error_02*` stack tests, `fetch_async_error_stack`, promise/rejection tests — all pass