### PR TITLE
fix(ext/node): use signatureAlgorithm digest for X509 ECDSA verify

### DIFF
--- a/ext/node_crypto/x509.rs
+++ b/ext/node_crypto/x509.rs
@@ -1193,20 +1193,37 @@ pub fn op_node_x509_verify(
     AsymmetricPublicKey::Ec(ec_key) => {
       use crate::keys::EcPublicKey;
 
+      // The ECDSA digest is determined by the certificate's `signatureAlgorithm`
+      // (e.g. ecdsa-with-SHA256), not by the issuer key's curve. Using the
+      // curve's default hash (P-256 -> SHA-256, P-384 -> SHA-384) breaks
+      // cross-curve chains where, for example, a P-384 issuer signs with
+      // SHA-256 (as Apple App Attest certificates do). See #36309.
+      let prehash = match sig_alg_oid.as_str() {
+        // ecdsa-with-SHA1
+        "1.2.840.10045.4.1" => sha1::Sha1::digest(tbs_raw).to_vec(),
+        // ecdsa-with-SHA256
+        "1.2.840.10045.4.3.2" => sha2::Sha256::digest(tbs_raw).to_vec(),
+        // ecdsa-with-SHA384
+        "1.2.840.10045.4.3.3" => sha2::Sha384::digest(tbs_raw).to_vec(),
+        // ecdsa-with-SHA512
+        "1.2.840.10045.4.3.4" => sha2::Sha512::digest(tbs_raw).to_vec(),
+        _ => return Ok(false),
+      };
+
       match ec_key {
         EcPublicKey::P256(key) => {
-          use p256::ecdsa::signature::Verifier;
+          use p256::ecdsa::signature::hazmat::PrehashVerifier;
           let verifying_key = p256::ecdsa::VerifyingKey::from(key);
-          let sig = p256::ecdsa::DerSignature::try_from(sig_value)
+          let sig = p256::ecdsa::Signature::from_der(sig_value)
             .map_err(|_| X509VerifyError::ParseFailed)?;
-          Ok(verifying_key.verify(tbs_raw, &sig).is_ok())
+          Ok(verifying_key.verify_prehash(&prehash, &sig).is_ok())
         }
         EcPublicKey::P384(key) => {
-          use p384::ecdsa::signature::Verifier;
+          use p384::ecdsa::signature::hazmat::PrehashVerifier;
           let verifying_key = p384::ecdsa::VerifyingKey::from(key);
-          let sig = p384::ecdsa::DerSignature::try_from(sig_value)
+          let sig = p384::ecdsa::Signature::from_der(sig_value)
             .map_err(|_| X509VerifyError::ParseFailed)?;
-          Ok(verifying_key.verify(tbs_raw, &sig).is_ok())
+          Ok(verifying_key.verify_prehash(&prehash, &sig).is_ok())
         }
         _ => Err(X509VerifyError::UnsupportedEcCurve),
       }

--- a/tests/unit_node/crypto/crypto_key_test.ts
+++ b/tests/unit_node/crypto/crypto_key_test.ts
@@ -1082,6 +1082,43 @@ Deno.test("X509Certificate verify", function () {
   );
 });
 
+// https://github.com/denoland/deno/issues/36309
+// The ECDSA digest must come from the certificate's `signatureAlgorithm`
+// (ecdsa-with-SHA256 here), not from the issuer key's curve. This leaf is a
+// P-256 certificate signed by a P-384 issuer using SHA-256 (as Apple App
+// Attest chains are), which previously failed to verify.
+Deno.test("X509Certificate verify cross-curve ecdsa chain", function () {
+  const crossCurveCaPem = `-----BEGIN CERTIFICATE-----
+MIIBxTCCAUqgAwIBAgIUFkZzTvCTV/eJVr87jS1GKZX8IPEwCgYIKoZIzj0EAwIw
+GTEXMBUGA1UEAwwOQ3Jvc3MgQ3VydmUgQ0EwHhcNMjYwNzI3MDkxMDM5WhcNMzYw
+NzI0MDkxMDM5WjAZMRcwFQYDVQQDDA5Dcm9zcyBDdXJ2ZSBDQTB2MBAGByqGSM49
+AgEGBSuBBAAiA2IABMHiEl3CJP/jRs2u4jJHI3mxa/4V4ZBAqpdS42dqGRqqEiDd
+by0zCuZ4saLZPz9rvsN7CxcjrdV0Z621vQm+TBImHi7CL7E5qAZxrR31UJ9p52+k
+8BoATUfoSXNQo/28raNTMFEwHQYDVR0OBBYEFGgsWnzOP+cQ5BzulgStVdGbOBJf
+MB8GA1UdIwQYMBaAFGgsWnzOP+cQ5BzulgStVdGbOBJfMA8GA1UdEwEB/wQFMAMB
+Af8wCgYIKoZIzj0EAwIDaQAwZgIxAKv8tBXbbA9pR41GWxQmSf/bXDhQNntG3YsG
+Y1JH0fXeJ+NNjfZle1b9S5Ljks6pAQIxALmcMTDbr96MVRa0QxNI57OFuA6vJ7G6
+ISCPbtKAgkiabrWVGfhcIhEqc8vz91mJDA==
+-----END CERTIFICATE-----
+`;
+  const crossCurveLeafPem = `-----BEGIN CERTIFICATE-----
+MIIBjTCCARKgAwIBAgIUU8z17ymc8g9qPv+IPSe9DYG7WfswCgYIKoZIzj0EAwIw
+GTEXMBUGA1UEAwwOQ3Jvc3MgQ3VydmUgQ0EwHhcNMjYwNzI3MDkxMDM5WhcNMjcw
+NzI3MDkxMDM5WjAPMQ0wCwYDVQQDDARsZWFmMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAEyqluuCFjuMl2Iuhtg504A5jQJRyxrsM1/iJxIY54enUe6RqldPZ2YfM4
+leCAHympKdYAPGCidW2W17+vfpSfPaNCMEAwHQYDVR0OBBYEFLkgR+1YYc8WTdWR
+aX362SwZYmhsMB8GA1UdIwQYMBaAFGgsWnzOP+cQ5BzulgStVdGbOBJfMAoGCCqG
+SM49BAMCA2kAMGYCMQDtzRY/6GrdVfX+dDs0AvNwRzgmICSOKC4977cMqz28GuMI
+vPPlLPVytaNmuuygy04CMQDPQT9pqF1pmYbMtLXPEaN228ngdOkzVKUN6rInB0Jo
+s/KhMqowHz1KcSoPuUZ82rI=
+-----END CERTIFICATE-----
+`;
+  const leaf = new X509Certificate(crossCurveLeafPem);
+  const ca = new X509Certificate(crossCurveCaPem);
+  assertEquals(leaf.checkIssued(ca), true);
+  assertEquals(leaf.verify(ca.publicKey), true);
+});
+
 Deno.test("X509Certificate infoAccess", function () {
   const x509 = new X509Certificate(certPem);
   const infoAccess = x509.infoAccess;


### PR DESCRIPTION
`X509Certificate.prototype.verify(publicKey)` returned `false` for valid
cross-curve ECDSA certificate chains. A P-256 leaf certificate signed by a
P-384 issuer using `ecdsa-with-SHA256` failed to verify under Deno, while
Node.js verifies it successfully. This broke, among other things, Apple App
Attest attestation verification, whose chains mix curves.

The EC branch of `op_node_x509_verify` used the RustCrypto `Verifier`
implementation, which ties the ECDSA digest to the key's curve (P-256 implies
SHA-256, P-384 implies SHA-384). But the digest is a property of the
certificate's `signatureAlgorithm`, not of the signing key's curve — ECDSA
permits any curve with any hash. So when a P-384 issuer key signed with
SHA-256, verification hashed the TBS with SHA-384 and failed.

The digest is now selected from the `signatureAlgorithm` OID
(`ecdsa-with-SHA1/256/384/512`) and the signature is checked against the
prehash via `verify_prehash`, decoupling the hash from the curve. This matches
the approach already used by the Web Crypto ECDSA verifier.

Added a `node:crypto` unit test with a P-256 leaf signed by a P-384 issuer
using SHA-256; it now verifies as expected. Same-curve chains continue to
verify.

Closes #36309
