### PR TITLE
fix(net): clean up cancellation resources on early errors

### DIFF
--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -74,16 +74,20 @@ async function write(rid, data) {
 }
 
 async function resolveDns(query, recordType, options) {
+  const signal = options?.signal;
+  if (signal) {
+    signal.throwIfAborted();
+  }
   let cancelRid;
   let abortHandler;
-  if (options?.signal) {
-    options.signal.throwIfAborted();
-    cancelRid = createCancelHandle();
-    abortHandler = () => core.tryClose(cancelRid);
-    options.signal[abortSignal.add](abortHandler);
-  }
 
   try {
+    if (signal) {
+      cancelRid = createCancelHandle();
+      abortHandler = () => core.tryClose(cancelRid);
+      signal[abortSignal.add](abortHandler);
+    }
+
     const res = await op_dns_resolve({
       cancelRid,
       query,
@@ -92,11 +96,18 @@ async function resolveDns(query, recordType, options) {
     }, /* useEdns0 */ true);
     return ArrayPrototypeMap(res, (recordWithTtl) => recordWithTtl.data);
   } finally {
-    if (options?.signal) {
-      options.signal[abortSignal.remove](abortHandler);
+    if (cancelRid !== undefined) {
+      // The op consumes this on its normal path. Close it here as well in case
+      // the op returned before taking ownership.
+      core.tryClose(cancelRid);
+    }
+    if (abortHandler !== undefined) {
+      signal[abortSignal.remove](abortHandler);
+    }
 
+    if (signal) {
       // always throw the abort error when aborted
-      options.signal.throwIfAborted();
+      signal.throwIfAborted();
     }
   }
 }
@@ -695,17 +706,21 @@ function createListenDatagram(udpOpFn, unixOpFn) {
 async function connect(args) {
   switch (args.transport ?? "tcp") {
     case "tcp": {
-      let cancelRid;
-      let abortHandler;
-      if (args?.signal) {
-        args.signal.throwIfAborted();
-        cancelRid = createCancelHandle();
-        abortHandler = () => core.tryClose(cancelRid);
-        args.signal[abortSignal.add](abortHandler);
+      const signal = args?.signal;
+      if (signal) {
+        signal.throwIfAborted();
       }
       const port = validatePort(args.port);
+      let cancelRid;
+      let abortHandler;
 
       try {
+        if (signal) {
+          cancelRid = createCancelHandle();
+          abortHandler = () => core.tryClose(cancelRid);
+          signal[abortSignal.add](abortHandler);
+        }
+
         const { 0: rid, 1: localAddr, 2: remoteAddr } =
           await op_net_connect_tcp(
             {
@@ -725,9 +740,16 @@ async function connect(args) {
 
         return new TcpConn(rid, remoteAddr, localAddr);
       } finally {
-        if (args?.signal) {
-          args.signal[abortSignal.remove](abortHandler);
-          args.signal.throwIfAborted();
+        if (cancelRid !== undefined) {
+          // The op consumes this on its normal path. Close it here as well in
+          // case the op returned before taking ownership.
+          core.tryClose(cancelRid);
+        }
+        if (abortHandler !== undefined) {
+          signal[abortSignal.remove](abortHandler);
+        }
+        if (signal) {
+          signal.throwIfAborted();
         }
       }
     }

--- a/tests/unit/net_test.ts
+++ b/tests/unit/net_test.ts
@@ -1476,6 +1476,48 @@ Deno.test(
   },
 );
 
+Deno.test(
+  { permissions: { net: true } },
+  async function netTcpInvalidPortWithAbortSignalDoesNotLeak() {
+    const controller = new AbortController();
+    await assertRejects(
+      () => Deno.connect({ port: -1, signal: controller.signal }),
+      RangeError,
+    );
+  },
+);
+
+Deno.test(
+  { permissions: { net: false } },
+  async function netTcpPermissionErrorWithAbortSignalDoesNotLeak() {
+    const controller = new AbortController();
+    await assertRejects(
+      () =>
+        Deno.connect({
+          hostname: "127.0.0.1",
+          port: 80,
+          signal: controller.signal,
+        }),
+      Deno.errors.NotCapable,
+    );
+  },
+);
+
+Deno.test(
+  { permissions: { net: false } },
+  async function resolveDnsPermissionErrorWithAbortSignalDoesNotLeak() {
+    const controller = new AbortController();
+    await assertRejects(
+      () =>
+        Deno.resolveDns("example.com", "A", {
+          nameServer: { ipAddr: "127.0.0.1" },
+          signal: controller.signal,
+        }),
+      Deno.errors.NotCapable,
+    );
+  },
+);
+
 Deno.test({
   ignore: Deno.build.os === "linux",
   permissions: { net: true },


### PR DESCRIPTION
## Summary

- allocate network cancellation handles only after synchronous validation
- defensively close cancellation handles when `connect()` or `resolveDns()` exits before the native operation consumes them
- cover invalid arguments and early permission errors with resource-sanitizer regressions

## Cause

The JavaScript wrappers registered cancellation resources before every failure path was protected by cleanup. Validation and early native-operation errors could therefore return without consuming or closing the handle.

## Tests

- `cargo build --bin deno`
- `cargo test -p unit_tests --test unit -- net_test`
- focused resource-sanitizer tests for invalid ports and permission errors
- `./tools/format.js --check ext/net/01_net.js tests/unit/net_test.ts`
