### PR TITLE
fix(sqlite): refuse symlink database paths

### DIFF
--- a/ext/kv/sqlite.rs
+++ b/ext/kv/sqlite.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -55,6 +56,25 @@ enum Mode {
   InMemory,
 }
 
+fn resolve_sqlite_system_path_alias(path: &Path) -> PathBuf {
+  // SQLITE_OPEN_NOFOLLOW rejects symlinks in every path component. macOS
+  // exposes its temporary directories through root-owned aliases, so resolve
+  // only those fixed system prefixes and leave every user-controlled path
+  // component visible to SQLite.
+  #[cfg(target_os = "macos")]
+  for prefix in [Path::new("/var"), Path::new("/tmp")] {
+    if let Ok(suffix) = path.strip_prefix(prefix)
+      && let Ok(prefix) = deno_path_util::fs::canonicalize_path_maybe_not_exists(
+        &sys_traits::impls::RealSys,
+        prefix,
+      )
+    {
+      return prefix.join(suffix);
+    }
+  }
+  path.to_path_buf()
+}
+
 #[async_trait(?Send)]
 impl DatabaseHandler for SqliteDbHandler {
   type DB = denokv_sqlite::Sqlite;
@@ -98,7 +118,9 @@ impl DatabaseHandler for SqliteDbHandler {
             Some("Deno.openKv"),
           )
           .map_err(JsErrorBox::from_err)?;
-        Ok(Some(PathOrInMemory::Path(path.into_owned_path())))
+        Ok(Some(PathOrInMemory::Path(
+          resolve_sqlite_system_path_alias(&path),
+        )))
       }
     }
 
@@ -133,21 +155,16 @@ impl DatabaseHandler for SqliteDbHandler {
             None,
           ),
           (Some(PathOrInMemory::Path(path)), _) => {
-            let flags =
-              OpenFlags::default().difference(OpenFlags::SQLITE_OPEN_URI);
-            let resolved_path =
-              deno_path_util::fs::canonicalize_path_maybe_not_exists(
-                // todo(dsherret): probably should use the FileSystem in the op state instead
-                &sys_traits::impls::RealSys,
-                path,
-              )
-              .map_err(JsErrorBox::from_err)?;
+            let flags = OpenFlags::default()
+              .difference(OpenFlags::SQLITE_OPEN_URI)
+              | OpenFlags::SQLITE_OPEN_NOFOLLOW;
             let path = path.clone();
+            let notifier_key = path.clone();
             (
               Arc::new(move || {
                 rusqlite::Connection::open_with_flags(&path, flags)
               }) as ConnGen,
-              Some(resolved_path),
+              Some(notifier_key),
             )
           }
           (None, Some(path)) => {

--- a/ext/kv/sqlite.rs
+++ b/ext/kv/sqlite.rs
@@ -75,6 +75,36 @@ fn resolve_sqlite_system_path_alias(path: &Path) -> PathBuf {
   path.to_path_buf()
 }
 
+/// SQLite does not enforce `SQLITE_OPEN_NOFOLLOW` on Windows (its
+/// `winFullPathname` never resolves reparse points), so reject symlinks and
+/// junctions in every path component manually before opening.
+#[cfg(windows)]
+fn refuse_reparse_point_components(path: &Path) -> std::io::Result<()> {
+  let mut current = PathBuf::new();
+  for component in path.components() {
+    current.push(component);
+    #[allow(
+      clippy::disallowed_methods,
+      reason = "the database path is always on the real fs"
+    )]
+    match std::fs::symlink_metadata(&current) {
+      Ok(metadata) if metadata.file_type().is_symlink() => {
+        return Err(std::io::Error::new(
+          std::io::ErrorKind::InvalidInput,
+          format!(
+            "unable to open database file: \"{}\" is a symlink",
+            current.display()
+          ),
+        ));
+      }
+      Ok(_) => {}
+      // Missing components are created (or rejected) by SQLite itself.
+      Err(_) => break,
+    }
+  }
+  Ok(())
+}
+
 #[async_trait(?Send)]
 impl DatabaseHandler for SqliteDbHandler {
   type DB = denokv_sqlite::Sqlite;
@@ -158,8 +188,22 @@ impl DatabaseHandler for SqliteDbHandler {
             let flags = OpenFlags::default()
               .difference(OpenFlags::SQLITE_OPEN_URI)
               | OpenFlags::SQLITE_OPEN_NOFOLLOW;
+            #[cfg(windows)]
+            refuse_reparse_point_components(path)
+              .map_err(JsErrorBox::from_err)?;
+            // Open with the unresolved path so SQLITE_OPEN_NOFOLLOW keeps
+            // rejecting symlinks, but key the notifier on the normalized
+            // absolute path so lexical aliases of the same database (e.g.
+            // `db.sqlite` and `./db.sqlite`) share one notifier. Resolving
+            // symlinks here cannot redirect the open: paths containing
+            // symlinks are refused above.
+            let notifier_key =
+              deno_path_util::fs::canonicalize_path_maybe_not_exists(
+                &sys_traits::impls::RealSys,
+                path,
+              )
+              .map_err(JsErrorBox::from_err)?;
             let path = path.clone();
-            let notifier_key = path.clone();
             (
               Arc::new(move || {
                 rusqlite::Connection::open_with_flags(&path, flags)

--- a/ext/node_sqlite/database.rs
+++ b/ext/node_sqlite/database.rs
@@ -8,6 +8,7 @@ use std::ffi::CString;
 use std::ffi::c_char;
 use std::ffi::c_void;
 use std::path::Path;
+use std::path::PathBuf;
 use std::ptr::NonNull;
 use std::ptr::null;
 use std::rc::Rc;
@@ -45,6 +46,50 @@ const SQLITE_DBCONFIG_ENABLE_ATTACH_WRITE: i32 = 1021;
 const MAX_SAFE_JS_INTEGER: i64 = 9_007_199_254_740_991;
 
 const NUM_LIMITS: usize = 11;
+
+fn resolve_sqlite_system_path_alias(path: &Path) -> PathBuf {
+  // SQLITE_OPEN_NOFOLLOW rejects symlinks in every path component. macOS
+  // exposes its temporary directories through root-owned aliases, so resolve
+  // only those fixed system prefixes and leave every user-controlled path
+  // component visible to SQLite.
+  #[cfg(target_os = "macos")]
+  if let Some(path) = path.to_str() {
+    for (uri_prefix, prefix) in [
+      ("file:///var", Path::new("/var")),
+      ("file:///tmp", Path::new("/tmp")),
+    ] {
+      let Some(suffix) = path.strip_prefix(uri_prefix) else {
+        continue;
+      };
+      if !matches!(
+        suffix.as_bytes().first(),
+        None | Some(b'/') | Some(b'?') | Some(b'#')
+      ) {
+        continue;
+      }
+      #[allow(
+        clippy::disallowed_methods,
+        reason = "node:sqlite operates on the real file system"
+      )]
+      if let Ok(prefix) = std::fs::canonicalize(prefix) {
+        return PathBuf::from(format!("file://{}{}", prefix.display(), suffix));
+      }
+    }
+  }
+  #[cfg(target_os = "macos")]
+  for prefix in [Path::new("/var"), Path::new("/tmp")] {
+    if let Ok(suffix) = path.strip_prefix(prefix) {
+      #[allow(
+        clippy::disallowed_methods,
+        reason = "node:sqlite operates on the real file system"
+      )]
+      if let Ok(prefix) = std::fs::canonicalize(prefix) {
+        return prefix.join(suffix);
+      }
+    }
+  }
+  path.to_path_buf()
+}
 
 /// Static mapping of JavaScript property names to SQLite limits.
 /// Order matches SQLite limit constant values (0-10).
@@ -748,11 +793,13 @@ fn open_db(
       Some("node:sqlite"),
     )?
     .into_path();
+  let location = resolve_sqlite_system_path_alias(&location);
 
   if options.read_only {
     let conn = rusqlite::Connection::open_with_flags(
-      location,
-      rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+      &location,
+      rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+        | rusqlite::OpenFlags::SQLITE_OPEN_NOFOLLOW,
     )?;
     if disable_attach {
       assert!(set_db_config(
@@ -784,7 +831,10 @@ fn open_db(
     return Ok((conn, disable_attach));
   }
 
-  let conn = rusqlite::Connection::open(location)?;
+  let conn = rusqlite::Connection::open_with_flags(
+    &location,
+    rusqlite::OpenFlags::default() | rusqlite::OpenFlags::SQLITE_OPEN_NOFOLLOW,
+  )?;
   conn.busy_timeout(std::time::Duration::from_millis(options.timeout))?;
 
   if options.allow_extension {

--- a/ext/node_sqlite/database.rs
+++ b/ext/node_sqlite/database.rs
@@ -91,6 +91,36 @@ fn resolve_sqlite_system_path_alias(path: &Path) -> PathBuf {
   path.to_path_buf()
 }
 
+/// SQLite does not enforce `SQLITE_OPEN_NOFOLLOW` on Windows (its
+/// `winFullPathname` never resolves reparse points), so reject symlinks and
+/// junctions in every path component manually before opening.
+#[cfg(windows)]
+fn refuse_reparse_point_components(path: &Path) -> Result<(), rusqlite::Error> {
+  let mut current = PathBuf::new();
+  for component in path.components() {
+    current.push(component);
+    #[allow(
+      clippy::disallowed_methods,
+      reason = "node:sqlite operates on the real file system"
+    )]
+    match std::fs::symlink_metadata(&current) {
+      Ok(metadata) if metadata.file_type().is_symlink() => {
+        return Err(rusqlite::Error::SqliteFailure(
+          rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CANTOPEN),
+          Some(format!(
+            "unable to open database file: \"{}\" is a symlink",
+            current.display()
+          )),
+        ));
+      }
+      Ok(_) => {}
+      // Missing components are created (or rejected) by SQLite itself.
+      Err(_) => break,
+    }
+  }
+  Ok(())
+}
+
 /// Static mapping of JavaScript property names to SQLite limits.
 /// Order matches SQLite limit constant values (0-10).
 /// Keep in sync with LIMIT_NAMES in ext/node/polyfills/sqlite.ts.
@@ -794,6 +824,8 @@ fn open_db(
     )?
     .into_path();
   let location = resolve_sqlite_system_path_alias(&location);
+  #[cfg(windows)]
+  refuse_reparse_point_components(&location)?;
 
   if options.read_only {
     let conn = rusqlite::Connection::open_with_flags(

--- a/tests/unit/kv_test.ts
+++ b/tests/unit/kv_test.ts
@@ -73,6 +73,7 @@ Deno.test({
 
       const open = (path: string) =>
         new Deno.Command(Deno.execPath(), {
+          clearEnv: true,
           args: [
             "run",
             "--quiet",

--- a/tests/unit/kv_test.ts
+++ b/tests/unit/kv_test.ts
@@ -5,6 +5,7 @@ import {
   AssertionError,
   assertNotEquals,
   assertRejects,
+  assertStringIncludes,
   assertThrows,
 } from "./test_util.ts";
 import { assertType, IsExact } from "@std/testing/types";
@@ -44,6 +45,86 @@ Deno.test({
       TypeError,
       "Filename cannot start with ':' unless prefixed with './'",
     );
+  },
+});
+
+Deno.test({
+  name: "openKv does not follow a symlink outside permitted directories",
+  permissions: {
+    read: true,
+    write: true,
+    run: [Deno.execPath()],
+  },
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const dir = await Deno.makeTempDir({ prefix: "open_kv_symlink" });
+    try {
+      const allowedDir = `${dir}/allowed`;
+      const outsideDir = `${dir}/outside`;
+      const target = `${outsideDir}/target.sqlite3`;
+      const link = `${allowedDir}/link.sqlite3`;
+      const runner = `${allowedDir}/runner.ts`;
+      await Deno.mkdir(allowedDir);
+      await Deno.mkdir(outsideDir);
+      await Deno.writeTextFile(
+        runner,
+        "const db = await Deno.openKv(Deno.args[0]); db.close();",
+      );
+
+      const open = (path: string) =>
+        new Deno.Command(Deno.execPath(), {
+          args: [
+            "run",
+            "--quiet",
+            "--unstable-kv",
+            `--allow-read=${allowedDir}`,
+            `--allow-write=${allowedDir}`,
+            `--deny-read=${allowedDir}/directory-link/denied`,
+            `--deny-write=${allowedDir}/directory-link/denied`,
+            runner,
+            path,
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        }).output();
+      const assertRefused = async (path: string) => {
+        const result = await open(path);
+
+        assertEquals(
+          result.code,
+          1,
+          new TextDecoder().decode(result.stderr),
+        );
+        assertStringIncludes(
+          new TextDecoder().decode(result.stderr),
+          "unable to open database file",
+        );
+      };
+
+      const regularPath = `${allowedDir}/regular.sqlite3`;
+      const regularResult = await open(regularPath);
+      assertEquals(
+        regularResult.code,
+        0,
+        new TextDecoder().decode(regularResult.stderr),
+      );
+      assert((await Deno.stat(regularPath)).isFile);
+
+      await Deno.symlink(target, link);
+      await assertRefused(link);
+      await assertRejects(() => Deno.stat(target), Deno.errors.NotFound);
+
+      const directoryLink = `${allowedDir}/directory-link`;
+      const nestedTarget = `${outsideDir}/nested.sqlite3`;
+      await Deno.symlink(outsideDir, directoryLink);
+      await assertRefused(`${directoryLink}/nested.sqlite3`);
+      await assertRejects(
+        () => Deno.stat(nestedTarget),
+        Deno.errors.NotFound,
+      );
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
   },
 });
 

--- a/tests/unit/kv_test.ts
+++ b/tests/unit/kv_test.ts
@@ -55,7 +55,6 @@ Deno.test({
     write: true,
     run: [Deno.execPath()],
   },
-  ignore: Deno.build.os === "windows",
   async fn() {
     const dir = await Deno.makeTempDir({ prefix: "open_kv_symlink" });
     try {
@@ -111,13 +110,13 @@ Deno.test({
       );
       assert((await Deno.stat(regularPath)).isFile);
 
-      await Deno.symlink(target, link);
+      await Deno.symlink(target, link, { type: "file" });
       await assertRefused(link);
       await assertRejects(() => Deno.stat(target), Deno.errors.NotFound);
 
       const directoryLink = `${allowedDir}/directory-link`;
       const nestedTarget = `${outsideDir}/nested.sqlite3`;
-      await Deno.symlink(outsideDir, directoryLink);
+      await Deno.symlink(outsideDir, directoryLink, { type: "dir" });
       await assertRefused(`${directoryLink}/nested.sqlite3`);
       await assertRejects(
         () => Deno.stat(nestedTarget),

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -4,6 +4,7 @@ import {
   assert,
   assertEquals,
   assertStrictEquals,
+  assertStringIncludes,
   assertThrows,
 } from "@std/assert";
 import * as nodeAssert from "node:assert";
@@ -87,6 +88,111 @@ Deno.test(
     db.close();
   },
 );
+
+Deno.test({
+  permissions: {
+    read: true,
+    write: true,
+    run: [Deno.execPath()],
+  },
+  ignore: Deno.build.os === "windows",
+  name: "[node/sqlite] DatabaseSync does not follow symlink database paths",
+  async fn() {
+    const dir = Deno.makeTempDirSync({ prefix: "node_sqlite_symlink" });
+    try {
+      const allowedDir = `${dir}/allowed`;
+      const outsideDir = `${dir}/outside`;
+      const runner = `${allowedDir}/runner.ts`;
+      Deno.mkdirSync(allowedDir);
+      Deno.mkdirSync(outsideDir);
+      Deno.writeTextFileSync(
+        runner,
+        `import { DatabaseSync } from "node:sqlite";
+const db = new DatabaseSync(Deno.args[1], {
+  readOnly: Deno.args[0] === "read",
+});
+db.close();
+`,
+      );
+
+      const openDatabase = (
+        mode: "read" | "write",
+        path: string,
+      ) =>
+        new Deno.Command(Deno.execPath(), {
+          args: [
+            "run",
+            "--quiet",
+            `--allow-read=${allowedDir}`,
+            `--deny-read=${allowedDir}/directory-link/denied`,
+            ...(mode === "write"
+              ? [
+                `--allow-write=${allowedDir}`,
+                `--deny-write=${allowedDir}/directory-link/denied`,
+              ]
+              : []),
+            runner,
+            mode,
+            path,
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        }).output();
+      const assertRefused = async (
+        mode: "read" | "write",
+        path: string,
+      ) => {
+        const result = await openDatabase(mode, path);
+        assertEquals(
+          result.code,
+          1,
+          new TextDecoder().decode(result.stderr),
+        );
+        assertStringIncludes(
+          new TextDecoder().decode(result.stderr),
+          "unable to open database file",
+        );
+      };
+
+      const regularPath = `${allowedDir}/regular.db`;
+      const regularResult = await openDatabase("write", regularPath);
+      assertEquals(
+        regularResult.code,
+        0,
+        new TextDecoder().decode(regularResult.stderr),
+      );
+      assert(Deno.statSync(regularPath).isFile);
+
+      const writeTarget = `${outsideDir}/write-target.db`;
+      const writeLink = `${allowedDir}/write-link.db`;
+      Deno.symlinkSync(writeTarget, writeLink);
+      await assertRefused("write", writeLink);
+      assertThrows(
+        () => Deno.statSync(writeTarget),
+        Deno.errors.NotFound,
+      );
+
+      const directoryLink = `${allowedDir}/directory-link`;
+      const nestedTarget = `${outsideDir}/nested-target.db`;
+      Deno.symlinkSync(outsideDir, directoryLink);
+      await assertRefused("write", `${directoryLink}/nested-target.db`);
+      assertThrows(
+        () => Deno.statSync(nestedTarget),
+        Deno.errors.NotFound,
+      );
+
+      const readTarget = `${outsideDir}/read-target.db`;
+      const readTargetDb = new DatabaseSync(readTarget);
+      readTargetDb.exec("CREATE TABLE data(value TEXT)");
+      readTargetDb.close();
+      const readLink = `${allowedDir}/read-link.db`;
+      Deno.symlinkSync(readTarget, readLink);
+      await assertRefused("read", readLink);
+    } finally {
+      Deno.removeSync(dir, { recursive: true });
+    }
+  },
+});
 
 Deno.test("[node/sqlite] StatementSync bind bigints", () => {
   const db = new DatabaseSync(":memory:");

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -120,6 +120,7 @@ db.close();
         path: string,
       ) =>
         new Deno.Command(Deno.execPath(), {
+          clearEnv: true,
           args: [
             "run",
             "--quiet",

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -95,7 +95,6 @@ Deno.test({
     write: true,
     run: [Deno.execPath()],
   },
-  ignore: Deno.build.os === "windows",
   name: "[node/sqlite] DatabaseSync does not follow symlink database paths",
   async fn() {
     const dir = Deno.makeTempDirSync({ prefix: "node_sqlite_symlink" });
@@ -166,7 +165,7 @@ db.close();
 
       const writeTarget = `${outsideDir}/write-target.db`;
       const writeLink = `${allowedDir}/write-link.db`;
-      Deno.symlinkSync(writeTarget, writeLink);
+      Deno.symlinkSync(writeTarget, writeLink, { type: "file" });
       await assertRefused("write", writeLink);
       assertThrows(
         () => Deno.statSync(writeTarget),
@@ -175,7 +174,7 @@ db.close();
 
       const directoryLink = `${allowedDir}/directory-link`;
       const nestedTarget = `${outsideDir}/nested-target.db`;
-      Deno.symlinkSync(outsideDir, directoryLink);
+      Deno.symlinkSync(outsideDir, directoryLink, { type: "dir" });
       await assertRefused("write", `${directoryLink}/nested-target.db`);
       assertThrows(
         () => Deno.statSync(nestedTarget),
@@ -187,7 +186,7 @@ db.close();
       readTargetDb.exec("CREATE TABLE data(value TEXT)");
       readTargetDb.close();
       const readLink = `${allowedDir}/read-link.db`;
-      Deno.symlinkSync(readTarget, readLink);
+      Deno.symlinkSync(readTarget, readLink, { type: "file" });
       await assertRefused("read", readLink);
     } finally {
       Deno.removeSync(dir, { recursive: true });


### PR DESCRIPTION
## Summary

- open explicit disk-backed KV databases and both read-only and read-write `node:sqlite` databases with `SQLITE_OPEN_NOFOLLOW`
- preserve macOS temporary-path and file-URL compatibility by resolving only the fixed `/var` and `/tmp` system aliases before SQLite validates the remaining components
- add scoped-permission coverage for regular paths, final symlinks, and intermediate directory symlinks with nested deny scopes

## Validation

- `./tools/format.js ext/kv/sqlite.rs ext/node_sqlite/database.rs tests/unit/kv_test.ts tests/unit_node/sqlite_test.ts`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=4 cargo check -p deno`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=4 cargo build -p deno --bin deno`
- `./target/debug/deno test -A --import-map=import_map.json tests/unit_node/sqlite_test.ts`
- `./target/debug/deno test -A --import-map=import_map.json tests/unit/kv_test.ts --filter "openKv does not follow a symlink outside permitted directories"`
- `./target/debug/deno test -A --unstable-kv --import-map=import_map.json tests/unit/kv_test.ts --filter "different kv instances for enqueue and queueListen"`
- direct disk-backed `node:sqlite` and `Deno.openKv` smoke tests under `/tmp`
