### PR TITLE
feat(process): add Deno.processExited to await a non-child process's exit

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5238,6 +5238,63 @@ declare namespace Deno {
    */
   export function kill(pid: number, signo?: Signal | number): void;
 
+  /** Options for {@linkcode Deno.processExited}.
+   *
+   * @category Subprocess
+   */
+  export interface ProcessExitedOptions {
+    /** An {@linkcode AbortSignal} that, when aborted, stops waiting and
+     * rejects the returned promise with the signal's abort reason. Aborting
+     * does not affect the target process; it only abandons the wait. */
+    signal?: AbortSignal;
+  }
+
+  /** Returns a promise that resolves once the process identified by `pid` has
+   * exited.
+   *
+   * Unlike the `status` promise of a {@linkcode Deno.ChildProcess}, this works
+   * for any process, not only one this runtime spawned. It is intended for
+   * code that knows a process only by its id — for example a program that
+   * shuts down a daemon started elsewhere: send the process a signal with
+   * {@linkcode Deno.kill}, then await its exit before releasing resources the
+   * daemon held or reporting the shutdown as complete.
+   *
+   * ```ts
+   * const pid = Number(await Deno.readTextFile("daemon.pid"));
+   * Deno.kill(pid, "SIGTERM");
+   * await Deno.processExited(pid);
+   * // The daemon is now gone; safe to clean up after it.
+   * await Deno.remove("daemon.pid");
+   * ```
+   *
+   * The wait is event-driven: it is backed by `pidfd_open` on Linux, a
+   * `kqueue` process filter on macOS and the BSDs, and a process handle wait
+   * on Windows, so it reacts the instant the process exits rather than
+   * polling.
+   *
+   * If no process with the given `pid` exists — including the case where it
+   * exited between a preceding {@linkcode Deno.kill} and this call — the
+   * returned promise resolves immediately, because the process is not running.
+   *
+   * A process id identifies a process only until that process is reaped, after
+   * which the operating system may reuse the id for an unrelated process. As
+   * with {@linkcode Deno.kill}, if the target has already exited and its id has
+   * been recycled, this waits on whatever process now holds the id.
+   *
+   * The wait can be abandoned by passing an {@linkcode AbortSignal}; aborting
+   * rejects the returned promise with the signal's reason and does not affect
+   * the target process.
+   *
+   * Requires `allow-run` permission.
+   *
+   * @tags allow-run
+   * @category Subprocess
+   */
+  export function processExited(
+    pid: number,
+    options?: ProcessExitedOptions,
+  ): Promise<void>;
+
   /** The type of the resource record to resolve via DNS using
    * {@linkcode Deno.resolveDns}.
    *

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5239,6 +5239,63 @@ declare namespace Deno {
    */
   export function kill(pid: number, signo?: Signal | number): void;
 
+  /** Options for {@linkcode Deno.processExited}.
+   *
+   * @category Subprocess
+   */
+  export interface ProcessExitedOptions {
+    /** An {@linkcode AbortSignal} that, when aborted, stops waiting and
+     * rejects the returned promise with the signal's abort reason. Aborting
+     * does not affect the target process; it only abandons the wait. */
+    signal?: AbortSignal;
+  }
+
+  /** Returns a promise that resolves once the process identified by `pid` has
+   * exited.
+   *
+   * Unlike the `status` promise of a {@linkcode Deno.ChildProcess}, this works
+   * for any process, not only one this runtime spawned. It is intended for
+   * code that knows a process only by its id — for example a program that
+   * shuts down a daemon started elsewhere: send the process a signal with
+   * {@linkcode Deno.kill}, then await its exit before releasing resources the
+   * daemon held or reporting the shutdown as complete.
+   *
+   * ```ts
+   * const pid = Number(await Deno.readTextFile("daemon.pid"));
+   * Deno.kill(pid, "SIGTERM");
+   * await Deno.processExited(pid);
+   * // The daemon is now gone; safe to clean up after it.
+   * await Deno.remove("daemon.pid");
+   * ```
+   *
+   * The wait is event-driven: it is backed by `pidfd_open` on Linux, a
+   * `kqueue` process filter on macOS and the BSDs, and a process handle wait
+   * on Windows, so it reacts the instant the process exits rather than
+   * polling.
+   *
+   * If no process with the given `pid` exists — including the case where it
+   * exited between a preceding {@linkcode Deno.kill} and this call — the
+   * returned promise resolves immediately, because the process is not running.
+   *
+   * A process id identifies a process only until that process is reaped, after
+   * which the operating system may reuse the id for an unrelated process. As
+   * with {@linkcode Deno.kill}, if the target has already exited and its id has
+   * been recycled, this waits on whatever process now holds the id.
+   *
+   * The wait can be abandoned by passing an {@linkcode AbortSignal}; aborting
+   * rejects the returned promise with the signal's reason and does not affect
+   * the target process.
+   *
+   * Requires `allow-run` permission.
+   *
+   * @tags allow-run
+   * @category Subprocess
+   */
+  export function processExited(
+    pid: number,
+    options?: ProcessExitedOptions,
+  ): Promise<void>;
+
   /** The type of the resource record to resolve via DNS using
    * {@linkcode Deno.resolveDns}.
    *

--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -5,6 +5,8 @@ const { core, internals, primordials } = __bootstrap;
 const {
   op_kill,
   op_node_spawn_child,
+  op_process_wait,
+  op_process_wait_open,
   op_run,
   op_run_status,
   op_spawn_child,
@@ -24,6 +26,7 @@ const {
   Uint8Array,
   TypeError,
   NumberIsFinite,
+  NumberIsInteger,
   ObjectEntries,
   SafeArrayIterator,
   String,
@@ -63,6 +66,51 @@ function opKill(pid, signo, apiName) {
 
 function kill(pid, signo = "SIGTERM") {
   opKill(pid, signo, "Deno.kill()");
+}
+
+async function processExited(pid, options = { __proto__: null }) {
+  if (typeof pid !== "number" || !NumberIsInteger(pid)) {
+    throw new TypeError(`Process ID must be an integer, received: ${pid}`);
+  }
+  const signal = options?.signal;
+  // Honor an already-aborted signal before opening the wait. `null` and
+  // `undefined` both mean "no signal", as elsewhere that AbortSignal options
+  // are accepted.
+  if (signal?.aborted) {
+    throw signal.reason;
+  }
+  const rid = op_process_wait_open(pid, "Deno.processExited()");
+  // Start the wait immediately: the op closes the resource when it settles
+  // (whether it completes or is cancelled), so once it's running the
+  // descriptor/handle can't be leaked even if the signal wiring below throws.
+  const waitPromise = op_process_wait(rid);
+  if (signal === undefined || signal === null) {
+    await waitPromise;
+    return;
+  }
+  const onAbort = () => {
+    core.tryClose(rid);
+  };
+  try {
+    // A `signal` that isn't an AbortSignal throws here; cancel the abandoned
+    // wait rather than leaving it running.
+    signal[abortSignal.add](onAbort);
+  } catch (error) {
+    core.tryClose(rid);
+    throw error;
+  }
+  try {
+    // Closing the resource on abort cancels the wait op, which rejects
+    // `waitPromise`; surface the signal's reason instead of the cancellation.
+    await waitPromise;
+  } catch (error) {
+    if (signal.aborted) {
+      throw signal.reason;
+    }
+    throw error;
+  } finally {
+    signal[abortSignal.remove](onAbort);
+  }
 }
 
 function opRunStatus(rid) {
@@ -880,6 +928,7 @@ return {
   kill,
   nodeSpawnChild,
   nodeSpawnSyncChild,
+  processExited,
   Process,
   run,
   spawn,

--- a/ext/process/Cargo.toml
+++ b/ext/process/Cargo.toml
@@ -37,4 +37,4 @@ tokio.workspace = true
 nix = { workspace = true, features = ["signal", "process"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_System_Threading"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Threading"] }

--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -58,6 +58,7 @@ use serde::Deserialize;
 use tokio::process::Child as AsyncChild;
 
 pub mod ipc;
+mod wait;
 use ipc::IpcAdvancedStreamResource;
 use ipc::IpcJsonStreamResource;
 use ipc::IpcRefTracker;
@@ -250,6 +251,8 @@ deno_core::extension!(
     op_spawn_kill,
     op_spawn_child_ref,
     op_spawn_child_unref,
+    wait::op_process_wait_open,
+    wait::op_process_wait,
     deprecated::op_run,
     deprecated::op_run_status,
     deprecated::op_kill,
@@ -448,6 +451,9 @@ pub enum ProcessError {
   #[class(inherit)]
   #[error(transparent)]
   Signal(#[from] SignalError),
+  #[class(inherit)]
+  #[error(transparent)]
+  Canceled(#[from] deno_core::Canceled),
   #[class(inherit)]
   #[error(transparent)]
   Other(#[from] JsErrorBox),

--- a/ext/process/wait.rs
+++ b/ext/process/wait.rs
@@ -1,0 +1,471 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Waiting on the exit of a process that this runtime did not spawn.
+//!
+//! `Deno.Command`'s `status` promise can only observe a child this process
+//! created, because it is backed by the child handle returned from spawning.
+//! Code that only knows a process by its pid — for example a separate program
+//! tasked with shutting down a daemon started elsewhere — has no such handle.
+//! This module fills that gap with an event-driven wait that resolves the
+//! moment the target process exits, without polling.
+//!
+//! Each platform exposes a native primitive for this:
+//!
+//! - Linux: `pidfd_open` turns a pid into a file descriptor that becomes
+//!   readable when the process exits.
+//! - macOS and the BSDs: a `kqueue` registration with the `EVFILT_PROC` filter
+//!   and the `NOTE_EXIT` flag delivers an event when the process exits.
+//! - Windows: a process handle opened with `SYNCHRONIZE` becomes signaled when
+//!   the process terminates.
+//!
+//! On all three the descriptor/handle is registered with the async runtime (or
+//! the OS thread pool on Windows) so the wait costs nothing until the process
+//! actually exits.
+
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use deno_core::CancelFuture;
+use deno_core::CancelHandle;
+use deno_core::OpState;
+use deno_core::RcRef;
+use deno_core::Resource;
+use deno_core::ResourceId;
+use deno_core::op2;
+use deno_permissions::PermissionsContainer;
+
+use super::ProcessError;
+
+/// A live wait on some process's exit, held in the resource table so the
+/// caller can cancel it (by closing the resource) and so the underlying OS
+/// descriptor/handle is released on drop.
+struct ProcessWaitResource {
+  waiter: Waiter,
+  cancel: CancelHandle,
+}
+
+impl Resource for ProcessWaitResource {
+  fn name(&self) -> Cow<'_, str> {
+    "processWait".into()
+  }
+
+  fn close(self: Rc<Self>) {
+    self.cancel.cancel();
+  }
+}
+
+impl ProcessWaitResource {
+  async fn wait(self: Rc<Self>) -> Result<(), ProcessError> {
+    self.waiter.wait().await
+  }
+}
+
+/// Platform-specific backing for a single process-exit wait.
+enum Waiter {
+  /// The process was already gone when the wait was opened, so the wait
+  /// resolves immediately.
+  AlreadyExited,
+  #[cfg(any(target_os = "linux", target_os = "android"))]
+  Pidfd(tokio::io::unix::AsyncFd<std::os::fd::OwnedFd>),
+  #[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "dragonfly"
+  ))]
+  Kqueue(tokio::io::unix::AsyncFd<std::os::fd::OwnedFd>),
+  #[cfg(windows)]
+  Handle(windows_impl::ProcessHandle),
+}
+
+impl Waiter {
+  async fn wait(&self) -> Result<(), ProcessError> {
+    match self {
+      Waiter::AlreadyExited => Ok(()),
+      #[cfg(any(target_os = "linux", target_os = "android"))]
+      Waiter::Pidfd(async_fd) => {
+        // A pidfd becomes readable once, and stays readable, when the process
+        // exits. Readiness alone is the signal; there is nothing to read.
+        async_fd.readable().await.map_err(ProcessError::Io)?;
+        Ok(())
+      }
+      #[cfg(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+      ))]
+      Waiter::Kqueue(async_fd) => {
+        use std::os::fd::AsRawFd;
+        loop {
+          let mut guard =
+            async_fd.readable().await.map_err(ProcessError::Io)?;
+          if kqueue_impl::drain_exit_event(async_fd.get_ref().as_raw_fd())? {
+            return Ok(());
+          }
+          // No event was ready after all; re-arm and wait again.
+          guard.clear_ready();
+        }
+      }
+      #[cfg(windows)]
+      Waiter::Handle(handle) => handle.wait().await,
+    }
+  }
+}
+
+/// Open a wait on the process with `pid`. If the process is already gone,
+/// returns [`Waiter::AlreadyExited`] rather than an error, so that the common
+/// race — the process exits between the caller signaling it and opening this
+/// wait — resolves as a completed wait instead of failing.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn open_waiter(pid: i32) -> Result<Waiter, ProcessError> {
+  use std::os::fd::FromRawFd;
+  use std::os::fd::OwnedFd;
+  use std::os::fd::RawFd;
+
+  // SAFETY: `pidfd_open` takes a pid and a flags word; 0 is a valid flags
+  // value and no pointers are involved.
+  let ret =
+    unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0) };
+  if ret < 0 {
+    let err = std::io::Error::last_os_error();
+    return match err.raw_os_error() {
+      Some(libc::ESRCH) => Ok(Waiter::AlreadyExited),
+      _ => Err(ProcessError::Io(err)),
+    };
+  }
+  // SAFETY: `pidfd_open` returned a non-negative descriptor that we now own.
+  let owned = unsafe { OwnedFd::from_raw_fd(ret as RawFd) };
+  set_cloexec(&owned)?;
+  let async_fd = tokio::io::unix::AsyncFd::with_interest(
+    owned,
+    tokio::io::Interest::READABLE,
+  )
+  .map_err(ProcessError::Io)?;
+  Ok(Waiter::Pidfd(async_fd))
+}
+
+#[cfg(any(
+  target_os = "macos",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd",
+  target_os = "dragonfly"
+))]
+fn open_waiter(pid: i32) -> Result<Waiter, ProcessError> {
+  use std::os::fd::FromRawFd;
+  use std::os::fd::OwnedFd;
+
+  // SAFETY: `kqueue` takes no arguments and returns a new descriptor or -1.
+  let kq = unsafe { libc::kqueue() };
+  if kq < 0 {
+    return Err(ProcessError::Io(std::io::Error::last_os_error()));
+  }
+  // SAFETY: `kq` is a fresh descriptor returned by `kqueue`.
+  let owned = unsafe { OwnedFd::from_raw_fd(kq) };
+  set_cloexec(&owned)?;
+
+  // SAFETY: `kevent` is zero-initialized and then populated with a valid
+  // EVFILT_PROC/NOTE_EXIT registration for `pid`.
+  let mut change: libc::kevent = unsafe { std::mem::zeroed() };
+  change.ident = pid as usize;
+  change.filter = libc::EVFILT_PROC;
+  change.flags = libc::EV_ADD | libc::EV_ONESHOT;
+  change.fflags = libc::NOTE_EXIT;
+
+  // SAFETY: register one change and retrieve no events; `kq` and `change` are
+  // valid and the event/timeout pointers are null as permitted for a pure
+  // registration call.
+  let ret = unsafe {
+    libc::kevent(kq, &change, 1, std::ptr::null_mut(), 0, std::ptr::null())
+  };
+  if ret < 0 {
+    let err = std::io::Error::last_os_error();
+    return match err.raw_os_error() {
+      Some(libc::ESRCH) => Ok(Waiter::AlreadyExited),
+      _ => Err(ProcessError::Io(err)),
+    };
+  }
+  let async_fd = tokio::io::unix::AsyncFd::with_interest(
+    owned,
+    tokio::io::Interest::READABLE,
+  )
+  .map_err(ProcessError::Io)?;
+  Ok(Waiter::Kqueue(async_fd))
+}
+
+#[cfg(windows)]
+fn open_waiter(pid: i32) -> Result<Waiter, ProcessError> {
+  windows_impl::open(pid)
+}
+
+#[cfg(not(any(
+  target_os = "linux",
+  target_os = "android",
+  target_os = "macos",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd",
+  target_os = "dragonfly",
+  windows
+)))]
+fn open_waiter(_pid: i32) -> Result<Waiter, ProcessError> {
+  Err(ProcessError::Io(std::io::Error::new(
+    std::io::ErrorKind::Unsupported,
+    "waiting on a non-child process is not supported on this platform",
+  )))
+}
+
+// The pidfd/kqueue descriptors are only ever polled for readiness (and drained
+// with a zero-timeout `kevent`), never read or written, so they don't need
+// O_NONBLOCK — and setting it on a kqueue descriptor fails with ENOTTY on macOS
+// because that routes through the kqueue's absent ioctl handler. Only the
+// close-on-exec flag matters, so a later `Deno.Command` spawn doesn't inherit
+// the descriptor.
+#[cfg(any(
+  target_os = "linux",
+  target_os = "android",
+  target_os = "macos",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd",
+  target_os = "dragonfly"
+))]
+fn set_cloexec(fd: &impl std::os::fd::AsRawFd) -> Result<(), ProcessError> {
+  let raw = fd.as_raw_fd();
+  // SAFETY: `raw` is valid; F_SETFD accepts the descriptor flags word.
+  if unsafe { libc::fcntl(raw, libc::F_SETFD, libc::FD_CLOEXEC) } < 0 {
+    return Err(ProcessError::Io(std::io::Error::last_os_error()));
+  }
+  Ok(())
+}
+
+#[cfg(any(
+  target_os = "macos",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd",
+  target_os = "dragonfly"
+))]
+mod kqueue_impl {
+  use super::ProcessError;
+
+  /// Retrieve at most one pending kqueue event without blocking. Returns `true`
+  /// when an exit event was delivered, `false` on a spurious wakeup with no
+  /// event ready.
+  pub(super) fn drain_exit_event(
+    kq: std::os::fd::RawFd,
+  ) -> Result<bool, ProcessError> {
+    // SAFETY: zero-initialized output event; `kevent` fills it in.
+    let mut ev: libc::kevent = unsafe { std::mem::zeroed() };
+    let ts = libc::timespec {
+      tv_sec: 0,
+      tv_nsec: 0,
+    };
+    // SAFETY: retrieve up to one event with a zero timeout (non-blocking); the
+    // changelist is empty and the output event/timeout pointers are valid.
+    let n = unsafe { libc::kevent(kq, std::ptr::null(), 0, &mut ev, 1, &ts) };
+    if n < 0 {
+      let err = std::io::Error::last_os_error();
+      // Interrupted before an event could be read; the readiness loop retries.
+      if err.raw_os_error() == Some(libc::EINTR) {
+        return Ok(false);
+      }
+      return Err(ProcessError::Io(err));
+    }
+    // The only filter registered is EVFILT_PROC/NOTE_EXIT, so any delivered
+    // event means the process has exited.
+    Ok(n > 0)
+  }
+}
+
+#[cfg(windows)]
+mod windows_impl {
+  use std::os::windows::io::AsRawHandle;
+  use std::os::windows::io::FromRawHandle;
+  use std::os::windows::io::OwnedHandle;
+
+  use windows_sys::Win32::Foundation::BOOLEAN;
+  use windows_sys::Win32::Foundation::ERROR_INVALID_PARAMETER;
+  use windows_sys::Win32::Foundation::FALSE;
+  use windows_sys::Win32::Foundation::GetLastError;
+  use windows_sys::Win32::Foundation::HANDLE;
+  use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+  use windows_sys::Win32::Foundation::WAIT_OBJECT_0;
+  use windows_sys::Win32::Storage::FileSystem::SYNCHRONIZE;
+  use windows_sys::Win32::System::Threading::INFINITE;
+  use windows_sys::Win32::System::Threading::OpenProcess;
+  use windows_sys::Win32::System::Threading::RegisterWaitForSingleObject;
+  use windows_sys::Win32::System::Threading::UnregisterWaitEx;
+  use windows_sys::Win32::System::Threading::WT_EXECUTEINWAITTHREAD;
+  use windows_sys::Win32::System::Threading::WT_EXECUTEONLYONCE;
+  use windows_sys::Win32::System::Threading::WaitForSingleObject;
+
+  use super::ProcessError;
+  use super::Waiter;
+
+  type Sender = tokio::sync::oneshot::Sender<()>;
+
+  /// A process handle opened with `SYNCHRONIZE`, whose signaled state tracks
+  /// the process's termination.
+  pub(super) struct ProcessHandle {
+    handle: OwnedHandle,
+  }
+
+  pub(super) fn open(pid: i32) -> Result<Waiter, ProcessError> {
+    // SAFETY: Win32 call; `pid` is a positive process id and `FALSE` disables
+    // handle inheritance.
+    let raw = unsafe { OpenProcess(SYNCHRONIZE, FALSE, pid as u32) };
+    if raw.is_null() {
+      // SAFETY: reads the calling thread's last error.
+      let err = unsafe { GetLastError() };
+      // The process id doesn't refer to a live process — treat as exited.
+      if err == ERROR_INVALID_PARAMETER {
+        return Ok(Waiter::AlreadyExited);
+      }
+      return Err(ProcessError::Io(std::io::Error::from_raw_os_error(
+        err as i32,
+      )));
+    }
+    // SAFETY: `raw` is a valid handle that `OpenProcess` transferred to us.
+    let handle = unsafe { OwnedHandle::from_raw_handle(raw as _) };
+    if is_signaled(&handle) {
+      // Dropping `handle` closes it.
+      return Ok(Waiter::AlreadyExited);
+    }
+    Ok(Waiter::Handle(ProcessHandle { handle }))
+  }
+
+  fn is_signaled(handle: &OwnedHandle) -> bool {
+    // SAFETY: Win32 call with a valid handle and a zero timeout, which polls
+    // the signaled state without blocking.
+    let r = unsafe { WaitForSingleObject(handle.as_raw_handle() as _, 0) };
+    r == WAIT_OBJECT_0
+  }
+
+  impl ProcessHandle {
+    pub(super) async fn wait(&self) -> Result<(), ProcessError> {
+      let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+      // The boxed sender is handed to the wait-thread callback. It is freed by
+      // `Registration::drop` only after `UnregisterWaitEx` guarantees the
+      // callback is no longer running.
+      let boxed: *mut Option<Sender> = Box::into_raw(Box::new(Some(tx)));
+      let mut wait_object: HANDLE = std::ptr::null_mut();
+      // SAFETY: registers a one-shot wait on the process handle; `boxed` stays
+      // valid until the registration is dropped.
+      let rc = unsafe {
+        RegisterWaitForSingleObject(
+          &mut wait_object,
+          self.handle.as_raw_handle() as _,
+          Some(callback),
+          boxed as *mut _,
+          INFINITE,
+          WT_EXECUTEINWAITTHREAD | WT_EXECUTEONLYONCE,
+        )
+      };
+      if rc == 0 {
+        let err = std::io::Error::last_os_error();
+        // SAFETY: registration failed, so the callback will never run; reclaim
+        // the box we just leaked.
+        drop(unsafe { Box::from_raw(boxed) });
+        return Err(ProcessError::Io(err));
+      }
+      // Unregisters the wait and frees the box when this future completes or is
+      // dropped (the caller cancelled the wait).
+      let _registration = Registration { wait_object, boxed };
+      // A receive error means the sender was dropped without sending, which
+      // only happens once the callback has fired; either way the wait is over.
+      let _ = rx.await;
+      Ok(())
+    }
+  }
+
+  struct Registration {
+    wait_object: HANDLE,
+    boxed: *mut Option<Sender>,
+  }
+
+  impl Drop for Registration {
+    fn drop(&mut self) {
+      // SAFETY: `UnregisterWaitEx` with `INVALID_HANDLE_VALUE` blocks until any
+      // in-flight callback has returned, after which the boxed sender is no
+      // longer referenced and can be freed. If the call fails (it shouldn't for
+      // a valid wait object) a callback may still be pending, so the box is
+      // leaked rather than freed, to avoid a use-after-free.
+      unsafe {
+        if UnregisterWaitEx(self.wait_object, INVALID_HANDLE_VALUE) != 0 {
+          drop(Box::from_raw(self.boxed));
+        }
+      }
+    }
+  }
+
+  unsafe extern "system" fn callback(
+    ptr: *mut std::ffi::c_void,
+    _fired: BOOLEAN,
+  ) {
+    // SAFETY: `ptr` is the boxed sender passed to `RegisterWaitForSingleObject`.
+    // It outlives this callback because the owning `Registration` frees it only
+    // after `UnregisterWaitEx(INVALID_HANDLE_VALUE)` waits for us to return.
+    let sender = unsafe { &mut *(ptr as *mut Option<Sender>) };
+    if let Some(tx) = sender.take() {
+      let _ = tx.send(());
+    }
+  }
+}
+
+/// Opens an event-driven wait on the exit of the process identified by `pid`.
+///
+/// Requires full run permission (`--allow-run`), the same capability that
+/// [`op_kill`](super::deprecated::op_kill) requires to signal a process it did
+/// not spawn.
+#[op2(fast, stack_trace)]
+#[smi]
+pub(crate) fn op_process_wait_open(
+  state: &mut OpState,
+  #[smi] pid: i32,
+  #[string] api_name: String,
+) -> Result<ResourceId, ProcessError> {
+  state
+    .borrow_mut::<PermissionsContainer>()
+    .check_run_all(&api_name)?;
+
+  if pid <= 0 {
+    return Err(ProcessError::InvalidPid);
+  }
+
+  let waiter = open_waiter(pid)?;
+  let rid = state.resource_table.add(ProcessWaitResource {
+    waiter,
+    cancel: Default::default(),
+  });
+  Ok(rid)
+}
+
+/// Resolves when the process behind the wait opened by
+/// [`op_process_wait_open`] exits. Closing the resource cancels the wait.
+#[op2]
+pub(crate) async fn op_process_wait(
+  state: Rc<RefCell<OpState>>,
+  #[smi] rid: ResourceId,
+) -> Result<(), ProcessError> {
+  let resource = state
+    .borrow()
+    .resource_table
+    .get::<ProcessWaitResource>(rid)
+    .map_err(ProcessError::Resource)?;
+  let cancel = RcRef::map(resource.clone(), |r| &r.cancel);
+  let result = resource.clone().wait().or_cancel(cancel).await;
+  // Release the descriptor/handle once the wait settles, whether it completed
+  // or was cancelled.
+  if let Ok(resource) = state.borrow_mut().resource_table.take_any(rid) {
+    resource.close();
+  }
+  match result {
+    Ok(inner) => inner,
+    Err(canceled) => Err(ProcessError::Canceled(canceled)),
+  }
+}

--- a/ext/process/wait.rs
+++ b/ext/process/wait.rs
@@ -87,8 +87,10 @@ impl Waiter {
       #[cfg(any(target_os = "linux", target_os = "android"))]
       Waiter::Pidfd(async_fd) => {
         // A pidfd becomes readable once, and stays readable, when the process
-        // exits. Readiness alone is the signal; there is nothing to read.
-        async_fd.readable().await.map_err(ProcessError::Io)?;
+        // exits. Readiness alone is the signal; there is nothing to read, and
+        // the fd is closed right after, so the ready guard is dropped without
+        // clearing readiness.
+        let _guard = async_fd.readable().await.map_err(ProcessError::Io)?;
         Ok(())
       }
       #[cfg(any(

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -245,6 +245,7 @@ const denoNs = {
   utime: fs.utime,
   utimeSync: fs.utimeSync,
   kill: undefined,
+  processExited: undefined,
   addSignalListener: signals.addSignalListener,
   removeSignalListener: signals.removeSignalListener,
   refTimer: timers.refTimer,
@@ -288,6 +289,10 @@ core.defineGlobalProperties(denoNs, {
     lazyWebsocket,
   ),
   kill: core.propWritableLazyLoaded((process) => process.kill, lazyProcess),
+  processExited: core.propWritableLazyLoaded(
+    (process) => process.processExited,
+    lazyProcess,
+  ),
   Command: core.propWritableLazyLoaded(
     (process) => process.Command,
     lazyProcess,

--- a/tests/unit/process_exited_test.ts
+++ b/tests/unit/process_exited_test.ts
@@ -1,0 +1,120 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+import { assert, assertEquals, assertRejects } from "./test_util.ts";
+
+function spawnHanging(): Deno.ChildProcess {
+  // A process that never exits on its own, so the test controls when it dies.
+  return new Deno.Command(Deno.execPath(), {
+    args: ["eval", "await new Promise(() => {});"],
+    stdout: "null",
+    stderr: "null",
+  }).spawn();
+}
+
+Deno.test(
+  { permissions: { run: false } },
+  async function processExitedPermissions() {
+    await assertRejects(
+      () => Deno.processExited(Deno.pid),
+      Deno.errors.NotCapable,
+    );
+  },
+);
+
+Deno.test(
+  { permissions: { run: true } },
+  async function processExitedInvalidPid() {
+    await assertRejects(() => Deno.processExited(1.5), TypeError);
+    await assertRejects(() => Deno.processExited(NaN), TypeError);
+    await assertRejects(() => Deno.processExited(0), TypeError);
+    await assertRejects(() => Deno.processExited(-1), TypeError);
+  },
+);
+
+Deno.test(
+  { permissions: { run: true, read: true } },
+  async function processExitedResolvesOnExit() {
+    const child = spawnHanging();
+    // The wait is registered synchronously (before the first await) while the
+    // process is still alive, so terminating it right after is race-free.
+    const exited = Deno.processExited(child.pid);
+    child.kill("SIGTERM");
+    assertEquals(await exited, undefined);
+    await child.status;
+  },
+);
+
+Deno.test(
+  { permissions: { run: true, read: true } },
+  async function processExitedResolvesWhenAlreadyExited() {
+    const child = new Deno.Command(Deno.execPath(), {
+      args: ["eval", ""],
+      stdout: "null",
+      stderr: "null",
+    }).spawn();
+    const pid = child.pid;
+    // Ensure the process is gone (and reaped) before we start waiting.
+    await child.status;
+    assertEquals(await Deno.processExited(pid), undefined);
+  },
+);
+
+Deno.test(
+  { permissions: { run: true, read: true } },
+  async function processExitedNullSignalIsNoSignal() {
+    // `{ signal: null }` is a common "no signal" idiom and must not be treated
+    // as an (invalid) abort signal.
+    const child = spawnHanging();
+    // @ts-ignore `null` is accepted at runtime as "no signal".
+    const exited = Deno.processExited(child.pid, { signal: null });
+    child.kill("SIGTERM");
+    assertEquals(await exited, undefined);
+    await child.status;
+  },
+);
+
+Deno.test(
+  { permissions: { run: true, read: true } },
+  async function processExitedAbort() {
+    const child = spawnHanging();
+    const ac = new AbortController();
+    const exited = Deno.processExited(child.pid, { signal: ac.signal });
+    ac.abort();
+    const err = await assertRejects(() => exited, DOMException);
+    assertEquals(err.name, "AbortError");
+    // Aborting the wait must not have killed the process.
+    child.kill("SIGTERM");
+    await child.status;
+  },
+);
+
+Deno.test(
+  { permissions: { run: true, read: true } },
+  async function processExitedAbortWithReason() {
+    const child = spawnHanging();
+    const ac = new AbortController();
+    ac.abort(new Error("stop waiting"));
+    await assertRejects(
+      () => Deno.processExited(child.pid, { signal: ac.signal }),
+      Error,
+      "stop waiting",
+    );
+    child.kill("SIGTERM");
+    await child.status;
+  },
+);
+
+Deno.test(
+  { permissions: { run: true, read: true } },
+  async function processExitedSurvivesWaitAcrossManyResources() {
+    // Opening and completing many waits should not leak descriptors/handles.
+    const child = spawnHanging();
+    const waits = [];
+    for (let i = 0; i < 8; i++) {
+      waits.push(Deno.processExited(child.pid));
+    }
+    child.kill("SIGTERM");
+    await Promise.all(waits);
+    assert(true);
+    await child.status;
+  },
+);


### PR DESCRIPTION
Disclosure: this change was authored by an AI assistant (Claude Opus 4.8).

`Deno.Command().status` resolves when a child exits, but it is backed by the child handle returned from spawning, so it can only observe a process this runtime created. Code that knows a process only by its pid — for example a separate program tasked with shutting a daemon down cleanly: read the pid, send a signal, then wait until the process has actually gone before releasing a resource it held or deleting its state file — had no equivalent. The only tool for a foreign pid was a liveness probe (signal 0), which answers "alive right now" at a single instant; turning that into "wait until it exits" required a polling loop that reacts late by up to one interval and burns cycles.

Every major platform already offers an event-driven primitive for exactly this. This change adds `Deno.processExited(pid, options?)`, a small portable abstraction over them, returning a promise that resolves the moment the process exits:

- Linux: `pidfd_open` turns the pid into a descriptor that becomes readable on exit; it is registered with the reactor via tokio's `AsyncFd`.
- macOS and the BSDs: a `kqueue` registration with the `EVFILT_PROC` filter and `NOTE_EXIT` flag; the kqueue descriptor itself is polled for readiness through `AsyncFd` and drained with a zero-timeout `kevent`.
- Windows: a process handle opened with `SYNCHRONIZE` is waited on with `RegisterWaitForSingleObject`, which signals a channel from the OS thread pool.

The wait is a cancellable resource: closing it cancels the wait and the op releases the underlying descriptor or handle whether it completed or was cancelled. An optional `AbortSignal` abandons the wait (rejecting with the signal's reason) without affecting the target process.

If no process holds the pid — including the race where it exits between a caller's signal and this call — the promise resolves immediately, since a process that isn't running has, for this purpose, exited. As with `Deno.kill`, a pid identifies a process only until it is reaped, after which the operating system may reuse it; waiting on a recycled pid waits on whatever now holds it.

The API requires full run permission (`--allow-run`), matching the capability `Deno.kill` already requires to signal a process this runtime did not spawn.

Fixes #36223

<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
