### PR TITLE
fix(npm): reject symlinked package materialization dirs

### DIFF
--- a/libs/npm_cache/Cargo.toml
+++ b/libs/npm_cache/Cargo.toml
@@ -49,5 +49,5 @@ sha2.workspace = true
 sha1.workspace = true
 
 [dev-dependencies]
-sys_traits = { workspace = true, features = ["real"] }
+sys_traits = { workspace = true, features = ["memory", "real"] }
 tempfile.workspace = true

--- a/libs/npm_cache/fs_util.rs
+++ b/libs/npm_cache/fs_util.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 use sys_traits::FsCreateDirAll;
 use sys_traits::FsDirEntry;
 use sys_traits::FsHardLink;
+use sys_traits::FsMetadata;
+use sys_traits::FsMetadataValue;
 use sys_traits::FsReadDir;
 use sys_traits::FsRemoveFile;
 use sys_traits::PathsInErrorsExt;
@@ -14,20 +16,20 @@ use sys_traits::ThreadSleep;
 
 #[sys_traits::auto_impl]
 pub trait HardLinkDirRecursiveSys:
-  HardLinkFileSys + FsCreateDirAll + FsReadDir
+  HardLinkFileSys + FsCreateDirAll + FsMetadata + FsReadDir
 {
 }
 
 /// Hardlinks the files in one directory to another directory.
 ///
-/// Note: Does not handle symlinks.
+/// Note: Does not hardlink source symlinks and rejects symlinked destinations.
 pub fn hard_link_dir_recursive<TSys: HardLinkDirRecursiveSys>(
   sys: &TSys,
   from: &Path,
   to: &Path,
 ) -> Result<(), std::io::Error> {
   let sys = sys.with_paths_in_errors();
-  sys.fs_create_dir_all(to)?;
+  create_dir_all_no_symlink(sys.as_ref(), to)?;
   let read_dir = sys.fs_read_dir(from)?;
 
   for entry in read_dir {
@@ -44,6 +46,38 @@ pub fn hard_link_dir_recursive<TSys: HardLinkDirRecursiveSys>(
   }
 
   Ok(())
+}
+
+fn create_dir_all_no_symlink<TSys>(
+  sys: &TSys,
+  path: &Path,
+) -> Result<(), std::io::Error>
+where
+  TSys: FsCreateDirAll + FsMetadata,
+{
+  ensure_not_symlink(sys, path)?;
+  sys.fs_create_dir_all(path)?;
+  ensure_not_symlink(sys, path)
+}
+
+fn ensure_not_symlink<TSys>(
+  sys: &TSys,
+  path: &Path,
+) -> Result<(), std::io::Error>
+where
+  TSys: FsMetadata,
+{
+  match sys.fs_symlink_metadata(path) {
+    Ok(metadata) if metadata.file_type().is_symlink() => {
+      Err(std::io::Error::new(
+        ErrorKind::AlreadyExists,
+        "refusing to materialize package into symlinked directory",
+      ))
+    }
+    Ok(_) => Ok(()),
+    Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+    Err(err) => Err(err),
+  }
 }
 
 #[sys_traits::auto_impl]
@@ -94,4 +128,33 @@ pub fn hard_link_file<TSys: HardLinkFileSys>(
     }
   }
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use std::path::Path;
+
+  use sys_traits::FsCreateDirAll;
+  use sys_traits::FsRead;
+  use sys_traits::FsSymlinkDir;
+  use sys_traits::FsWrite;
+
+  use super::*;
+
+  #[test]
+  fn hard_link_dir_recursive_rejects_symlink_destination_directory() {
+    let sys = sys_traits::impls::InMemorySys::default();
+    let from = Path::new("/from");
+    let to = Path::new("/to");
+    let target = Path::new("/target");
+    sys.fs_create_dir_all(from).unwrap();
+    sys.fs_create_dir_all(target).unwrap();
+    sys.fs_write(from.join("file"), "package contents").unwrap();
+    sys.fs_symlink_dir(target, to).unwrap();
+
+    let err = hard_link_dir_recursive(&sys, from, to).unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::AlreadyExists);
+    assert!(sys.fs_read_to_string(target.join("file")).is_err());
+  }
 }

--- a/libs/npm_cache/fs_util.rs
+++ b/libs/npm_cache/fs_util.rs
@@ -48,7 +48,8 @@ pub fn hard_link_dir_recursive<TSys: HardLinkDirRecursiveSys>(
   Ok(())
 }
 
-fn create_dir_all_no_symlink<TSys>(
+/// Creates a directory and rejects a symlink at the destination.
+pub fn create_dir_all_no_symlink<TSys>(
   sys: &TSys,
   path: &Path,
 ) -> Result<(), std::io::Error>
@@ -60,7 +61,8 @@ where
   ensure_not_symlink(sys, path)
 }
 
-fn ensure_not_symlink<TSys>(
+/// Returns an error when the path is a symlink.
+pub fn ensure_not_symlink<TSys>(
   sys: &TSys,
   path: &Path,
 ) -> Result<(), std::io::Error>

--- a/libs/npm_cache/lib.rs
+++ b/libs/npm_cache/lib.rs
@@ -41,6 +41,8 @@ mod rt;
 mod tarball;
 mod tarball_extract;
 
+pub use fs_util::create_dir_all_no_symlink;
+pub use fs_util::ensure_not_symlink;
 pub use fs_util::hard_link_dir_recursive;
 pub use fs_util::hard_link_file;
 pub use registry_info::RegistryInfoProvider;

--- a/libs/npm_installer/fs.rs
+++ b/libs/npm_installer/fs.rs
@@ -5,6 +5,8 @@ use std::io::ErrorKind;
 use std::path::Path;
 
 use sys_traits::FsDirEntry;
+use sys_traits::FsMetadata;
+use sys_traits::FsMetadataValue;
 use sys_traits::FsSymlinkDir;
 use sys_traits::PathsInErrorsExt;
 
@@ -22,13 +24,14 @@ pub trait CloneDirRecursiveSys:
 /// is not guaranteed - it may be a hardlink, copy, or other platform-specific
 /// operation.
 ///
-/// Note: Does not handle symlinks.
+/// Note: Does not copy source symlinks and rejects symlinked destinations.
 pub fn clone_dir_recursive<TSys: CloneDirRecursiveSys>(
   sys: &TSys,
   from: &Path,
   to: &Path,
 ) -> Result<(), std::io::Error> {
   let sys = sys.with_paths_in_errors();
+  ensure_not_symlink(sys.as_ref(), to)?;
   if cfg!(target_vendor = "apple") {
     if let Some(parent) = to.parent() {
       sys.fs_create_dir_all(parent)?;
@@ -66,6 +69,7 @@ pub trait CopyDirRecursiveSys:
   + sys_traits::FsCloneFile
   + sys_traits::FsCreateDir
   + sys_traits::FsHardLink
+  + sys_traits::FsMetadata
   + sys_traits::FsReadDir
   + sys_traits::FsRemoveFile
 {
@@ -73,14 +77,14 @@ pub trait CopyDirRecursiveSys:
 
 /// Copies a directory to another directory.
 ///
-/// Note: Does not handle symlinks.
+/// Note: Does not copy source symlinks and rejects symlinked destinations.
 pub fn copy_dir_recursive<TSys: CopyDirRecursiveSys>(
   sys: &TSys,
   from: &Path,
   to: &Path,
 ) -> Result<(), std::io::Error> {
   let sys = sys.with_paths_in_errors();
-  sys.fs_create_dir_all(to)?;
+  create_dir_all_no_symlink(sys.as_ref(), to)?;
   let read_dir = sys.fs_read_dir(from)?;
 
   for entry in read_dir {
@@ -104,6 +108,38 @@ pub fn copy_dir_recursive<TSys: CopyDirRecursiveSys>(
   }
 
   Ok(())
+}
+
+fn create_dir_all_no_symlink<TSys>(
+  sys: &TSys,
+  path: &Path,
+) -> Result<(), std::io::Error>
+where
+  TSys: sys_traits::FsCreateDirAll + FsMetadata,
+{
+  ensure_not_symlink(sys, path)?;
+  sys.fs_create_dir_all(path)?;
+  ensure_not_symlink(sys, path)
+}
+
+fn ensure_not_symlink<TSys>(
+  sys: &TSys,
+  path: &Path,
+) -> Result<(), std::io::Error>
+where
+  TSys: FsMetadata,
+{
+  match sys.fs_symlink_metadata(path) {
+    Ok(metadata) if metadata.file_type().is_symlink() => {
+      Err(std::io::Error::new(
+        ErrorKind::AlreadyExists,
+        "refusing to materialize package into symlinked directory",
+      ))
+    }
+    Ok(_) => Ok(()),
+    Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+    Err(err) => Err(err),
+  }
 }
 
 pub fn symlink_dir<TSys: sys_traits::BaseFsSymlinkDir>(
@@ -142,6 +178,7 @@ mod test {
   use sys_traits::FsCreateDirAll;
   use sys_traits::FsHardLink;
   use sys_traits::FsRead;
+  use sys_traits::FsSymlinkDir;
   use sys_traits::FsWrite;
   use test_util::TempDir;
 
@@ -173,5 +210,22 @@ mod test {
     );
     // and the other end of the hardlink was not written through
     assert_eq!(sys.fs_read_to_string(&binary).unwrap(), "binary contents");
+  }
+
+  #[test]
+  fn copy_dir_recursive_rejects_symlink_destination_directory() {
+    let sys = sys_traits::impls::InMemorySys::default();
+    let from = Path::new("/from");
+    let to = Path::new("/to");
+    let target = Path::new("/target");
+    sys.fs_create_dir_all(from).unwrap();
+    sys.fs_create_dir_all(target).unwrap();
+    sys.fs_write(from.join("file"), "package contents").unwrap();
+    sys.fs_symlink_dir(target, to).unwrap();
+
+    let err = copy_dir_recursive(&sys, from, to).unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::AlreadyExists);
+    assert!(sys.fs_read_to_string(target.join("file")).is_err());
   }
 }

--- a/libs/npm_installer/fs.rs
+++ b/libs/npm_installer/fs.rs
@@ -5,8 +5,6 @@ use std::io::ErrorKind;
 use std::path::Path;
 
 use sys_traits::FsDirEntry;
-use sys_traits::FsMetadata;
-use sys_traits::FsMetadataValue;
 use sys_traits::FsSymlinkDir;
 use sys_traits::PathsInErrorsExt;
 
@@ -31,7 +29,7 @@ pub fn clone_dir_recursive<TSys: CloneDirRecursiveSys>(
   to: &Path,
 ) -> Result<(), std::io::Error> {
   let sys = sys.with_paths_in_errors();
-  ensure_not_symlink(sys.as_ref(), to)?;
+  deno_npm_cache::ensure_not_symlink(sys.as_ref(), to)?;
   if cfg!(target_vendor = "apple") {
     if let Some(parent) = to.parent() {
       sys.fs_create_dir_all(parent)?;
@@ -84,7 +82,7 @@ pub fn copy_dir_recursive<TSys: CopyDirRecursiveSys>(
   to: &Path,
 ) -> Result<(), std::io::Error> {
   let sys = sys.with_paths_in_errors();
-  create_dir_all_no_symlink(sys.as_ref(), to)?;
+  deno_npm_cache::create_dir_all_no_symlink(sys.as_ref(), to)?;
   let read_dir = sys.fs_read_dir(from)?;
 
   for entry in read_dir {
@@ -108,38 +106,6 @@ pub fn copy_dir_recursive<TSys: CopyDirRecursiveSys>(
   }
 
   Ok(())
-}
-
-fn create_dir_all_no_symlink<TSys>(
-  sys: &TSys,
-  path: &Path,
-) -> Result<(), std::io::Error>
-where
-  TSys: sys_traits::FsCreateDirAll + FsMetadata,
-{
-  ensure_not_symlink(sys, path)?;
-  sys.fs_create_dir_all(path)?;
-  ensure_not_symlink(sys, path)
-}
-
-fn ensure_not_symlink<TSys>(
-  sys: &TSys,
-  path: &Path,
-) -> Result<(), std::io::Error>
-where
-  TSys: FsMetadata,
-{
-  match sys.fs_symlink_metadata(path) {
-    Ok(metadata) if metadata.file_type().is_symlink() => {
-      Err(std::io::Error::new(
-        ErrorKind::AlreadyExists,
-        "refusing to materialize package into symlinked directory",
-      ))
-    }
-    Ok(_) => Ok(()),
-    Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
-    Err(err) => Err(err),
-  }
 }
 
 pub fn symlink_dir<TSys: sys_traits::BaseFsSymlinkDir>(

--- a/libs/npm_installer/local.rs
+++ b/libs/npm_installer/local.rs
@@ -30,6 +30,8 @@ use deno_npm_cache::NpmCache;
 use deno_npm_cache::NpmCacheHttpClient;
 use deno_npm_cache::NpmCacheSys;
 use deno_npm_cache::TarballCache;
+use deno_npm_cache::create_dir_all_no_symlink;
+use deno_npm_cache::ensure_not_symlink;
 use deno_npm_cache::hard_link_file;
 use deno_path_util::fs::atomic_write_file_with_retries;
 use deno_resolver::npm::get_package_folder_id_folder_name;
@@ -1303,8 +1305,9 @@ pub(crate) fn clone_dir_recursive_except_node_modules_child(
   to: &Path,
 ) -> Result<(), std::io::Error> {
   let sys = sys.with_paths_in_errors();
+  ensure_not_symlink(sys.as_ref(), to)?;
   _ = sys.fs_remove_dir_all(to);
-  sys.fs_create_dir_all(to)?;
+  create_dir_all_no_symlink(sys.as_ref(), to)?;
   for entry in sys.fs_read_dir(from)? {
     let entry = entry?;
     if entry.file_name().to_str() == Some("node_modules") {
@@ -2255,10 +2258,30 @@ mod test {
   use sys_traits::FsCreateDirAll;
   use sys_traits::FsMetadata;
   use sys_traits::FsRead;
+  use sys_traits::FsSymlinkDir;
   use sys_traits::FsWrite;
   use test_util::TempDir;
 
   use super::*;
+
+  #[test]
+  fn clone_dir_recursive_except_node_modules_child_rejects_symlink_destination()
+  {
+    let sys = sys_traits::impls::InMemorySys::default();
+    let from = Path::new("/from");
+    let to = Path::new("/to");
+    let target = Path::new("/target");
+    sys.fs_create_dir_all(from).unwrap();
+    sys.fs_create_dir_all(target).unwrap();
+    sys.fs_write(from.join("file"), "package contents").unwrap();
+    sys.fs_symlink_dir(target, to).unwrap();
+
+    let err = clone_dir_recursive_except_node_modules_child(&sys, from, to)
+      .unwrap_err();
+
+    assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+    assert!(sys.fs_read_to_string(target.join("file")).is_err());
+  }
 
   #[test]
   fn test_setup_cache() {


### PR DESCRIPTION
## Summary

- reject symlinked package materialization destinations
- apply the check to both hard-link and copy paths
- cover both helpers with in-memory filesystem regressions

## Details

Package initialization previously treated an existing symlinked destination
as a directory. Creating the destination and then hard-linking or copying
package files could therefore write through that redirected path.

Materialization now checks each destination directory before and after
creation using symlink-aware metadata. Existing ordinary directories continue
to work as before, while a symlinked destination returns an ordinary
filesystem error.

## Validation

- `./tools/format.js --check`
- `cargo test -p deno_npm_cache hard_link_dir_recursive -- --nocapture`
- `cargo test -p deno_npm_installer copy_dir_recursive -- --nocapture`

AI assistance was used to help implement and test this change.
