### PR TITLE
fix(clean): reject symlinked node_modules cleanup roots

### DIFF
--- a/cli/tools/clean.rs
+++ b/cli/tools/clean.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::ffi::OsString;
+use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -575,11 +576,47 @@ fn clean_node_modules(
   dir: &Path,
   dry_run: bool,
 ) -> Result<(), AnyError> {
-  if !dir.ends_with("node_modules") || !dir.is_dir() {
+  if !dir.ends_with("node_modules") {
     bail!("expected a node_modules directory, got: {}", dir.display());
   }
+
+  let dir_metadata = std::fs::symlink_metadata(dir).with_context(|| {
+    format!("failed to stat node_modules directory at {}", dir.display())
+  })?;
+  if dir_metadata.file_type().is_symlink() {
+    bail!(
+      "refusing to clean symlinked node_modules directory at {}",
+      dir.display()
+    );
+  }
+  if !dir_metadata.is_dir() {
+    bail!("expected a node_modules directory, got: {}", dir.display());
+  }
+
   let base = dir.join(".deno");
-  if !base.exists() {
+  let base_metadata = match std::fs::symlink_metadata(&base) {
+    Ok(metadata) => metadata,
+    Err(err)
+      if matches!(
+        err.kind(),
+        ErrorKind::NotFound | ErrorKind::NotADirectory
+      ) =>
+    {
+      return Ok(());
+    }
+    Err(err) => {
+      return Err(err).with_context(|| {
+        format!("failed to stat node_modules/.deno at {}", base.display())
+      });
+    }
+  };
+  if base_metadata.file_type().is_symlink() {
+    bail!(
+      "refusing to clean symlinked node_modules/.deno directory at {}",
+      base.display()
+    );
+  }
+  if !base_metadata.is_dir() {
     return Ok(());
   }
 
@@ -682,11 +719,16 @@ fn clean_node_modules(
 
 #[cfg(test)]
 mod tests {
+  use std::collections::HashSet;
   use std::path::Path;
   use std::path::PathBuf;
 
+  use test_util::TempDir;
+
   use super::Found::*;
+  use super::clean_node_modules;
   use super::format_locked_files_message;
+  use crate::util::fs::FsCleaner;
   use crate::util::windows::LockingProcess;
 
   #[test]
@@ -737,6 +779,33 @@ mod tests {
     let message = format_locked_files_message(&paths, &[]);
     assert!(message.starts_with("15 files could not be removed"));
     assert!(message.contains("... and 5 more"));
+  }
+
+  #[test]
+  fn clean_node_modules_refuses_symlinked_deno_dir() {
+    let temp_dir = TempDir::new();
+    temp_dir.create_dir_all("node_modules");
+    temp_dir.create_dir_all("victim/important_dir");
+    temp_dir.write("victim/important_dir/secret.txt", "secret");
+    temp_dir.symlink_dir("victim", "node_modules/.deno");
+
+    let mut cleaner = FsCleaner::new(None);
+    let node_modules = temp_dir.path().join("node_modules");
+    let err = clean_node_modules(
+      &mut cleaner,
+      &HashSet::new(),
+      node_modules.as_path(),
+      false,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("refusing to clean symlinked"));
+    assert!(
+      temp_dir
+        .path()
+        .join("victim/important_dir/secret.txt")
+        .exists()
+    );
   }
 
   #[test]

--- a/cli/tools/clean.rs
+++ b/cli/tools/clean.rs
@@ -580,9 +580,24 @@ fn clean_node_modules(
     bail!("expected a node_modules directory, got: {}", dir.display());
   }
 
-  let dir_metadata = std::fs::symlink_metadata(dir).with_context(|| {
-    format!("failed to stat node_modules directory at {}", dir.display())
-  })?;
+  let dir_metadata = match std::fs::symlink_metadata(dir) {
+    Ok(metadata) => metadata,
+    // Keep the original error message when the path is simply missing or has a
+    // non-directory component, rather than surfacing a raw stat error.
+    Err(err)
+      if matches!(
+        err.kind(),
+        ErrorKind::NotFound | ErrorKind::NotADirectory
+      ) =>
+    {
+      bail!("expected a node_modules directory, got: {}", dir.display());
+    }
+    Err(err) => {
+      return Err(err).with_context(|| {
+        format!("failed to stat node_modules directory at {}", dir.display())
+      });
+    }
+  };
   if dir_metadata.file_type().is_symlink() {
     bail!(
       "refusing to clean symlinked node_modules directory at {}",
@@ -628,6 +643,9 @@ fn clean_node_modules(
   // remove the actual packages from node_modules/.deno
   let entries = match std::fs::read_dir(&base) {
     Ok(entries) => entries,
+    // `base` was confirmed to be a real directory above, so reaching this arm
+    // means it was concurrently removed (TOCTOU) between that check and here.
+    // There's nothing left to clean in that case.
     Err(err)
       if matches!(
         err.kind(),


### PR DESCRIPTION
## Summary

- validate `node_modules` cleanup roots without following symlinks
- reject symlinked `node_modules` and `.deno` directories before traversal
- preserve the existing no-op behavior for missing or non-directory `.deno` paths

## Details

`deno clean --except` previously checked its local npm cleanup roots with
filesystem operations that followed symlinks. An existing symlink at either
root could therefore redirect cleanup outside the selected `node_modules`
tree.

The cleanup path now inspects both roots with symlink-aware metadata before
enumerating or removing entries. A redirected root produces an ordinary
command error without touching its target.

## Validation

- `./tools/format.js --check`
- `cargo test -p deno --lib clean_node_modules_refuses_symlinked_deno_dir -- --nocapture`
- `cargo build --bin deno`

AI assistance was used to help implement and test this change.
