### PR TITLE
fix(ext/node): implement util.diff

### DIFF
--- a/ext/node/polyfills/util.ts
+++ b/ext/node/polyfills/util.ts
@@ -7,6 +7,7 @@ const {
   ArrayIsArray,
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
+  ArrayPrototypeReverse,
   Date,
   DatePrototypeGetDate,
   DatePrototypeGetHours,
@@ -60,7 +61,11 @@ const {
   validateNumber,
   validateObject,
   validateString,
+  validateStringArray,
 } = core.loadExtScript("ext:deno_node/internal/validators.mjs");
+const { myersDiff } = core.loadExtScript(
+  "ext:deno_node/internal/assert/myers_diff.js",
+);
 const { parseArgs } = core.loadExtScript(
   "ext:deno_node/internal/util/parse_args/parse_args.js",
 );
@@ -404,8 +409,29 @@ function convertProcessSignalToExitCode(signalCode) {
   return 128 + signals[signalCode];
 }
 
+function validateDiffInput(value, name) {
+  if (!ArrayIsArray(value)) {
+    validateString(value, name);
+    return;
+  }
+  validateStringArray(value, name);
+}
+
+// https://nodejs.org/api/util.html#utildiffactual-expected
+function diff(actual, expected) {
+  if (actual === expected) {
+    return [];
+  }
+
+  validateDiffInput(actual, "actual");
+  validateDiffInput(expected, "expected");
+
+  return ArrayPrototypeReverse(myersDiff(actual, expected));
+}
+
 return {
   callbackify,
+  diff,
   debuglog,
   debug: debuglog,
   format,

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4942,6 +4942,7 @@
     "parallel/test-diagnostics-channel-http2-server-stream-created.js": {},
     "parallel/test-diagnostics-channel-http2-server-stream-finish.js": {},
     "parallel/test-diagnostics-channel-http2-server-stream-start.js": {},
+    "parallel/test-diff.js": {},
     "parallel/test-dns-lookup-promises.js": {},
     "parallel/test-double-tls-server.js": {},
     "parallel/test-dummy-stdio.js": {


### PR DESCRIPTION
## Summary

Implements [`util.diff(actual, expected)`](https://nodejs.org/api/util.html#utildiffactual-expected) (added in Node 24), which was missing in Deno (`require('util').diff` was `undefined`).

`util.diff` returns a Myers diff between two strings or string arrays as an array of `[op, value]` entries, where `op` is `-1` (delete), `0` (no-op), or `1` (insert):

```js
const { diff } = require('util');
diff('ab', 'ac'); // [ [0, 'a'], [1, 'b'], [-1, 'c'] ]
```

## Implementation

This is a thin wrapper matching Node's `lib/internal/util/diff.js` — it validates the inputs (string or string-array) and returns `myersDiff(actual, expected)` reversed. Deno already had the two pieces it needs:

- **`myersDiff`** in `internal/assert/myers_diff.js` (already used by `node:assert`) — byte-identical to Node's, same `{ DELETE: -1, NOP: 0, INSERT: 1 }` operations, so the output matches exactly.
- **`validateString`/`validateStringArray`** in `internal/validators.mjs`.

So the change is just wiring these into `util.ts` plus the small `diff`/`validateDiffInput` functions.

## Test results

Enables `parallel/test-diff.js` — **all 6 steps pass**:
- type validation for `actual`/`expected` (string, array-of-strings, per-element)
- equal inputs → `[]`
- string diff and array diff output

## Test plan

- [x] `test-diff.js` passes through the node_compat runner
- [x] `./tools/format.js` && `./tools/lint.js --js` clean
- [x] `require('util')` intact (`diff`/`inspect`/`format`/`promisify` all present); `util.diff('ab','ac')` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)