### PR TITLE
feat(add): `--unscoped` flag to alias packages by their unscoped name

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1679,6 +1679,13 @@ fn add_no_save_arg() -> Arg {
     .conflicts_with("save-optional")
 }
 
+fn add_unscoped_arg() -> Arg {
+  Arg::new("unscoped")
+    .long("unscoped")
+    .help("Use the package name without its scope as the alias (ex. `jsr:@david/jsonc-morph` is added as `jsonc-morph`). Packages given an explicit alias are unaffected.")
+    .action(ArgAction::SetTrue)
+}
+
 fn add_subcommand() -> Command {
   command(
     "add",
@@ -1719,6 +1726,7 @@ Or multiple dependencies at once:
           .help("Save exact version without the caret (^)")
           .action(ArgAction::SetTrue),
       )
+      .arg(add_unscoped_arg())
       .arg(package_json_arg())
       .arg(env_file_arg())
       .arg(min_dep_age_arg())
@@ -3382,6 +3390,7 @@ These must be added to the path manually if required."), UnstableArgsConfig::Res
             .conflicts_with("entrypoint")
             .conflicts_with("global"),
         )
+        .arg(add_unscoped_arg().conflicts_with("entrypoint").conflicts_with("global"))
         .arg(lockfile_only_arg().conflicts_with("global"))
         .arg(package_json_arg().conflicts_with("entrypoint").conflicts_with("global"))
         .arg(
@@ -6595,6 +6604,7 @@ fn add_parse_inner(
     lockfile_only: matches.get_flag("lockfile-only"),
     save_exact: matches.get_flag("save-exact"),
     package_json: matches.get_flag("package-json"),
+    unscoped: matches.get_flag("unscoped"),
   }
 }
 
@@ -15945,6 +15955,7 @@ mod tests {
             lockfile_only: false,
             save_exact: false,
             package_json: false,
+            unscoped: false,
           })
         );
       }
@@ -15966,6 +15977,7 @@ mod tests {
           lockfile_only: true,
           save_exact: false,
           package_json: false,
+          unscoped: false,
         });
         expected_flags.frozen_lockfile = Some(true);
         assert_eq!(r.unwrap(), expected_flags);
@@ -15983,6 +15995,7 @@ mod tests {
             lockfile_only: false,
             save_exact: false,
             package_json: false,
+            unscoped: false,
           }),
         );
       }
@@ -15999,6 +16012,7 @@ mod tests {
             lockfile_only: false,
             save_exact: false,
             package_json: false,
+            unscoped: false,
           }),
         );
       }
@@ -16015,6 +16029,7 @@ mod tests {
             lockfile_only: false,
             save_exact: false,
             package_json: false,
+            unscoped: false,
           }),
         );
       }
@@ -16031,6 +16046,7 @@ mod tests {
             lockfile_only: false,
             save_exact: false,
             package_json: false,
+            unscoped: false,
           }),
         );
       }
@@ -16047,6 +16063,25 @@ mod tests {
             lockfile_only: false,
             save_exact: false,
             package_json: false,
+            unscoped: false,
+          }),
+        );
+      }
+      {
+        let r =
+          flags_from_vec(svec!["deno", cmd, "--unscoped", "jsr:@david/which"]);
+        assert_eq!(
+          r.unwrap(),
+          mk_flags(AddFlags {
+            packages: svec!["jsr:@david/which"],
+            dev: false,
+            optional: false,
+            no_save: false,
+            default_registry: Some(DefaultRegistry::Npm),
+            lockfile_only: false,
+            save_exact: false,
+            package_json: false,
+            unscoped: true,
           }),
         );
       }
@@ -16097,6 +16132,7 @@ mod tests {
             lockfile_only: false,
             save_exact: false,
             package_json: false,
+            unscoped: false,
           }),
           permissions: PermissionFlags {
             allow_import: Some(svec!["example.com"]),

--- a/cli/tools/pm/mod.rs
+++ b/cli/tools/pm/mod.rs
@@ -606,7 +606,8 @@ pub async fn add(
   ));
 
   let mut selected_packages = Vec::with_capacity(add_flags.packages.len());
-  let mut package_reqs = Vec::with_capacity(add_flags.packages.len());
+  let mut package_reqs: Vec<AddRmPackageReq> =
+    Vec::with_capacity(add_flags.packages.len());
 
   let initial_cwd = cli_factory.cli_options()?.initial_cwd().to_path_buf();
   for entry_text in add_flags.packages.iter() {
@@ -620,7 +621,29 @@ pub async fn add(
     .with_context(|| format!("Failed to parse package: {}", entry_text))?;
 
     match req {
-      Ok(add_req) => package_reqs.push(add_req),
+      Ok(mut add_req) => {
+        if add_flags.unscoped {
+          add_req.use_unscoped_alias();
+          // packages from different scopes can share an unscoped name
+          // (ex. `@luca/flag` and `@other/flag`), which would otherwise
+          // silently overwrite each other in the config
+          if let Some(existing) =
+            package_reqs.iter().find(|r| r.alias == add_req.alias)
+          {
+            bail!(
+              "{} and {} would both be added as \"{}\". Provide an explicit alias for one of them (ex. `{}`).",
+              existing.package_name(),
+              add_req.package_name(),
+              add_req.alias,
+              crate::colors::yellow(format!(
+                "deno {cmd_name} my-alias@{}",
+                add_req.package_name()
+              )),
+            );
+          }
+        }
+        package_reqs.push(add_req)
+      }
       // Currently unreachable: default_registry is always Some (defaults to Npm),
       // so parse() always resolves a prefix. Kept as a safety fallback in case
       // the API is called with None from elsewhere.
@@ -1027,6 +1050,34 @@ impl From<crate::args::DefaultRegistry> for Prefix {
   }
 }
 impl AddRmPackageReq {
+  /// The package name with its registry prefix (ex. `jsr:@std/path`).
+  pub fn package_name(&self) -> String {
+    match &self.value {
+      AddRmPackageReqValue::Jsr(req) => format!("jsr:{}", req.name),
+      AddRmPackageReqValue::Npm(req) => format!("npm:{}", req.name),
+    }
+  }
+
+  /// Drops the scope from the alias (ex. `@david/jsonc-morph` becomes
+  /// `jsonc-morph`).
+  ///
+  /// Does nothing when the name has no scope, or when the user provided an
+  /// alias of their own, which is the case whenever the alias isn't the
+  /// package name.
+  pub fn use_unscoped_alias(&mut self) {
+    let name = match &self.value {
+      AddRmPackageReqValue::Jsr(req) | AddRmPackageReqValue::Npm(req) => {
+        &req.name
+      }
+    };
+    if self.alias == *name
+      && let Some((_scope, unscoped_name)) =
+        name.strip_prefix('@').and_then(|name| name.split_once('/'))
+    {
+      self.alias = StackString::from(unscoped_name);
+    }
+  }
+
   pub fn parse(
     entry_text: &str,
     default_prefix: Option<Prefix>,
@@ -1697,8 +1748,8 @@ mod test {
       let s = format!("on input: {input}, maybe_prefix: {maybe_prefix:?}");
       assert_eq!(
         AddRmPackageReq::parse(input, maybe_prefix)
-          .expect(&s)
-          .expect(&s),
+          .unwrap()
+          .unwrap(),
         expected,
         "{s}",
       );
@@ -1711,5 +1762,47 @@ mod test {
         .to_string(),
       "@scope/pkg@tag",
     );
+  }
+
+  #[test]
+  fn test_use_unscoped_alias() {
+    let cases = [
+      (
+        ("jsr:@david/jsonc-morph", None),
+        jsr_pkg_req("jsonc-morph", "@david/jsonc-morph"),
+      ),
+      (
+        ("jsr:@std/path@^1.0.0", None),
+        jsr_pkg_req("path", "@std/path@^1.0.0"),
+      ),
+      (
+        ("npm:@types/node", None),
+        npm_pkg_req("node", "@types/node@*"),
+      ),
+      (
+        ("@scope/pkg", Some(Prefix::Npm)),
+        npm_pkg_req("pkg", "@scope/pkg@*"),
+      ),
+      // an explicit alias always wins
+      (
+        ("my-alias@jsr:@david/jsonc-morph", None),
+        jsr_pkg_req("my-alias", "@david/jsonc-morph"),
+      ),
+      // unscoped names are unaffected
+      (("npm:chalk", None), npm_pkg_req("chalk", "chalk@*")),
+      (
+        ("chalk", Some(Prefix::Npm)),
+        npm_pkg_req("chalk", "chalk@*"),
+      ),
+    ];
+
+    for ((input, maybe_prefix), expected) in cases {
+      let s = format!("on input: {input}, maybe_prefix: {maybe_prefix:?}");
+      let mut req = AddRmPackageReq::parse(input, maybe_prefix)
+        .unwrap()
+        .unwrap();
+      req.use_unscoped_alias();
+      assert_eq!(req, expected, "{s}");
+    }
   }
 }

--- a/libs/cli_parser/src/convert.rs
+++ b/libs/cli_parser/src/convert.rs
@@ -2242,6 +2242,7 @@ fn install_parse(
           lockfile_only,
           save_exact: result.get_bool("save-exact"),
           package_json: result.get_bool("package-json"),
+          unscoped: result.get_bool("unscoped"),
         }),
         npm_target,
       ));
@@ -2506,6 +2507,7 @@ fn add_parse(result: &ParseResult, flags: &mut Flags) {
     lockfile_only: result.get_bool("lockfile-only"),
     save_exact: result.get_bool("save-exact"),
     package_json: result.get_bool("package-json"),
+    unscoped: result.get_bool("unscoped"),
   });
 }
 

--- a/libs/cli_parser/src/defs.rs
+++ b/libs/cli_parser/src/defs.rs
@@ -1692,6 +1692,10 @@ pub static INSTALL_SUBCOMMAND: CommandDef = CommandDef {
       .long_aliases(&["exact"])
       .set_true()
       .conflicts_with(&["entrypoint", "global"]),
+    ArgDef::new("unscoped")
+      .long("unscoped")
+      .set_true()
+      .conflicts_with(&["entrypoint", "global"]),
     ArgDef::new("package-json")
       .long("package-json")
       .set_true()
@@ -1976,6 +1980,7 @@ pub static ADD_SUBCOMMAND: CommandDef = CommandDef {
       .long("save-exact")
       .long_aliases(&["exact"])
       .set_true(),
+    ArgDef::new("unscoped").long("unscoped").set_true(),
     ArgDef::new("npm")
       .long("npm")
       .set_true()

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -64,6 +64,7 @@ pub struct AddFlags {
   pub lockfile_only: bool,
   pub save_exact: bool,
   pub package_json: bool,
+  pub unscoped: bool,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/libs/cli_parser/src/tests_full.rs
+++ b/libs/cli_parser/src/tests_full.rs
@@ -6694,6 +6694,7 @@ fn add_or_install_subcommand() {
           lockfile_only: false,
           save_exact: false,
           package_json: false,
+          unscoped: false,
         })
       );
     }
@@ -6715,6 +6716,7 @@ fn add_or_install_subcommand() {
         lockfile_only: true,
         save_exact: false,
         package_json: false,
+        unscoped: false,
       });
       expected_flags.frozen_lockfile = Some(true);
       assert_eq!(r.unwrap(), expected_flags);
@@ -6732,6 +6734,7 @@ fn add_or_install_subcommand() {
           lockfile_only: false,
           save_exact: false,
           package_json: false,
+          unscoped: false,
         }),
       );
     }
@@ -6748,6 +6751,7 @@ fn add_or_install_subcommand() {
           lockfile_only: false,
           save_exact: false,
           package_json: false,
+          unscoped: false,
         }),
       );
     }
@@ -6764,6 +6768,7 @@ fn add_or_install_subcommand() {
           lockfile_only: false,
           save_exact: false,
           package_json: false,
+          unscoped: false,
         }),
       );
     }
@@ -6780,6 +6785,7 @@ fn add_or_install_subcommand() {
           lockfile_only: false,
           save_exact: false,
           package_json: false,
+          unscoped: false,
         }),
       );
     }
@@ -6796,6 +6802,25 @@ fn add_or_install_subcommand() {
           lockfile_only: false,
           save_exact: false,
           package_json: false,
+          unscoped: false,
+        }),
+      );
+    }
+    {
+      let r =
+        flags_from_vec(svec!["deno", cmd, "--unscoped", "jsr:@david/which"]);
+      assert_eq!(
+        r.unwrap(),
+        mk_flags(AddFlags {
+          packages: svec!["jsr:@david/which"],
+          dev: false,
+          optional: false,
+          no_save: false,
+          default_registry: Some(DefaultRegistry::Npm),
+          lockfile_only: false,
+          save_exact: false,
+          package_json: false,
+          unscoped: true,
         }),
       );
     }
@@ -6846,6 +6871,7 @@ fn add_or_install_subcommand() {
           lockfile_only: false,
           save_exact: false,
           package_json: false,
+          unscoped: false,
         }),
         permissions: PermissionFlags {
           allow_import: Some(svec!["example.com"]),

--- a/tests/specs/add/unscoped/deno_json/__test__.jsonc
+++ b/tests/specs/add/unscoped/deno_json/__test__.jsonc
@@ -1,0 +1,62 @@
+{
+  "tempDir": true,
+  "tests": {
+    // the alias is the package name without its scope
+    "basic": {
+      "steps": [
+        {
+          "args": "add --unscoped jsr:@denotest/add npm:@denotest/esm-basic",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('deno.json').trim())"
+          ],
+          "output": "deno.json.out"
+        }
+      ]
+    },
+    "install_subcommand": {
+      "steps": [
+        {
+          "args": "install --unscoped jsr:@denotest/add",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('deno.json').trim())"
+          ],
+          "output": "install.out"
+        }
+      ]
+    },
+    // an explicit alias is used as-is
+    "explicit_alias_wins": {
+      "steps": [
+        {
+          "args": "add --unscoped my-alias@jsr:@denotest/add",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('deno.json').trim())"
+          ],
+          "output": "explicit_alias.out"
+        }
+      ]
+    },
+    // packages in different scopes can share an unscoped name
+    "collision": {
+      "steps": [
+        {
+          "args": "add --unscoped jsr:@denotest/add npm:@denotest/add",
+          "output": "collision.out",
+          "exitCode": 1
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/add/unscoped/deno_json/collision.out
+++ b/tests/specs/add/unscoped/deno_json/collision.out
@@ -1,0 +1,1 @@
+error: jsr:@denotest/add and npm:@denotest/add would both be added as "add". Provide an explicit alias for one of them (ex. `deno add my-alias@npm:@denotest/add`).

--- a/tests/specs/add/unscoped/deno_json/deno.json
+++ b/tests/specs/add/unscoped/deno_json/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "manual"
+}

--- a/tests/specs/add/unscoped/deno_json/deno.json.out
+++ b/tests/specs/add/unscoped/deno_json/deno.json.out
@@ -1,0 +1,7 @@
+{
+  "nodeModulesDir": "manual",
+  "imports": {
+    "add": "jsr:@denotest/add@^1.0.0",
+    "esm-basic": "npm:@denotest/esm-basic@^1.0.0"
+  }
+}

--- a/tests/specs/add/unscoped/deno_json/explicit_alias.out
+++ b/tests/specs/add/unscoped/deno_json/explicit_alias.out
@@ -1,0 +1,6 @@
+{
+  "nodeModulesDir": "manual",
+  "imports": {
+    "my-alias": "jsr:@denotest/add@^1.0.0"
+  }
+}

--- a/tests/specs/add/unscoped/deno_json/install.out
+++ b/tests/specs/add/unscoped/deno_json/install.out
@@ -1,0 +1,6 @@
+{
+  "nodeModulesDir": "manual",
+  "imports": {
+    "add": "jsr:@denotest/add@^1.0.0"
+  }
+}

--- a/tests/specs/add/unscoped/package_json/__test__.jsonc
+++ b/tests/specs/add/unscoped/package_json/__test__.jsonc
@@ -1,0 +1,53 @@
+{
+  "tempDir": true,
+  "tests": {
+    // npm packages land in package.json under the unscoped alias
+    "npm": {
+      "steps": [
+        {
+          "args": "add --unscoped npm:@denotest/esm-basic",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('package.json').trim())"
+          ],
+          "output": "package.json.out"
+        }
+      ]
+    },
+    // jsr packages prefer deno.json even when only a package.json exists
+    "jsr": {
+      "steps": [
+        {
+          "args": "add --unscoped jsr:@denotest/add",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('deno.json').trim())"
+          ],
+          "output": "jsr_deno.json.out"
+        }
+      ]
+    },
+    // a jsr package forced into package.json uses the @jsr npm alias
+    "jsr_package_json_flag": {
+      "steps": [
+        {
+          "args": "add --unscoped --package-json jsr:@denotest/add",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('package.json').trim())"
+          ],
+          "output": "jsr_package.json.out"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/add/unscoped/package_json/jsr_deno.json.out
+++ b/tests/specs/add/unscoped/package_json/jsr_deno.json.out
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "add": "jsr:@denotest/add@^1.0.0"
+  }
+}

--- a/tests/specs/add/unscoped/package_json/jsr_package.json.out
+++ b/tests/specs/add/unscoped/package_json/jsr_package.json.out
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "add": "npm:@jsr/denotest__add@^1.0.0"
+  }
+}

--- a/tests/specs/add/unscoped/package_json/package.json
+++ b/tests/specs/add/unscoped/package_json/package.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/tests/specs/add/unscoped/package_json/package.json.out
+++ b/tests/specs/add/unscoped/package_json/package.json.out
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "esm-basic": "npm:@denotest/esm-basic@^1.0.0"
+  }
+}


### PR DESCRIPTION
`deno add --unscoped jsr:@david/jsonc-morph` adds the package to the import map as "jsonc-morph" instead of "@david/jsonc-morph", which is the same result as spelling out `jsonc-morph@jsr:@david/jsonc-morph`.

`jsonc-morph@jsr:@david/jsonc-morph` is a mouthful, so `--unscoped` is nicer to write and doesn't have any duplication.

The reason I want this, is so I can recommend:

```
npm install jsonc-morph
deno install --unscoped jsr:@david/jsonc-morph
```

Then the users all import from the same `"jsonc-morph"` bare specifier.

Also supported on `deno install <pkg>`. Applies to package.json too, where a differing alias is written using npm's alias syntax ("esm-basic": "npm:@denotest/esm-basic@^1.0.0").

An alias the user provided always wins, and unscoped package names are unaffected. Because two scopes can share a name, adding packages that would collapse to the same alias is an error rather than letting one silently overwrite the other.

This PR was created and iterated on with AI.