### PR TITLE
perf(fs): open files on the blocking pool in async readFile/writeFile

### DIFF
--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -461,8 +461,10 @@ impl FileSystem for RealFs {
     options: OpenOptions,
     data: Box<[u8]>,
   ) -> FsResult<()> {
-    let mut file = open_with_checked_path(options, &path.as_checked_path())?;
+    // Open on the blocking pool as well: open() can block (e.g. FIFOs,
+    // network filesystems) and must not stall the runtime thread.
     spawn_blocking(move || {
+      let mut file = open_with_checked_path(options, &path.as_checked_path())?;
       #[cfg(unix)]
       if let Some(mode) = options.mode {
         use std::os::unix::fs::PermissionsExt;
@@ -489,8 +491,10 @@ impl FileSystem for RealFs {
     path: CheckedPathBuf,
     options: OpenOptions,
   ) -> FsResult<Cow<'static, [u8]>> {
-    let mut file = open_with_checked_path(options, &path.as_checked_path())?;
+    // Open on the blocking pool as well: open() can block (e.g. FIFOs,
+    // network filesystems) and must not stall the runtime thread.
     spawn_blocking(move || {
+      let mut file = open_with_checked_path(options, &path.as_checked_path())?;
       let mut buf = Vec::new();
       file.read_to_end(&mut buf)?;
       Ok::<_, FsError>(Cow::Owned(buf))

--- a/tests/unit_node/_fs/_fs_rmdir_test.ts
+++ b/tests/unit_node/_fs/_fs_rmdir_test.ts
@@ -84,7 +84,7 @@ Deno.test("SYNC: prevent removing a file", () => {
   const dir = Deno.makeTempDirSync();
   const fileName = "foo.txt";
   const path = join(dir, fileName);
-  Deno.writeTextFile(path, "Hello, world!");
+  Deno.writeTextFileSync(path, "Hello, world!");
   nodeAssert.throws(
     () => rmdirSync(path),
     {
@@ -100,7 +100,7 @@ Deno.test("ASYNC: prevent removing a file", async () => {
   const dir = await Deno.makeTempDir();
   const fileName = "foo.txt";
   const path = join(dir, fileName);
-  Deno.writeTextFile(path, "Hello, world!");
+  await Deno.writeTextFile(path, "Hello, world!");
   await nodeAssert.rejects(
     async () => await rmdirPromise(path),
     {


### PR DESCRIPTION
read_file_async and write_file_async called open() synchronously on the
runtime thread and only moved the subsequent read/write onto the blocking
pool. A blocking open (a FIFO waiting for its peer, a slow network
filesystem) therefore stalled the entire event loop, and N concurrent
readFile() calls serialized their opens on the runtime thread instead of
parallelizing. open_async already opens inside spawn_blocking for exactly
this reason; this applies the same treatment to readFile/writeFile.

Verified with a FIFO: Deno.readFile() of a FIFO whose writer shows up
300ms later used to freeze timers for the whole wait; with this change
the event loop keeps ticking while the open blocks. Error propagation is
unchanged since errors flow out of the spawned task either way.

https://claude.ai/code/session_01QXBexiVeaPBqGPgAxcTLNQ