### PR TITLE
fix(ext/node): keep process.cwd() in sync with Deno.chdir()

### DIFF
--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -163,8 +163,29 @@ function cwd() {
   return op_fs_cwd();
 }
 
+// A listener the `node:process` polyfill registers so that libraries which
+// wrap `process.chdir`/`process.cwd` (e.g. `graceful-fs`, which caches the cwd
+// and only invalidates that cache on `process.chdir`) observe changes made via
+// `Deno.chdir`. See https://github.com/denoland/deno/issues/36294.
+let onChdirListener = null;
+let chdirInProgress = false;
+
+function setOnChdirListener(listener) {
+  onChdirListener = listener;
+}
+
 function chdir(directory) {
   op_fs_chdir(pathFromURL(directory));
+  // Guard against re-entrancy: the listener typically replays the change
+  // through `process.chdir`, which routes back into this function.
+  if (onChdirListener !== null && !chdirInProgress) {
+    chdirInProgress = true;
+    try {
+      onChdirListener();
+    } finally {
+      chdirInProgress = false;
+    }
+  }
 }
 
 function makeTempDirSync(options = { __proto__: null }) {
@@ -973,6 +994,7 @@ function writeTextFile(
 
 return {
   chdir,
+  setOnChdirListener,
   chmod,
   chmodSync,
   chown,

--- a/ext/node/polyfills/_process/process.ts
+++ b/ext/node/polyfills/_process/process.ts
@@ -84,6 +84,23 @@ function chdir(directory: string): void {
 /** https://nodejs.org/api/process.html#process_process_cwd */
 const cwd = fs.cwd;
 
+// Libraries such as `graceful-fs` (pulled in by `fs-extra` and many others)
+// wrap `process.chdir`/`process.cwd` to cache the working directory, only
+// invalidating that cache when `process.chdir` is called. `Deno.chdir` changes
+// the working directory without going through `process.chdir`, which would
+// leave `process.cwd()` stale. Replay `Deno.chdir` through the currently
+// installed `process.chdir` (when it has been wrapped) so those caches stay in
+// sync. See https://github.com/denoland/deno/issues/36294.
+fs.setOnChdirListener(() => {
+  const process = globalThis.process;
+  if (
+    process !== undefined && process !== null &&
+    typeof process.chdir === "function" && process.chdir !== chdir
+  ) {
+    process.chdir(fs.cwd());
+  }
+});
+
 /** https://nodejs.org/api/process.html#process_process_nexttick_callback_args */
 const nextTick = _nextTick;
 

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -101,6 +101,46 @@ Deno.test({
   },
 });
 
+// Regression test for https://github.com/denoland/deno/issues/36294
+// `graceful-fs` (via `fs-extra`, and many others) wraps `process.cwd`/
+// `process.chdir` to cache the cwd, invalidating the cache only on
+// `process.chdir`. `Deno.chdir` must replay through `process.chdir` so those
+// caches don't go stale.
+Deno.test({
+  name: "Deno.chdir keeps a wrapped process.cwd in sync",
+  fn() {
+    const currentDir = Deno.cwd();
+    const tempDir = Deno.makeTempDirSync();
+
+    // Emulate graceful-fs's cwd caching.
+    const origCwd = process.cwd;
+    const origChdir = process.chdir;
+    let cached: string | null = null;
+    process.cwd = function () {
+      if (cached === null) cached = origCwd.call(process);
+      return cached;
+    };
+    process.chdir = function (dir: string) {
+      cached = null;
+      return origChdir.call(process, dir);
+    };
+
+    try {
+      process.cwd(); // prime the cache with the original directory
+      Deno.chdir(tempDir);
+      assertEquals(
+        Deno.realPathSync(process.cwd()),
+        Deno.realPathSync(tempDir),
+      );
+      assertEquals(process.cwd(), Deno.cwd());
+    } finally {
+      process.cwd = origCwd;
+      process.chdir = origChdir;
+      Deno.chdir(currentDir);
+    }
+  },
+});
+
 Deno.test({
   name: "process.version",
   fn() {


### PR DESCRIPTION
`process.cwd()` could return a stale directory after `Deno.chdir()`.

Libraries such as `graceful-fs` (pulled in transitively by `fs-extra` and a
large chunk of the npm ecosystem) monkey-patch `process.chdir`/`process.cwd`
to cache the working directory, invalidating that cache only when
`process.chdir()` is called. `Deno.chdir()` changes the working directory
without going through `process.chdir()`, so those caches were never
invalidated and `process.cwd()` kept returning the old directory.

The reported symptom (#36294) was bundling with rollup failing after
`Deno.chdir()` — but only when `gltf-pipeline` (`-> fs-extra -> graceful-fs`)
was imported. Rollup resolves its entry module relative to `process.cwd()`,
which pointed at the pre-`chdir` directory, so it couldn't find the entry.

A minimal reproduction:

```js
import { processGlb } from "npm:gltf-pipeline@4.0.2";
import process from "node:process";
Deno.chdir("./src");
console.log(Deno.cwd(), process.cwd());
// before: /repro/src   /repro       <- process.cwd() stale
// after:  /repro/src   /repro/src
```

This adds a post-`chdir` listener to the `fs.chdir` used by `Deno.chdir`, which
the `node:process` polyfill registers. When the working directory changes via
`Deno.chdir`, the listener replays the change through the currently installed
`process.chdir` (only when it has been wrapped away from our own
implementation), so userland caches like graceful-fs's observe it. A
re-entrancy guard prevents the replay from looping back through `chdir`.

Added a `node:process` unit test that emulates graceful-fs's cwd caching and
asserts `process.cwd()` follows `Deno.chdir()`.

Closes #36294
