### PR TITLE
perf(core): avoid duplicating lazy ESM snapshot sources

### DIFF
--- a/libs/core/runtime/bindings.rs
+++ b/libs/core/runtime/bindings.rs
@@ -183,7 +183,7 @@ pub(crate) fn create_external_references(
 
 /// Result of [`externalize_sources`]: the `v8::OneByteConst` backings, the
 /// original source strings they borrow from (kept alive), and the specifiers of
-/// the externalized `lazy_loaded_js` sources (parallel to the trailing
+/// the externalized `lazy_loaded_*` sources (parallel to the trailing
 /// `original_sources` entries).
 pub(crate) type ExternalizedSources = (
   Box<[v8::OneByteConst]>,
@@ -222,13 +222,14 @@ pub(crate) fn externalize_sources(
     } else {
       0
     };
-  // Record the externalized `lazy_loaded_js` specifiers in iteration order
+  // Record the externalized `lazy_loaded_*` specifiers in iteration order
   // (these become the trailing entries of `original_sources`). `snapshot()`
-  // uses them to drop non-consumed scripts' bytes from the sidecar.
-  let lazy_js_specifiers: Box<[ModuleName]> = if externalize_lazy_js {
+  // uses them to drop non-consumed sources' bytes from the sidecar.
+  let lazy_source_specifiers: Box<[ModuleName]> = if externalize_lazy_js {
     sources
-      .lazy_js
+      .lazy_esm
       .iter()
+      .chain(sources.lazy_js.iter())
       .map(|s| s.specifier.try_clone().unwrap())
       .collect()
   } else {
@@ -293,7 +294,7 @@ pub(crate) fn externalize_sources(
     (
       externals,
       original_sources.into_boxed_slice(),
-      lazy_js_specifiers,
+      lazy_source_specifiers,
     )
   }
 }

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -163,14 +163,14 @@ pub type ExtensionTranspiler =
 pub(crate) struct IsolateAllocations {
   pub(crate) externalized_sources: Box<[v8::OneByteConst]>,
   pub(crate) original_sources: Box<[FastString]>,
-  /// Specifiers of the externalized `lazy_loaded_js` sources, parallel to the
+  /// Specifiers of the externalized `lazy_loaded_*` sources, parallel to the
   /// trailing entries of `original_sources` (only populated when building a
   /// snapshot). Used at serialize time to drop the bytes of *non-consumed*
-  /// lazy scripts from the snapshot sidecar — their external-reference slots
+  /// lazy sources from the snapshot sidecar — their external-reference slots
   /// must stay (for index alignment) but nothing references them, so storing
   /// empty bytes avoids duplicating residual sources (which the binary already
   /// ships via the residual table).
-  pub(crate) lazy_js_specifiers: Box<[ModuleName]>,
+  pub(crate) lazy_source_specifiers: Box<[ModuleName]>,
   pub(crate) near_heap_limit_callback_data:
     Option<(Box<RefCell<dyn Any>>, v8::NearHeapLimitCallback)>,
 }
@@ -961,7 +961,7 @@ impl JsRuntime {
     (
       isolate_allocations.externalized_sources,
       isolate_allocations.original_sources,
-      isolate_allocations.lazy_js_specifiers,
+      isolate_allocations.lazy_source_specifiers,
     ) = bindings::externalize_sources(
       &mut sources,
       snapshot_sources,
@@ -2874,24 +2874,26 @@ impl JsRuntimeForSnapshot {
     self.inner.prepare_for_cleanup();
     let original_sources =
       std::mem::take(&mut self.0.allocations.original_sources);
-    let lazy_js_specifiers =
-      std::mem::take(&mut self.0.allocations.lazy_js_specifiers);
-    // `lazy_loaded_js` sources are externalized for the snapshot (so consumed
-    // scripts bake in as clean external strings), but only the *consumed* ones
+    let lazy_source_specifiers =
+      std::mem::take(&mut self.0.allocations.lazy_source_specifiers);
+    // `lazy_loaded_*` sources are externalized for the snapshot (so consumed
+    // sources bake in as clean external strings), but only the *consumed* ones
     // are actually referenced by snapshotted code. Non-consumed (residual)
-    // scripts are already shipped via the residual table, so persisting their
+    // sources are already shipped via the residual table, so persisting their
     // bytes here would duplicate them. Store empty bytes for those slots — the
     // external-reference index is preserved (nothing references it), avoiding
     // the duplication.
     let consumed: std::collections::HashSet<String> =
       self.consumed_lazy_specifiers().into_iter().collect();
-    let lazy_js_start = original_sources.len() - lazy_js_specifiers.len();
+    let lazy_source_start =
+      original_sources.len() - lazy_source_specifiers.len();
     let external_strings = original_sources
       .iter()
       .enumerate()
       .map(|(i, s)| {
-        if i >= lazy_js_start
-          && !consumed.contains(lazy_js_specifiers[i - lazy_js_start].as_str())
+        if i >= lazy_source_start
+          && !consumed
+            .contains(lazy_source_specifiers[i - lazy_source_start].as_str())
         {
           return &[][..];
         }

--- a/libs/core/runtime/tests/snapshot.rs
+++ b/libs/core/runtime/tests/snapshot.rs
@@ -482,6 +482,17 @@ fn lazy_loaded_esm_not_snapshotted_but_metadata_survives() {
 
   let snapshot = Box::leak(snapshot);
 
+  // The source is already embedded in the residual source table passed to the
+  // runtime below. Keep its external-string slot for snapshot index alignment,
+  // but do not duplicate its bytes in the snapshot sidecar.
+  {
+    let (_, sidecar) = crate::runtime::snapshot::deconstruct(snapshot);
+    assert_eq!(
+      sidecar.snapshot_data.external_strings.last().copied(),
+      Some(&[][..])
+    );
+  }
+
   // When loading from the snapshot, the lazy ESM module should NOT
   // be in the module map (not compiled/instantiated), but the metadata
   // should be present in known_lazy_esm.


### PR DESCRIPTION
## Summary

- track lazy ESM specifiers alongside lazy JS specifiers while externalizing snapshot sources
- serialize empty external-string slots for unconsumed lazy sources already present in the residual source table
- assert that an unconsumed lazy ESM slot is empty and still loads successfully after restoring the snapshot

## Why

The CLI snapshot sidecar retained all 615,312 bytes of its 104 unconsumed lazy ESM sources. The same sources are already embedded in the residual source table for first-use loading. Unconsumed lazy JS sources already used empty sidecar slots; this applies the same treatment to lazy ESM while preserving external-reference indices.

This does not add runtime decompression or a writable source buffer. The source remains available from the existing residual table.

## Size impact

macOS arm64 release build with `DENO_SNAPSHOT_MINIFY_SOURCES=1`:

| | Before | After | Change |
|---|---:|---:|---:|
| CLI snapshot | 2,550,903 | 1,935,591 | -615,312 bytes |
| `__TEXT,__const` | 24,557,528 | 23,942,216 | -615,312 bytes |
| linked binary | 119,975,968 | 119,348,512 | -627,456 bytes |

The V8 blob is unchanged at 1,604,320 bytes; the sidecar drops from 946,575 to 331,263 bytes.

## Validation

- `./tools/format.js --check libs/core/runtime/bindings.rs libs/core/runtime/jsruntime.rs libs/core/runtime/tests/snapshot.rs`
- `cargo test --locked -p deno_core`

