### PR TITLE
fix(node): keep interface list alive during IPv6 lookup

### DIFF
--- a/ext/node/ops/udp.rs
+++ b/ext/node/ops/udp.rs
@@ -215,52 +215,81 @@ fn resolve_ipv6_interface(
   // No zone id was provided. Try to find interface by matching the address.
   #[cfg(unix)]
   {
-    use std::ffi::CStr;
-    let target_addr =
-      Ipv6Addr::from_str(addr_str.split('%').next().unwrap_or(addr_str))?;
+    resolve_ipv6_interface_by_address(addr_str, |name| {
+      // SAFETY: if_nametoindex is safe with a valid C string from getifaddrs.
+      unsafe { libc::if_nametoindex(name.as_ptr()) }
+    })
+  }
+  #[cfg(not(unix))]
+  {
+    // Default to 0 if we couldn't resolve.
+    Ok(0)
+  }
+}
 
-    // Get all interfaces and find one with matching address
-    let mut addrs: *mut libc::ifaddrs = std::ptr::null_mut();
-    // SAFETY: getifaddrs is safe to call with a valid pointer
-    if unsafe { libc::getifaddrs(&mut addrs) } == 0 {
-      let mut current = addrs;
-      while !current.is_null() {
-        // SAFETY: we checked current is not null
-        let ifa = unsafe { &*current };
-        if !ifa.ifa_addr.is_null() {
-          // SAFETY: we checked ifa_addr is not null
-          let family = unsafe { (*ifa.ifa_addr).sa_family };
-          if family == libc::AF_INET6 as libc::sa_family_t {
-            // SAFETY: we verified this is AF_INET6
-            let sockaddr_in6 =
-              unsafe { &*(ifa.ifa_addr as *const libc::sockaddr_in6) };
-            let addr = Ipv6Addr::from(sockaddr_in6.sin6_addr.s6_addr);
-            if addr == target_addr {
-              // SAFETY: ifa_name is a valid C string
-              let name = unsafe { CStr::from_ptr(ifa.ifa_name) };
-              if let Ok(name_str) = name.to_str()
-                && let Ok(c_name) = std::ffi::CString::new(name_str)
-              {
-                // SAFETY: if_nametoindex is safe with valid C string
-                let idx = unsafe { libc::if_nametoindex(c_name.as_ptr()) };
-                // SAFETY: freeifaddrs is safe to call with the pointer from getifaddrs
-                unsafe { libc::freeifaddrs(addrs) };
-                if idx != 0 {
-                  return Ok(idx);
-                }
-              }
+#[cfg(unix)]
+struct IfAddrsList(*mut libc::ifaddrs);
+
+#[cfg(unix)]
+impl Drop for IfAddrsList {
+  fn drop(&mut self) {
+    if !self.0.is_null() {
+      // SAFETY: this guard is created only for a list returned by
+      // getifaddrs, and it owns the list until this single drop.
+      unsafe { libc::freeifaddrs(self.0) };
+    }
+  }
+}
+
+#[cfg(unix)]
+fn resolve_ipv6_interface_by_address(
+  addr_str: &str,
+  if_nametoindex: impl Fn(&std::ffi::CStr) -> u32,
+) -> Result<u32, NodeUdpError> {
+  use std::ffi::CStr;
+
+  let target_addr =
+    Ipv6Addr::from_str(addr_str.split('%').next().unwrap_or(addr_str))?;
+
+  // Get all interfaces and find one with matching address.
+  let mut addrs: *mut libc::ifaddrs = std::ptr::null_mut();
+  // SAFETY: getifaddrs is safe to call with a valid pointer.
+  if unsafe { libc::getifaddrs(&mut addrs) } != 0 {
+    return Ok(0);
+  }
+  let addrs = IfAddrsList(addrs);
+
+  let mut result = 0;
+  let mut current = addrs.0;
+  while !current.is_null() {
+    // SAFETY: we checked current is not null.
+    let ifa = unsafe { &*current };
+    if !ifa.ifa_addr.is_null() {
+      // SAFETY: we checked ifa_addr is not null.
+      let family = unsafe { (*ifa.ifa_addr).sa_family };
+      if family == libc::AF_INET6 as libc::sa_family_t {
+        // SAFETY: we verified this is AF_INET6.
+        let sockaddr_in6 =
+          unsafe { &*(ifa.ifa_addr as *const libc::sockaddr_in6) };
+        let addr = Ipv6Addr::from(sockaddr_in6.sin6_addr.s6_addr);
+        if addr == target_addr {
+          // SAFETY: ifa_name is a valid C string for the lifetime of addrs.
+          let name = unsafe { CStr::from_ptr(ifa.ifa_name) };
+          if let Ok(name_str) = name.to_str()
+            && let Ok(c_name) = std::ffi::CString::new(name_str)
+          {
+            result = if_nametoindex(&c_name);
+            if result != 0 {
+              break;
             }
           }
         }
-        current = ifa.ifa_next;
       }
-      // SAFETY: freeifaddrs is safe to call with the pointer from getifaddrs
-      unsafe { libc::freeifaddrs(addrs) };
     }
+    current = ifa.ifa_next;
   }
 
-  // Default to 0 if we couldn't resolve
-  Ok(0)
+  Ok(result)
 }
 
 #[op2]
@@ -695,5 +724,23 @@ pub fn op_node_udp_open(
       std::io::ErrorKind::Unsupported,
       "UDP socket IPC handle passing is not supported on this platform",
     )))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  #[cfg(unix)]
+  #[test]
+  fn ipv6_interface_resolution_handles_if_nametoindex_failure() {
+    use std::cell::Cell;
+
+    let lookup_count = Cell::new(0);
+    let result = super::resolve_ipv6_interface_by_address("::1", |_| {
+      lookup_count.set(lookup_count.get() + 1);
+      0
+    })
+    .expect("interface resolution should not fail");
+    assert!(lookup_count.get() > 0);
+    assert_eq!(result, 0);
   }
 }


### PR DESCRIPTION
## Summary

- keep the `getifaddrs` list owned for the full IPv6 interface traversal
- release the list once after interface resolution completes
- return the default interface index when name-to-index lookup fails

## Details

IPv6 multicast interface resolution released the interface list as soon as an address matched, before knowing whether the corresponding interface-name lookup succeeded. When that lookup returned index `0`, traversal continued even though the list was no longer alive, and the normal cleanup path attempted to release it again.

This change gives the list a single lifetime guard that remains active through traversal. Interface-name conversion, address matching, successful index selection, and the index-`0` fallback remain unchanged.

## Validation

- `cargo test -p deno_node ipv6_interface_resolution --lib`
- `cargo build -p deno --bin deno`
- `cargo test -p unit_node_tests --test unit_node -- unit_node::dgram_test`
- `./tools/format.js --check`
