### PR TITLE
fix(check): inject the desktop type lib for `deno check --desktop`

### DIFF
--- a/cli/tools/installer/local.rs
+++ b/cli/tools/installer/local.rs
@@ -400,6 +400,12 @@ pub async fn sync_types_command(
     .root_dir_url()
     .join("__deno_root__.ts")
     .ok();
+  // Honor `--desktop` (`deno check --desktop` / `deno desktop`): it maps to
+  // `TsTypeLib::DenoDesktop`, which pulls in the additive `deno.desktop` lib
+  // (declaring desktop-only globals like `Notification`). Fall back to
+  // `DenoWindow` otherwise.
+  let ts_type_lib = cli_options.ts_type_lib_window();
+  let is_desktop = ts_type_lib == TsTypeLib::DenoDesktop;
   let resolved_compiler_options = root_specifier.as_ref().and_then(|spec| {
     factory
       .compiler_options_resolver()
@@ -407,7 +413,7 @@ pub async fn sync_types_command(
       .and_then(|resolver| {
         resolver
           .for_specifier(spec)
-          .compiler_options_for_lib(TsTypeLib::DenoWindow)
+          .compiler_options_for_lib(ts_type_lib)
           .ok()
       })
       .map(|opts| opts.0.clone())
@@ -439,6 +445,7 @@ pub async fn sync_types_command(
     resolved_compiler_options.as_ref(),
     manage_root_tsconfig,
     type_check_remote,
+    is_desktop,
   )
   .await?;
 

--- a/cli/tools/installer/npm_compat.rs
+++ b/cli/tools/installer/npm_compat.rs
@@ -287,6 +287,7 @@ pub async fn setup_npm_compat(
   resolved_compiler_options: Option<&Value>,
   manage_root_tsconfig: bool,
   type_check_remote: bool,
+  is_desktop: bool,
 ) -> Result<Vec<InstalledJsrPackage>, AnyError> {
   let deno_json = read_deno_json(project_root)?;
   let deno_compiler_options = deno_json
@@ -482,6 +483,7 @@ pub async fn setup_npm_compat(
     node_types.type_root.as_deref(),
     &excludes,
     manage_root_tsconfig,
+    is_desktop,
   )?;
 
   Ok(installed)
@@ -832,6 +834,7 @@ fn generate_deno_tsconfig(
   node_types_root: Option<&str>,
   excludes: &[String],
   manage_root_tsconfig: bool,
+  is_desktop: bool,
 ) -> Result<(), AnyError> {
   let generated = crate::tsc::tsconfig_gen::generate_tsconfig(
     project_root,
@@ -850,6 +853,7 @@ fn generate_deno_tsconfig(
     node_types_root,
     excludes,
     manage_root_tsconfig,
+    is_desktop,
   )
   .map_err(|e| anyhow!("Failed to generate tsconfig: {e}"))?;
 

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -58,26 +58,37 @@ pub use self::diagnostics::Position;
 pub use self::js::TscConstants;
 
 pub fn get_types_declaration_file_text() -> String {
-  concat_lib_texts(&[
-    "deno.ns",
-    "deno.console",
-    "deno.url",
-    "deno.web",
-    "deno.fetch",
-    "deno.webgpu",
-    "deno.websocket",
-    "deno.webstorage",
-    "deno.canvas",
-    "deno.crypto",
-    "deno.broadcast_channel",
-    "deno.net",
-    "deno.shared_globals",
-    "deno.cache",
-    "esnext.temporal",
-    "deno.window",
-    "deno.unstable",
-  ])
+  concat_lib_texts(WINDOW_LIB_NAMES)
 }
+
+/// The full window lib set plus `deno.desktop`, used by `deno check --desktop`
+/// (and `deno desktop`). `deno.desktop` is additive: it declares the extra
+/// desktop-only globals (e.g. `Notification`) on top of the window globals.
+pub fn get_desktop_types_declaration_file_text() -> String {
+  let mut names = WINDOW_LIB_NAMES.to_vec();
+  names.push("deno.desktop");
+  concat_lib_texts(&names)
+}
+
+const WINDOW_LIB_NAMES: &[&str] = &[
+  "deno.ns",
+  "deno.console",
+  "deno.url",
+  "deno.web",
+  "deno.fetch",
+  "deno.webgpu",
+  "deno.websocket",
+  "deno.webstorage",
+  "deno.canvas",
+  "deno.crypto",
+  "deno.broadcast_channel",
+  "deno.net",
+  "deno.shared_globals",
+  "deno.cache",
+  "esnext.temporal",
+  "deno.window",
+  "deno.unstable",
+];
 
 /// The `Deno` namespace only, without Deno's web-platform globals (`fetch`,
 /// `FormData`, `console`, WebGPU, ...). For projects that opt into the `dom`

--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -19,6 +19,7 @@ use deno_core::serde_json::json;
 use deno_core::url::Url;
 
 use super::get_deno_ns_declaration_file_text;
+use super::get_desktop_types_declaration_file_text;
 use super::get_types_declaration_file_text;
 
 /// Whether Deno should honor a user's `tsconfig.json` at `project_root`.
@@ -188,6 +189,7 @@ pub fn generate_tsconfig(
   node_types_root: Option<&str>,
   excludes: &[String],
   manage_root_tsconfig: bool,
+  is_desktop: bool,
 ) -> Result<GeneratedTsConfig, std::io::Error> {
   // Write Deno type definitions to .deno/types/deno/ (private typeRoot).
   let types_dir = project_root.join(".deno/types/deno");
@@ -203,6 +205,7 @@ pub fn generate_tsconfig(
     &types_dir.join("index.d.ts"),
     node_types_root.is_some(),
     has_dom,
+    is_desktop,
     &no_types_shims,
   )?;
 
@@ -546,15 +549,24 @@ fn effective_lib_has_dom(
 
 /// Write the Deno type declarations to a `.d.ts` file. When `has_dom` is set the
 /// project opts into the `dom` lib, so emit only the `Deno` namespace and let
-/// `dom` own the web-platform globals (they'd otherwise collide).
+/// `dom` own the web-platform globals (they'd otherwise collide). When
+/// `is_desktop` is set (`deno check --desktop` / `deno desktop`) the window set
+/// is emitted plus the additive `deno.desktop` lib (which declares desktop-only
+/// globals like `Notification`).
 fn write_deno_types(
   path: &Path,
   has_node_types: bool,
   has_dom: bool,
+  is_desktop: bool,
   no_types_shims: &[String],
 ) -> Result<(), std::io::Error> {
+  // `dom` and `desktop` are mutually exclusive in practice (desktop implies no
+  // dom). If both were somehow set, `has_dom` wins (emit only the `Deno`
+  // namespace) so we never collide with the `dom` lib's globals.
   let types_text = if has_dom {
     get_deno_ns_declaration_file_text()
+  } else if is_desktop {
+    get_desktop_types_declaration_file_text()
   } else {
     get_types_declaration_file_text()
   };

--- a/tests/specs/check/desktop_flag/__test__.jsonc
+++ b/tests/specs/check/desktop_flag/__test__.jsonc
@@ -1,4 +1,8 @@
 {
+  // Each sub-test runs in its own temp copy so the `.deno/` cache and generated
+  // types from one (e.g. the `--desktop` run's `Notification` declarations)
+  // don't leak into the other.
+  "tempDir": true,
   "tests": {
     "without_flag": {
       "args": "check main.ts",
@@ -6,9 +10,6 @@
       "exitCode": 1
     },
     "with_flag": {
-      // ignored: --desktop lib (Notification type) isn't injected into tsc.
-      // https://github.com/denoland/deno/issues/36085
-      "ignore": true,
       "args": "check --desktop main.ts",
       "output": "with_flag.out",
       "exitCode": 0


### PR DESCRIPTION
`deno check --desktop` maps to `TsTypeLib::DenoDesktop`, but the native
`sync-types` pipeline hardcoded `DenoWindow`, so the `deno.desktop` type lib
(which declares `Notification` and the other desktop-only globals) was never
materialized into the Deno declarations stock tsc consumes. Code using
`Notification` failed to type-check even with `--desktop`.

`sync-types` now reads the effective lib from `ts_type_lib_window()` and,
when desktop is active, appends `deno.desktop` (additive over the window
set) to the materialized `.deno/types/deno` declarations, threaded via an
`is_desktop` flag down to where the types file is written.

This re-enables the `with_flag` case of `check/desktop_flag`. That spec also
gains `tempDir: true` so its two sub-tests no longer share a source
directory - the `--desktop` run's generated `.deno` was leaking into the
`without_flag` run.