### PR TITLE
fix(ffi): reject resizable buffers in nonblocking calls

### DIFF
--- a/ext/ffi/call.rs
+++ b/ext/ffi/call.rs
@@ -323,8 +323,11 @@ where
     &def.parameters,
     &mut backing_store_holder,
   )?;
-  let out_buffer_ptr =
-    out_buffer_as_ptr_nonblocking(scope, out_buffer, &mut backing_store_holder);
+  let out_buffer_ptr = out_buffer_as_ptr_nonblocking(
+    scope,
+    out_buffer,
+    &mut backing_store_holder,
+  )?;
 
   let join_handle = spawn_blocking(move || {
     let PtrSymbol { cif, ptr } = symbol.clone();
@@ -378,8 +381,11 @@ pub fn op_ffi_call_nonblocking(
     &symbol.parameter_types,
     &mut backing_store_holder,
   )?;
-  let out_buffer_ptr =
-    out_buffer_as_ptr_nonblocking(scope, out_buffer, &mut backing_store_holder);
+  let out_buffer_ptr = out_buffer_as_ptr_nonblocking(
+    scope,
+    out_buffer,
+    &mut backing_store_holder,
+  )?;
 
   let join_handle = spawn_blocking(move || {
     let Symbol {

--- a/ext/ffi/ir.rs
+++ b/ext/ffi/ir.rs
@@ -21,8 +21,17 @@ impl BackingStoreHolder {
     Self(Vec::new())
   }
 
-  fn push(&mut self, store: v8::SharedRef<v8::BackingStore>) {
+  fn push(
+    &mut self,
+    store: v8::SharedRef<v8::BackingStore>,
+  ) -> Result<(), IRError> {
+    // A shared reference keeps the backing store object alive, but it cannot
+    // keep a user-resizable store's data pointer stable across an async call.
+    if store.is_resizable_by_user_javascript() {
+      return Err(IRError::ResizableBackingStore);
+    }
     self.0.push(store);
+    Ok(())
   }
 }
 
@@ -67,6 +76,10 @@ pub enum IRError {
   InvalidArrayBuffer,
   #[error("Invalid FFI struct type, expected ArrayBuffer, or ArrayBufferView")]
   InvalidStructType,
+  #[error(
+    "Resizable backing stores are not supported for nonblocking FFI calls"
+  )]
+  ResizableBackingStore,
   #[error("Invalid FFI function type, expected null, or External")]
   InvalidFunctionType,
 }
@@ -99,15 +112,17 @@ pub fn out_buffer_as_ptr_nonblocking(
   scope: &mut v8::PinScope<'_, '_>,
   out_buffer: Option<v8::Local<v8::TypedArray>>,
   holder: &mut BackingStoreHolder,
-) -> Option<OutBuffer> {
+) -> Result<Option<OutBuffer>, IRError> {
   match out_buffer {
     Some(out_buffer) => {
       let ab = out_buffer.buffer(scope).unwrap();
-      holder.push(ab.get_backing_store());
-      ab.data()
-        .map(|non_null| OutBuffer(non_null.as_ptr() as *mut u8))
+      holder.push(ab.get_backing_store())?;
+      Ok(
+        ab.data()
+          .map(|non_null| OutBuffer(non_null.as_ptr() as *mut u8)),
+      )
     }
-    None => None,
+    None => Ok(None),
   }
 }
 
@@ -459,11 +474,11 @@ pub fn ffi_parse_buffer_arg_nonblocking(
 ) -> Result<NativeValue, IRError> {
   // Retain the backing store before extracting the raw pointer.
   if let Ok(value) = v8::Local::<v8::ArrayBuffer>::try_from(arg) {
-    holder.push(value.get_backing_store());
+    holder.push(value.get_backing_store())?;
   } else if let Ok(value) = v8::Local::<v8::ArrayBufferView>::try_from(arg)
     && let Some(ab) = value.buffer(scope)
   {
-    holder.push(ab.get_backing_store());
+    holder.push(ab.get_backing_store())?;
   }
   let pointer = parse_buffer_arg(arg)?;
   Ok(NativeValue { pointer })
@@ -512,11 +527,11 @@ pub fn ffi_parse_struct_arg_nonblocking(
   holder: &mut BackingStoreHolder,
 ) -> Result<NativeValue, IRError> {
   if let Ok(value) = v8::Local::<v8::ArrayBuffer>::try_from(arg) {
-    holder.push(value.get_backing_store());
+    holder.push(value.get_backing_store())?;
   } else if let Ok(value) = v8::Local::<v8::ArrayBufferView>::try_from(arg)
     && let Some(ab) = value.buffer(scope)
   {
-    holder.push(ab.get_backing_store());
+    holder.push(ab.get_backing_store())?;
   }
   ffi_parse_struct_arg(scope, arg)
 }

--- a/tests/ffi/testdata/test.js
+++ b/tests/ffi/testdata/test.js
@@ -4,6 +4,7 @@
 // Run using cargo test or `--v8-flags=--allow-natives-syntax`
 
 import {
+  assertRejects,
   assertThrows,
   assert,
   assertNotEquals,
@@ -274,6 +275,12 @@ const dylib = Deno.dlopen(libPath, {
     parameters: [{ struct: Rect }],
     result: "void",
   },
+  print_rect_nested_async: {
+    name: "print_rect",
+    nonblocking: true,
+    parameters: [{ struct: RectNestedCached }],
+    result: "void",
+  },
   create_mixed: {
     parameters: ["u8", "f32", { struct: Rect }, "pointer", "buffer"],
     result: { struct: Mixed }
@@ -510,6 +517,36 @@ dylib.symbols.nonblocking_buffer(buffer3, buffer3.length).then(() => {
 });
 await deferred.promise;
 
+const fixedArrayBuffer = new ArrayBuffer(8);
+new Uint8Array(fixedArrayBuffer).set([1, 2, 3, 4, 5, 6, 7, 8]);
+await dylib.symbols.nonblocking_buffer(fixedArrayBuffer, 8);
+await dylib.symbols.nonblocking_buffer(
+  new Uint8Array(fixedArrayBuffer),
+  8,
+);
+
+const resizableArrayBuffer = new ArrayBuffer(8, { maxByteLength: 16 });
+new Uint8Array(resizableArrayBuffer).set([1, 2, 3, 4, 5, 6, 7, 8]);
+const growableSharedArrayBuffer = new SharedArrayBuffer(8, {
+  maxByteLength: 16,
+});
+new Uint8Array(growableSharedArrayBuffer).set([1, 2, 3, 4, 5, 6, 7, 8]);
+assertEquals(
+  dylib.symbols.hash(resizableArrayBuffer, 8),
+  dylib.symbols.hash(fixedArrayBuffer, 8),
+);
+for (const buffer of [
+  resizableArrayBuffer,
+  new Uint8Array(resizableArrayBuffer),
+  new Uint8Array(growableSharedArrayBuffer),
+]) {
+  await assertRejects(
+    () => dylib.symbols.nonblocking_buffer(buffer, 8),
+    TypeError,
+    "Resizable backing stores are not supported for nonblocking FFI calls",
+  );
+}
+
 let start = performance.now();
 dylib.symbols.sleep_blocking(100);
 assert(performance.now() - start >= 100);
@@ -680,6 +717,18 @@ const rect_sync = dylib.symbols.make_rect(10, 20, 100, 200);
 assertInstanceOf(rect_sync, Uint8Array);
 assertEquals(rect_sync.length, 4 * 8);
 assertEquals(Array.from(new Float64Array(rect_sync.buffer)), [10, 20, 100, 200]);
+const resizableRectBuffer = new ArrayBuffer(4 * 8, {
+  maxByteLength: 8 * 8,
+});
+new Float64Array(resizableRectBuffer).set([10, 20, 100, 200]);
+await assertRejects(
+  () =>
+    dylib.symbols.print_rect_nested_async(
+      new Float64Array(resizableRectBuffer),
+    ),
+  TypeError,
+  "Resizable backing stores are not supported for nonblocking FFI calls",
+);
 // Test struct passing
 dylib.symbols.print_rect(rect_sync);
 // Test struct passing asynchronously


### PR DESCRIPTION
## Summary

- validate retained V8 backing stores before dispatching nonblocking FFI calls
- reject user-resizable stores for buffer arguments, struct arguments, and result storage
- preserve synchronous FFI behavior and fixed-buffer support

## Background

Nonblocking FFI calls retain a backing-store reference and pass its data pointer to a worker thread. The reference keeps the backing-store object alive, but a user-resizable store can still change its data pointer after the call is dispatched.

The nonblocking path now accepts only fixed backing stores before retaining and forwarding their pointers. This applies consistently to direct `ArrayBuffer` values, views, nested struct inputs, and the internal storage used for struct results.

## Tests

- `cargo test -p deno_ffi`
- `cargo build -p deno -p test_server -p test_ffi`
- `cargo test -p integration_tests --test integration ffi::ffi_basic`
- `cargo clippy -p deno_ffi --all-targets -- -D warnings`
- `./tools/format.js ext/ffi/ir.rs ext/ffi/call.rs tests/ffi/testdata/test.js`
