### PR TITLE
fix(ext/node): check TTY fd permissions in constructor

### DIFF
--- a/ext/node/ops/tty_wrap.rs
+++ b/ext/node/ops/tty_wrap.rs
@@ -54,8 +54,7 @@ use crate::ops::stream_wrap::LibUvStreamWrap;
 
 /// Check that non-stdio file descriptors (fd > 2) have --allow-all permission.
 /// Stdio fds 0, 1, 2 are always allowed.
-#[op2(fast)]
-pub fn op_tty_check_fd_permission(
+fn check_tty_fd_permission(
   state: &mut OpState,
   fd: i32,
 ) -> Result<(), deno_permissions::PermissionCheckError> {
@@ -68,6 +67,14 @@ pub fn op_tty_check_fd_permission(
       .check_write_all("node:tty TTY()")?;
   }
   Ok(())
+}
+
+#[op2(fast)]
+pub fn op_tty_check_fd_permission(
+  state: &mut OpState,
+  fd: i32,
+) -> Result<(), deno_permissions::PermissionCheckError> {
+  check_tty_fd_permission(state, fd)
 }
 
 #[derive(CppgcInherits)]
@@ -171,8 +178,9 @@ impl TTY {
     #[this] this: v8::Global<v8::Object>,
     scope: &mut v8::PinScope,
     op_state: &mut OpState,
-  ) -> TTY {
+  ) -> Result<TTY, deno_permissions::PermissionCheckError> {
     assert!(fd >= 0);
+    check_tty_fd_permission(op_state, fd)?;
 
     let obj = v8::Local::new(scope, &this);
     let (tty, err) = TTY::new(obj, fd, op_state);
@@ -202,7 +210,7 @@ impl TTY {
         v8::String::new_external_onebyte_static(scope, b"uv_tty_init").unwrap();
       ctx_obj.set(scope, syscall_key.into(), syscall_str.into());
     }
-    tty
+    Ok(tty)
   }
 
   #[fast]

--- a/tests/unit_node/tty_test.ts
+++ b/tests/unit_node/tty_test.ts
@@ -64,6 +64,41 @@ Deno.test("[node/tty isatty] returns false for raw file fd", () => {
   }
 });
 
+Deno.test("[node/tty] raw TTY constructor checks non-stdio fd permissions", async () => {
+  const helper = `
+    import process from "node:process";
+    try {
+      const { TTY } = process.binding("tty_wrap");
+      new TTY(3, {});
+      console.log("constructed");
+    } catch (error) {
+      console.log(error.name + ":" + error.message);
+    }
+  `;
+  const tmpScript = await Deno.makeTempFile({ suffix: ".mjs" });
+  await Deno.writeTextFile(tmpScript, helper);
+  try {
+    const output = await new Deno.Command(Deno.execPath(), {
+      args: ["run", "--quiet", tmpScript],
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const stdout = new TextDecoder().decode(output.stdout);
+    const stderr = new TextDecoder().decode(output.stderr);
+
+    assert(
+      output.success,
+      `raw TTY constructor child failed: ${stdout} ${stderr}`,
+    );
+    assert(
+      stdout.includes("NotCapable:"),
+      `raw TTY constructor should require permission: ${stdout} ${stderr}`,
+    );
+  } finally {
+    await Deno.remove(tmpScript);
+  }
+});
+
 Deno.test({
   name: "[node/tty] HandleWrap.close calls uv_close for TTY handles",
   ignore: Deno.build.os === "windows",


### PR DESCRIPTION
## Summary

- apply the existing file-descriptor permission check inside the TTY constructor
- preserve the established behavior for standard descriptors 0, 1, and 2
- add a regression test for direct construction with a non-stdio descriptor

## Details

The public `node:tty` wrappers validate non-stdio descriptors before constructing a TTY handle, while direct internal construction skipped that validation. Moving the shared check into the constructor keeps every call path consistent without changing standard-input/output/error handling.

## Validation

- `./tools/format.js --check ext/node/ops/tty_wrap.rs tests/unit_node/tty_test.ts`
- `cargo fmt --check`
- `cargo build -p deno`
- `cargo test -p unit_tests --test unit -- tty_test`