### PR TITLE
fix(ext/web): validate AbortSignal.any() input like Node

### DIFF
--- a/ext/web/03_abort_signal.js
+++ b/ext/web/03_abort_signal.js
@@ -6,6 +6,7 @@
 (function () {
 const { core, primordials } = __bootstrap;
 const {
+  ArrayIsArray,
   ArrayPrototypePush,
   FunctionPrototypeApply,
   ObjectPrototypeIsPrototypeOf,
@@ -18,6 +19,7 @@ const {
   Symbol,
   SymbolFor,
   TypeError,
+  TypeErrorPrototype,
   WeakRefPrototypeDeref,
 } = primordials;
 
@@ -73,8 +75,39 @@ class AbortSignal extends EventTarget {
 
   static any(signals) {
     const prefix = "Failed to execute 'AbortSignal.any'";
-    webidl.requiredArguments(arguments.length, 1, prefix);
-    return createDependentAbortSignal(signals, prefix);
+    // Node tags these validation errors with `ERR_INVALID_ARG_TYPE`; the
+    // WebIDL machinery otherwise throws plain (code-less) TypeErrors.
+    try {
+      webidl.requiredArguments(arguments.length, 1, prefix);
+    } catch (e) {
+      e.code = "ERR_INVALID_ARG_TYPE";
+      throw e;
+    }
+    // Validate array elements up front so a non-AbortSignal member reports
+    // Node's `signals[i] is not of type AbortSignal.` message. Non-array
+    // iterables fall through to the sequence converter below.
+    if (ArrayIsArray(signals)) {
+      for (let i = 0; i < signals.length; i++) {
+        if (!ObjectPrototypeIsPrototypeOf(AbortSignalPrototype, signals[i])) {
+          const err = new TypeError(
+            `signals[${i}] is not of type AbortSignal.`,
+          );
+          err.code = "ERR_INVALID_ARG_TYPE";
+          throw err;
+        }
+      }
+    }
+    try {
+      return createDependentAbortSignal(signals, prefix);
+    } catch (e) {
+      if (
+        ObjectPrototypeIsPrototypeOf(TypeErrorPrototype, e) &&
+        e.code === undefined
+      ) {
+        e.code = "ERR_INVALID_ARG_TYPE";
+      }
+      throw e;
+    }
   }
 
   static abort(reason = undefined) {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -189,6 +189,7 @@
       "ignore": true,
       "reason": "Tests Node.js internal modules (require('internal/...')) which are not exposed in Deno"
     },
+    "parallel/test-abortsignal-any.mjs": {},
     "parallel/test-als-defaultvalue.js": {},
     "parallel/test-arm-math-illegal-instruction.js": {},
     "parallel/test-assert-async.js": {},


### PR DESCRIPTION
## Summary

`AbortSignal.any()` didn't report Node-compatible errors for invalid input. Node throws a `TypeError` tagged `code: 'ERR_INVALID_ARG_TYPE'` when the argument isn't an iterable of `AbortSignal`s; Deno's WebIDL path threw a code-less `TypeError` with a different message.

This adds Node-compatible validation:
- Missing / non-iterable argument (`AbortSignal.any()`, `.any(null)`, `.any(undefined)`) → `TypeError` with `code: 'ERR_INVALID_ARG_TYPE'`.
- A non-`AbortSignal` array element (`AbortSignal.any([sig, undefined])`) → `TypeError` with `code: 'ERR_INVALID_ARG_TYPE'` and Node's message `signals[i] is not of type AbortSignal.`.

The validation is additive — valid inputs are unchanged: arrays, empty arrays, and non-array iterables (e.g. a `Set`) all still produce a working dependent signal, and abort propagation is unaffected. (This follows the same "Node error codes on a Web API" approach used for the compression streams in #36285.)

## Test results

Enables `parallel/test-abortsignal-any.mjs` (all 13 steps: the 3 validation cases plus the 10 behavioral cases).

## Test plan

- [x] `test-abortsignal-any.mjs` passes through the node_compat runner
- [x] Smoke: `AbortSignal.any([s1, s2])`, `AbortSignal.any([])`, and `AbortSignal.any(new Set([...]))` all work; abort reason propagates
- [x] `./tools/format.js` && `./tools/lint.js --js` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)