### PR TITLE
feat(cli/lint): support custom file extensions though preprocessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,17 +1022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.0",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "2.9.4"
+version = "2.9.3"
 dependencies = [
  "anstream",
  "async-trait",
@@ -2781,10 +2770,7 @@ dependencies = [
 [[package]]
 name = "deno_lint"
 version = "0.84.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f077fbc572115bf86a5e6ed8314aa7b5ad18266e03df3db5c32004a6b1cd1df"
 dependencies = [
- "anyhow",
  "deno_ast",
  "deno_semver",
  "derive_more",
@@ -4597,13 +4583,13 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.17.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
- "foldhash 0.2.0",
+ "getrandom 0.3.3",
  "libm",
- "portable-atomic",
+ "rand 0.9.2",
  "siphasher 1.0.1",
 ]
 
@@ -5046,9 +5032,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5058,13 +5046,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -6550,7 +6536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8000,9 +7986,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "potential_utf"
@@ -8232,17 +8218,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "fastbloom",
- "getrandom 0.4.1",
+ "getrandom 0.3.3",
  "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -8321,17 +8306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.1",
- "rand_core 0.10.0",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8374,15 +8348,6 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.0",
-]
 
 [[package]]
 name = "rand_xorshift"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno"
-version = "2.9.4"
+version = "2.9.3"
 authors.workspace = true
 default-run = "deno"
 edition.workspace = true
@@ -172,6 +172,7 @@ rustyline.workspace = true
 rustyline-derive.workspace = true
 same-file.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 serde_repr.workspace = true
 sha2.workspace = true
 shlex.workspace = true

--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -89,12 +89,14 @@ const state = {
   plugins: [],
   installedPlugins: new Set(),
   ignoredRules: new Set(),
+  processors: new Map(),
 };
 
 function resetState() {
   state.plugins = [];
   state.installedPlugins.clear();
   state.ignoredRules.clear();
+  state.processors.clear();
 }
 
 /**
@@ -218,10 +220,7 @@ export class SourceCode {
   }
 
   get ast() {
-    const program = /** @type {*} */ (getNode(
-      this.#ctx,
-      this.#ctx.rootOffset,
-    ));
+    const program = /** @type {*} */ (getNode(this.#ctx, this.#ctx.rootOffset));
 
     return program;
   }
@@ -327,7 +326,8 @@ export class SourceCode {
     for (let i = 0; i < comments.length; i++) {
       const comment = comments[i];
       if (
-        comment.range[0] >= node.range[0] && comment.range[1] <= node.range[1]
+        comment.range[0] >= node.range[0] &&
+        comment.range[1] <= node.range[1]
       ) {
         inside.push(comment);
       }
@@ -413,14 +413,7 @@ export class Context {
       }
     }
 
-    doReport(
-      this.id,
-      data.message,
-      data.hint,
-      start,
-      end,
-      fixes,
-    );
+    doReport(this.id, data.message, data.hint, start, end, fixes);
   }
 }
 
@@ -509,9 +502,16 @@ function installPlugin(plugin, specifier) {
   state.plugins.push(plugin);
   state.installedPlugins.add(plugin.name);
 
+  if (plugin.processors) {
+    for (const ext of Object.keys(plugin.processors)) {
+      state.processors.set(ext, plugin.processors[ext]);
+    }
+  }
+
   return {
     name: plugin.name,
     ruleNames: Object.keys(plugin.rules),
+    extensions: plugin.processors ? Object.keys(plugin.processors) : [],
   };
 }
 
@@ -626,12 +626,7 @@ function setNodeGetters(ctx) {
       // See the npm `zimmerframe` library.
       enumerable: name !== "parent",
       get() {
-        return readValue(
-          this[INTERNAL_CTX],
-          this[INTERNAL_IDX],
-          i,
-          getNode,
-        );
+        return readValue(this[INTERNAL_CTX], this[INTERNAL_IDX], i, getNode);
       },
     });
   }
@@ -692,7 +687,7 @@ function readType(buf, idx) {
  * @returns {Deno.lint.Node["range"]}
  */
 function readSpan(ctx, idx) {
-  let offset = ctx.spansOffset + (idx * SPAN_SIZE);
+  let offset = ctx.spansOffset + idx * SPAN_SIZE;
   const start = readU32(ctx.buf, offset);
   offset += 4;
   const end = readU32(ctx.buf, offset);
@@ -706,7 +701,7 @@ function readSpan(ctx, idx) {
  * @returns {number}
  */
 function readRawPropOffset(buf, idx) {
-  const offset = (idx * NODE_SIZE) + PROP_OFFSET;
+  const offset = idx * NODE_SIZE + PROP_OFFSET;
   return readU32(buf, offset);
 }
 
@@ -725,7 +720,7 @@ function readPropOffset(ctx, idx) {
  * @returns {number}
  */
 function readChild(buf, idx) {
-  const offset = (idx * NODE_SIZE) + CHILD_OFFSET;
+  const offset = idx * NODE_SIZE + CHILD_OFFSET;
   return readU32(buf, offset);
 }
 /**
@@ -734,7 +729,7 @@ function readChild(buf, idx) {
  * @returns {number}
  */
 function readNext(buf, idx) {
-  const offset = (idx * NODE_SIZE) + NEXT_OFFSET;
+  const offset = idx * NODE_SIZE + NEXT_OFFSET;
   return readU32(buf, offset);
 }
 
@@ -744,7 +739,7 @@ function readNext(buf, idx) {
  * @returns {number}
  */
 function readParent(buf, idx) {
-  const offset = (idx * NODE_SIZE) + PARENT_OFFSET;
+  const offset = idx * NODE_SIZE + PARENT_OFFSET;
   return readU32(buf, offset);
 }
 
@@ -885,8 +880,7 @@ const DECODER = new TextDecoder();
  * @returns {number}
  */
 function readU32(buf, i) {
-  return (buf[i] << 24) + (buf[i + 1] << 16) + (buf[i + 2] << 8) +
-    buf[i + 3];
+  return (buf[i] << 24) + (buf[i + 1] << 16) + (buf[i + 2] << 8) + buf[i + 3];
 }
 
 /**
@@ -1019,7 +1013,8 @@ class MatchCtx {
       }
 
       if (
-        propIdx < propIds.length - 1 && propIds[propIdx + 1] === AST_PROP_LENGTH
+        propIdx < propIds.length - 1 &&
+        propIds[propIdx + 1] === AST_PROP_LENGTH
       ) {
         return count;
       }
@@ -1595,6 +1590,53 @@ function _dump(ctx) {
 internals.installPlugins = installPlugins;
 internals.runPluginsForFile = runPluginsForFile;
 internals.resetState = resetState;
+internals.preprocessFile = preprocessFile;
+internals.postprocessDiagnostics = postprocessDiagnostics;
+
+/**
+ * @param {string} extension
+ * @param {string} text
+ * @param {string} filename
+ * @returns {string | null} JSON-serialized blocks or null
+ */
+function preprocessFile(extension, text, filename) {
+  const processor = state.processors.get(extension);
+
+  if (!processor || !processor.preprocess) return null;
+
+  const blocks = processor.preprocess(text, filename);
+
+  if (!Array.isArray(blocks)) return null;
+
+  const normalized = blocks.map((block) => {
+    if (typeof block === "string") {
+      return { text: block, filename };
+    }
+
+    return { text: block.text, filename: block.filename || filename };
+  });
+
+  return JSON.stringify(normalized);
+}
+
+/**
+ * @param {string} extension
+ * @param {string} diagnosticsJson
+ * @param {string} filename
+ * @returns {string} JSON-serialized processed diagnostics
+ */
+function postprocessDiagnostics(extension, diagnosticsJson, filename) {
+  const processor = state.processors.get(extension);
+  const diagnostics = JSON.parse(diagnosticsJson);
+
+  if (!processor || !processor.postprocess) {
+    return JSON.stringify(diagnostics.flat());
+  }
+
+  const processed = processor.postprocess(diagnostics, filename);
+
+  return JSON.stringify(processed);
+}
 
 /**
  * @param {Deno.lint.Plugin} plugin

--- a/cli/ops/lint.rs
+++ b/cli/ops/lint.rs
@@ -13,6 +13,7 @@ use deno_core::op2;
 use deno_lint::diagnostic::LintDiagnostic;
 use deno_lint::diagnostic::LintDiagnosticDetails;
 use deno_lint::diagnostic::LintDiagnosticRange;
+use deno_lint::diagnostic::LintDiagnosticSeverity;
 use deno_lint::diagnostic::LintDocsUrl;
 use deno_lint::diagnostic::LintFix;
 use deno_lint::diagnostic::LintFixChange;
@@ -169,6 +170,7 @@ impl LintPluginContainer {
         custom_docs_url: LintDocsUrl::None,
         info: vec![],
       },
+      severity: LintDiagnosticSeverity::Error,
     };
     self.diagnostics.push(lint_diagnostic);
     Ok(())

--- a/cli/tools/lint/linter.rs
+++ b/cli/tools/lint/linter.rs
@@ -11,6 +11,7 @@ use deno_ast::MediaType;
 use deno_ast::ModuleSpecifier;
 use deno_ast::ParsedSource;
 use deno_ast::SourceTextInfo;
+use deno_ast::SourceTextProvider;
 use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
 use deno_core::futures::FutureExt as _;
@@ -114,6 +115,7 @@ impl CliLinter {
       parsed_source,
       self.deno_lint_config.clone(),
       external_linter_container.get_callback(),
+      None,
     );
     if let Some(err) = external_linter_container.take_error() {
       return Err(err);
@@ -139,7 +141,30 @@ impl CliLinter {
     let external_linter_container =
       ExternalLinterContainer::new(self.maybe_plugin_runner.clone(), None);
 
-    if self.fix {
+    let has_processor = if let Some(runner) = &self.maybe_plugin_runner {
+      if let Some(file_ext) = file_path.extension().and_then(|e| e.to_str()) {
+        let dot_ext = format!(".{file_ext}");
+        let infos = runner.plugin_info.lock();
+        infos.iter().any(|info| {
+          info
+            .extensions
+            .iter()
+            .any(|ext| ext.eq_ignore_ascii_case(&dot_ext))
+        })
+      } else {
+        false
+      }
+    } else {
+      false
+    };
+
+    if has_processor {
+      self.lint_file_processed(
+        file_path,
+        source_code,
+        external_linter_container,
+      )
+    } else if self.fix {
       self.lint_file_and_fix(
         &specifier,
         media_type,
@@ -156,6 +181,7 @@ impl CliLinter {
           source_code,
           config: self.deno_lint_config.clone(),
           external_linter: external_linter_container.get_callback(),
+          source_mapping: None,
         })
         .map_err(AnyError::from)?;
 
@@ -165,6 +191,225 @@ impl CliLinter {
 
       Ok((source, diagnostics))
     }
+  }
+
+  /// Lints a file that has a custom plugin preprocessor/postprocessor (e.g. `.vue` or `.svelte`).
+  ///
+  /// This method runs the V8 preprocessor to extract script blocks, lints each block using
+  /// `deno_lint` with source offset mapping, runs the V8 postprocessor on the aggregated diagnostics,
+  /// and executes iterative autofix mapping back to the parent file coordinates.
+  fn lint_file_processed(
+    &self,
+    file_path: &Path,
+    source_code: String,
+    external_linter_container: ExternalLinterContainer,
+  ) -> Result<(ParsedSource, Vec<LintDiagnostic>), AnyError> {
+    let runner = self.maybe_plugin_runner.as_ref().unwrap();
+    let file_ext = file_path.extension().and_then(|e| e.to_str()).unwrap();
+    let dot_ext = format!(".{file_ext}");
+
+    let mut current_source_code = source_code.clone();
+    let mut fix_iterations = 0;
+
+    // Loop to apply autofixes iteratively (max 5 times to handle overlapping fixes)
+    loop {
+      // Preprocess the markup source code to extract script blocks (e.g. from <script> tags)
+      let preprocess_fut =
+        runner.preprocess(&dot_ext, &current_source_code, file_path);
+      let blocks = deno_core::futures::executor::block_on(preprocess_fut)?;
+
+      let mut all_diagnostics = Vec::new();
+      let mut parsed_source = None;
+
+      if let Some(ref blocks) = blocks {
+        let mut block_diagnostics_batch = Vec::new();
+        // Lint each extracted block individually
+        for block in blocks {
+          let block_media_type = if block.filename.ends_with(".ts")
+            || block.filename.ends_with(".tsx")
+          {
+            MediaType::TypeScript
+          } else {
+            MediaType::JavaScript
+          };
+
+          let block_specifier = specifier_from_file_path(file_path)?;
+          let byte_offset = current_source_code.find(&block.text).unwrap_or(0);
+
+          // Build source mapping to allow deno_lint engine to offset coordinates back to original file
+          let source_mapping = deno_lint::linter::SourceMapping {
+            original_source: current_source_code.clone(),
+            byte_offset,
+          };
+
+          let (block_source, block_diagnostics) = self
+            .linter
+            .lint_file(deno_lint::linter::LintFileOptions {
+              specifier: block_specifier,
+              media_type: block_media_type,
+              source_code: block.text.clone(),
+              config: self.deno_lint_config.clone(),
+              external_linter: external_linter_container.get_callback(),
+              source_mapping: Some(source_mapping),
+            })
+            .map_err(AnyError::from)?;
+
+          if parsed_source.is_none() {
+            parsed_source = Some(block_source);
+          }
+          block_diagnostics_batch.push(block_diagnostics);
+        }
+
+        // Run postprocess in V8 to filter and combine all block diagnostics
+        let source_text_info =
+          deno_ast::SourceTextInfo::new(current_source_code.clone().into());
+        let start_pos = (&source_text_info).start_pos();
+        let serializable_batch: Vec<Vec<SerializableLintDiagnostic>> =
+          block_diagnostics_batch
+            .iter()
+            .map(|batch| {
+              batch
+                .iter()
+                .map(|d| {
+                  SerializableLintDiagnostic::from_diagnostic(d, start_pos)
+                })
+                .collect()
+            })
+            .collect();
+        let diagnostics_json = serde_json::to_string(&serializable_batch)?;
+        let postprocess_fut =
+          runner.postprocess(&dot_ext, &diagnostics_json, file_path);
+        let postprocessed_json =
+          deno_core::futures::executor::block_on(postprocess_fut)?;
+        let serializable_diagnostics: Vec<SerializableLintDiagnostic> =
+          serde_json::from_str(&postprocessed_json)?;
+        all_diagnostics = serializable_diagnostics
+          .into_iter()
+          .map(|d| d.into_diagnostic(&source_text_info))
+          .collect::<Result<Vec<_>, _>>()?;
+      }
+
+      let source = parsed_source.unwrap_or_else(|| {
+        deno_ast::parse_program(deno_ast::ParseParams {
+          specifier: specifier_from_file_path(file_path).unwrap(),
+          text: "".into(),
+          media_type: MediaType::Unknown,
+          capture_tokens: false,
+          scope_analysis: false,
+          maybe_syntax: None,
+        })
+        .unwrap()
+      });
+
+      // If not running with --fix or no diagnostics to fix, we are done
+      if !self.fix || all_diagnostics.is_empty() {
+        return Ok((source, all_diagnostics));
+      }
+
+      // Apply mapped autofixes relative to the original parent file content
+      let text_info = SourceTextInfo::from_string(current_source_code.clone());
+      let Some(new_text) = apply_lint_fixes(&text_info, &all_diagnostics)
+      else {
+        return Ok((source, all_diagnostics));
+      };
+
+      current_source_code = new_text;
+      fix_iterations += 1;
+
+      if fix_iterations > 5 {
+        break;
+      }
+    }
+
+    // Write updated/fixed text back to disk atomically if changes were made
+    if current_source_code != source_code {
+      atomic_write_file_with_retries(
+        &CliSys::default(),
+        file_path,
+        current_source_code.as_bytes(),
+        crate::cache::CACHE_PERM,
+      )?;
+    }
+
+    // Run a final lint pass to get accurate ParsedSource and diagnostics after fixing
+    let preprocess_fut =
+      runner.preprocess(&dot_ext, &current_source_code, file_path);
+    let blocks = deno_core::futures::executor::block_on(preprocess_fut)?;
+    let mut all_diagnostics = Vec::new();
+    let mut parsed_source = None;
+    if let Some(ref blocks) = blocks {
+      let mut block_diagnostics_batch = Vec::new();
+      for block in blocks {
+        let block_media_type = if block.filename.ends_with(".ts")
+          || block.filename.ends_with(".tsx")
+        {
+          MediaType::TypeScript
+        } else {
+          MediaType::JavaScript
+        };
+        let block_specifier = specifier_from_file_path(file_path)?;
+        let byte_offset = current_source_code.find(&block.text).unwrap_or(0);
+        let source_mapping = deno_lint::linter::SourceMapping {
+          original_source: current_source_code.clone(),
+          byte_offset,
+        };
+        let (block_source, block_diagnostics) = self
+          .linter
+          .lint_file(deno_lint::linter::LintFileOptions {
+            specifier: block_specifier,
+            media_type: block_media_type,
+            source_code: block.text.clone(),
+            config: self.deno_lint_config.clone(),
+            external_linter: external_linter_container.get_callback(),
+            source_mapping: Some(source_mapping),
+          })
+          .map_err(AnyError::from)?;
+        if parsed_source.is_none() {
+          parsed_source = Some(block_source);
+        }
+        block_diagnostics_batch.push(block_diagnostics);
+      }
+      let source_text_info =
+        deno_ast::SourceTextInfo::new(current_source_code.clone().into());
+      let start_pos = (&source_text_info).start_pos();
+      let serializable_batch: Vec<Vec<SerializableLintDiagnostic>> =
+        block_diagnostics_batch
+          .iter()
+          .map(|batch| {
+            batch
+              .iter()
+              .map(|d| {
+                SerializableLintDiagnostic::from_diagnostic(d, start_pos)
+              })
+              .collect()
+          })
+          .collect();
+      let diagnostics_json = serde_json::to_string(&serializable_batch)?;
+      let postprocess_fut =
+        runner.postprocess(&dot_ext, &diagnostics_json, file_path);
+      let postprocessed_json =
+        deno_core::futures::executor::block_on(postprocess_fut)?;
+      let serializable_diagnostics: Vec<SerializableLintDiagnostic> =
+        serde_json::from_str(&postprocessed_json)?;
+      all_diagnostics = serializable_diagnostics
+        .into_iter()
+        .map(|d| d.into_diagnostic(&source_text_info))
+        .collect::<Result<Vec<_>, _>>()?;
+    }
+
+    let source = parsed_source.unwrap_or_else(|| {
+      deno_ast::parse_program(deno_ast::ParseParams {
+        specifier: specifier_from_file_path(file_path).unwrap(),
+        text: "".into(),
+        media_type: MediaType::Unknown,
+        capture_tokens: false,
+        scope_analysis: false,
+        maybe_syntax: None,
+      })
+      .unwrap()
+    });
+
+    Ok((source, all_diagnostics))
   }
 
   fn lint_file_and_fix(
@@ -182,6 +427,7 @@ impl CliLinter {
       source_code,
       config: self.deno_lint_config.clone(),
       external_linter: external_linter_container.get_callback(),
+      source_mapping: None,
     })?;
 
     if let Some(err) = external_linter_container.take_error() {
@@ -263,6 +509,7 @@ fn apply_lint_fixes_and_relint(
       media_type,
       config: config.clone(),
       external_linter: external_linter_container.get_callback(),
+      source_mapping: None,
     })?;
     let mut new_diagnostics = source.diagnostics().clone();
     new_diagnostics.retain(|d| !original_source.diagnostics().contains(d));
@@ -501,5 +748,148 @@ mod test {
     ]);
     assert_eq!(changes.len(), 1);
     assert_eq!(changes[0].range, 0..125);
+  }
+}
+
+/// A serializable representation of a `LintDiagnostic` designed for V8/JSON serialization boundaries.
+///
+/// This struct converts non-serializable Swc types (like `SourcePos` and `SourceRange`) to simple
+/// 0-indexed byte offsets relative to the start of the file.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SerializableLintDiagnostic {
+  pub specifier: String,
+  pub code: String,
+  pub message: String,
+  pub hint: Option<String>,
+  pub range: Option<(usize, usize)>,
+  pub severity: String,
+  pub fixes: Vec<SerializableLintFix>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SerializableLintFix {
+  pub description: String,
+  pub changes: Vec<SerializableLintFixChange>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SerializableLintFixChange {
+  pub new_text: String,
+  pub range: (usize, usize),
+}
+
+impl SerializableLintDiagnostic {
+  /// Converts a `LintDiagnostic` into its serializable format.
+  ///
+  /// Maps coordinate bounds (e.g. diagnostic ranges and potential code fixes) to 0-indexed byte
+  /// offsets using the provided file starting position as a baseline.
+  pub fn from_diagnostic(
+    d: &LintDiagnostic,
+    start_pos: deno_ast::StartSourcePos,
+  ) -> Self {
+    let range = d.range.as_ref().map(|r| {
+      (
+        r.range.start.as_byte_index(start_pos),
+        r.range.end.as_byte_index(start_pos),
+      )
+    });
+    let fixes = d
+      .details
+      .fixes
+      .iter()
+      .map(|f| SerializableLintFix {
+        description: f.description.to_string(),
+        changes: f
+          .changes
+          .iter()
+          .map(|c| SerializableLintFixChange {
+            new_text: c.new_text.to_string(),
+            range: (
+              c.range.start.as_byte_index(start_pos),
+              c.range.end.as_byte_index(start_pos),
+            ),
+          })
+          .collect(),
+      })
+      .collect();
+
+    Self {
+      specifier: d.specifier.to_string(),
+      code: d.details.code.clone(),
+      message: d.details.message.clone(),
+      hint: d.details.hint.clone(),
+      range,
+      severity: d.severity.as_str().to_string(),
+      fixes,
+    }
+  }
+
+  /// Reconstructs a full `LintDiagnostic` from its serializable representation.
+  ///
+  /// Recreates Swc coordinate systems and constructs exact diagnostic/fix ranges by offset-shifting
+  /// the source text's baseline starting position.
+  pub fn into_diagnostic(
+    self,
+    source_text_info: &deno_ast::SourceTextInfo,
+  ) -> Result<LintDiagnostic, deno_core::anyhow::Error> {
+    use std::borrow::Cow;
+
+    use deno_ast::ModuleSpecifier;
+    use deno_ast::SourceRange;
+    use deno_ast::SourceTextProvider;
+    use deno_lint::diagnostic::LintDiagnosticDetails;
+    use deno_lint::diagnostic::LintDiagnosticRange;
+    use deno_lint::diagnostic::LintDiagnosticSeverity;
+    use deno_lint::diagnostic::LintDocsUrl;
+    use deno_lint::diagnostic::LintFix;
+    use deno_lint::diagnostic::LintFixChange;
+
+    let specifier = ModuleSpecifier::parse(&self.specifier)?;
+    let start_pos = source_text_info.start_pos().as_source_pos();
+
+    let range = self.range.map(|(start, end)| LintDiagnosticRange {
+      text_info: source_text_info.clone(),
+      range: SourceRange::new(start_pos + start, start_pos + end),
+      description: None,
+    });
+
+    let fixes = self
+      .fixes
+      .into_iter()
+      .map(|f| LintFix {
+        description: Cow::Owned(f.description),
+        changes: f
+          .changes
+          .into_iter()
+          .map(|c| LintFixChange {
+            new_text: Cow::Owned(c.new_text),
+            range: SourceRange::new(
+              start_pos + c.range.0,
+              start_pos + c.range.1,
+            ),
+          })
+          .collect(),
+      })
+      .collect();
+
+    let severity = if self.severity == "warning" {
+      LintDiagnosticSeverity::Warning
+    } else {
+      LintDiagnosticSeverity::Error
+    };
+
+    Ok(LintDiagnostic {
+      specifier,
+      range,
+      details: LintDiagnosticDetails {
+        message: self.message,
+        code: self.code,
+        hint: self.hint,
+        fixes,
+        custom_docs_url: LintDocsUrl::None,
+        info: vec![],
+      },
+      severity,
+    })
   }
 }

--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -78,6 +78,68 @@ const JSON_SCHEMA_VERSION: u8 = 1;
 
 static STDIN_FILE_NAME: &str = "$deno$stdin.mts";
 
+/// Preloads all configured plugins across all workspace members, spins up the V8 plugin host,
+/// and collects any custom extensions they preprocess (e.g. `".vue"`).
+///
+/// This avoids reloading plugins for each file and resolves custom extensions prior to workspace directory crawling.
+async fn preload_plugins_and_get_extensions(
+  members_lint_options: &[(WorkspaceDirectoryRc, LintOptions)],
+) -> Result<(Option<Arc<PluginHostProxy>>, Vec<String>), AnyError> {
+  // Collect and deduplicate all plugin specifiers across the entire workspace members
+  let mut all_plugin_specifiers = Vec::new();
+  for (_, member_options) in members_lint_options {
+    all_plugin_specifiers.extend(member_options.plugins.clone());
+  }
+  all_plugin_specifiers.sort();
+  all_plugin_specifiers.dedup();
+
+  if all_plugin_specifiers.is_empty() {
+    return Ok((None, Vec::new()));
+  }
+
+  #[allow(clippy::print_stdout, reason = "actually want to output")]
+  #[allow(clippy::print_stderr, reason = "actually want to output")]
+  fn logger_printer(msg: &str, is_err: bool) {
+    if is_err {
+      eprint!("{}", msg);
+    } else {
+      print!("{}", msg);
+    }
+  }
+
+  // Extract all exclude rules from workspace members
+  let logger = PluginLogger::new(logger_printer);
+  let mut all_excludes = Vec::new();
+  for (_, member_options) in members_lint_options {
+    if let Some(exclude) = &member_options.rules.exclude {
+      all_excludes.extend(exclude.clone());
+    }
+  }
+  all_excludes.sort();
+  all_excludes.dedup();
+
+  // Create the runner host and load all plugins asynchronously
+  let runner = create_runner_and_load_plugins(
+    all_plugin_specifiers,
+    logger,
+    Some(all_excludes),
+  )
+  .await?;
+
+  // Collect all custom extensions preprocessed by loaded plugins
+  let mut additional_extensions = Vec::new();
+  {
+    let infos = runner.plugin_info.lock();
+    for info in infos.iter() {
+      additional_extensions.extend(info.extensions.clone());
+    }
+  }
+  additional_extensions.sort();
+  additional_extensions.dedup();
+
+  Ok((Some(Arc::new(runner)), additional_extensions))
+}
+
 pub async fn lint(
   flags: Arc<Flags>,
   lint_flags: LintFlags,
@@ -97,6 +159,11 @@ pub async fn lint(
   let compiler_options_resolver = factory.compiler_options_resolver()?;
   let workspace_lint_options =
     cli_options.resolve_workspace_lint_options(&lint_flags)?;
+  let members_lint_options =
+    cli_options.resolve_lint_options_for_members(&lint_flags)?;
+  let (plugin_runner, additional_extensions) =
+    preload_plugins_and_get_extensions(&members_lint_options).await?;
+
   let success = if is_stdin {
     lint_stdin(
       cli_options,
@@ -113,9 +180,13 @@ pub async fn lint(
       compiler_options_resolver.clone(),
       cli_options.start_dir.clone(),
       &workspace_lint_options,
+      plugin_runner.clone(),
     );
-    let paths_with_options_batches =
-      resolve_paths_with_options_batches(cli_options, &lint_flags)?;
+    let paths_with_options_batches = resolve_paths_with_options_batches(
+      cli_options,
+      &lint_flags,
+      &additional_extensions,
+    )?;
     for paths_with_options in paths_with_options_batches {
       linter
         .lint_files(
@@ -144,8 +215,16 @@ async fn lint_with_watch_inner(
   let factory = CliFactory::from_flags(flags);
   let cli_options = factory.cli_options()?;
   let _ = watcher_communicator.watch_paths(cli_options.watch_paths());
-  let mut paths_with_options_batches =
-    resolve_paths_with_options_batches(cli_options, &lint_flags)?;
+  let members_lint_options =
+    cli_options.resolve_lint_options_for_members(&lint_flags)?;
+  let (plugin_runner, additional_extensions) =
+    preload_plugins_and_get_extensions(&members_lint_options).await?;
+
+  let mut paths_with_options_batches = resolve_paths_with_options_batches(
+    cli_options,
+    &lint_flags,
+    &additional_extensions,
+  )?;
   for paths_with_options in &mut paths_with_options_batches {
     _ = watcher_communicator.watch_paths(
       file_watcher::watch_paths_for_file_patterns(
@@ -177,6 +256,7 @@ async fn lint_with_watch_inner(
     factory.compiler_options_resolver()?.clone(),
     cli_options.start_dir.clone(),
     &cli_options.resolve_workspace_lint_options(&lint_flags)?,
+    plugin_runner.clone(),
   );
   for paths_with_options in paths_with_options_batches {
     linter
@@ -229,13 +309,18 @@ struct PathsWithOptions {
 fn resolve_paths_with_options_batches(
   cli_options: &CliOptions,
   lint_flags: &LintFlags,
+  additional_extensions: &[String],
 ) -> Result<Vec<PathsWithOptions>, AnyError> {
   let members_lint_options =
     cli_options.resolve_lint_options_for_members(lint_flags)?;
   let mut paths_with_options_batches =
     Vec::with_capacity(members_lint_options.len());
   for (dir, lint_options) in members_lint_options {
-    let files = collect_lint_files(cli_options, lint_options.files.clone());
+    let files = collect_lint_files(
+      cli_options,
+      lint_options.files.clone(),
+      additional_extensions,
+    );
     if !files.is_empty() {
       paths_with_options_batches.push(PathsWithOptions {
         dir,
@@ -263,6 +348,7 @@ struct WorkspaceLinter {
   workspace_module_graph: Option<WorkspaceModuleGraphFuture>,
   has_error: Arc<AtomicFlag>,
   file_count: usize,
+  plugin_runner: Option<Arc<PluginHostProxy>>,
 }
 
 impl WorkspaceLinter {
@@ -273,6 +359,7 @@ impl WorkspaceLinter {
     compiler_options_resolver: Arc<CompilerOptionsResolver>,
     workspace_dir: Arc<WorkspaceDirectory>,
     workspace_options: &WorkspaceLintOptions,
+    plugin_runner: Option<Arc<PluginHostProxy>>,
   ) -> Self {
     let reporter_lock =
       Arc::new(Mutex::new(create_reporter(workspace_options.reporter_kind)));
@@ -286,6 +373,7 @@ impl WorkspaceLinter {
       workspace_module_graph: None,
       has_error: Default::default(),
       file_count: 0,
+      plugin_runner,
     }
   }
 
@@ -334,8 +422,8 @@ impl WorkspaceLinter {
       }
     }
 
-    let mut plugin_runner = None;
-    if !plugin_specifiers.is_empty() {
+    let mut plugin_runner = self.plugin_runner.clone();
+    if plugin_runner.is_none() && !plugin_specifiers.is_empty() {
       let logger = plugins::PluginLogger::new(logger_printer);
       let runner = plugins::create_runner_and_load_plugins(
         plugin_specifiers,
@@ -344,7 +432,7 @@ impl WorkspaceLinter {
       )
       .await?;
       plugin_runner = Some(Arc::new(runner));
-    } else if lint_rules.rules.is_empty() {
+    } else if plugin_runner.is_none() && lint_rules.rules.is_empty() {
       bail!("No rules have been configured")
     }
 
@@ -505,9 +593,15 @@ impl WorkspaceLinter {
 fn collect_lint_files(
   cli_options: &CliOptions,
   files: FilePatterns,
+  additional_extensions: &[String],
 ) -> Vec<PathBuf> {
   FileCollector::new(|e| {
     is_script_ext(e.path)
+      || additional_extensions.iter().any(|ext| {
+        e.path.extension().is_some_and(|e_ext| {
+          e_ext.eq_ignore_ascii_case(ext.trim_start_matches('.'))
+        })
+      })
       || (e.path.extension().is_none() && cli_options.ext_flag().is_some())
   })
   .ignore_git_folder()

--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -49,12 +49,26 @@ pub enum PluginHostRequest {
     maybe_token: Option<CancellationToken>,
     tx: oneshot::Sender<PluginHostResponse>,
   },
+  Preprocess {
+    extension: String,
+    text: String,
+    file_path: PathBuf,
+    tx: oneshot::Sender<PluginHostResponse>,
+  },
+  Postprocess {
+    extension: String,
+    diagnostics_json: String,
+    file_path: PathBuf,
+    tx: oneshot::Sender<PluginHostResponse>,
+  },
 }
 
 pub enum PluginHostResponse {
   // TODO: write to structs
   LoadPlugin(Result<Vec<PluginInfo>, AnyError>),
   Run(Result<Vec<LintDiagnostic>, AnyError>),
+  Preprocess(Result<Option<Vec<ExtractedBlock>>, AnyError>),
+  Postprocess(Result<String, AnyError>),
 }
 
 impl std::fmt::Debug for PluginHostResponse {
@@ -62,6 +76,8 @@ impl std::fmt::Debug for PluginHostResponse {
     match self {
       Self::LoadPlugin(_arg0) => f.debug_tuple("LoadPlugin").finish(),
       Self::Run(_arg0) => f.debug_tuple("Run").finish(),
+      Self::Preprocess(_arg0) => f.debug_tuple("Preprocess").finish(),
+      Self::Postprocess(_arg0) => f.debug_tuple("Postprocess").finish(),
     }
   }
 }
@@ -97,6 +113,8 @@ v8_static_strings! {
   DEFAULT = "default",
   INSTALL_PLUGINS = "installPlugins",
   RUN_PLUGINS_FOR_FILE = "runPluginsForFile",
+  PREPROCESS_FILE = "preprocessFile",
+  POSTPROCESS_DIAGNOSTICS = "postprocessDiagnostics",
 }
 
 #[derive(Debug)]
@@ -123,6 +141,8 @@ pub struct PluginHost {
   worker: MainWorker,
   install_plugins_fn: v8::Global<v8::Function>,
   run_plugins_for_file_fn: v8::Global<v8::Function>,
+  preprocess_file_fn: v8::Global<v8::Function>,
+  postprocess_diagnostics_fn: v8::Global<v8::Function>,
   rx: mpsc::Receiver<PluginHostRequest>,
 }
 
@@ -173,7 +193,12 @@ async fn create_plugin_runner_inner(
   let obj = runtime.execute_script("lint.js", "Deno[Deno.internal]")?;
 
   log::debug!("Lint plugins loaded, capturing default exports");
-  let (install_plugins_fn, run_plugins_for_file_fn) = {
+  let (
+    install_plugins_fn,
+    run_plugins_for_file_fn,
+    preprocess_file_fn,
+    postprocess_diagnostics_fn,
+  ) = {
     deno_core::scope!(scope, runtime);
     let module_exports: v8::Local<v8::Object> =
       v8::Local::new(scope, obj).try_into().unwrap();
@@ -193,9 +218,26 @@ async fn create_plugin_runner_inner(
     let run_plugins_for_file_fn: v8::Local<v8::Function> =
       run_plugins_for_file_fn_val.try_into().unwrap();
 
+    let preprocess_file_fn_name = PREPROCESS_FILE.v8_string(scope).unwrap();
+    let preprocess_file_fn_val = module_exports
+      .get(scope, preprocess_file_fn_name.into())
+      .unwrap();
+    let preprocess_file_fn: v8::Local<v8::Function> =
+      preprocess_file_fn_val.try_into().unwrap();
+
+    let postprocess_diagnostics_fn_name =
+      POSTPROCESS_DIAGNOSTICS.v8_string(scope).unwrap();
+    let postprocess_diagnostics_fn_val = module_exports
+      .get(scope, postprocess_diagnostics_fn_name.into())
+      .unwrap();
+    let postprocess_diagnostics_fn: v8::Local<v8::Function> =
+      postprocess_diagnostics_fn_val.try_into().unwrap();
+
     (
       v8::Global::new(scope, install_plugins_fn),
       v8::Global::new(scope, run_plugins_for_file_fn),
+      v8::Global::new(scope, preprocess_file_fn),
+      v8::Global::new(scope, postprocess_diagnostics_fn),
     )
   };
 
@@ -203,6 +245,8 @@ async fn create_plugin_runner_inner(
     worker,
     install_plugins_fn,
     run_plugins_for_file_fn,
+    preprocess_file_fn,
+    postprocess_diagnostics_fn,
     rx: rx_req,
   })
 }
@@ -211,6 +255,7 @@ async fn create_plugin_runner_inner(
 pub struct PluginInfo {
   pub name: String,
   pub rule_names: Vec<String>,
+  pub extensions: Vec<String>,
 }
 
 impl PluginInfo {
@@ -223,6 +268,15 @@ impl PluginInfo {
 
     rules
   }
+}
+
+/// An extracted script block returned by a plugin's preprocessor.
+#[derive(Debug, serde::Deserialize)]
+pub struct ExtractedBlock {
+  /// The extracted script source code text.
+  pub text: String,
+  /// The virtual filename of this script block.
+  pub filename: String,
 }
 
 impl PluginHost {
@@ -296,6 +350,28 @@ impl PluginHost {
           );
           let _ = tx.send(PluginHostResponse::Run(r));
         }
+        PluginHostRequest::Preprocess {
+          extension,
+          text,
+          file_path,
+          tx,
+        } => {
+          let r = self.preprocess_file(&extension, &text, &file_path);
+          let _ = tx.send(PluginHostResponse::Preprocess(r));
+        }
+        PluginHostRequest::Postprocess {
+          extension,
+          diagnostics_json,
+          file_path,
+          tx,
+        } => {
+          let r = self.postprocess_diagnostics(
+            &extension,
+            &diagnostics_json,
+            &file_path,
+          );
+          let _ = tx.send(PluginHostResponse::Postprocess(r));
+        }
       }
     }
     log::debug!("Lint PluginHost run loop finished");
@@ -361,6 +437,93 @@ impl PluginHost {
       _run_plugins_result
     };
     Ok(())
+  }
+
+  /// Preprocesses a file using the custom preprocessors registered in V8 plugins.
+  ///
+  /// Extracts code blocks from custom files (e.g. Vue SFC blocks) before they are passed to the parser.
+  fn preprocess_file(
+    &mut self,
+    extension: &str,
+    text: &str,
+    file_path: &Path,
+  ) -> Result<Option<Vec<ExtractedBlock>>, AnyError> {
+    deno_core::scope!(scope, &mut self.worker.js_runtime);
+    let extension_v8: v8::Local<v8::Value> =
+      v8::String::new(scope, extension).unwrap().into();
+    let text_v8: v8::Local<v8::Value> =
+      v8::String::new(scope, text).unwrap().into();
+    let file_path_v8: v8::Local<v8::Value> =
+      v8::String::new(scope, &file_path.display().to_string())
+        .unwrap()
+        .into();
+
+    let preprocess_file_fn = v8::Local::new(scope, &self.preprocess_file_fn);
+    let undefined = v8::undefined(scope);
+
+    let result = {
+      v8::tc_scope!(tc_scope, scope);
+      let call_res = preprocess_file_fn.call(
+        tc_scope,
+        undefined.into(),
+        &[extension_v8, text_v8, file_path_v8],
+      );
+      if let Some(exception) = tc_scope.exception() {
+        let error = JsError::from_v8_exception(tc_scope, exception);
+        return Err(error.into());
+      }
+      call_res
+    };
+
+    let result_local = result.unwrap();
+    if result_local.is_null_or_undefined() {
+      return Ok(None);
+    }
+
+    let json_str = result_local.to_rust_string_lossy(scope);
+    let blocks: Vec<ExtractedBlock> = serde_json::from_str(&json_str)?;
+    Ok(Some(blocks))
+  }
+
+  /// Postprocesses diagnostics generated from a file using the custom postprocessors registered in V8 plugins.
+  ///
+  /// Filters, adjusts, or merges diagnostic reports for custom files (e.g. mapping coordinates back to the original templates).
+  fn postprocess_diagnostics(
+    &mut self,
+    extension: &str,
+    diagnostics_json: &str,
+    file_path: &Path,
+  ) -> Result<String, AnyError> {
+    deno_core::scope!(scope, &mut self.worker.js_runtime);
+    let extension_v8: v8::Local<v8::Value> =
+      v8::String::new(scope, extension).unwrap().into();
+    let diagnostics_json_v8: v8::Local<v8::Value> =
+      v8::String::new(scope, diagnostics_json).unwrap().into();
+    let file_path_v8: v8::Local<v8::Value> =
+      v8::String::new(scope, &file_path.display().to_string())
+        .unwrap()
+        .into();
+
+    let postprocess_diagnostics_fn =
+      v8::Local::new(scope, &self.postprocess_diagnostics_fn);
+    let undefined = v8::undefined(scope);
+
+    let result = {
+      v8::tc_scope!(tc_scope, scope);
+      let call_res = postprocess_diagnostics_fn.call(
+        tc_scope,
+        undefined.into(),
+        &[extension_v8, diagnostics_json_v8, file_path_v8],
+      );
+      if let Some(exception) = tc_scope.exception() {
+        let error = JsError::from_v8_exception(tc_scope, exception);
+        return Err(error.into());
+      }
+      call_res
+    };
+
+    let json_str = result.unwrap().to_rust_string_lossy(scope);
+    Ok(json_str)
   }
 
   async fn load_plugins(
@@ -507,6 +670,60 @@ impl PluginHostProxy {
 
     if let Ok(PluginHostResponse::Run(diagnostics_result)) = rx.await {
       return diagnostics_result;
+    }
+    bail!("Plugin host has closed")
+  }
+
+  /// Dispatches a preprocessing request to the V8 plugin host thread to extract script blocks from a file.
+  pub async fn preprocess(
+    &self,
+    extension: &str,
+    text: &str,
+    file_path: &Path,
+  ) -> Result<Option<Vec<ExtractedBlock>>, AnyError> {
+    let (tx, rx) = oneshot::channel();
+    self
+      .tx
+      .send(PluginHostRequest::Preprocess {
+        extension: extension.to_string(),
+        text: text.to_string(),
+        file_path: file_path.to_path_buf(),
+        tx,
+      })
+      .await?;
+
+    if let Ok(val) = rx.await {
+      let PluginHostResponse::Preprocess(result) = val else {
+        unreachable!()
+      };
+      return result;
+    }
+    bail!("Plugin host has closed")
+  }
+
+  /// Dispatches a postprocessing request to the V8 plugin host thread to run diagnostics postprocessing on a file.
+  pub async fn postprocess(
+    &self,
+    extension: &str,
+    diagnostics_json: &str,
+    file_path: &Path,
+  ) -> Result<String, AnyError> {
+    let (tx, rx) = oneshot::channel();
+    self
+      .tx
+      .send(PluginHostRequest::Postprocess {
+        extension: extension.to_string(),
+        diagnostics_json: diagnostics_json.to_string(),
+        file_path: file_path.to_path_buf(),
+        tx,
+      })
+      .await?;
+
+    if let Ok(val) = rx.await {
+      let PluginHostResponse::Postprocess(result) = val else {
+        unreachable!()
+      };
+      return result;
     }
     bail!("Plugin host has closed")
   }

--- a/cli/tools/lint/rules/no_slow_types.rs
+++ b/cli/tools/lint/rules/no_slow_types.rs
@@ -9,6 +9,7 @@ use deno_graph::fast_check::FastCheckDiagnostic;
 use deno_lint::diagnostic::LintDiagnostic;
 use deno_lint::diagnostic::LintDiagnosticDetails;
 use deno_lint::diagnostic::LintDiagnosticRange;
+use deno_lint::diagnostic::LintDiagnosticSeverity;
 use deno_lint::diagnostic::LintDocsUrl;
 use deno_lint::tags;
 
@@ -61,6 +62,7 @@ impl PackageLintRule for NoSlowTypesRule {
             .map(|u| LintDocsUrl::Custom(u.into_owned()))
             .unwrap_or_default(),
         },
+        severity: LintDiagnosticSeverity::Error,
       })
       .collect()
   }


### PR DESCRIPTION
Solves: https://github.com/denoland/deno/issues/36344

The reasoning behind this PR is to extends linting plugins capabilities for extended languages (Vue, Svelte) support through preprocessing in similar fashion to the eslint API.

I'm new to the deno ecosystem but I wanted to test the desktop app creation api, for the task I choosed an existing Vue/Nuxt project but during the migration noticed the lack of linting on vue templates (deno_lint) just ignores the files. This Pr is one of the steps to address that, the other would be https://github.com/denoland/deno_lint/pull/1537.

I came into this issue [first](https://github.com/denoland/deno_lint/issues/1463) and commented the basic idea there. This pr is complementary to that deno_lint proposal due to file discovery being managed here.

For the sake of transparency, gemini models (3.6 flash) were used during the development and testing of the changes.

## AI summary

This change aligns Deno's linter plugin API with ESLint by implementing support for custom diagnostic postprocessing and coordinate position mapping. It enables plugins targeting custom templates/file formats (such as Vue or Svelte) to map generated diagnostics and quick-fixes back to their original source coordinates.

### Key Changes

* **Plugin Coordinate Mapping (`cli/tools/lint/linter.rs`)**: Introduced a serializable diagnostic bridge (`SerializableLintDiagnostic`) that translates SWC compiler coordinates (`SourcePos`/`SourceRange`) to 0-indexed byte offsets relative to the file start before passing them to the V8 bridge, and reconstructs correct source ranges upon receiving postprocessed results.
* **V8 Postprocessing Bridge (`cli/tools/lint/plugins.rs`)**: Updated the plugin execution runner to return diagnostic lists as a raw JSON block to let V8-managed postprocessors filter, merge, or adjust reports.
* **Workspace Member Exclusion Propagator (`cli/tools/lint/mod.rs`)**: Merged and deduplicated exclude patterns from all workspace members to make sure plugin rules correctly respect local ignore directives.
* **Diagnostic Severity Field (`cli/ops/lint.rs`, `cli/tools/lint/rules/no_slow_types.rs`)**: Explicitly initialized the `severity` field on manual diagnostic allocations.