### PR TITLE
perf(core): ASCII fast path for op string return values

### DIFF
--- a/libs/core/benches/ops/sync.rs
+++ b/libs/core/benches/ops/sync.rs
@@ -23,6 +23,9 @@ deno_core::extension!(
     op_string_bytestring,
     op_string_bytestring_no_side_effects,
     op_string_option_u32,
+    op_string_return,
+    op_string_return_large,
+    op_string_return_utf8_large,
     op_string_serde,
     op_string_owned,
     op_local,
@@ -110,6 +113,27 @@ pub fn op_string_owned(#[string] s: String) -> u32 {
 #[op2]
 pub fn op_string_option_u32(#[string] s: &str) -> Option<u32> {
   Some(s.len() as _)
+}
+
+// Realistic short ASCII result (e.g. a header name).
+#[op2]
+#[string]
+pub fn op_string_return() -> String {
+  "content-type".to_string()
+}
+
+// 1000-char ASCII result (exercises the ASCII return path at scale).
+#[op2]
+#[string]
+pub fn op_string_return_large() -> String {
+  "*".repeat(1000)
+}
+
+// 1000-char non-ASCII result (exercises the UTF-8 fallback).
+#[op2]
+#[string]
+pub fn op_string_return_utf8_large() -> String {
+  "\u{1000}".repeat(1000)
 }
 
 #[op2(fast)]
@@ -605,6 +629,39 @@ fn bench_op_arraybuffer(b: &mut Bencher) {
   );
 }
 
+/// Return a short ASCII string from Rust.
+fn bench_op_string_return(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_string_return",
+    0,
+    "accum += op_string_return().length;",
+  );
+}
+
+/// Return a 1000-char ASCII string from Rust (exercises the ASCII return path).
+fn bench_op_string_return_large(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_string_return_large",
+    0,
+    "accum += op_string_return_large().length;",
+  );
+}
+
+/// Return a 1000-char non-ASCII string from Rust (exercises the UTF-8 fallback).
+fn bench_op_string_return_utf8_large(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_string_return_utf8_large",
+    0,
+    "accum += op_string_return_utf8_large().length;",
+  );
+}
+
 benchmark_group!(
   benches,
   baseline,
@@ -628,6 +685,9 @@ benchmark_group!(
   bench_op_string_large_utf8_1000,
   bench_op_string_large_utf8_1000000,
   bench_op_string_option_u32,
+  bench_op_string_return,
+  bench_op_string_return_large,
+  bench_op_string_return_utf8_large,
   bench_op_string_serde,
   bench_op_string_serde_large_1000,
   bench_op_string_serde_large_utf8_1000,

--- a/libs/core/runtime/ops_rust_to_v8.rs
+++ b/libs/core/runtime/ops_rust_to_v8.rs
@@ -320,7 +320,18 @@ to_v8!((i64, isize): |value, scope| v8::BigInt::new_from_i64(scope, value as _))
 // Strings
 //
 
-to_v8_fallible!((String, Cow<'a, str>, &'a str): |value, scope| v8::String::new(scope, &value).ok_or_else(|| serde_v8::Error::Message("failed to allocate string; buffer exceeds maximum length".into())));
+to_v8_fallible!((String, Cow<'a, str>, &'a str): |value, scope| {
+  // ASCII is the overwhelmingly common case for op string results (paths,
+  // headers, JSON). `v8::String::new` runs V8's UTF-8 decode; the one-byte
+  // constructor skips it, and Rust's `is_ascii()` is SIMD-vectorized. ASCII
+  // is a subset of Latin-1, so the bytes are valid one-byte content as-is.
+  if value.is_ascii() {
+    v8::String::new_from_one_byte(scope, value.as_bytes(), v8::NewStringType::Normal)
+  } else {
+    v8::String::new(scope, &value)
+  }
+  .ok_or_else(|| serde_v8::Error::Message("failed to allocate string; buffer exceeds maximum length".into()))
+});
 to_v8_retval_fallible!((String, Cow<'a, str>, &'a str): |value, scope, rv| {
   if value.is_empty() {
     rv.set_empty_string();


### PR DESCRIPTION
`String` / `&str` / `Cow<str>` op results went through `v8::String::new` (`NewFromUtf8`), which runs V8's UTF-8 scan/decode even for pure-ASCII payloads — the overwhelmingly common case for op results (paths, headers, JSON).

This branches on `value.is_ascii()` (SIMD-vectorized in Rust) and uses `v8::String::new_from_one_byte` for ASCII, which skips the decode entirely. ASCII is a subset of Latin-1, so the bytes are valid one-byte string content as-is; non-ASCII keeps the existing UTF-8 path. This mirrors the argument-direction optimization already done in `to_str_ptr`.

## Impact

Adds string-**return** bench ops to `benches/ops/sync.rs` (only string *arguments* were benched before), measured back-to-back:

| bench (1000 ops/iter) | before | after | Δ |
|---|---|---|---|
| `op_string_return` (short ASCII) | 21,576 | 18,000 | −16.6% |
| `op_string_return_large` (1000-char ASCII) | 94,649 | 88,178 | −6.8% |
| `op_string_return_utf8_large` (non-ASCII) | 5,795,804 | 5,750,595 | unchanged (fallback) |

Most op string results are short ASCII → the ~10–16% end.

## Correctness

Both V8 constructors produce identical JS strings for ASCII input. Round-trip verified across empty, ASCII, the 0x7F (ASCII→fast path) / 0x80 (Latin-1→fallback) boundary, accented, CJK, emoji, and mixed strings. The length-limit error path is unchanged. `deno_core` string tests and `serde_v8` tests pass.