### PR TITLE
fix(check): align skipLibCheck default with tsgo

### DIFF
--- a/cli/tsc/tsconfig_gen.rs
+++ b/cli/tsc/tsconfig_gen.rs
@@ -1717,8 +1717,10 @@ fn merge_deno_options(base: &mut Map<String, Value>, user_opts: &Value) {
     // NOTE: `paths`, `baseUrl`, `rootDirs` are deliberately NOT passed through
     // here - they hold project-root-relative paths that must be rebased onto
     // `.deno/` (the generated tsconfig lives one level down). They're handled in
-    // `build_tsconfig`.
-    "skipLibCheck",
+    // `build_tsconfig`. `skipLibCheck` is likewise NOT passed through here: the
+    // raw pass reads the project-root deno.json and misses a `--config <other>`
+    // override, so it's applied from the resolved options (see
+    // `RESOLVED_OPTION_KEYS`), which honor `--config`.
     "strict",
     "strictBindCallApply",
     "strictBuiltinIteratorReturn",
@@ -1752,10 +1754,9 @@ fn merge_deno_options(base: &mut Map<String, Value>, user_opts: &Value) {
 /// than the raw deno.json. These fold in Deno's source-kind defaults and CLI
 /// overrides (e.g. `--check-js`), so they win over the base and the raw pass.
 ///
-/// Deliberately excludes `skipLibCheck` (the base default matches TypeScript's,
-/// and the raw pass honors a user override) and the path-like options
-/// (`paths`/`baseUrl`/`rootDirs`), which come from the raw config so
-/// `build_tsconfig` can rebase them onto `.deno/`.
+/// Deliberately excludes the path-like options (`paths`/`baseUrl`/`rootDirs`),
+/// which come from the raw config so `build_tsconfig` can rebase them onto
+/// `.deno/`.
 const RESOLVED_OPTION_KEYS: &[&str] = &[
   "allowUnreachableCode",
   "allowUnusedLabels",
@@ -1778,6 +1779,12 @@ const RESOLVED_OPTION_KEYS: &[&str] = &[
   "noUncheckedIndexedAccess",
   "noUnusedLocals",
   "noUnusedParameters",
+  // Applied from the resolved options (which honor `--config`) rather than the
+  // raw project-root deno.json pass. The resolved options carry the effective
+  // `skipLibCheck` (base default true, matching tsgo's `--init`; a user
+  // `skipLibCheck: false` overrides it), so it is honored regardless of how the
+  // config is provided.
+  "skipLibCheck",
   "strict",
   "strictBindCallApply",
   "strictBuiltinIteratorReturn",

--- a/libs/resolver/deno_json.rs
+++ b/libs/resolver/deno_json.rs
@@ -343,7 +343,10 @@ pub fn get_base_compiler_options_for_emit(
       },
       "resolveJsonModule": true,
       "sourceMap": false,
-      "skipLibCheck": false,
+      // Default to skipping `.d.ts` type-checking, matching tsgo's `--init`
+      // default. A user `skipLibCheck: false` still overrides this via the
+      // merge below.
+      "skipLibCheck": true,
       "strict": match source_kind {
         CompilerOptionsSourceKind::DenoJson => true,
         CompilerOptionsSourceKind::TsConfig => false,
@@ -834,6 +837,9 @@ impl CompilerOptionsData {
     })
   }
 
+  /// Whether to skip `.d.ts` type-checking. Defaults to true (matching tsgo's
+  /// `--init` default and the base check options); a user `skipLibCheck: false`
+  /// overrides it. Honors `--config` and `extends` (later sources win).
   pub fn skip_lib_check(&self) -> bool {
     *self.memoized.skip_lib_check.get_or_init(|| {
       self
@@ -848,7 +854,7 @@ impl CompilerOptionsData {
             .get("skipLibCheck")?
             .as_bool()
         })
-        .unwrap_or(false)
+        .unwrap_or(true)
     })
   }
 

--- a/tests/specs/check/check_dts/__test__.jsonc
+++ b/tests/specs/check/check_dts/__test__.jsonc
@@ -1,8 +1,20 @@
 {
-  // ignored: .d.ts entrypoint not checked under skipLibCheck:true.
-  // https://github.com/denoland/deno/issues/36085
-  "ignore": true,
-  "args": "check --quiet dts/check_dts.d.ts",
-  "output": "dts/check_dts.out",
-  "exitCode": 1
+  // Each variant generates a `.deno/` under a different `skipLibCheck`, so
+  // isolate them in per-test temp dirs.
+  "tempDir": true,
+  "tests": {
+    // Aligned with tsgo: `skipLibCheck` defaults to true, so the `.d.ts`
+    // entrypoint is not type-checked and its error does not surface.
+    "default": {
+      "args": "check --quiet dts/check_dts.d.ts",
+      "output": ""
+    },
+    // With `skipLibCheck: false` the `.d.ts` entrypoint IS checked, so the error
+    // surfaces.
+    "skip_lib_check_false": {
+      "args": "check --quiet --config skip_lib_check_false.json dts/check_dts.d.ts",
+      "output": "dts/check_dts.out",
+      "exitCode": 1
+    }
+  }
 }

--- a/tests/specs/check/check_dts/dts/check_dts.out
+++ b/tests/specs/check/check_dts/dts/check_dts.out
@@ -1,6 +1,6 @@
 TS1039 [ERROR]: Initializers are not allowed in ambient contexts.
 export const a: string = Deno.version.deno;
-                         ~~~~~~~~~~~~~~~~~
+[WILDLINE]
     at file:///[WILDCARD]/check_dts.d.ts:2:26
 
 error: Type checking failed.

--- a/tests/specs/check/check_dts/skip_lib_check_false.json
+++ b/tests/specs/check/check_dts/skip_lib_check_false.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "skipLibCheck": false
+  }
+}

--- a/tests/specs/check/dts_importing_non_existent/__test__.jsonc
+++ b/tests/specs/check/dts_importing_non_existent/__test__.jsonc
@@ -1,8 +1,20 @@
 {
-  // ignored: .d.ts entrypoint not checked under skipLibCheck:true.
-  // https://github.com/denoland/deno/issues/36085
-  "ignore": true,
-  "args": "check index.js",
-  "output": "check.out",
-  "exitCode": 1
+  // Each variant generates a `.deno/` under a different `skipLibCheck`, so
+  // isolate them in per-test temp dirs.
+  "tempDir": true,
+  "tests": {
+    // Aligned with tsgo: `skipLibCheck` defaults to true, so the referenced
+    // `.d.ts` is not type-checked and its unresolved import does not surface.
+    "default": {
+      "args": "check index.js",
+      "output": "Check [WILDCARD]index.js\n"
+    },
+    // With `skipLibCheck: false` the referenced `.d.ts` IS checked, so the
+    // unresolved import surfaces.
+    "skip_lib_check_false": {
+      "args": "check --config skip_lib_check_false.json index.js",
+      "output": "check.out",
+      "exitCode": 1
+    }
+  }
 }

--- a/tests/specs/check/dts_importing_non_existent/check.out
+++ b/tests/specs/check/dts_importing_non_existent/check.out
@@ -1,5 +1,7 @@
 Check [WILDCARD]index.js
-TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/test'.
+TS2307 [ERROR]: Cannot find module './test' or its corresponding type declarations.
+export { Test } from "./test";
+[WILDLINE]
     at file:///[WILDLINE]/index.d.ts:1:22
 
 error: Type checking failed.

--- a/tests/specs/check/dts_importing_non_existent/skip_lib_check_false.json
+++ b/tests/specs/check/dts_importing_non_existent/skip_lib_check_false.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "skipLibCheck": false
+  }
+}

--- a/tests/specs/check/dts_unresolved_import_entrypoint/__test__.jsonc
+++ b/tests/specs/check/dts_unresolved_import_entrypoint/__test__.jsonc
@@ -1,24 +1,26 @@
 {
-  // ignored (entrypoint*): .d.ts entrypoints not checked under skipLibCheck:true.
-  // https://github.com/denoland/deno/issues/36085
+  // Each variant generates a `.deno/` and check cache under a different
+  // `skipLibCheck`, so isolate them in per-test temp dirs to avoid clobbering
+  // each other's generated config and type-check cache.
+  "tempDir": true,
   "tests": {
+    // Aligned with tsgo: `skipLibCheck` defaults to true, so a `.d.ts`
+    // entrypoint is not type-checked and its unresolved import does not surface.
     "entrypoint": {
-      "ignore": true,
       "args": "check --quiet foo.d.ts",
-      "output": "entrypoint.out",
-      "exitCode": 1
+      "output": ""
     },
-    // The unresolved import must surface for a `.d.ts` entrypoint whether or
-    // not `skipLibCheck` is set (the issue was reported with it off).
-    "entrypoint_skip_lib_check_false": {
-      "ignore": true,
-      "args": "check --quiet --config skip_lib_check_false.json foo.d.ts",
-      "output": "entrypoint.out",
-      "exitCode": 1
-    },
+    // Same with the base config (no deno.json): `skipLibCheck` still defaults to
+    // true, so the `.d.ts` entrypoint is skipped.
     "entrypoint_default_config": {
-      "ignore": true,
       "args": "check --quiet --no-config foo.d.ts",
+      "output": ""
+    },
+    // With `skipLibCheck: false` the `.d.ts` entrypoint IS checked, so the
+    // unresolved import surfaces. The override must be honored even when it
+    // comes from a `--config <other>` file rather than the discovered deno.json.
+    "entrypoint_skip_lib_check_false": {
+      "args": "check --quiet --config skip_lib_check_false.json foo.d.ts",
       "output": "entrypoint.out",
       "exitCode": 1
     },

--- a/tests/specs/check/dts_unresolved_import_entrypoint/entrypoint.out
+++ b/tests/specs/check/dts_unresolved_import_entrypoint/entrypoint.out
@@ -1,5 +1,6 @@
-TS2307 [ERROR]: Import "asdfsdf" not a dependency
-  hint: If you want to use the npm package, try running `deno add npm:asdfsdf`
+TS2307 [ERROR]: Cannot find module 'asdfsdf' or its corresponding type declarations.
+import foo from "asdfsdf";
+                ~~~~~~~~~
     at file:///[WILDCARD]/foo.d.ts:1:17
 
 error: Type checking failed.

--- a/tests/specs/run/error_type_definitions/deno.json
+++ b/tests/specs/run/error_type_definitions/deno.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "skipLibCheck": false
+  }
+}


### PR DESCRIPTION
Deno's base check compiler options defaulted `skipLibCheck` to false, while
the generated tsconfig used by native `deno check` defaulted it to true. That
split meant the two halves of the check pipeline disagreed on whether `.d.ts`
files are type-checked, and it also made the native check-hash collide across
runs that used different effective `skipLibCheck` values (a clean run under the
implicit false default would satisfy a later run that should have checked lib
files, and vice versa).

This flips the resolved base default to true so the whole pipeline (native
check, the in-isolate check path shared by `deno run --check`/`test`/`cache`,
and the LSP) agrees on tsgo's `--init` default of `skipLibCheck: true`. A user
`skipLibCheck: false` still overrides it, and that override is now sourced from
the resolved compiler options (which honor `--config <other>`) rather than the
raw project-root deno.json pass, so it is respected however the config is
provided.

With the default settled, this re-enables the `.d.ts` entrypoint check specs
that were ignored under #36085: under the aligned default a `.d.ts` entrypoint
(or a referenced `.d.ts` dependency) is not type-checked, and each spec now also
covers the `skipLibCheck: false` path that does surface the error. The specs run
in per-test temp dirs so their generated `.deno/` and check caches don't clobber
one another.

Closes #36085