### PR TITLE
fix(fs): require sys permission for umask

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4617,7 +4617,8 @@ declare namespace Deno {
       | "statfs"
       | "getPriority"
       | "setPriority"
-      | "ca";
+      | "ca"
+      | "umask";
   }
 
   /** The permission descriptor for the `allow-ffi` and `deny-ffi` permissions, which controls
@@ -5102,11 +5103,11 @@ declare namespace Deno {
    * console.log(Deno.umask());  // e.g. 63 (0o077)
    * ```
    *
-   * This API is under consideration to determine if permissions are required to
-   * call it.
+   * Requires `allow-sys="umask"` permission.
    *
    * *Note*: This API is not implemented on Windows
    *
+   * @tags allow-sys
    * @category File System
    */
   export function umask(mask?: number): number;

--- a/ext/fs/ops.rs
+++ b/ext/fs/ops.rs
@@ -156,6 +156,9 @@ pub fn op_fs_umask(
 ) -> Result<u32, FsOpsError>
 where
 {
+  state
+    .borrow_mut::<deno_permissions::PermissionsContainer>()
+    .check_sys("umask", "Deno.umask()")?;
   state.borrow::<FileSystemRc>().umask(mask).context("umask")
 }
 

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -241,7 +241,8 @@ export function umask(mask?: number | string): number {
   }
   // Note: reading the umask without setting has an inherent race condition
   // (two syscalls: set to 0 then restore). Node.js has the same issue and
-  // has deprecated process.umask() with no arguments.
+  // has deprecated process.umask() with no arguments. In Deno, the underlying
+  // op requires allow-sys=umask for both reading and setting.
   return op_fs_umask(null);
 }
 

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -2953,9 +2953,8 @@ impl SysDescriptor {
       "hostname" | "inspector" | "osRelease" | "osUptime" | "loadavg"
       | "networkInterfaces" | "systemMemoryInfo" | "uid" | "gid" | "cpus"
       | "homedir" | "getegid" | "statfs" | "getPriority" | "setPriority"
-      | "userInfo" | "setegid" | "seteuid" | "setgid" | "setuid" | "ca" => {
-        Ok(Self(kind))
-      }
+      | "userInfo" | "setegid" | "seteuid" | "setgid" | "setuid" | "ca"
+      | "umask" => Ok(Self(kind)),
 
       // the underlying permission check changed to `userInfo` to better match the API,
       // alias this to avoid breaking existing projects with `--allow-sys=username`

--- a/tests/unit/files_test.ts
+++ b/tests/unit/files_test.ts
@@ -33,7 +33,7 @@ Deno.test(
 
 Deno.test(
   {
-    permissions: { read: true, write: true },
+    permissions: { read: true, write: true, sys: ["umask"] },
   },
   function openSyncMode() {
     const path = Deno.makeTempDirSync() + "/test_openSync.txt";
@@ -51,7 +51,7 @@ Deno.test(
 
 Deno.test(
   {
-    permissions: { read: true, write: true },
+    permissions: { read: true, write: true, sys: ["umask"] },
   },
   async function openMode() {
     const path = (await Deno.makeTempDir()) + "/test_open.txt";
@@ -69,7 +69,7 @@ Deno.test(
 
 Deno.test(
   {
-    permissions: { read: true, write: true },
+    permissions: { read: true, write: true, sys: ["umask"] },
   },
   function openSyncUrl() {
     const tempDir = Deno.makeTempDirSync();
@@ -94,7 +94,7 @@ Deno.test(
 
 Deno.test(
   {
-    permissions: { read: true, write: true },
+    permissions: { read: true, write: true, sys: ["umask"] },
   },
   async function openUrl() {
     const tempDir = await Deno.makeTempDir();

--- a/tests/unit/make_temp_test.ts
+++ b/tests/unit/make_temp_test.ts
@@ -28,7 +28,7 @@ Deno.test({ permissions: { write: true } }, function makeTempDirSyncSuccess() {
 });
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   function makeTempDirSyncMode() {
     const path = Deno.makeTempDirSync();
     const pathInfo = Deno.statSync(path);
@@ -70,7 +70,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   async function makeTempDirMode() {
     const path = await Deno.makeTempDir();
     const pathInfo = Deno.statSync(path);
@@ -103,7 +103,7 @@ Deno.test({ permissions: { write: true } }, function makeTempFileSyncSuccess() {
 });
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   function makeTempFileSyncMode() {
     const path = Deno.makeTempFileSync();
     const pathInfo = Deno.statSync(path);
@@ -146,7 +146,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   async function makeTempFileMode() {
     const path = await Deno.makeTempFile();
     const pathInfo = Deno.statSync(path);

--- a/tests/unit/mkdir_test.ts
+++ b/tests/unit/mkdir_test.ts
@@ -25,7 +25,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   function mkdirSyncMode() {
     const path = Deno.makeTempDirSync() + "/dir";
     Deno.mkdirSync(path, { mode: 0o737 });
@@ -49,7 +49,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   async function mkdirMode() {
     const path = Deno.makeTempDirSync() + "/dir";
     await Deno.mkdir(path, { mode: 0o737 });
@@ -96,7 +96,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   function mkdirSyncRecursiveMode() {
     const nested = Deno.makeTempDirSync() + "/nested";
     const path = nested + "/dir";
@@ -107,7 +107,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   async function mkdirRecursiveMode() {
     const nested = Deno.makeTempDirSync() + "/nested";
     const path = nested + "/dir";
@@ -118,7 +118,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   function mkdirSyncRecursiveIfExists() {
     const path = Deno.makeTempDirSync() + "/dir";
     Deno.mkdirSync(path, { mode: 0o737 });
@@ -136,7 +136,7 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  { permissions: { read: true, write: true, sys: ["umask"] } },
   async function mkdirRecursiveIfExists() {
     const path = Deno.makeTempDirSync() + "/dir";
     await Deno.mkdir(path, { mode: 0o737 });

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -109,6 +109,7 @@ fn run_test(test: &CollectedTest) -> TestResult {
 
   if test.name.ends_with("::worker_permissions_test")
     || test.name.ends_with("::worker_test")
+    || test.name.ends_with("::umask_test")
   {
     deno = deno.arg("--unstable-worker-options");
   }

--- a/tests/unit/umask_test.ts
+++ b/tests/unit/umask_test.ts
@@ -1,9 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { assertEquals } from "./test_util.ts";
+import process from "node:process";
+import { assertEquals, assertThrows } from "./test_util.ts";
 
 Deno.test(
   {
     ignore: Deno.build.os === "windows",
+    permissions: { sys: ["umask"] },
   },
   function umaskSuccess() {
     const prevMask = Deno.umask(0o020);
@@ -11,5 +13,107 @@ Deno.test(
     const finalMask = Deno.umask();
     assertEquals(newMask, 0o020);
     assertEquals(finalMask, prevMask);
+  },
+);
+
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { sys: false },
+  },
+  function umaskRequiresSysPermission() {
+    assertThrows(() => {
+      Deno.umask();
+    }, Deno.errors.NotCapable);
+    assertThrows(() => {
+      Deno.umask(0);
+    }, Deno.errors.NotCapable);
+  },
+);
+
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { sys: ["umask"] },
+  },
+  function processUmaskSuccess() {
+    const initialMask = process.umask();
+    const previousMask = process.umask(0o027);
+    const changedMask = process.umask(initialMask);
+    assertEquals(previousMask, initialMask);
+    assertEquals(changedMask, 0o027);
+  },
+);
+
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { sys: false },
+  },
+  function processUmaskRequiresSysPermission() {
+    assertThrows(() => {
+      process.umask();
+    }, Deno.errors.NotCapable);
+    assertThrows(() => {
+      process.umask(0);
+    }, Deno.errors.NotCapable);
+  },
+);
+
+Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { sys: ["umask"] },
+  },
+  async function workerWithoutSysPermissionCannotUseUmask() {
+    const prevMask = Deno.umask(0o022);
+    const workerUrl = URL.createObjectURL(
+      new Blob([
+        `
+const results = [];
+try {
+  Deno.umask();
+  results.push("read");
+} catch (err) {
+  results.push(
+    err instanceof Deno.errors.NotCapable
+      ? "read NotCapable"
+      : err instanceof Error
+      ? err.name
+      : "unknown",
+  );
+}
+try {
+  Deno.umask(0);
+  results.push("changed");
+} catch (err) {
+  results.push(
+    err instanceof Deno.errors.NotCapable
+      ? "set NotCapable"
+      : err instanceof Error
+      ? err.name
+      : "unknown",
+  );
+}
+postMessage(results);
+`,
+      ], { type: "application/typescript" }),
+    );
+    const worker = new Worker(workerUrl, {
+      type: "module",
+      deno: { permissions: "none" },
+    });
+
+    try {
+      const result = await new Promise((resolve) => {
+        worker.onmessage = (event) => resolve(event.data);
+      });
+      assertEquals(result, ["read NotCapable", "set NotCapable"]);
+      assertEquals(Deno.umask(), 0o022);
+    } finally {
+      worker.terminate();
+      URL.revokeObjectURL(workerUrl);
+      Deno.umask(prevMask);
+    }
   },
 );


### PR DESCRIPTION
## Summary

- add `umask` as a scoped `allow-sys` permission
- require that permission when querying or changing the process umask
- document the requirement for both `Deno.umask()` and the shared Node operation
- add coverage for Deno and Node query/set behavior, including worker permissions

## Testing

- `cargo fmt --all -- --check`
- `./tools/format.js --check cli/tsc/dts/lib.deno.ns.d.ts ext/fs/ops.rs ext/node/polyfills/process.ts runtime/permissions/lib.rs tests/unit/umask_test.ts`
- `cargo build -p deno`
- `cargo test -p deno_permissions`
- `cargo test -p unit_tests --test unit -- umask_test`
- direct `process.umask()` query/set checks with `--allow-sys=umask` and `--deny-sys=umask`