### PR TITLE
fix(check): write per-file check tsconfig to system temp, not project root

### DIFF
--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -318,9 +318,15 @@ async fn native_check(
         }
       }
     }
-    // Write to a unique temp file rather than a fixed path: sibling `deno check`
-    // runs in the same directory (e.g. spec-test variants) would otherwise race
-    // on it, and a fixed path leaves an artifact behind.
+    // Write to the system temp dir, not the project root: this config only
+    // references absolute paths (`extends` the base config by absolute path,
+    // `files` are absolute, `include` is empty), and tsc runs with its cwd
+    // pinned to `project_root` regardless of where the config lives, so its
+    // location does not affect resolution. Keeping it out of the project tree
+    // avoids leaving an artifact behind and, more importantly, avoids racing
+    // with anything enumerating the project directory - e.g. a sibling
+    // spec-test variant that copies the directory while this ephemeral file
+    // briefly exists (and then vanishes when the guard drops).
     let content = deno_core::serde_json::json!({
       "extends": base_tsconfig.to_string_lossy().replace('\\', "/"),
       "include": [],
@@ -329,7 +335,7 @@ async fn native_check(
     let mut tmp = tempfile::Builder::new()
       .prefix("deno-check-")
       .suffix(".tsconfig.json")
-      .tempfile_in(&project_root)?;
+      .tempfile()?;
     std::io::Write::write_all(
       &mut tmp,
       deno_core::serde_json::to_string_pretty(&content)?.as_bytes(),


### PR DESCRIPTION
The native `deno check` pipeline generated a per-file
`deno-check-*.tsconfig.json` as an ephemeral tempfile in the project
root, deleted as soon as tsc finished. While it briefly existed it could
race with anything reading the project directory. Concretely, a spec
test with `tempDir: true` copies its directory during setup, and if a
sibling in-place `check` variant was mid-write, the copy enumerated the
entry and then panicked when the file vanished before it could be
copied. That is the Windows CI failure in `pkg_json_imports::compile`
and `compile_node_modules_dir_auto`.

The config references only absolute paths (it extends the base config by
absolute path, its `files` are absolute, and `include` is empty), and
tsc runs with its working directory pinned to the project root no matter
where the config file lives, so the file's location has no effect on
resolution. Writing it to the system temp directory keeps it out of the
project tree entirely, which removes the race and also stops leaving a
transient artifact where editors, file watchers, and git can see it.