### PR TITLE
perf(core): run the common-path tick drain in Rust

### DIFF
--- a/libs/core/runtime/jsrealm.rs
+++ b/libs/core/runtime/jsrealm.rs
@@ -176,6 +176,14 @@ impl ContextState {
     self.tick_info[0] != 0
   }
 
+  /// Mirrors JS `hasRejectionToWarn()`. `tick_info[1]` is written from Rust in
+  /// the promise reject callback and cleared from JS in
+  /// `processTicksAndRejections`; both run on the event loop thread so no
+  /// synchronization is needed for this read.
+  pub(crate) fn has_rejection_to_warn(&self) -> bool {
+    self.tick_info[1] != 0
+  }
+
   pub(crate) fn new(
     op_driver: Rc<OpDriverImpl>,
     isolate_ptr: v8::UnsafeRawIsolatePtr,

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -3641,10 +3641,35 @@ impl JsRuntime {
 
   /// Drain nextTick queue and macrotask queue (no op resolution).
   /// Used when ticks are pending but no async ops completed.
+  ///
+  /// This mirrors the JS `drainTicks()` (see `01_core.js`) exactly, but keeps
+  /// the common path — no `process.nextTick` scheduled and no promise rejection
+  /// to warn about, which is every pure-Deno workload — entirely on the Rust
+  /// side. In that case `drainTicks` just runs `op_run_microtasks()` (a
+  /// `perform_microtask_checkpoint`) and returns; doing it here avoids a
+  /// Rust->JS call plus the JS->Rust op call it would otherwise make. Only when
+  /// a tick or rejection is actually pending do we cross into JS to run
+  /// `processTicksAndRejections`. The flag checks and checkpoint ordering are
+  /// byte-for-byte identical to `drainTicks`, so the nextTick-before-`.then`
+  /// and rejectionhandled-before-unhandledrejection invariants are preserved.
   fn drain_next_tick_and_macrotasks<'s, 'i>(
     scope: &mut v8::PinScope<'s, 'i>,
     context_state: &ContextState,
   ) -> Result<(), Box<JsError>> {
+    if !context_state.has_tick_scheduled()
+      && !context_state.has_rejection_to_warn()
+    {
+      scope.perform_microtask_checkpoint();
+      if !context_state.has_tick_scheduled()
+        && !context_state.has_rejection_to_warn()
+      {
+        return Ok(());
+      }
+    }
+
+    // Slow path: a nextTick or rejection is pending. Cross into JS to run
+    // `drainTicks`, which goes straight to `processTicksAndRejections` given
+    // the flags above.
     let undefined: v8::Local<v8::Value> = v8::undefined(scope).into();
 
     v8::tc_scope!(let tc_scope, scope);


### PR DESCRIPTION
Every event-loop tick that resolves an async op calls `drain_next_tick_and_macrotasks`, which unconditionally crossed into JS to run `drainTicks()`. On the common path — no `process.nextTick` scheduled and no promise rejection to warn about, i.e. every pure-Deno workload — `drainTicks()` just runs `op_run_microtasks()` (a `perform_microtask_checkpoint`) and returns. That's a Rust→JS call **plus** a JS→Rust op call per tick to do work Rust can do directly.

This PR performs the common-path microtask checkpoint in Rust and only crosses into JS (to run `processTicksAndRejections`) when a tick or rejection is actually pending.

## Correctness

The flag checks (`has_tick_scheduled` / `has_rejection_to_warn`, both reads of the shared `tick_info` buffer written on the event-loop thread) and the checkpoint ordering are **byte-for-byte identical** to `drainTicks()`, so the nextTick-before-`.then` and rejectionhandled-before-unhandledrejection invariants are preserved:

- `drainTicks()` common path: `if (!hasTick && !hasRejection) { op_run_microtasks(); if (!hasTick && !hasRejection) return; } processTicksAndRejections();`
- Rust equivalent: same two flag checks around one `perform_microtask_checkpoint()`, falling through to the JS `drainTicks` (→ `processTicksAndRejections`) only when a flag is set.

## Impact

~8% faster on the async op microbench (`libs/core/benches/ops/async.rs`), adjacent back-to-back:

| bench (1000 ops/iter) | before | after | Δ |
|---|---|---|---|
| `op_async_void_deferred` | 445,993 | 405,585 | −9.1% |
| `op_async_void_deferred_return` | 445,195 | 404,194 | −9.2% |
| `op_async_yield_deferred` | 441,102 | 404,394 | −8.3% |
| `op_async_yield_lazy` | 548,766 | 500,767 | −8.7% |

No regression across deferred/lazy/yield ops.

## Tests

- Full `deno_core` suite passes.
- nextTick/rejection/microtask ordering specs pass (`next_tick_microtask_order` esm+cjs, `unhandled_rejection*`, `rejection_handled`, `queue_microtask_error*`, `_058_tasks_microtasks_close`).
- Timer/setImmediate ordering specs pass.