### PR TITLE
fix(fetch): scope redirect-sensitive headers by origin

### DIFF
--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -23,7 +23,6 @@ const {
   SafeArrayIterator,
   SafePromisePrototypeFinally,
   String,
-  StringPrototypeEndsWith,
   StringPrototypeIndexOf,
   StringPrototypeSlice,
   StringPrototypeSplit,
@@ -801,14 +800,8 @@ function httpRedirectFetch(request, response, terminator, inspectorCtx = null) {
     }
   }
 
-  // Drop confidential headers when redirecting to a less secure protocol
-  // or to a different domain that is not a superdomain
-  if (
-    (locationURL.protocol !== currentURL.protocol &&
-      locationURL.protocol !== "https:") ||
-    (locationURL.host !== currentURL.host &&
-      !isSubdomain(locationURL.host, currentURL.host))
-  ) {
+  // Drop redirect-sensitive headers when crossing origins.
+  if (locationURL.origin !== currentURL.origin) {
     for (let i = 0; i < request.headerList.length; i++) {
       if (
         ArrayPrototypeIncludes(
@@ -998,22 +991,6 @@ function abortFetch(request, responseObject, error) {
     if (response.body !== null) response.body.error(error);
   }
   return error;
-}
-
-/**
- * Checks if the given string is a subdomain of the given domain.
- *
- * @param {String} subdomain
- * @param {String} domain
- * @returns {Boolean}
- */
-function isSubdomain(subdomain, domain) {
-  const dot = subdomain.length - domain.length - 1;
-  return (
-    dot > 0 &&
-    subdomain[dot] === "." &&
-    StringPrototypeEndsWith(subdomain, domain)
-  );
 }
 
 /**

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -521,6 +521,91 @@ Deno.test(
 );
 
 Deno.test(
+  {
+    permissions: { net: true, read: true, write: true },
+    ignore: Deno.build.os === "windows",
+  },
+  async function fetchRedirectSensitiveHeadersAreOriginScoped() {
+    const started = Promise.withResolvers<number>();
+    await using _server = Deno.serve({
+      port: 0,
+      onListen: ({ port }) => started.resolve(port),
+    }, (request) => {
+      const url = new URL(request.url);
+      if (url.pathname === "/redirect") {
+        return Response.redirect(url.searchParams.get("location")!, 302);
+      }
+      return Response.json({
+        authorization: request.headers.get("authorization"),
+        cookie: request.headers.get("cookie"),
+        proxyAuthorization: request.headers.get("proxy-authorization"),
+        safe: request.headers.get("x-safe"),
+      });
+    });
+
+    const port = await started.promise;
+    using client = Deno.createHttpClient({
+      proxy: {
+        transport: "tcp",
+        hostname: "localhost",
+        port,
+      },
+    });
+    const headers = {
+      authorization: "Bearer parent",
+      cookie: "session=parent",
+      "proxy-authorization": "Basic parent",
+      "x-safe": "keep",
+    };
+
+    async function redirect(
+      from: string,
+      to: string,
+    ): Promise<Record<string, string | null>> {
+      const response = await fetch(
+        `${from}/redirect?location=${encodeURIComponent(`${to}/target`)}`,
+        { client, headers },
+      );
+      return await response.json();
+    }
+
+    assertEquals(
+      await redirect(
+        "http://parent.example.test",
+        "http://parent.example.test",
+      ),
+      {
+        authorization: "Bearer parent",
+        cookie: "session=parent",
+        proxyAuthorization: "Basic parent",
+        safe: "keep",
+      },
+    );
+
+    const strippedHeaders = {
+      authorization: null,
+      cookie: null,
+      proxyAuthorization: null,
+      safe: "keep",
+    };
+    assertEquals(
+      await redirect(
+        "http://parent.example.test",
+        "http://child.parent.example.test",
+      ),
+      strippedHeaders,
+    );
+    assertEquals(
+      await redirect(
+        "http://parent.example.test",
+        "https://parent.example.test",
+      ),
+      strippedHeaders,
+    );
+  },
+);
+
+Deno.test(
   { permissions: { net: true } },
   async function fetchInitStringBody() {
     const data = "Hello World";


### PR DESCRIPTION
Align redirect header forwarding with the [HTTP-redirect fetch](https://fetch.spec.whatwg.org/#http-redirect-fetch) origin boundary.

- remove authorization-class request headers whenever a redirect crosses origins
- preserve same-origin forwarding and unrelated request headers
- cover same-origin, parent-to-subdomain, and scheme-changing redirects with local TCP proxy transport

Tests:
- `cargo test -p deno_fetch`
- `cargo test -p unit_tests --test unit -- fetch_test`
- `cargo check -p deno --bin deno`
- `cargo build -p deno --bin deno`