### PR TITLE
fix(node): retain consumed HTTP stream wrapper

### DIFF
--- a/ext/node/ops/llhttp/binding.rs
+++ b/ext/node/ops/llhttp/binding.rs
@@ -94,6 +94,8 @@ struct Inner {
   /// When set, the parser reads directly from the stream handle
   /// via a ReadInterceptor, bypassing the JS readable stream.
   consumed_stream: Option<*mut uv_stream_t>,
+  /// Persistent handle to the JS stream wrapper object while consumed.
+  consumed_stream_handle: Option<v8::Global<v8::Object>>,
   /// Persistent handle to the JS wrapper object for callbacks during consume.
   consume_callbacks: Option<v8::Global<v8::Object>>,
   /// Raw isolate pointer for creating scopes in the interceptor callback.
@@ -149,6 +151,7 @@ impl HTTPParser {
         last_bytes_parsed: 0,
         last_errno: 0,
         consumed_stream: None,
+        consumed_stream_handle: None,
         consume_callbacks: None,
         consume_isolate: v8::UnsafeRawIsolatePtr::null(),
       }),
@@ -1179,6 +1182,7 @@ impl HTTPParser {
     inner.consume_callbacks = Some(v8::Global::new(scope, callbacks));
     inner.consume_isolate = unsafe { scope.as_raw_isolate_ptr() };
     inner.consumed_stream = Some(stream);
+    inner.consumed_stream_handle = Some(v8::Global::new(scope, handle));
 
     // Register the read interceptor
     let interceptor = ReadInterceptor {
@@ -1196,6 +1200,7 @@ impl HTTPParser {
     if let Some(stream) = inner.consumed_stream.take() {
       LibUvStreamWrap::set_read_interceptor_for_stream(stream, None);
     }
+    inner.consumed_stream_handle = None;
     inner.consume_callbacks = None;
     inner.consume_isolate = v8::UnsafeRawIsolatePtr::null();
   }

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -18,9 +18,12 @@ import https from "node:https";
 import zlib from "node:zlib";
 import net, { type AddressInfo, Socket } from "node:net";
 import fs from "node:fs";
+import process from "node:process";
 import type { Duplex } from "node:stream";
 import { text } from "node:stream/consumers";
 import { channel } from "node:diagnostics_channel";
+import * as v8 from "node:v8";
+import { runInNewContext } from "node:vm";
 
 import { assert, assertEquals, assertStringIncludes, fail } from "@std/assert";
 import { assertSpyCalls, spy } from "@std/testing/mock";
@@ -36,6 +39,35 @@ import { execCode } from "../unit/test_util.ts";
 // tests reusing the same port (e.g. 4505) don't fail with EADDRINUSE.
 Deno.test.beforeEach(() => {
   http.globalAgent.destroy();
+});
+
+Deno.test("[node/http] HTTPParser.consume keeps stream handle alive", async () => {
+  v8.setFlagsFromString("--expose_gc");
+  const gc = runInNewContext("gc") as () => void;
+
+  // @ts-ignore: untyped internal binding for direct lifecycle coverage.
+  const { HTTPParser } = process.binding("http_parser");
+  // @ts-ignore: untyped internal binding for direct lifecycle coverage.
+  const { TCP } = process.binding("tcp_wrap");
+
+  const parser = new HTTPParser();
+  parser.initialize(HTTPParser.REQUEST, {});
+
+  let weak: WeakRef<object> | undefined;
+  {
+    const tcp = new TCP(0);
+    weak = new WeakRef(tcp);
+    parser.consume(tcp);
+    tcp.close();
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  for (let i = 0; i < 5; i++) {
+    gc();
+  }
+
+  assert(weak?.deref() !== undefined);
+  parser.unconsume();
 });
 
 Deno.test("[node/http listen]", async () => {


### PR DESCRIPTION
## Summary

- keep the stream wrapper reachable while `HTTPParser` owns its read interceptor
- release the wrapper when `unconsume()` removes the interceptor
- cover the `consume()` / close / garbage collection / `unconsume()` lifecycle

## Why

`HTTPParser.consume()` retained the native stream pointer and callback object, but not the JavaScript wrapper that owns the stream. Closing and collecting the wrapper before `unconsume()` could leave the parser holding a pointer whose owner had already been finalized.

## Validation

- `./x build`
- `./x test-node http_test`
- `./tools/format.js ext/node/ops/llhttp/binding.rs tests/unit_node/http_test.ts`
- `./tools/lint.js --js`
- `cargo clippy -p deno_node --lib -- -D warnings`
