### PR TITLE
perf(ext/node): cheaper nextTick and keep-alive handle detection

### DIFF
--- a/ext/node/polyfills/_http_agent.js
+++ b/ext/node/polyfills/_http_agent.js
@@ -21,6 +21,9 @@ const {
   symbols,
 } = core.loadExtScript("ext:deno_node/internal/async_hooks.ts");
 const { async_id_symbol } = symbols;
+const { kReusedHandle } = core.loadExtScript(
+  "ext:deno_node/internal_binding/symbols.ts",
+);
 const { once } = core.loadExtScript("ext:deno_node/internal/util.mjs");
 const {
   validateNumber,
@@ -74,6 +77,7 @@ class ReusedHandle {
   constructor(type, handle) {
     this.type = type;
     this.handle = handle;
+    this[kReusedHandle] = true;
   }
 }
 

--- a/ext/node/polyfills/_next_tick.ts
+++ b/ext/node/polyfills/_next_tick.ts
@@ -45,10 +45,9 @@ function nextTick<T extends Array<unknown>>(
   callback: (...args: T) => void,
   ...args: T
 ): void;
-function nextTick<T extends Array<unknown>>(
+function nextTick(
   this: unknown,
-  callback: (...args: T) => void,
-  ...args: T
+  callback: (...args: unknown[]) => void,
 ) {
   // If we're snapshotting we don't want to push nextTick to be run. We'll
   // enable next ticks in "__bootstrapNodeProcess()";
@@ -62,24 +61,25 @@ function nextTick<T extends Array<unknown>>(
     return;
   }
 
-  // TODO(bartlomieju): seems superfluous if we don't depend on `arguments`
+  // Use `arguments` instead of a rest parameter so the common
+  // `nextTick(callback)` case allocates no array (matches Node).
   let args_;
-  switch (args.length) {
-    case 0:
-      break;
+  switch (arguments.length) {
     case 1:
-      args_ = [args[0]];
       break;
     case 2:
-      args_ = [args[0], args[1]];
+      args_ = [arguments[1]];
       break;
     case 3:
-      args_ = [args[0], args[1], args[2]];
+      args_ = [arguments[1], arguments[2]];
+      break;
+    case 4:
+      args_ = [arguments[1], arguments[2], arguments[3]];
       break;
     default:
-      args_ = new Array(args.length);
-      for (let i = 0; i < args.length; i++) {
-        args_[i] = args[i];
+      args_ = new Array(arguments.length - 1);
+      for (let i = 1; i < arguments.length; i++) {
+        args_[i - 1] = arguments[i];
       }
   }
 

--- a/ext/node/polyfills/internal/stream_base_commons.ts
+++ b/ext/node/polyfills/internal/stream_base_commons.ts
@@ -26,6 +26,9 @@ const { core, primordials } = __bootstrap;
 const { ownerSymbol } = core.loadExtScript(
   "ext:deno_node/internal/async_hooks.ts",
 );
+const { kReusedHandle } = core.loadExtScript(
+  "ext:deno_node/internal_binding/symbols.ts",
+);
 // deno-lint-ignore no-unused-vars
 const { HandleWrap } = core.loadExtScript(
   "ext:deno_node/internal_binding/handle_wrap.ts",
@@ -117,7 +120,7 @@ function handleWriteReq(req: any, data: any, encoding: string) {
 function onWriteComplete(this: any, status: number) {
   let stream = this.handle[ownerSymbol];
 
-  if (stream.constructor.name === "ReusedHandle") {
+  if (stream[kReusedHandle]) {
     stream = stream.handle;
   }
 
@@ -272,7 +275,7 @@ function onStreamRead(
 
   let stream = this[ownerSymbol];
 
-  if (stream.constructor.name === "ReusedHandle") {
+  if (stream[kReusedHandle]) {
     stream = stream.handle;
   }
 

--- a/ext/node/polyfills/internal_binding/symbols.ts
+++ b/ext/node/polyfills/internal_binding/symbols.ts
@@ -29,9 +29,13 @@ const { Symbol } = primordials;
 
 const asyncIdSymbol: unique symbol = Symbol("asyncIdSymbol");
 const ownerSymbol: unique symbol = Symbol("ownerSymbol");
+// Brands http agent ReusedHandle wrappers so per-chunk stream callbacks can
+// detect them without a constructor-name string comparison.
+const kReusedHandle: unique symbol = Symbol("kReusedHandle");
 
 return {
   asyncIdSymbol,
   ownerSymbol,
+  kReusedHandle,
 };
 })();

--- a/ext/node/polyfills/net.ts
+++ b/ext/node/polyfills/net.ts
@@ -50,6 +50,9 @@ const {
   newAsyncId,
   ownerSymbol,
 } = core.loadExtScript("ext:deno_node/internal/async_hooks.ts");
+const { kReusedHandle } = core.loadExtScript(
+  "ext:deno_node/internal_binding/symbols.ts",
+);
 const {
   AbortError,
   ERR_INVALID_ADDRESS_FAMILY,
@@ -508,7 +511,7 @@ function _afterConnectImpl(
 ) {
   let socket = handle[ownerSymbol];
 
-  if (socket.constructor.name === "ReusedHandle") {
+  if (socket[kReusedHandle]) {
     socket = socket.handle;
   }
 


### PR DESCRIPTION
Two small allocations removed from the hottest node-compat glue.

process.nextTick used a rest parameter, so every call allocated an args
array even in the dominant nextTick(cb) case, then copied it into a
second array. It now reads 'arguments' the way Node does, so the
no-extra-args case allocates nothing; the existing core drain loop
already handles args === undefined. This fires per stream read/write
completion and throughout the node:http request lifecycle.

The socket read/write completion callbacks and the connect callback
detected the http agent's keep-alive ReusedHandle wrapper by comparing
stream.constructor.name against a string on every inbound chunk and
every write completion. ReusedHandle instances now carry a symbol brand
that those callbacks check with a plain property load.

Verified with the process, http, and net node-compat suites plus a
keep-alive agent smoke test exercising the reused-handle path, and a
nextTick call with zero through five extra arguments.

https://claude.ai/code/session_01QXBexiVeaPBqGPgAxcTLNQ