### PR TITLE
fix(fmt): honor .editorconfig when formatting from stdin

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -65,20 +65,28 @@ pub async fn format(
     let start_dir = &cli_options.start_dir;
     let fmt_config = start_dir
       .to_fmt_config(FilePatterns::new_with_base(start_dir.dir_path()))?;
-    let fmt_options = FmtOptions::resolve(
+    let mut fmt_options = FmtOptions::resolve(
       fmt_config,
       cli_options.resolve_config_unstable_fmt_options(),
       &fmt_flags,
     );
-    return format_stdin(
-      &fmt_flags,
-      fmt_options,
-      cli_options
-        .ext_flag()
-        .as_ref()
-        .map(|s| s.as_str())
-        .unwrap_or("ts"),
+    let ext = cli_options
+      .ext_flag()
+      .as_ref()
+      .map(|s| s.as_str())
+      .unwrap_or("ts")
+      .to_string();
+    // Honor `.editorconfig` for stdin the same way file-based formatting
+    // does, resolving it against a synthetic path in the current directory
+    // (https://github.com/denoland/deno/issues/36172).
+    let editorconfig_cache = EditorConfigCache::new();
+    let stdin_path = cli_options.initial_cwd().join(format!("_stdin.{ext}"));
+    fmt_options.options = resolve_per_file_options(
+      &fmt_options.options,
+      &editorconfig_cache,
+      &stdin_path,
     );
+    return format_stdin(&fmt_flags, fmt_options, &ext);
   }
 
   if let Some(watch_flags) = &flags.watch {

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -74,11 +74,15 @@ pub async fn format(
       .ext_flag()
       .as_ref()
       .map(|s| s.as_str())
-      .unwrap_or("ts")
-      .to_string();
-    // Honor `.editorconfig` for stdin the same way file-based formatting
-    // does, resolving it against a synthetic path in the current directory
-    // (https://github.com/denoland/deno/issues/36172).
+      .unwrap_or("ts");
+    // Honor `.editorconfig` for stdin the same way file-based formatting does,
+    // resolving it against a synthetic `_stdin.<ext>` path. The resolution base
+    // is the current working directory, not the (possibly relocated via
+    // `--config`) config start dir: stdin has no real location, so the cwd is
+    // the only meaningful place to look for an `.editorconfig`
+    // (https://github.com/denoland/deno/issues/36172). Build the synthetic path
+    // once and pass it down so editorconfig matching and the dprint call can
+    // never diverge on the name.
     let editorconfig_cache = EditorConfigCache::new();
     let stdin_path = cli_options.initial_cwd().join(format!("_stdin.{ext}"));
     fmt_options.options = resolve_per_file_options(
@@ -86,7 +90,7 @@ pub async fn format(
       &editorconfig_cache,
       &stdin_path,
     );
-    return format_stdin(&fmt_flags, fmt_options, &ext);
+    return format_stdin(&fmt_flags, fmt_options, &stdin_path);
   }
 
   if let Some(watch_flags) = &flags.watch {
@@ -1241,7 +1245,7 @@ fn format_ensure_stable(
 fn format_stdin(
   fmt_flags: &FmtFlags,
   fmt_options: FmtOptions,
-  ext: &str,
+  file_path: &Path,
 ) -> Result<(), AnyError> {
   let mut source = String::new();
   if stdin().read_to_string(&mut source).is_err() {
@@ -1251,9 +1255,8 @@ fn format_stdin(
     had_bom: false,
     text: source.into(),
   };
-  let file_path = PathBuf::from(format!("_stdin.{ext}"));
   let formatted_text = format_file(
-    &file_path,
+    file_path,
     &file,
     &fmt_options.options,
     &fmt_options.unstable,

--- a/tests/specs/fmt/editorconfig/__test__.jsonc
+++ b/tests/specs/fmt/editorconfig/__test__.jsonc
@@ -56,6 +56,23 @@
       "output": "[WILDCARD]Found 1 not formatted file in 1 file\n",
       "exitCode": 1
     },
+    "stdin_infers_indent_size": {
+      // Formatting from stdin must honor .editorconfig (indent_size=4)
+      // resolved from the current directory, matching file-based formatting
+      // (https://github.com/denoland/deno/issues/36172). The input is
+      // indented with 2 spaces and should be reformatted to 4.
+      "args": "fmt -",
+      "input": "function greet(name: string) {\n  return \"hello \" + name;\n}\n",
+      "output": "function greet(name: string) {\n    return \"hello \" + name;\n}\n"
+    },
+    "stdin_no_editorconfig_flag_opts_out": {
+      // --no-editorconfig disables reading .editorconfig for stdin too, so
+      // deno's default 2-space indent applies and the already-2-space input
+      // is left unchanged.
+      "args": "fmt --no-editorconfig -",
+      "input": "function greet(name: string) {\n  return \"hello \" + name;\n}\n",
+      "output": "function greet(name: string) {\n  return \"hello \" + name;\n}\n"
+    },
     "logs_at_debug": {
       // With -L debug, fmt notes that it found and is using the .editorconfig.
       "args": "fmt --check -L debug indent_size_4.ts",

--- a/tests/specs/fmt/editorconfig/__test__.jsonc
+++ b/tests/specs/fmt/editorconfig/__test__.jsonc
@@ -73,6 +73,23 @@
       "input": "function greet(name: string) {\n  return \"hello \" + name;\n}\n",
       "output": "function greet(name: string) {\n  return \"hello \" + name;\n}\n"
     },
+    "stdin_check_reports_not_formatted": {
+      // `fmt --check -` honors .editorconfig (indent_size=4) for stdin; the
+      // 2-space input differs from the formatted result, so check reports it
+      // via "Not formatted stdin" rather than emitting the reformatted text.
+      "args": "fmt --check -",
+      "input": "function greet(name: string) {\n  return \"hello \" + name;\n}\n",
+      "output": "Not formatted stdin\n"
+    },
+    "stdin_deno_json_use_editor_config_false_opts_out": {
+      // "useEditorConfig": false in deno.json disables .editorconfig for stdin
+      // too, so the root indent_size=4 is ignored and deno's default 2-space
+      // indent leaves the already-2-space input unchanged. Locks the deno.json
+      // opt-out for stdin, not just the --no-editorconfig CLI flag.
+      "args": "fmt --config opt_out/deno.json -",
+      "input": "function greet(name: string) {\n  return \"hello \" + name;\n}\n",
+      "output": "function greet(name: string) {\n  return \"hello \" + name;\n}\n"
+    },
     "logs_at_debug": {
       // With -L debug, fmt notes that it found and is using the .editorconfig.
       "args": "fmt --check -L debug indent_size_4.ts",


### PR DESCRIPTION
`deno fmt -` (stdin) resolved formatting options from `deno.json` but never read `.editorconfig`, while formatting a file on disk did. So piping a file through `deno fmt` ignored editorconfig settings like `indent_size`.

Fix resolves `.editorconfig` for a synthetic path in the current directory and folds it into the stdin format options, the same way file-based formatting does. `useEditorConfig: false` in deno.json and `--no-editorconfig` still opt out.

Added spec coverage in `tests/specs/fmt/editorconfig` for the stdin path (applies editorconfig, and opts out under `--no-editorconfig`).

Closes #36172