### PR TITLE
fix(ext/net): release completed QUIC stream resources

### DIFF
--- a/ext/net/03_quic.js
+++ b/ext/net/03_quic.js
@@ -1,5 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { core, primordials } from "ext:core/mod.js";
+import { core, internals, primordials } from "ext:core/mod.js";
 import {
   op_quic_connecting_0rtt,
   op_quic_connecting_1rtt,
@@ -53,6 +53,12 @@ const {
   ObjectPrototypeIsPrototypeOf,
   PromisePrototypeThen,
   ReflectConstruct,
+  SafeSet,
+  SetPrototypeAdd,
+  SetPrototypeClear,
+  SetPrototypeDelete,
+  SetPrototypeForEach,
+  SetPrototypeGetSize,
   Symbol,
   SymbolAsyncIterator,
 } = primordials;
@@ -61,6 +67,46 @@ let getEndpointResource;
 
 function promiseFinallyWithoutUnhandled(p, f) {
   return PromisePrototypeThen(p, f, f);
+}
+
+class QuicStreamResourceTracker {
+  #closed = false;
+  #resources = new SafeSet();
+
+  constructor(closed) {
+    // A connection owns all of its active stream resources. Keeping one
+    // connection-close handler lets completed streams release that ownership.
+    promiseFinallyWithoutUnhandled(closed, () => {
+      this.#closed = true;
+      SetPrototypeForEach(this.#resources, (rid) => core.tryClose(rid));
+      SetPrototypeClear(this.#resources);
+    });
+  }
+
+  track(rid) {
+    if (this.#closed) {
+      core.tryClose(rid);
+      return () => {};
+    }
+
+    SetPrototypeAdd(this.#resources, rid);
+    let resources = this.#resources;
+    return () => {
+      if (resources !== undefined) {
+        SetPrototypeDelete(resources, rid);
+        resources = undefined;
+      }
+    };
+  }
+
+  release(rid) {
+    SetPrototypeDelete(this.#resources, rid);
+    core.tryClose(rid);
+  }
+
+  get size() {
+    return SetPrototypeGetSize(this.#resources);
+  }
 }
 
 function transportOptions({
@@ -213,6 +259,7 @@ class QuicIncoming {
 
 let webtransportConnect;
 let webtransportAccept;
+let getQuicStreamResourceCount;
 
 class QuicConn {
   #resource;
@@ -221,6 +268,7 @@ class QuicConn {
   #closed;
   #handshake;
   #endpoint;
+  #streamResources;
 
   constructor(resource, endpoint) {
     this.#resource = resource;
@@ -228,6 +276,7 @@ class QuicConn {
 
     this.#closed = op_quic_connection_closed(this.#resource);
     core.unrefOpPromise(this.#closed);
+    this.#streamResources = new QuicStreamResourceTracker(this.#closed);
   }
 
   get endpoint() {
@@ -253,10 +302,20 @@ class QuicConn {
       this.#resource,
       waitUntilAvailable ?? false,
     );
-    if (sendOrder !== null && sendOrder !== undefined) {
-      op_quic_send_stream_set_priority(txRid, sendOrder);
+    try {
+      if (sendOrder !== null && sendOrder !== undefined) {
+        op_quic_send_stream_set_priority(txRid, sendOrder);
+      }
+      return new QuicBidirectionalStream(
+        txRid,
+        rxRid,
+        this.#streamResources,
+      );
+    } catch (error) {
+      this.#streamResources.release(txRid);
+      this.#streamResources.release(rxRid);
+      throw error;
     }
-    return new QuicBidirectionalStream(txRid, rxRid, this.#closed);
   }
 
   async createUnidirectionalStream(
@@ -266,16 +325,21 @@ class QuicConn {
       this.#resource,
       waitUntilAvailable ?? false,
     );
-    if (sendOrder !== null && sendOrder !== undefined) {
-      op_quic_send_stream_set_priority(rid, sendOrder);
+    try {
+      if (sendOrder !== null && sendOrder !== undefined) {
+        op_quic_send_stream_set_priority(rid, sendOrder);
+      }
+      return writableStream(rid, this.#streamResources);
+    } catch (error) {
+      this.#streamResources.release(rid);
+      throw error;
     }
-    return writableStream(rid, this.#closed);
   }
 
   get incomingBidirectionalStreams() {
     if (this.#bidiStream === null) {
       this.#bidiStream = ReadableStream.from(
-        bidiStream(this.#resource, this.#closed),
+        bidiStream(this.#resource, this.#streamResources),
       );
     }
     return this.#bidiStream;
@@ -284,7 +348,7 @@ class QuicConn {
   get incomingUnidirectionalStreams() {
     if (this.#uniStream === null) {
       this.#uniStream = ReadableStream.from(
-        uniStream(this.#resource, this.#closed),
+        uniStream(this.#resource, this.#streamResources),
       );
     }
     return this.#uniStream;
@@ -320,6 +384,8 @@ class QuicConn {
   }
 
   static {
+    getQuicStreamResourceCount = (conn) => conn.#streamResources.size;
+
     webtransportConnect = async function webtransportConnect(conn, url) {
       const {
         0: connectTxRid,
@@ -327,14 +393,28 @@ class QuicConn {
         2: settingsTxRid,
         3: settingsRxRid,
       } = await op_webtransport_connect(conn.#resource, url);
-      const connect = new QuicBidirectionalStream(
-        connectTxRid,
-        connectRxRid,
-        conn.closed,
-      );
-      const settingsTx = writableStream(settingsTxRid, conn.closed);
-      const settingsRx = readableStream(settingsRxRid, conn.closed);
-      return { connect, settingsTx, settingsRx };
+      try {
+        const connect = new QuicBidirectionalStream(
+          connectTxRid,
+          connectRxRid,
+          conn.#streamResources,
+        );
+        const settingsTx = writableStream(
+          settingsTxRid,
+          conn.#streamResources,
+        );
+        const settingsRx = readableStream(
+          settingsRxRid,
+          conn.#streamResources,
+        );
+        return { connect, settingsTx, settingsRx };
+      } catch (error) {
+        conn.#streamResources.release(connectTxRid);
+        conn.#streamResources.release(connectRxRid);
+        conn.#streamResources.release(settingsTxRid);
+        conn.#streamResources.release(settingsRxRid);
+        throw error;
+      }
     };
 
     webtransportAccept = async function webtransportAccept(conn) {
@@ -345,14 +425,28 @@ class QuicConn {
         3: settingsTxRid,
         4: settingsRxRid,
       } = await op_webtransport_accept(conn.#resource);
-      const connect = new QuicBidirectionalStream(
-        connectTxRid,
-        connectRxRid,
-        conn.closed,
-      );
-      const settingsTx = writableStream(settingsTxRid, conn.closed);
-      const settingsRx = readableStream(settingsRxRid, conn.closed);
-      return { url, connect, settingsTx, settingsRx };
+      try {
+        const connect = new QuicBidirectionalStream(
+          connectTxRid,
+          connectRxRid,
+          conn.#streamResources,
+        );
+        const settingsTx = writableStream(
+          settingsTxRid,
+          conn.#streamResources,
+        );
+        const settingsRx = readableStream(
+          settingsRxRid,
+          conn.#streamResources,
+        );
+        return { url, connect, settingsTx, settingsRx };
+      } catch (error) {
+        conn.#streamResources.release(connectTxRid);
+        conn.#streamResources.release(connectRxRid);
+        conn.#streamResources.release(settingsTxRid);
+        conn.#streamResources.release(settingsRxRid);
+        throw error;
+      }
     };
   }
 }
@@ -386,37 +480,50 @@ class QuicReceiveStream extends ReadableStream {
   }
 }
 
-function readableStream(rid, closed) {
-  // stream can be indirectly closed by closing connection.
-  promiseFinallyWithoutUnhandled(closed, () => {
-    core.tryClose(rid);
-  });
-  return readableStreamForRid(
-    rid,
-    true,
-    (...args) => ReflectConstruct(QuicReceiveStream, args),
-  );
+function readableStream(rid, resources) {
+  const onClose = resources.track(rid);
+  try {
+    return readableStreamForRid(
+      rid,
+      true,
+      (...args) => ReflectConstruct(QuicReceiveStream, args),
+      undefined,
+      onClose,
+    );
+  } catch (error) {
+    resources.release(rid);
+    throw error;
+  }
 }
 
-function writableStream(rid, closed) {
-  // stream can be indirectly closed by closing connection.
-  promiseFinallyWithoutUnhandled(closed, () => {
-    core.tryClose(rid);
-  });
-  return writableStreamForRid(
-    rid,
-    true,
-    (...args) => ReflectConstruct(QuicSendStream, args),
-  );
+function writableStream(rid, resources) {
+  const onClose = resources.track(rid);
+  try {
+    return writableStreamForRid(
+      rid,
+      true,
+      (...args) => ReflectConstruct(QuicSendStream, args),
+      { __proto__: null, onClose },
+    );
+  } catch (error) {
+    resources.release(rid);
+    throw error;
+  }
 }
 
 class QuicBidirectionalStream {
   #readable;
   #writable;
 
-  constructor(txRid, rxRid, closed) {
-    this.#readable = readableStream(rxRid, closed);
-    this.#writable = writableStream(txRid, closed);
+  constructor(txRid, rxRid, resources) {
+    try {
+      this.#readable = readableStream(rxRid, resources);
+      this.#writable = writableStream(txRid, resources);
+    } catch (error) {
+      resources.release(txRid);
+      resources.release(rxRid);
+      throw error;
+    }
   }
 
   get readable() {
@@ -428,11 +535,11 @@ class QuicBidirectionalStream {
   }
 }
 
-async function* bidiStream(conn, closed) {
+async function* bidiStream(conn, resources) {
   try {
     while (true) {
       const r = await op_quic_connection_accept_bi(conn);
-      yield new QuicBidirectionalStream(r[0], r[1], closed);
+      yield new QuicBidirectionalStream(r[0], r[1], resources);
     }
   } catch (error) {
     if (ObjectPrototypeIsPrototypeOf(BadResourcePrototype, error)) {
@@ -442,11 +549,11 @@ async function* bidiStream(conn, closed) {
   }
 }
 
-async function* uniStream(conn, closed) {
+async function* uniStream(conn, resources) {
   try {
     while (true) {
       const uniRid = await op_quic_connection_accept_uni(conn);
-      yield readableStream(uniRid, closed);
+      yield readableStream(uniRid, resources);
     }
   } catch (error) {
     if (ObjectPrototypeIsPrototypeOf(BadResourcePrototype, error)) {
@@ -493,6 +600,8 @@ function connectQuic(options) {
     (conn) => new QuicConn(conn, endpoint),
   );
 }
+
+internals.getQuicStreamResourceCount = getQuicStreamResourceCount;
 
 export {
   connectQuic,

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -1154,8 +1154,13 @@ function resourceForReadableStream(stream, length, onError) {
 const DEFAULT_CHUNK_SIZE = 64 * 1024; // 64 KiB
 
 // A finalization registry to clean up underlying resources that are GC'ed.
-const RESOURCE_REGISTRY = new SafeFinalizationRegistry((rid) => {
-  core.tryClose(rid);
+const RESOURCE_REGISTRY = new SafeFinalizationRegistry((resource) => {
+  if (typeof resource === "number") {
+    core.tryClose(resource);
+  } else {
+    core.tryClose(resource.rid);
+    resource.onClose();
+  }
 });
 
 const _readAll = Symbol("[[readAll]]");
@@ -1186,9 +1191,18 @@ function annotateResourceStreamError(e) {
  *
  * @param {number} rid The resource ID to read from.
  * @param {boolean=} autoClose If the resource should be auto-closed when the stream closes. Defaults to true.
+ * @param {function(*)=} cfn A custom stream constructor.
+ * @param {function(*, *)=} onError A custom resource read error handler.
+ * @param {function()=} onClose Called when the resource is no longer owned by the stream.
  * @returns {ReadableStream<Uint8Array>}
  */
-function readableStreamForRid(rid, autoClose = true, cfn, onError) {
+function readableStreamForRid(
+  rid,
+  autoClose = true,
+  cfn,
+  onError,
+  onClose,
+) {
   const stream = cfn ? cfn(_brand) : new ReadableStream(_brand);
   stream[_resourceBacking] = { rid, autoClose };
 
@@ -1196,6 +1210,11 @@ function readableStreamForRid(rid, autoClose = true, cfn, onError) {
     if (!autoClose) return;
     RESOURCE_REGISTRY.unregister(stream);
     core.tryClose(rid);
+    if (onClose !== undefined) {
+      const callback = onClose;
+      onClose = undefined;
+      callback();
+    }
   };
 
   const cancelRead = () => {
@@ -1203,7 +1222,13 @@ function readableStreamForRid(rid, autoClose = true, cfn, onError) {
   };
 
   if (autoClose) {
-    RESOURCE_REGISTRY.register(stream, rid, stream);
+    RESOURCE_REGISTRY.register(
+      stream,
+      onClose === undefined
+        ? rid
+        : { __proto__: null, rid, onClose },
+      stream,
+    );
   }
 
   const underlyingSource = {
@@ -1453,20 +1478,34 @@ async function readableStreamCollectIntoUint8Array(stream) {
  *
  * @param {number} rid The resource ID to write to.
  * @param {boolean=} autoClose If the resource should be auto-closed when the stream closes. Defaults to true.
+ * @param {function(*)=} cfn A custom stream constructor.
+ * @param {{ bufferSize?: number, onClose?: function() }=} options Additional stream options.
  * @returns {ReadableStream<Uint8Array>}
  */
 function writableStreamForRid(rid, autoClose = true, cfn, options) {
   const stream = cfn ? cfn(_brand) : new WritableStream(_brand);
   stream[_resourceBacking] = { rid, autoClose };
+  let onClose = options?.onClose;
 
   const tryClose = () => {
     if (!autoClose) return;
     RESOURCE_REGISTRY.unregister(stream);
     core.tryClose(rid);
+    if (onClose !== undefined) {
+      const callback = onClose;
+      onClose = undefined;
+      callback();
+    }
   };
 
   if (autoClose) {
-    RESOURCE_REGISTRY.register(stream, rid, stream);
+    RESOURCE_REGISTRY.register(
+      stream,
+      onClose === undefined
+        ? rid
+        : { __proto__: null, rid, onClose },
+      stream,
+    );
   }
 
   const bufferSize = options?.bufferSize ?? 0;

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -1224,9 +1224,7 @@ function readableStreamForRid(
   if (autoClose) {
     RESOURCE_REGISTRY.register(
       stream,
-      onClose === undefined
-        ? rid
-        : { __proto__: null, rid, onClose },
+      onClose === undefined ? rid : { __proto__: null, rid, onClose },
       stream,
     );
   }
@@ -1501,9 +1499,7 @@ function writableStreamForRid(rid, autoClose = true, cfn, options) {
   if (autoClose) {
     RESOURCE_REGISTRY.register(
       stream,
-      onClose === undefined
-        ? rid
-        : { __proto__: null, rid, onClose },
+      onClose === undefined ? rid : { __proto__: null, rid, onClose },
       stream,
     );
   }

--- a/tests/unit/quic_test.ts
+++ b/tests/unit/quic_test.ts
@@ -12,6 +12,11 @@ interface Pair {
   endpoint: Deno.QuicEndpoint;
 }
 
+function trackedStreamResourceCount(conn: Deno.QuicConn): number {
+  // @ts-ignore Deno.internal is available to the unit test suite.
+  return Deno[Deno.internal].getQuicStreamResourceCount(conn);
+}
+
 async function pair(opt?: Deno.QuicTransportOptions): Promise<Pair> {
   const endpoint = new Deno.QuicEndpoint({ hostname: "localhost" });
   const listener = endpoint.listen({
@@ -89,6 +94,29 @@ Deno.test("unidirectional stream", async () => {
 
   endpoint.close();
   client.close();
+});
+
+Deno.test("completed streams release connection cleanup state", async () => {
+  const { server, client, endpoint } = await pair();
+
+  const bi = await server.createBidirectionalStream();
+  assertEquals(trackedStreamResourceCount(server), 2);
+  await Promise.all([bi.readable.cancel(), bi.writable.close()]);
+  assertEquals(trackedStreamResourceCount(server), 0);
+
+  const uni = await server.createUnidirectionalStream();
+  assertEquals(trackedStreamResourceCount(server), 1);
+  await uni.close();
+  assertEquals(trackedStreamResourceCount(server), 0);
+
+  await server.createBidirectionalStream();
+  assertEquals(trackedStreamResourceCount(server), 2);
+  server.close();
+  await server.closed;
+  assertEquals(trackedStreamResourceCount(server), 0);
+
+  await client.closed;
+  endpoint.close();
 });
 
 Deno.test("datagrams", async () => {


### PR DESCRIPTION
QUIC stream resources currently register individual callbacks on the connection close promise. Those callbacks remain associated with the connection even after their streams have completed.

This change gives each connection a registry of its active stream resource IDs. Resource-backed streams remove their IDs when they close, cancel, abort, error, or are finalized, while connection teardown closes any IDs that are still active. Stream setup error paths also release every resource they received.

A focused regression test checks completed bidirectional and unidirectional streams as well as connection teardown.

Validation:
- `cargo test -p unit_tests --test unit quic_test -- --nocapture`
- `tests/unit/streams_test.ts` (64 passed)
- `tools/format.js --check` on changed files