### PR TITLE
fix(ext/net): isolate startTls internal options

### DIFF
--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -201,6 +201,7 @@ async function startTls(
   } = { __proto__: null },
 ) {
   return startTlsInternal(conn, {
+    __proto__: null,
     hostname,
     caCerts,
     alpnProtocols,

--- a/tests/unit/tls_test.ts
+++ b/tests/unit/tls_test.ts
@@ -1330,6 +1330,73 @@ Deno.test(
 
 Deno.test(
   { permissions: { read: true, net: true } },
+  async function startTlsDoesNotInheritInternalOptions() {
+    let tls: ReturnType<typeof listenTls> | undefined;
+    const original = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      "rejectUnauthorized",
+    );
+
+    Object.defineProperty(Object.prototype, "rejectUnauthorized", {
+      configurable: true,
+      value: false,
+    });
+
+    try {
+      const currentTls = listenTls();
+      tls = currentTls;
+
+      const server = (async () => {
+        const conn = await currentTls.listener.accept();
+        try {
+          await assertRejects(
+            () => conn.handshake(),
+            Deno.errors.InvalidData,
+            "received fatal alert",
+          );
+        } finally {
+          conn.close();
+        }
+      })();
+
+      const client = (async () => {
+        const tcpConn = await Deno.connect({
+          hostname: currentTls.hostname,
+          port: currentTls.port,
+        });
+        const options = Object.assign(Object.create(null), {
+          hostname: currentTls.hostname,
+        });
+        const conn = await Deno.startTls(tcpConn, options);
+        try {
+          await assertRejects(
+            () => conn.handshake(),
+            Deno.errors.InvalidData,
+            "invalid peer certificate: UnknownIssuer",
+          );
+        } finally {
+          conn.close();
+        }
+      })();
+
+      await Promise.all([server, client]);
+    } finally {
+      tls?.listener.close();
+      if (original === undefined) {
+        Reflect.deleteProperty(Object.prototype, "rejectUnauthorized");
+      } else {
+        Object.defineProperty(
+          Object.prototype,
+          "rejectUnauthorized",
+          original,
+        );
+      }
+    }
+  },
+);
+
+Deno.test(
+  { permissions: { read: true, net: true } },
   async function tlsHandshakeFailure() {
     let tls: { listener: Deno.TlsListener; port: number; hostname: string };
 


### PR DESCRIPTION
## Summary

- make the option record created by Deno.startTls use a null prototype
- keep explicitly supplied internal options unchanged
- add a regression that certificate validation remains enabled when Object.prototype has a same-named property

## Motivation

Deno.startTls rebuilds its public options before forwarding them to the shared implementation. The rebuilt record was an ordinary object, so lookup of an internal-only option could observe an inherited value. Keeping that record self-contained makes the public defaults deterministic while preserving internal callers that explicitly provide the option.

## Testing

- cargo build --bin deno
- cargo test -p unit_tests --test unit -- tls_test
- deno lint --config tests/config/deno.json ext/net/02_tls.js tests/unit/tls_test.ts
- ./tools/format.js --check ext/net/02_tls.js tests/unit/tls_test.ts