### PR TITLE
fix(ext/node): implement v8.promiseHooks API

### DIFF
--- a/ext/node/polyfills/v8.ts
+++ b/ext/node/polyfills/v8.ts
@@ -7,7 +7,9 @@
 const { core, primordials } = __bootstrap;
 const {
   Array,
+  ArrayPrototypeIndexOf,
   ArrayPrototypePush,
+  ArrayPrototypeSplice,
   BigInt64Array,
   BigUint64Array,
   DataView,
@@ -650,6 +652,165 @@ class DefaultDeserializer extends Deserializer {
     );
   }
 }
+// ---------------------------------------------------------------------------
+// v8.promiseHooks
+// https://nodejs.org/api/v8.html#promise-hooks
+// ---------------------------------------------------------------------------
+
+type PromiseHookFn = (
+  promise: Promise<unknown>,
+  parent?: Promise<unknown>,
+) => void;
+
+function validatePlainFunction(value: unknown, name: string) {
+  // Reject non-functions as well as async functions and async generators -
+  // none of them can be used as promise hooks.
+  const ctorName = typeof value === "function"
+    ? (value as { constructor?: { name?: string } }).constructor?.name
+    : undefined;
+  if (
+    typeof value !== "function" ||
+    ctorName === "AsyncFunction" ||
+    ctorName === "AsyncGeneratorFunction"
+  ) {
+    throw new TypeError(
+      `The "${name}" argument must be of type function. Received ${typeof value}`,
+    );
+  }
+}
+
+// Track all registered hooks so we can rebuild the combined hooks
+// when individual hooks are added/removed.
+const initHooks: PromiseHookFn[] = [];
+const beforeHooks: PromiseHookFn[] = [];
+const afterHooks: PromiseHookFn[] = [];
+const resolveHooks: PromiseHookFn[] = [];
+
+// Re-entrancy guard: V8 promise hooks fire for ALL promise operations,
+// including any promises created/resolved inside the hooks themselves.
+let inPromiseHook = false;
+
+// Register dispatchers once. core.setPromiseHooks is additive (no removal),
+// so we install permanent dispatchers that check the current hook arrays.
+let hooksInstalled = false;
+
+function ensureHooksInstalled() {
+  if (hooksInstalled) return;
+  hooksInstalled = true;
+  core.setPromiseHooks(
+    (promise: Promise<unknown>, parent?: Promise<unknown>) => {
+      if (inPromiseHook || initHooks.length === 0) return;
+      inPromiseHook = true;
+      try {
+        for (let i = 0; i < initHooks.length; i++) {
+          initHooks[i](promise, parent);
+        }
+      } finally {
+        inPromiseHook = false;
+      }
+    },
+    (promise: Promise<unknown>) => {
+      if (inPromiseHook || beforeHooks.length === 0) return;
+      inPromiseHook = true;
+      try {
+        for (let i = 0; i < beforeHooks.length; i++) {
+          beforeHooks[i](promise);
+        }
+      } finally {
+        inPromiseHook = false;
+      }
+    },
+    (promise: Promise<unknown>) => {
+      if (inPromiseHook || afterHooks.length === 0) return;
+      inPromiseHook = true;
+      try {
+        for (let i = 0; i < afterHooks.length; i++) {
+          afterHooks[i](promise);
+        }
+      } finally {
+        inPromiseHook = false;
+      }
+    },
+    (promise: Promise<unknown>) => {
+      if (inPromiseHook || resolveHooks.length === 0) return;
+      inPromiseHook = true;
+      try {
+        for (let i = 0; i < resolveHooks.length; i++) {
+          resolveHooks[i](promise);
+        }
+      } finally {
+        inPromiseHook = false;
+      }
+    },
+  );
+}
+
+function removeHook(arr: PromiseHookFn[], value: PromiseHookFn) {
+  const idx = ArrayPrototypeIndexOf(arr, value);
+  if (idx !== -1) {
+    ArrayPrototypeSplice(arr, idx, 1);
+  }
+}
+
+const promiseHooks = {
+  onInit(initHook: PromiseHookFn): () => void {
+    validatePlainFunction(initHook, "initHook");
+    ArrayPrototypePush(initHooks, initHook);
+    ensureHooksInstalled();
+    return () => removeHook(initHooks, initHook);
+  },
+  onBefore(beforeHook: PromiseHookFn): () => void {
+    validatePlainFunction(beforeHook, "beforeHook");
+    ArrayPrototypePush(beforeHooks, beforeHook);
+    ensureHooksInstalled();
+    return () => removeHook(beforeHooks, beforeHook);
+  },
+  onAfter(afterHook: PromiseHookFn): () => void {
+    validatePlainFunction(afterHook, "afterHook");
+    ArrayPrototypePush(afterHooks, afterHook);
+    ensureHooksInstalled();
+    return () => removeHook(afterHooks, afterHook);
+  },
+  onSettled(settledHook: PromiseHookFn): () => void {
+    validatePlainFunction(settledHook, "settledHook");
+    ArrayPrototypePush(resolveHooks, settledHook);
+    ensureHooksInstalled();
+    return () => removeHook(resolveHooks, settledHook);
+  },
+  createHook(
+    { init, before, after, settled }: {
+      init?: PromiseHookFn;
+      before?: PromiseHookFn;
+      after?: PromiseHookFn;
+      settled?: PromiseHookFn;
+    },
+  ): () => void {
+    if (init !== undefined) {
+      validatePlainFunction(init, "initHook");
+      ArrayPrototypePush(initHooks, init);
+    }
+    if (before !== undefined) {
+      validatePlainFunction(before, "beforeHook");
+      ArrayPrototypePush(beforeHooks, before);
+    }
+    if (after !== undefined) {
+      validatePlainFunction(after, "afterHook");
+      ArrayPrototypePush(afterHooks, after);
+    }
+    if (settled !== undefined) {
+      validatePlainFunction(settled, "settledHook");
+      ArrayPrototypePush(resolveHooks, settled);
+    }
+    ensureHooksInstalled();
+    return () => {
+      if (init !== undefined) removeHook(initHooks, init);
+      if (before !== undefined) removeHook(beforeHooks, before);
+      if (after !== undefined) removeHook(afterHooks, after);
+      if (settled !== undefined) removeHook(resolveHooks, settled);
+    };
+  },
+};
+
 return {
   cachedDataVersionTag,
   getHeapCodeStatistics,
@@ -670,5 +831,6 @@ return {
   Deserializer,
   DefaultSerializer,
   DefaultDeserializer,
+  promiseHooks,
 };
 })();

--- a/ext/node/polyfills/v8.ts
+++ b/ext/node/polyfills/v8.ts
@@ -9,6 +9,7 @@ const {
   Array,
   ArrayPrototypeIndexOf,
   ArrayPrototypePush,
+  ArrayPrototypeSlice,
   ArrayPrototypeSplice,
   BigInt64Array,
   BigUint64Array,
@@ -702,8 +703,11 @@ function ensureHooksInstalled() {
       if (inPromiseHook || initHooks.length === 0) return;
       inPromiseHook = true;
       try {
-        for (let i = 0; i < initHooks.length; i++) {
-          initHooks[i](promise, parent);
+        // Snapshot the list: a hook that removes itself (or another) during
+        // dispatch must not shift the indices of hooks still to be called.
+        const hooks = ArrayPrototypeSlice(initHooks, 0);
+        for (let i = 0; i < hooks.length; i++) {
+          hooks[i](promise, parent);
         }
       } finally {
         inPromiseHook = false;
@@ -713,8 +717,9 @@ function ensureHooksInstalled() {
       if (inPromiseHook || beforeHooks.length === 0) return;
       inPromiseHook = true;
       try {
-        for (let i = 0; i < beforeHooks.length; i++) {
-          beforeHooks[i](promise);
+        const hooks = ArrayPrototypeSlice(beforeHooks, 0);
+        for (let i = 0; i < hooks.length; i++) {
+          hooks[i](promise);
         }
       } finally {
         inPromiseHook = false;
@@ -724,8 +729,9 @@ function ensureHooksInstalled() {
       if (inPromiseHook || afterHooks.length === 0) return;
       inPromiseHook = true;
       try {
-        for (let i = 0; i < afterHooks.length; i++) {
-          afterHooks[i](promise);
+        const hooks = ArrayPrototypeSlice(afterHooks, 0);
+        for (let i = 0; i < hooks.length; i++) {
+          hooks[i](promise);
         }
       } finally {
         inPromiseHook = false;
@@ -735,8 +741,9 @@ function ensureHooksInstalled() {
       if (inPromiseHook || resolveHooks.length === 0) return;
       inPromiseHook = true;
       try {
-        for (let i = 0; i < resolveHooks.length; i++) {
-          resolveHooks[i](promise);
+        const hooks = ArrayPrototypeSlice(resolveHooks, 0);
+        for (let i = 0; i < hooks.length; i++) {
+          hooks[i](promise);
         }
       } finally {
         inPromiseHook = false;
@@ -785,22 +792,17 @@ const promiseHooks = {
       settled?: PromiseHookFn;
     },
   ): () => void {
-    if (init !== undefined) {
-      validatePlainFunction(init, "initHook");
-      ArrayPrototypePush(initHooks, init);
-    }
-    if (before !== undefined) {
-      validatePlainFunction(before, "beforeHook");
-      ArrayPrototypePush(beforeHooks, before);
-    }
-    if (after !== undefined) {
-      validatePlainFunction(after, "afterHook");
-      ArrayPrototypePush(afterHooks, after);
-    }
-    if (settled !== undefined) {
-      validatePlainFunction(settled, "settledHook");
-      ArrayPrototypePush(resolveHooks, settled);
-    }
+    // Validate every provided callback before registering any of them, so a
+    // later validation failure can't leave earlier hooks permanently
+    // registered with no stop function to remove them.
+    if (init !== undefined) validatePlainFunction(init, "initHook");
+    if (before !== undefined) validatePlainFunction(before, "beforeHook");
+    if (after !== undefined) validatePlainFunction(after, "afterHook");
+    if (settled !== undefined) validatePlainFunction(settled, "settledHook");
+    if (init !== undefined) ArrayPrototypePush(initHooks, init);
+    if (before !== undefined) ArrayPrototypePush(beforeHooks, before);
+    if (after !== undefined) ArrayPrototypePush(afterHooks, after);
+    if (settled !== undefined) ArrayPrototypePush(resolveHooks, settled);
     ensureHooksInstalled();
     return () => {
       if (init !== undefined) removeHook(initHooks, init);

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3003,6 +3003,8 @@
     "parallel/test-process-uptime.js": {},
     "parallel/test-process-warning.js": {},
     "parallel/test-promise-handled-rejection-no-warning.js": {},
+    "parallel/test-promise-hook-on-before.js": {},
+    "parallel/test-promise-hook-on-init.js": {},
     "parallel/test-promise-unhandled-default.js": {},
     "parallel/test-promise-unhandled-issue-43655.js": {},
     "parallel/test-promise-unhandled-silent.js": {},


### PR DESCRIPTION
## Summary

Implements the Node.js [`v8.promiseHooks`](https://nodejs.org/api/v8.html#promise-hooks) API — `onInit`, `onBefore`, `onAfter`, `onSettled`, and `createHook` — on top of Deno core's existing `core.setPromiseHooks` V8 bindings.

This is the clean, self-contained half of #32905, carved out and reimplemented against current `main` (the original PR was based on a since-rewritten `v8.ts` and `process.ts`). The `--unhandled-rejections` half will follow separately, rebuilt on top of the current `synchronizeListeners`.

### Implementation notes

- **Validation**: rejects non-functions, async functions, and async generators, matching Node's error message (`The "<name>" argument must be of type function`).
- **Re-entrancy guard**: V8 promise hooks fire for *all* promise operations, including promises created inside the hooks themselves — a flag prevents infinite recursion.
- **Single-registration dispatcher**: `core.setPromiseHooks` is additive-only (no removal), so we install permanent dispatchers once that consult the current hook arrays. The stop function returned by each registration splices the hook back out.

### Tests

Enables two node_compat tests, both passing:

- `parallel/test-promise-hook-on-init.js`
- `parallel/test-promise-hook-on-before.js`

The remaining hook tests (`on-after`, `on-resolve`, `create-hook`) are left disabled: they assert exact hook-invocation counts that Deno's internal runtime promises perturb, and need further work to reconcile.

## Test plan

- [x] `cargo test -p node_compat_tests test-promise-hook-on-init` — passes
- [x] `cargo test -p node_compat_tests test-promise-hook-on-before` — passes
- [x] `./tools/format.js` && `./tools/lint.js --js` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)