### PR TITLE
test: resolve DENO_TSC_BIN in the harness, not a CI env export

### DIFF
--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -1269,10 +1269,12 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             },
           },
           {
-            // Pre-download the compiler `deno check` uses and export
-            // DENO_TSC_BIN so the test step doesn't re-download it for every
-            // test's fresh DENO_DIR. See tools/download_tsc.ts. Run it with the
-            // built deno binary (the test job has no system `deno` on PATH).
+            // Warm the cache with the compiler `deno check` uses (into the
+            // default target/.native_tsc/deno_dir) so the test step doesn't
+            // re-download it for every test's fresh DENO_DIR. The harness
+            // resolves that path and injects DENO_TSC_BIN per-test itself (see
+            // test_util::native_tsc_bin_path); no env export needed. Run it with
+            // the built deno binary (the test job has no system `deno` on PATH).
             name: "Pre-download native tsc",
             if: testCrateNameExpr.equals("integration").or(
               testCrateNameExpr.equals("specs"),

--- a/tests/util/lib/builders.rs
+++ b/tests/util/lib/builders.rs
@@ -286,18 +286,22 @@ impl TestContextBuilder {
     };
 
     // Point `deno check` at a pre-downloaded native compiler so each test's
-    // fresh temp `DENO_DIR` doesn't re-download it. CI (and local runs) obtain
-    // it via `tools/download_tsc.ts`, which exports `DENO_TSC_BIN`; propagate it
-    // explicitly so it survives `env_clear()`. Tests that set `DENO_TSC_BIN`
-    // themselves win.
+    // fresh temp `DENO_DIR` doesn't re-download it. `tools/download_tsc.ts`
+    // materializes it under `<target>/.native_tsc/deno_dir`; the harness resolves
+    // that path itself and injects `DENO_TSC_BIN` per-test (like `JSR_URL`),
+    // instead of relying on a CI script exporting it into the ambient env. An
+    // explicit ambient `DENO_TSC_BIN` (e.g. a local `export`) still wins, as does
+    // a value a test sets itself.
     let mut envs = self.envs.clone();
-    if !envs.contains_key("DENO_TSC_BIN")
-      && let Some(tsc_bin) = std::env::var_os("DENO_TSC_BIN")
-    {
-      envs.insert(
-        "DENO_TSC_BIN".to_string(),
-        tsc_bin.to_string_lossy().into_owned(),
-      );
+    if !envs.contains_key("DENO_TSC_BIN") {
+      let tsc_bin = std::env::var_os("DENO_TSC_BIN")
+        .map(|v| v.to_string_lossy().into_owned())
+        .or_else(|| {
+          crate::native_tsc_bin_path().map(|p| p.to_string_lossy().into_owned())
+        });
+      if let Some(tsc_bin) = tsc_bin {
+        envs.insert("DENO_TSC_BIN".to_string(), tsc_bin);
+      }
     }
 
     TestContext {

--- a/tests/util/lib/lib.rs
+++ b/tests/util/lib/lib.rs
@@ -159,6 +159,39 @@ pub fn root_path() -> PathRef {
   p.parent()
 }
 
+/// Path to the pre-downloaded native TypeScript compiler, if present.
+///
+/// `tools/download_tsc.ts` materializes it under
+/// `<target>/.native_tsc/deno_dir/tsc/<version>/<platform>/lib/tsc`. The harness
+/// injects this per-test as `DENO_TSC_BIN` (see `TestContextBuilder::build`) so
+/// `deno check`/`run --check`/`cache --check` reuse it instead of downloading
+/// the compiler into every test's fresh `DENO_DIR`. Returns `None` when it
+/// hasn't been downloaded yet.
+pub fn native_tsc_bin_path() -> Option<PathRef> {
+  let exe = if cfg!(windows) { "tsc.exe" } else { "tsc" };
+  // `tools/download_tsc.ts` defaults its cache to `./target/.native_tsc/deno_dir`
+  // (relative to the repo root), i.e. the `target` root - not the per-profile
+  // `target/debug`|`target/release` dir that `target_dir()` returns.
+  let tsc_root = root_path()
+    .join("target")
+    .join(".native_tsc")
+    .join("deno_dir")
+    .join("tsc");
+  for version in std::fs::read_dir(tsc_root.as_path()).ok()?.flatten() {
+    for platform in std::fs::read_dir(version.path())
+      .into_iter()
+      .flatten()
+      .flatten()
+    {
+      let bin = PathRef::new(platform.path()).join("lib").join(exe);
+      if bin.exists() {
+        return Some(bin);
+      }
+    }
+  }
+  None
+}
+
 pub fn prebuilt_path() -> PathRef {
   third_party_path().join("prebuilt")
 }

--- a/tools/download_tsc.ts
+++ b/tools/download_tsc.ts
@@ -8,13 +8,16 @@
 //
 // It warms the cache by type-checking a trivial file with the built `deno`
 // binary (which downloads the compiler via its normal path), then locates the
-// resulting `tsc` binary. On success it prints the binary's path and, when run
-// under GitHub Actions, appends `DENO_TSC_BIN=<path>` to `$GITHUB_ENV` so the
-// subsequent test step points every `deno check` at it.
+// resulting `tsc` binary and prints its path. When run with the default cache
+// directory, the test harness resolves that same path itself and injects
+// `DENO_TSC_BIN` per-test (see `test_util::native_tsc_bin_path`), so this script
+// only needs to warm the cache - it does not export the path into the env.
 //
 //   deno run -A tools/download_tsc.ts [cache_deno_dir]
 //
-// For local `cargo test` runs of the `deno check` tests, export the path first:
+// For local `cargo test` runs, running it once with the default cache directory
+// is enough; the harness finds the compiler under `target/.native_tsc/deno_dir`.
+// To point tests at a specific binary instead, export it explicitly:
 //
 //   export DENO_TSC_BIN=$(deno run -A tools/download_tsc.ts)
 //
@@ -97,10 +100,3 @@ if (!tscBin) {
 
 tscBin = Deno.realPathSync(tscBin);
 console.log(tscBin);
-
-const githubEnv = Deno.env.get("GITHUB_ENV");
-if (githubEnv) {
-  Deno.writeTextFileSync(githubEnv, `DENO_TSC_BIN=${tscBin}\n`, {
-    append: true,
-  });
-}


### PR DESCRIPTION
The native-check spec tests (`deno check`, `deno run --check`, `deno cache
--check`) need the pinned native TypeScript compiler. CI pre-downloaded it
and exported `DENO_TSC_BIN` into the ambient environment, and the test
harness propagated that per command. When the ambient variable didn't reach
a test, native check fell back to downloading the compiler from the
unreachable test npm registry and the test failed - for example the
`specs::check::ts_suppression_unresolved_import::*` tests currently failing
on main.

This makes the harness resolve the compiler itself rather than depending on
a CI-exported variable. `tools/download_tsc.ts` warms the compiler into its
default `target/.native_tsc/deno_dir` cache, and the harness computes that
path (`test_util::native_tsc_bin_path`) and injects `DENO_TSC_BIN` per test,
the same way `JSR_URL` is provided. An explicit ambient `DENO_TSC_BIN` (such
as a local `export`) still takes precedence, so local workflows are
unaffected. `download_tsc.ts` no longer writes `$GITHUB_ENV`; the CI step
only warms the cache.