### PR TITLE
fix(ext/node): stop http2 file reads after stream close

### DIFF
--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -2834,6 +2834,17 @@ function processRespondWithFD(
 
   self.once("close", stopReading);
 
+  function handleReadError() {
+    stopReading();
+    // Match Node: a read failure (e.g. EBADF from a bad fd) resets the
+    // stream with NGHTTP2_INTERNAL_ERROR rather than leaking the
+    // underlying fs error to user code.
+    if (!self.destroyed && !self.closed) {
+      closeStream(self, NGHTTP2_INTERNAL_ERROR, kForceRstStream);
+    }
+    self.destroy();
+  }
+
   function readAndWrite(err) {
     if (err || self.destroyed || self.closed) {
       stopReading();
@@ -2845,32 +2856,30 @@ function processRespondWithFD(
       return;
     }
     reading = true;
-    fs.read(fd, buf, 0, readLen, seekable ? pos : null, (err, bytesRead) => {
-      reading = false;
-      if (err) {
-        stopReading();
-        // Match Node: a read failure (e.g. EBADF from a bad fd) resets the
-        // stream with NGHTTP2_INTERNAL_ERROR rather than leaking the
-        // underlying fs error to user code.
-        if (!self.destroyed && !self.closed) {
-          closeStream(self, NGHTTP2_INTERNAL_ERROR, kForceRstStream);
+    try {
+      fs.read(fd, buf, 0, readLen, seekable ? pos : null, (err, bytesRead) => {
+        reading = false;
+        if (err) {
+          handleReadError();
+          return;
         }
-        self.destroy();
-        return;
-      }
-      if (stopped || self.destroyed || self.closed) {
-        stopReading();
-        return;
-      }
-      if (bytesRead === 0) {
-        finish();
-        return;
-      }
-      if (seekable) pos += bytesRead;
-      // deno-lint-ignore deno-internal/prefer-primordials
-      const chunk = buf.slice(0, bytesRead);
-      self.write(chunk, readAndWrite);
-    });
+        if (stopped || self.destroyed || self.closed) {
+          stopReading();
+          return;
+        }
+        if (bytesRead === 0) {
+          finish();
+          return;
+        }
+        if (seekable) pos += bytesRead;
+        // deno-lint-ignore deno-internal/prefer-primordials
+        const chunk = buf.slice(0, bytesRead);
+        self.write(chunk, readAndWrite);
+      });
+    } catch {
+      reading = false;
+      handleReadError();
+    }
   }
 
   function finish() {

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -2815,6 +2815,7 @@ function processRespondWithFD(
 
   const ownsFd = self.ownsFd;
   let stopped = false;
+  let reading = false;
   let fdClosed = false;
 
   function closeOwnedFd() {
@@ -2824,10 +2825,11 @@ function processRespondWithFD(
   }
 
   function stopReading() {
-    if (stopped) return;
     stopped = true;
     self.removeListener("close", stopReading);
-    closeOwnedFd();
+    if (!reading) {
+      closeOwnedFd();
+    }
   }
 
   self.once("close", stopReading);
@@ -2842,8 +2844,9 @@ function processRespondWithFD(
       finish();
       return;
     }
+    reading = true;
     fs.read(fd, buf, 0, readLen, seekable ? pos : null, (err, bytesRead) => {
-      if (stopped) return;
+      reading = false;
       if (err) {
         stopReading();
         // Match Node: a read failure (e.g. EBADF from a bad fd) resets the
@@ -2855,7 +2858,7 @@ function processRespondWithFD(
         self.destroy();
         return;
       }
-      if (self.destroyed || self.closed) {
+      if (stopped || self.destroyed || self.closed) {
         stopReading();
         return;
       }
@@ -2871,11 +2874,10 @@ function processRespondWithFD(
   }
 
   function finish() {
-    if (stopped) return;
-    stopped = true;
-    self.removeListener("close", stopReading);
-    closeOwnedFd();
-    self.end();
+    stopReading();
+    if (!self.destroyed && !self.closed) {
+      self.end();
+    }
   }
 
   const ret = ReflectApply(

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -1130,6 +1130,77 @@ Deno.test(
   () => testRespondWithCancellation(false),
 );
 
+Deno.test(
+  "[node/http2] respondWithFile closes owned fd when fs.read throws",
+  async () => {
+    const filePath = await Deno.makeTempFile();
+    await Deno.writeFile(filePath, new Uint8Array(256));
+
+    const originalRead = fs.read;
+    const originalClose = fs.close;
+    let closeCalls = 0;
+
+    Object.defineProperty(fs, "read", {
+      configurable: true,
+      writable: true,
+      value: () => {
+        throw new Error("fs.read failed");
+      },
+    });
+    Object.defineProperty(fs, "close", {
+      configurable: true,
+      writable: true,
+      value: (...args: unknown[]) => {
+        closeCalls++;
+        return Reflect.apply(
+          originalClose as unknown as (...args: unknown[]) => unknown,
+          fs,
+          args,
+        );
+      },
+    });
+
+    const streamClose = Promise.withResolvers<void>();
+    const server = http2.createServer();
+    server.on("stream", (stream) => {
+      stream.on("error", () => {});
+      stream.once("close", () => streamClose.resolve());
+      stream.respondWithFile(filePath);
+    });
+
+    let client: http2.ClientHttp2Session | undefined;
+    try {
+      const port = await new Promise<number>((resolve) => {
+        server.listen(0, "127.0.0.1", () => {
+          resolve((server.address() as net.AddressInfo).port);
+        });
+      });
+      client = http2.connect(`http://127.0.0.1:${port}`);
+      client.on("error", () => {});
+      const request = client.request({ ":path": "/" });
+      request.on("error", () => {});
+      request.end();
+
+      await streamClose.promise;
+      assertEquals(closeCalls, 1);
+    } finally {
+      client?.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      Object.defineProperty(fs, "read", {
+        configurable: true,
+        writable: true,
+        value: originalRead,
+      });
+      Object.defineProperty(fs, "close", {
+        configurable: true,
+        writable: true,
+        value: originalClose,
+      });
+      await Deno.remove(filePath);
+    }
+  },
+);
+
 // Regression test for https://github.com/denoland/deno/issues/33317
 // `http2.createSecureServer({ allowHTTP1: true })` must handle HTTP/1.1
 // clients without throwing `ReferenceError: kIncomingMessage is not defined`.


### PR DESCRIPTION
*Written by Codex; split off from https://github.com/denoland/deno/pull/35657 by request*

HTTP/2 respondWithFile and respondWithFD send file data by chaining fs.read callbacks and writing each chunk to the stream. If the peer closes the connection while a file response is in progress, the stream can close while that read loop still has work scheduled. The loop should not keep reading from the file after the stream has no consumer.

Stop the read loop when the stream closes. If a read is already in flight, defer closing an owned file descriptor until that read callback returns. This avoids racing fs.close() against fs.read(), while still making connection aborts stop scheduling more file reads.

Keep the existing read-error path intact so actual read failures still reset and destroy the stream as before. Normal completion and response setup failures still close owned file descriptors once.

<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
