### PR TITLE
fix(ext/web): close transfer MessagePort when a transferred readable is cancelled

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -7771,6 +7771,11 @@ function setUpCrossRealmTransformWritable(stream, port) {
         backpressurePromise.resolve();
         backpressurePromise = undefined;
       }
+      // The peer signalled it is done (e.g. the transferred readable was
+      // cancelled while still open). Close this port too, mirroring the
+      // readable side, so the transfer's internal MessagePort isn't leaked
+      // (https://github.com/denoland/deno/issues/36015).
+      port.close();
     }
   });
   port.addEventListener("messageerror", (event) => {

--- a/tests/unit/streams_test.ts
+++ b/tests/unit/streams_test.ts
@@ -1170,3 +1170,37 @@ Deno.test(
     await Deno.remove(outPath);
   },
 );
+
+// Cancelling a transferred ReadableStream while it is still open must close the
+// transfer's internal MessagePort. Otherwise the default resource sanitizer
+// reports a leaked message port (https://github.com/denoland/deno/issues/36015).
+Deno.test(
+  async function transferredReadableCancelWhileOpenClosesPort() {
+    const workerCode = `
+      self.onmessage = async (e) => {
+        const reader = e.data.getReader();
+        await reader.read(); // consume one chunk; the stream stays open
+        await reader.cancel("stop"); // cancel while still open
+        self.postMessage("done");
+        self.close();
+      };
+    `;
+    const worker = new Worker(
+      "data:application/javascript," + encodeURIComponent(workerCode),
+      { type: "module" },
+    );
+
+    const readable = new ReadableStream({
+      pull(controller) {
+        // Never closes, so the stream is still open when it is cancelled.
+        controller.enqueue(new Uint8Array(16));
+      },
+    });
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+    worker.onmessage = () => resolve();
+    worker.postMessage(readable, [readable]);
+    await promise;
+    worker.terminate();
+  },
+);

--- a/tests/unit/streams_test.ts
+++ b/tests/unit/streams_test.ts
@@ -1190,17 +1190,27 @@ Deno.test(
       { type: "module" },
     );
 
+    const { promise: cancelled, resolve: onCancel } = Promise
+      .withResolvers<string>();
     const readable = new ReadableStream({
       pull(controller) {
         // Never closes, so the stream is still open when it is cancelled.
         controller.enqueue(new Uint8Array(16));
       },
+      cancel(reason) {
+        // `pipeTo` only cancels the source after the transferred port's
+        // "error" handler has run (and thus after `port.close()`), so awaiting
+        // this is a deterministic assertion on the fix rather than relying on a
+        // cross-channel race with the worker's "done" message and the sanitizer.
+        onCancel(reason);
+      },
     });
 
-    const { promise, resolve } = Promise.withResolvers<void>();
-    worker.onmessage = () => resolve();
+    const { promise: done, resolve: onDone } = Promise.withResolvers<void>();
+    worker.onmessage = () => onDone();
     worker.postMessage(readable, [readable]);
-    await promise;
+    assertEquals(await cancelled, "stop");
+    await done;
     worker.terminate();
   },
 );


### PR DESCRIPTION
When a `ReadableStream` is transferred to a worker and then cancelled while still open, the transfer's internal `MessagePort` was never closed, so `Deno.test`'s resource sanitizer reported a leaked message port.

The cross-realm transform is asymmetric: on an `"error"` message the **readable** side closes its port (as does the normal `"close"` path on both sides), but the **writable** side only errored its controller and left its own port open. When the reader cancels a still-open stream it posts `"error"` to the writable side, whose port then leaked.

Fix closes the port in the writable `"error"` handler too, mirroring the readable side. Draining to completion and cancelling an already-ended stream were unaffected and remain so.

## Test

`transferredReadableCancelWhileOpenClosesPort` in `tests/unit/streams_test.ts` transfers a never-closing readable to a worker, cancels it mid-stream, and passes only if no port is leaked (caught by the default sanitizer).

Closes #36015