### PR TITLE
fix(ext/node): handle readv short reads

### DIFF
--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -153,8 +153,6 @@ const {
   op_node_fs_read_deferred,
   op_node_fs_read_file_sync,
   op_node_fs_read_sync,
-  op_node_fs_seek,
-  op_node_fs_seek_sync,
   op_node_fs_write_deferred,
   op_node_fs_write_sync,
   op_node_lchmod,
@@ -478,6 +476,59 @@ type ReadvCallback = (
   buffers: readonly ArrayBufferView[],
 ) => void;
 
+function prepareReadvBuffers(
+  buffers: readonly ArrayBufferView[],
+  allowDirect: boolean,
+) {
+  const views: Uint8Array[] = [];
+  const lengths: number[] = [];
+  let length = 0;
+  for (let i = 0; i < buffers.length; i++) {
+    const view = arrayBufferViewToUint8Array(buffers[i]);
+    const viewLength = TypedArrayPrototypeGetByteLength(view);
+    ArrayPrototypePush(views, view);
+    ArrayPrototypePush(lengths, viewLength);
+    length += viewLength;
+  }
+
+  if (allowDirect && views.length === 1) {
+    return { buffer: views[0], lengths, needsScatter: false, views };
+  }
+
+  // A staging buffer preserves one-read semantics while safely supporting
+  // duplicate and overlapping views.
+  return {
+    buffer: new Uint8Array(length),
+    lengths,
+    needsScatter: true,
+    views,
+  };
+}
+
+function scatterReadvBuffer(
+  source: Uint8Array,
+  views: Uint8Array[],
+  lengths: number[],
+  bytesRead: number,
+) {
+  let offset = 0;
+  for (let i = 0; i < views.length && offset < bytesRead; i++) {
+    const view = views[i];
+    const length = MathMin(
+      lengths[i],
+      TypedArrayPrototypeGetByteLength(view),
+      bytesRead - offset,
+    );
+    if (length > 0) {
+      TypedArrayPrototypeSet(
+        view,
+        TypedArrayPrototypeSubarray(source, offset, offset + length),
+      );
+    }
+    offset += lengths[i];
+  }
+}
+
 function readv(
   fd: number,
   buffers: readonly ArrayBufferView[],
@@ -505,41 +556,18 @@ function readv(
     lazyProcess().default.nextTick(cb, null, 0, buffers);
     return;
   }
+  const { buffer, lengths, views } = prepareReadvBuffers(buffers, false);
 
-  const innerReadv = async (
-    fd: number,
-    buffers: readonly ArrayBufferView[],
-    position: number | null,
-  ) => {
-    if (typeof position === "number") {
-      await op_node_fs_seek(fd, position, 0);
-    }
-
-    let readTotal = 0;
-    let readInBuf = 0;
-    let bufIdx = 0;
-    let buf = buffers[bufIdx];
-    while (bufIdx < buffers.length) {
-      const nread = op_node_fs_read_sync(fd, buf, -1n);
-      if (nread === null) {
-        break;
-      }
-      readInBuf += nread;
-      if (readInBuf === TypedArrayPrototypeGetByteLength(buf)) {
-        readTotal += readInBuf;
-        readInBuf = 0;
-        bufIdx += 1;
-        buf = buffers[bufIdx];
-      }
-    }
-    readTotal += readInBuf;
-
-    return readTotal;
-  };
-
-  PromisePrototypeThen(innerReadv(fd, buffers, pos), (numRead) => {
-    cb(null, numRead, buffers);
-  }, (err) => cb(err, -1, buffers));
+  PromisePrototypeThen(
+    op_node_fs_read_deferred(fd, buffer, pos === null ? -1n : BigInt(pos)),
+    (numRead) => {
+      scatterReadvBuffer(buffer, views, lengths, numRead);
+      cb(null, numRead, buffers);
+    },
+    (err) => {
+      cb(denoErrorToNodeError(err, { syscall: "read" }), 0, buffers);
+    },
+  );
 }
 
 ObjectDefineProperty(readv, customPromisifyArgs, {
@@ -568,29 +596,25 @@ function readvSync(
   }
   if (typeof position === "number") {
     validateInteger(position, "position", 0);
-    op_node_fs_seek_sync(fd, position, 0);
   }
 
-  let readTotal = 0;
-  let readInBuf = 0;
-  let bufIdx = 0;
-  let buf = buffers[bufIdx];
-  while (bufIdx < buffers.length) {
-    const nread = op_node_fs_read_sync(fd, buf, -1n);
-    if (nread === null) {
-      break;
+  const { buffer, lengths, needsScatter, views } = prepareReadvBuffers(
+    buffers,
+    true,
+  );
+  try {
+    const numRead = op_node_fs_read_sync(
+      fd,
+      buffer,
+      typeof position === "number" ? BigInt(position) : -1n,
+    );
+    if (needsScatter) {
+      scatterReadvBuffer(buffer, views, lengths, numRead);
     }
-    readInBuf += nread;
-    if (readInBuf === TypedArrayPrototypeGetByteLength(buf)) {
-      readTotal += readInBuf;
-      readInBuf = 0;
-      bufIdx += 1;
-      buf = buffers[bufIdx];
-    }
+    return numRead;
+  } catch (err) {
+    throw denoErrorToNodeError(err as Error, { syscall: "read" });
   }
-  readTotal += readInBuf;
-
-  return readTotal;
 }
 
 function readvPromise(

--- a/tests/unit_node/_fs/_fs_read_test.ts
+++ b/tests/unit_node/_fs/_fs_read_test.ts
@@ -12,6 +12,68 @@ import { Buffer } from "node:buffer";
 import * as path from "@std/path";
 import { open as openPromise } from "node:fs/promises";
 
+async function runReadvFixture<T>(
+  mode: "file" | "pipe-sync" | "pipe-async",
+): Promise<T> {
+  const fixture = path.fromFileUrl(
+    new URL("./testdata/readv_short_read.ts", import.meta.url),
+  );
+  const isPipe = mode !== "file";
+  const child = new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", fixture, mode],
+    stdin: isPipe ? "piped" : "null",
+    stdout: "piped",
+    stderr: "piped",
+    signal: AbortSignal.timeout(10_000),
+  }).spawn();
+
+  let output: Deno.CommandOutput;
+  try {
+    if (mode === "pipe-async") {
+      const reader = child.stderr.getReader();
+      let ready = "";
+      try {
+        const decoder = new TextDecoder();
+        while (!ready.includes("\n")) {
+          const chunk = await reader.read();
+          assertFalse(chunk.done);
+          ready += decoder.decode(chunk.value, { stream: true });
+        }
+      } finally {
+        reader.releaseLock();
+      }
+      assertEquals(ready, "ready\n");
+    }
+
+    if (isPipe) {
+      const writer = child.stdin.getWriter();
+      await writer.write(new TextEncoder().encode("abc"));
+      writer.releaseLock();
+    }
+
+    output = await child.output();
+  } catch (error) {
+    try {
+      child.kill();
+    } catch {
+      // The child may have already exited due to the timeout signal.
+    }
+    await child.status;
+    throw error;
+  } finally {
+    if (isPipe) {
+      try {
+        await child.stdin.close();
+      } catch {
+        // The child's pipe may already be closed on an error path.
+      }
+    }
+  }
+  const stderr = new TextDecoder().decode(output.stderr);
+  assert(output.success, stderr);
+  return JSON.parse(new TextDecoder().decode(output.stdout));
+}
+
 async function readTest<T extends NodeJS.ArrayBufferView>(
   testData: string,
   buffer: T,
@@ -64,6 +126,81 @@ Deno.test({
       },
     );
   },
+});
+
+Deno.test("readv returns short reads and preserves positions", async () => {
+  const result = await runReadvFixture("file");
+  assertEquals(result, {
+    sync: {
+      bytesRead: 3,
+      eofBytesRead: 0,
+      dataViewBacking: [255, 97, 98, 254],
+      uint16Backing: [253, 252, 99, 0, 0, 0, 251, 250],
+    },
+    async: {
+      bytesRead: 3,
+      eofBytesRead: 0,
+      buffersMatch: true,
+      callbackWasAsync: true,
+      dataViewBacking: [255, 97, 98, 254],
+      uint16Backing: [253, 252, 99, 0, 0, 0, 251, 250],
+    },
+    positionedSync: {
+      bytesRead: 2,
+      positioned: [100, 101],
+      cursor: [97],
+    },
+    positionedAsync: {
+      bytesRead: 2,
+      buffersMatch: true,
+      callbackWasAsync: true,
+      positioned: [100, 101],
+      cursor: [97],
+    },
+    empty: {
+      sync: 0,
+      async: {
+        bytesRead: 0,
+        buffersMatch: true,
+        callbackWasAsync: true,
+      },
+    },
+    invalidZeroLength: {
+      syncCode: "EBADF",
+      async: {
+        code: "EBADF",
+        bytesRead: 0,
+        buffersMatch: true,
+        callbackWasAsync: true,
+      },
+    },
+    nonNumberPosition: [98],
+    overlapping: {
+      bytesRead: 4,
+      buffer: [99, 100],
+    },
+  });
+});
+
+Deno.test("readv returns a short pipe read without waiting for EOF", async (t) => {
+  await t.step("sync", async () => {
+    const result = await runReadvFixture("pipe-sync");
+    assertEquals(result, {
+      bytesRead: 3,
+      buffers: [[97, 98], [99, 0, 0, 0]],
+    });
+  });
+
+  await t.step("async", async () => {
+    const result = await runReadvFixture("pipe-async");
+    assertEquals(result, {
+      bytesRead: 3,
+      buffersMatch: true,
+      callbackWasAsync: true,
+      timerFired: true,
+      buffers: [[97, 98], [99, 0, 0, 0]],
+    });
+  });
 });
 
 Deno.test({

--- a/tests/unit_node/_fs/testdata/readv_short_read.ts
+++ b/tests/unit_node/_fs/testdata/readv_short_read.ts
@@ -1,0 +1,235 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+import { closeSync, openSync, readSync, readv, readvSync } from "node:fs";
+
+function viewBytes(view: NodeJS.ArrayBufferView): number[] {
+  return [
+    ...new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
+  ];
+}
+
+function makeBuffers() {
+  const dataViewBacking = new Uint8Array([255, 0, 0, 254]);
+  const uint16Backing = new Uint8Array([253, 252, 0, 0, 0, 0, 251, 250]);
+  const buffers = [
+    new Uint8Array(0),
+    new DataView(dataViewBacking.buffer, 1, 2),
+    new Uint8Array(0),
+    new Uint16Array(uint16Backing.buffer, 2, 2),
+  ];
+  return { buffers, dataViewBacking, uint16Backing };
+}
+
+function readvAsync(
+  fd: number,
+  buffers: NodeJS.ArrayBufferView[],
+  position?: number,
+) {
+  let callReturned = false;
+  const promise = new Promise<{
+    bytesRead: number;
+    buffersMatch: boolean;
+    callbackWasAsync: boolean;
+  }>((resolve, reject) => {
+    const callback = (
+      err: NodeJS.ErrnoException | null,
+      bytesRead: number,
+      returnedBuffers: readonly NodeJS.ArrayBufferView[],
+    ) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve({
+        bytesRead,
+        buffersMatch: returnedBuffers === buffers,
+        callbackWasAsync: callReturned,
+      });
+    };
+    if (position === undefined) {
+      readv(fd, buffers, callback);
+    } else {
+      readv(fd, buffers, position, callback);
+    }
+  });
+  callReturned = true;
+  return promise;
+}
+
+async function testFileReads() {
+  const file = Deno.makeTempFileSync();
+  try {
+    Deno.writeTextFileSync(file, "abc");
+
+    const syncViews = makeBuffers();
+    const syncFd = openSync(file, "r");
+    const syncBytesRead = readvSync(syncFd, syncViews.buffers);
+    const syncEofBytesRead = readvSync(syncFd, [new Uint8Array(1)]);
+    closeSync(syncFd);
+
+    const asyncViews = makeBuffers();
+    const asyncFd = openSync(file, "r");
+    const asyncResult = await readvAsync(asyncFd, asyncViews.buffers);
+    const asyncEofResult = await readvAsync(asyncFd, [new Uint8Array(1)]);
+    closeSync(asyncFd);
+
+    Deno.writeTextFileSync(file, "abcdef");
+    const syncPositionBuffer = new Uint8Array(2);
+    const syncCursorBuffer = new Uint8Array(1);
+    const syncPositionFd = openSync(file, "r");
+    const syncPositionBytesRead = readvSync(
+      syncPositionFd,
+      [syncPositionBuffer],
+      3,
+    );
+    readSync(syncPositionFd, syncCursorBuffer, 0, 1, null);
+    closeSync(syncPositionFd);
+
+    const asyncPositionBuffer = new Uint8Array(2);
+    const asyncCursorBuffer = new Uint8Array(1);
+    const asyncPositionFd = openSync(file, "r");
+    const asyncPositionResult = await readvAsync(
+      asyncPositionFd,
+      [asyncPositionBuffer],
+      3,
+    );
+    readSync(asyncPositionFd, asyncCursorBuffer, 0, 1, null);
+    closeSync(asyncPositionFd);
+
+    const emptyFd = openSync(file, "r");
+    const emptySync = readvSync(emptyFd, [new Uint8Array(0)]);
+    const emptyAsync = await readvAsync(emptyFd, [new Uint8Array(0)]);
+    closeSync(emptyFd);
+
+    const closedFd = openSync(file, "r");
+    closeSync(closedFd);
+    let invalidZeroLengthSyncCode;
+    try {
+      readvSync(closedFd, [new Uint8Array(0)]);
+    } catch (error) {
+      invalidZeroLengthSyncCode = (error as NodeJS.ErrnoException).code;
+    }
+    const invalidZeroLengthBuffers = [new Uint8Array(0)];
+    let invalidZeroLengthCallReturned = false;
+    const invalidZeroLengthPromise = new Promise<{
+      code: string | undefined;
+      bytesRead: number;
+      buffersMatch: boolean;
+      callbackWasAsync: boolean;
+    }>((resolve) => {
+      readv(
+        closedFd,
+        invalidZeroLengthBuffers,
+        (error, bytesRead, returnedBuffers) => {
+          resolve({
+            code: error?.code,
+            bytesRead,
+            buffersMatch: returnedBuffers === invalidZeroLengthBuffers,
+            callbackWasAsync: invalidZeroLengthCallReturned,
+          });
+        },
+      );
+    });
+    invalidZeroLengthCallReturned = true;
+    const invalidZeroLengthAsync = await invalidZeroLengthPromise;
+
+    const nonNumberPositionFd = openSync(file, "r");
+    readSync(nonNumberPositionFd, new Uint8Array(1), 0, 1, null);
+    const nonNumberPositionBuffer = new Uint8Array(1);
+    const readvSyncWithUnknownPosition = readvSync as unknown as (
+      fd: number,
+      buffers: NodeJS.ArrayBufferView[],
+      position: unknown,
+    ) => number;
+    readvSyncWithUnknownPosition(
+      nonNumberPositionFd,
+      [nonNumberPositionBuffer],
+      "4",
+    );
+    closeSync(nonNumberPositionFd);
+
+    const overlappingBuffer = new Uint8Array(2);
+    const overlappingFd = openSync(file, "r");
+    const overlappingBytesRead = readvSync(overlappingFd, [
+      overlappingBuffer,
+      overlappingBuffer,
+    ]);
+    closeSync(overlappingFd);
+
+    return {
+      sync: {
+        bytesRead: syncBytesRead,
+        eofBytesRead: syncEofBytesRead,
+        dataViewBacking: [...syncViews.dataViewBacking],
+        uint16Backing: [...syncViews.uint16Backing],
+      },
+      async: {
+        ...asyncResult,
+        eofBytesRead: asyncEofResult.bytesRead,
+        dataViewBacking: [...asyncViews.dataViewBacking],
+        uint16Backing: [...asyncViews.uint16Backing],
+      },
+      positionedSync: {
+        bytesRead: syncPositionBytesRead,
+        positioned: [...syncPositionBuffer],
+        cursor: [...syncCursorBuffer],
+      },
+      positionedAsync: {
+        ...asyncPositionResult,
+        positioned: [...asyncPositionBuffer],
+        cursor: [...asyncCursorBuffer],
+      },
+      empty: {
+        sync: emptySync,
+        async: emptyAsync,
+      },
+      invalidZeroLength: {
+        syncCode: invalidZeroLengthSyncCode,
+        async: invalidZeroLengthAsync,
+      },
+      nonNumberPosition: [...nonNumberPositionBuffer],
+      overlapping: {
+        bytesRead: overlappingBytesRead,
+        buffer: [...overlappingBuffer],
+      },
+    };
+  } finally {
+    Deno.removeSync(file);
+  }
+}
+
+function testPipeSync() {
+  const buffers = [new Uint8Array(2), new Uint8Array(4)];
+  const bytesRead = readvSync(0, buffers);
+  return { bytesRead, buffers: buffers.map(viewBytes) };
+}
+
+async function testPipeAsync() {
+  const buffers = [new Uint8Array(2), new Uint8Array(4)];
+  let timerFired = false;
+  setTimeout(() => {
+    timerFired = true;
+    Deno.stderr.writeSync(new TextEncoder().encode("ready\n"));
+  }, 0);
+  const result = await readvAsync(0, buffers);
+  return { ...result, timerFired, buffers: buffers.map(viewBytes) };
+}
+
+const mode = Deno.args[0];
+let result;
+switch (mode) {
+  case "file":
+    result = await testFileReads();
+    break;
+  case "pipe-sync":
+    result = testPipeSync();
+    break;
+  case "pipe-async":
+    result = await testPipeAsync();
+    break;
+  default:
+    throw new Error(`Unknown mode: ${mode}`);
+}
+Deno.stdout.writeSync(
+  new TextEncoder().encode(`${JSON.stringify(result)}\n`),
+);


### PR DESCRIPTION
## Summary

- make node:fs readv and readvSync return after one read, including EOF and short reads
- keep callback reads non-blocking and positioned reads from moving the descriptor cursor
- preserve empty, mixed-view, and overlapping-buffer behavior

## Tests

- cargo test -p unit_node_tests --test unit_node _fs_read_test -- --nocapture
- cargo test -p unit_node_tests --test unit_node _fs_handle_test -- --nocapture
- cargo test -p unit_node_tests --test unit_node _fs_raw_fd_test -- --nocapture