### PR TITLE
perf(snapshot): mangle internal source identifiers

### DIFF
--- a/runtime/transpile.rs
+++ b/runtime/transpile.rs
@@ -150,7 +150,9 @@ const filename = Deno.args[0] ?? "source.js";
 const source = await new Response(Deno.stdin.readable).text();
 const result = minifySync(filename, source, {
   compress: false,
-  mangle: false,
+  mangle: {
+    keepNames: true,
+  },
   codegen: {
     removeWhitespace: true,
     legalComments: "none",


### PR DESCRIPTION
## Summary

- enable Rolldown identifier mangling for release snapshot sources
- preserve function and class names with `keepNames: true`
- keep semantic compression disabled

## Why

Release snapshot sources are already passed through Rolldown to remove comments and whitespace, but identifier mangling is disabled. Name-preserving mangling substantially reduces the residual source table and also shrinks sources stored in the V8 snapshot sidecar, without runtime compression or decompression.

Keeping semantic compression disabled limits this change to binding renaming. `keepNames` retains observable function and class names.

## Size impact

macOS arm64 release build with `DENO_SNAPSHOT_MINIFY_SOURCES=1`:

| | Before | After | Change |
|---|---:|---:|---:|
| Residual source files | 2,565,415 | 1,838,699 | -726,716 bytes |
| CLI snapshot | 2,550,903 | 2,285,429 | -265,474 bytes |
| `__TEXT,__const` | 24,557,528 | 23,562,200 | -995,328 bytes |
| linked binary | 119,975,968 | 118,968,736 | -1,007,232 bytes |

The V8 blob drops from 1,604,320 to 1,586,400 bytes and the sidecar from 946,575 to 699,021 bytes.

## Validation

- `./tools/format.js --check runtime/transpile.rs`
- full locked release build
- all Node built-in modules import successfully
- observable function names and arities for `globalThis`, `Deno`, and every Node built-in export match the non-mangled build
- `deno check`, `fmt --check`, `lint`, and focused `deno test` smokes
- file-stat decoding and `CompressionStream` smokes
