### PR TITLE
fix(core): serialize windows snapshot isolate creation

### DIFF
--- a/libs/core/runtime/setup.rs
+++ b/libs/core/runtime/setup.rs
@@ -262,20 +262,16 @@ pub fn create_isolate(
     if let Some(snapshot) = maybe_startup_snapshot {
       params = params.snapshot_blob(v8::StartupData::from(snapshot.0));
     }
-    static FIRST_SNAPSHOT_INIT: AtomicBool = AtomicBool::new(false);
-    static SNAPSHOW_INIT_MUT: Mutex<()> = Mutex::new(());
+    static SNAPSHOT_INIT_MUT: Mutex<()> = Mutex::new(());
 
-    // On Windows, the snapshot deserialization code appears to be crashing and we are not
-    // certain of the reason. We take a mutex the first time an isolate with a snapshot to
-    // prevent this. https://github.com/denoland/deno/issues/15590
-    if cfg!(windows)
-      && has_snapshot
-      && FIRST_SNAPSHOT_INIT.load(Ordering::SeqCst)
-    {
-      let _g = SNAPSHOW_INIT_MUT.lock().unwrap();
-      let res = v8::Isolate::new(params);
-      FIRST_SNAPSHOT_INIT.store(true, Ordering::SeqCst);
-      res
+    // On Windows, concurrent snapshot deserialization can crash
+    // (https://github.com/denoland/deno/issues/15590). Serialize all
+    // snapshot-backed Isolate::new calls. The previous FIRST_SNAPSHOT_INIT
+    // guard started false and was only set inside the locked branch, so the
+    // mutex never ran.
+    if cfg!(windows) && has_snapshot {
+      let _g = SNAPSHOT_INIT_MUT.lock().unwrap();
+      v8::Isolate::new(params)
     } else {
       v8::Isolate::new(params)
     }


### PR DESCRIPTION
## Summary

- The Windows snapshot-deserialization mutex added for #15590 was dead code: `FIRST_SNAPSHOT_INIT` started as `false` and was only set to `true` inside the locked branch, so `SNAPSHOW_INIT_MUT` never ran.
- Serialize every Windows snapshot-backed `Isolate::new` call instead, matching the original intent of avoiding concurrent snapshot deserialization crashes.
- Rename `SNAPSHOW_INIT_MUT` → `SNAPSHOT_INIT_MUT`.

## Context / reproducer

Embedding Deno with the CLI startup snapshot and creating multiple snapshot-backed isolates concurrently (e.g. parallel `cargo test` threads) can abort on Windows. In [Belgie](https://github.com/mplemay/belgie), that surfaces as `Option::unwrap()` on `None` from `Deno.core.setUpAsyncStub(...)` during the deferred fast-op upgrade (`libs/core/runtime/bindings.rs`), which then fails to unwind inside a V8 callback (`STATUS_STACK_BUFFER_OVERRUN`).

Belgie currently works around this by serializing worker creation in-process; this PR restores Deno's intended fix so embedders do not need that workaround.

## Test plan

- [ ] Existing Windows CI / deno_core tests that create snapshot-backed isolates
- [ ] Parallel snapshot isolate creation on Windows no longer races through unlocked `Isolate::new`

Closes #15590