### PR TITLE
test: tolerate delta-upgrade line in upgrade::stable output

### DIFF
--- a/tests/specs/upgrade/stable/upgrade.out
+++ b/tests/specs/upgrade/stable/upgrade.out
@@ -2,8 +2,7 @@ Current Deno version: [WILDCARD]
 Looking up stable version
 
 Found latest stable version [WILDCARD]
-
-Downloading https://github.com/denoland/deno/releases/download/[WILDCARD]/deno-[WILDCARD].zip
+[WILDCARD]Downloading https://github.com/denoland/deno/releases/download/[WILDCARD]/deno-[WILDCARD].zip
 Deno is upgrading to version [WILDCARD]
 
 Upgraded successfully to Deno [WILDCARD] (stable)


### PR DESCRIPTION
The `specs::upgrade::stable` test copies the current binary and runs
`deno upgrade --force`, matching the output against `upgrade.out`. When
the upgrade takes the delta path (as it does upgrading v2.9.3 to the
newly released v2.9.4), an extra line is printed:

    Found latest stable version v2.9.4

    Attempting delta upgrade (1 step)
    Downloading https://github.com/denoland/deno/releases/download/v2.9.4/...

The expected output hard-coded a blank line immediately before
`Downloading`, so the delta case, where the blank line sits before the
`Attempting delta upgrade` message rather than before `Downloading`,
failed to match. This started failing on every PR once v2.9.4 shipped.

The fix replaces the hard-coded blank line with a wildcard that absorbs
the optional delta message, so both the delta and full-download paths
match. Verified locally: the test now passes while exercising the delta
path (local debug build v2.9.3 upgrading to stable v2.9.4).