### PR TITLE
fix(ext/fetch): enforce permissions for proxy transports

### DIFF
--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -871,6 +871,11 @@ pub fn op_fetch_custom_client(
     match proxy {
       Proxy::Http { url, .. } => {
         let url = Url::parse(url)?;
+        if !matches!(url.scheme(), "http" | "https" | "socks5" | "socks5h") {
+          return Err(FetchError::ClientCreate(
+            HttpClientCreateError::InvalidProxyUrl,
+          ));
+        }
         permissions.check_net_url(&url, "Deno.createHttpClient()")?;
       }
       Proxy::Tcp { hostname, port } => {
@@ -900,7 +905,6 @@ pub fn op_fetch_custom_client(
         }
       }
       Proxy::Vsock { cid, port } => {
-        let permissions = state.borrow_mut::<PermissionsContainer>();
         permissions.check_net_vsock(*cid, *port, "Deno.createHttpClient()")?;
       }
     }
@@ -1058,6 +1062,7 @@ pub fn create_http_client(
         .map_err(|_| HttpClientCreateError::InvalidAddress(local_address))
     })
     .transpose()?;
+  let permissions = options.permissions.clone();
   let http_connector = dns::PermissionedHttpConnector::new(
     options.dns_resolver.clone(),
     local_address,
@@ -1131,6 +1136,7 @@ pub fn create_http_client(
     tls: tls_config,
     tls_proxy: proxy_tls_config,
     user_agent: Some(user_agent.clone()),
+    permissions,
   };
 
   if let Some(pool_max_idle_per_host) = options.pool_max_idle_per_host {

--- a/ext/fetch/proxy.rs
+++ b/ext/fetch/proxy.rs
@@ -3,9 +3,12 @@
 //! Parts of this module should be able to be replaced with other crates
 //! eventually, once generic versions appear in hyper-util, et al.
 
+use std::borrow::Cow;
 use std::env;
 use std::future::Future;
 use std::net::IpAddr;
+#[cfg(not(windows))]
+use std::path::Path;
 #[cfg(not(windows))]
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -14,6 +17,8 @@ use std::task::Context;
 use std::task::Poll;
 
 use deno_core::futures::TryFutureExt;
+use deno_permissions::OpenAccessKind;
+use deno_permissions::PermissionsContainer;
 use deno_tls::rustls::ClientConfig as TlsConfig;
 use http::Uri;
 use http::header::HeaderValue;
@@ -51,6 +56,7 @@ pub(crate) struct ProxyConnector<C> {
   /// Notably, does not include ALPN
   pub(crate) tls_proxy: Arc<TlsConfig>,
   pub(crate) user_agent: Option<HeaderValue>,
+  pub(crate) permissions: Option<PermissionsContainer>,
 }
 
 impl<C> ProxyConnector<C> {
@@ -69,6 +75,7 @@ impl<C> ProxyConnector<C> {
       tls: Arc::new(tls),
       tls_proxy: self.tls_proxy,
       user_agent: self.user_agent,
+      permissions: self.permissions,
     })
   }
 
@@ -87,6 +94,7 @@ impl<C> ProxyConnector<C> {
       tls: Arc::new(tls),
       tls_proxy: self.tls_proxy,
       user_agent: self.user_agent,
+      permissions: self.permissions,
     })
   }
 }
@@ -630,11 +638,18 @@ where
           auth,
         } => {
           let tls = TlsConnector::from(self.tls.clone());
+          let mut permissions = self.permissions.clone();
           Box::pin(async move {
             let socks_addr = (
               proxy_dst.host().unwrap(),
               proxy_dst.port().map(|p| p.as_u16()).unwrap_or(1080),
             );
+            if let Some(permissions) = permissions.as_mut() {
+              permissions.check_net(
+                &(socks_addr.0, Some(socks_addr.1)),
+                "fetch() proxy",
+              )?;
+            }
             let host = orig_dst.host().ok_or("no host in url")?;
             let host = host
               .strip_prefix('[')
@@ -688,8 +703,21 @@ where
         }
         #[cfg(not(windows))]
         Target::Unix { path } => {
-          let path = path.clone();
+          let mut path = path.clone();
+          let mut permissions = self.permissions.clone();
           Box::pin(async move {
+            if let Some(permissions) = permissions.as_mut() {
+              let resolved_path = permissions
+                .check_open(
+                  Cow::Borrowed(Path::new(&path)),
+                  OpenAccessKind::ReadWriteNoFollow,
+                  Some("fetch() proxy"),
+                )?
+                .into_path();
+              permissions
+                .check_net_unix_socket(&resolved_path, Some("fetch() proxy"))?;
+              path = resolved_path.into_owned();
+            }
             let io = UnixStream::connect(&path).await?;
             Ok(Proxied::Unix(TokioIo::new(io)))
           })
@@ -699,11 +727,17 @@ where
           target_os = "linux",
           target_os = "macos"
         ))]
-        Target::Vsock { cid, port } => Box::pin(async move {
-          let addr = tokio_vsock::VsockAddr::new(cid, port);
-          let io = VsockStream::connect(addr).await?;
-          Ok(Proxied::Vsock(TokioIo::new(io)))
-        }),
+        Target::Vsock { cid, port } => {
+          let mut permissions = self.permissions.clone();
+          Box::pin(async move {
+            if let Some(permissions) = permissions.as_mut() {
+              permissions.check_net_vsock(cid, port, "fetch() proxy")?;
+            }
+            let addr = tokio_vsock::VsockAddr::new(cid, port);
+            let io = VsockStream::connect(addr).await?;
+            Ok(Proxied::Vsock(TokioIo::new(io)))
+          })
+        }
       };
       return Box::pin(async move {
         check_dst.await?;

--- a/ext/fetch/proxy.rs
+++ b/ext/fetch/proxy.rs
@@ -3,6 +3,7 @@
 //! Parts of this module should be able to be replaced with other crates
 //! eventually, once generic versions appear in hyper-util, et al.
 
+#[cfg(not(windows))]
 use std::borrow::Cow;
 use std::env;
 use std::future::Future;
@@ -17,6 +18,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use deno_core::futures::TryFutureExt;
+#[cfg(not(windows))]
 use deno_permissions::OpenAccessKind;
 use deno_permissions::PermissionsContainer;
 use deno_tls::rustls::ClientConfig as TlsConfig;

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -2488,6 +2488,61 @@ Deno.test(
   },
 );
 
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { write: true, run: true },
+  },
+  async function fetchEnvUnixProxyRequiresUnixPermissions() {
+    const socketPath = tmpUnixSocketPath();
+    const scriptPath = Deno.makeTempFileSync({ suffix: ".js" });
+    Deno.writeTextFileSync(
+      scriptPath,
+      `
+      try {
+        await fetch("http://example.com/");
+        console.log("FETCH_OK");
+      } catch (error) {
+        console.log(error.name + ":" + error.message);
+        console.log(error.cause?.name + ":" + error.cause?.message);
+      }
+      `,
+    );
+
+    async function run(extraPermissions: string[]) {
+      const { code, stdout, stderr } = await new Deno.Command(
+        Deno.execPath(),
+        {
+          args: [
+            "run",
+            "--no-prompt",
+            "--allow-env=ALL_PROXY",
+            "--allow-net=example.com",
+            ...extraPermissions,
+            scriptPath,
+          ],
+          env: { ALL_PROXY: `unix:${socketPath}` },
+          stdout: "piped",
+          stderr: "piped",
+        },
+      ).output();
+      const output = new TextDecoder().decode(stdout) +
+        new TextDecoder().decode(stderr);
+      assertEquals(code, 0);
+      return output;
+    }
+
+    const missingFilePermissions = await run([]);
+    assertStringIncludes(missingFilePermissions, "Requires read access");
+
+    const missingUnixNetPermission = await run([
+      `--allow-read=${socketPath}`,
+      `--allow-write=${socketPath}`,
+    ]);
+    assertStringIncludes(missingUnixNetPermission, "Requires net access");
+  },
+);
+
 // Regression test for https://github.com/denoland/deno/issues/29281
 // A server advertising `Content-Encoding: gzip` (or br) while returning an
 // empty body should not fail decompression with "unexpected end of file".
@@ -2637,6 +2692,26 @@ Deno.test(
         });
       },
       TypeError,
+    );
+  },
+);
+
+Deno.test(
+  {
+    permissions: { net: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function createHttpClientRejectsUnixSchemeInProxyUrl() {
+    assertThrows(
+      () => {
+        Deno.createHttpClient({
+          proxy: {
+            url: "unix://tmp/%2E%2E/tmp/deno-proxy.sock",
+          },
+        });
+      },
+      TypeError,
+      "invalid proxy url",
     );
   },
 );


### PR DESCRIPTION
## Summary

Some proxy transports connect directly instead of going through the regular HTTP connector. Check the actual SOCKS, Unix, and VSOCK proxy endpoints before opening those connections.

Legacy `proxy.url` values now reject schemes that do not match the supported HTTP and SOCKS URL forms, keeping initial validation aligned with the transport that is ultimately selected. Explicit typed Unix proxy configuration continues to work as before, and embedders that construct clients without a permission container retain their existing behavior.

## Validation

- Built the development Deno binary with `cargo build -p deno`
- Ran focused rebuilt-runtime tests for environment Unix proxies and legacy custom-client URL handling
- Ran `cargo test -p unit_tests --test unit -- fetch_test`
- Ran `cargo test -p deno_fetch`
