### PR TITLE
chore: bump v8 crate to 150.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11149,9 +11149,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "150.2.0"
+version = "150.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f4e905df70d6c00b95e69c5f0831fd5eb5889b0116ae2b30293578c19cd1bc"
+checksum = "a60e502a2130c372cdee0df8c1e614dab69a04ba439067dc4c0763cfd1ab92f7"
 dependencies = [
  "bindgen 0.72.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11149,9 +11149,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "150.3.0"
+version = "150.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60e502a2130c372cdee0df8c1e614dab69a04ba439067dc4c0763cfd1ab92f7"
+checksum = "42a978ff11f15b24e5c05a7123cf2b68f41e763546699781a924ef4e2cf43a49"
 dependencies = [
  "bindgen 0.72.1",
  "bitflags 2.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ deno_task_shell = "=0.33.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"
-v8 = { version = "150.2.0", default-features = false, features = ["simdutf"] }
+v8 = { version = "150.3.0", default-features = false, features = ["simdutf"] }
 
 denokv_proto = "0.14.0"
 denokv_remote = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ deno_task_shell = "=0.33.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"
-v8 = { version = "150.3.0", default-features = false, features = ["simdutf"] }
+v8 = { version = "150.4.0", default-features = false, features = ["simdutf"] }
 
 denokv_proto = "0.14.0"
 denokv_remote = "0.14.0"


### PR DESCRIPTION
Routine bump of the `v8` crate from **150.2.0** to **150.4.0** to stay current. The underlying C++ V8 engine is unchanged at `15.0.245.2`; the delta is entirely in the rusty_v8 binding layer's string paths.

- **150.2.0 → 150.3.0** — fewer `String::Length()` FFI calls, `simdutf` for `new_from_utf8`, single-pass UTF-16 → UTF-8, SIMD one-byte ASCII detection, direct `ValueView` field access.
- **150.3.0 → 150.4.0** — [rusty_v8#2029](https://github.com/denoland/rusty_v8/pull/2029): SIMD ASCII detection in `new_from_utf8`, fused one-byte read paths in `to_rust_cow_lossy` / `to_rust_string_lossy`. (`git diff v150.3.0..v150.4.0` = exactly that PR.)

## Impact: no change for Deno, no regressions

Benchmarked to confirm this is a safe bump, **not** to claim a speedup. E2E across `TextDecoder.decode`, `TextEncoder.encodeInto`, and `TextEncoder.encode` (ascii / latin1 / twobyte / emoji, 256 B – 64 KB, best-of-5 interleaved) is **neutral within noise, with no regressions**.

The rusty_v8 functions themselves are measurably faster in isolation (e.g. `new_from_utf8` ASCII +44–49%, `to_rust_string_lossy` +12–18% at ≥4 KB), but that does not surface in Deno because:

- `op_decode` already fast-paths ASCII with `simdutf::validate_ascii` + `new_from_one_byte`, short-circuiting *before* `new_from_utf8` — so the headline `new_from_utf8` ASCII win is redundant for `TextDecoder.decode`.
- For the other paths the string conversion is a small fraction of total op cost (dispatch + buffer + JS wrapper), so the gains fall below E2E noise.

Those wins benefit direct/embedder callers of these rusty_v8 APIs; Deno's own hot paths are already optimized upstream of the code #2029 touched.

**Net: stay-current version bump, verified regression-free.**
