### PR TITLE
fix(ext/node): route .node/.json through extension handlers under load hooks

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -2011,8 +2011,18 @@ Module.prototype.load = function (filename) {
             throw err;
           }
         } else {
-          // Default to CJS when format is unspecified
-          this._compile(source, this.filename, undefined, true);
+          // Format unspecified by hooks: honor the file's registered
+          // extension handler the way Node.js does, so native addons (.node)
+          // and JSON are routed correctly instead of always compiling as
+          // CommonJS JavaScript. Those handlers read/ignore the file
+          // themselves, so the source already fetched by the hook chain is
+          // discarded.
+          const extension = findLongestRegisteredExtension(this.filename);
+          if (extension === ".node" || extension === ".json") {
+            Module._extensions[extension](this, this.filename);
+          } else {
+            this._compile(source, this.filename, undefined, true);
+          }
         }
         this.loaded = true;
         return;

--- a/tests/specs/node/module_register_hooks/__test__.jsonc
+++ b/tests/specs/node/module_register_hooks/__test__.jsonc
@@ -8,6 +8,10 @@
       "args": "run -A main_load.cjs",
       "output": "main_load.out"
     },
+    "load_hook_node_addon": {
+      "args": "run -A main_load_node_addon.cjs",
+      "output": "main_load_node_addon.out"
+    },
     "chained_hooks": {
       "args": "run -A main_chained.cjs",
       "output": "main_chained.out"

--- a/tests/specs/node/module_register_hooks/main_load_node_addon.cjs
+++ b/tests/specs/node/module_register_hooks/main_load_node_addon.cjs
@@ -1,0 +1,38 @@
+// Regression test for https://github.com/denoland/deno/issues/36240
+// A registered `load` hook must not cause `require()` of a `.node` native
+// addon to be compiled as CommonJS JavaScript. The file extension must still
+// route to `Module._extensions[".node"]`, matching Node.js.
+const { mkdtempSync, writeFileSync } = require("node:fs");
+const { registerHooks } = require("node:module");
+const { tmpdir } = require("node:os");
+const { join } = require("node:path");
+
+const dir = mkdtempSync(join(tmpdir(), "deno-36240-"));
+const dummy = "\x00\x01\x02not-a-real-native-addon\x03\x04";
+const before = join(dir, "before.node");
+const after = join(dir, "after.node");
+writeFileSync(before, dummy);
+writeFileSync(after, dummy);
+
+console.log("--- before registerHooks ---");
+try {
+  require(before);
+} catch (e) {
+  console.log(e.constructor.name);
+}
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    return nextLoad(url, context);
+  },
+});
+
+console.log("--- after registerHooks ---");
+try {
+  require(after);
+} catch (e) {
+  console.log(e.constructor.name);
+}

--- a/tests/specs/node/module_register_hooks/main_load_node_addon.out
+++ b/tests/specs/node/module_register_hooks/main_load_node_addon.out
@@ -1,0 +1,4 @@
+--- before registerHooks ---
+TypeError
+--- after registerHooks ---
+TypeError


### PR DESCRIPTION
Fixes #36240

## Problem

When a `module.registerHooks({ load })` hook is registered, CJS `require()` of a `.node` native addon compiled the raw binary as JavaScript instead of dispatching to `Module._extensions['.node']`, surfacing as `SyntaxError: Invalid or unexpected token`.

The same file `require()`d without a load hook works correctly (native-addon error). The divergence made `tsdown` (via `import-without-cache`, which registers a `load` hook) break when it later `require()`s a package with a native addon.

## Cause

`Module.prototype.load` in `ext/node/polyfills/01_require.js` has two paths:

- **No load hooks**: routes by file extension via `findLongestRegisteredExtension`, so `.node` → `Module._extensions['.node']` → `op_napi_open`.
- **Load hooks active**: dispatches purely on the hook-provided `format`. When the hook leaves `format` unspecified (the default `nextLoad` never sets one), it unconditionally compiled the source as CommonJS JavaScript, ignoring the file extension.

## Fix

Mirror Node.js: when the hook format is unspecified, route the file through its registered extension handler (`.node`, `.json`) instead of always compiling as CommonJS. Those handlers read/ignore the file themselves, so the source already fetched by the hook chain is discarded.

## Test

Added `load_hook_node_addon` spec test under `tests/specs/node/module_register_hooks/`: `require()`ing a bogus `.node` file now yields the same native-addon `TypeError` both before and after `registerHooks({ load })`, rather than a `SyntaxError` afterward. Files are written to a temp dir to keep the test hermetic.
