### PR TITLE
fix(npm): tolerate malformed `scripts` field in packuments

### DIFF
--- a/libs/npm_cache/lib.rs
+++ b/libs/npm_cache/lib.rs
@@ -568,9 +568,15 @@ fn has_install_script(
   let Some(scripts) = raw_fields.get("scripts") else {
     return Ok(false);
   };
-  let scripts =
+  // Historically some packuments contain a malformed `scripts` field that is
+  // not a map (e.g. an empty string, see #36323). Treat anything that doesn't
+  // deserialize as an object as having no lifecycle scripts rather than failing
+  // to load the entire packument.
+  let Ok(scripts) =
     serde_json::from_str::<BTreeMap<String, &RawValue>>(scripts.get())
-      .map_err(JsErrorBox::from_err)?;
+  else {
+    return Ok(false);
+  };
   Ok(
     scripts.contains_key("preinstall")
       || scripts.contains_key("install")
@@ -875,5 +881,33 @@ mod tests {
       )
       .unwrap();
     assert!(!cache_metadata.full_packument);
+  }
+
+  #[test]
+  fn slim_package_info_bytes_tolerates_malformed_scripts() {
+    // Some historical packuments contain a `scripts` field that isn't a map
+    // (e.g. npm:jsox@1.1.121 has `"scripts":""`). Loading the packument should
+    // succeed and treat it as having no lifecycle scripts (see #36323).
+    let input = br#"{
+      "name":"pkg",
+      "dist-tags":{"latest":"1.0.0"},
+      "versions":{
+        "1.0.0":{"version":"1.0.0","scripts":""},
+        "1.0.1":{"version":"1.0.1","scripts":[]},
+        "1.0.2":{"version":"1.0.2","scripts":{"postinstall":"node x.js"}}
+      },
+      "time":{"1.0.0":"2026-01-01T00:00:00.000Z"}
+    }"#;
+
+    let output = slim_package_info_bytes(input, None, false).unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    // malformed `scripts` values are dropped and don't mark an install script
+    assert!(value["versions"]["1.0.0"].get("hasInstallScript").is_none());
+    assert!(value["versions"]["1.0.1"].get("hasInstallScript").is_none());
+    // a well-formed `scripts` map with a lifecycle hook is still detected
+    assert_eq!(value["versions"]["1.0.2"]["hasInstallScript"], true);
+
+    // the whole packument still parses back into an NpmPackageInfo
+    deno_npm::registry::NpmPackageInfo::from_packument_bytes(output).unwrap();
   }
 }


### PR DESCRIPTION
Installing or inspecting some packages that historically shipped a malformed
`package.json` fails on 2.9.x. For example `deno info npm:jsox` errors with:

```
error: Failed loading https://registry.npmjs.org/jsox for package "jsox"
Caused by: invalid type: string "", expected a map at line 1 column 2
```

The cause is in the slim-packument caching path. When building the cached
packument, `has_install_script` deserializes each version's `scripts` field
into a `BTreeMap<String, &RawValue>` and propagates any error. The version
`jsox@1.1.121` has `"scripts": ""` (an empty string rather than an object),
so the parse fails and the error bubbles all the way up, aborting the load of
the entire packument.

This treats a `scripts` field that doesn't deserialize into an object as
having no lifecycle scripts, matching how the rest of the registry parsing
already tolerates malformed historical fields, instead of failing the whole
load.

Verified that `deno info npm:jsox` now succeeds against a clean cache, and
added a unit test covering non-object `scripts` values.

Closes #36323
