### PR TITLE
fix(ext/node): handle pre-quoted shell arguments

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1320,8 +1320,11 @@ function normalizeSpawnArguments(
         emittedShellDeprecation = true;
       }
       const escapedParts = [
-        escapeShellArg(file),
-        ...new SafeArrayIterator(ArrayPrototypeMap(args, escapeShellArg)),
+        escapeShellArg(stripShellArgQuotes(file)),
+        ...new SafeArrayIterator(ArrayPrototypeMap(
+          args,
+          (arg) => escapeShellArg(stripShellArgQuotes(arg)),
+        )),
       ];
       command = ArrayPrototypeJoin(escapedParts, " ");
     } else {
@@ -1448,6 +1451,27 @@ function waitForStreamToClose(stream) {
   stream.once("close", onClose);
   stream.once("error", onError);
   return deferred.promise;
+}
+
+/**
+ * Removes one layer of quotes that callers added around a complete shell
+ * argument. The argument is escaped again before being passed to the shell.
+ */
+function stripShellArgQuotes(arg) {
+  if (arg.length < 2) {
+    return arg;
+  }
+  const doubleQuoted = StringPrototypeStartsWith(arg, '"') &&
+    StringPrototypeEndsWith(arg, '"');
+  // cmd.exe treats single quotes as ordinary characters, while POSIX shells
+  // recognize both single and double quotes.
+  const singleQuoted = lazyProcess().default.platform !== "win32" &&
+    StringPrototypeStartsWith(arg, "'") &&
+    StringPrototypeEndsWith(arg, "'");
+  if (doubleQuoted || singleQuoted) {
+    return StringPrototypeSlice(arg, 1, -1);
+  }
+  return arg;
 }
 
 /**

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1622,6 +1622,55 @@ Deno.test(function spawnSyncShellMetacharactersEscaped() {
   assertEquals(ret.stdout.trim(), "a&b|c<d>e");
 });
 
+Deno.test({
+  name: "spawn shell preserves pre-quoted arguments",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    for (const quote of ["'", '"']) {
+      const deferred = withTimeout<number | null>();
+      const child = spawn(
+        "printf",
+        [`${quote}<%s>\\n${quote}`, `${quote}hello world${quote}`],
+        { shell: true },
+      );
+      let stdout = "";
+      child.stdout!.setEncoding("utf-8");
+      child.stdout!.on("data", (chunk) => stdout += chunk);
+      child.on("error", deferred.reject);
+      child.on("close", deferred.resolve);
+      assertEquals(await deferred.promise, 0);
+      assertEquals(stdout, "<hello world>\n");
+    }
+  },
+});
+
+Deno.test({
+  name: "spawnSync shell preserves pre-quoted arguments",
+  ignore: Deno.build.os === "windows",
+  fn() {
+    for (const quote of ["'", '"']) {
+      const ret = spawnSync(
+        "printf",
+        [`${quote}<%s>\\n${quote}`, `${quote}hello world${quote}`],
+        { shell: true, encoding: "utf-8" },
+      );
+      assertEquals(ret.status, 0);
+      assertEquals(ret.stdout, "<hello world>\n");
+    }
+
+    const breakout = spawnSync(
+      "printf",
+      ["'%s\\n'", "'safe'; printf injected; 'still-safe'"],
+      { shell: true, encoding: "utf-8" },
+    );
+    assertEquals(breakout.status, 0);
+    assertEquals(
+      breakout.stdout,
+      "safe'; printf injected; 'still-safe\n",
+    );
+  },
+});
+
 Deno.test(function spawnSyncReturnsPid() {
   const ret = spawnSync(Deno.execPath(), ["eval", "console.log('hi')"]);
   assertEquals(ret.status, 0);


### PR DESCRIPTION
## Summary

- normalize one caller-added outer quote layer before applying Deno's existing shell escaping
- keep the `shell: true` command-injection mitigation intact by re-escaping every normalized value
- add async and sync regressions, including a quote-breakout attempt that must remain literal

Fixes #36363.

## Context

Node joins `args` into the shell command and now deprecates this usage as [DEP0190](https://nodejs.org/api/deprecations.html#DEP0190) because it can lead to command injection. Deno intentionally escapes these values after [GHSA-hmh4-3xvx-q5hr](https://github.com/denoland/deno/security/advisories/GHSA-hmh4-3xvx-q5hr), so fully matching Node here would regress that fix.

This handles packages such as `jsr` that pass already-quoted complete arguments while preserving Deno's safer behavior.

## Tests

- `cargo build -p deno --bin deno`
- `./tools/format.js ext/node/polyfills/internal/child_process.ts tests/unit_node/child_process_test.ts`
- `./tools/lint.js ext/node/polyfills/internal/child_process.ts tests/unit_node/child_process_test.ts`
- `./x test-node child_process_test`
- `./x test-spec child_process_shell_escape`
- `./x test-compat test-child-process-spawn-shell`
