### PR TITLE
chore: link deno.com/agents.md from `deno --help`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1029,6 +1029,8 @@ static DENO_HELP: &str = cstr!(
 <y>Standard Library:</> https://jsr.io/@std
 <y>Bugs:</> https://github.com/denoland/deno/issues
 <y>Discord:</> https://discord.gg/deno
+
+<p(245)>If you are an AI agent, read</> <c>https://deno.com/agents.md</> <p(245)>to get started.</>
 ");
 
 pub fn flags_from_vec(args: Vec<OsString>) -> clap::error::Result<Flags> {


### PR DESCRIPTION
`deno --help` is where a coding agent looks first when it finds the binary in a
project, so it is the natural place to advertise the agent onboarding guide
added in denoland/docs#3429. One line in the help footer, next to the existing
docs and standard library links.

Should land after denoland/dotcom#1998, which is what makes the URL resolve.