### PR TITLE
fix(runtime): reject overflowing worker resource limits

### DIFF
--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -60,6 +60,12 @@ use crate::args::has_trace_permissions_enabled;
 use crate::sys::DenoLibSys;
 use crate::util::checksum;
 
+const BYTES_PER_MB: usize = 1024 * 1024;
+
+fn resource_limit_mb_to_bytes(value: usize) -> usize {
+  value.saturating_mul(BYTES_PER_MB)
+}
+
 pub struct CreateModuleLoaderResult {
   pub module_loader: Rc<dyn ModuleLoader>,
   pub node_require_loader: Rc<dyn NodeRequireLoader>,
@@ -433,21 +439,23 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
         if let Some(max_old) =
           limits.max_old_generation_size_mb.filter(|&v| v > 0)
         {
-          params =
-            params.set_max_old_generation_size_in_bytes(max_old * 1024 * 1024);
+          params = params.set_max_old_generation_size_in_bytes(
+            resource_limit_mb_to_bytes(max_old),
+          );
         }
         if let Some(max_young) =
           limits.max_young_generation_size_mb.filter(|&v| v > 0)
         {
-          params = params
-            .set_max_young_generation_size_in_bytes(max_young * 1024 * 1024);
+          params = params.set_max_young_generation_size_in_bytes(
+            resource_limit_mb_to_bytes(max_young),
+          );
         }
         if let Some(code_range) = limits.code_range_size_mb.filter(|&v| v > 0) {
-          params =
-            params.set_code_range_size_in_bytes(code_range * 1024 * 1024);
+          params = params.set_code_range_size_in_bytes(
+            resource_limit_mb_to_bytes(code_range),
+          );
         }
 
-        let mb = 1024 * 1024;
         // Read back resolved values (including V8 defaults for
         // unspecified fields), matching Node.js behavior.
         // Note: integer division truncates sub-MB fractions, which is fine
@@ -455,10 +463,10 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
         let resolved = deno_node::ops::worker_threads::ResolvedResourceLimits {
           max_young_generation_size_mb: params
             .max_young_generation_size_in_bytes()
-            / mb,
+            / BYTES_PER_MB,
           max_old_generation_size_mb: params.max_old_generation_size_in_bytes()
-            / mb,
-          code_range_size_mb: params.code_range_size_in_bytes() / mb,
+            / BYTES_PER_MB,
+          code_range_size_mb: params.code_range_size_in_bytes() / BYTES_PER_MB,
           stack_size_mb: limits
             .stack_size_mb
             .unwrap_or(deno_node::ops::worker_threads::DEFAULT_STACK_SIZE_MB),

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -62,8 +62,13 @@ use crate::util::checksum;
 
 const BYTES_PER_MB: usize = 1024 * 1024;
 
-fn resource_limit_mb_to_bytes(value: usize) -> usize {
-  value.saturating_mul(BYTES_PER_MB)
+fn validated_resource_limit_mb_to_bytes(value: usize) -> usize {
+  // `op_create_worker` rejects overflow before invoking this callback. Keep
+  // this conversion checked so the downstream path cannot silently choose a
+  // different overflow policy.
+  value
+    .checked_mul(BYTES_PER_MB)
+    .expect("worker resource limits must be validated before worker creation")
 }
 
 pub struct CreateModuleLoaderResult {
@@ -440,19 +445,19 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
           limits.max_old_generation_size_mb.filter(|&v| v > 0)
         {
           params = params.set_max_old_generation_size_in_bytes(
-            resource_limit_mb_to_bytes(max_old),
+            validated_resource_limit_mb_to_bytes(max_old),
           );
         }
         if let Some(max_young) =
           limits.max_young_generation_size_mb.filter(|&v| v > 0)
         {
           params = params.set_max_young_generation_size_in_bytes(
-            resource_limit_mb_to_bytes(max_young),
+            validated_resource_limit_mb_to_bytes(max_young),
           );
         }
         if let Some(code_range) = limits.code_range_size_mb.filter(|&v| v > 0) {
           params = params.set_code_range_size_in_bytes(
-            resource_limit_mb_to_bytes(code_range),
+            validated_resource_limit_mb_to_bytes(code_range),
           );
         }
 

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -50,6 +50,8 @@ use crate::web_worker::WorkerThreadType;
 use crate::web_worker::run_web_worker;
 use crate::worker::FormatJsErrorFn;
 
+const BYTES_PER_MB: usize = 1024 * 1024;
+
 pub const UNSTABLE_FEATURE_NAME: &str = "worker-options";
 
 /// Default OS stack size for the thread a worker's isolate runs on.
@@ -70,6 +72,41 @@ pub struct ResourceLimits {
   pub max_old_generation_size_mb: Option<usize>,
   pub code_range_size_mb: Option<usize>,
   pub stack_size_mb: Option<usize>,
+}
+
+fn resource_limit_mb_to_bytes(
+  name: &'static str,
+  value: usize,
+) -> Result<usize, CreateWorkerError> {
+  value
+    .checked_mul(BYTES_PER_MB)
+    .ok_or(CreateWorkerError::ResourceLimitTooLarge(name))
+}
+
+fn validate_resource_limits(
+  limits: &ResourceLimits,
+) -> Result<(), CreateWorkerError> {
+  if let Some(value) = limits
+    .max_young_generation_size_mb
+    .filter(|&value| value > 0)
+  {
+    resource_limit_mb_to_bytes(
+      "resourceLimits.maxYoungGenerationSizeMb",
+      value,
+    )?;
+  }
+  if let Some(value) =
+    limits.max_old_generation_size_mb.filter(|&value| value > 0)
+  {
+    resource_limit_mb_to_bytes("resourceLimits.maxOldGenerationSizeMb", value)?;
+  }
+  if let Some(value) = limits.code_range_size_mb.filter(|&value| value > 0) {
+    resource_limit_mb_to_bytes("resourceLimits.codeRangeSizeMb", value)?;
+  }
+  if let Some(value) = limits.stack_size_mb.filter(|&value| value > 0) {
+    resource_limit_mb_to_bytes("resourceLimits.stackSizeMb", value)?;
+  }
+  Ok(())
 }
 
 pub struct CreateWebWorkerArgs {
@@ -290,6 +327,9 @@ pub enum CreateWorkerError {
   #[class(inherit)]
   #[error("{0}")]
   Io(#[from] std::io::Error),
+  #[class(range)]
+  #[error("Worker {0} is too large")]
+  ResourceLimitTooLarge(&'static str),
 }
 
 /// Create worker as the host
@@ -344,6 +384,9 @@ fn op_create_worker(
     })
     .unwrap_or(false);
   let worker_id = WorkerId::new();
+  if let Some(ref limits) = args.resource_limits {
+    validate_resource_limits(limits)?;
+  }
 
   let module_specifier = deno_core::resolve_url(&specifier)?;
   // Synchronously capture the root blob so a racing `URL.revokeObjectURL`
@@ -371,7 +414,10 @@ fn op_create_worker(
     .unwrap_or(DEFAULT_WORKER_STACK_SIZE_MB);
   let thread_builder = std::thread::Builder::new()
     .name(format!("{worker_id}"))
-    .stack_size(stack_size_mb * 1024 * 1024);
+    .stack_size(resource_limit_mb_to_bytes(
+      "resourceLimits.stackSizeMb",
+      stack_size_mb,
+    )?);
   let maybe_worker_metadata = if let Some(data) = maybe_worker_metadata {
     let transferables =
       deserialize_js_transferables(state, data.transferables)?;

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -50,6 +50,8 @@ use crate::web_worker::WorkerThreadType;
 use crate::web_worker::run_web_worker;
 use crate::worker::FormatJsErrorFn;
 
+const BYTES_PER_MB: usize = 1024 * 1024;
+
 pub const UNSTABLE_FEATURE_NAME: &str = "worker-options";
 
 /// Default OS stack size for the thread a worker's isolate runs on.
@@ -70,6 +72,41 @@ pub struct ResourceLimits {
   pub max_old_generation_size_mb: Option<usize>,
   pub code_range_size_mb: Option<usize>,
   pub stack_size_mb: Option<usize>,
+}
+
+fn resource_limit_mb_to_bytes(
+  name: &'static str,
+  value: usize,
+) -> Result<usize, CreateWorkerError> {
+  value
+    .checked_mul(BYTES_PER_MB)
+    .ok_or(CreateWorkerError::ResourceLimitTooLarge(name))
+}
+
+fn validate_resource_limits(
+  limits: &ResourceLimits,
+) -> Result<(), CreateWorkerError> {
+  if let Some(value) = limits
+    .max_young_generation_size_mb
+    .filter(|&value| value > 0)
+  {
+    resource_limit_mb_to_bytes(
+      "resourceLimits.maxYoungGenerationSizeMb",
+      value,
+    )?;
+  }
+  if let Some(value) =
+    limits.max_old_generation_size_mb.filter(|&value| value > 0)
+  {
+    resource_limit_mb_to_bytes("resourceLimits.maxOldGenerationSizeMb", value)?;
+  }
+  if let Some(value) = limits.code_range_size_mb.filter(|&value| value > 0) {
+    resource_limit_mb_to_bytes("resourceLimits.codeRangeSizeMb", value)?;
+  }
+  if let Some(value) = limits.stack_size_mb.filter(|&value| value > 0) {
+    resource_limit_mb_to_bytes("resourceLimits.stackSizeMb", value)?;
+  }
+  Ok(())
 }
 
 pub struct CreateWebWorkerArgs {
@@ -251,6 +288,9 @@ pub enum CreateWorkerError {
   #[class(inherit)]
   #[error("{0}")]
   Io(#[from] std::io::Error),
+  #[class(range)]
+  #[error("Worker {0} is too large")]
+  ResourceLimitTooLarge(&'static str),
 }
 
 /// Create worker as the host
@@ -305,6 +345,9 @@ fn op_create_worker(
     })
     .unwrap_or(false);
   let worker_id = WorkerId::new();
+  if let Some(ref limits) = args.resource_limits {
+    validate_resource_limits(limits)?;
+  }
 
   let module_specifier = deno_core::resolve_url(&specifier)?;
   // Synchronously capture the root blob so a racing `URL.revokeObjectURL`
@@ -332,7 +375,10 @@ fn op_create_worker(
     .unwrap_or(DEFAULT_WORKER_STACK_SIZE_MB);
   let thread_builder = std::thread::Builder::new()
     .name(format!("{worker_id}"))
-    .stack_size(stack_size_mb * 1024 * 1024);
+    .stack_size(resource_limit_mb_to_bytes(
+      "resourceLimits.stackSizeMb",
+      stack_size_mb,
+    )?);
   let maybe_worker_metadata = if let Some(data) = maybe_worker_metadata {
     let transferables =
       deserialize_js_transferables(state, data.transferables)?;

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -78,6 +78,9 @@ fn resource_limit_mb_to_bytes(
   name: &'static str,
   value: usize,
 ) -> Result<usize, CreateWorkerError> {
+  // Node allows its floating-point-to-size conversion to truncate. Deno
+  // intentionally rejects limits that do not fit after conversion to bytes so
+  // the thread and V8 paths have one deterministic overflow policy.
   value
     .checked_mul(BYTES_PER_MB)
     .ok_or(CreateWorkerError::ResourceLimitTooLarge(name))

--- a/tests/specs/node/worker_threads_resource_limits/__test__.jsonc
+++ b/tests/specs/node/worker_threads_resource_limits/__test__.jsonc
@@ -16,6 +16,10 @@
       "args": "run --allow-read oom_main.mjs",
       "output": "oom_main.out",
       "exitCode": 0
+    },
+    "resource_limits_overflow": {
+      "args": "run overflow_main.mjs",
+      "output": "overflow_main.out"
     }
   }
 }

--- a/tests/specs/node/worker_threads_resource_limits/overflow_main.mjs
+++ b/tests/specs/node/worker_threads_resource_limits/overflow_main.mjs
@@ -1,0 +1,24 @@
+import { Worker } from "node:worker_threads";
+
+const OVERFLOW_VALUE = 2 ** 44;
+
+for (
+  const field of [
+    "maxYoungGenerationSizeMb",
+    "maxOldGenerationSizeMb",
+    "codeRangeSizeMb",
+    "stackSizeMb",
+  ]
+) {
+  try {
+    new Worker("setTimeout(() => {}, 1_000_000)", {
+      eval: true,
+      resourceLimits: {
+        [field]: OVERFLOW_VALUE,
+      },
+    });
+    console.log(`${field}: created`);
+  } catch (err) {
+    console.log(`${field}: ${err.name}: ${err.message}`);
+  }
+}

--- a/tests/specs/node/worker_threads_resource_limits/overflow_main.out
+++ b/tests/specs/node/worker_threads_resource_limits/overflow_main.out
@@ -1,0 +1,4 @@
+maxYoungGenerationSizeMb: RangeError: Worker resourceLimits.maxYoungGenerationSizeMb is too large
+maxOldGenerationSizeMb: RangeError: Worker resourceLimits.maxOldGenerationSizeMb is too large
+codeRangeSizeMb: RangeError: Worker resourceLimits.codeRangeSizeMb is too large
+stackSizeMb: RangeError: Worker resourceLimits.stackSizeMb is too large


### PR DESCRIPTION
## Summary

- validate all four positive `node:worker_threads` resource limits before creating a worker
- return a synchronous `RangeError` when a megabyte value cannot be represented in bytes
- keep downstream V8 size conversion checked and non-wrapping

## Details

`node:worker_threads` converts `resourceLimits` values from megabytes to bytes. Those multiplications could overflow `usize`, producing invalid heap, code-range, or thread-stack sizes and, for some values, terminating the process.

Node allows its floating-point-to-size conversion to truncate. Deno intentionally rejects values that cannot be represented in bytes so the thread-stack and V8 paths share one deterministic overflow policy.

The worker host now validates `maxYoungGenerationSizeMb`, `maxOldGenerationSizeMb`, `codeRangeSizeMb`, and `stackSizeMb` before starting a worker. The selected explicit or default stack size also goes through the checked conversion.

## Validation

- `dprint check cli/lib/worker.rs runtime/ops/worker_host.rs tests/specs/node/worker_threads_resource_limits/__test__.jsonc tests/specs/node/worker_threads_resource_limits/overflow_main.mjs tests/specs/node/worker_threads_resource_limits/overflow_main.out`
- `rustfmt --check --edition 2024 cli/lib/worker.rs runtime/ops/worker_host.rs`
- `cargo build --bin deno`
- `cargo build -p test_server`
- `env -u NO_COLOR cargo test -p specs_tests --test specs node::worker_threads_resource_limits -- --nocapture`
- `cargo clippy -p deno_lib -p deno_runtime --lib --features deno_core/v8 -- -D warnings`
