### PR TITLE
fix(compile): bump libsui to 0.16.4 to fix Windows resource SizeOfImage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,12 +1886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debug-ignore"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
-
-[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4355,19 +4349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "editpe"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cede2bb1b07dd598d269f973792c43e0cd92686d3b452bd6e01d7a8eb01211"
-dependencies = [
- "debug-ignore",
- "indexmap",
- "log",
- "thiserror 1.0.69",
- "zerocopy 0.7.32",
-]
-
-[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6611,15 +6592,16 @@ dependencies = [
 
 [[package]]
 name = "libsui"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca68ddfd95a7422fda71830518f057cb14aa784a0feed007bc5ef9dff04818b1"
+checksum = "3cd44dd0a322ec9fb05619e59067d1c767718238677369d9c5f004ea26a1184b"
 dependencies = [
- "editpe",
  "image",
+ "indexmap",
  "libc",
  "object",
  "sha2",
+ "thiserror 1.0.69",
  "windows 0.58.0",
  "zerocopy 0.7.32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,7 +376,7 @@ imara-diff = "=0.2.0"
 lax-css = "=0.2.4"
 lax-markup = "=0.2.5"
 lax-sql = "=0.2.1"
-libsui = "=0.16.3"
+libsui = "=0.16.4"
 object = { version = "0.36.3", default-features = false, features = ["read_core", "pe"] }
 open = "5.0.1"
 pathdiff = "0.2.1"


### PR DESCRIPTION
Bumps libsui from 0.16.3 to 0.16.4.

libsui 0.16.4 corrects the SizeOfImage field in the PE header when `deno
compile` appends the embedded payload (and, with `--icon`, the icon) as a
resource section. The previous version grew SizeOfImage by the unaligned raw
length of the appended resource data, under-counting the image by up to one
section-alignment page. On Windows an undersized SizeOfImage leaves the tail of
the resource section outside the mapped image, which shows up either as an
access violation at startup before any JavaScript runs, or as the runtime
failing to find the embedded section and reporting "Could not find standalone
binary section" when an icon is embedded.

This is what regressed compiled binaries between 2.9.2 and 2.9.3 on Windows.
libsui itself did not change between those releases; the base `deno` binary's
section layout shifted just enough that the latent SizeOfImage miscalculation
began clipping the resource section. The fix recomputes SizeOfImage from the
final section table so it always covers every section's aligned virtual extent.
The libsui change (denoland/sui#79) also adds cross-platform regression tests
for this.

Closes #36206
Closes #36238