### PR TITLE
fix(node): scope raw descriptor adoption

### DIFF
--- a/ext/io/fd_table.rs
+++ b/ext/io/fd_table.rs
@@ -143,16 +143,10 @@ impl FdTable {
   /// Returns `Some(replace_registration)` if adoption may proceed (pass the
   /// flag to `finish_uv_adopt` on success), or `None` if the fd may not be
   /// adopted and the caller should reject it.
-  pub fn begin_uv_adopt(
-    &self,
-    fd: i32,
-    allow_untracked: bool,
-  ) -> Option<bool> {
+  pub fn begin_uv_adopt(&self, fd: i32, allow_untracked: bool) -> Option<bool> {
     if self.is_inherited_extra_stdio(fd) || self.is_uv_adoptable(fd) {
       Some(true)
-    } else if (0..=2).contains(&fd)
-      || (allow_untracked && !self.contains(fd))
-    {
+    } else if (0..=2).contains(&fd) || (allow_untracked && !self.contains(fd)) {
       Some(false)
     } else {
       None

--- a/ext/io/fd_table.rs
+++ b/ext/io/fd_table.rs
@@ -25,6 +25,10 @@ pub enum FdOwnership {
   /// that it exists for duplicate detection. The entry is removed
   /// when uv_close fires, but no file is dropped.
   UvOwned,
+  /// A raw fd returned by a Deno op specifically for later adoption by a
+  /// libuv wrapper. FdTable does not own this fd; it only records that this
+  /// isolate is allowed to claim it via `PipeWrap::open`/`TCPWrap::open`.
+  Adoptable,
 }
 
 /// Central table tracking all known file descriptors.
@@ -76,12 +80,22 @@ impl FdTable {
     true
   }
 
+  /// Register an fd that may be adopted by a uv wrapper later. Returns false
+  /// if already registered.
+  pub fn register_uv_adoptable(&mut self, fd: i32) -> bool {
+    if self.entries.contains_key(&fd) {
+      return false;
+    }
+    self.entries.insert(fd, FdOwnership::Adoptable);
+    true
+  }
+
   /// Get the File for a TableOwned fd. Returns None for UvOwned or missing.
   pub fn get(&self, fd: i32) -> Option<&Rc<dyn File>> {
     match self.entries.get(&fd) {
       Some(FdOwnership::TableOwned(file)) => Some(file),
       Some(FdOwnership::InheritedExtraStdio(file)) => Some(file),
-      _ => None,
+      Some(FdOwnership::UvOwned | FdOwnership::Adoptable) | None => None,
     }
   }
 
@@ -92,6 +106,7 @@ impl FdTable {
       Some(FdOwnership::TableOwned(file)) => Some(file),
       Some(FdOwnership::InheritedExtraStdio(file)) => Some(file),
       Some(FdOwnership::UvOwned) => None,
+      Some(FdOwnership::Adoptable) => None,
       None => None,
     }
   }
@@ -109,23 +124,38 @@ impl FdTable {
     )
   }
 
+  /// Check if an fd was explicitly registered as adoptable by a uv wrapper.
+  pub fn is_uv_adoptable(&self, fd: i32) -> bool {
+    matches!(self.entries.get(&fd), Some(FdOwnership::Adoptable))
+  }
+
   /// Check whether a libuv stream wrap (`PipeWrap::open`, `TCPWrap::open`)
-  /// may adopt `fd`. Stdio fds (0-2) are pre-registered and may be re-opened;
-  /// inherited extra stdio fds may be adopted (e.g. via `net.Socket({ fd })`)
-  /// and are consumed by `finish_uv_adopt` only once the uv open actually
-  /// claims the fd, so a failed open leaves the fd usable by node:fs. Any
-  /// other tracked fd is a duplicate.
+  /// may adopt `fd`. Stdio fds (0-2) may be re-opened; inherited extra stdio
+  /// fds may be adopted (e.g. via `net.Socket({ fd })`) and are consumed by
+  /// `finish_uv_adopt` only once the uv open actually claims the fd, so a
+  /// failed open leaves the fd usable by node:fs. Fds explicitly registered
+  /// as uv-adoptable by Deno internals may also be adopted. Any other fd is
+  /// rejected.
   ///
-  /// Returns `Some(was_inherited)` if adoption may proceed (pass the flag to
-  /// `finish_uv_adopt` on success), or `None` if the fd is already tracked
-  /// and the caller should reject with `EEXIST`.
-  pub fn begin_uv_adopt(&self, fd: i32) -> Option<bool> {
-    if self.is_inherited_extra_stdio(fd) {
+  /// Unknown non-stdio fds are process-wide rather than isolate-local, so
+  /// callers must reject them unless the current isolate has all permissions.
+  ///
+  /// Returns `Some(replace_registration)` if adoption may proceed (pass the
+  /// flag to `finish_uv_adopt` on success), or `None` if the fd may not be
+  /// adopted and the caller should reject it.
+  pub fn begin_uv_adopt(
+    &self,
+    fd: i32,
+    allow_untracked: bool,
+  ) -> Option<bool> {
+    if self.is_inherited_extra_stdio(fd) || self.is_uv_adoptable(fd) {
       Some(true)
-    } else if self.contains(fd) && !(0..=2).contains(&fd) {
-      None
-    } else {
+    } else if (0..=2).contains(&fd)
+      || (allow_untracked && !self.contains(fd))
+    {
       Some(false)
+    } else {
+      None
     }
   }
 
@@ -134,8 +164,8 @@ impl FdTable {
   /// the node:fs dup is released, and its close is deferred until any
   /// `Rc<dyn File>` clone held by an in-flight node:fs stream drops), then
   /// tracks the fd as UvOwned so it can't be re-adopted by another wrap.
-  pub fn finish_uv_adopt(&mut self, fd: i32, was_inherited: bool) {
-    if was_inherited {
+  pub fn finish_uv_adopt(&mut self, fd: i32, replace_registration: bool) {
+    if replace_registration {
       self.remove(fd);
     }
     self.register_uv_owned(fd);
@@ -145,5 +175,49 @@ impl FdTable {
 impl Default for FdTable {
   fn default() -> Self {
     Self::new()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn uv_adopt_rejects_unknown_non_stdio_fds() {
+    let fd_table = FdTable::new();
+
+    assert_eq!(fd_table.begin_uv_adopt(0, false), Some(false));
+    assert_eq!(fd_table.begin_uv_adopt(1, false), Some(false));
+    assert_eq!(fd_table.begin_uv_adopt(2, false), Some(false));
+    assert_eq!(fd_table.begin_uv_adopt(3, false), None);
+    assert_eq!(fd_table.begin_uv_adopt(40, false), None);
+  }
+
+  #[test]
+  fn uv_adopt_rejects_already_uv_owned_fds() {
+    let mut fd_table = FdTable::new();
+    assert!(fd_table.register_uv_owned(40));
+
+    assert_eq!(fd_table.begin_uv_adopt(40, false), None);
+    assert_eq!(fd_table.begin_uv_adopt(40, true), None);
+  }
+
+  #[test]
+  fn uv_adopt_allows_registered_adoptable_fds_once() {
+    let mut fd_table = FdTable::new();
+    assert!(fd_table.register_uv_adoptable(40));
+
+    assert_eq!(fd_table.begin_uv_adopt(40, false), Some(true));
+    fd_table.finish_uv_adopt(40, true);
+    assert_eq!(fd_table.begin_uv_adopt(40, false), None);
+  }
+
+  #[test]
+  fn uv_adopt_allows_untracked_fds_once_when_requested() {
+    let mut fd_table = FdTable::new();
+
+    assert_eq!(fd_table.begin_uv_adopt(40, true), Some(false));
+    fd_table.finish_uv_adopt(40, false);
+    assert_eq!(fd_table.begin_uv_adopt(40, true), None);
   }
 }

--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -816,9 +816,7 @@ fn register_created_pipe(
 #[cfg(unix)]
 #[op2]
 #[serde]
-pub fn op_node_create_pipe(
-  state: &mut OpState,
-) -> Result<(i32, i32), FsError> {
+pub fn op_node_create_pipe(state: &mut OpState) -> Result<(i32, i32), FsError> {
   let mut fds = [0i32; 2];
   // SAFETY: pipe() writes two valid fds into the array on success.
   let ret = unsafe { libc::pipe(fds.as_mut_ptr()) };
@@ -832,9 +830,7 @@ pub fn op_node_create_pipe(
 #[cfg(windows)]
 #[op2]
 #[serde]
-pub fn op_node_create_pipe(
-  state: &mut OpState,
-) -> Result<(i32, i32), FsError> {
+pub fn op_node_create_pipe(state: &mut OpState) -> Result<(i32, i32), FsError> {
   use windows_sys::Win32::Foundation::CloseHandle;
   use windows_sys::Win32::System::Pipes::CreatePipe;
 

--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -784,26 +784,57 @@ pub async fn op_node_rmdir(
   Ok(())
 }
 
-/// Create an anonymous pipe pair and return (read_fd, write_fd).
-/// The returned fds are NOT registered in FdTable; the caller
-/// is responsible for registering or closing them.
+fn register_created_pipe(
+  state: &mut OpState,
+  read_fd: i32,
+  write_fd: i32,
+) -> Result<(), FsError> {
+  let (read_registered, write_registered) = {
+    let fd_table = state.borrow_mut::<deno_io::FdTable>();
+    let read_registered = fd_table.register_uv_adoptable(read_fd);
+    let write_registered = fd_table.register_uv_adoptable(write_fd);
+    if read_registered && !write_registered {
+      fd_table.remove(read_fd);
+    } else if write_registered && !read_registered {
+      fd_table.remove(write_fd);
+    }
+    (read_registered, write_registered)
+  };
+  if read_registered && write_registered {
+    return Ok(());
+  }
+  // SAFETY: these are the two newly-created descriptors, and neither was
+  // returned to JavaScript after registration failed.
+  unsafe {
+    libc::close(read_fd);
+    libc::close(write_fd);
+  }
+  Err(ebadf())
+}
+
+/// Create an anonymous pipe pair and register both ends for later adoption.
 #[cfg(unix)]
 #[op2]
 #[serde]
-pub fn op_node_create_pipe() -> Result<(i32, i32), FsError> {
+pub fn op_node_create_pipe(
+  state: &mut OpState,
+) -> Result<(i32, i32), FsError> {
   let mut fds = [0i32; 2];
   // SAFETY: pipe() writes two valid fds into the array on success.
   let ret = unsafe { libc::pipe(fds.as_mut_ptr()) };
   if ret != 0 {
     return Err(FsError::Io(std::io::Error::last_os_error()));
   }
+  register_created_pipe(state, fds[0], fds[1])?;
   Ok((fds[0], fds[1]))
 }
 
 #[cfg(windows)]
 #[op2]
 #[serde]
-pub fn op_node_create_pipe() -> Result<(i32, i32), FsError> {
+pub fn op_node_create_pipe(
+  state: &mut OpState,
+) -> Result<(i32, i32), FsError> {
   use windows_sys::Win32::Foundation::CloseHandle;
   use windows_sys::Win32::System::Pipes::CreatePipe;
 
@@ -853,6 +884,7 @@ pub fn op_node_create_pipe() -> Result<(i32, i32), FsError> {
     return Err(ebadf());
   }
 
+  register_created_pipe(state, read_fd, write_fd)?;
   Ok((read_fd, write_fd))
 }
 

--- a/ext/node/ops/pipe_wrap.rs
+++ b/ext/node/ops/pipe_wrap.rs
@@ -320,8 +320,7 @@ impl PipeWrap {
     // Descriptors explicitly associated with this isolate may be adopted
     // directly. Preserve Node compatibility for an untracked raw descriptor
     // only when the isolate has all permissions.
-    let untracked =
-      fd > 2 && !state.borrow::<deno_io::FdTable>().contains(fd);
+    let untracked = fd > 2 && !state.borrow::<deno_io::FdTable>().contains(fd);
     let allow_untracked = untracked
       && state
         .borrow::<PermissionsContainer>()

--- a/ext/node/ops/pipe_wrap.rs
+++ b/ext/node/ops/pipe_wrap.rs
@@ -9,6 +9,7 @@
 
 use std::cell::Cell;
 use std::cell::RefCell;
+use std::path::Path;
 use std::rc::Rc;
 
 use deno_core::CppgcInherits;
@@ -313,11 +314,25 @@ impl PipeWrap {
 
   #[fast]
   fn open(&self, state: &mut OpState, #[smi] fd: i32) -> i32 {
-    // See `FdTable::begin_uv_adopt` for the duplicate-fd policy (stdio and
-    // inherited extra stdio fds may be adopted; other tracked fds are
-    // rejected).
-    let Some(was_inherited) =
-      state.borrow::<deno_io::FdTable>().begin_uv_adopt(fd)
+    if fd < 0 {
+      return uv_compat::UV_EBADF;
+    }
+    // Descriptors explicitly associated with this isolate may be adopted
+    // directly. Preserve Node compatibility for an untracked raw descriptor
+    // only when the isolate has all permissions.
+    let untracked =
+      fd > 2 && !state.borrow::<deno_io::FdTable>().contains(fd);
+    let allow_untracked = untracked
+      && state
+        .borrow::<PermissionsContainer>()
+        .check_has_all_permissions(Path::new("node:net.Socket({ fd })"))
+        .is_ok();
+    if untracked && !allow_untracked {
+      return -libc::EPERM;
+    }
+    let Some(replace_registration) = state
+      .borrow::<deno_io::FdTable>()
+      .begin_uv_adopt(fd, allow_untracked)
     else {
       return -libc::EEXIST;
     };
@@ -340,7 +355,7 @@ impl PipeWrap {
     if ret == 0 {
       state
         .borrow_mut::<deno_io::FdTable>()
-        .finish_uv_adopt(fd, was_inherited);
+        .finish_uv_adopt(fd, replace_registration);
       self.base.set_fd(fd);
     }
     ret

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -8,6 +8,7 @@
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::net::ToSocketAddrs;
+use std::path::Path;
 use std::rc::Rc;
 
 use deno_core::CppgcInherits;
@@ -383,12 +384,22 @@ impl TCPWrap {
     if fd < 0 {
       return uv_compat::UV_EBADF;
     }
-    // See `FdTable::begin_uv_adopt` for the duplicate-fd policy (stdio and
-    // inherited extra stdio fds may be adopted — the latter covers an
-    // inherited TCP socket claimed via net.Socket({ fd }) or
-    // server.listen({ fd }); other tracked fds are rejected).
-    let Some(was_inherited) =
-      state.borrow::<deno_io::FdTable>().begin_uv_adopt(fd)
+    // Descriptors explicitly associated with this isolate may be adopted
+    // directly. Preserve Node compatibility for an untracked raw descriptor
+    // only when the isolate has all permissions.
+    let untracked =
+      fd > 2 && !state.borrow::<deno_io::FdTable>().contains(fd);
+    let allow_untracked = untracked
+      && state
+        .borrow::<PermissionsContainer>()
+        .check_has_all_permissions(Path::new("node:net.Socket({ fd })"))
+        .is_ok();
+    if untracked && !allow_untracked {
+      return -libc::EPERM;
+    }
+    let Some(replace_registration) = state
+      .borrow::<deno_io::FdTable>()
+      .begin_uv_adopt(fd, allow_untracked)
     else {
       return -libc::EEXIST;
     };
@@ -430,7 +441,7 @@ impl TCPWrap {
     if ret == 0 {
       state
         .borrow_mut::<deno_io::FdTable>()
-        .finish_uv_adopt(fd, was_inherited);
+        .finish_uv_adopt(fd, replace_registration);
       self.base.set_fd(fd);
     }
     ret

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -387,8 +387,7 @@ impl TCPWrap {
     // Descriptors explicitly associated with this isolate may be adopted
     // directly. Preserve Node compatibility for an untracked raw descriptor
     // only when the isolate has all permissions.
-    let untracked =
-      fd > 2 && !state.borrow::<deno_io::FdTable>().contains(fd);
+    let untracked = fd > 2 && !state.borrow::<deno_io::FdTable>().contains(fd);
     let allow_untracked = untracked
       && state
         .borrow::<PermissionsContainer>()

--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -1157,6 +1157,17 @@ fn spawn_child_node(
   let stdout_fd = child_stdio_to_fd!(child, stdout);
   let stderr_fd = child_stdio_to_fd!(child, stderr);
 
+  {
+    let fd_table = state.borrow_mut::<deno_io::FdTable>();
+    for fd in [stdin_fd, stdout_fd, stderr_fd]
+      .into_iter()
+      .flatten()
+      .chain(extra_pipe_fds.iter().flatten().copied())
+    {
+      fd_table.register_uv_adoptable(fd as i32);
+    }
+  }
+
   let child_rid = state.resource_table.add(ChildResource {
     child: RefCell::new(child),
     pid,

--- a/tests/specs/node/pipe_open_fd/__test__.jsonc
+++ b/tests/specs/node/pipe_open_fd/__test__.jsonc
@@ -13,6 +13,11 @@
       "args": "run -A duplicate_fd.ts",
       "output": "duplicate_fd.out"
     },
+    "isolate_fd_ownership": {
+      "args":
+        "run --allow-read --unstable-worker-options isolate_fd_ownership.ts",
+      "output": "isolate_fd_ownership.out"
+    },
     "main_read": {
       "if": "unix",
       "args": "run -A main_read.ts",

--- a/tests/specs/node/pipe_open_fd/__test__.jsonc
+++ b/tests/specs/node/pipe_open_fd/__test__.jsonc
@@ -14,8 +14,7 @@
       "output": "duplicate_fd.out"
     },
     "isolate_fd_ownership": {
-      "args":
-        "run --allow-read --unstable-worker-options isolate_fd_ownership.ts",
+      "args": "run --allow-read --unstable-worker-options isolate_fd_ownership.ts",
       "output": "isolate_fd_ownership.out"
     },
     "main_read": {

--- a/tests/specs/node/pipe_open_fd/isolate_fd_ownership.out
+++ b/tests/specs/node/pipe_open_fd/isolate_fd_ownership.out
@@ -1,0 +1,5 @@
+(node:[WILDCARD]) internal/test/binding: These APIs are for internal testing only. Do not use them.
+(node:[WILDCARD]) internal/test/binding: These APIs are for internal testing only. Do not use them.
+PASS: worker rejected an unregistered descriptor
+PASS: owner adopted its registered descriptor
+PASS: descriptor could only be adopted once

--- a/tests/specs/node/pipe_open_fd/isolate_fd_ownership.ts
+++ b/tests/specs/node/pipe_open_fd/isolate_fd_ownership.ts
@@ -1,0 +1,46 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { Pipe, constants: PipeConstants, createPipe } = require(
+  "internal/test/binding",
+).internalBinding("pipe_wrap");
+
+const [readFd, writeFd] = createPipe();
+const worker = new Worker(
+  new URL("./isolate_fd_ownership_worker.ts", import.meta.url),
+  { type: "module", deno: { permissions: "none" } },
+);
+
+const workerResult = await new Promise<number>((resolve, reject) => {
+  worker.onmessage = (event) => resolve(event.data);
+  worker.onerror = (event) => reject(event.error);
+  worker.postMessage(readFd);
+});
+worker.terminate();
+
+if (workerResult === 0) {
+  throw new Error("worker adopted a descriptor owned by another isolate");
+}
+console.log("PASS: worker rejected an unregistered descriptor");
+
+const readPipe = new Pipe(PipeConstants.SOCKET);
+if (readPipe.open(readFd) !== 0) {
+  throw new Error("owner could not adopt its registered descriptor");
+}
+console.log("PASS: owner adopted its registered descriptor");
+
+const duplicatePipe = new Pipe(PipeConstants.SOCKET);
+if (duplicatePipe.open(readFd) === 0) {
+  throw new Error("descriptor was adopted more than once");
+}
+console.log("PASS: descriptor could only be adopted once");
+
+const writePipe = new Pipe(PipeConstants.SOCKET);
+if (writePipe.open(writeFd) !== 0) {
+  throw new Error("owner could not adopt the other pipe descriptor");
+}
+
+await Promise.all([
+  new Promise<void>((resolve) => readPipe.close(resolve)),
+  new Promise<void>((resolve) => writePipe.close(resolve)),
+]);

--- a/tests/specs/node/pipe_open_fd/isolate_fd_ownership_worker.ts
+++ b/tests/specs/node/pipe_open_fd/isolate_fd_ownership_worker.ts
@@ -1,0 +1,16 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { Pipe, constants: PipeConstants } = require("internal/test/binding")
+  .internalBinding("pipe_wrap");
+
+globalThis.onmessage = (event) => {
+  const pipe = new Pipe(PipeConstants.SOCKET);
+  const result = pipe.open(event.data);
+  globalThis.postMessage(result);
+  if (result === 0) {
+    pipe.close(() => globalThis.close());
+  } else {
+    globalThis.close();
+  }
+};

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -779,7 +779,7 @@ Deno.test({
         // deno-lint-ignore no-explicit-any
         const rawFd = (client as any)._handle.fdForIpc();
         assert(rawFd >= 0);
-        const cp = spawn(Deno.execPath(), ["run", "-A", script], {
+        const cp = spawn(Deno.execPath(), ["run", script], {
           stdio: ["ignore", "ignore", "pipe", rawFd],
         });
         cp.stderr?.on("data", (data) => {
@@ -823,7 +823,7 @@ Deno.test({
       const rawFd = (bootstrap as any)._handle.fdForIpc();
       assert(rawFd >= 0);
       bootstrap.close(() => {
-        const cp = spawn(Deno.execPath(), ["run", "-A", script], {
+        const cp = spawn(Deno.execPath(), ["run", script], {
           stdio: ["ignore", "ignore", "pipe", rawFd],
         });
         cp.stderr?.on("data", (data) => {


### PR DESCRIPTION
## Summary

- distinguish isolate-registered descriptors from untracked process descriptors
- register pipe and child-process descriptors before handing them to Node stream wrappers
- preserve stdio, inherited extra-stdio, and fully-authorized raw descriptor compatibility

## Details

`TCPWrap.open()` and `PipeWrap.open()` previously treated any untracked OS descriptor as available for adoption. The OS descriptor table is process-wide, while Deno's descriptor tracking is isolate-local, so an untracked number may belong to a different isolate.

This change adds an explicit adoptable state for descriptors produced for the current isolate. Unknown non-stdio descriptors are rejected unless the isolate has all permissions, preserving the existing raw-descriptor compatibility path for fully-authorized programs. Successful adoption remains one-time.

## Validation

- `cargo build -p deno --bin deno`
- `cargo test -p deno_io fd_table --lib`
- `cargo test -p deno_node --lib`
- `cargo test -p deno_process --lib`
- `cargo test -p specs_tests --test specs -- specs::node::pipe_open_fd`
- `cargo test -p specs_tests --test specs -- specs::node::net_socket_fd::tcp_open`
- `cargo test -p unit_node_tests --test unit_node -- unit_node::child_process_test`
- `./tools/format.js --check`
