### PR TITLE
perf(net): use the peer address returned by accept() instead of getpeername

### DIFF
--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -220,7 +220,7 @@ pub async fn op_net_accept_tcp(
     .try_borrow_mut()
     .ok_or_else(|| NetError::AcceptTaskOngoing)?;
   let cancel = RcRef::map(resource, |r| &r.cancel);
-  let (tcp_stream, _socket_addr) = listener
+  let (tcp_stream, remote_addr) = listener
     .accept()
     .try_or_cancel(cancel)
     .await
@@ -234,7 +234,6 @@ pub async fn op_net_accept_tcp(
     _fd_raw = Some(fd.as_raw_fd() as u32);
   }
   let local_addr = tcp_stream.local_addr()?;
-  let remote_addr = tcp_stream.peer_addr()?;
 
   let mut state = state.borrow_mut();
   let rid = state
@@ -903,13 +902,12 @@ pub async fn op_net_accept_vsock(
     .try_borrow_mut()
     .ok_or_else(|| NetError::AcceptTaskOngoing)?;
   let cancel = RcRef::map(resource, |r| &r.cancel);
-  let (vsock_stream, _socket_addr) = listener
+  let (vsock_stream, remote_addr) = listener
     .accept()
     .try_or_cancel(cancel)
     .await
     .map_err(accept_err)?;
   let local_addr = vsock_stream.local_addr()?;
-  let remote_addr = vsock_stream.peer_addr()?;
 
   let mut state = state.borrow_mut();
   let rid = state

--- a/ext/net/ops_unix.rs
+++ b/ext/net/ops_unix.rs
@@ -123,14 +123,13 @@ pub async fn op_net_accept_unix(
     .try_borrow_mut()
     .ok_or(NetError::ListenerBusy)?;
   let cancel = RcRef::map(resource, |r| &r.cancel);
-  let (unix_stream, _socket_addr) = listener
+  let (unix_stream, remote_addr) = listener
     .accept()
     .try_or_cancel(cancel)
     .await
     .map_err(crate::ops::accept_err)?;
 
   let local_addr = unix_stream.local_addr()?;
-  let remote_addr = unix_stream.peer_addr()?;
   let local_addr_path = unix_socket_addr_path(&local_addr)?;
   let remote_addr_path = unix_socket_addr_path(&remote_addr)?;
   let resource = UnixStreamResource::new(unix_stream.into_split());


### PR DESCRIPTION
The TCP, vsock, and unix accept ops discarded the peer address that
accept() already returns and then re-fetched the same value with
peer_addr(), paying an extra getpeername(2) syscall on every accepted
connection. This binds the address from the accept() return value
instead. The tunnel accept op is left alone since its listener comes
from the deno_tunnel crate and does not go through accept(2).

https://claude.ai/code/session_01QXBexiVeaPBqGPgAxcTLNQ