### PR TITLE
fix(core): don't resolve internal module imports with the user's import map

### DIFF
--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -76,11 +76,15 @@ use crate::source_map::SourceMapper;
 
 const DATA_PREFIX: &str = "data:";
 
+fn is_internal_scheme(scheme: &str) -> bool {
+  matches!(scheme, "ext" | "node" | "checkin")
+}
+
 fn is_internal_module_specifier(specifier: &str) -> bool {
   let Ok(specifier) = ModuleSpecifier::parse(specifier) else {
     return false;
   };
-  matches!(specifier.scheme(), "ext" | "node" | "checkin")
+  is_internal_scheme(specifier.scheme())
 }
 
 fn residual_source_from_static_table(
@@ -1549,6 +1553,11 @@ impl ModuleMap {
     referrer: &str,
     kind: ResolutionKind,
   ) -> ModuleResolveResponse {
+    if let Some(resolved_specifier) =
+      self.maybe_resolve_internal_import(specifier, referrer)
+    {
+      return Ok(resolved_specifier);
+    }
     let resolved_specifier =
       self.loader.borrow().resolve(specifier, referrer, kind)?;
     self.validate_ext_module_import(&resolved_specifier, referrer)?;
@@ -1563,6 +1572,11 @@ impl ModuleMap {
     kind: ResolutionKind,
     import_attributes: &HashMap<String, String>,
   ) -> ModuleResolveResponse {
+    if let Some(resolved_specifier) =
+      self.maybe_resolve_internal_import(specifier, referrer)
+    {
+      return Ok(resolved_specifier);
+    }
     let resolved_specifier = self.loader.borrow().resolve_with_scope(
       scope,
       specifier,
@@ -1572,6 +1586,33 @@ impl ModuleMap {
     )?;
     self.validate_ext_module_import(&resolved_specifier, referrer)?;
     Ok(resolved_specifier)
+  }
+
+  /// Resolves an internal specifier imported by an internal module without
+  /// consulting the loader. Returns `None` when this isn't such an import, in
+  /// which case the loader decides.
+  ///
+  /// Internal modules that aren't baked into the snapshot get instantiated at
+  /// runtime, at which point the installed loader is the embedder's
+  /// user-facing one. In Deno that loader applies the user's import map, so an
+  /// entry like `{ "ext:core/mod.js": "./mod.js" }` used to rewrite the imports
+  /// of internal modules such as `ext:cli/40_test_common.js` or
+  /// `node:_http_agent`, breaking instantiation. Internal specifiers are owned
+  /// by the runtime and always resolve to themselves.
+  ///
+  /// This trusts the referrer only as far as `validate_ext_module_import`
+  /// does — a `node:`-looking referrer that user code made up (e.g. via
+  /// `node:vm`'s `filename` option) isn't enough on its own.
+  fn maybe_resolve_internal_import(
+    &self,
+    specifier: &str,
+    referrer: &str,
+  ) -> Option<ModuleSpecifier> {
+    if !self.is_internal_referrer(referrer) {
+      return None;
+    }
+    let specifier = ModuleSpecifier::parse(specifier).ok()?;
+    is_internal_scheme(specifier.scheme()).then_some(specifier)
   }
 
   fn validate_ext_module_import(
@@ -2785,7 +2826,7 @@ impl ModuleMap {
   ) -> Result<v8::Global<v8::Value>, CoreError> {
     let specifier = ModuleSpecifier::parse(module_specifier)?;
     let previous_loading_internal_modules =
-      matches!(specifier.scheme(), "ext" | "node" | "checkin")
+      is_internal_scheme(specifier.scheme())
         .then(|| self.loading_internal_modules.replace(true));
     let result = self.lazy_load_es_module_with_code_inner(
       scope,

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -2337,6 +2337,52 @@ fn builtin_core_module() {
   runtime.module_map().set_loading_internal_modules(false);
 }
 
+// An internal module that is lazily loaded at runtime gets its imports
+// resolved by the embedder's loader, which in Deno applies the user's import
+// map. Mapping `ext:core/mod.js` used to rewrite internal imports too and
+// break instantiation. Regression test for
+// https://github.com/denoland/deno/issues/36302.
+#[test]
+fn lazy_loaded_internal_module_ignores_loader_remapping() {
+  /// Stands in for an import map that maps every specifier.
+  struct RemappingLoader;
+
+  impl ModuleLoader for RemappingLoader {
+    fn resolve(
+      &self,
+      _specifier: &str,
+      _referrer: &str,
+      _kind: ResolutionKind,
+    ) -> ModuleResolveResponse {
+      Ok(ModuleSpecifier::parse("file:///remapped.js").unwrap())
+    }
+
+    fn load(
+      &self,
+      _module_specifier: &ModuleSpecifier,
+      _maybe_referrer: Option<&ModuleLoadReferrer>,
+      _options: ModuleLoadOptions,
+    ) -> ModuleLoadResponse {
+      unreachable!();
+    }
+  }
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    module_loader: Some(Rc::new(RemappingLoader)),
+    ..Default::default()
+  });
+
+  runtime
+    .lazy_load_es_module_with_code(
+      "ext:test/lazy.js",
+      r#"
+      import { core } from "ext:core/mod.js";
+      if (typeof core === "undefined") throw new Error("core missing");
+    "#,
+    )
+    .unwrap();
+}
+
 #[test]
 fn import_meta_filename_dirname() {
   #[cfg(not(target_os = "windows"))]

--- a/tests/specs/import_map/internal_specifiers/__test__.jsonc
+++ b/tests/specs/import_map/internal_specifiers/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  "tests": {
+    // internal modules lazily loaded at runtime must not be resolved through
+    // the user's import map
+    "test": {
+      "args": "test --quiet main_test.js",
+      "output": "test.out"
+    },
+    "node_builtin": {
+      "args": "run --quiet node_http.js",
+      "output": "node_http.out"
+    },
+    // ...but user code that remaps a `node:` builtin still gets the mapping
+    "user_remap": {
+      "args": "run --quiet user_remap.js",
+      "output": "user_remap.out"
+    }
+  }
+}

--- a/tests/specs/import_map/internal_specifiers/deno.json
+++ b/tests/specs/import_map/internal_specifiers/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "ext:core/mod.js": "./remapped.js",
+    "ext:cli/40_test_common.js": "./remapped.js",
+    "node:net": "./remapped.js"
+  }
+}

--- a/tests/specs/import_map/internal_specifiers/main_test.js
+++ b/tests/specs/import_map/internal_specifiers/main_test.js
@@ -1,0 +1,5 @@
+Deno.test("internal test harness modules are not remapped", () => {
+  if (typeof Deno.test !== "function") {
+    throw new Error("unreachable");
+  }
+});

--- a/tests/specs/import_map/internal_specifiers/node_http.js
+++ b/tests/specs/import_map/internal_specifiers/node_http.js
@@ -1,0 +1,5 @@
+// `node:http`'s polyfill internally imports `node:net`, which the import map
+// remaps. Internal modules must not go through the user's import map.
+import http from "node:http";
+
+console.log("createServer:", typeof http.createServer);

--- a/tests/specs/import_map/internal_specifiers/node_http.out
+++ b/tests/specs/import_map/internal_specifiers/node_http.out
@@ -1,0 +1,1 @@
+createServer: function

--- a/tests/specs/import_map/internal_specifiers/remapped.js
+++ b/tests/specs/import_map/internal_specifiers/remapped.js
@@ -1,0 +1,2 @@
+export const remapped = true;
+export default { remapped: true };

--- a/tests/specs/import_map/internal_specifiers/test.out
+++ b/tests/specs/import_map/internal_specifiers/test.out
@@ -1,0 +1,5 @@
+running 1 test from ./main_test.js
+internal test harness modules are not remapped ... ok [WILDLINE]
+
+ok | 1 passed | 0 failed [WILDLINE]
+

--- a/tests/specs/import_map/internal_specifiers/user_remap.js
+++ b/tests/specs/import_map/internal_specifiers/user_remap.js
@@ -1,0 +1,4 @@
+// A remapped `node:` specifier in *user* code must keep working.
+import net from "node:net";
+
+console.log("remapped:", net.remapped);

--- a/tests/specs/import_map/internal_specifiers/user_remap.out
+++ b/tests/specs/import_map/internal_specifiers/user_remap.out
@@ -1,0 +1,1 @@
+remapped: true


### PR DESCRIPTION
Fixes #36302.

## Problem

Modules baked into the snapshot are already instantiated, so they never resolve. But internal modules that are **lazily loaded at runtime** get their imports resolved through whatever module loader the embedder installed — in the CLI, the one that applies the user's import map. So an import map entry for an internal specifier rewrote *internal* imports too.

Three distinct failures from the reporter's `deno.json`:

| trigger | error |
| --- | --- |
| `deno test` (loads `ext:cli/40_test_common.js`) | `Cannot resolve module "ext:core/mod.js" from "ext:cli/40_test_common.js"` — as reported |
| `new WebSocket(...)` (loads `ext:deno_websocket/01_websocket.js`) | same error, so plain `deno run` is affected too, not just `deno test` |
| `import "node:http"` with `{"node:net": "./fake.js"}` | `Loading unprepared module: .../fake.js, imported from: node:_http_agent` — the node polyfills got the user's stub instead of the real builtin |

## Fix

`ModuleMap::resolve` / `resolve_with_scope` now resolve internal (`ext:`/`node:`/`checkin:`) specifiers to themselves instead of calling the loader, when they're imported by an internal module.

The gate is `is_internal_referrer()`, which requires the `loading_internal_modules` / `will_snapshot` flag and not merely a referrer that *looks* internal. That matters: `node:vm` lets user code forge the referrer (`filename: "node:vm"`, or `SourceTextModule`'s `identifier`), and an earlier revision of this patch gated on the referrer string alone, which let `import("ext:core/ops")` through and broke the "vm default loader does not trust internal scheme filenames" test in `tests/unit_node/vm_test.ts`. Trusting the referrer exactly as far as the existing `validate_ext_module_import` does opens no new hole.

User code that remaps a `node:` builtin for its own imports is unaffected.

## Tests

- `libs/core/modules/tests.rs` — deno_core-level regression test with a loader that remaps every specifier. Reproduces the issue's exact error message when the fix is disabled.
- `tests/specs/import_map/internal_specifiers/` — 3 cases: `deno test`, `node:http` with `node:net` remapped, and a guard that user-code `node:` remapping still works.

Both new tests were verified to fail on the unfixed code and pass with the fix.

## Not covered

A genuine *dynamic* `import()` of an internal specifier from inside an internal module still goes through the loader, because the trust flag isn't set at evaluation time. That's unchanged behavior rather than a regression; tightening it would require tracking the flag per-module instead of as a single cell.
