### PR TITLE
fix(node_crypto): prefer SAN in X509Certificate.checkHost

### DIFF
--- a/ext/node/polyfills/internal/crypto/x509.ts
+++ b/ext/node/polyfills/internal/crypto/x509.ts
@@ -179,10 +179,8 @@ class X509Certificate {
     if (StringPrototypeIncludes(name, "\0")) {
       throw new ERR_INVALID_ARG_VALUE("name", name);
     }
-    getFlags(options);
-    if (op_node_x509_check_host(this.#handle, name)) {
-      return name;
-    }
+    const flags = getFlags(options);
+    return op_node_x509_check_host(this.#handle, name, flags) ?? undefined;
   }
 
   checkIP(ip: string, options?: unknown): string | undefined {

--- a/ext/node_crypto/x509.rs
+++ b/ext/node_crypto/x509.rs
@@ -315,20 +315,134 @@ pub fn op_node_x509_check_email(
   false
 }
 
-#[op2(fast)]
+const X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT: u32 = 0x1;
+const X509_CHECK_FLAG_NEVER_CHECK_SUBJECT: u32 = 0x2;
+const X509_CHECK_FLAG_NO_WILDCARDS: u32 = 0x4;
+const X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS: u32 = 0x8;
+const X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS: u32 = 0x10;
+
+fn eq_ascii_case_insensitive(left: &[u8], right: &[u8]) -> bool {
+  left.len() == right.len()
+    && left
+      .iter()
+      .zip(right)
+      .all(|(left, right)| left.eq_ignore_ascii_case(right))
+}
+
+fn valid_dns_wildcard(pattern: &[u8], flags: u32) -> Option<usize> {
+  let mut wildcard = None;
+  let mut label_start = true;
+  let mut label_hyphen = false;
+  let mut label_idna = false;
+  let mut dots = 0;
+
+  for (index, byte) in pattern.iter().copied().enumerate() {
+    match byte {
+      b'*' => {
+        let at_label_end =
+          index + 1 == pattern.len() || pattern[index + 1] == b'.';
+        if wildcard.is_some()
+          || label_idna
+          || dots != 0
+          || (flags & X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS != 0
+            && (!label_start || !at_label_end))
+          || (!label_start && !at_label_end)
+        {
+          return None;
+        }
+        wildcard = Some(index);
+        label_start = false;
+      }
+      b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' => {
+        if label_start
+          && pattern[index..]
+            .get(..4)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"xn--"))
+        {
+          label_idna = true;
+        }
+        label_start = false;
+        label_hyphen = false;
+      }
+      b'.' => {
+        if label_start || label_hyphen {
+          return None;
+        }
+        label_start = true;
+        label_hyphen = false;
+        label_idna = false;
+        dots += 1;
+      }
+      b'-' => {
+        if label_start {
+          return None;
+        }
+        label_hyphen = true;
+      }
+      _ => return None,
+    }
+  }
+
+  if label_start || label_hyphen || dots < 2 {
+    None
+  } else {
+    wildcard
+  }
+}
+
+fn dns_name_matches(pattern: &str, host: &str, flags: u32) -> bool {
+  let pattern = pattern.as_bytes();
+  let host = host.as_bytes();
+
+  if flags & X509_CHECK_FLAG_NO_WILDCARDS != 0 {
+    return eq_ascii_case_insensitive(pattern, host);
+  }
+
+  let Some(wildcard) = valid_dns_wildcard(pattern, flags) else {
+    return eq_ascii_case_insensitive(pattern, host);
+  };
+  let prefix = &pattern[..wildcard];
+  let suffix = &pattern[wildcard + 1..];
+  if host.len() < prefix.len() + suffix.len()
+    || !eq_ascii_case_insensitive(prefix, &host[..prefix.len()])
+    || !eq_ascii_case_insensitive(suffix, &host[host.len() - suffix.len()..])
+  {
+    return false;
+  }
+
+  let wildcard_match = &host[prefix.len()..host.len() - suffix.len()];
+  let full_label_wildcard = prefix.is_empty() && suffix.starts_with(b".");
+  if full_label_wildcard && wildcard_match.is_empty() {
+    return false;
+  }
+  if !full_label_wildcard
+    && host
+      .get(..4)
+      .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"xn--"))
+  {
+    return false;
+  }
+  if wildcard_match == b"*" {
+    return true;
+  }
+
+  let allow_multiple_labels =
+    full_label_wildcard && flags & X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS != 0;
+  wildcard_match.iter().all(|byte| {
+    byte.is_ascii_alphanumeric()
+      || *byte == b'-'
+      || (allow_multiple_labels && *byte == b'.')
+  })
+}
+
+#[op2]
+#[string]
 pub fn op_node_x509_check_host(
   #[cppgc] cert: &Certificate,
   #[string] host: &str,
-) -> bool {
+  #[smi] flags: u32,
+) -> Option<String> {
   let cert = cert.inner.get().deref();
-
-  let subject = cert.subject();
-  if subject
-    .iter_common_name()
-    .any(|e| e.as_str().unwrap_or("") == host)
-  {
-    return true;
-  }
 
   let subject_alt = cert
     .extensions()
@@ -339,17 +453,31 @@ pub fn op_node_x509_check_host(
       _ => None,
     });
 
+  let mut has_dns_subject_alt_name = false;
   if let Some(subject_alt) = subject_alt {
     for name in &subject_alt.general_names {
-      if let extensions::GeneralName::DNSName(n) = name
-        && *n == host
-      {
-        return true;
+      if let extensions::GeneralName::DNSName(name) = name {
+        has_dns_subject_alt_name = true;
+        if dns_name_matches(name, host, flags) {
+          return Some((*name).to_string());
+        }
       }
     }
   }
 
-  false
+  if (has_dns_subject_alt_name
+    && flags & X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT == 0)
+    || flags & X509_CHECK_FLAG_NEVER_CHECK_SUBJECT != 0
+  {
+    return None;
+  }
+
+  cert
+    .subject()
+    .iter_common_name()
+    .filter_map(|name| name.as_str().ok())
+    .find(|name| dns_name_matches(name, host, flags))
+    .map(str::to_string)
 }
 
 #[op2]

--- a/tests/unit_node/crypto/crypto_key_test.ts
+++ b/tests/unit_node/crypto/crypto_key_test.ts
@@ -971,6 +971,33 @@ G1IJUv6oiGF/MvWCr84REVgc1j78xomGANJIu2hN7bnD1nEMON6em8IfnDOUtynV
 -----END CERTIFICATE-----
 `;
 
+const sanCertPem = `-----BEGIN CERTIFICATE-----
+MIIBwzCCAWmgAwIBAgIUAZF3l5HHizmYaqUZRaY3fM7TaqQwCgYIKoZIzj0EAwIw
+GjEYMBYGA1UEAwwPY24uZXhhbXBsZS50ZXN0MB4XDTI2MDcyMjE5NDMyMVoXDTM2
+MDcxOTE5NDMyMVowGjEYMBYGA1UEAwwPY24uZXhhbXBsZS50ZXN0MFkwEwYHKoZI
+zj0CAQYIKoZIzj0DAQcDQgAEdHf1iA+OMuvH9EN8W6IcTbpp/9rMl5dvdyawarmu
+SwfatSh3pPwHUfN0gJasTpZ5MD4mEKxDTWcLXbxUWSGHW6OBjDCBiTAdBgNVHQ4E
+FgQU0gM5LL6wyVEVwdSIr0Oc0hlRpoIwHwYDVR0jBBgwFoAU0gM5LL6wyVEVwdSI
+r0Oc0hlRpoIwDwYDVR0TAQH/BAUwAwEB/zA2BgNVHREELzAtghBzYW4uZXhhbXBs
+ZS50ZXN0ghMqLndpbGQuZXhhbXBsZS50ZXN0hwR/AAABMAoGCCqGSM49BAMCA0gA
+MEUCIEYSYmEPKKAIG932dtmImwEydH+bW0X1IPiSRJSaApKqAiEA7zyiMsewkZ83
+n4dxDpYQwy0m16M9/Vi8VNpVplsx6jE=
+-----END CERTIFICATE-----
+`;
+
+const ipSanCertPem = `-----BEGIN CERTIFICATE-----
+MIIBoDCCAUagAwIBAgIUA/thpHNOxdv4S0TM+/ITydpASEAwCgYIKoZIzj0EAwIw
+HTEbMBkGA1UEAwwSaXAtY24uZXhhbXBsZS50ZXN0MB4XDTI2MDcyMjE5NDY1MloX
+DTM2MDcxOTE5NDY1MlowHTEbMBkGA1UEAwwSaXAtY24uZXhhbXBsZS50ZXN0MFkw
+EwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwrR+TUk4j6E62nekyxXugA2Ytz8gxzTu
+0vpJWTaodwAFvxkbuhRgipgDQYudYg8q3MMb4/5pJ2m3Y9SJp9YDhaNkMGIwHQYD
+VR0OBBYEFAxuEQbGQoAxsLMaEoOxwlTsQH6yMB8GA1UdIwQYMBaAFAxuEQbGQoAx
+sLMaEoOxwlTsQH6yMA8GA1UdEwEB/wQFMAMBAf8wDwYDVR0RBAgwBocEfwAAATAK
+BggqhkjOPQQDAgNIADBFAiAVfEdpBSek4dLwByCZ2Nlr0JnrWbG0o+aT183n2d/3
+RAIhALRPuXSqj6MVAWsu6rAX62D49NIvS1vu36MvJ18QhyPg
+-----END CERTIFICATE-----
+`;
+
 const x509KeyPem = `-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEA1FYyCvsg04Jwk9wsQoTtBN+6vVbh3a5Snii3kM1CVtsnM0nz
 c1/9M3x6Y2Psylont/c9xwialsbYhtsMYjiPHN1qljr81ZnVgA5YehH5CJYPhO1Q
@@ -1048,6 +1075,48 @@ Deno.test("X509Certificate checkIP", function () {
   const x509 = new X509Certificate(certPem);
   assertEquals(x509.checkIP("127.0.0.1"), undefined);
   assertEquals(x509.checkIP("::"), undefined);
+});
+
+Deno.test("X509Certificate checkHost uses DNS subject alternative names", function () {
+  const x509 = new X509Certificate(sanCertPem);
+
+  // A DNS SAN takes precedence over a conflicting subject common name.
+  assertEquals(x509.checkHost("cn.example.test"), undefined);
+  assertEquals(
+    x509.checkHost("cn.example.test", { subject: "always" }),
+    "cn.example.test",
+  );
+
+  assertEquals(x509.checkHost("san.example.test"), "san.example.test");
+  assertEquals(x509.checkHost("SAN.EXAMPLE.TEST"), "san.example.test");
+  assertEquals(
+    x509.checkHost("sub.wild.example.test"),
+    "*.wild.example.test",
+  );
+  assertEquals(x509.checkHost("deep.sub.wild.example.test"), undefined);
+  assertEquals(
+    x509.checkHost("deep.sub.wild.example.test", {
+      multiLabelWildcards: true,
+    }),
+    "*.wild.example.test",
+  );
+  assertEquals(
+    x509.checkHost("sub.wild.example.test", { wildcards: false }),
+    undefined,
+  );
+
+  // IP SANs are matched by checkIP(), not checkHost().
+  assertEquals(x509.checkHost("127.0.0.1"), undefined);
+  assertEquals(x509.checkIP("127.0.0.1"), "127.0.0.1");
+
+  // A non-DNS SAN does not disable subject common-name fallback.
+  const ipSan = new X509Certificate(ipSanCertPem);
+  assertEquals(ipSan.checkHost("ip-cn.example.test"), "ip-cn.example.test");
+  assertEquals(ipSan.checkIP("127.0.0.1"), "127.0.0.1");
+
+  // With no DNS SAN, checkHost() falls back to the subject common name.
+  const commonNameOnly = new X509Certificate(certPem);
+  assertEquals(commonNameOnly.checkHost("agent1"), "agent1");
 });
 
 Deno.test("X509Certificate checkIssued", function () {


### PR DESCRIPTION
## Summary

- prefer DNS subject alternative names when matching hostnames
- preserve common-name fallback when no DNS subject alternative name is present
- align case-insensitive and wildcard matching with Node and OpenSSL behavior

## Details

The compatibility implementation checked the subject common name before DNS subject alternative names and returned the caller's input rather than the certificate name that matched. This updates the host-check path to evaluate DNS subject alternative names first, apply the configured subject and wildcard policies, and return the matched certificate name. IP subject alternative names continue to be handled by `checkIP()`.

## Tests

- `./tools/format.js --check`
- `cargo clippy -p deno_node_crypto --all-targets -- -D warnings`
- `cargo test -p deno_node_crypto --lib`
- `cargo build --bin deno`
- `cargo build -p test_server`
- `cargo test -p unit_node_tests --test unit_node -- unit_node::crypto::crypto_key_test --nocapture`
