### PR TITLE
fix(node): clean up Web Stream finished listeners

### DIFF
--- a/ext/node/polyfills/internal/streams/end-of-stream.js
+++ b/ext/node/polyfills/internal/streams/end-of-stream.js
@@ -337,6 +337,9 @@ function eosWeb(stream, options, callback) {
     resolverFn,
     resolverFn,
   );
+  // Deno diverges from upstream, which returns `nop`, to honor the returned
+  // cleanup function contract.
+  // https://github.com/nodejs/node/pull/46205
   return cleanup;
 }
 

--- a/ext/node/polyfills/internal/streams/end-of-stream.js
+++ b/ext/node/polyfills/internal/streams/end-of-stream.js
@@ -301,6 +301,12 @@ function eos(stream, options, callback) {
 function eosWeb(stream, options, callback) {
   let isAborted = false;
   let abort = nop;
+  let disposable;
+  const cleanup = () => {
+    callback = nop;
+    disposable?.[SymbolDispose]();
+    disposable = undefined;
+  };
   if (options.signal) {
     abort = () => {
       isAborted = true;
@@ -313,10 +319,10 @@ function eosWeb(stream, options, callback) {
       lazyProcess().nextTick(abort);
     } else {
       addAbortListener ??= _mod2.addAbortListener;
-      const disposable = addAbortListener(options.signal, abort);
+      disposable = addAbortListener(options.signal, abort);
       const originalCallback = callback;
       callback = once((...args) => {
-        disposable[SymbolDispose]();
+        cleanup();
         originalCallback.apply(stream, args);
       });
     }
@@ -331,7 +337,7 @@ function eosWeb(stream, options, callback) {
     resolverFn,
     resolverFn,
   );
-  return nop;
+  return cleanup;
 }
 
 function finished(stream, opts) {

--- a/tests/unit_node/stream_test.ts
+++ b/tests/unit_node/stream_test.ts
@@ -5,6 +5,7 @@ import { fromFileUrl, relative } from "@std/path";
 import { finished, pipeline } from "node:stream/promises";
 import {
   Duplex,
+  finished as finishedCallback,
   getDefaultHighWaterMark,
   promises,
   Stream,
@@ -58,6 +59,59 @@ Deno.test("finished on web streams", async () => {
     assertEquals(chunk, "asd");
   }
   await promise;
+});
+
+Deno.test("finished cleanup removes web stream abort listener", async () => {
+  let abortListener: EventListener | undefined;
+  let removeCount = 0;
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener(_type: string, listener: EventListener) {
+      abortListener = listener;
+    },
+    removeEventListener(_type: string, listener: EventListener) {
+      assertEquals(listener, abortListener);
+      removeCount++;
+    },
+  } as unknown as AbortSignal;
+  let streamController!: ReadableStreamDefaultController;
+  const stream = new ReadableStream({
+    start(controller) {
+      streamController = controller;
+    },
+  });
+  let callbackCount = 0;
+
+  const cleanup = finishedCallback(
+    stream as unknown as NodeJS.ReadableStream,
+    { signal },
+    () => callbackCount++,
+  );
+  cleanup();
+  cleanup();
+
+  assertEquals(removeCount, 1);
+  abortListener?.(new Event("abort"));
+  streamController.close();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assertEquals(callbackCount, 0);
+});
+
+Deno.test("finished promise cleanup works for web streams", async () => {
+  let streamController!: ReadableStreamDefaultController;
+  const stream = new ReadableStream({
+    start(controller) {
+      streamController = controller;
+    },
+  });
+  const completion = finished(
+    stream as unknown as NodeJS.ReadableStream,
+    { cleanup: true, signal: new AbortController().signal },
+  );
+
+  streamController.close();
+  await completion;
 });
 
 // https://github.com/denoland/deno/issues/28905

--- a/tests/unit_node/stream_test.ts
+++ b/tests/unit_node/stream_test.ts
@@ -99,6 +99,19 @@ Deno.test("finished cleanup removes web stream abort listener", async () => {
 });
 
 Deno.test("finished promise cleanup works for web streams", async () => {
+  let abortListener: EventListener | undefined;
+  let removeCount = 0;
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener(_type: string, listener: EventListener) {
+      abortListener = listener;
+    },
+    removeEventListener(_type: string, listener: EventListener) {
+      assertEquals(listener, abortListener);
+      removeCount++;
+    },
+  } as unknown as AbortSignal;
   let streamController!: ReadableStreamDefaultController;
   const stream = new ReadableStream({
     start(controller) {
@@ -107,11 +120,12 @@ Deno.test("finished promise cleanup works for web streams", async () => {
   });
   const completion = finished(
     stream as unknown as NodeJS.ReadableStream,
-    { cleanup: true, signal: new AbortController().signal },
+    { cleanup: true, signal },
   );
 
   streamController.close();
   await completion;
+  assertEquals(removeCount, 1);
 });
 
 // https://github.com/denoland/deno/issues/28905


### PR DESCRIPTION
## What changed

- return a real, idempotent cleanup function for Web Streams passed to `stream.finished()`
- detach the associated abort listener and suppress pending completion callbacks after cleanup
- cover callback cleanup and promise auto-cleanup behavior with focused tests

## Why

The Web Stream path captured the disposable returned by `addAbortListener()`, but returned a no-op cleanup function to callers. This did not match the documented Node API contract and could keep callback state attached after callers requested cleanup.

Normal completion now runs the same cleanup before invoking the stored callback, preserving stream settlement and abort behavior while remaining compatible with `{ cleanup: true }` in `node:stream/promises`.

## Tests

- `unit_node::stream_test` (12 passed)
- `./tools/format.js --check ext/node/polyfills/internal/streams/end-of-stream.js tests/unit_node/stream_test.ts`
