### PR TITLE
perf(ext/web): remove per-chunk allocations in text encoding streams

### DIFF
--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -343,6 +343,8 @@ class TextEncoder {
 
 const encodeIntoBuf = new Uint32Array(2);
 const encodeIntoOpts = { __proto__: null, allowShared: true };
+const allowSharedOpts = { __proto__: null, allowShared: true };
+const decodeStreamOpts = { __proto__: null, stream: true };
 const ENCODE_INTO_PACKED_SENTINEL = -1;
 const ENCODE_INTO_PACKED_MULTIPLIER = 0x100000000;
 
@@ -375,10 +377,13 @@ class TextDecoderStream {
       // without a per-chunk promise or microtask hop when transform() returns
       // undefined. Throws propagate to the stream via transformAlgorithm.
       transform: (chunk, controller) => {
-        chunk = webidl.converters.BufferSource(chunk, prefix, "chunk", {
-          allowShared: true,
-        });
-        const decoded = this.#decoder.decode(chunk, { stream: true });
+        chunk = webidl.converters.BufferSource(
+          chunk,
+          prefix,
+          "chunk",
+          allowSharedOpts,
+        );
+        const decoded = this.#decoder.decode(chunk, decodeStreamOpts);
         if (decoded) {
           controller.enqueue(decoded);
         }
@@ -474,7 +479,9 @@ class TextEncoderStream {
       // without a per-chunk promise or microtask hop when transform() returns
       // undefined. Throws propagate to the stream via transformAlgorithm.
       transform: (chunk, controller) => {
-        chunk = webidl.converters.DOMString(chunk);
+        if (typeof chunk !== "string") {
+          chunk = webidl.converters.DOMString(chunk);
+        }
         if (chunk === "") {
           return;
         }


### PR DESCRIPTION
TextDecoderStream's transform allocated two fresh option object
literals ({ allowShared: true } and { stream: true }) on every chunk;
both are loop-invariant, so hoist them to module-level constants, the
same treatment encodeIntoOpts already received in this file.
TextEncoderStream invoked the DOMString webidl converter on every
chunk even though chunks are almost always already strings; guard the
call with a typeof check, matching TextEncoder.encode. Non-string
chunks still go through the converter for spec-compliant coercion.

https://claude.ai/code/session_01QXBexiVeaPBqGPgAxcTLNQ