### PR TITLE
fix(jupyter): report codemirror_mode as a string

### DIFF
--- a/cli/js/jupyter_kernel.js
+++ b/cli/js/jupyter_kernel.js
@@ -612,7 +612,7 @@ async function startJupyterKernel() {
         mimetype: "text/x.typescript",
         file_extension: ".ts",
         pygments_lexer: "typescript",
-        codemirror_mode: { name: "typescript" },
+        codemirror_mode: "typescript",
         nbconvert_exporter: "script",
       },
       banner: "Welcome to Deno kernel",

--- a/tests/integration/jupyter_tests.rs
+++ b/tests/integration/jupyter_tests.rs
@@ -516,6 +516,7 @@ async fn jupyter_kernel_info() -> Result<()> {
         "mimetype": "text/x.typescript",
         "file_extension": ".ts",
         "pygments_lexer": "typescript",
+        "codemirror_mode": "typescript",
         "nbconvert_exporter": "script"
       },
     }),


### PR DESCRIPTION
The Jupyter `kernel_info_reply` reported `codemirror_mode` as an object
`{ name: "typescript" }` that omitted a `version` field. Consumers that
model `codemirror_mode` as either a bare string or an object with a
required numeric `version` (for example runtimed, which backs the Zed
REPL) cannot deserialize this shape: it is not a plain string, and the
object variant requires `version`. The result was a deserialization
failure that broke the Zed REPL when talking to Deno.

This changes the kernel to report the bare string `"typescript"`, which
is the simplest spec-valid form and is accepted by every consumer. The
maintainer of runtimed asked us to fix it on the Deno side rather than
loosen the protocol type, see
https://github.com/runtimed/runtimed/pull/311#issuecomment-5046801084.

I checked the remaining `language_info` fields (`name`, `version`,
`mimetype`, `file_extension`, `pygments_lexer`, `nbconvert_exporter`)
while I was here; they are all plain strings and were already correct.
`codemirror_mode` was the only offending field.

The existing `jupyter_kernel_info` integration test now also asserts on
`codemirror_mode`.
