### PR TITLE
fix(desktop) type declarations for getContext on raw desktop backend

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -232,6 +232,11 @@ declare namespace Deno {
     );
 
     getContext(
+      contextId: "bitmaprenderer",
+      options?: any,
+    ): ImageBitmapRenderingContext | null;
+    getContext(contextId: "webgpu", options?: any): GPUCanvasContext | null;
+    getContext(
       contextId: OffscreenRenderingContextId,
       options?: any,
     ): OffscreenRenderingContext | null;

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -231,6 +231,10 @@ declare namespace Deno {
       },
     );
 
+    /**
+     * Get a drawing context for the canvas.
+     * If this was previously called, it will return the same context.
+     */
     getContext(
       contextId: "bitmaprenderer",
       options?: any,
@@ -240,6 +244,12 @@ declare namespace Deno {
       contextId: OffscreenRenderingContextId,
       options?: any,
     ): OffscreenRenderingContext | null;
+    // Spec also defines "2d", "webgl", and "webgl2" context ids; Deno does
+    // not implement those and getContext returns null for them.
+    getContext(
+      contextId: "2d" | "webgl" | "webgl2",
+      options?: any,
+    ): null;
 
     present(): void;
   }

--- a/cli/tsc/dts/lib.deno_canvas.d.ts
+++ b/cli/tsc/dts/lib.deno_canvas.d.ts
@@ -252,6 +252,7 @@ interface GPUCanvasContext {
  * @category Canvas */
 declare var GPUCanvasContext: {
   prototype: GPUCanvasContext;
+  new (): GPUCanvasContext;
 };
 
 /** A rendering context that displays the contents of an {@linkcode ImageBitmap}
@@ -275,6 +276,7 @@ interface ImageBitmapRenderingContext {
  * @category Canvas */
 declare var ImageBitmapRenderingContext: {
   prototype: ImageBitmapRenderingContext;
+  new (): ImageBitmapRenderingContext;
 };
 
 /** A canvas that can be rendered to off the main thread and without being

--- a/cli/tsc/dts/lib.deno_canvas.d.ts
+++ b/cli/tsc/dts/lib.deno_canvas.d.ts
@@ -247,11 +247,13 @@ interface GPUCanvasContext {
  *
  * A `GPUCanvasContext` is obtained from
  * {@linkcode OffscreenCanvas.getContext} with the `"webgpu"` context id rather
- * than constructed directly.
+ * than constructed directly. The construct signature below exists only so that
+ * `instanceof GPUCanvasContext` type checks and narrows.
  *
  * @category Canvas */
 declare var GPUCanvasContext: {
   prototype: GPUCanvasContext;
+  /** Not a supported way to create a context; present so `instanceof` narrows. */
   new (): GPUCanvasContext;
 };
 
@@ -271,11 +273,13 @@ interface ImageBitmapRenderingContext {
  *
  * An `ImageBitmapRenderingContext` is obtained from
  * {@linkcode OffscreenCanvas.getContext} with the `"bitmaprenderer"` context id
- * rather than constructed directly.
+ * rather than constructed directly. The construct signature below exists only so
+ * that `instanceof ImageBitmapRenderingContext` type checks and narrows.
  *
  * @category Canvas */
 declare var ImageBitmapRenderingContext: {
   prototype: ImageBitmapRenderingContext;
+  /** Not a supported way to create a context; present so `instanceof` narrows. */
   new (): ImageBitmapRenderingContext;
 };
 

--- a/tests/specs/check/unsafe_window_surface_getcontext/__test__.jsonc
+++ b/tests/specs/check/unsafe_window_surface_getcontext/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "check main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/check/unsafe_window_surface_getcontext/__test__.jsonc
+++ b/tests/specs/check/unsafe_window_surface_getcontext/__test__.jsonc
@@ -1,5 +1,4 @@
 {
   "args": "check main.ts",
-  "output": "main.out",
-  "exitCode": 0
+  "output": "main.out"
 }

--- a/tests/specs/check/unsafe_window_surface_getcontext/main.out
+++ b/tests/specs/check/unsafe_window_surface_getcontext/main.out
@@ -1,0 +1,1 @@
+Check [WILDCARD]main.ts

--- a/tests/specs/check/unsafe_window_surface_getcontext/main.ts
+++ b/tests/specs/check/unsafe_window_surface_getcontext/main.ts
@@ -1,0 +1,22 @@
+// Type-level checks that Deno.UnsafeWindowSurface.getContext narrows per
+// context id, mirroring the OffscreenCanvas.getContext overloads.
+
+function assertType<T>(_value: T): void {}
+
+declare const surface: Deno.UnsafeWindowSurface;
+
+assertType<GPUCanvasContext | null>(surface.getContext("webgpu"));
+assertType<ImageBitmapRenderingContext | null>(
+  surface.getContext("bitmaprenderer"),
+);
+declare const contextId: OffscreenRenderingContextId;
+assertType<OffscreenRenderingContext | null>(surface.getContext(contextId));
+
+// The constructor objects have construct signatures, so instanceof narrows.
+declare const context: unknown;
+if (context instanceof GPUCanvasContext) {
+  assertType<GPUCanvasContext>(context);
+}
+if (context instanceof ImageBitmapRenderingContext) {
+  assertType<ImageBitmapRenderingContext>(context);
+}

--- a/tests/specs/check/unsafe_window_surface_getcontext/main.ts
+++ b/tests/specs/check/unsafe_window_surface_getcontext/main.ts
@@ -1,22 +1,39 @@
 // Type-level checks that Deno.UnsafeWindowSurface.getContext narrows per
-// context id, mirroring the OffscreenCanvas.getContext overloads.
+// context id, mirroring the OffscreenCanvas.getContext overloads. Strict
+// equality (not assignability) is used so the exact return types - and the
+// overload order, which is the easiest thing to break later - are pinned.
 
-function assertType<T>(_value: T): void {}
+type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type AssertTrue<T extends true> = T;
 
 declare const surface: Deno.UnsafeWindowSurface;
 
-assertType<GPUCanvasContext | null>(surface.getContext("webgpu"));
-assertType<ImageBitmapRenderingContext | null>(
-  surface.getContext("bitmaprenderer"),
-);
+const webgpu = surface.getContext("webgpu");
+type _Webgpu = AssertTrue<Equals<typeof webgpu, GPUCanvasContext | null>>;
+
+const bitmaprenderer = surface.getContext("bitmaprenderer");
+type _Bitmaprenderer = AssertTrue<
+  Equals<typeof bitmaprenderer, ImageBitmapRenderingContext | null>
+>;
+
 declare const contextId: OffscreenRenderingContextId;
-assertType<OffscreenRenderingContext | null>(surface.getContext(contextId));
+const dynamic = surface.getContext(contextId);
+type _Dynamic = AssertTrue<
+  Equals<typeof dynamic, OffscreenRenderingContext | null>
+>;
+
+// Not implemented by Deno; getContext returns null for these context ids.
+const unimplemented = surface.getContext("2d");
+type _Unimplemented = AssertTrue<Equals<typeof unimplemented, null>>;
 
 // The constructor objects have construct signatures, so instanceof narrows.
 declare const context: unknown;
 if (context instanceof GPUCanvasContext) {
-  assertType<GPUCanvasContext>(context);
+  type _Gpu = AssertTrue<Equals<typeof context, GPUCanvasContext>>;
 }
 if (context instanceof ImageBitmapRenderingContext) {
-  assertType<ImageBitmapRenderingContext>(context);
+  type _Bitmap = AssertTrue<
+    Equals<typeof context, ImageBitmapRenderingContext>
+  >;
 }


### PR DESCRIPTION
This updates the declared types on getContext to match the way they're used in the documentation (returning a `GPUCanvasContext` for `contextId: "webgpu"`).

Fixes #36214
I used Claude Code while working on this PR

<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Edited (2026-08-01):

This PR also adds `new ()` construct signatures to the `GPUCanvasContext` and
`ImageBitmapRenderingContext` constructor objects, so `instanceof` type checks and narrows.
Without a construct signature, `x instanceof GPUCanvasContext` raises `TS2359`; the alternative
`Function & { prototype: X }` clears `TS2359` but narrows to `{}` rather than `X`. This is a
second, independent type-level fix that also benefits `OffscreenCanvas` users. The construct
signature is documented as not being a supported way to create a context.
