### PR TITLE
perf(fs): remove extra full-buffer copy in readFile ops

### DIFF
--- a/ext/fs/ops.rs
+++ b/ext/fs/ops.rs
@@ -1558,7 +1558,7 @@ pub fn op_fs_read_file_sync(
     .context_path("readfile", &path)?;
 
   // todo(https://github.com/denoland/deno/issues/27107): do not clone here
-  Ok(buf.into_owned().to_vec().into())
+  Ok(buf.into_owned().into())
 }
 
 #[op2(stack_trace)]
@@ -1606,7 +1606,7 @@ pub async fn op_fs_read_file_async(
   };
 
   // todo(https://github.com/denoland/deno/issues/27107): do not clone here
-  Ok(buf.into_owned().to_vec().into())
+  Ok(buf.into_owned().into())
 }
 
 #[op2(stack_trace)]


### PR DESCRIPTION
op_fs_read_file_sync and op_fs_read_file_async returned the file contents
via buf.into_owned().to_vec().into(). The Cow's into_owned() already yields
the owned Vec<u8>, so the subsequent .to_vec() performed a second full-file
allocation and memcpy before the zero-copy Uint8Array conversion (which
moves the Vec into a V8 backing store without copying). Dropping it removes
a whole-file copy from every Deno.readFile()/readFileSync() call, including
node:fs readFile which routes through the same ops.

The into_boxed_slice() inside the Uint8Array conversion does not reallocate
here because std's File::read_to_end pre-sizes the buffer exactly from the
file metadata. The existing todo about issue #27107 (serving deno compile
VFS bytes without copying out of the Cow) is unaffected and stays.

https://claude.ai/code/session_01QXBexiVeaPBqGPgAxcTLNQ