### PR TITLE
fix(core): validate op buffer backing stores

### DIFF
--- a/libs/core/runtime/ops.rs
+++ b/libs/core/runtime/ops.rs
@@ -349,6 +349,241 @@ pub fn serde_v8_to_rust<'a, 's, 'i, T: Deserialize<'a>>(
   from_v8(scope, input)
 }
 
+#[inline(always)]
+fn validate_buffer_backing_store(
+  store: &v8::SharedRef<v8::BackingStore>,
+) -> Result<(), &'static str> {
+  if store.is_resizable_by_user_javascript() {
+    return Err("resizable buffers are not supported");
+  }
+  if store.is_shared() {
+    return Err("shared buffers are not supported");
+  }
+  Ok(())
+}
+
+/// An op buffer that either borrows a fixed V8 backing store or owns a
+/// snapshot of a backing store that JavaScript can resize or share.
+pub enum V8SliceOrCopy<T>
+where
+  T: V8Sliceable,
+{
+  V8(serde_v8::V8Slice<T>),
+  Copy(Vec<T>),
+}
+
+impl<T> V8SliceOrCopy<T>
+where
+  T: V8Sliceable,
+{
+  pub fn to_vec(&self) -> Vec<T> {
+    self.as_ref().to_vec()
+  }
+
+  pub fn to_boxed_slice(&self) -> Box<[T]> {
+    self.as_ref().into()
+  }
+}
+
+/// A fast-call buffer backed either by a fixed V8 view or an owned snapshot.
+pub enum FastV8Slice<'a, T> {
+  V8(&'a mut [T]),
+  Copy(Vec<T>),
+}
+
+impl<T> AsMut<[T]> for FastV8Slice<'_, T> {
+  fn as_mut(&mut self) -> &mut [T] {
+    match self {
+      Self::V8(slice) => slice,
+      Self::Copy(slice) => slice.as_mut(),
+    }
+  }
+}
+
+impl<T> AsRef<[T]> for V8SliceOrCopy<T>
+where
+  T: V8Sliceable,
+{
+  fn as_ref(&self) -> &[T] {
+    match self {
+      Self::V8(slice) => slice.as_ref(),
+      Self::Copy(slice) => slice.as_ref(),
+    }
+  }
+}
+
+/// Copies an ArrayBufferView without first creating a Rust slice over its
+/// backing store.
+pub fn copy_array_buffer_view<T>(
+  view: v8::Local<v8::ArrayBufferView>,
+) -> Result<Vec<T>, &'static str>
+where
+  T: V8Sliceable,
+{
+  let byte_length = view.byte_length();
+  if !byte_length.is_multiple_of(std::mem::size_of::<T>()) {
+    return Err("buffer length is not aligned");
+  }
+
+  let length = byte_length / std::mem::size_of::<T>();
+  let mut copy = Vec::<T>::with_capacity(length);
+  // SAFETY: `copy` has capacity for `byte_length` bytes. CopyContents writes
+  // initialized bytes into the allocation, using relaxed copying for shared
+  // stores, and we set the element length only after verifying that it filled
+  // the entire view.
+  let destination = unsafe {
+    std::slice::from_raw_parts_mut(
+      copy.as_mut_ptr().cast::<std::mem::MaybeUninit<u8>>(),
+      byte_length,
+    )
+  };
+  if view.copy_contents_uninit(destination) != byte_length {
+    return Err("buffer changed while being copied");
+  }
+  // SAFETY: CopyContents initialized all bytes in the allocation above.
+  unsafe { copy.set_len(length) };
+  Ok(copy)
+}
+
+/// Converts a fast-call ArrayBufferView without borrowing invalidatable or
+/// concurrently writable backing memory.
+///
+/// # Safety
+///
+/// The returned buffer must not outlive the fast call or the `storage`
+/// provided for V8's inline typed-array contents.
+#[inline(always)]
+pub unsafe fn to_fast_v8_slice<'a, T, const COPY_INVALID: bool>(
+  view: v8::Local<v8::ArrayBufferView>,
+  storage: &'a mut [u8],
+) -> Result<FastV8Slice<'a, T>, &'static str>
+where
+  T: V8Sliceable,
+{
+  let Some(store) = view.get_backing_store() else {
+    return Err("buffer missing");
+  };
+  if store.is_resizable_by_user_javascript() || store.is_shared() {
+    if COPY_INVALID {
+      return copy_array_buffer_view(view).map(FastV8Slice::Copy);
+    }
+    return Err("resizable or shared buffers are not supported");
+  }
+
+  // SAFETY: the backing store is fixed and unshared, `storage` outlives the
+  // returned slice, and the caller keeps the V8 view alive for the fast call.
+  let (input_ptr, input_len) = unsafe { view.get_contents_raw_parts(storage) };
+  let input_ptr = if input_ptr.is_null() {
+    std::ptr::dangling_mut()
+  } else {
+    input_ptr
+  };
+  // SAFETY: V8 returned `input_len` initialized bytes either in `storage` or
+  // in the fixed, unshared backing store kept alive by `view`.
+  let slice = unsafe { std::slice::from_raw_parts_mut(input_ptr, input_len) };
+  // SAFETY: the view's concrete typed-array class guarantees element
+  // alignment; the result is checked below before use.
+  let (before, slice, after) = unsafe { slice.align_to_mut::<T>() };
+  if !before.is_empty() || !after.is_empty() {
+    return Err("buffer length is not aligned");
+  }
+  Ok(FastV8Slice::V8(slice))
+}
+
+/// Retrieve an immutable op buffer, copying backing stores whose contents
+/// cannot safely be represented by a borrowed Rust slice.
+pub fn to_v8_slice_or_copy<'a, T>(
+  input: v8::Local<'a, v8::Value>,
+) -> Result<V8SliceOrCopy<T>, &'static str>
+where
+  T: V8Sliceable,
+  v8::Local<'a, T::V8>: TryFrom<v8::Local<'a, v8::Value>>,
+  v8::Local<'a, v8::ArrayBufferView>: From<v8::Local<'a, T::V8>>,
+{
+  let Ok(buf) = v8::Local::<T::V8>::try_from(input) else {
+    return Err("expected typed ArrayBufferView");
+  };
+  let buf: v8::Local<v8::ArrayBufferView> = buf.into();
+  let Some(store) = buf.get_backing_store() else {
+    return Err("buffer missing");
+  };
+  if store.is_resizable_by_user_javascript() || store.is_shared() {
+    return copy_array_buffer_view(buf).map(V8SliceOrCopy::Copy);
+  }
+  let offset = buf.byte_offset();
+  let length = buf.byte_length();
+  // SAFETY: the fixed, unshared backing store remains valid for the lifetime
+  // of the V8Slice, and the view provides an in-bounds byte range.
+  Ok(V8SliceOrCopy::V8(unsafe {
+    serde_v8::V8Slice::from_parts(store, offset..offset + length)
+  }))
+}
+
+fn copy_array_buffer(
+  buffer: v8::Local<v8::ArrayBuffer>,
+) -> Result<Vec<u8>, &'static str> {
+  let length = buffer.byte_length();
+  let mut copy = Vec::<u8>::with_capacity(length);
+  if length != 0 {
+    let Some(source) = buffer.data() else {
+      return Err("buffer missing");
+    };
+    // SAFETY: the destination has capacity for `length` bytes. A resizable
+    // ArrayBuffer cannot be resized concurrently from another JavaScript
+    // agent, and this helper does not re-enter JavaScript while copying.
+    unsafe {
+      std::ptr::copy_nonoverlapping(
+        source.as_ptr().cast::<u8>(),
+        copy.as_mut_ptr(),
+        length,
+      );
+      copy.set_len(length);
+    }
+  }
+  Ok(copy)
+}
+
+/// Retrieve an immutable ArrayBuffer op argument, copying a resizable backing
+/// store before Rust receives a slice.
+pub fn to_v8_slice_buffer_or_copy(
+  input: v8::Local<v8::Value>,
+) -> Result<V8SliceOrCopy<u8>, &'static str> {
+  let Ok(buf) = v8::Local::<v8::ArrayBuffer>::try_from(input) else {
+    return Err("expected ArrayBuffer");
+  };
+  let store = buf.get_backing_store();
+  if store.is_shared() {
+    return Err("shared buffers are not supported");
+  }
+  if store.is_resizable_by_user_javascript() {
+    return copy_array_buffer(buf).map(V8SliceOrCopy::Copy);
+  }
+  Ok(V8SliceOrCopy::V8(unsafe {
+    serde_v8::V8Slice::from_parts(store, 0..buf.byte_length())
+  }))
+}
+
+/// Retrieve an immutable ArrayBuffer or ArrayBufferView op argument, copying
+/// backing stores that JavaScript can resize or share.
+pub fn to_v8_slice_any_or_copy(
+  input: v8::Local<v8::Value>,
+) -> Result<V8SliceOrCopy<u8>, &'static str> {
+  if let Ok(buf) = v8::Local::<v8::ArrayBufferView>::try_from(input) {
+    let offset = buf.byte_offset();
+    let length = buf.byte_length();
+    let Some(store) = buf.get_backing_store() else {
+      return Err("buffer missing");
+    };
+    if store.is_resizable_by_user_javascript() || store.is_shared() {
+      return copy_array_buffer_view(buf).map(V8SliceOrCopy::Copy);
+    }
+    return Ok(V8SliceOrCopy::V8(unsafe {
+      serde_v8::V8Slice::from_parts(store, offset..offset + length)
+    }));
+  }
+  to_v8_slice_buffer_or_copy(input)
+}
+
 /// Retrieve a [`serde_v8::V8Slice`] from a typed array in an [`v8::ArrayBufferView`].
 pub fn to_v8_slice<'a, T>(
   input: v8::Local<'a, v8::Value>,
@@ -364,6 +599,7 @@ where
       let Some(buffer) = buf.get_backing_store() else {
         return Err("buffer missing");
       };
+      validate_buffer_backing_store(&buffer)?;
       (buffer, buf.byte_offset(), buf.byte_length())
     }
     _ => {
@@ -424,6 +660,8 @@ pub unsafe fn to_slice_buffer(
     let Ok(buf) = v8::Local::<v8::ArrayBuffer>::try_from(input) else {
       return Err("expected ArrayBuffer");
     };
+    let store = buf.get_backing_store();
+    validate_buffer_backing_store(&store)?;
     let len = buf.byte_length();
     let slice = if len > 0 {
       if let Some(ptr) = buf.data() {
@@ -450,8 +688,14 @@ pub unsafe fn to_slice_buffer_any(
   unsafe {
     let (data, len) = {
       if let Ok(buf) = v8::Local::<v8::ArrayBufferView>::try_from(input) {
+        let Some(store) = buf.get_backing_store() else {
+          return Err("buffer missing");
+        };
+        validate_buffer_backing_store(&store)?;
         (NonNull::new(buf.data()), buf.byte_length())
       } else if let Ok(buf) = v8::Local::<v8::ArrayBuffer>::try_from(input) {
+        let store = buf.get_backing_store();
+        validate_buffer_backing_store(&store)?;
         (buf.data(), buf.byte_length())
       } else {
         return Err("expected ArrayBuffer or ArrayBufferView");
@@ -477,9 +721,10 @@ pub fn to_v8_slice_buffer(
   let Ok(buf) = v8::Local::<v8::ArrayBuffer>::try_from(input) else {
     return Err("expected ArrayBuffer");
   };
-  let slice = unsafe {
-    serde_v8::V8Slice::from_parts(buf.get_backing_store(), 0..buf.byte_length())
-  };
+  let store = buf.get_backing_store();
+  validate_buffer_backing_store(&store)?;
+  let slice =
+    unsafe { serde_v8::V8Slice::from_parts(store, 0..buf.byte_length()) };
   Ok(slice)
 }
 
@@ -512,6 +757,7 @@ pub fn to_v8_slice_any(
     let Some(buf) = buf.get_backing_store() else {
       return Err("buffer missing");
     };
+    validate_buffer_backing_store(&buf)?;
     return Ok(unsafe {
       serde_v8::V8Slice::<u8>::from_parts(buf, offset..offset + len)
     });
@@ -1674,20 +1920,76 @@ mod tests {
         assert(new {arr}(out)[0] == 1);"
         ),
       )?;
-      // Resizable
+      // Read-only resizable input is snapshotted before Rust receives it.
       run_test2(
-        JIT_SLOW_ITERATIONS,
+        JIT_ITERATIONS,
         op,
         &format!(
           r"
         let inbuf = new ArrayBuffer(10 * {size}, {{ maxByteLength: 100 * {size} }});
         let in_u8 = new {arr}(inbuf);
         in_u8[5] = 1;
-        let out = new ArrayBuffer(10 * {size}, {{ maxByteLength: 100 * {size} }});
+        let out = new ArrayBuffer(10 * {size});
         {op}(new {arr}(inbuf, 5 * {size}, 5), 5, new {arr}(out), 10);
         assert(new {arr}(out)[0] == 1);"
         ),
       )?;
+      // Shared read-only input is also snapshotted.
+      run_test2(
+        JIT_ITERATIONS,
+        op,
+        &format!(
+          r"
+        let inbuf = new SharedArrayBuffer(10 * {size});
+        let in_u8 = new {arr}(inbuf);
+        in_u8[5] = 1;
+        let out = new ArrayBuffer(10 * {size});
+        {op}(new {arr}(inbuf, 5 * {size}, 5), 5, new {arr}(out), 10);
+        assert(new {arr}(out)[0] == 1);"
+        ),
+      )?;
+      // Mutable resizable and shared outputs cannot be borrowed by Rust.
+      for output in [
+        format!(
+          "new {arr}(new ArrayBuffer(10 * {size}, {{ maxByteLength: 100 * {size} }}))"
+        ),
+        format!("new {arr}(new SharedArrayBuffer(10 * {size}))"),
+      ] {
+        run_test2(
+          JIT_ITERATIONS,
+          op,
+          &format!(
+            r"
+          try {{
+            {op}(new {arr}(10), 10, {output}, 10);
+            assert(false);
+          }} catch (e) {{
+            assertErrorContains(e, 'buffers are not supported');
+          }}"
+          ),
+        )?;
+      }
+      // Raw pointer arguments never receive invalidatable backing stores.
+      for input in [
+        format!(
+          "new {arr}(new ArrayBuffer(10 * {size}, {{ maxByteLength: 100 * {size} }}))"
+        ),
+        format!("new {arr}(new SharedArrayBuffer(10 * {size}))"),
+      ] {
+        run_test2(
+          JIT_ITERATIONS,
+          op_ptr,
+          &format!(
+            r"
+          try {{
+            {op_ptr}({input}, 10, new {arr}(10), 10);
+            assert(false);
+          }} catch (e) {{
+            assertErrorContains(e, 'buffers are not supported');
+          }}"
+          ),
+        )?;
+      }
     }
     Ok(())
   }
@@ -1720,6 +2022,24 @@ mod tests {
         op_buffer_jsbuffer(new Uint8Array(inbuf, 5, 5), 5, new Uint8Array(out), 10);
         assert(new Uint8Array(out)[0] == 1);",
     )?;
+    for input in [
+      "new Uint8Array(new ArrayBuffer(10, { maxByteLength: 100 }))",
+      "new Uint8Array(new SharedArrayBuffer(10))",
+    ] {
+      run_test2(
+        JIT_SLOW_ITERATIONS,
+        "op_buffer_jsbuffer",
+        &format!(
+          r"
+        try {{
+          op_buffer_jsbuffer({input}, 10, new Uint8Array(10), 10);
+          assert(false);
+        }} catch (e) {{
+          assertErrorContains(e, 'buffers are not supported');
+        }}"
+        ),
+      )?;
+    }
     Ok(())
   }
 
@@ -1825,6 +2145,26 @@ mod tests {
       "op_buffer_any_length",
       "assert(op_buffer_any_length(new DataView(new ArrayBuffer(10))) == 10);",
     )?;
+    run_test2(
+      JIT_ITERATIONS,
+      "op_buffer_any_length",
+      "assert(op_buffer_any_length(new Uint8Array(new ArrayBuffer(10, { maxByteLength: 100 }))) == 10);",
+    )?;
+    run_test2(
+      JIT_ITERATIONS,
+      "op_buffer_any_length",
+      "assert(op_buffer_any_length(new Uint8Array(new SharedArrayBuffer(10))) == 10);",
+    )?;
+    run_test2(
+      JIT_ITERATIONS,
+      "op_buffer_any_length",
+      "assert(op_buffer_any_length(new DataView(new ArrayBuffer(12, { maxByteLength: 100 }), 2, 7)) == 7);",
+    )?;
+    run_test2(
+      JIT_ITERATIONS,
+      "op_buffer_any_length",
+      "assert(op_buffer_any_length(new DataView(new SharedArrayBuffer(12), 2, 7)) == 7);",
+    )?;
     Ok(())
   }
 
@@ -1859,6 +2199,30 @@ mod tests {
       let outbuf = new ArrayBuffer(10);
       op_arraybuffer_slice(inbuf, 10, outbuf, 10);
       assert((new Uint8Array(outbuf))[0] == 1);",
+    )?;
+    run_test2(
+      JIT_ITERATIONS,
+      "op_arraybuffer_slice",
+      r"let inbuf = new ArrayBuffer(10, { maxByteLength: 100 });
+      (new Uint8Array(inbuf))[0] = 1;
+      let outbuf = new ArrayBuffer(10);
+      op_arraybuffer_slice(inbuf, 10, outbuf, 10);
+      assert((new Uint8Array(outbuf))[0] == 1);",
+    )?;
+    run_test2(
+      JIT_ITERATIONS,
+      "op_arraybuffer_slice",
+      r"try {
+        op_arraybuffer_slice(
+          new ArrayBuffer(10),
+          10,
+          new ArrayBuffer(10, { maxByteLength: 100 }),
+          10,
+        );
+        assert(false);
+      } catch (e) {
+        assertErrorContains(e, 'buffers are not supported');
+      }",
     )?;
     Ok(())
   }
@@ -1925,6 +2289,22 @@ mod tests {
       op_buffer_copy(input, input, input);
       assert(input[0] == 1);",
     )?;
+    for input in [
+      "new Uint8Array(new ArrayBuffer(10, { maxByteLength: 100 }))",
+      "new Uint8Array(new SharedArrayBuffer(10))",
+    ] {
+      run_test2(
+        JIT_ITERATIONS,
+        "op_buffer_copy",
+        &format!(
+          r"
+        const input = {input};
+        input[0] = 1;
+        op_buffer_copy(input, input, input);
+        assert(input[0] == 1);"
+        ),
+      )?;
+    }
     Ok(())
   }
 
@@ -2381,6 +2761,25 @@ mod tests {
       "assert(await op_async_buffer_impl(new Uint8Array(10)) == 10)",
     )
     .await?;
+    for input in [
+      "new Uint8Array(new ArrayBuffer(10, { maxByteLength: 100 }))",
+      "new Uint8Array(new SharedArrayBuffer(10))",
+    ] {
+      run_async_test(
+        2,
+        "op_async_buffer",
+        &format!(
+          r"
+        try {{
+          await op_async_buffer({input});
+          assert(false);
+        }} catch (e) {{
+          assertErrorContains(e, 'buffers are not supported');
+        }}"
+        ),
+      )
+      .await?;
+    }
     Ok(())
   }
 

--- a/libs/ops/op2/dispatch_fast.rs
+++ b/libs/ops/op2/dispatch_fast.rs
@@ -663,6 +663,17 @@ pub(crate) fn generate_dispatch_fast(
   Ok(Some((fast_definition, fast_definition_metrics, fast_fn)))
 }
 
+fn buffer_can_copy_invalid_backing_store(buffer: BufferType) -> bool {
+  matches!(
+    buffer,
+    BufferType::Slice(RefType::Ref, _)
+      | BufferType::Vec(_)
+      | BufferType::BoxSlice(_)
+      | BufferType::Bytes
+      | BufferType::BytesMut
+  )
+}
+
 fn fast_api_typed_array_to_buffer(
   generator_state: &mut GeneratorState,
   arg_ident: &Ident,
@@ -672,22 +683,25 @@ fn fast_api_typed_array_to_buffer(
   let convert = byte_slice_to_buffer(arg_ident, input, buffer)?;
   let throw_exception =
     throw_type_error(generator_state, "expected ArrayBufferView");
+  let throw_invalid_buffer = throw_type_error(
+    generator_state,
+    "resizable or shared buffers are not supported for this operation",
+  );
+  let temp = format_ident!("{input}_temp");
+  let element = buffer.element();
+  let copy_invalid = buffer_can_copy_invalid_backing_store(buffer);
   Ok(quote! {
     let Ok(#input) = #input.try_cast::<deno_core::v8::ArrayBufferView>() else {
         #throw_exception
     };
     let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-    // SAFETY: we are certain the implied lifetime is valid here as the slices never escape the
-    // fastcall.
-    let #input = unsafe {
-      let (input_ptr, input_len) = #input.get_contents_raw_parts(&mut buffer);
-      let input_ptr = if input_ptr.is_null() { ::std::ptr::dangling_mut() } else { input_ptr };
-      let slice = ::std::slice::from_raw_parts_mut::<'s>(input_ptr, input_len);
-      let (before, slice, after) = slice.align_to_mut();
-      debug_assert!(before.is_empty());
-      debug_assert!(after.is_empty());
-      slice
+    // SAFETY: the temporary buffer does not outlive the fast call.
+    let Ok(mut #temp) = (unsafe {
+      deno_core::_ops::to_fast_v8_slice::<#element, #copy_invalid>(#input, &mut buffer)
+    }) else {
+      #throw_invalid_buffer
     };
+    let #input = #temp.as_mut();
     #convert
   })
 }
@@ -736,6 +750,19 @@ fn map_v8_fastcall_arg_to_arg(
       let buf = v8slice_to_buffer(arg_ident, &arg_temp, *buffer)?;
       quote!(
         let Ok(mut #arg_temp) = deno_core::_ops::to_v8_slice(#arg_ident.into()) else {
+          #throw_exception
+        };
+        #buf
+      )
+    }
+    Arg::Buffer(buffer, _, BufferSource::ArrayBuffer)
+      if buffer_can_copy_invalid_backing_store(*buffer) =>
+    {
+      let throw_exception =
+        throw_type_error(generator_state, "expected ArrayBuffer");
+      let buf = v8slice_to_buffer(arg_ident, &arg_temp, *buffer)?;
+      quote!(
+        let Ok(mut #arg_temp) = deno_core::_ops::to_v8_slice_buffer_or_copy(#arg_ident.into()) else {
           #throw_exception
         };
         #buf

--- a/libs/ops/op2/dispatch_slow.rs
+++ b/libs/ops/op2/dispatch_slow.rs
@@ -932,6 +932,17 @@ pub fn from_arg_array_or_buffer(
   }
 }
 
+fn buffer_can_copy_invalid_backing_store(buffer_type: BufferType) -> bool {
+  matches!(
+    buffer_type,
+    BufferType::Slice(RefType::Ref, _)
+      | BufferType::Vec(_)
+      | BufferType::BoxSlice(_)
+      | BufferType::Bytes
+      | BufferType::BytesMut
+  )
+}
+
 pub fn from_arg_buffer(
   generator_state: &mut GeneratorState,
   arg_ident: &Ident,
@@ -947,6 +958,8 @@ pub fn from_arg_buffer(
   let to_v8_slice = if matches!(buffer_mode, BufferMode::Detach) {
     generator_state.needs_scope = true;
     gs_quote!(generator_state(scope) => { deno_core::_ops::to_v8_slice_detachable::<#array>(&mut #scope, #arg_ident) })
+  } else if buffer_can_copy_invalid_backing_store(buffer_type) {
+    quote!(deno_core::_ops::to_v8_slice_or_copy::<#array>(#arg_ident))
   } else {
     quote!(deno_core::_ops::to_v8_slice::<#array>(#arg_ident))
   };
@@ -980,6 +993,8 @@ pub fn from_arg_arraybuffer(
 
   let to_v8_slice = if matches!(buffer_mode, BufferMode::Detach) {
     quote!(to_v8_slice_buffer_detachable)
+  } else if buffer_can_copy_invalid_backing_store(buffer_type) {
+    quote!(to_v8_slice_buffer_or_copy)
   } else {
     quote!(to_v8_slice_buffer)
   };
@@ -1013,6 +1028,8 @@ pub fn from_arg_any_buffer(
 
   let to_v8_slice = if matches!(buffer_mode, BufferMode::Detach) {
     quote!(to_v8_slice_any_detachable)
+  } else if buffer_can_copy_invalid_backing_store(buffer_type) {
+    quote!(to_v8_slice_any_or_copy)
   } else {
     quote!(to_v8_slice_any)
   };

--- a/libs/ops/op2/test_cases/sync/buffers.out
+++ b/libs/ops/op2/test_cases/sync/buffers.out
@@ -136,22 +136,23 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg0 = unsafe {
-                    let (input_ptr, input_len) = arg0
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg0_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u8, true>(arg0, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg0 = arg0_temp.as_mut();
                 let arg0 = arg0;
                 let Ok(arg1) = arg1.try_cast::<deno_core::v8::ArrayBufferView>() else {
                     {
@@ -168,22 +169,23 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg1 = unsafe {
-                    let (input_ptr, input_len) = arg1
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg1_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u8, false>(arg1, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg1 = arg1_temp.as_mut();
                 let arg1 = arg1;
                 let Ok(arg2) = arg2.try_cast::<deno_core::v8::ArrayBufferView>() else {
                     {
@@ -200,22 +202,23 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg2 = unsafe {
-                    let (input_ptr, input_len) = arg2
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg2_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u8, false>(arg2, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg2 = arg2_temp.as_mut();
                 let arg2 = if arg2.len() == 0 {
                     ::std::ptr::null_mut()
                 } else {
@@ -236,22 +239,23 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg3 = unsafe {
-                    let (input_ptr, input_len) = arg3
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg3_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u8, false>(arg3, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg3 = arg3_temp.as_mut();
                 let arg3 = if arg3.len() == 0 {
                     ::std::ptr::null_mut()
                 } else {
@@ -278,7 +282,9 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
-                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+                arg0_temp = match unsafe {
+                    deno_core::_ops::to_v8_slice_or_copy::<u8>(arg0)
+                } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
@@ -478,22 +484,23 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg0 = unsafe {
-                    let (input_ptr, input_len) = arg0
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg0_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u32, true>(arg0, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg0 = arg0_temp.as_mut();
                 let arg0 = arg0;
                 let Ok(arg1) = arg1.try_cast::<deno_core::v8::ArrayBufferView>() else {
                     {
@@ -510,22 +517,23 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg1 = unsafe {
-                    let (input_ptr, input_len) = arg1
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg1_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u32, false>(arg1, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg1 = arg1_temp.as_mut();
                 let arg1 = arg1;
                 let Ok(arg2) = arg2.try_cast::<deno_core::v8::ArrayBufferView>() else {
                     {
@@ -542,22 +550,23 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg2 = unsafe {
-                    let (input_ptr, input_len) = arg2
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg2_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u32, false>(arg2, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg2 = arg2_temp.as_mut();
                 let arg2 = if arg2.len() == 0 {
                     ::std::ptr::null_mut()
                 } else {
@@ -578,22 +587,23 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg3 = unsafe {
-                    let (input_ptr, input_len) = arg3
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg3_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u32, false>(arg3, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg3 = arg3_temp.as_mut();
                 let arg3 = if arg3.len() == 0 {
                     ::std::ptr::null_mut()
                 } else {
@@ -620,7 +630,9 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
-                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
+                arg0_temp = match unsafe {
+                    deno_core::_ops::to_v8_slice_or_copy::<u32>(arg0)
+                } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
@@ -733,7 +745,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                     None
                 } else {
                     arg0_temp = match unsafe {
-                        deno_core::_ops::to_v8_slice::<u8>(arg0)
+                        deno_core::_ops::to_v8_slice_or_copy::<u8>(arg0)
                     } {
                         Ok(arg0) => arg0,
                         Err(arg0_err) => {

--- a/libs/ops/op2/test_cases/sync/buffers_copy.out
+++ b/libs/ops/op2/test_cases/sync/buffers_copy.out
@@ -131,22 +131,23 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg0 = unsafe {
-                    let (input_ptr, input_len) = arg0
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg0_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u8, true>(arg0, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg0 = arg0_temp.as_mut();
                 let arg0 = arg0.to_vec();
                 let Ok(arg1) = arg1.try_cast::<deno_core::v8::ArrayBufferView>() else {
                     {
@@ -163,22 +164,23 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg1 = unsafe {
-                    let (input_ptr, input_len) = arg1
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg1_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u8, true>(arg1, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg1 = arg1_temp.as_mut();
                 let arg1 = arg1.to_vec().into_boxed_slice();
                 let Ok(arg2) = arg2.try_cast::<deno_core::v8::ArrayBufferView>() else {
                     {
@@ -195,22 +197,23 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg2 = unsafe {
-                    let (input_ptr, input_len) = arg2
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg2_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u8, true>(arg2, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg2 = arg2_temp.as_mut();
                 let arg2 = arg2.to_vec().into();
                 Self::call(arg0, arg1, arg2)
             };
@@ -233,7 +236,9 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
-                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+                arg0_temp = match unsafe {
+                    deno_core::_ops::to_v8_slice_or_copy::<u8>(arg0)
+                } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
@@ -243,7 +248,9 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 let arg0 = arg0_temp.to_vec();
                 let arg1 = args.get(1usize as i32);
                 let mut arg1_temp;
-                arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
+                arg1_temp = match unsafe {
+                    deno_core::_ops::to_v8_slice_or_copy::<u8>(arg1)
+                } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
                         deno_core::_ops::throw_error_one_byte_info(&info, arg1_err);
@@ -253,7 +260,9 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 let arg1 = arg1_temp.to_boxed_slice();
                 let arg2 = args.get(2usize as i32);
                 let mut arg2_temp;
-                arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
+                arg2_temp = match unsafe {
+                    deno_core::_ops::to_v8_slice_or_copy::<u8>(arg2)
+                } {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
                         deno_core::_ops::throw_error_one_byte_info(&info, arg2_err);
@@ -400,22 +409,23 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg0 = unsafe {
-                    let (input_ptr, input_len) = arg0
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg0_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u32, true>(arg0, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg0 = arg0_temp.as_mut();
                 let arg0 = arg0.to_vec();
                 let Ok(arg1) = arg1.try_cast::<deno_core::v8::ArrayBufferView>() else {
                     {
@@ -432,22 +442,23 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     }
                 };
                 let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
-                let arg1 = unsafe {
-                    let (input_ptr, input_len) = arg1
-                        .get_contents_raw_parts(&mut buffer);
-                    let input_ptr = if input_ptr.is_null() {
-                        ::std::ptr::dangling_mut()
-                    } else {
-                        input_ptr
-                    };
-                    let slice = ::std::slice::from_raw_parts_mut::<
-                        's,
-                    >(input_ptr, input_len);
-                    let (before, slice, after) = slice.align_to_mut();
-                    debug_assert!(before.is_empty());
-                    debug_assert!(after.is_empty());
-                    slice
+                let Ok(mut arg1_temp) = (unsafe {
+                    deno_core::_ops::to_fast_v8_slice::<u32, true>(arg1, &mut buffer)
+                }) else {
+                    {
+                        let scope = ::std::pin::pin!(
+                            unsafe { deno_core::v8::CallbackScope::new(& *
+                            fast_api_callback_options) }
+                        );
+                        let mut scope = scope.init();
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "resizable or shared buffers are not supported for this operation",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
                 };
+                let arg1 = arg1_temp.as_mut();
                 let arg1 = arg1.to_vec().into_boxed_slice();
                 Self::call(arg0, arg1)
             };
@@ -470,7 +481,9 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
-                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
+                arg0_temp = match unsafe {
+                    deno_core::_ops::to_v8_slice_or_copy::<u32>(arg0)
+                } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
@@ -480,7 +493,9 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 let arg0 = arg0_temp.to_vec();
                 let arg1 = args.get(1usize as i32);
                 let mut arg1_temp;
-                arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
+                arg1_temp = match unsafe {
+                    deno_core::_ops::to_v8_slice_or_copy::<u32>(arg1)
+                } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
                         deno_core::_ops::throw_error_one_byte_info(&info, arg1_err);

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -3,6 +3,8 @@ import {
   Buffer,
   constants,
   File as BufferFile,
+  isAscii,
+  isUtf8,
   resolveObjectURL,
   transcode,
 } from "node:buffer";
@@ -10,6 +12,20 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { strictEqual } from "node:assert";
 
 const { MAX_STRING_LENGTH } = constants;
+
+Deno.test("[node/buffer] isUtf8 and isAscii snapshot shared and resizable inputs", () => {
+  const shared = new Uint8Array(new SharedArrayBuffer(4));
+  shared.set([0x64, 0x65, 0x6e, 0x6f]);
+  assertEquals(isUtf8(shared), true);
+  assertEquals(isAscii(shared), true);
+
+  const resizable = new Uint8Array(
+    new ArrayBuffer(4, { maxByteLength: 8 }),
+  );
+  resizable.set([0x64, 0x65, 0x6e, 0x6f]);
+  assertEquals(isUtf8(resizable), true);
+  assertEquals(isAscii(resizable), true);
+});
 
 Deno.test({
   name: "[node/buffer] alloc fails if size is not a number",


### PR DESCRIPTION
This updates op2 buffer conversion so generated ops do not borrow slices from backing stores whose address or concurrency properties can change.

Read-only shared and resizable inputs are snapshotted before dispatch, preserving ordinary input behavior. Mutable, retained, and raw-pointer mappings reject those stores because copying would change their mutation or ownership contract. Detach-mode buffers keep their existing ownership-transfer path.

The fast and slow dispatch paths now apply the same rules. Regression coverage exercises shared and resizable typed arrays, ArrayBuffers, DataViews, retained buffers, raw pointers, copy-mode inputs, and Node isUtf8/isAscii compatibility.

Tests:
- cargo test -p deno_ops
- cargo test -p deno_core
- cargo test -p unit_node_tests --test unit_node -- buffer_test
- cargo clippy -p deno_core -p deno_ops --all-targets -- -D warnings
- ./tools/format.js --check
- ./tools/lint.js --js