### PR TITLE
fix(core): make Unix pipe fd ownership explicit

### DIFF
--- a/libs/core/uv_compat/pipe.rs
+++ b/libs/core/uv_compat/pipe.rs
@@ -43,8 +43,12 @@ pub struct uv_pipe_t {
   pub data: *mut c_void,
   pub flags: u32,
 
+  /// A raw descriptor owned directly by this handle. This is mutually
+  /// exclusive with `internal_stream` and `internal_listener`, which own
+  /// their descriptors through Tokio wrappers.
   #[cfg(unix)]
   pub(crate) internal_fd: Option<RawFd>,
+  /// A non-owning reactor registration for `internal_fd`.
   #[cfg(unix)]
   pub(crate) internal_async_fd: Option<tokio::io::unix::AsyncFd<RawFdWrapper>>,
 
@@ -133,13 +137,35 @@ pub(crate) struct PipeConnectPending {
       dyn std::future::Future<Output = std::io::Result<tokio::net::UnixStream>>,
     >,
   >,
+  /// Descriptor borrowed from the stream captured by `future`. This keeps
+  /// the `fd` getter available while a pre-bound descriptor is connecting.
+  #[cfg(unix)]
+  pub raw_fd: Option<RawFd>,
 }
 
 impl uv_pipe_t {
   /// Get the raw fd if one has been opened on this pipe.
   #[cfg(unix)]
   pub fn fd(&self) -> Option<RawFd> {
-    self.internal_fd
+    use std::os::unix::io::AsRawFd;
+
+    self
+      .internal_stream
+      .as_ref()
+      .map(|stream| stream.as_raw_fd())
+      .or_else(|| {
+        self
+          .internal_listener
+          .as_ref()
+          .map(|listener| listener.as_raw_fd())
+      })
+      .or(self.internal_fd)
+      .or_else(|| {
+        self
+          .internal_connect
+          .as_ref()
+          .and_then(|pending| pending.raw_fd)
+      })
   }
 
   /// Get the bind path if one was set.
@@ -157,8 +183,6 @@ impl uv_pipe_t {
 /// kernel attaches it to the outgoing message.
 #[cfg(unix)]
 pub unsafe fn uv_pipe_fd_for_ipc(pipe: *mut uv_pipe_t) -> c_int {
-  use std::os::fd::AsRawFd;
-
   if pipe.is_null() {
     return -1;
   }
@@ -166,13 +190,7 @@ pub unsafe fn uv_pipe_fd_for_ipc(pipe: *mut uv_pipe_t) -> c_int {
   // SAFETY: Caller guarantees pipe is initialized and valid.
   unsafe {
     let p = &*pipe;
-    let fd = if let Some(stream) = p.internal_stream.as_ref() {
-      stream.as_raw_fd()
-    } else if let Some(listener) = p.internal_listener.as_ref() {
-      listener.as_raw_fd()
-    } else {
-      p.internal_fd.unwrap_or(-1)
-    };
+    let fd = p.fd().unwrap_or(-1);
     if fd < 0 {
       return -1;
     }
@@ -661,8 +679,13 @@ pub unsafe fn uv_pipe_listen(
       libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
     }
 
-    // Wrap as tokio UnixListener using from_std.
+    // Transfer ownership to the Tokio listener. From this point onward,
+    // dropping either the std or Tokio wrapper closes the descriptor.
     use std::os::unix::io::FromRawFd;
+    let fd = (*pipe)
+      .internal_fd
+      .take()
+      .expect("pipe descriptor disappeared before listen");
     let std_listener = std::os::unix::net::UnixListener::from_raw_fd(fd);
     let listener = match tokio::net::UnixListener::from_std(std_listener) {
       Ok(l) => l,
@@ -695,9 +718,8 @@ pub unsafe fn uv_pipe_accept(
 ) -> c_int {
   unsafe {
     if let Some(stream) = (*server).internal_backlog.pop_front() {
-      use std::os::unix::io::AsRawFd;
-      let fd = stream.as_raw_fd();
-      (*client).internal_fd = Some(fd);
+      // The accepted Tokio stream is the sole descriptor owner.
+      debug_assert!((*client).internal_fd.is_none());
       (*client).internal_stream = Some(stream);
       (*client).flags |= UV_HANDLE_ACTIVE;
       // Add to pipe_handles so writes/reads are polled.
@@ -731,11 +753,27 @@ pub unsafe fn uv_pipe_connect(
 ) -> c_int {
   let path = path.to_string();
 
-  // If the pipe has a pre-bound fd (from uv_pipe_bind), use it
-  // for the connect. Otherwise create a fresh connection.
-  let bound_fd = unsafe { (*pipe).internal_fd };
+  // If the pipe has a pre-bound fd (from uv_pipe_bind), transfer it to a
+  // std UnixStream captured by the connect future. The future then owns the
+  // descriptor until it either becomes a Tokio stream or is dropped.
+  let bound_stream = unsafe {
+    use std::os::unix::io::FromRawFd;
+
+    (*pipe).internal_async_fd = None;
+    (*pipe)
+      .internal_fd
+      .take()
+      .map(|fd| std::os::unix::net::UnixStream::from_raw_fd(fd))
+  };
+  let raw_fd = bound_stream.as_ref().map(|stream| {
+    use std::os::unix::io::AsRawFd;
+    stream.as_raw_fd()
+  });
   let future = Box::pin(async move {
-    if let Some(fd) = bound_fd {
+    if let Some(stream) = bound_stream {
+      use std::os::unix::io::AsRawFd;
+
+      let fd = stream.as_raw_fd();
       // Non-blocking connect on the pre-bound socket.
       // SAFETY: fd is a valid socket from uv_pipe_bind.
       unsafe {
@@ -796,10 +834,8 @@ pub unsafe fn uv_pipe_connect(
           drop(async_fd);
         }
 
-        // Wrap the connected fd as a tokio UnixStream.
-        use std::os::unix::io::FromRawFd;
-        let std_stream = std::os::unix::net::UnixStream::from_raw_fd(fd);
-        tokio::net::UnixStream::from_std(std_stream)
+        // Transfer the connected stream into Tokio.
+        tokio::net::UnixStream::from_std(stream)
       }
     } else {
       tokio::net::UnixStream::connect(&path).await
@@ -807,13 +843,12 @@ pub unsafe fn uv_pipe_connect(
   });
 
   unsafe {
-    // Drop any AsyncFd created by a prior read_start_pipe call.
-    // The connect future will create a UnixStream that registers
-    // the same fd with the reactor; having both would corrupt
-    // readiness tracking.
-    (*pipe).internal_async_fd = None;
-
-    (*pipe).internal_connect = Some(PipeConnectPending { req, cb, future });
+    (*pipe).internal_connect = Some(PipeConnectPending {
+      req,
+      cb,
+      future,
+      raw_fd,
+    });
     (*pipe).flags |= UV_HANDLE_ACTIVE;
 
     let inner = super::get_inner((*pipe).loop_);
@@ -1196,6 +1231,15 @@ pub(crate) unsafe fn close_pipe(pipe: *mut uv_pipe_t) {
 
     #[cfg(unix)]
     {
+      debug_assert!(
+        (*pipe).internal_fd.is_none()
+          || ((*pipe).internal_stream.is_none()
+            && (*pipe).internal_listener.is_none()),
+        "raw and Tokio pipe descriptor owners overlap"
+      );
+
+      // AsyncFd only borrows internal_fd, so deregister it before dropping
+      // the raw owner. Streams and listeners close their own descriptors.
       (*pipe).internal_async_fd = None;
       (*pipe).internal_stream = None;
       (*pipe).internal_listener = None;
@@ -1733,11 +1777,8 @@ pub(crate) unsafe fn poll_pipe_handle(
     if let Some((req, cb, result)) = connect_result {
       let status = match result {
         Ok(stream) => {
-          use std::os::unix::io::AsRawFd;
-          // Drop the AsyncFd from uv_pipe_open (if any) since the
-          // connected stream now owns the fd.
-          (*pipe_ptr).internal_async_fd = None;
-          (*pipe_ptr).internal_fd = Some(stream.as_raw_fd());
+          // The completed Tokio stream is the sole descriptor owner.
+          debug_assert!((*pipe_ptr).internal_fd.is_none());
           (*pipe_ptr).internal_stream = Some(stream);
           0
         }

--- a/libs/core/uv_compat/tests.rs
+++ b/libs/core/uv_compat/tests.rs
@@ -2032,6 +2032,10 @@ fn assert_fd_closed(fd: i32) {
 }
 
 #[cfg(unix)]
+#[allow(
+  clippy::disallowed_methods,
+  reason = "uv_compat tests require real Unix socket paths"
+)]
 fn pipe_test_socket_path(name: &str) -> std::path::PathBuf {
   static NEXT_ID: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
@@ -3285,6 +3289,10 @@ async fn pipe_bound_connect_transfers_raw_fd_ownership() {
     assert_fd_closed(fd);
 
     drop(listener);
+    #[allow(
+      clippy::disallowed_methods,
+      reason = "clean up the real Unix socket created by Tokio"
+    )]
     let _ = std::fs::remove_file(server_path);
   })
   .await;

--- a/libs/core/uv_compat/tests.rs
+++ b/libs/core/uv_compat/tests.rs
@@ -2023,6 +2023,24 @@ fn get_errno() -> i32 {
 }
 
 #[cfg(unix)]
+fn assert_fd_closed(fd: i32) {
+  unsafe {
+    set_errno(0);
+    assert_eq!(libc::fcntl(fd, libc::F_GETFD), -1);
+  }
+  assert_eq!(get_errno(), libc::EBADF);
+}
+
+#[cfg(unix)]
+fn pipe_test_socket_path(name: &str) -> std::path::PathBuf {
+  static NEXT_ID: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+  let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+  std::env::temp_dir()
+    .join(format!("deno-uv-{name}-{}-{id}.sock", std::process::id()))
+}
+
+#[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_init_sets_fields() {
   run_test(async |_runtime, uv_loop| {
@@ -3060,6 +3078,7 @@ async fn pipe_open_not_active_until_read_start() {
     // Create an OS pipe pair.
     let mut pipe_fds = [0i32; 2];
     assert_eq!(unsafe { libc::pipe(pipe_fds.as_mut_ptr()) }, 0);
+    let read_fd = pipe_fds[0];
     let write_fd = pipe_fds[1];
     let _write_guard = FdGuard(write_fd);
 
@@ -3133,6 +3152,140 @@ async fn pipe_open_not_active_until_read_start() {
       uv_close(&mut pipe as *mut uv_pipe_t as *mut uv_handle_t, None);
     }
     tick(runtime).await;
+    assert_fd_closed(read_fd);
+  })
+  .await;
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn pipe_listener_transfers_raw_fd_ownership() {
+  run_test(async |runtime, uv_loop| {
+    let socket_path = pipe_test_socket_path("pipe-owner");
+    let socket_path = socket_path.to_string_lossy().into_owned();
+    let mut pipe = new_pipe(false);
+
+    unsafe {
+      assert_ok(pipe::uv_pipe_init(uv_loop, &mut pipe, 0));
+      assert_ok(pipe::uv_pipe_bind(&mut pipe, &socket_path));
+    }
+    let fd = pipe.fd().expect("bound pipe should have a descriptor");
+    assert_eq!(pipe.internal_fd, Some(fd));
+
+    unsafe {
+      assert_ok(pipe::uv_pipe_listen(&mut pipe, 128, None));
+    }
+    assert!(
+      pipe.internal_fd.is_none(),
+      "the raw owner must be cleared after listener adoption"
+    );
+    assert!(pipe.internal_listener.is_some());
+    assert_eq!(pipe.fd(), Some(fd));
+
+    unsafe {
+      uv_close(&mut pipe as *mut uv_pipe_t as *mut uv_handle_t, None);
+    }
+    tick(runtime).await;
+    assert_fd_closed(fd);
+  })
+  .await;
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn pipe_accept_keeps_only_the_tokio_fd_owner() {
+  use std::os::unix::io::AsRawFd;
+
+  run_test(async |runtime, uv_loop| {
+    let (accepted, peer) = std::os::unix::net::UnixStream::pair().unwrap();
+    accepted.set_nonblocking(true).unwrap();
+    let accepted = tokio::net::UnixStream::from_std(accepted).unwrap();
+    let fd = accepted.as_raw_fd();
+
+    let mut server = new_pipe(false);
+    let mut client = new_pipe(false);
+    unsafe {
+      assert_ok(pipe::uv_pipe_init(uv_loop, &mut server, 0));
+      assert_ok(pipe::uv_pipe_init(uv_loop, &mut client, 0));
+    }
+    server.internal_backlog.push_back(accepted);
+
+    unsafe {
+      assert_ok(pipe::uv_pipe_accept(&mut server, &mut client));
+    }
+    assert!(
+      client.internal_fd.is_none(),
+      "an accepted Tokio stream must be the sole descriptor owner"
+    );
+    assert!(client.internal_stream.is_some());
+    assert_eq!(client.fd(), Some(fd));
+
+    unsafe {
+      uv_close(&mut client as *mut uv_pipe_t as *mut uv_handle_t, None);
+      uv_close(&mut server as *mut uv_pipe_t as *mut uv_handle_t, None);
+    }
+    tick(runtime).await;
+    assert_fd_closed(fd);
+    drop(peer);
+  })
+  .await;
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn pipe_bound_connect_transfers_raw_fd_ownership() {
+  run_test(async |runtime, uv_loop| {
+    let server_path = pipe_test_socket_path("pipe-connect-server");
+    let client_path = pipe_test_socket_path("pipe-connect-client");
+    let listener = tokio::net::UnixListener::bind(&server_path).unwrap();
+    let server_path = server_path.to_string_lossy().into_owned();
+    let client_path = client_path.to_string_lossy().into_owned();
+
+    let mut pipe = new_pipe(false);
+    let mut req = new_connect();
+    unsafe {
+      assert_ok(pipe::uv_pipe_init(uv_loop, &mut pipe, 0));
+      assert_ok(pipe::uv_pipe_bind(&mut pipe, &client_path));
+    }
+    let fd = pipe.fd().expect("bound pipe should have a descriptor");
+
+    unsafe {
+      assert_ok(pipe::uv_pipe_connect(
+        &mut req,
+        &mut pipe,
+        &server_path,
+        None,
+      ));
+    }
+    assert!(
+      pipe.internal_fd.is_none(),
+      "the connect future must take ownership of the bound descriptor"
+    );
+    assert_eq!(pipe.fd(), Some(fd));
+
+    for _ in 0..10 {
+      tick(runtime).await;
+      if pipe.internal_stream.is_some() {
+        break;
+      }
+      tokio::task::yield_now().await;
+    }
+
+    assert!(
+      pipe.internal_fd.is_none(),
+      "a connected Tokio stream must be the sole descriptor owner"
+    );
+    assert!(pipe.internal_stream.is_some());
+    assert_eq!(pipe.fd(), Some(fd));
+
+    unsafe {
+      uv_close(&mut pipe as *mut uv_pipe_t as *mut uv_handle_t, None);
+    }
+    tick(runtime).await;
+    assert_fd_closed(fd);
+
+    drop(listener);
+    let _ = std::fs::remove_file(server_path);
   })
   .await;
 }


### PR DESCRIPTION
## Summary

- keep raw Unix pipe descriptors owned by the pipe handle until ownership is transferred
- make Tokio streams and listeners the sole closer after connect, accept, or listen
- retain explicit cleanup for descriptor-only pipes and non-owning `AsyncFd` registrations
- cover raw, listener, accepted-stream, and bound-connect ownership transitions

## Tests

- `./tools/format.js`
- `cargo test -p deno_core 'uv_compat::tests' --lib`
- `cargo clippy -p deno_core --lib --tests --no-deps -- -D warnings`
- `cargo build -p deno --bin deno`
