### PR TITLE
fix(test): escape control characters in test names

### DIFF
--- a/cli/js/40_test_common.js
+++ b/cli/js/40_test_common.js
@@ -5,37 +5,54 @@ const { serializePermissions } = core.loadExtScript(
 );
 const ops = core.ops;
 const {
-  StringPrototypeReplaceAll,
+  NumberPrototypeToString,
   SafeArrayIterator,
+  StringPrototypeCharCodeAt,
+  StringPrototypePadStart,
+  StringPrototypeSlice,
 } = primordials;
 
-const ESCAPE_ASCII_CHARS = [
-  ["\b", "\\b"],
-  ["\f", "\\f"],
-  ["\t", "\\t"],
-  ["\n", "\\n"],
-  ["\r", "\\r"],
-  ["\v", "\\v"],
-];
+function escapeControlChar(code) {
+  switch (code) {
+    case 0x08:
+      return "\\b";
+    case 0x09:
+      return "\\t";
+    case 0x0a:
+      return "\\n";
+    case 0x0b:
+      return "\\v";
+    case 0x0c:
+      return "\\f";
+    case 0x0d:
+      return "\\r";
+  }
+  return `\\x${
+    StringPrototypePadStart(NumberPrototypeToString(code, 16), 2, "0")
+  }`;
+}
 
 /**
  * @param {string} name
  * @returns {string}
  */
 export function escapeName(name) {
-  // Check if we need to escape a character
+  let escapedName = "";
+  let lastIndex = 0;
+
   for (let i = 0; i < name.length; i++) {
-    const ch = name.charCodeAt(i);
-    if (ch <= 13 && ch >= 8) {
-      // Slow path: We do need to escape it
-      for (const [escape, replaceWith] of ESCAPE_ASCII_CHARS) {
-        name = StringPrototypeReplaceAll(name, escape, replaceWith);
-      }
-      return name;
+    const code = StringPrototypeCharCodeAt(name, i);
+    if (code <= 0x1f || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
+      escapedName += StringPrototypeSlice(name, lastIndex, i) +
+        escapeControlChar(code);
+      lastIndex = i + 1;
     }
   }
 
-  // We didn't need to escape anything, return original string
+  if (lastIndex !== 0) {
+    return escapedName + StringPrototypeSlice(name, lastIndex);
+  }
+
   return name;
 }
 

--- a/cli/tools/test/reporters/tap.rs
+++ b/cli/tools/test/reporters/tap.rs
@@ -97,7 +97,7 @@ impl TapTestReporter {
     result: &TestStepResult,
   ) {
     if self.step_n == 0 {
-      drop_println!("# Subtest: {}", desc.root_name)
+      drop_println!("# Subtest: {}", Self::escape_description(&desc.root_name))
     }
 
     let (status, directive) = match result {

--- a/tests/specs/test/control_chars/__test__.jsonc
+++ b/tests/specs/test/control_chars/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tests": {
+    "pretty": {
+      "args": "test --reporter=pretty control_chars.ts",
+      "exitCode": 0,
+      "output": "pretty.out"
+    },
+    "tap": {
+      "args": "test --reporter=tap control_chars.ts",
+      "exitCode": 0,
+      "output": "tap.out"
+    }
+  }
+}

--- a/tests/specs/test/control_chars/control_chars.ts
+++ b/tests/specs/test/control_chars/control_chars.ts
@@ -1,3 +1,5 @@
-Deno.test("\x1b[1F\x1b[2Kroot", async (t) => {
-  await t.step("\x1b]52;c;bad\x07step", () => {});
+// Exercises all three escaped ranges: C0 (ESC 0x1b, BEL 0x07), DEL (0x7f),
+// and C1 (0x9b CSI, 0x80).
+Deno.test("\x1b[1F\x1b[2Kroot\x7f\x9b", async (t) => {
+  await t.step("\x1b]52;c;bad\x07step\x80", () => {});
 });

--- a/tests/specs/test/control_chars/control_chars.ts
+++ b/tests/specs/test/control_chars/control_chars.ts
@@ -1,0 +1,3 @@
+Deno.test("\x1b[1F\x1b[2Kroot", async (t) => {
+  await t.step("\x1b]52;c;bad\x07step", () => {});
+});

--- a/tests/specs/test/control_chars/pretty.out
+++ b/tests/specs/test/control_chars/pretty.out
@@ -1,0 +1,8 @@
+[WILDCARD]
+running 1 test from ./control_chars.ts
+\x1b[1F\x1b[2Kroot ...
+  \x1b]52;c;bad\x07step ... ok ([WILDCARD])
+\x1b[1F\x1b[2Kroot ... ok ([WILDCARD])
+
+ok | 1 passed (1 step) | 0 failed ([WILDCARD])
+

--- a/tests/specs/test/control_chars/pretty.out
+++ b/tests/specs/test/control_chars/pretty.out
@@ -1,8 +1,8 @@
 [WILDCARD]
 running 1 test from ./control_chars.ts
-\x1b[1F\x1b[2Kroot ...
-  \x1b]52;c;bad\x07step ... ok ([WILDCARD])
-\x1b[1F\x1b[2Kroot ... ok ([WILDCARD])
+\x1b[1F\x1b[2Kroot\x7f\x9b ...
+  \x1b]52;c;bad\x07step\x80 ... ok ([WILDCARD])
+\x1b[1F\x1b[2Kroot\x7f\x9b ... ok ([WILDCARD])
 
 ok | 1 passed (1 step) | 0 failed ([WILDCARD])
 

--- a/tests/specs/test/control_chars/tap.out
+++ b/tests/specs/test/control_chars/tap.out
@@ -1,7 +1,7 @@
 TAP version 14
 # ./control_chars.ts
-# Subtest: \\x1b[1F\\x1b[2Kroot
-    ok 1 - \\x1b]52;c;bad\\x07step
+# Subtest: \\x1b[1F\\x1b[2Kroot\\x7f\\x9b
+    ok 1 - \\x1b]52;c;bad\\x07step\\x80
     1..1
-ok 1 - \\x1b[1F\\x1b[2Kroot
+ok 1 - \\x1b[1F\\x1b[2Kroot\\x7f\\x9b
 1..1

--- a/tests/specs/test/control_chars/tap.out
+++ b/tests/specs/test/control_chars/tap.out
@@ -1,0 +1,7 @@
+TAP version 14
+# ./control_chars.ts
+# Subtest: \\x1b[1F\\x1b[2Kroot
+    ok 1 - \\x1b]52;c;bad\\x07step
+    1..1
+ok 1 - \\x1b[1F\\x1b[2Kroot
+1..1


### PR DESCRIPTION
Test and step names containing control characters could alter reporter formatting.

This change escapes C0, DEL, and C1 characters in the shared test-name formatter and consistently escapes TAP subtest headings. It adds pretty and TAP regression coverage for root and step names.

Tests:
- `./tools/format.js --check cli/js/40_test_common.js cli/tools/test/reporters/tap.rs tests/specs/test/control_chars`
- `cargo test specs::test::control_chars -- --nocapture`