### PR TITLE
fix(ext/node): gate constrained memory cgroup reads

### DIFF
--- a/ext/node/ops/process.rs
+++ b/ext/node/ops/process.rs
@@ -576,16 +576,19 @@ fn get_resource_usage() -> [f64; 16] {
 #[number]
 pub fn op_node_process_constrained_memory<TSys: ExtNodeSys + 'static>(
   state: &mut OpState,
-) -> u64 {
+) -> Result<u64, PermissionCheckError> {
   #[cfg(any(target_os = "android", target_os = "linux"))]
   {
+    state
+      .borrow_mut::<PermissionsContainer>()
+      .check_sys("systemMemoryInfo", "node:process.constrainedMemory()")?;
     let sys = state.borrow::<TSys>();
-    cgroup::cgroup_memory_limit(sys).unwrap_or(0)
+    Ok(cgroup::cgroup_memory_limit(sys).unwrap_or(0))
   }
   #[cfg(not(any(target_os = "android", target_os = "linux")))]
   {
     let _ = state;
-    0
+    Ok(0)
   }
 }
 

--- a/ext/node/ops/process.rs
+++ b/ext/node/ops/process.rs
@@ -572,7 +572,7 @@ fn get_resource_usage() -> [f64; 16] {
 
 /// Returns the cgroup-constrained memory limit, or 0 if unconstrained.
 /// This matches Node.js `process.constrainedMemory()` semantics.
-#[op2(fast)]
+#[op2(fast, stack_trace)]
 #[number]
 pub fn op_node_process_constrained_memory<TSys: ExtNodeSys + 'static>(
   state: &mut OpState,
@@ -581,7 +581,7 @@ pub fn op_node_process_constrained_memory<TSys: ExtNodeSys + 'static>(
   {
     state
       .borrow_mut::<PermissionsContainer>()
-      .check_sys("systemMemoryInfo", "node:process.constrainedMemory()")?;
+      .check_sys("systemMemoryInfo", "node:process.constrainedMemory")?;
     let sys = state.borrow::<TSys>();
     Ok(cgroup::cgroup_memory_limit(sys).unwrap_or(0))
   }

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1629,6 +1629,20 @@ Deno.test("importedResourceUsage", async () => {
   assert(resourceUsage === process.resourceUsage);
 });
 
+Deno.test({
+  name:
+    "process.constrainedMemory requires systemMemoryInfo permission on Linux",
+  ignore: Deno.build.os !== "linux" && Deno.build.os !== "android",
+  permissions: { sys: false },
+  fn() {
+    assertThrows(
+      () => process.constrainedMemory(),
+      Deno.errors.NotCapable,
+      'Requires sys access to "systemMemoryInfo"',
+    );
+  },
+});
+
 Deno.test("process.stdout.columns writable", () => {
   process.stdout.columns = 80;
   assertEquals(process.stdout.columns, 80);

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1631,7 +1631,7 @@ Deno.test("importedResourceUsage", async () => {
 
 Deno.test({
   name:
-    "process.constrainedMemory requires systemMemoryInfo permission on Linux",
+    "process.constrainedMemory requires systemMemoryInfo permission on Linux and Android",
   ignore: Deno.build.os !== "linux" && Deno.build.os !== "android",
   permissions: { sys: false },
   fn() {
@@ -1640,6 +1640,25 @@ Deno.test({
       Deno.errors.NotCapable,
       'Requires sys access to "systemMemoryInfo"',
     );
+  },
+});
+
+Deno.test({
+  name: "process.constrainedMemory works with sys permission",
+  ignore: Deno.build.os !== "linux" && Deno.build.os !== "android",
+  permissions: { sys: true },
+  fn() {
+    assert(typeof process.constrainedMemory() === "number");
+  },
+});
+
+Deno.test({
+  name:
+    "process.constrainedMemory returns 0 without sys permission outside Linux and Android",
+  ignore: Deno.build.os === "linux" || Deno.build.os === "android",
+  permissions: { sys: false },
+  fn() {
+    assertEquals(process.constrainedMemory(), 0);
   },
 });
 


### PR DESCRIPTION
## Summary

- check `systemMemoryInfo` access before Linux and Android cgroup memory reads
- preserve the permissionless `0` result on platforms where no cgroup files are read
- cover denied system-memory access on Linux and Android

## Why

`process.constrainedMemory()` reads cgroup memory-limit files on Linux and Android. Related memory APIs already route host memory reads through the `systemMemoryInfo` access check, so this aligns the Node-compatible path with that behavior.

## Tests

- `./tools/format.js --check`
- `cargo check -p deno_node`
- `cargo build --bin deno`
- `cargo test -p unit_node_tests --test unit_node -- process_test`
- rebuilt-runtime check on macOS with system access denied returns `0`

The Linux and Android denial branch is covered by platform CI.