### PR TITLE
fix(check): resolve npm type-reference directives without node_modules

### DIFF
--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -52,6 +52,10 @@ struct NpmCacheProjects {
 struct NodeTypesSetup {
   type_root: Option<String>,
   undici_types_dir: Option<PathBuf>,
+  /// Absolute path to the resolved `@types/node` package directory (under
+  /// `node_modules` or the materialized `.deno/npm-compat` copy), used to build
+  /// the type-reference typeRoot in global-cache mode.
+  node_types_dir: Option<PathBuf>,
 }
 
 fn path_for_typescript(path: &Path) -> String {
@@ -468,6 +472,22 @@ pub async fn setup_npm_compat(
     excludes.push("vendor".to_string());
   }
 
+  // In global-cache mode (no real `node_modules`), lay out a `typeRoots`-
+  // resolvable directory of the imported npm packages so stock tsc can resolve
+  // TypeScript type-reference directives (`/// <reference types="<pkg>" />`),
+  // which resolve via `typeRoots`/`node_modules` rather than `paths`. With a
+  // real `node_modules` (`auto`/`manual`) the package walk already handles this.
+  let type_ref_root = if use_global_cache_layout {
+    let extra = node_types
+      .node_types_dir
+      .clone()
+      .map(|dir| vec![("@types/node".to_string(), dir)])
+      .unwrap_or_default();
+    setup_type_ref_root(project_root, &npm_cache_projects.package_paths, &extra)
+  } else {
+    None
+  };
+
   // Generate .deno/tsconfig.json and ensure root tsconfig.json extends it
   generate_deno_tsconfig(
     project_root,
@@ -480,6 +500,7 @@ pub async fn setup_npm_compat(
     &npm_cache_projects.package_paths,
     &npm_cache_projects.references,
     node_types.type_root.as_deref(),
+    type_ref_root.as_deref(),
     &excludes,
     manage_root_tsconfig,
   )?;
@@ -534,11 +555,13 @@ async fn ensure_types_node(
   // Reuse an @types/node the project already installed under node_modules.
   if !use_global_cache_layout {
     let node_modules = project_root.join("node_modules");
-    if node_modules.join("@types/node").exists() {
+    let node_types_dir = node_modules.join("@types/node");
+    if node_types_dir.exists() {
       let undici_types_dir = node_modules.join("undici-types");
       return NodeTypesSetup {
         type_root: Some("../node_modules/@types".to_string()),
         undici_types_dir: undici_types_dir.exists().then_some(undici_types_dir),
+        node_types_dir: Some(node_types_dir),
       };
     }
   }
@@ -551,6 +574,7 @@ async fn ensure_types_node(
     return NodeTypesSetup {
       type_root: Some(type_root),
       undici_types_dir: undici_types_dir.exists().then_some(undici_types_dir),
+      node_types_dir: Some(node_dir),
     };
   }
   match download_npm_package(&modules_dir, "@types/node", None, http_client)
@@ -569,12 +593,98 @@ async fn ensure_types_node(
       NodeTypesSetup {
         type_root: node_dir.exists().then_some(type_root),
         undici_types_dir: undici_types_dir.exists().then_some(undici_types_dir),
+        node_types_dir: node_dir.exists().then_some(node_dir),
       }
     }
     _ => NodeTypesSetup {
       type_root: None,
       undici_types_dir: None,
+      node_types_dir: None,
     },
+  }
+}
+
+/// Materialize a `typeRoots`-resolvable layout for TypeScript
+/// **type-reference directives** (`/// <reference types="<pkg>" />`) in
+/// global-cache (`nodeModulesDir: "none"`) mode.
+///
+/// tsgo resolves a reference directive's `types="<pkg>"` through `typeRoots`
+/// (looking for `<typeRoot>/<pkg>`) and a `node_modules` walk - never through
+/// `compilerOptions.paths` (which only steers module imports). With a real
+/// `node_modules` (`auto`/`manual`) the walk finds the package; in `none` mode
+/// there is none, so a bare `/// <reference types="@types/node" />` or
+/// `/// <reference types="@denotest/augments-global/import-meta" />` fails to
+/// resolve. This lays out `.deno/type-refs/<pkg-name>` symlinks pointing at the
+/// resolved global-cache package folders so `typeRoots` can find each package
+/// under its real (possibly scoped) name, honoring its `package.json`
+/// `exports`/`types` and internal relative references. Returns the relative
+/// typeRoot (`./type-refs`) to add to the generated tsconfig, or `None` when
+/// nothing was materialized.
+///
+/// Symlinks (not copies) so the package's own relative `/// <reference />`
+/// directives and `exports` targets resolve against the real files; `.deno/` is
+/// gitignored, so these never enter the user's tree.
+fn setup_type_ref_root(
+  project_root: &Path,
+  npm_package_paths: &BTreeMap<String, PathBuf>,
+  extra_packages: &[(String, PathBuf)],
+) -> Option<String> {
+  let type_refs_dir = project_root.join(".deno/type-refs");
+  // Regenerate from scratch so stale entries (a removed dependency) don't linger.
+  if type_refs_dir.exists() {
+    let _ = std::fs::remove_dir_all(&type_refs_dir);
+  }
+
+  // Resolve each import target to `(package name, folder)`, then fold in the
+  // extra packages (e.g. an `@types/node` materialized under `.deno/npm-compat`
+  // that isn't a resolver snapshot entry).
+  let mut entries: Vec<(String, PathBuf)> = npm_package_paths
+    .iter()
+    .filter_map(|(target, folder)| {
+      let npm_ref =
+        deno_semver::npm::NpmPackageReqReference::from_str(target).ok()?;
+      Some((npm_ref.req().name.to_string(), folder.clone()))
+    })
+    .collect();
+  entries.extend(extra_packages.iter().cloned());
+
+  // Deduplicate by resolved package name; the same package may be reachable via
+  // several import targets (the `npm:` scheme and an alias).
+  let mut linked = false;
+  let mut seen: std::collections::BTreeSet<String> =
+    std::collections::BTreeSet::new();
+  for (pkg_name, folder) in entries {
+    if !seen.insert(pkg_name.clone()) {
+      continue;
+    }
+    if !folder.exists() {
+      continue;
+    }
+    let link_path = type_refs_dir.join(&pkg_name);
+    // A scoped package (`@types/node`) needs its `@types` parent created first.
+    if let Some(parent) = link_path.parent()
+      && std::fs::create_dir_all(parent).is_err()
+    {
+      continue;
+    }
+    if symlink_dir(&folder, &link_path).is_ok() {
+      linked = true;
+    }
+  }
+
+  linked.then(|| "./type-refs".to_string())
+}
+
+/// Create a directory symlink at `link` pointing at `target`, portably across
+/// platforms.
+fn symlink_dir(target: &Path, link: &Path) -> std::io::Result<()> {
+  #[cfg(windows)]
+  {
+    std::os::windows::fs::symlink_dir(target, link)
+  }
+  #[cfg(not(windows))]
+  {
+    std::os::unix::fs::symlink(target, link)
   }
 }
 
@@ -830,6 +940,7 @@ fn generate_deno_tsconfig(
   npm_package_paths: &BTreeMap<String, PathBuf>,
   npm_project_references: &[String],
   node_types_root: Option<&str>,
+  type_ref_root: Option<&str>,
   excludes: &[String],
   manage_root_tsconfig: bool,
 ) -> Result<(), AnyError> {
@@ -848,6 +959,7 @@ fn generate_deno_tsconfig(
     npm_package_paths,
     npm_project_references,
     node_types_root,
+    type_ref_root,
     excludes,
     manage_root_tsconfig,
   )

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -186,6 +186,7 @@ pub fn generate_tsconfig(
   npm_package_paths: &BTreeMap<String, PathBuf>,
   npm_project_references: &[String],
   node_types_root: Option<&str>,
+  type_ref_root: Option<&str>,
   excludes: &[String],
   manage_root_tsconfig: bool,
 ) -> Result<GeneratedTsConfig, std::io::Error> {
@@ -231,6 +232,7 @@ pub fn generate_tsconfig(
     npm_package_paths,
     npm_project_references,
     node_types_root,
+    type_ref_root,
     excludes,
   );
 
@@ -765,6 +767,7 @@ fn build_tsconfig(
   npm_package_paths: &BTreeMap<String, PathBuf>,
   npm_project_references: &[String],
   node_types_root: Option<&str>,
+  type_ref_root: Option<&str>,
   excludes: &[String],
 ) -> Value {
   let mut compiler_options = base_compiler_options();
@@ -773,9 +776,25 @@ fn build_tsconfig(
   // globals (timers, node: builtins, Buffer, URLPattern, ...) resolve. Add the
   // selected local or npm-compat type root alongside the generated Deno types.
   if let Some(node_types_root) = node_types_root {
-    compiler_options
-      .insert("typeRoots".to_string(), json!(["./types", node_types_root]));
+    let mut type_roots = vec![json!("./types"), json!(node_types_root)];
+    // In global-cache mode a `type-refs` directory lays out each imported npm
+    // package under its real name so tsc can resolve type-reference directives
+    // (`/// <reference types="@types/node" />` etc.), which resolve via
+    // `typeRoots`/`node_modules` and not `paths`. It is a *reference-resolution*
+    // root only: `types: ["deno", "node"]` stays explicit so its entries aren't
+    // auto-loaded as ambient globals.
+    if let Some(type_ref_root) = type_ref_root {
+      type_roots.push(json!(type_ref_root));
+    }
+    compiler_options.insert("typeRoots".to_string(), Value::Array(type_roots));
     compiler_options.insert("types".to_string(), json!(["deno", "node"]));
+  } else if let Some(type_ref_root) = type_ref_root {
+    // No @types/node (its download failed), but there are still npm packages to
+    // expose for type-reference directives. Keep `./types` first so `@types/deno`
+    // resolves, then the type-ref root; `types` stays unset so nothing is
+    // auto-loaded as a global.
+    compiler_options
+      .insert("typeRoots".to_string(), json!(["./types", type_ref_root]));
   }
 
   // Merge user's deno.json compilerOptions (filtered to stock-tsc-compatible
@@ -2361,6 +2380,7 @@ interface AlsoKeep {
       &BTreeMap::new(),
       &[],
       None,
+      None,
       &[],
     );
 
@@ -2386,6 +2406,7 @@ interface AlsoKeep {
       Path::new("/tmp/project/node_modules/@jsr"),
       &BTreeMap::new(),
       &[],
+      None,
       None,
       &excludes,
     );
@@ -2417,6 +2438,7 @@ interface AlsoKeep {
       &BTreeMap::new(),
       &[],
       None,
+      None,
       &[],
     );
 
@@ -2444,6 +2466,7 @@ interface AlsoKeep {
       Path::new("/tmp/project/node_modules/@jsr"),
       &BTreeMap::new(),
       &references,
+      None,
       None,
       &[],
     );
@@ -2480,6 +2503,7 @@ interface AlsoKeep {
       Path::new("/tmp/project/node_modules/@jsr"),
       &BTreeMap::new(),
       &[],
+      None,
       None,
       &[],
     );

--- a/tests/specs/check/import_meta_no_errors/__test__.jsonc
+++ b/tests/specs/check/import_meta_no_errors/__test__.jsonc
@@ -2,9 +2,6 @@
   "tempDir": true,
   "tests": {
     "node_modules_dir_none": {
-      // ignored: with node_modules_dir "none", tsc can't resolve the
-      // @types/node type reference. https://github.com/denoland/deno/issues/36085
-      "ignore": true,
       "steps": [
         {
           "args": "run -A ./set_node_modules_dir.ts none",

--- a/tests/specs/check/type_reference_import_meta/__test__.jsonc
+++ b/tests/specs/check/type_reference_import_meta/__test__.jsonc
@@ -2,9 +2,6 @@
   "tempDir": true,
   "tests": {
     "node_modules_dir_none": {
-      // ignored: with node_modules_dir "none", tsc can't resolve the ImportMeta
-      // augmentation type reference. https://github.com/denoland/deno/issues/36085
-      "ignore": true,
       "steps": [
         {
           "args": "run -A ./set_node_modules_dir.ts none",


### PR DESCRIPTION
With `nodeModulesDir: "none"`, native `deno check` could not resolve
TypeScript type-reference directives (`/// <reference types="<pkg>" />`)
pointing at npm or `@types` packages. tsgo resolves reference directives
through `typeRoots`/`node_modules`, never through the `compilerOptions.paths`
that `deno sync-types` generates for regular module imports, and in
global-cache mode there is no `node_modules` to walk. So a bare
`types="@types/node"` (or a subpath like
`types="@denotest/augments-global/import-meta"`) failed to resolve even
though the package was cached.

`deno sync-types` now materializes a `.deno/type-refs/` directory in
global-cache mode containing a directory symlink per imported npm package,
keyed by the package's real name and pointing at its global-cache folder,
and appends it to the generated tsconfig's `typeRoots`. Using symlinks
keeps each package's own `exports` and internal reference directives
resolving against the real files. `types` stays explicitly `["deno",
"node"]`, so the extra type root is only consulted for on-demand reference
resolution and never auto-loads ambient globals.

This re-enables the `node_modules_dir_none` cases of
`check/import_meta_no_errors` and `check/type_reference_import_meta`.