### PR TITLE
fix(core): allow dynamic imports during cached module evaluation

### DIFF
--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -2952,28 +2952,29 @@ impl ModuleMap {
     module_specifier: &str,
   ) -> Result<v8::Global<v8::Value>, CoreError> {
     // Use existing module if already constructed.
-    {
+    let cached_handle = {
       let data = self.data.borrow();
-      if let Some(id) = data.get_id(module_specifier, RequestedModuleType::None)
-      {
-        let handle = data.get_handle(id).unwrap();
-        let handle_local = v8::Local::new(scope, handle);
-        if handle_local.get_status() == v8::ModuleStatus::Instantiated {
-          let value = handle_local.evaluate(scope).unwrap();
-          if !self.evaluating_top_level.get() {
-            scope.perform_microtask_checkpoint();
-          }
-          let promise = v8::Local::<v8::Promise>::try_from(value).unwrap();
-          let result = promise.result(scope);
-          if !result.is_undefined() {
-            return Err(
-              CoreErrorKind::Js(exception_to_err(scope, result, false, true))
-                .into_box(),
-            );
-          }
+      data
+        .get_id(module_specifier, RequestedModuleType::None)
+        .and_then(|id| data.get_handle(id))
+    };
+    if let Some(handle) = cached_handle {
+      let handle_local = v8::Local::new(scope, handle);
+      if handle_local.get_status() == v8::ModuleStatus::Instantiated {
+        let value = handle_local.evaluate(scope).unwrap();
+        if !self.evaluating_top_level.get() {
+          scope.perform_microtask_checkpoint();
         }
-        return Ok(v8::Global::new(scope, handle_local.get_module_namespace()));
+        let promise = v8::Local::<v8::Promise>::try_from(value).unwrap();
+        let result = promise.result(scope);
+        if !result.is_undefined() {
+          return Err(
+            CoreErrorKind::Js(exception_to_err(scope, result, false, true))
+              .into_box(),
+          );
+        }
       }
+      return Ok(v8::Global::new(scope, handle_local.get_module_namespace()));
     }
 
     let module_id = self.build_synthetic_esm_module(scope, module_specifier)?;

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -688,6 +688,39 @@ async fn test_lazy_load_esm_evaluates_pre_instantiated_sibling() {
   result.await.unwrap();
 }
 
+/// Regression test for https://github.com/denoland/deno/issues/36216
+///
+/// Evaluating a pre-instantiated module cached under a synthetic ESM specifier
+/// can synchronously start a dynamic import. The cache-hit path must not keep
+/// `ModuleMapData` borrowed while V8 runs the module body, because starting
+/// the import allocates a new module load ID from the same map.
+#[test]
+fn test_cached_synthetic_esm_evaluation_allows_dynamic_import() {
+  let mut runtime = JsRuntime::new(Default::default());
+  let module_map = runtime.module_map().clone();
+
+  deno_core::scope!(scope, runtime);
+  module_map.add_synthetic_esm_module(
+    ascii_str!("custom:synthetic").into(),
+    ascii_str!("ext:test/backing.js").into(),
+  );
+  let module_id = module_map
+    .new_es_module(
+      scope,
+      false,
+      ascii_str!("custom:synthetic").into(),
+      ascii_str!(r#"import("file:///dynamic_import.js").catch(() => {});"#)
+        .into(),
+      false,
+      None,
+    )
+    .unwrap();
+  module_map.instantiate_module(scope, module_id).unwrap();
+  module_map
+    .lazy_load_synthetic_esm_module(scope, "custom:synthetic")
+    .unwrap();
+}
+
 /// Regression test for https://github.com/denoland/deno/issues/34307
 ///
 /// Two concurrent dynamic `import()` calls each spawn their own


### PR DESCRIPTION
Fixes #36216

## Summary

Release the `ModuleMapData` borrow before evaluating a cached module in the synthetic ESM fast path. This allows evaluated module code to start a dynamic import without re-entering the same `RefCell` while it is still borrowed.

Add a minimal regression test using a pre-instantiated module cached under a synthetic ESM specifier whose body starts a dynamic import.

## Root cause

The cache-hit path kept an immutable `ModuleMapData` borrow alive across `module.evaluate()`. Starting a dynamic import synchronously allocates a new module load ID, which requires a mutable borrow of the same map and caused a `RefCell already borrowed` panic.

## Validation

- `./tools/format.js --check`
- `cargo test -p deno_core --lib` (443 passed, 2 ignored)
- `cargo clippy -p deno_core --tests -- -D warnings`
