### PR TITLE
fix(fetch): copy static bodies when cloning

### DIFF
--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -246,16 +246,32 @@ class InnerBody {
         this.streamOrStatic,
       ) && !this.streamOrStatic.consumed
     ) {
+      let body = this.streamOrStatic.body;
+      let source = this.source;
+      if (typeof body !== "string") {
+        body = TypedArrayPrototypeSlice(body);
+        if (
+          source !== null &&
+          TypedArrayPrototypeGetSymbolToStringTag(source) === "Uint8Array"
+        ) {
+          source = body;
+        }
+      }
       second = new InnerBody({
-        body: this.streamOrStatic.body,
+        body,
         consumed: false,
       });
+      second.source = source;
     } else {
+      const secondSource = this.source !== null &&
+          TypedArrayPrototypeGetSymbolToStringTag(this.source) === "Uint8Array"
+        ? TypedArrayPrototypeSlice(this.source)
+        : this.source;
       const { 0: out1, 1: out2 } = readableStreamTee(this.stream, true);
       this.streamOrStatic = out1;
       second = new InnerBody(out2);
+      second.source = secondSource;
     }
-    second.source = this.source;
     second.length = this.length;
     return second;
   }

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -59,6 +59,11 @@ const {
 const noop = () => {};
 const noopAsync = async () => {};
 
+function isUint8Array(value) {
+  return value !== null &&
+    TypedArrayPrototypeGetSymbolToStringTag(value) === "Uint8Array";
+}
+
 /** @type {WeakMap<ReadableStream<Uint8Array>, number>} */
 const staticBodyLength = new SafeWeakMap();
 
@@ -240,6 +245,8 @@ class InnerBody {
    */
   clone() {
     let second;
+    // Byte-backed sources need an O(n) snapshot so cloned bodies cannot expose
+    // each other's storage. Immutable sources can remain shared.
     if (
       !ObjectPrototypeIsPrototypeOf(
         ReadableStreamPrototype,
@@ -250,10 +257,7 @@ class InnerBody {
       let source = this.source;
       if (typeof body !== "string") {
         body = TypedArrayPrototypeSlice(body);
-        if (
-          source !== null &&
-          TypedArrayPrototypeGetSymbolToStringTag(source) === "Uint8Array"
-        ) {
+        if (isUint8Array(source)) {
           source = body;
         }
       }
@@ -263,8 +267,7 @@ class InnerBody {
       });
       second.source = source;
     } else {
-      const secondSource = this.source !== null &&
-          TypedArrayPrototypeGetSymbolToStringTag(this.source) === "Uint8Array"
+      const secondSource = isUint8Array(this.source)
         ? TypedArrayPrototypeSlice(this.source)
         : this.source;
       const { 0: out1, 1: out2 } = readableStreamTee(this.stream, true);
@@ -597,7 +600,7 @@ function extractBody(object) {
     // no observable side-effect for users so far, but could change
     stream = { body: source, consumed: false };
     length = null; // NOTE: string length != byte length
-  } else if (TypedArrayPrototypeGetSymbolToStringTag(source) === "Uint8Array") {
+  } else if (isUint8Array(source)) {
     stream = { body: source, consumed: false };
     length = TypedArrayPrototypeGetByteLength(source);
   }

--- a/tests/unit/body_test.ts
+++ b/tests/unit/body_test.ts
@@ -33,6 +33,67 @@ Deno.test(async function arrayBufferFromByteArrays() {
   }
 });
 
+Deno.test(async function requestCloneStaticBodyIsIndependent() {
+  const request = new Request("http://example.com/", {
+    method: "POST",
+    body: new Uint8Array([65, 65, 65, 65]),
+  });
+  const clone = request.clone();
+
+  const cloneBytes = new Uint8Array(await clone.arrayBuffer());
+  cloneBytes.fill(66);
+
+  assertEquals(await request.text(), "AAAA");
+});
+
+Deno.test(async function responseCloneStaticBodyIsIndependent() {
+  const response = new Response(new Uint8Array([65, 65, 65, 65]));
+  const clone = response.clone();
+
+  const responseBytes = await response.bytes();
+  responseBytes.fill(66);
+
+  assertEquals(await clone.text(), "AAAA");
+});
+
+Deno.test(
+  { permissions: { net: true } },
+  async function requestCloneMaterializedStaticBodyIsIndependentAcrossRedirect() {
+    const started = Promise.withResolvers<number>();
+    let firstBody = "";
+    await using _server = Deno.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      onListen: ({ port }) => started.resolve(port),
+    }, async (request) => {
+      const body = await request.text();
+      if (new URL(request.url).pathname === "/redirect") {
+        firstBody = body;
+        return new Response(null, {
+          status: 307,
+          headers: { location: "/final" },
+        });
+      }
+      return Response.json([firstBody, body]);
+    });
+    const port = await started.promise;
+
+    const request = new Request(`http://127.0.0.1:${port}/redirect`, {
+      method: "POST",
+      body: new Uint8Array([65, 65, 65, 65]),
+    });
+    // Force clone() through the stream tee path.
+    void request.body;
+    const clone = request.clone();
+
+    const { value: requestBytes } = await request.body!.getReader().read();
+    requestBytes!.fill(66);
+
+    const response = await fetch(clone);
+    assertEquals(await response.json(), ["AAAA", "AAAA"]);
+  },
+);
+
 // Regression test: set/delete on a FormData with many entries sharing a name
 // must run in linear time. A quadratic implementation would take many seconds
 // (or minutes) at this size; the linear implementation finishes in

--- a/tests/unit/body_test.ts
+++ b/tests/unit/body_test.ts
@@ -56,6 +56,21 @@ Deno.test(async function responseCloneStaticBodyIsIndependent() {
   assertEquals(await clone.text(), "AAAA");
 });
 
+Deno.test(async function responseClonePreservesImmutableAndNullBodies() {
+  for (const body of ["AAAA", new Blob(["AAAA"])]) {
+    const response = new Response(body);
+    const clone = response.clone();
+
+    assertEquals(await response.text(), "AAAA");
+    assertEquals(await clone.text(), "AAAA");
+  }
+
+  const response = new Response();
+  const clone = response.clone();
+  assertEquals(response.body, null);
+  assertEquals(clone.body, null);
+});
+
 Deno.test(
   { permissions: { net: true } },
   async function requestCloneMaterializedStaticBodyIsIndependentAcrossRedirect() {


### PR DESCRIPTION
## Summary

- give cloned Request and Response byte bodies independent storage
- preserve sharing for immutable string and Blob sources
- cover static, materialized, immutable-source, and null-body clone paths

## Details

The static-body clone fast path constructed a second body using the same Uint8Array and cached source as the original. Consuming either body through arrayBuffer() or bytes() exposed storage that was still shared with the other body.

Copy byte-backed bodies when cloning and associate the cloned source with that copy. If the body stream was already materialized, snapshot the byte-backed source before teeing so body-preserving redirects replay the clone snapshot. This deliberately incurs an O(n) copy for byte-backed sources; immutable string and Blob sources remain shared.

## Validation

- ./tools/format.js --check ext/fetch/22_body.js tests/unit/body_test.ts
- ./tools/lint.js --js
- cargo build --bin deno --bin test_server
- cargo test -p unit_tests --test unit body_test -- --nocapture
