### PR TITLE
fix(ext/web): clean up abort handlers when listeners are removed

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -787,11 +787,7 @@ function innerInvokeEventListeners(
     }
 
     if (once) {
-      ArrayPrototypeSplice(
-        targetListeners[type],
-        ArrayPrototypeIndexOf(targetListeners[type], listener),
-        1,
-      );
+      removeListener(targetListeners, type, listener);
     }
 
     if (passive) {
@@ -871,6 +867,20 @@ function normalizeEventHandlerOptions(
     return {
       capture: Boolean(options.capture),
     };
+  }
+}
+
+function removeListener(targetListeners, type, listener) {
+  const index = ArrayPrototypeIndexOf(targetListeners[type], listener);
+  if (index === -1) {
+    return;
+  }
+
+  ArrayPrototypeSplice(targetListeners[type], index, 1);
+  if (listener.signal && listener.abortListener) {
+    listener.signal.removeEventListener("abort", listener.abortListener);
+    listener.signal = undefined;
+    listener.abortListener = undefined;
   }
 }
 
@@ -1020,21 +1030,29 @@ class EventTarget {
         return;
       }
     }
+    let signal;
+    let abortListener;
     if (options?.signal) {
-      const signal = options?.signal;
+      signal = options.signal;
       if (signal.aborted) {
         // If signal is not null and its aborted flag is set, then return.
         return;
       } else {
         // If listener's signal is not null, then add the following abort
         // abort steps to it: Remove an event listener.
-        signal.addEventListener("abort", () => {
+        abortListener = () => {
           self.removeEventListener(type, callback, options);
-        });
+        };
+        signal.addEventListener("abort", abortListener);
       }
     }
 
-    ArrayPrototypePush(listeners[type], { callback, options });
+    ArrayPrototypePush(listeners[type], {
+      callback,
+      options,
+      signal,
+      abortListener,
+    });
   }
 
   removeEventListener(
@@ -1067,7 +1085,7 @@ class EventTarget {
             listener.options.capture === options.capture)) &&
         listener.callback === callback
       ) {
-        ArrayPrototypeSplice(listeners[type], i, 1);
+        removeListener(listeners, type, listener);
         break;
       }
     }

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -870,14 +870,18 @@ function normalizeEventHandlerOptions(
   }
 }
 
-function removeListener(targetListeners, type, listener) {
-  const index = ArrayPrototypeIndexOf(targetListeners[type], listener);
+function removeListener(
+  targetListeners,
+  type,
+  listener,
+  index = ArrayPrototypeIndexOf(targetListeners[type], listener),
+) {
   if (index === -1) {
     return;
   }
 
   ArrayPrototypeSplice(targetListeners[type], index, 1);
-  if (listener.signal && listener.abortListener) {
+  if (listener.abortListener) {
     listener.signal.removeEventListener("abort", listener.abortListener);
     listener.signal = undefined;
     listener.abortListener = undefined;
@@ -1085,7 +1089,7 @@ class EventTarget {
             listener.options.capture === options.capture)) &&
         listener.callback === callback
       ) {
-        removeListener(listeners, type, listener);
+        removeListener(listeners, type, listener, i);
         break;
       }
     }

--- a/tests/unit/event_target_test.ts
+++ b/tests/unit/event_target_test.ts
@@ -352,6 +352,47 @@ Deno.test(function eventTargetAddEventListenerGlobalAbort() {
   });
 });
 
+Deno.test(function eventTargetManualRemoveCleansAbortSignalListener() {
+  const target = new EventTarget();
+  const controller = new AbortController();
+  const listener = () => {};
+
+  target.addEventListener("test", listener, { signal: controller.signal });
+  target.removeEventListener("test", listener);
+
+  let removeCount = 0;
+  const originalRemoveEventListener = target.removeEventListener;
+  target.removeEventListener = function (...args) {
+    removeCount++;
+    return originalRemoveEventListener.apply(this, args);
+  };
+  controller.abort();
+
+  assertEquals(removeCount, 0);
+});
+
+Deno.test(function eventTargetOnceListenerCleansAbortSignalListener() {
+  const target = new EventTarget();
+  const controller = new AbortController();
+  const listener = () => {};
+
+  target.addEventListener("test", listener, {
+    once: true,
+    signal: controller.signal,
+  });
+  target.dispatchEvent(new Event("test"));
+
+  let removeCount = 0;
+  const originalRemoveEventListener = target.removeEventListener;
+  target.removeEventListener = function (...args) {
+    removeCount++;
+    return originalRemoveEventListener.apply(this, args);
+  };
+  controller.abort();
+
+  assertEquals(removeCount, 0);
+});
+
 Deno.test(function eventTargetBrandChecking() {
   const self = {};
 


### PR DESCRIPTION
## Summary

- detach an `AbortSignal` abort handler when its associated event listener is explicitly removed
- apply the same cleanup when a `once` listener is consumed
- reuse the already-known listener index during explicit removal
- add regression coverage for both removal paths

## Root cause

`addEventListener()` registered a handler on the supplied abort signal, but the event listener entry did not retain the state needed to unregister that handler. Removing the event listener therefore left the abort handler attached until the signal itself was aborted.

The listener entry now tracks the paired signal and abort handler. A shared removal helper removes the event listener and detaches that handler for both explicit and `once` removal.

## Tests

- `cargo build -p deno -p test_server`
- `cargo test -p unit_tests --test unit -- event_target_test`
- `./tools/format.js --check ext/web/02_event.js tests/unit/event_target_test.ts`
- `./tools/lint.js --js`
