### PR TITLE
fix(ext/websocket): disable HTTP/2 server push on wss upgrade path

### DIFF
--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -326,7 +326,11 @@ async fn handshake_http2(
     return Err(HandshakeError::NoH2Alpn);
   }
 
-  let h2 = h2::client::Builder::new();
+  let mut h2 = h2::client::Builder::new();
+  // We don't use HTTP/2 server push, and leaving it enabled exposes an h2
+  // state-machine assertion that a malicious server can trip to abort the
+  // process (a second 1xx response on a PUSH_PROMISE stream).
+  h2.enable_push(false);
   let (mut send, conn) = h2.handshake::<_, Bytes>(connection).await?;
   spawn(conn);
   let mut request = Request::builder();

--- a/tests/unit/websocket_test.ts
+++ b/tests/unit/websocket_test.ts
@@ -54,6 +54,27 @@ Deno.test(async function websocketH2SendSmallPacket() {
   await promise;
 });
 
+// Regression test: the WebSocket-over-HTTP/2 client must disable HTTP/2 server
+// push (SETTINGS_ENABLE_PUSH = 0). Leaving push enabled exposes an h2
+// state-machine assertion that a malicious server can trip via a crafted
+// PUSH_PROMISE sequence, aborting the whole process. The test server attempts a
+// server push and reports the outcome as its first message: a safe client makes
+// h2 reject the push ("push-rejected").
+Deno.test(async function websocketH2DisablesServerPush() {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const ws = new WebSocket(new URL("wss://localhost:4266/"));
+  ws.onerror = (e) => reject(e);
+  ws.onmessage = (m) => {
+    try {
+      assertEquals(m.data, "push-rejected");
+    } finally {
+      ws.close();
+    }
+  };
+  ws.onclose = () => resolve();
+  await promise;
+});
+
 Deno.test(async function websocketH2SendLargePacket() {
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   const ws = new WebSocket(new URL("wss://localhost:4249/"));

--- a/tests/util/lib/lib.rs
+++ b/tests/util/lib/lib.rs
@@ -345,7 +345,7 @@ fn ensure_test_server_built() {
   }
 }
 
-pub const TEST_SERVERS_COUNT: usize = 38;
+pub const TEST_SERVERS_COUNT: usize = 39;
 
 #[derive(Default)]
 struct HttpServerCount {

--- a/tests/util/server/servers/mod.rs
+++ b/tests/util/server/servers/mod.rs
@@ -85,6 +85,7 @@ const HTTPS_CLIENT_AUTH_PORT: u16 = 5552;
 const WS_PORT: u16 = 4242;
 const WSS_PORT: u16 = 4243;
 const WSS2_PORT: u16 = 4249;
+const WSS2_PUSH_PORT: u16 = 4266;
 const WS_CLOSE_PORT: u16 = 4244;
 const WS_HANG_PORT: u16 = 4264;
 const WS_PING_PORT: u16 = 4245;
@@ -118,6 +119,7 @@ pub async fn run_all_servers() {
   let ws_close_server_fut = ws::run_ws_close_server(WS_CLOSE_PORT);
   let ws_hang_server_fut = ws::run_ws_hang_handshake(WS_HANG_PORT);
   let wss2_server_fut = ws::run_wss2_server(WSS2_PORT);
+  let wss2_push_server_fut = ws::run_wss2_push_server(WSS2_PUSH_PORT);
 
   let tls_server_fut = run_tls_server(TLS_PORT);
   let tls_client_auth_server_fut =
@@ -161,6 +163,7 @@ pub async fn run_all_servers() {
     ws_ping_server_fut.boxed_local(),
     wss_server_fut.boxed_local(),
     wss2_server_fut.boxed_local(),
+    wss2_push_server_fut.boxed_local(),
     tls_server_fut.boxed_local(),
     tls_client_auth_server_fut.boxed_local(),
     ws_close_server_fut.boxed_local(),

--- a/tests/util/server/servers/ws.rs
+++ b/tests/util/server/servers/ws.rs
@@ -120,6 +120,49 @@ pub async fn run_wss2_server(port: u16) {
   }
 }
 
+// A malicious-ish wss2 server used to guard against the HTTP/2 server-push
+// assertion DoS: a client that leaves `ENABLE_PUSH` at h2's default (enabled)
+// can be crashed by a crafted PUSH_PROMISE sequence. Deno's WebSocket client
+// disables push (`enable_push(false)`), so h2 refuses this server's push
+// attempt with `PeerDisabledServerPush`. The server reports which happened as
+// the first WebSocket text frame ("push-rejected" when the client is safe),
+// then echoes like the normal wss2 server.
+pub async fn run_wss2_push_server(port: u16) {
+  let mut tls = get_tls_listener_stream(
+    "wss2 (push)",
+    port,
+    SupportedHttpVersions::Http2Only,
+  )
+  .await;
+  while let Some(Ok(tls)) = tls.next().await {
+    tokio::spawn(async move {
+      let mut h2 = h2::server::Builder::new();
+      h2.enable_connect_protocol();
+      let server: Handshake<_, Bytes> = h2.handshake(tls);
+      let mut server = match server.await {
+        Ok(server) => server,
+        Err(e) => {
+          println!("Failed to handshake h2: {e:?}");
+          return;
+        }
+      };
+      loop {
+        let Some(conn) = server.accept().await else {
+          break;
+        };
+        let (recv, send) = match conn {
+          Ok(conn) => conn,
+          Err(e) => {
+            println!("Failed to accept a connection: {e:?}");
+            break;
+          }
+        };
+        tokio::spawn(handle_wss_push_stream(recv, send));
+      }
+    });
+  }
+}
+
 async fn echo_websocket_handler(
   ws: fastwebsockets::WebSocket<TokioIo<Upgraded>>,
 ) -> Result<(), anyhow::Error> {
@@ -215,6 +258,89 @@ async fn handle_wss_stream(
   let f1 = tokio::spawn(tokio::task::unconstrained(async move {
     let ws = WebSocket::after_handshake(a, Role::Server);
     let mut ws = FragmentCollector::new(ws);
+    loop {
+      let frame = ws.read_frame().await.unwrap();
+      if frame.opcode == OpCode::Close {
+        break;
+      }
+      ws.write_frame(frame).await.unwrap();
+    }
+  }));
+  let (mut br, mut bw) = tokio::io::split(b);
+  let f2 = tokio::spawn(tokio::task::unconstrained(async move {
+    loop {
+      let Some(Ok(data)) = poll_fn(|cx| body.poll_data(cx)).await else {
+        return;
+      };
+      body.flow_control().release_capacity(data.len()).unwrap();
+      let Ok(_) = bw.write_all(&data).await else {
+        break;
+      };
+    }
+  }));
+  let f3 = tokio::spawn(tokio::task::unconstrained(async move {
+    loop {
+      let mut buf = [0; 65536];
+      let n = br.read(&mut buf).await.unwrap();
+      if n == 0 {
+        break;
+      }
+      resp.reserve_capacity(n);
+      poll_fn(|cx| resp.poll_capacity(cx)).await;
+      resp
+        .send_data(Bytes::copy_from_slice(&buf[0..n]), false)
+        .unwrap();
+    }
+    resp.send_data(Bytes::new(), true).unwrap();
+  }));
+  _ = join3(f1, f2, f3).await;
+  Ok(())
+}
+
+async fn handle_wss_push_stream(
+  recv: Request<RecvStream>,
+  mut send: SendResponse<Bytes>,
+) -> Result<(), h2::Error> {
+  if recv.method() != Method::CONNECT {
+    send.send_reset(Reason::REFUSED_STREAM);
+    return Ok(());
+  }
+  let Some(protocol) = recv.extensions().get::<h2::ext::Protocol>() else {
+    send.send_reset(Reason::REFUSED_STREAM);
+    return Ok(());
+  };
+  if protocol.as_str() != "websocket" && protocol.as_str() != "WebSocket" {
+    send.send_reset(Reason::REFUSED_STREAM);
+    return Ok(());
+  }
+
+  // Attempt a server push. h2 refuses this with `PeerDisabledServerPush` when
+  // the client advertised `SETTINGS_ENABLE_PUSH = 0`, which is exactly what a
+  // patched Deno client does. If the client left push enabled, the push
+  // succeeds instead - the unsafe configuration this test guards against.
+  let push_req = Request::builder()
+    .method(Method::GET)
+    .uri("https://localhost/pushed")
+    .body(())
+    .unwrap();
+  let push_allowed = send.push_request(push_req).is_ok();
+
+  let mut body = recv.into_body();
+  let mut response = Response::new(());
+  *response.status_mut() = StatusCode::OK;
+  let mut resp = send.send_response(response, false)?;
+  let (a, b) = tokio::io::duplex(65536);
+  let f1 = tokio::spawn(tokio::task::unconstrained(async move {
+    let ws = WebSocket::after_handshake(a, Role::Server);
+    let mut ws = FragmentCollector::new(ws);
+    let status = if push_allowed {
+      "push-allowed"
+    } else {
+      "push-rejected"
+    };
+    ws.write_frame(Frame::text(status.as_bytes().to_vec().into()))
+      .await
+      .unwrap();
     loop {
       let frame = ws.read_frame().await.unwrap();
       if frame.opcode == OpCode::Close {


### PR DESCRIPTION
The WebSocket-over-HTTP/2 fallback path in `ext/websocket` — the RFC 8441
Extended CONNECT handshake Deno uses when a `wss://` connection's ordinary
HTTP/1.1 Upgrade fails — constructed its `h2::client::Builder` without disabling
server push, so the connection ran with h2's default (push enabled). The client
has no use for HTTP/2 server push in the first place.

Leaving push enabled exposes a reachable assertion in the `h2` crate: a server
that opens a stream via `PUSH_PROMISE` and then sends two informational (1xx)
`HEADERS` frames on it re-enters h2's "initial response" counting path a second
time and trips `assert!(!stream.is_counted)`, panicking the connection task.
Because release builds set `panic = "abort"`, that panic aborts the entire
process rather than just failing the one connection.

The fallback is fully controllable by the peer: a malicious or compromised
`wss://` server can simply fail the HTTP/1.1 Upgrade to force a connecting Deno
client down the HTTP/2 path, then send the crafted frame sequence. The realistic
exposure is a Deno process induced to open a `wss://` connection to an
attacker-influenced endpoint (a proxy/gateway to a third-party upstream, or an
SSRF-adjacent scenario). It is a denial of service only — not memory unsafety,
code execution, or information disclosure — and the underlying defect lives in
`h2` itself; Deno's part is only that it never opted out of push.

The fix is a one-liner: call `enable_push(false)` on the builder, matching what
every other major `h2` consumer (hyper, awc, pingora, hickory) already does.
Advertising `SETTINGS_ENABLE_PUSH = 0` makes the vulnerable state unreachable,
with no functional downside since the WebSocket client never wants push.

To guard against regressions, this adds a dedicated wss2 test server that
attempts a server push on the accepted CONNECT stream and reports the outcome as
its first WebSocket frame. With the fix, h2 refuses the push
(`PeerDisabledServerPush`) and the client observes `push-rejected`; without it,
the push succeeds and the test fails. I confirmed the test discriminates by
reverting the fix locally (client received `push-allowed`) and restoring it
(`push-rejected`).
