### PR TITLE
fix(watch): don't let a re-raised signal kill the watcher on restart

### DIFF
--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -457,6 +457,15 @@ where
         // Dispatch SIGTERM to give JS code a chance for async cleanup
         // before restarting. If handlers are registered, wait for the
         // operation to finish gracefully before restarting.
+        //
+        // Suppress the OS default action for a terminating signal during this
+        // window: a JS handler may unregister itself and re-raise a real
+        // SIGTERM (the `signal-exit` "unload + re-raise" pattern bundled in
+        // Vite 8 / rolldown), which would otherwise terminate the watcher
+        // instead of restarting it. Set this before `raise()` because the
+        // re-raise happens synchronously inside the handler.
+        // https://github.com/denoland/deno/issues/35942
+        deno_signals::set_suppress_default_exit(true);
         if deno_signals::raise(deno_signals::SIGTERM) {
           info!(
             "{} Waiting for graceful termination...",
@@ -468,6 +477,7 @@ where
           )
           .await;
         }
+        deno_signals::set_suppress_default_exit(false);
         deno_runtime::deno_inspector_server::notify_restart();
         print_after_restart();
         continue;

--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -458,14 +458,16 @@ where
         // before restarting. If handlers are registered, wait for the
         // operation to finish gracefully before restarting.
         //
-        // Suppress the OS default action for a terminating signal during this
+        // Suppress the OS default action for the SIGTERM we re-raise in this
         // window: a JS handler may unregister itself and re-raise a real
         // SIGTERM (the `signal-exit` "unload + re-raise" pattern bundled in
         // Vite 8 / rolldown), which would otherwise terminate the watcher
-        // instead of restarting it. Set this before `raise()` because the
-        // re-raise happens synchronously inside the handler.
-        // https://github.com/denoland/deno/issues/35942
-        deno_signals::set_suppress_default_exit(true);
+        // instead of restarting it. Arm before `raise()` because the re-raise
+        // happens synchronously inside the handler. The guard is one-shot and
+        // disarms on drop, so a genuine external SIGTERM (or a Ctrl+C) in this
+        // window is not swallowed. See issue #35942.
+        let _suppress_guard =
+          deno_signals::suppress_default_exit_for(deno_signals::SIGTERM);
         if deno_signals::raise(deno_signals::SIGTERM) {
           info!(
             "{} Waiting for graceful termination...",
@@ -477,7 +479,6 @@ where
           )
           .await;
         }
-        deno_signals::set_suppress_default_exit(false);
         deno_runtime::deno_inspector_server::notify_restart();
         print_after_restart();
         continue;

--- a/ext/signals/lib.rs
+++ b/ext/signals/lib.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 
@@ -18,6 +19,26 @@ static SIGHUP: i32 = 1;
 static SIGWINCH: i32 = 28;
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+// While set, an unhandled terminating signal (SIGTERM/SIGINT/SIGHUP) delivered
+// to the OS signal thread is consumed instead of running the exit callbacks and
+// the OS default action. The file watcher enables this for the duration of a
+// graceful restart, where a JS signal handler may unregister itself and re-raise
+// a real OS signal (the `signal-exit` "unload + re-raise" pattern used by Vite
+// 8 / rolldown) that would otherwise kill the watcher instead of restarting it.
+// See https://github.com/denoland/deno/issues/35942.
+static SUPPRESS_DEFAULT_EXIT: AtomicBool = AtomicBool::new(false);
+
+/// Suppress (or restore) the OS default action for an unhandled terminating
+/// signal. While suppressed, a SIGTERM/SIGINT/SIGHUP with no registered handler
+/// is consumed rather than terminating the process.
+pub fn set_suppress_default_exit(suppress: bool) {
+  SUPPRESS_DEFAULT_EXIT.store(suppress, Ordering::SeqCst);
+}
+
+fn is_terminating_signal(signal: i32) -> bool {
+  signal == SIGHUP || signal == SIGTERM || signal == SIGINT
+}
 
 type Handler = Box<dyn Fn() + Send>;
 type Handlers = HashMap<i32, Vec<(u32, bool, Handler)>>;
@@ -62,7 +83,13 @@ fn init() -> Handle {
     for signal in signals.forever() {
       let handled = handle_signal(signal);
       if !handled {
-        if signal == SIGHUP || signal == SIGTERM || signal == SIGINT {
+        if is_terminating_signal(signal) {
+          // A graceful restart (file watcher) may have unregistered the JS
+          // handler and re-raised this signal; consume it instead of killing
+          // the process. See https://github.com/denoland/deno/issues/35942.
+          if SUPPRESS_DEFAULT_EXIT.load(Ordering::SeqCst) {
+            continue;
+          }
           run_exit();
         }
         signal_hook::low_level::emulate_default_handler(signal).unwrap();
@@ -85,6 +112,14 @@ fn init() -> Handle {
       _ => return 0,
     };
     let handled = handle_signal(signal);
+    if !handled
+      && is_terminating_signal(signal)
+      && SUPPRESS_DEFAULT_EXIT.load(Ordering::SeqCst)
+    {
+      // Consume a re-raised terminating signal during a graceful restart
+      // (https://github.com/denoland/deno/issues/35942).
+      return 1;
+    }
     handled as _
   }
 

--- a/ext/signals/lib.rs
+++ b/ext/signals/lib.rs
@@ -3,7 +3,8 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::sync::OnceLock;
-use std::sync::atomic::AtomicBool;
+#[cfg(unix)]
+use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 
@@ -20,20 +21,49 @@ static SIGWINCH: i32 = 28;
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 
-// While set, an unhandled terminating signal (SIGTERM/SIGINT/SIGHUP) delivered
-// to the OS signal thread is consumed instead of running the exit callbacks and
-// the OS default action. The file watcher enables this for the duration of a
+// The single terminating signal number the OS signal thread should consume once
+// (instead of running the exit callbacks and the OS default action), or 0 when
+// nothing is suppressed. The file watcher arms this for the duration of a
 // graceful restart, where a JS signal handler may unregister itself and re-raise
 // a real OS signal (the `signal-exit` "unload + re-raise" pattern used by Vite
 // 8 / rolldown) that would otherwise kill the watcher instead of restarting it.
 // See https://github.com/denoland/deno/issues/35942.
-static SUPPRESS_DEFAULT_EXIT: AtomicBool = AtomicBool::new(false);
+#[cfg(unix)]
+static SUPPRESSED_SIGNAL: AtomicI32 = AtomicI32::new(0);
 
-/// Suppress (or restore) the OS default action for an unhandled terminating
-/// signal. While suppressed, a SIGTERM/SIGINT/SIGHUP with no registered handler
-/// is consumed rather than terminating the process.
-pub fn set_suppress_default_exit(suppress: bool) {
-  SUPPRESS_DEFAULT_EXIT.store(suppress, Ordering::SeqCst);
+/// Arm one-shot suppression of the OS default action for `signal` and return a
+/// guard that disarms on drop.
+///
+/// A graceful restart re-raises exactly one signal after unregistering its JS
+/// handler; only that single matching signal is consumed, so a genuine external
+/// signal (e.g. `kill <pid>` from a supervisor) in the same window still
+/// terminates. Signals other than `signal` — notably a real Ctrl+C — are never
+/// suppressed.
+///
+/// This only works because the re-raise happens synchronously inside the signal
+/// handler thread. A signal that arrives after the guard is dropped, or a
+/// library that re-raises after an `await`, lands with the flag already cleared
+/// and still terminates — this is a best-effort window, not a hard guarantee.
+///
+/// The mechanism is a no-op on non-unix targets: the bug only reproduces with a
+/// real OS re-raise, which does not exist on Windows (`raise()` is synthetic
+/// there).
+pub fn suppress_default_exit_for(signal: i32) -> SuppressDefaultExitGuard {
+  #[cfg(unix)]
+  SUPPRESSED_SIGNAL.store(signal, Ordering::Relaxed);
+  #[cfg(not(unix))]
+  let _ = signal;
+  SuppressDefaultExitGuard(())
+}
+
+/// Disarms the suppression armed by [`suppress_default_exit_for`] on drop.
+pub struct SuppressDefaultExitGuard(());
+
+impl Drop for SuppressDefaultExitGuard {
+  fn drop(&mut self) {
+    #[cfg(unix)]
+    SUPPRESSED_SIGNAL.store(0, Ordering::Relaxed);
+  }
 }
 
 fn is_terminating_signal(signal: i32) -> bool {
@@ -85,9 +115,15 @@ fn init() -> Handle {
       if !handled {
         if is_terminating_signal(signal) {
           // A graceful restart (file watcher) may have unregistered the JS
-          // handler and re-raised this signal; consume it instead of killing
-          // the process. See https://github.com/denoland/deno/issues/35942.
-          if SUPPRESS_DEFAULT_EXIT.load(Ordering::SeqCst) {
+          // handler and re-raised this signal; consume that single re-raise
+          // instead of killing the process. `compare_exchange` disarms as it
+          // matches, so at most one signal is swallowed and a genuine external
+          // signal still terminates. See
+          // https://github.com/denoland/deno/issues/35942.
+          if SUPPRESSED_SIGNAL
+            .compare_exchange(signal, 0, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+          {
             continue;
           }
           run_exit();
@@ -112,14 +148,6 @@ fn init() -> Handle {
       _ => return 0,
     };
     let handled = handle_signal(signal);
-    if !handled
-      && is_terminating_signal(signal)
-      && SUPPRESS_DEFAULT_EXIT.load(Ordering::SeqCst)
-    {
-      // Consume a re-raised terminating signal during a graceful restart
-      // (https://github.com/denoland/deno/issues/35942).
-      return 1;
-    }
     handled as _
   }
 

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -2396,6 +2396,57 @@ async fn run_watch_sigterm_on_restart() {
   check_alive_then_kill(child);
 }
 
+/// Test that a JS SIGTERM handler which unregisters itself and re-raises a
+/// real OS SIGTERM (the `signal-exit` "unload + re-raise" pattern bundled in
+/// Vite 8 / rolldown) does not kill the watcher: the process must restart on
+/// file change instead of terminating.
+/// Regression test for https://github.com/denoland/deno/issues/35942.
+#[cfg(unix)]
+#[test(flaky)]
+async fn run_watch_sigterm_reraise_on_restart() {
+  let t = TempDir::new();
+  let file_to_watch = t.path().join("file_to_watch.js");
+  let contents = r#"
+    import process from "node:process";
+    const handler = () => {
+      console.log("SIGTERM handler");
+      // Unregister self, then re-raise a real OS SIGTERM.
+      process.off("SIGTERM", handler);
+      process.kill(process.pid, "SIGTERM");
+    };
+    process.on("SIGTERM", handler);
+    setInterval(() => {}, 1000);
+  "#;
+  file_to_watch.write(contents);
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch")
+    .arg("-L")
+    .arg("debug")
+    .arg("--allow-all")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+
+  // Trigger a restart; the handler fires, unregisters itself and re-raises a
+  // real SIGTERM.
+  file_to_watch.write(format!("{contents}\n// changed"));
+
+  wait_contains("SIGTERM handler", &mut stdout_lines).await;
+  // The re-raised real SIGTERM must be suppressed so the watcher restarts
+  // instead of dying.
+  wait_contains("Restarting", &mut stderr_lines).await;
+  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+  check_alive_then_kill(child);
+}
+
 /// Test that both SIGINT and SIGTERM are dispatched on Ctrl+C in watch mode.
 #[cfg(unix)]
 #[test(flaky)]

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -2447,6 +2447,110 @@ async fn run_watch_sigterm_reraise_on_restart() {
   check_alive_then_kill(child);
 }
 
+/// A genuine external SIGTERM (e.g. `kill <pid>` from a supervisor) delivered
+/// around the graceful-restart window must still terminate the watcher.
+/// Suppression is one-shot: it swallows only the single re-raised SIGTERM, not
+/// a later external one. Guards against the flag being too broad/long-lived.
+#[cfg(unix)]
+#[test(flaky)]
+async fn run_watch_external_sigterm_still_terminates() {
+  use nix::sys::signal;
+  use nix::sys::signal::Signal;
+  use nix::unistd::Pid;
+
+  let t = TempDir::new();
+  let file_to_watch = t.path().join("file_to_watch.js");
+  // Same unregister-and-re-raise pattern that opens the suppression window.
+  let contents = r#"
+    import process from "node:process";
+    const handler = () => {
+      console.log("SIGTERM handler");
+      process.off("SIGTERM", handler);
+      process.kill(process.pid, "SIGTERM");
+    };
+    process.on("SIGTERM", handler);
+    setInterval(() => {}, 1000);
+  "#;
+  file_to_watch.write(contents);
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch")
+    .arg("-L")
+    .arg("debug")
+    .arg("--allow-all")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+
+  file_to_watch.write(format!("{contents}\n// changed"));
+  wait_contains("SIGTERM handler", &mut stdout_lines).await;
+
+  // The one re-raise is consumed; a second, external SIGTERM must not be
+  // suppressed and must bring the watcher down.
+  signal::kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM).unwrap();
+
+  let status = child.wait().unwrap();
+  assert!(!status.success());
+}
+
+/// Ctrl+C (SIGINT) around the graceful-restart window must still exit the
+/// watcher: only the re-raised SIGTERM is suppressed, never SIGINT.
+#[cfg(unix)]
+#[test(flaky)]
+async fn run_watch_ctrl_c_during_restart_still_exits() {
+  use std::os::unix::process::ExitStatusExt;
+
+  use nix::sys::signal;
+  use nix::sys::signal::Signal;
+  use nix::unistd::Pid;
+
+  let t = TempDir::new();
+  let file_to_watch = t.path().join("file_to_watch.js");
+  // A SIGTERM listener opens the graceful window on restart (raise() reports a
+  // handler). There is no SIGINT listener, so a Ctrl+C in the window is
+  // unhandled and must terminate rather than being swallowed.
+  let contents = r#"
+    Deno.addSignalListener("SIGTERM", () => {
+      console.log("received SIGTERM");
+    });
+    setInterval(() => {}, 1000);
+  "#;
+  file_to_watch.write(contents);
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch")
+    .arg("-L")
+    .arg("debug")
+    .arg("--allow-all")
+    .arg(&file_to_watch)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_for_watcher("file_to_watch.js", &mut stderr_lines).await;
+
+  // Trigger a restart to open the graceful window, then Ctrl+C during it.
+  file_to_watch.write(format!("{contents}\n// changed"));
+  wait_contains("received SIGTERM", &mut stdout_lines).await;
+  signal::kill(Pid::from_raw(child.id() as i32), Signal::SIGINT).unwrap();
+
+  // The watcher must terminate (by clean exit or by the signal) rather than
+  // suppressing the Ctrl+C and continuing to run.
+  let status = child.wait().unwrap();
+  assert!(status.code().is_some() || status.signal().is_some());
+}
+
 /// Test that both SIGINT and SIGTERM are dispatched on Ctrl+C in watch mode.
 #[cfg(unix)]
 #[test(flaky)]


### PR DESCRIPTION
On file change the watcher raises a synthetic SIGTERM to give JS code a chance to clean up before restarting. If a handler unregisters itself and then re-raises a *real* OS SIGTERM — the `signal-exit` "unload + re-raise" pattern bundled in Vite 8 / rolldown — that real signal reaches the signal thread with no handler registered, so it ran the exit callbacks + the OS default action and terminated the whole watcher instead of restarting it. Any Vite 8 dev server under `deno run --watch` dies on the first restart.

## Fix

Add a scoped suppression flag to `deno_signals`. While set, an unhandled terminating signal (SIGTERM/SIGINT/SIGHUP) is consumed instead of running the exit callbacks and the OS default action. The file watcher enables it around the graceful-restart window — set *before* `raise()`, since the re-raise happens synchronously inside the JS handler — and clears it once the graceful wait is done.

Scoped to the restart path only; normal exit and Ctrl+C behavior are unchanged.

## Test

`run_watch_sigterm_reraise_on_restart` in `tests/integration/watcher_tests.rs` reproduces the unload+re-raise pattern with `node:process` and asserts the watcher restarts (was: process died).

Closes #35942