### PR TITLE
perf: compress bundled AppImage runtimes

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -401,6 +401,25 @@ fn check_appimage_runtime_hashes() {
   }
 }
 
+fn compress_appimage_runtimes(out_dir: &Path) {
+  let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+  let output_dir = out_dir.join("appimage_runtime");
+  std::fs::create_dir_all(&output_dir).unwrap();
+
+  for (rel, _) in APPIMAGE_RUNTIME_HASHES {
+    let path = Path::new(&manifest_dir).join(rel);
+    let contents = std::fs::read(&path).unwrap();
+    let compressed = zstd::bulk::compress(&contents, 19).unwrap();
+    let mut output = Vec::with_capacity(4 + compressed.len());
+    output.extend_from_slice(&(contents.len() as u32).to_le_bytes());
+    output.extend_from_slice(&compressed);
+
+    let file_name = path.file_name().unwrap().to_string_lossy();
+    std::fs::write(output_dir.join(format!("{file_name}.zstd")), output)
+      .unwrap();
+  }
+}
+
 fn emit_dts_rerun_if_changed() {
   let dts_dir = Path::new("tsc/dts");
   for entry in std::fs::read_dir(dts_dir).unwrap() {
@@ -413,12 +432,15 @@ fn emit_dts_rerun_if_changed() {
 }
 
 fn main() {
+  let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+
+  check_appimage_runtime_hashes();
+  compress_appimage_runtimes(&out_dir);
+
   // Skip building from docs.rs.
   if env::var_os("DOCS_RS").is_some() {
     return;
   }
-
-  check_appimage_runtime_hashes();
 
   deno_napi::print_linker_flags("deno");
   deno_webgpu::print_linker_flags("deno");
@@ -434,8 +456,6 @@ fn main() {
 
   // To debug snapshot issues uncomment:
   // op_fetch_asset::trace_serializer();
-
-  let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
 
   process_node_types(&out_dir);
 

--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -3332,13 +3332,18 @@ fn create_macos_dmg(
   Ok(())
 }
 
-/// AppImage Type-2 runtime ELF stubs, vendored from
-/// github.com/AppImage/type2-runtime at tag `20251108`. Prepended verbatim to
-/// the SquashFS payload to form the final AppImage.
-const APPIMAGE_RUNTIME_X86_64: &[u8] =
-  include_bytes!("appimage_runtime/runtime-x86_64");
-const APPIMAGE_RUNTIME_AARCH64: &[u8] =
-  include_bytes!("appimage_runtime/runtime-aarch64");
+/// Zstd-compressed AppImage Type-2 runtime ELF stubs, vendored from
+/// github.com/AppImage/type2-runtime at tag `20251108`. The selected runtime
+/// is decompressed and prepended to the SquashFS payload when creating an
+/// AppImage.
+const APPIMAGE_RUNTIME_X86_64: &[u8] = include_bytes!(concat!(
+  env!("OUT_DIR"),
+  "/appimage_runtime/runtime-x86_64.zstd"
+));
+const APPIMAGE_RUNTIME_AARCH64: &[u8] = include_bytes!(concat!(
+  env!("OUT_DIR"),
+  "/appimage_runtime/runtime-aarch64.zstd"
+));
 
 /// 1×1 transparent PNG, used when the caller didn't supply an icon.
 /// appimagetool-built AppImages expect a top-level `<Name>.png` to exist.
@@ -3356,17 +3361,23 @@ const STUB_ICON_PNG: &[u8] = &[
 /// arch (e.g. `x86_64-unknown-linux-gnu` → `x86_64`).
 fn appimage_runtime_for_target(
   target: Option<&str>,
-) -> Result<&'static [u8], AnyError> {
+) -> Result<Vec<u8>, AnyError> {
   let arch = target
     .and_then(|t| t.split('-').next())
     .unwrap_or(std::env::consts::ARCH);
-  match arch {
-    "x86_64" => Ok(APPIMAGE_RUNTIME_X86_64),
-    "aarch64" => Ok(APPIMAGE_RUNTIME_AARCH64),
+  let compressed = match arch {
+    "x86_64" => APPIMAGE_RUNTIME_X86_64,
+    "aarch64" => APPIMAGE_RUNTIME_AARCH64,
     other => bail!(
       "No bundled AppImage runtime for arch '{other}'; supported: x86_64, aarch64"
     ),
-  }
+  };
+  let uncompressed_len =
+    u32::from_le_bytes(compressed[..4].try_into().unwrap());
+  zstd::bulk::decompress(&compressed[4..], uncompressed_len as usize)
+    .with_context(|| {
+      format!("Failed to decompress AppImage runtime for {arch}")
+    })
 }
 
 /// Unix mode bits for a filesystem entry. On non-Unix hosts (cross-compiling
@@ -3517,7 +3528,7 @@ fn create_linux_appimage(
   let mut out = std::fs::File::create(appimage_path).with_context(|| {
     format!("Failed to create AppImage at {}", appimage_path.display())
   })?;
-  out.write_all(runtime_elf)?;
+  out.write_all(&runtime_elf)?;
   out.write_all(&squashfs.into_inner())?;
   drop(out);
 
@@ -5776,12 +5787,15 @@ def456  other.zip
 
   #[test]
   fn appimage_runtime_target_arch_lookup() {
-    assert!(
-      appimage_runtime_for_target(Some("x86_64-unknown-linux-gnu")).is_ok()
-    );
-    assert!(
-      appimage_runtime_for_target(Some("aarch64-unknown-linux-gnu")).is_ok()
-    );
+    let x86_64 =
+      appimage_runtime_for_target(Some("x86_64-unknown-linux-gnu")).unwrap();
+    assert_eq!(x86_64.len(), 944_632);
+    assert_eq!(&x86_64[..4], b"\x7fELF");
+
+    let aarch64 =
+      appimage_runtime_for_target(Some("aarch64-unknown-linux-gnu")).unwrap();
+    assert_eq!(aarch64.len(), 936_456);
+    assert_eq!(&aarch64[..4], b"\x7fELF");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- compress the bundled x86_64 and aarch64 AppImage runtime stubs with zstd at build time
- decompress only the selected target runtime when creating an AppImage
- preserve cross-target AppImage generation and validate the decompressed ELF sizes and magic

Both uncompressed runtime stubs were previously embedded in every Deno binary. The compressed payloads total 856,583 bytes, down from 1,881,088 bytes. Normal Deno execution does not decompress them or allocate a corresponding heap buffer; decompression only occurs in the AppImage packaging path.

## Size impact

Measured from clean, consecutive aarch64 macOS release builds at the same revision with:

```
DENO_SNAPSHOT_MINIFY_SOURCES=1 cargo build --release --locked -p deno --bin deno
```

| Measurement | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Binary size | 120,999,168 bytes | 119,975,968 bytes | -1,023,200 bytes |
| `__TEXT,__const` | 25,581,528 bytes | 24,557,528 bytes | -1,024,000 bytes |
| `__TEXT,__text` | 51,627,596 bytes | 51,627,596 bytes | unchanged |

This removes exactly 1000 KiB from `__TEXT,__const`.

## Validation

- decompressed both generated payloads and verified their SHA-256 hashes match the vendored originals
- `DENO_SNAPSHOT_MINIFY_SOURCES=1 cargo test --release --locked -p deno --lib appimage_ -- --nocapture` (3 passed)
- release build completed successfully
- `target/release/deno eval 'console.log("ok")'`
- `./tools/format.js cli/build.rs cli/tools/desktop.rs`
