### PR TITLE
docs: fix stale paths in ext/node and ext/napi READMEs

### DIFF
--- a/ext/napi/README.md
+++ b/ext/napi/README.md
@@ -9,7 +9,7 @@ ensuring compatibility.
 ## Adding a new function
 
 Add the symbol name to
-[`cli/napi_sym/symbol_exports.json`](../napi_sym/symbol_exports.json).
+[`cli/napi_sym/symbol_exports.json`](./sym/symbol_exports.json).
 
 ```diff
 {
@@ -27,7 +27,7 @@ Determine where to place the implementation. `napi_get_boolean` is related to JS
 values so we will place it in `js_native_api.rs`. If something is not clear,
 just create a new file module.
 
-See [`napi_sym`](../napi_sym/) for writing the implementation:
+See [`napi_sym`](./sym/) for writing the implementation:
 
 ```rust
 #[napi_sym::napi_sym]

--- a/ext/napi/sym/README.md
+++ b/ext/napi/sym/README.md
@@ -35,4 +35,4 @@ This is done using `/DEF:` on Windows, `-exported_symbol,_` on macOS and
 `--export-dynamic-symbol=` on Linux. See [`cli/build.rs`](../build.rs).
 
 On Windows, you need to generate the `.def` file by running
-[`tools/napi/generate_symbols_lists.js`](../../tools/napi/generate_symbols_lists.js).
+[`tools/napi/generate_symbols_lists.js`](../../../tools/napi/generate_symbols_lists.js).

--- a/ext/node/polyfills/README.md
+++ b/ext/node/polyfills/README.md
@@ -101,8 +101,7 @@ const leftPad = require("left-pad");
 
 ### Setting up the test runner and running tests
 
-See
-[tests/node_compat/runner/README.md](../../../tests/node_compat/runner/README.md).
+See [tests/node_compat/README.md](../../../tests/node_compat/README.md).
 
 ### Best practices
 
@@ -161,4 +160,4 @@ It's not as clean, but prevents the callback being called twice.
 
 Node compatibility can be measured by how many native Node tests pass. If you'd
 like to know what you can work on, check out the list of Node tests remaining
-[here](../../../tests/node_compat/runner/TODO.md).
+[here](../../../tests/node_compat/README.md).


### PR DESCRIPTION
Supersedes #36244 — a botched force-push on my side briefly made that PR's diff show the entire repo, and it was closed before the repaired branch propagated; GitHub won't reopen a PR after a post-close force-push. This is the same small fix, now clean: 3 files, 5 links, dprint-formatted.

Fixes 5 broken relative links (mechanical link audit; new targets verified to exist):

- `ext/node/polyfills/README.md` — links to `tests/node_compat/runner/README.md` and `runner/TODO.md`: the runner docs were folded into `tests/node_compat/README.md`, and `TODO.md` no longer exists anywhere in the repo. Both links now point at `tests/node_compat/README.md` (labels updated to match); if there's a better home for the "tests remaining" reference, happy to adjust.
- `ext/napi/README.md` — `../napi_sym/` and `../napi_sym/symbol_exports.json`: the crate moved to `ext/napi/sym/`
- `ext/napi/sym/README.md` — `../../tools/napi/generate_symbols_lists.js` resolves to `ext/tools/...`; the script lives at the repo root → `../../../tools/...`

Docs only; formatted with the repo's dprint config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)