### PR TITLE
fix(core): construct registered op errors natively

### DIFF
--- a/ext/webgpu/01_webgpu.js
+++ b/ext/webgpu/01_webgpu.js
@@ -105,7 +105,10 @@ class GPUValidationError extends GPUError {
     this[_message] = message;
   }
 }
-core.registerErrorClass("GPUValidationError", GPUValidationError);
+core.registerErrorBuilder(
+  "GPUValidationError",
+  (message) => new GPUValidationError(message),
+);
 
 class GPUOutOfMemoryError extends GPUError {
   constructor(message) {
@@ -117,7 +120,10 @@ class GPUOutOfMemoryError extends GPUError {
     this[_message] = message;
   }
 }
-core.registerErrorClass("GPUOutOfMemoryError", GPUOutOfMemoryError);
+core.registerErrorBuilder(
+  "GPUOutOfMemoryError",
+  (message) => new GPUOutOfMemoryError(message),
+);
 
 class GPUInternalError extends GPUError {
   constructor() {
@@ -125,7 +131,10 @@ class GPUInternalError extends GPUError {
     this[webidl.brand] = webidl.brand;
   }
 }
-core.registerErrorClass("GPUInternalError", GPUInternalError);
+core.registerErrorBuilder(
+  "GPUInternalError",
+  () => new GPUInternalError(),
+);
 
 class GPUPipelineError extends DOMException {
   #reason;

--- a/ext/webgpu/01_webgpu.js
+++ b/ext/webgpu/01_webgpu.js
@@ -105,6 +105,9 @@ class GPUValidationError extends GPUError {
     this[_message] = message;
   }
 }
+// These errors rely on Web IDL brand and private message state established by
+// their constructors. Keep them builder-only: registered classes intentionally
+// bypass constructors during native op-error construction.
 core.registerErrorBuilder(
   "GPUValidationError",
   (message) => new GPUValidationError(message),

--- a/ext/webgpu/error.rs
+++ b/ext/webgpu/error.rs
@@ -173,6 +173,9 @@ pub enum GPUError {
   // TODO(@crowlKats): consider adding an unreachable value that uses unreachable!()
   #[class("UNREACHABLE")]
   Lost(GPUDeviceLostReason),
+  // These classes are builder-only because their JS constructors establish
+  // Web IDL brands and private state. Keep ops returning them slow-only: a fast
+  // callback cannot invoke the builder and would fall back to a plain Error.
   #[class("GPUValidationError")]
   Validation(String),
   #[class("GPUOutOfMemoryError")]

--- a/libs/core/00_infra.js
+++ b/libs/core/00_infra.js
@@ -84,11 +84,9 @@
 
   const errorMap = {};
   // Maps a registered error class name to its constructor. Unlike `errorMap`
-  // (which stores builder closures), this keeps a reference to the class itself
-  // so the Rust side can restore the exact prototype when building an exception
-  // natively (e.g. from inside a V8 fast call, where re-entering JS to call
-  // `buildCustomError` is forbidden). Null prototype so class names can't
-  // collide with `Object.prototype` members.
+  // (which stores builder closures), this lets native error construction
+  // restore the exact prototype. Null prototype and immutable entries keep
+  // lookups independent of inherited properties or later map mutations.
   const errorConstructors = { __proto__: null };
   // Builtin v8 / JS errors
   registerErrorClass("Error", Error);
@@ -132,7 +130,12 @@
 
   function registerErrorClass(className, errorClass) {
     registerErrorBuilder(className, (msg) => new errorClass(msg));
-    errorConstructors[className] = errorClass;
+    ObjectDefineProperty(errorConstructors, className, {
+      value: errorClass,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
   }
 
   function registerErrorBuilder(className, errorBuilder) {

--- a/libs/core/00_infra.js
+++ b/libs/core/00_infra.js
@@ -14,6 +14,7 @@
     ObjectAssign,
     ObjectDefineProperty,
     ObjectFreeze,
+    ObjectHasOwn,
     Promise,
     PromiseReject,
     PromiseResolve,
@@ -117,9 +118,16 @@
         const keys = [];
         for (const property of new SafeArrayIterator(additionalProperties)) {
           const key = property[0];
-          if (!(key in error)) {
+          // Match native registered-error construction: preserve existing own
+          // properties without consulting or invoking prototype accessors.
+          if (!ObjectHasOwn(error, key)) {
             keys.push(key);
-            error[key] = property[1];
+            ObjectDefineProperty(error, key, {
+              value: property[1],
+              writable: true,
+              enumerable: true,
+              configurable: true,
+            });
           }
         }
         Object.defineProperty(error, SymbolFor("errorAdditionalPropertyKeys"), {
@@ -141,8 +149,11 @@
       enumerable: true,
       configurable: false,
     });
-    // Op errors bypass registered constructors in both slow and fast dispatch.
-    // Classes that depend on constructor-created state must use a builder.
+    // Registered op errors bypass their constructors in both slow and fast
+    // dispatch. Native reconstruction requires a non-Proxy function with an
+    // own data `prototype`; other constructors remain builder-only and become
+    // plain Error instances on fast dispatch. Classes that depend on
+    // constructor-created state must use a builder and remain slow-only.
     registerErrorClassNative?.(className, errorClass);
   }
 

--- a/libs/core/00_infra.js
+++ b/libs/core/00_infra.js
@@ -42,6 +42,7 @@
 
   let isLeakTracingEnabled = false;
   let submitLeakTrace;
+  let registerErrorClassNative;
 
   // Exposed for testing promise id wraparound behavior.
   function __setNextPromiseId(promiseId) {
@@ -56,8 +57,12 @@
     return isLeakTracingEnabled;
   }
 
-  function __initializeCoreMethods(submitLeakTrace_) {
+  function __initializeCoreMethods(
+    submitLeakTrace_,
+    registerErrorClassNative_,
+  ) {
     submitLeakTrace = submitLeakTrace_;
+    registerErrorClassNative = registerErrorClassNative_;
   }
 
   const build = {
@@ -136,6 +141,9 @@
       enumerable: true,
       configurable: false,
     });
+    // Op errors bypass registered constructors in both slow and fast dispatch.
+    // Classes that depend on constructor-created state must use a builder.
+    registerErrorClassNative?.(className, errorClass);
   }
 
   function registerErrorBuilder(className, errorBuilder) {

--- a/libs/core/01_core.js
+++ b/libs/core/01_core.js
@@ -67,6 +67,7 @@
     op_op_names,
     op_print,
     op_ref_op,
+    op_register_error_class,
     op_resources,
     op_run_microtasks,
     op_serialize,
@@ -123,6 +124,7 @@
 
   __initializeCoreMethods(
     submitLeakTrace,
+    op_register_error_class,
   );
 
   function submitLeakTrace(id) {

--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -268,29 +268,84 @@ pub fn throw_js_error_class(
   scope: &mut v8::PinScope,
   error: &dyn JsErrorClass,
 ) {
-  let exception = build_js_error_class_exception(scope, error);
+  let class = error.get_class();
+  let prototype = registered_error_class_prototype(scope, &class);
+  let exception =
+    build_js_error_class_exception(scope, error, &class, prototype);
   scope.throw_exception(exception);
 }
 
-/// Builds a JS exception for `error` using only native V8 APIs, without
-/// re-entering JavaScript.
+/// Throws `error` using its registered class when native construction is
+/// available.
 ///
-/// This mirrors what the JS `Deno.core.buildCustomError` callback does
-/// (restoring the registered error class so `instanceof` holds, and attaching
-/// the additional properties), but never invokes user-reachable JS. That makes
-/// it safe to call from inside a V8 fast call, where re-entering JS is
-/// forbidden: the callback could run an attacker-controlled prototype setter
-/// that detaches an `ArrayBuffer` argument out from under the JIT, a
-/// use-after-free (GHSA-p4r3-6jgx-4cj5).
+/// Returns `false` when the class cannot be reconstructed natively, including
+/// classes that only have a custom JavaScript builder. Callers that support
+/// custom builders may then fall back to [`to_v8_error`].
+pub fn try_throw_js_error_class(
+  scope: &mut v8::PinScope,
+  error: &dyn JsErrorClass,
+) -> bool {
+  let class = error.get_class();
+  let Some(prototype) = registered_error_class_prototype(scope, &class) else {
+    return false;
+  };
+  let exception =
+    build_js_error_class_exception(scope, error, &class, Some(prototype));
+  scope.throw_exception(exception);
+  true
+}
+
+fn registered_error_class_prototype<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  class: &str,
+) -> Option<v8::Local<'s, v8::Value>> {
+  let constructors = JsRealm::exception_state_from_scope(scope)
+    .js_error_constructors
+    .borrow()
+    .clone()?;
+  let constructors = v8::Local::new(scope, constructors);
+  let class_key = v8::String::new(scope, class)?;
+  let descriptor =
+    constructors.get_own_property_descriptor(scope, class_key.into())?;
+  let descriptor =
+    TryInto::<v8::Local<v8::Object>>::try_into(descriptor).ok()?;
+  let value_key = v8::String::new(scope, "value")?;
+  if descriptor.has_own_property(scope, value_key.into()) != Some(true) {
+    return None;
+  }
+  let ctor = descriptor.get(scope, value_key.into())?;
+
+  // Proxy constructors and non-standard constructor objects retain their
+  // custom-builder behavior. For ordinary functions, inspect the own property
+  // descriptor so an unusual accessor cannot run during error construction.
+  if !ctor.is_function() || ctor.is_proxy() {
+    return None;
+  }
+  let ctor = TryInto::<v8::Local<v8::Object>>::try_into(ctor).ok()?;
+  let prototype_key = v8::String::new(scope, "prototype")?;
+  let descriptor =
+    ctor.get_own_property_descriptor(scope, prototype_key.into())?;
+  let descriptor =
+    TryInto::<v8::Local<v8::Object>>::try_into(descriptor).ok()?;
+  if descriptor.has_own_property(scope, value_key.into()) != Some(true) {
+    return None;
+  }
+  let prototype = descriptor.get(scope, value_key.into())?;
+  prototype.is_object().then_some(prototype)
+}
+
+/// Builds a JS exception for `error` using native V8 APIs.
 ///
-/// Reading data properties off the cached `errorConstructors` map and calling
-/// `SetPrototype` / `CreateDataProperty` / `DefineOwnProperty` never execute
-/// user JS, so the fast-call contract is upheld.
+/// This mirrors the observable shape produced by `buildCustomError` for a
+/// registered class: it restores the registered prototype, defines the class
+/// name and additional properties directly on the exception, and records the
+/// additional-property keys used when converting the exception back to Rust.
 fn build_js_error_class_exception<'s, 'i>(
   scope: &mut v8::PinScope<'s, 'i>,
   error: &dyn JsErrorClass,
+  class: &str,
+  prototype: Option<v8::Local<'s, v8::Value>>,
 ) -> v8::Local<'s, v8::Value> {
-  let class = error.get_class();
   let message = v8::String::new(scope, &error.get_message()).unwrap();
   let exception = v8::Exception::error(scope, message);
 
@@ -304,23 +359,8 @@ fn build_js_error_class_exception<'s, 'i>(
   // `Deno.errors.NotFound`) by re-parenting the prototype, so that
   // `err instanceof Deno.errors.NotFound` holds. We never call the class
   // constructor (that would run JS); we only borrow its `.prototype`.
-  let constructors = JsRealm::exception_state_from_scope(scope)
-    .js_error_constructors
-    .borrow()
-    .clone();
-  if let Some(constructors) = constructors {
-    let constructors = v8::Local::new(scope, constructors);
-    let class_key = v8::String::new(scope, &class).unwrap();
-    if let Some(ctor) = constructors.get(scope, class_key.into())
-      && let Ok(ctor) = TryInto::<v8::Local<v8::Object>>::try_into(ctor)
-    {
-      let prototype_key = v8::String::new(scope, "prototype").unwrap();
-      if let Some(prototype) = ctor.get(scope, prototype_key.into())
-        && prototype.is_object()
-      {
-        exception_obj.set_prototype(scope, prototype);
-      }
-    }
+  if let Some(prototype) = prototype {
+    exception_obj.set_prototype(scope, prototype);
   }
 
   // Set `name` explicitly. The registered classes assign `this.name` in their
@@ -328,11 +368,12 @@ fn build_js_error_class_exception<'s, 'i>(
   // reproduce since we never run the constructor. The registration key matches
   // that assigned name, so using the class here mirrors `new ErrorClass(...)`.
   let name_key = v8::String::new(scope, "name").unwrap();
-  let class_value = v8::String::new(scope, &class).unwrap();
-  exception_obj.create_data_property(
+  let class_value = v8::String::new(scope, class).unwrap();
+  exception_obj.define_own_property(
     scope,
     name_key.into(),
     class_value.into(),
+    v8::PropertyAttribute::NONE,
   );
 
   // Copy the additional properties (e.g. `code`) and record their keys under
@@ -341,8 +382,9 @@ fn build_js_error_class_exception<'s, 'i>(
   let mut added_keys = vec![];
   for (key, value) in error.get_additional_properties() {
     let key = v8::String::new(scope, &key).unwrap();
-    // Match `buildCustomError`: don't clobber a property the class defines.
-    if exception_obj.has(scope, key.into()) == Some(true) {
+    // Don't clobber properties already present on the new exception. Checking
+    // only the exception itself keeps inherited accessors out of construction.
+    if exception_obj.has_own_property(scope, key.into()) == Some(true) {
       continue;
     }
     let value = match value {
@@ -351,7 +393,12 @@ fn build_js_error_class_exception<'s, 'i>(
       }
       PropertyValue::Number(value) => v8::Number::new(scope, value).into(),
     };
-    exception_obj.create_data_property(scope, key.into(), value);
+    exception_obj.define_own_property(
+      scope,
+      key.into(),
+      value,
+      v8::PropertyAttribute::NONE,
+    );
     added_keys.push(v8::Local::<v8::Value>::from(key));
   }
   if !added_keys.is_empty() {

--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
 use std::fmt;
@@ -268,10 +269,21 @@ pub fn throw_js_error_class(
   scope: &mut v8::PinScope,
   error: &dyn JsErrorClass,
 ) {
+  if try_throw_js_error_class(scope, error) {
+    return;
+  }
   let class = error.get_class();
-  let prototype = registered_error_class_prototype(scope, &class);
-  let exception =
-    build_js_error_class_exception(scope, error, &class, prototype);
+  let exception = build_js_error_class_exception(scope, error, &class, None);
+  scope.throw_exception(exception);
+}
+
+/// Throws an op error through native registered-class construction when
+/// available, falling back to its JavaScript builder otherwise.
+pub fn throw_op_error(scope: &mut v8::PinScope, error: &dyn JsErrorClass) {
+  if try_throw_js_error_class(scope, error) {
+    return;
+  }
+  let exception = to_v8_error(scope, error);
   scope.throw_exception(exception);
 }
 
@@ -295,51 +307,118 @@ pub fn try_throw_js_error_class(
   true
 }
 
+pub(crate) fn register_error_class<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  class: &str,
+  constructor: v8::Local<'s, v8::Value>,
+) {
+  let Some(prototype) = error_class_prototype(scope, constructor) else {
+    return;
+  };
+  let state = JsRealm::exception_state_from_scope(scope);
+  let mut prototypes = state.registered_error_class_prototypes.borrow_mut();
+  if !prototypes.contains_key(class) {
+    prototypes.insert(class.to_owned(), v8::Global::new(scope, prototype));
+  }
+}
+
+/// Rebuild the native prototype cache after loading a snapshot. Registrations
+/// performed later notify Rust directly through `op_register_error_class`.
+pub(crate) fn snapshot_registered_error_classes<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  constructors: v8::Local<'s, v8::Object>,
+) {
+  let Some(class_names) = constructors.get_own_property_names(
+    scope,
+    v8::GetPropertyNamesArgsBuilder::new()
+      .mode(v8::KeyCollectionMode::OwnOnly)
+      .property_filter(v8::PropertyFilter::SKIP_SYMBOLS)
+      .key_conversion(v8::KeyConversionMode::ConvertToString)
+      .build(),
+  ) else {
+    return;
+  };
+
+  let mut prototypes = HashMap::with_capacity(class_names.length() as usize);
+  for index in 0..class_names.length() {
+    let Some(class_key) = class_names.get_index(scope, index) else {
+      continue;
+    };
+    let Ok(class_key) = v8::Local::<v8::String>::try_from(class_key) else {
+      continue;
+    };
+    let Some(constructor) =
+      own_data_property(scope, constructors, class_key.into())
+    else {
+      continue;
+    };
+    let Some(prototype) = error_class_prototype(scope, constructor) else {
+      continue;
+    };
+    prototypes.insert(
+      class_key.to_rust_string_lossy(scope),
+      v8::Global::new(scope, prototype),
+    );
+  }
+
+  *JsRealm::exception_state_from_scope(scope)
+    .registered_error_class_prototypes
+    .borrow_mut() = prototypes;
+}
+
 fn registered_error_class_prototype<'s, 'i>(
   scope: &mut v8::PinScope<'s, 'i>,
   class: &str,
 ) -> Option<v8::Local<'s, v8::Value>> {
-  let constructors = JsRealm::exception_state_from_scope(scope)
-    .js_error_constructors
+  let prototype = JsRealm::exception_state_from_scope(scope)
+    .registered_error_class_prototypes
     .borrow()
-    .clone()?;
-  let constructors = v8::Local::new(scope, constructors);
-  let class_key = v8::String::new(scope, class)?;
-  let descriptor =
-    constructors.get_own_property_descriptor(scope, class_key.into())?;
+    .get(class)
+    .cloned()?;
+  Some(v8::Local::new(scope, prototype))
+}
+
+fn error_class_prototype<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  constructor: v8::Local<'s, v8::Value>,
+) -> Option<v8::Local<'s, v8::Value>> {
+  // Proxy constructors and non-standard constructor objects retain their
+  // custom-builder behavior. For ordinary functions, inspect the own property
+  // descriptor once at registration so later mutation cannot affect throws.
+  if !constructor.is_function() || constructor.is_proxy() {
+    return None;
+  }
+  let constructor =
+    TryInto::<v8::Local<v8::Object>>::try_into(constructor).ok()?;
+  let prototype_key = v8::String::new(scope, "prototype")?;
+  let prototype = own_data_property(scope, constructor, prototype_key.into())?;
+  prototype.is_object().then_some(prototype)
+}
+
+fn own_data_property<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  object: v8::Local<'s, v8::Object>,
+  key: v8::Local<'s, v8::Name>,
+) -> Option<v8::Local<'s, v8::Value>> {
+  let descriptor = object.get_own_property_descriptor(scope, key)?;
   let descriptor =
     TryInto::<v8::Local<v8::Object>>::try_into(descriptor).ok()?;
+  // A data descriptor has its own `value`; an accessor descriptor does not.
   let value_key = v8::String::new(scope, "value")?;
   if descriptor.has_own_property(scope, value_key.into()) != Some(true) {
     return None;
   }
-  let ctor = descriptor.get(scope, value_key.into())?;
-
-  // Proxy constructors and non-standard constructor objects retain their
-  // custom-builder behavior. For ordinary functions, inspect the own property
-  // descriptor so an unusual accessor cannot run during error construction.
-  if !ctor.is_function() || ctor.is_proxy() {
-    return None;
-  }
-  let ctor = TryInto::<v8::Local<v8::Object>>::try_into(ctor).ok()?;
-  let prototype_key = v8::String::new(scope, "prototype")?;
-  let descriptor =
-    ctor.get_own_property_descriptor(scope, prototype_key.into())?;
-  let descriptor =
-    TryInto::<v8::Local<v8::Object>>::try_into(descriptor).ok()?;
-  if descriptor.has_own_property(scope, value_key.into()) != Some(true) {
-    return None;
-  }
-  let prototype = descriptor.get(scope, value_key.into())?;
-  prototype.is_object().then_some(prototype)
+  descriptor.get(scope, value_key.into())
 }
 
 /// Builds a JS exception for `error` using native V8 APIs.
 ///
-/// This mirrors the observable shape produced by `buildCustomError` for a
-/// registered class: it restores the registered prototype, defines the class
-/// name and additional properties directly on the exception, and records the
+/// This restores the registered prototype, defines the class name and
+/// additional properties directly on the exception, and records the
 /// additional-property keys used when converting the exception back to Rust.
+/// Unlike `buildCustomError`, native construction intentionally defines an own
+/// data property even when the prototype has a property with the same name.
+/// This avoids invoking inherited accessors while an op callback is active.
 fn build_js_error_class_exception<'s, 'i>(
   scope: &mut v8::PinScope<'s, 'i>,
   error: &dyn JsErrorClass,

--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -269,7 +269,7 @@ pub fn throw_js_error_class(
   scope: &mut v8::PinScope,
   error: &dyn JsErrorClass,
 ) {
-  if try_throw_js_error_class(scope, error) {
+  if try_throw_registered_error_class(scope, error) {
     return;
   }
   let class = error.get_class();
@@ -280,7 +280,7 @@ pub fn throw_js_error_class(
 /// Throws an op error through native registered-class construction when
 /// available, falling back to its JavaScript builder otherwise.
 pub fn throw_op_error(scope: &mut v8::PinScope, error: &dyn JsErrorClass) {
-  if try_throw_js_error_class(scope, error) {
+  if try_throw_registered_error_class(scope, error) {
     return;
   }
   let exception = to_v8_error(scope, error);
@@ -293,7 +293,7 @@ pub fn throw_op_error(scope: &mut v8::PinScope, error: &dyn JsErrorClass) {
 /// Returns `false` when the class cannot be reconstructed natively, including
 /// classes that only have a custom JavaScript builder. Callers that support
 /// custom builders may then fall back to [`to_v8_error`].
-pub fn try_throw_js_error_class(
+fn try_throw_registered_error_class(
   scope: &mut v8::PinScope,
   error: &dyn JsErrorClass,
 ) -> bool {
@@ -317,14 +317,17 @@ pub(crate) fn register_error_class<'s, 'i>(
   };
   let state = JsRealm::exception_state_from_scope(scope);
   let mut prototypes = state.registered_error_class_prototypes.borrow_mut();
+  // The JS registry rejects duplicate class names, so the first successfully
+  // captured prototype is also the only valid registration for this realm.
   if !prototypes.contains_key(class) {
     prototypes.insert(class.to_owned(), v8::Global::new(scope, prototype));
   }
 }
 
-/// Rebuild the native prototype cache after loading a snapshot. Registrations
-/// performed later notify Rust directly through `op_register_error_class`.
-pub(crate) fn snapshot_registered_error_classes<'s, 'i>(
+/// Capture the native prototype cache after loading bootstrap code or a
+/// snapshot. Registrations performed later notify Rust directly through
+/// `op_register_error_class`.
+pub(crate) fn capture_registered_error_classes<'s, 'i>(
   scope: &mut v8::PinScope<'s, 'i>,
   constructors: v8::Local<'s, v8::Object>,
 ) {

--- a/libs/core/ops_builtin.rs
+++ b/libs/core/ops_builtin.rs
@@ -104,6 +104,7 @@ builtin_ops! {
   ops_builtin_types::op_is_weak_map,
   ops_builtin_types::op_is_weak_set,
   ops_builtin_v8::op_add_main_module_handler,
+  ops_builtin_v8::op_register_error_class,
   ops_builtin_v8::op_set_handled_promise_rejection_handler,
   ops_builtin_v8::op_timer_schedule,
   ops_builtin_v8::op_timer_track,

--- a/libs/core/ops_builtin_v8.rs
+++ b/libs/core/ops_builtin_v8.rs
@@ -42,6 +42,15 @@ pub fn op_add_main_module_handler(
 }
 
 #[op2(fast)]
+pub fn op_register_error_class<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  #[string] class_name: &str,
+  constructor: v8::Local<'s, v8::Value>,
+) {
+  error::register_error_class(scope, class_name, constructor);
+}
+
+#[op2(fast)]
 pub fn op_set_handled_promise_rejection_handler(
   scope: &mut v8::PinScope,
   f: Option<v8::Local<v8::Function>>,

--- a/libs/core/runtime/exception_state.rs
+++ b/libs/core/runtime/exception_state.rs
@@ -27,8 +27,8 @@ pub(crate) struct ExceptionState {
     RefCell<Option<v8::Global<v8::Function>>>,
   /// Map of registered error class name to its constructor (the JS
   /// `Deno.core.errorConstructors` object). Used to natively rebuild an
-  /// exception with the correct prototype without re-entering JS, e.g. from a
-  /// V8 fast call. See [`crate::error::throw_js_error_class`].
+  /// exception with the correct prototype across op dispatch paths. See
+  /// [`crate::error::throw_js_error_class`].
   pub(crate) js_error_constructors: RefCell<Option<v8::Global<v8::Object>>>,
   pub(crate) js_handled_promise_rejection_cb:
     RefCell<Option<v8::Global<v8::Function>>>,

--- a/libs/core/runtime/exception_state.rs
+++ b/libs/core/runtime/exception_state.rs
@@ -2,6 +2,7 @@
 
 use std::cell::Cell;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 
 use crate::error::JsError;
@@ -25,11 +26,11 @@ pub(crate) struct ExceptionState {
     RefCell<VecDeque<(v8::Global<v8::Promise>, v8::Global<v8::Value>)>>,
   pub(crate) js_build_custom_error_cb:
     RefCell<Option<v8::Global<v8::Function>>>,
-  /// Map of registered error class name to its constructor (the JS
-  /// `Deno.core.errorConstructors` object). Used to natively rebuild an
-  /// exception with the correct prototype across op dispatch paths. See
-  /// [`crate::error::throw_js_error_class`].
-  pub(crate) js_error_constructors: RefCell<Option<v8::Global<v8::Object>>>,
+  /// Prototypes captured when error classes are registered. Looking them up
+  /// here keeps op-error construction native and independent of later
+  /// constructor mutations.
+  pub(crate) registered_error_class_prototypes:
+    RefCell<HashMap<String, v8::Global<v8::Value>>>,
   pub(crate) js_handled_promise_rejection_cb:
     RefCell<Option<v8::Global<v8::Function>>>,
   pub(crate) js_format_exception_cb: RefCell<Option<v8::Global<v8::Function>>>,
@@ -44,7 +45,7 @@ impl ExceptionState {
   pub(crate) fn prepare_to_destroy(&self) {
     // TODO(mmastrac): we can probably move this to Drop eventually
     self.js_build_custom_error_cb.borrow_mut().take();
-    self.js_error_constructors.borrow_mut().take();
+    self.registered_error_class_prototypes.borrow_mut().clear();
     self.js_handled_promise_rejection_cb.borrow_mut().take();
     self.js_format_exception_cb.borrow_mut().take();
     self.pending_promise_rejections.borrow_mut().clear();

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -1741,10 +1741,10 @@ impl JsRuntime {
         ERROR_CONSTRUCTORS,
         "Deno.core.errorConstructors",
       );
-      crate::error::snapshot_registered_error_classes(
-        scope,
-        error_constructors,
-      );
+      // The built-in Error classes register before `op_register_error_class`
+      // is installed, so every realm needs this initial bulk capture whether
+      // its bootstrap code was loaded from source or from a snapshot.
+      crate::error::capture_registered_error_classes(scope, error_constructors);
       let run_immediate_callbacks_cb: v8::Local<v8::Function> = bindings::get(
         scope,
         core_obj,

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -1691,7 +1691,6 @@ impl JsRuntime {
       drain_next_tick_and_macrotasks_cb,
       handle_rejections_cb,
       build_custom_error_cb,
-      error_constructors,
       run_immediate_callbacks_cb,
       wasm_instance_fn,
       wasm_instances_map,
@@ -1741,6 +1740,10 @@ impl JsRuntime {
         core_obj,
         ERROR_CONSTRUCTORS,
         "Deno.core.errorConstructors",
+      );
+      crate::error::snapshot_registered_error_classes(
+        scope,
+        error_constructors,
       );
       let run_immediate_callbacks_cb: v8::Local<v8::Function> = bindings::get(
         scope,
@@ -1883,7 +1886,6 @@ impl JsRuntime {
         v8::Global::new(scope, drain_next_tick_and_macrotasks_cb),
         v8::Global::new(scope, handle_rejections_cb),
         v8::Global::new(scope, build_custom_error_cb),
-        v8::Global::new(scope, error_constructors),
         v8::Global::new(scope, run_immediate_callbacks_cb),
         wasm_instance_fn.map(|f| v8::Global::new(scope, f)),
         wasm_instances_map.map(|m| v8::Global::new(scope, m)),
@@ -1913,11 +1915,6 @@ impl JsRuntime {
       .js_build_custom_error_cb
       .borrow_mut()
       .replace(build_custom_error_cb);
-    state_rc
-      .exception_state
-      .js_error_constructors
-      .borrow_mut()
-      .replace(error_constructors);
     state_rc
       .run_immediate_callbacks_cb
       .borrow_mut()

--- a/libs/core/runtime/tests/error.rs
+++ b/libs/core/runtime/tests/error.rs
@@ -5,6 +5,7 @@ use std::task::Poll;
 
 use deno_error::JsErrorBox;
 
+use crate::JsBuffer;
 use crate::JsRuntime;
 use crate::RuntimeOptions;
 use crate::op2;
@@ -16,7 +17,14 @@ async fn test_error_builder() {
     Err(JsErrorBox::new("DOMExceptionOperationError", "abc"))
   }
 
-  deno_core::extension!(test_ext, ops = [op_err]);
+  #[op2]
+  fn op_registered_err(
+    #[buffer(detach)] _buffer: JsBuffer,
+  ) -> Result<(), JsErrorBox> {
+    Err(JsErrorBox::new("RegisteredError", "registered message"))
+  }
+
+  deno_core::extension!(test_ext, ops = [op_err, op_registered_err]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init()],
     ..Default::default()
@@ -46,13 +54,11 @@ fn syntax_error() {
   assert_eq!(frame.column_number, Some(12));
 }
 
-// `throw_js_error_class` is what the op2 fast-call error path uses. Unlike the
-// slow path it cannot re-enter JS to call `buildCustomError`, so it rebuilds
-// the exception natively. This verifies that the native rebuild still restores
-// the registered error class (`instanceof`), name, message, the `code`
-// additional property, and the round-trip key symbol.
+// Native construction is shared by op dispatch paths for registered classes.
+// Verify that it restores the class and defines the expected own properties
+// without consulting inherited accessors.
 #[test]
-fn fast_call_error_preserves_class() {
+fn native_registered_error_preserves_class() {
   use std::borrow::Cow;
 
   use deno_error::JsErrorClass;
@@ -102,6 +108,20 @@ fn fast_call_error_preserves_class() {
         }
       };
       Deno.core.registerErrorClass("MyError", globalThis.MyError);
+      globalThis.nameSetterCalls = 0;
+      globalThis.codeSetterCalls = 0;
+      Object.defineProperty(globalThis.MyError.prototype, "name", {
+        configurable: true,
+        set() {
+          globalThis.nameSetterCalls++;
+        },
+      });
+      Object.defineProperty(globalThis.MyError.prototype, "code", {
+        configurable: true,
+        set() {
+          globalThis.codeSetterCalls++;
+        },
+      });
       "#,
     )
     .unwrap();
@@ -135,11 +155,23 @@ fn fast_call_error_preserves_class() {
         if (!(e instanceof globalThis.MyError)) {
           throw new Error("expected instanceof MyError, got " + e.name);
         }
+        if (globalThis.nameSetterCalls !== 0) {
+          throw new Error("name setter ran during native error construction");
+        }
+        if (globalThis.codeSetterCalls !== 0) {
+          throw new Error("code setter ran during native error construction");
+        }
+        if (!Object.hasOwn(e, "name")) {
+          throw new Error("expected own name property");
+        }
         if (e.name !== "MyError") {
           throw new Error("expected name 'MyError', got " + e.name);
         }
         if (e.message !== "custom message") {
           throw new Error("expected message 'custom message', got " + e.message);
+        }
+        if (!Object.hasOwn(e, "code")) {
+          throw new Error("expected own code property");
         }
         if (e.code !== "E_CUSTOM") {
           throw new Error("expected code 'E_CUSTOM', got " + e.code);

--- a/libs/core/runtime/tests/error.rs
+++ b/libs/core/runtime/tests/error.rs
@@ -5,7 +5,6 @@ use std::task::Poll;
 
 use deno_error::JsErrorBox;
 
-use crate::JsBuffer;
 use crate::JsRuntime;
 use crate::RuntimeOptions;
 use crate::op2;
@@ -17,11 +16,13 @@ async fn test_error_builder() {
     Err(JsErrorBox::new("DOMExceptionOperationError", "abc"))
   }
 
-  #[op2]
-  fn op_registered_err(
-    #[buffer(detach)] _buffer: JsBuffer,
-  ) -> Result<(), JsErrorBox> {
-    Err(JsErrorBox::new("RegisteredError", "registered message"))
+  #[op2(fast)]
+  fn op_registered_err(#[buffer] buffer: &[u8]) -> Result<(), JsErrorBox> {
+    if buffer.first() == Some(&1) {
+      Err(JsErrorBox::new("RegisteredError", "registered message"))
+    } else {
+      Ok(())
+    }
   }
 
   deno_core::extension!(test_ext, ops = [op_err, op_registered_err]);

--- a/libs/core/runtime/tests/error_builder_test.js
+++ b/libs/core/runtime/tests/error_builder_test.js
@@ -2,10 +2,20 @@
 const { core } = Deno;
 const { ops } = core;
 
+const domExceptionBrand = Symbol("DOMException brand");
+const domExceptionMessage = Symbol("DOMException message");
 class DOMException {
   constructor(message, code) {
-    this.msg = message;
+    this[domExceptionBrand] = true;
+    this[domExceptionMessage] = message;
     this.code = code;
+  }
+
+  get msg() {
+    if (this[domExceptionBrand] !== true) {
+      throw new TypeError("Illegal invocation");
+    }
+    return this[domExceptionMessage];
   }
 }
 
@@ -16,17 +26,92 @@ core.registerErrorBuilder(
   },
 );
 
+let registeredConstructorCalls = 0;
+let registeredNameSetterCalls = 0;
+class RegisteredError extends Error {
+  constructor(message) {
+    super(message);
+    registeredConstructorCalls++;
+  }
+}
+core.registerErrorClass("RegisteredError", RegisteredError);
+const registeredDescriptor = Object.getOwnPropertyDescriptor(
+  core.errorConstructors,
+  "RegisteredError",
+);
+if (registeredDescriptor.writable || registeredDescriptor.configurable) {
+  throw new Error("registered constructor entry is mutable");
+}
+let inheritedConstructorLookupCalls = 0;
+Object.setPrototypeOf(core.errorConstructors, {
+  get DOMExceptionOperationError() {
+    inheritedConstructorLookupCalls++;
+    return RegisteredError;
+  },
+});
+let ownConstructorLookupCalls = 0;
+Object.defineProperty(
+  core.errorConstructors,
+  "DOMExceptionOperationError",
+  {
+    configurable: true,
+    get() {
+      ownConstructorLookupCalls++;
+      return RegisteredError;
+    },
+  },
+);
+Object.defineProperty(RegisteredError.prototype, "name", {
+  configurable: true,
+  set() {
+    registeredNameSetterCalls++;
+  },
+});
+
+function assertBuilderOnlyError() {
+  try {
+    ops.op_err();
+    throw new Error("op_err didn't throw!");
+  } catch (err) {
+    if (!(err instanceof DOMException)) {
+      throw new Error("err not DOMException");
+    }
+    if (err.msg !== "abc") {
+      throw new Error("err.message is incorrect");
+    }
+    if (err.code !== "OperationError") {
+      throw new Error("err.code is incorrect");
+    }
+  }
+}
+
+assertBuilderOnlyError();
+if (ownConstructorLookupCalls !== 0) {
+  throw new Error("own constructor accessor was consulted");
+}
+delete core.errorConstructors.DOMExceptionOperationError;
+assertBuilderOnlyError();
+if (inheritedConstructorLookupCalls !== 0) {
+  throw new Error("inherited constructor lookup was consulted");
+}
+
 try {
-  ops.op_err();
-  throw new Error("op_err didn't throw!");
+  ops.op_registered_err(new Uint8Array());
+  throw new Error("op_registered_err didn't throw!");
 } catch (err) {
-  if (!(err instanceof DOMException)) {
-    throw new Error("err not DOMException");
+  if (!(err instanceof RegisteredError)) {
+    throw new Error("err not RegisteredError");
   }
-  if (err.msg !== "abc") {
+  if (registeredConstructorCalls !== 0) {
+    throw new Error("registered constructor was called");
+  }
+  if (registeredNameSetterCalls !== 0) {
+    throw new Error("registered name setter was called");
+  }
+  if (!Object.hasOwn(err, "name") || err.name !== "RegisteredError") {
+    throw new Error("err.name is incorrect");
+  }
+  if (err.message !== "registered message") {
     throw new Error("err.message is incorrect");
-  }
-  if (err.code !== "OperationError") {
-    throw new Error("err.code is incorrect");
   }
 }

--- a/libs/core/runtime/tests/error_builder_test.js
+++ b/libs/core/runtime/tests/error_builder_test.js
@@ -28,12 +28,14 @@ core.registerErrorBuilder(
 
 let registeredConstructorCalls = 0;
 let registeredNameSetterCalls = 0;
-class RegisteredError extends Error {
-  constructor(message) {
-    super(message);
-    registeredConstructorCalls++;
-  }
+function RegisteredError(message) {
+  registeredConstructorCalls++;
+  const error = new Error(message);
+  Object.setPrototypeOf(error, RegisteredError.prototype);
+  return error;
 }
+RegisteredError.prototype = Object.create(Error.prototype);
+const registeredPrototype = RegisteredError.prototype;
 core.registerErrorClass("RegisteredError", RegisteredError);
 const registeredDescriptor = Object.getOwnPropertyDescriptor(
   core.errorConstructors,
@@ -95,23 +97,52 @@ if (inheritedConstructorLookupCalls !== 0) {
   throw new Error("inherited constructor lookup was consulted");
 }
 
+function callRegisteredError(buffer) {
+  return ops.op_registered_err(buffer);
+}
+
+const fastBuffer = new Uint8Array(1);
+// Keep one call site hot enough for V8 to dispatch through the generated fast
+// callback, then make that same callback return an error.
+for (let i = 0; i < 6000; i++) {
+  callRegisteredError(fastBuffer);
+}
+fastBuffer[0] = 1;
+let err;
 try {
-  ops.op_registered_err(new Uint8Array());
+  callRegisteredError(fastBuffer);
   throw new Error("op_registered_err didn't throw!");
-} catch (err) {
-  if (!(err instanceof RegisteredError)) {
-    throw new Error("err not RegisteredError");
-  }
-  if (registeredConstructorCalls !== 0) {
-    throw new Error("registered constructor was called");
-  }
-  if (registeredNameSetterCalls !== 0) {
-    throw new Error("registered name setter was called");
-  }
-  if (!Object.hasOwn(err, "name") || err.name !== "RegisteredError") {
-    throw new Error("err.name is incorrect");
-  }
-  if (err.message !== "registered message") {
-    throw new Error("err.message is incorrect");
-  }
+} catch (error) {
+  err = error;
+}
+if (!(err instanceof RegisteredError)) {
+  throw new Error("err not RegisteredError");
+}
+if (registeredConstructorCalls !== 0) {
+  throw new Error("registered constructor was called");
+}
+if (registeredNameSetterCalls !== 0) {
+  throw new Error("registered name setter was called");
+}
+if (!Object.hasOwn(err, "name") || err.name !== "RegisteredError") {
+  throw new Error("err.name is incorrect");
+}
+if (err.message !== "registered message") {
+  throw new Error("err.message is incorrect");
+}
+if (fastBuffer.byteLength !== 1) {
+  throw new Error("fast op buffer was detached");
+}
+
+// Replacing a writable function prototype after registration must not change
+// the prototype captured by native error construction.
+RegisteredError.prototype = Object.create(Error.prototype);
+try {
+  callRegisteredError(fastBuffer);
+  throw new Error("op_registered_err didn't throw!");
+} catch (error) {
+  err = error;
+}
+if (Object.getPrototypeOf(err) !== registeredPrototype) {
+  throw new Error("registered prototype was not snapshotted");
 }

--- a/libs/core/runtime/tests/error_builder_test.js
+++ b/libs/core/runtime/tests/error_builder_test.js
@@ -26,6 +26,34 @@ core.registerErrorBuilder(
   },
 );
 
+let builderCodeGetterCalls = 0;
+class BuilderOnlyError extends Error {}
+Object.defineProperty(BuilderOnlyError.prototype, "code", {
+  configurable: true,
+  get() {
+    builderCodeGetterCalls++;
+    return "prototype code";
+  },
+});
+core.registerErrorBuilder(
+  "BuilderOnlyError",
+  (message) => new BuilderOnlyError(message),
+);
+const builderOnlyError = core.buildCustomError(
+  "BuilderOnlyError",
+  "builder message",
+  [["code", "E_BUILDER"]],
+);
+if (builderCodeGetterCalls !== 0) {
+  throw new Error("builder code getter was called");
+}
+if (!Object.hasOwn(builderOnlyError, "code")) {
+  throw new Error("builder code is not an own property");
+}
+if (builderOnlyError.code !== "E_BUILDER") {
+  throw new Error("builder code is incorrect");
+}
+
 let registeredConstructorCalls = 0;
 let registeredNameSetterCalls = 0;
 function RegisteredError(message) {
@@ -101,34 +129,55 @@ function callRegisteredError(buffer) {
   return ops.op_registered_err(buffer);
 }
 
+function getRegisteredError(buffer) {
+  try {
+    callRegisteredError(buffer);
+  } catch (error) {
+    return error;
+  }
+  throw new Error("op_registered_err didn't throw!");
+}
+
+function assertRegisteredErrorShape(error) {
+  if (!(error instanceof RegisteredError)) {
+    throw new Error("err not RegisteredError");
+  }
+  if (!Object.hasOwn(error, "name") || error.name !== "RegisteredError") {
+    throw new Error("err.name is incorrect");
+  }
+  if (error.message !== "registered message") {
+    throw new Error("err.message is incorrect");
+  }
+}
+
 const fastBuffer = new Uint8Array(1);
+// The first call is unoptimized and exercises slow dispatch. Registered
+// classes must skip their constructors here too.
+fastBuffer[0] = 1;
+let err = getRegisteredError(fastBuffer);
+assertRegisteredErrorShape(err);
+if (registeredConstructorCalls !== 0) {
+  throw new Error("slow path called registered constructor");
+}
+if (registeredNameSetterCalls !== 0) {
+  throw new Error("slow path called registered name setter");
+}
+
 // Keep one call site hot enough for V8 to dispatch through the generated fast
-// callback, then make that same callback return an error.
+// callback, then make that same callback return an error. Tier-up is
+// best-effort because this harness does not enable V8 native syntax.
+fastBuffer[0] = 0;
 for (let i = 0; i < 6000; i++) {
   callRegisteredError(fastBuffer);
 }
 fastBuffer[0] = 1;
-let err;
-try {
-  callRegisteredError(fastBuffer);
-  throw new Error("op_registered_err didn't throw!");
-} catch (error) {
-  err = error;
-}
-if (!(err instanceof RegisteredError)) {
-  throw new Error("err not RegisteredError");
-}
+err = getRegisteredError(fastBuffer);
+assertRegisteredErrorShape(err);
 if (registeredConstructorCalls !== 0) {
-  throw new Error("registered constructor was called");
+  throw new Error("fast path called registered constructor");
 }
 if (registeredNameSetterCalls !== 0) {
-  throw new Error("registered name setter was called");
-}
-if (!Object.hasOwn(err, "name") || err.name !== "RegisteredError") {
-  throw new Error("err.name is incorrect");
-}
-if (err.message !== "registered message") {
-  throw new Error("err.message is incorrect");
+  throw new Error("fast path called registered name setter");
 }
 if (fastBuffer.byteLength !== 1) {
   throw new Error("fast op buffer was detached");

--- a/libs/ops/op2/dispatch_fast.rs
+++ b/libs/ops/op2/dispatch_fast.rs
@@ -395,15 +395,9 @@ pub(crate) fn generate_fast_result_early_exit(
       Err(err) => {
         let scope = ::std::pin::pin!(#create_scope);
         let mut scope = scope.init();
-        // Build and throw the exception using only native V8 APIs. Calling
-        // `to_v8_error` here would synchronously invoke the JS
-        // `Deno.core.buildCustomError` callback, which can execute
-        // attacker-controlled JS (e.g. a setter on an error prototype's
-        // `name`) *inside* the fast call. That JS can detach an `ArrayBuffer`
-        // argument, leaving the JIT to write through a now-stale backing-store
-        // pointer once the fast call returns (use-after-free,
-        // GHSA-p4r3-6jgx-4cj5). The V8 fast-call contract forbids re-entering
-        // JS, so the error must be constructed without it.
+        // Keep fast-call error construction on the native registered-class
+        // path. This preserves the expected error shape without invoking a
+        // class constructor or custom builder from the callback.
         deno_core::error::throw_js_error_class(&mut scope, &err);
         // SAFETY: All fast return types have zero as a valid value
         return unsafe { std::mem::zeroed() };

--- a/libs/ops/op2/dispatch_fast.rs
+++ b/libs/ops/op2/dispatch_fast.rs
@@ -397,7 +397,8 @@ pub(crate) fn generate_fast_result_early_exit(
         let mut scope = scope.init();
         // Keep fast-call error construction on the native registered-class
         // path. This preserves the expected error shape without invoking a
-        // class constructor or custom builder from the callback.
+        // class constructor or custom builder from the callback. Re-entering
+        // JS here can invalidate fast-call arguments (GHSA-p4r3-6jgx-4cj5).
         deno_core::error::throw_js_error_class(&mut scope, &err);
         // SAFETY: All fast return types have zero as a valid value
         return unsafe { std::mem::zeroed() };

--- a/libs/ops/op2/dispatch_slow.rs
+++ b/libs/ops/op2/dispatch_slow.rs
@@ -1258,27 +1258,15 @@ pub(crate) fn throw_exception(
     with_scope(generator_state)
   };
 
-  let maybe_opctx = if generator_state.needs_opctx {
-    quote!()
-  } else {
-    with_opctx(generator_state)
-  };
-
-  let maybe_args = if generator_state.needs_args {
-    quote!()
-  } else {
-    with_fn_args(generator_state)
-  };
-
   gs_quote!(generator_state(scope) => {
     #maybe_scope
-    #maybe_args
-    #maybe_opctx
-    let exception = deno_core::error::to_v8_error(
-      &mut #scope,
-      &err,
-    );
-    #scope.throw_exception(exception);
+    if !deno_core::error::try_throw_js_error_class(&mut #scope, &err) {
+      let exception = deno_core::error::to_v8_error(
+        &mut #scope,
+        &err,
+      );
+      #scope.throw_exception(exception);
+    }
     return 1;
   })
 }

--- a/libs/ops/op2/dispatch_slow.rs
+++ b/libs/ops/op2/dispatch_slow.rs
@@ -1260,13 +1260,7 @@ pub(crate) fn throw_exception(
 
   gs_quote!(generator_state(scope) => {
     #maybe_scope
-    if !deno_core::error::try_throw_js_error_class(&mut #scope, &err) {
-      let exception = deno_core::error::to_v8_error(
-        &mut #scope,
-        &err,
-      );
-      #scope.throw_exception(exception);
-    }
+    deno_core::error::throw_op_error(&mut #scope, &err);
     return 1;
   })
 }

--- a/libs/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/libs/ops/op2/test_cases/async/async_arg_return_result.out
@@ -76,8 +76,16 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
+                        if !deno_core::error::try_throw_js_error_class(
+                            &mut scope,
+                            &err,
+                        ) {
+                            let exception = deno_core::error::to_v8_error(
+                                &mut scope,
+                                &err,
+                            );
+                            scope.throw_exception(exception);
+                        }
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/libs/ops/op2/test_cases/async/async_arg_return_result.out
@@ -76,16 +76,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        if !deno_core::error::try_throw_js_error_class(
-                            &mut scope,
-                            &err,
-                        ) {
-                            let exception = deno_core::error::to_v8_error(
-                                &mut scope,
-                                &err,
-                            );
-                            scope.throw_exception(exception);
-                        }
+                        deno_core::error::throw_op_error(&mut scope, &err);
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_opstate.out
+++ b/libs/ops/op2/test_cases/async/async_opstate.out
@@ -72,8 +72,16 @@ pub const fn op_async_opstate() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
+                        if !deno_core::error::try_throw_js_error_class(
+                            &mut scope,
+                            &err,
+                        ) {
+                            let exception = deno_core::error::to_v8_error(
+                                &mut scope,
+                                &err,
+                            );
+                            scope.throw_exception(exception);
+                        }
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_opstate.out
+++ b/libs/ops/op2/test_cases/async/async_opstate.out
@@ -72,16 +72,7 @@ pub const fn op_async_opstate() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        if !deno_core::error::try_throw_js_error_class(
-                            &mut scope,
-                            &err,
-                        ) {
-                            let exception = deno_core::error::to_v8_error(
-                                &mut scope,
-                                &err,
-                            );
-                            scope.throw_exception(exception);
-                        }
+                        deno_core::error::throw_op_error(&mut scope, &err);
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_precise_capture.out
+++ b/libs/ops/op2/test_cases/async/async_precise_capture.out
@@ -76,8 +76,16 @@ pub const fn op_async_impl_use() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
+                        if !deno_core::error::try_throw_js_error_class(
+                            &mut scope,
+                            &err,
+                        ) {
+                            let exception = deno_core::error::to_v8_error(
+                                &mut scope,
+                                &err,
+                            );
+                            scope.throw_exception(exception);
+                        }
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_precise_capture.out
+++ b/libs/ops/op2/test_cases/async/async_precise_capture.out
@@ -76,16 +76,7 @@ pub const fn op_async_impl_use() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        if !deno_core::error::try_throw_js_error_class(
-                            &mut scope,
-                            &err,
-                        ) {
-                            let exception = deno_core::error::to_v8_error(
-                                &mut scope,
-                                &err,
-                            );
-                            scope.throw_exception(exception);
-                        }
+                        deno_core::error::throw_op_error(&mut scope, &err);
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_result.out
+++ b/libs/ops/op2/test_cases/async/async_result.out
@@ -68,8 +68,16 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
+                        if !deno_core::error::try_throw_js_error_class(
+                            &mut scope,
+                            &err,
+                        ) {
+                            let exception = deno_core::error::to_v8_error(
+                                &mut scope,
+                                &err,
+                            );
+                            scope.throw_exception(exception);
+                        }
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_result.out
+++ b/libs/ops/op2/test_cases/async/async_result.out
@@ -68,16 +68,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        if !deno_core::error::try_throw_js_error_class(
-                            &mut scope,
-                            &err,
-                        ) {
-                            let exception = deno_core::error::to_v8_error(
-                                &mut scope,
-                                &err,
-                            );
-                            scope.throw_exception(exception);
-                        }
+                        deno_core::error::throw_op_error(&mut scope, &err);
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_result_impl.out
+++ b/libs/ops/op2/test_cases/async/async_result_impl.out
@@ -64,8 +64,10 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
                         unsafe { deno_core::v8::CallbackScope::new(info) }
                     );
                     let mut scope = scope.init();
-                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                    scope.throw_exception(exception);
+                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
+                        scope.throw_exception(exception);
+                    }
                     return 1;
                 }
             };
@@ -88,8 +90,16 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
+                        if !deno_core::error::try_throw_js_error_class(
+                            &mut scope,
+                            &err,
+                        ) {
+                            let exception = deno_core::error::to_v8_error(
+                                &mut scope,
+                                &err,
+                            );
+                            scope.throw_exception(exception);
+                        }
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_result_impl.out
+++ b/libs/ops/op2/test_cases/async/async_result_impl.out
@@ -64,10 +64,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
                         unsafe { deno_core::v8::CallbackScope::new(info) }
                     );
                     let mut scope = scope.init();
-                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
-                    }
+                    deno_core::error::throw_op_error(&mut scope, &err);
                     return 1;
                 }
             };
@@ -90,16 +87,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        if !deno_core::error::try_throw_js_error_class(
-                            &mut scope,
-                            &err,
-                        ) {
-                            let exception = deno_core::error::to_v8_error(
-                                &mut scope,
-                                &err,
-                            );
-                            scope.throw_exception(exception);
-                        }
+                        deno_core::error::throw_op_error(&mut scope, &err);
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_result_smi.out
+++ b/libs/ops/op2/test_cases/async/async_result_smi.out
@@ -92,8 +92,16 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
+                        if !deno_core::error::try_throw_js_error_class(
+                            &mut scope,
+                            &err,
+                        ) {
+                            let exception = deno_core::error::to_v8_error(
+                                &mut scope,
+                                &err,
+                            );
+                            scope.throw_exception(exception);
+                        }
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/async/async_result_smi.out
+++ b/libs/ops/op2/test_cases/async/async_result_smi.out
@@ -92,16 +92,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                             unsafe { deno_core::v8::CallbackScope::new(info) }
                         );
                         let mut scope = scope.init();
-                        if !deno_core::error::try_throw_js_error_class(
-                            &mut scope,
-                            &err,
-                        ) {
-                            let exception = deno_core::error::to_v8_error(
-                                &mut scope,
-                                &err,
-                            );
-                            scope.throw_exception(exception);
-                        }
+                        deno_core::error::throw_op_error(&mut scope, &err);
                         return 1;
                     }
                 };

--- a/libs/ops/op2/test_cases/sync/bool_result.out
+++ b/libs/ops/op2/test_cases/sync/bool_result.out
@@ -151,14 +151,10 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                         unsafe { deno_core::v8::CallbackScope::new(info) }
                     );
                     let mut scope = scope.init();
-                    let opctx: &'s _ = unsafe {
-                        &*(deno_core::v8::Local::<
-                            deno_core::v8::External,
-                        >::cast_unchecked(args.data())
-                            .value() as *const deno_core::_ops::OpCtx)
-                    };
-                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                    scope.throw_exception(exception);
+                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
+                        scope.throw_exception(exception);
+                    }
                     return 1;
                 }
             };

--- a/libs/ops/op2/test_cases/sync/bool_result.out
+++ b/libs/ops/op2/test_cases/sync/bool_result.out
@@ -151,10 +151,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                         unsafe { deno_core::v8::CallbackScope::new(info) }
                     );
                     let mut scope = scope.init();
-                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
-                    }
+                    deno_core::error::throw_op_error(&mut scope, &err);
                     return 1;
                 }
             };

--- a/libs/ops/op2/test_cases/sync/object_wrap.out
+++ b/libs/ops/op2/test_cases/sync/object_wrap.out
@@ -979,14 +979,10 @@ impl Foo {
                     &parts,
                 );
                 if let Err(err) = f(&mut scope, &args) {
-                    let opctx: &'s _ = unsafe {
-                        &*(deno_core::v8::Local::<
-                            deno_core::v8::External,
-                        >::cast_unchecked(args.data())
-                            .value() as *const deno_core::_ops::OpCtx)
-                    };
-                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                    scope.throw_exception(exception);
+                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
+                        scope.throw_exception(exception);
+                    }
                     return 1;
                 }
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<

--- a/libs/ops/op2/test_cases/sync/object_wrap.out
+++ b/libs/ops/op2/test_cases/sync/object_wrap.out
@@ -979,10 +979,7 @@ impl Foo {
                     &parts,
                 );
                 if let Err(err) = f(&mut scope, &args) {
-                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
-                    }
+                    deno_core::error::throw_op_error(&mut scope, &err);
                     return 1;
                 }
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<

--- a/libs/ops/op2/test_cases/sync/result_external.out
+++ b/libs/ops/op2/test_cases/sync/result_external.out
@@ -126,24 +126,16 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
             );
             let mut scope = scope.init();
             let mut rv = parts.return_value;
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info_parts(
-                info,
-                &parts,
-            );
             let result = { Self::call() };
             match result {
                 Ok(result) => {
                     rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope))
                 }
                 Err(err) => {
-                    let opctx: &'s _ = unsafe {
-                        &*(deno_core::v8::Local::<
-                            deno_core::v8::External,
-                        >::cast_unchecked(args.data())
-                            .value() as *const deno_core::_ops::OpCtx)
-                    };
-                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                    scope.throw_exception(exception);
+                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
+                        scope.throw_exception(exception);
+                    }
                     return 1;
                 }
             };

--- a/libs/ops/op2/test_cases/sync/result_external.out
+++ b/libs/ops/op2/test_cases/sync/result_external.out
@@ -132,10 +132,7 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
                     rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope))
                 }
                 Err(err) => {
-                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
-                    }
+                    deno_core::error::throw_op_error(&mut scope, &err);
                     return 1;
                 }
             };

--- a/libs/ops/op2/test_cases/sync/result_primitive.out
+++ b/libs/ops/op2/test_cases/sync/result_primitive.out
@@ -128,10 +128,6 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
             );
             let parts: deno_core::v8::FunctionCallbackInfoParts<'s> = info.get_parts();
             let mut rv = parts.return_value;
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info_parts(
-                info,
-                &parts,
-            );
             let result = { Self::call() };
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
@@ -140,14 +136,10 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
                         unsafe { deno_core::v8::CallbackScope::new(info) }
                     );
                     let mut scope = scope.init();
-                    let opctx: &'s _ = unsafe {
-                        &*(deno_core::v8::Local::<
-                            deno_core::v8::External,
-                        >::cast_unchecked(args.data())
-                            .value() as *const deno_core::_ops::OpCtx)
-                    };
-                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                    scope.throw_exception(exception);
+                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
+                        scope.throw_exception(exception);
+                    }
                     return 1;
                 }
             };

--- a/libs/ops/op2/test_cases/sync/result_primitive.out
+++ b/libs/ops/op2/test_cases/sync/result_primitive.out
@@ -136,10 +136,7 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
                         unsafe { deno_core::v8::CallbackScope::new(info) }
                     );
                     let mut scope = scope.init();
-                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
-                    }
+                    deno_core::error::throw_op_error(&mut scope, &err);
                     return 1;
                 }
             };

--- a/libs/ops/op2/test_cases/sync/result_scope.out
+++ b/libs/ops/op2/test_cases/sync/result_scope.out
@@ -142,14 +142,10 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    let opctx: &'s _ = unsafe {
-                        &*(deno_core::v8::Local::<
-                            deno_core::v8::External,
-                        >::cast_unchecked(args.data())
-                            .value() as *const deno_core::_ops::OpCtx)
-                    };
-                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                    scope.throw_exception(exception);
+                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
+                        scope.throw_exception(exception);
+                    }
                     return 1;
                 }
             };

--- a/libs/ops/op2/test_cases/sync/result_scope.out
+++ b/libs/ops/op2/test_cases/sync/result_scope.out
@@ -142,10 +142,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
-                    }
+                    deno_core::error::throw_op_error(&mut scope, &err);
                     return 1;
                 }
             };

--- a/libs/ops/op2/test_cases/sync/result_void.out
+++ b/libs/ops/op2/test_cases/sync/result_void.out
@@ -122,10 +122,6 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             );
             let parts: deno_core::v8::FunctionCallbackInfoParts<'s> = info.get_parts();
             let mut rv = parts.return_value;
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info_parts(
-                info,
-                &parts,
-            );
             let result = { Self::call() };
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
@@ -134,14 +130,10 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                         unsafe { deno_core::v8::CallbackScope::new(info) }
                     );
                     let mut scope = scope.init();
-                    let opctx: &'s _ = unsafe {
-                        &*(deno_core::v8::Local::<
-                            deno_core::v8::External,
-                        >::cast_unchecked(args.data())
-                            .value() as *const deno_core::_ops::OpCtx)
-                    };
-                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                    scope.throw_exception(exception);
+                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
+                        scope.throw_exception(exception);
+                    }
                     return 1;
                 }
             };

--- a/libs/ops/op2/test_cases/sync/result_void.out
+++ b/libs/ops/op2/test_cases/sync/result_void.out
@@ -130,10 +130,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                         unsafe { deno_core::v8::CallbackScope::new(info) }
                     );
                     let mut scope = scope.init();
-                    if !deno_core::error::try_throw_js_error_class(&mut scope, &err) {
-                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
-                        scope.throw_exception(exception);
-                    }
+                    deno_core::error::throw_op_error(&mut scope, &err);
                     return 1;
                 }
             };

--- a/tests/unit/webgpu_test.ts
+++ b/tests/unit/webgpu_test.ts
@@ -53,6 +53,44 @@ function checkWindowingSystem(): boolean {
   }
 }
 
+Deno.test(function webgpuErrorBuildersPreserveClassState() {
+  // Accessing the lazy global loads WebGPU and registers its error builders.
+  void GPUValidationError;
+  // @ts-ignore: Deno[Deno.internal].core is available to internal tests.
+  const core = Deno[Deno.internal].core;
+  const messageGetter = Object.getOwnPropertyDescriptor(
+    GPUError.prototype,
+    "message",
+  )!.get!;
+
+  const validation = core.buildCustomError(
+    "GPUValidationError",
+    "validation message",
+  );
+  assert(validation instanceof GPUValidationError);
+  assertEquals(messageGetter.call(validation), "validation message");
+  assert(!Object.hasOwn(validation, "message"));
+  assert(!("name" in validation));
+
+  const outOfMemory = core.buildCustomError(
+    "GPUOutOfMemoryError",
+    "out of memory message",
+  );
+  assert(outOfMemory instanceof GPUOutOfMemoryError);
+  assertEquals(messageGetter.call(outOfMemory), "out of memory message");
+  assert(!Object.hasOwn(outOfMemory, "message"));
+  assert(!("name" in outOfMemory));
+
+  const internal = core.buildCustomError(
+    "GPUInternalError",
+    "ignored message",
+  );
+  assert(internal instanceof GPUInternalError);
+  assertEquals(messageGetter.call(internal), undefined);
+  assert(!Object.hasOwn(internal, "message"));
+  assert(!("name" in internal));
+});
+
 Deno.test({
   permissions: { read: true, env: true },
   ignore: isWsl || isCIWithoutGPU,


### PR DESCRIPTION
## Summary

- construct registered op errors through the native V8 path in both slow and fast dispatch
- capture registered prototypes once instead of reading live JavaScript objects during a throw
- preserve JavaScript builders for builder-only and constructor-dependent error classes
- define additional error fields as own data properties in both native and builder construction

Synchronous op errors previously used different construction paths depending on dispatch. The slow path always called `buildCustomError`, so a registered class could invoke its constructor or prototype accessors while the op callback was still active. Registered ordinary error classes now use the same native construction path in both cases, while custom builders continue to handle objects that require constructor-specific state, including WebGPU errors.

## Security

The former fast path also read constructors and their `.prototype` properties from live JavaScript objects while the fast callback was active. Proxies or accessors could therefore re-enter JavaScript in the same unsafe context as GHSA-p4r3-6jgx-4cj5. Capturing ordinary-function prototypes at registration removes those live reads; the fast path performs only a Rust map lookup and native V8 construction.

## Upgrade note

For `deno_core` embedders, this is an observable contract change: registered-class constructors no longer run for slow-path op errors. Classes that depend on constructor side effects or derived, private, or branded state must use `registerErrorBuilder` and must not be returned by fast ops, because fast callbacks cannot invoke JavaScript builders.

The current V8 API no longer exposes the deprecated fast-callback fallback flag, so the fast path remains on native construction rather than attempting to repeat an op through the slow callback.

## Testing

- `./tools/format.js --check`
- `cargo test -p deno_core --lib -- --test-threads=1`
- `cargo test -p deno_ops`
- `cargo clippy -p deno_core -p deno_ops --all-targets -- -D warnings`
- `cargo build --bin deno --bin test_server`
- `cargo test -p unit_tests --test unit webgpu_test -- --nocapture`
