### PR TITLE
perf(ext/node): drop the hideStackFrames wrapper

### DIFF
--- a/ext/node/polyfills/internal/hide_stack_frames.ts
+++ b/ext/node/polyfills/internal/hide_stack_frames.ts
@@ -2,8 +2,7 @@
 
 (function () {
 const { primordials } = __bootstrap;
-const { ErrorCaptureStackTrace, ObjectDefineProperty, ReflectApply } =
-  primordials;
+const { ObjectDefineProperty } = primordials;
 
 // deno-lint-ignore no-explicit-any
 type GenericFunction = (...args: any[]) => any;
@@ -12,30 +11,15 @@ type GenericFunction = (...args: any[]) => any;
 function hideStackFrames<T extends GenericFunction = GenericFunction>(
   fn: T,
 ): T {
-  // Match Node's `lib/internal/errors.js`: wrap so a thrown error has its stack
-  // re-captured at the call site via Error.captureStackTrace. For callers that
-  // RETURN an Error rather than throwing, the V8-captured stack still includes
-  // the wrapper and the inner function -- so also rename both to
-  // `__node_internal_<name>`, which Deno's stack formatter
-  // (`runtime/fmt_errors.rs`) elides from user-visible output.
+  // Match modern Node's `lib/internal/errors.js`: rename the function to
+  // `__node_internal_<name>` and rely on stack preparation to elide frames
+  // with that prefix (deno_core's `format_stack_trace` for `err.stack` and
+  // `runtime/fmt_errors.rs` for runtime error display). No wrapper function:
+  // these are the hottest validators in the node compat layer, and a wrapper
+  // costs a rest-args array + try/catch on every call.
   const hidden = "__node_internal_" + fn.name;
-  // deno-lint-ignore no-explicit-any
-  function wrappedFn(this: any, ...args: any[]) {
-    try {
-      return ReflectApply(fn, this, args);
-    } catch (error) {
-      // deno-lint-ignore prefer-primordials
-      if (Error.stackTraceLimit) {
-        ErrorCaptureStackTrace(error, wrappedFn);
-      }
-      throw error;
-    }
-  }
-  ObjectDefineProperty(wrappedFn, "name", { __proto__: null, value: hidden });
   ObjectDefineProperty(fn, "name", { __proto__: null, value: hidden });
-  // deno-lint-ignore no-explicit-any
-  (wrappedFn as any).withoutStackTrace = fn;
-  return wrappedFn as unknown as T;
+  return fn;
 }
 
 return { hideStackFrames };

--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -2310,6 +2310,14 @@ pub fn format_stack_trace<'s, 'i>(
       }
       break;
     };
+    // Frames renamed with the `__node_internal_` prefix are internal
+    // validation/glue helpers that should not appear in user-visible
+    // stacks (Node's stack preparation elides them the same way).
+    if let Some(fn_name) = &frame.function_name
+      && fn_name.starts_with("__node_internal_")
+    {
+      continue;
+    }
     write!(
       result,
       "\n    at {}",


### PR DESCRIPTION
hideStackFrames wrapped ~55 functions, including the hottest validators
in the node compat layer (validateFunction, validateInt32,
getValidatedPath, getValidatedFd, ...), in a closure that materialized
a rest-args array plus a try/catch on every call. These wrappers nest:
a single fs.read() crosses six or more of them, and every
node:fs/net/http operation crosses several, so the glue cost multiplies
through the whole compat layer.

Modern Node no longer wraps: hideStackFrames only renames the function
to __node_internal_<name> and stack preparation elides frames with that
prefix. This does the same. runtime/fmt_errors.rs already elides the
prefix in runtime error display; this adds the matching name-prefix
elision to deno_core's default format_stack_trace so a programmatically
read err.stack stays clean too, mirroring where Node's own filtering
lives (its C++ stack preparation).

Stack shapes were verified by hand against Node for validator errors
(nextTick, readFileSync, fs.read, writeFileSync): the
TypeError [ERR_...] first line, the visible top frame, and the elided
internal frames are identical to the previous wrapper-based behavior.
The full unit_node suite and the nexttick node_compat tests pass. The
wrapper's withoutStackTrace escape hatch had no remaining consumers and
is removed.

https://claude.ai/code/session_01QXBexiVeaPBqGPgAxcTLNQ