### PR TITLE
fix: cancel stdin readable stream resources

### DIFF
--- a/ext/io/12_io.js
+++ b/ext/io/12_io.js
@@ -153,7 +153,7 @@ class Stdin {
     if (this.#readable === undefined) {
       this.#readable = lazyStreams().readableStreamForRidUnrefable(
         this.#rid,
-        { autoClose: false, closeOnCancel: true },
+        { autoClose: false, closeOnCancel: false },
       );
     }
     return this.#readable;

--- a/ext/io/12_io.js
+++ b/ext/io/12_io.js
@@ -151,7 +151,10 @@ class Stdin {
 
   get readable() {
     if (this.#readable === undefined) {
-      this.#readable = lazyStreams().readableStreamForRid(this.#rid, false);
+      this.#readable = lazyStreams().readableStreamForRidUnrefable(
+        this.#rid,
+        { autoClose: false, closeOnCancel: true },
+      );
     }
     return this.#readable;
   }
@@ -170,12 +173,18 @@ class Stdin {
     if (this.#opPromise) {
       core.refOpPromise(this.#opPromise);
     }
+    if (this.#readable) {
+      lazyStreams().readableStreamForRidUnrefableRef(this.#readable);
+    }
   }
 
   [UNREF]() {
     this.#ref = false;
     if (this.#opPromise) {
       core.unrefOpPromise(this.#opPromise);
+    }
+    if (this.#readable) {
+      lazyStreams().readableStreamForRidUnrefableUnref(this.#readable);
     }
   }
 }

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -62,6 +62,9 @@ use windows_sys::Win32::System::Console::STD_INPUT_HANDLE;
 #[cfg(windows)]
 use windows_sys::Win32::System::Console::STD_OUTPUT_HANDLE;
 
+#[cfg(unix)]
+const STDIN_READ_POLL_TIMEOUT_MS: i32 = 100;
+
 mod fd_table;
 pub mod fs;
 mod pipe;
@@ -715,6 +718,34 @@ impl StdFileResourceInner {
     }
   }
 
+  #[cfg(unix)]
+  fn poll_stdin_ready(file: &StdFile) -> io::Result<bool> {
+    use std::os::fd::AsRawFd;
+
+    let mut pollfd = libc::pollfd {
+      fd: file.as_raw_fd(),
+      events: libc::POLLIN,
+      revents: 0,
+    };
+    // SAFETY: `pollfd` is a valid single-element poll array for this call.
+    //
+    // A bounded timeout lets cancellation stop scheduling additional reads
+    // without keeping a blocking-pool thread parked indefinitely. Any positive
+    // return is handed to `read`, which owns EOF/POLLHUP/POLLERR semantics.
+    match unsafe { libc::poll(&mut pollfd, 1, STDIN_READ_POLL_TIMEOUT_MS) } {
+      0 => Ok(false),
+      n if n > 0 => Ok(true),
+      _ => {
+        let err = io::Error::last_os_error();
+        if err.kind() == ErrorKind::Interrupted {
+          Ok(false)
+        } else {
+          Err(err)
+        }
+      }
+    }
+  }
+
   #[cfg(windows)]
   async fn handle_stdin_read(
     &self,
@@ -1291,26 +1322,31 @@ impl crate::fs::File for StdFileResourceInner {
         self.handle_stdin_read(state.clone(), buf).await
       }
       #[cfg(not(windows))]
-      StdFileResourceKind::Stdin(_) => {
-        // Stdin may be set to non-blocking mode by Node's process.stdin.
-        // Retry on WouldBlock (see read_sync comment for details).
-        self
-          .with_inner_blocking_task(|file| {
-            let _terminal_input_guard =
-              deno_permissions::prompter::lock_terminal_input();
-            loop {
-              match file.read(&mut buf) {
-                Ok(nread) => return Ok((nread, buf)),
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                  std::thread::yield_now();
-                  continue;
-                }
-                Err(e) => return Err(e.into()),
+      StdFileResourceKind::Stdin(_) => loop {
+        let (maybe_nread, next_buf) = self
+          .with_inner_blocking_task(
+            |file| -> FsResult<(Option<usize>, BufMutView)> {
+              let _terminal_input_guard =
+                deno_permissions::prompter::lock_terminal_input();
+              if !Self::poll_stdin_ready(file)? {
+                return Ok((None, buf));
               }
-            }
-          })
-          .await
-      }
+              match file.read(&mut buf) {
+                Ok(nread) => Ok((Some(nread), buf)),
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                  Ok((None, buf))
+                }
+                Err(e) => Err(e.into()),
+              }
+            },
+          )
+          .await?;
+        buf = next_buf;
+        if let Some(nread) = maybe_nread {
+          return Ok((nread, buf));
+        }
+        tokio::task::yield_now().await;
+      },
       _ => {
         self
           .with_inner_blocking_task(|file| {

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -752,6 +752,7 @@ impl StdFileResourceInner {
   #[cfg(windows)]
   fn poll_stdin_pipe_ready(file: &StdFile) -> io::Result<Option<bool>> {
     use std::os::windows::io::AsRawHandle;
+
     use windows_sys::Win32::Storage::FileSystem::FILE_TYPE_PIPE;
     use windows_sys::Win32::Storage::FileSystem::GetFileType;
     use windows_sys::Win32::System::Pipes::PeekNamedPipe;
@@ -799,10 +800,10 @@ impl StdFileResourceInner {
       let fut = self.with_inner_blocking_task(move |file| {
         let _terminal_input_guard =
           deno_permissions::prompter::lock_terminal_input();
-        if let Some(false) =
-          Self::poll_stdin_pipe_ready(file).map_err(|e| (e.into(), buf))?
-        {
-          return Ok((None, buf));
+        match Self::poll_stdin_pipe_ready(file) {
+          Ok(Some(false)) => return Ok((None, buf)),
+          Ok(_) => {}
+          Err(e) => return Err((e.into(), buf)),
         }
 
         /* Start reading, and set the reading flag to true */

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -64,6 +64,9 @@ use windows_sys::Win32::System::Console::STD_OUTPUT_HANDLE;
 
 #[cfg(unix)]
 const STDIN_READ_POLL_TIMEOUT_MS: i32 = 100;
+#[cfg(windows)]
+const STDIN_READ_POLL_TIMEOUT: std::time::Duration =
+  std::time::Duration::from_millis(100);
 
 mod fd_table;
 pub mod fs;
@@ -747,6 +750,40 @@ impl StdFileResourceInner {
   }
 
   #[cfg(windows)]
+  fn poll_stdin_pipe_ready(file: &StdFile) -> io::Result<Option<bool>> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::FILE_TYPE_PIPE;
+    use windows_sys::Win32::Storage::FileSystem::GetFileType;
+    use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+
+    let handle = file.as_raw_handle();
+    if unsafe { GetFileType(handle) } != FILE_TYPE_PIPE {
+      return Ok(None);
+    }
+
+    let mut bytes_available = 0u32;
+    let result = unsafe {
+      PeekNamedPipe(
+        handle,
+        std::ptr::null_mut(),
+        0,
+        std::ptr::null_mut(),
+        &mut bytes_available,
+        std::ptr::null_mut(),
+      )
+    };
+    if result == 0 {
+      let err = io::Error::last_os_error();
+      if err.kind() == ErrorKind::BrokenPipe {
+        return Ok(Some(true));
+      }
+      return Err(err);
+    }
+
+    Ok(Some(bytes_available > 0))
+  }
+
+  #[cfg(windows)]
   async fn handle_stdin_read(
     &self,
     state: Arc<Mutex<WinTtyState>>,
@@ -762,6 +799,12 @@ impl StdFileResourceInner {
       let fut = self.with_inner_blocking_task(move |file| {
         let _terminal_input_guard =
           deno_permissions::prompter::lock_terminal_input();
+        if let Some(false) =
+          Self::poll_stdin_pipe_ready(file).map_err(|e| (e.into(), buf))?
+        {
+          return Ok((None, buf));
+        }
+
         /* Start reading, and set the reading flag to true */
         state.lock().reading = true;
         let nread = match file.read(&mut buf) {
@@ -819,15 +862,21 @@ impl StdFileResourceInner {
           return Err((FsError::FileBusy, buf));
         }
 
-        Ok((nread, buf))
+        Ok((Some(nread), buf))
       });
 
       match fut.await {
+        Ok((Some(nread), b)) => return Ok((nread, b)),
+        Ok((None, b)) => {
+          buf = b;
+          tokio::time::sleep(STDIN_READ_POLL_TIMEOUT).await;
+          continue;
+        }
         Err((FsError::FileBusy, b)) => {
           buf = b;
           continue;
         }
-        other => return other.map_err(|(e, _)| e),
+        Err((e, _)) => return Err(e),
       }
     }
   }

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -1294,14 +1294,35 @@ const _isUnref = Symbol("isUnref");
  * compatible with fast-path resource-backed streams.
  *
  * @param {number} rid The resource ID to read from.
- * @param constructor A class that extends ReadableStream.
+ * @param optionsOrConstructor Options for resource closure, or a class that extends ReadableStream.
  * @returns {ReadableStream<Uint8Array>}
  */
-function readableStreamForRidUnrefable(rid, constructor = ReadableStream) {
+function readableStreamForRidUnrefable(
+  rid,
+  optionsOrConstructor = ReadableStream,
+) {
+  let autoClose = true;
+  let closeOnCancel = true;
+  let constructor = ReadableStream;
+  if (typeof optionsOrConstructor === "function") {
+    constructor = optionsOrConstructor;
+  } else {
+    autoClose = optionsOrConstructor.autoClose ?? true;
+    closeOnCancel = optionsOrConstructor.closeOnCancel ?? autoClose;
+    constructor = optionsOrConstructor.readableStreamConstructor ??
+      ReadableStream;
+  }
+  if (typeof optionsOrConstructor === "boolean") {
+    autoClose = optionsOrConstructor;
+    closeOnCancel = optionsOrConstructor;
+  }
   const stream = new constructor(_brand);
   stream[promiseSymbol] = undefined;
   stream[_isUnref] = false;
-  stream[_resourceBackingUnrefable] = { rid, autoClose: true };
+  stream[_resourceBackingUnrefable] = { rid, autoClose };
+  const tryClose = () => {
+    if (autoClose) core.tryClose(rid);
+  };
   const underlyingSource = {
     type: "bytes",
     async pull(controller) {
@@ -1313,7 +1334,7 @@ function readableStreamForRidUnrefable(rid, constructor = ReadableStream) {
         const bytesRead = await promise;
         stream[promiseSymbol] = undefined;
         if (bytesRead === 0) {
-          core.tryClose(rid);
+          tryClose();
           controller.close();
           controller.byobRequest.respond(0);
         } else {
@@ -1321,11 +1342,14 @@ function readableStreamForRidUnrefable(rid, constructor = ReadableStream) {
         }
       } catch (e) {
         controller.error(annotateResourceStreamError(e));
-        core.tryClose(rid);
+        tryClose();
       }
     },
     cancel() {
-      core.tryClose(rid);
+      if (stream[promiseSymbol] !== undefined) {
+        core.unrefOpPromise(stream[promiseSymbol]);
+      }
+      if (closeOnCancel) core.tryClose(rid);
     },
     autoAllocateChunkSize: DEFAULT_CHUNK_SIZE,
   };

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -1306,15 +1306,14 @@ function readableStreamForRidUnrefable(
   let constructor = ReadableStream;
   if (typeof optionsOrConstructor === "function") {
     constructor = optionsOrConstructor;
+  } else if (typeof optionsOrConstructor === "boolean") {
+    autoClose = optionsOrConstructor;
+    closeOnCancel = optionsOrConstructor;
   } else {
     autoClose = optionsOrConstructor.autoClose ?? true;
     closeOnCancel = optionsOrConstructor.closeOnCancel ?? autoClose;
     constructor = optionsOrConstructor.readableStreamConstructor ??
       ReadableStream;
-  }
-  if (typeof optionsOrConstructor === "boolean") {
-    autoClose = optionsOrConstructor;
-    closeOnCancel = optionsOrConstructor;
   }
   const stream = new constructor(_brand);
   stream[promiseSymbol] = undefined;
@@ -1322,6 +1321,9 @@ function readableStreamForRidUnrefable(
   stream[_resourceBackingUnrefable] = { rid, autoClose };
   const tryClose = () => {
     if (autoClose) core.tryClose(rid);
+  };
+  const cancelRead = () => {
+    core.cancelRead(rid);
   };
   const underlyingSource = {
     type: "bytes",
@@ -1349,6 +1351,7 @@ function readableStreamForRidUnrefable(
       if (stream[promiseSymbol] !== undefined) {
         core.unrefOpPromise(stream[promiseSymbol]);
       }
+      cancelRead();
       if (closeOnCancel) core.tryClose(rid);
     },
     autoAllocateChunkSize: DEFAULT_CHUNK_SIZE,

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -1019,6 +1019,79 @@ console.log("executing javascript");
   assert_eq!(stdout_str, "executing javascript");
 }
 
+#[test]
+fn stdin_readable_cancel_exits() {
+  use std::time::Duration;
+
+  let source_code = r#"
+const reader = Deno.stdin.readable.getReader();
+const cancelPromise = new Promise((resolve, reject) => {
+  setTimeout(() => {
+    reader.cancel("shutdown").then(resolve, reject);
+  }, 10);
+});
+const result = await reader.read();
+await cancelPromise;
+console.log(JSON.stringify(result));
+reader.releaseLock();
+"#;
+
+  let mut child = util::deno_cmd()
+    .current_dir(util::testdata_path())
+    .arg("eval")
+    .arg(source_code)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .unwrap();
+  let _stdin = child.stdin.take().unwrap();
+  let start = std::time::Instant::now();
+  while start.elapsed() < Duration::from_secs(2) {
+    if child.try_wait().unwrap().is_some() {
+      let output = child.wait_with_output().unwrap();
+      assert!(output.status.success());
+      assert_eq!(String::from_utf8_lossy(&output.stdout), "{\"done\":true}\n");
+      assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+      return;
+    }
+    std::thread::sleep(Duration::from_millis(10));
+  }
+  child.kill().unwrap();
+  panic!("Deno did not exit after stdin readable cancellation");
+}
+
+#[test]
+fn stdin_readable_eof_keeps_stdin_readable() {
+  let source_code = r#"
+const chunks = [];
+for await (const chunk of Deno.stdin.readable) {
+  chunks.push(chunk);
+}
+const remaining = await Deno.stdin.read(new Uint8Array(1));
+console.log(new TextDecoder().decode(await new Blob(chunks).arrayBuffer()));
+console.log(remaining);
+"#;
+
+  let mut child = util::deno_cmd()
+    .current_dir(util::testdata_path())
+    .arg("eval")
+    .arg(source_code)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .unwrap();
+  {
+    let mut stdin = child.stdin.take().unwrap();
+    stdin.write_all(b"hello").unwrap();
+  }
+  let output = child.wait_with_output().unwrap();
+  assert!(output.status.success());
+  assert_eq!(String::from_utf8_lossy(&output.stdout), "hello\nnull\n");
+  assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+}
+
 #[cfg(windows)]
 // Clippy suggests to remove the `NoStd` prefix from all variants. I disagree.
 #[allow(clippy::enum_variant_names, reason = "NoStd prefix improves clarity")]

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -1092,6 +1092,54 @@ console.log(remaining);
   assert_eq!(String::from_utf8_lossy(&output.stderr), "");
 }
 
+#[test]
+fn stdin_readable_cancel_keeps_stdin_readable() {
+  let source_code = r#"
+const reader = Deno.stdin.readable.getReader();
+const cancelPromise = new Promise((resolve, reject) => {
+  setTimeout(() => {
+    reader.cancel("shutdown").then(resolve, reject);
+  }, 10);
+});
+await reader.read();
+await cancelPromise;
+reader.releaseLock();
+const buf = new Uint8Array(1);
+const nread = await Deno.stdin.read(buf);
+console.log(`${nread}:${String.fromCharCode(buf[0])}`);
+"#;
+
+  let mut child = util::deno_cmd()
+    .current_dir(util::testdata_path())
+    .arg("eval")
+    .arg(source_code)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .unwrap();
+  let mut stdin = child.stdin.take().unwrap();
+  let writer = std::thread::spawn(move || {
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    stdin.write_all(b"x").ok();
+  });
+  let start = std::time::Instant::now();
+  while start.elapsed() < std::time::Duration::from_secs(2) {
+    if child.try_wait().unwrap().is_some() {
+      let output = child.wait_with_output().unwrap();
+      writer.join().unwrap();
+      assert!(output.status.success());
+      assert_eq!(String::from_utf8_lossy(&output.stdout), "1:x\n");
+      assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+      return;
+    }
+    std::thread::sleep(std::time::Duration::from_millis(10));
+  }
+  child.kill().unwrap();
+  writer.join().unwrap();
+  panic!("Deno did not keep stdin readable after stdin readable cancellation");
+}
+
 #[cfg(windows)]
 // Clippy suggests to remove the `NoStd` prefix from all variants. I disagree.
 #[allow(clippy::enum_variant_names, reason = "NoStd prefix improves clarity")]


### PR DESCRIPTION
Fixes #30652.

Supersedes #34979. The earlier PR was closed by the contributor and GitHub would not allow it to be reopened after the branch was refreshed, so this PR carries the same narrow fix on a clean branch based on current `main`.

`Deno.stdin.readable` could resolve a canceled read while the underlying stdin read operation still kept the process alive. That meant JavaScript could finish after `await reader.cancel()`, but the Deno process would not exit until more stdin input arrived.

This changes stdin's readable stream to use the existing unrefable resource-backed stream path, keeps stdin's internal ref/unref hooks wired to that stream, and makes unrefable stream cancellation unref the pending read before closing the resource. On Unix, stdin async reads now avoid parking indefinitely inside a blocking read when no input is available, so cancellation can complete without waiting for later stdin data.

The follow-up behavior keeps normal EOF/error handling from closing the shared stdin rid while preserving the cancel path needed for the original liveness fix. It also adds regression coverage proving `Deno.stdin.read()` remains usable after `Deno.stdin.readable` reaches EOF and after cancellation.

Validation on macOS arm64 using Rust 1.95.0 from `rust-toolchain.toml`:
- `./x fmt`
- `./x lint`
- `./x check`
- `./x build`
- `rustup run 1.95.0 cargo check -p deno_io -p deno_web -p integration_tests`
- `rustup run 1.95.0 cargo test -p integration_tests --test integration run::stdin_readable_cancel_exits -- --exact --nocapture`
- `rustup run 1.95.0 cargo test -p integration_tests --test integration run::stdin_readable_eof_keeps_stdin_readable -- --exact --nocapture`
- `rustup run 1.95.0 cargo test -p integration_tests --test integration run::stdin_readable_cancel_keeps_stdin_readable -- --exact --nocapture`
- `git diff --check`

Disclosure: This PR was prepared with AI assistance under human direction and review.
