### PR TITLE
fix(ext/web): attach Node error codes to WHATWG API validation errors

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -7132,14 +7132,18 @@ class TransformStream {
       "transformer",
     );
     if (transformerDict.readableType !== undefined) {
-      throw new RangeError(
+      const err = new RangeError(
         `${prefix}: readableType transformers not supported`,
       );
+      err.code = "ERR_INVALID_ARG_VALUE";
+      throw err;
     }
     if (transformerDict.writableType !== undefined) {
-      throw new RangeError(
+      const err = new RangeError(
         `${prefix}: writableType transformers not supported`,
       );
+      err.code = "ERR_INVALID_ARG_VALUE";
+      throw err;
     }
     const readableHighWaterMark = extractHighWaterMark(readableStrategy, 0);
     const readableSizeAlgorithm = extractSizeAlgorithm(readableStrategy);

--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -85,7 +85,16 @@ class TextDecoder {
     ) {
       encoding = "utf-8";
     } else {
-      encoding = op_encoding_normalize_label(label);
+      try {
+        encoding = op_encoding_normalize_label(label);
+      } catch (err) {
+        // The op only rejects unknown encoding labels; Node attaches
+        // ERR_ENCODING_NOT_SUPPORTED to that error.
+        if (err !== null && typeof err === "object" && err.code === undefined) {
+          err.code = "ERR_ENCODING_NOT_SUPPORTED";
+        }
+        throw err;
+      }
     }
     this.#encoding = encoding;
     this.#fatal = options.fatal;

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -102,10 +102,16 @@ const {
 // from `opts` -- never mutate -- so a shared frozen object is safe.
 const EMPTY_OPTS = ObjectFreeze({ __proto__: null });
 
-function makeException(ErrorType, message, prefix, context) {
-  return new ErrorType(
+function makeException(ErrorType, message, prefix, context, code = undefined) {
+  const err = new ErrorType(
     `${prefix ? prefix + ": " : ""}${context ? context : "Value"} ${message}`,
   );
+  // Optional Node-compatible error code (e.g. ERR_INVALID_ARG_TYPE) so that
+  // node:* consumers observing `err.code` behave the same as on Node.
+  if (code !== undefined) {
+    err.code = code;
+  }
+  return err;
 }
 
 function toNumber(value) {
@@ -604,6 +610,7 @@ converters.ArrayBufferView = (
       "is not a view on an ArrayBuffer or SharedArrayBuffer",
       prefix,
       context,
+      "ERR_INVALID_ARG_TYPE",
     );
   }
   let buffer;
@@ -655,6 +662,7 @@ converters.BufferSource = (
       "is not an ArrayBuffer or a view on one",
       prefix,
       context,
+      "ERR_INVALID_ARG_TYPE",
     );
   }
   if (
@@ -667,6 +675,7 @@ converters.BufferSource = (
       "is not an ArrayBuffer, SharedArrayBuffer, or a view on one",
       prefix,
       context,
+      "ERR_INVALID_ARG_TYPE",
     );
   }
 
@@ -748,7 +757,9 @@ function requiredArguments(length, required, prefix, argNames) {
     const errMsg = `${prefix ? prefix + ": " : ""}${required} argument${
       required === 1 ? "" : "s"
     } required, but only ${length} present`;
-    throw new TypeError(errMsg);
+    const err = new TypeError(errMsg);
+    err.code = "ERR_MISSING_ARGS";
+    throw err;
   }
 }
 
@@ -825,12 +836,14 @@ function createDictionaryConverter(name, ...dictionaries) {
   return function (V, prefix, context, opts) {
     if (V === undefined || V === null) {
       if (hasRequiredKey) {
-        throw makeException(
+        const err = makeException(
           TypeError,
           "can not be converted to a dictionary",
           prefix,
           context,
         );
+        err.code = "ERR_INVALID_ARG_TYPE";
+        throw err;
       }
       const idlDict = { __proto__: null };
       // Fast path: copy primitive defaults via explicit loop (faster than
@@ -849,12 +862,14 @@ function createDictionaryConverter(name, ...dictionaries) {
     }
 
     if (typeof V !== "object" && typeof V !== "function") {
-      throw makeException(
+      const err = makeException(
         TypeError,
         "can not be converted to a dictionary",
         prefix,
         context,
       );
+      err.code = "ERR_INVALID_ARG_TYPE";
+      throw err;
     }
 
     const idlDict = { __proto__: null };
@@ -902,11 +917,14 @@ function createEnumConverter(name, values) {
     const S = String(V);
 
     if (!E.has(S)) {
-      throw new TypeError(
+      const err = new TypeError(
         `${
           prefix ? prefix + ": " : ""
         }The provided value '${S}' is not a valid enum value of type ${name}`,
       );
+      // Node attaches ERR_INVALID_ARG_VALUE to enum-validation TypeErrors.
+      err.code = "ERR_INVALID_ARG_VALUE";
+      throw err;
     }
 
     return S;

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4034,8 +4034,10 @@
     "parallel/test-webstreams-pipeline.js": {},
     "parallel/test-whatwg-encoding-custom-api-basics.js": {},
     "parallel/test-whatwg-encoding-custom-fatal-streaming.js": {},
+    "parallel/test-whatwg-encoding-custom-textdecoder-api-invalid-label.js": {},
     "parallel/test-whatwg-encoding-custom-textdecoder-fatal.js": {},
     "parallel/test-whatwg-encoding-custom-textdecoder-ignorebom.js": {},
+    "parallel/test-whatwg-encoding-custom-textdecoder-invalid-arg.js": {},
     "parallel/test-whatwg-encoding-custom-textdecoder-streaming.js": {},
     "parallel/test-whatwg-encoding-custom-textdecoder-utf16-surrogates.js": {},
     "parallel/test-whatwg-encoding-singlebyte.mjs": {},
@@ -4051,6 +4053,7 @@
       "reason": "Node 26 rewrote the to-ReadableStream adapter to attach a deduplicated error listener even for already-destroyed Readables; Deno short-circuits destroyed streams"
     },
     "parallel/test-whatwg-transformstream-cancel-write-race.js": {},
+    "parallel/test-whatwg-url-canparse.js": {},
     "parallel/test-whatwg-url-custom-deepequal.js": {},
     "parallel/test-whatwg-url-custom-global.js": {},
     "parallel/test-whatwg-url-custom-href-side-effect.js": {},


### PR DESCRIPTION
Node's web platform APIs (URL, streams, TextDecoder) attach an `ERR_*`
`code` to the TypeError/RangeError they throw for invalid arguments, and
`node:*` consumers, along with Node's own WHATWG compatibility tests,
assert on it. Deno throws the correct spec error type but without the
`code`, so those checks fail.

This attaches the codes at the shared, centralized webidl/web validation
sites so every web API benefits rather than patching each call site:

- webidl `requiredArguments` fallback branch now sets `ERR_MISSING_ARGS`
  (the `argNames` branch already did)
- webidl enum converter sets `ERR_INVALID_ARG_VALUE`
- webidl dictionary converter "not an object" sets `ERR_INVALID_ARG_TYPE`
- webidl `ArrayBufferView` / `BufferSource` type mismatch sets
  `ERR_INVALID_ARG_TYPE`, via a new optional `code` argument on
  `makeException`
- `TransformStream` `readableType`/`writableType` set
  `ERR_INVALID_ARG_VALUE`
- `TextDecoder` unknown encoding label sets `ERR_ENCODING_NOT_SUPPORTED`

The change is additive: it only sets `err.code`, leaving the error type
and message unchanged, so WPT (which does not observe `.code`) is
unaffected. Existing streams/text-encoding/url unit tests still pass.

Fixes `test-whatwg-url-canparse`,
`test-whatwg-encoding-custom-textdecoder-api-invalid-label` and
`test-whatwg-encoding-custom-textdecoder-invalid-arg`, and advances
several other whatwg compat tests (they now fail later, on their next
missing code or on unrelated blockers).

The remaining whatwg failures are not simple `.code` gaps and are out of
scope here: many whitebox Node internals the tests reach for that Deno
implements in Rust (`[kState]` internal slots, `require('internal/...')`,
`internalBinding`), a couple assert Node's proprietary brand-check
message ("Cannot read private member" vs Deno's spec "Illegal
invocation"), and a few need per-operation stream state codes plus
message-text changes.