### PR TITLE
fix(ffi): validate struct return buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,6 +2539,7 @@ dependencies = [
  "num-bigint",
  "serde",
  "serde_json",
+ "sys_traits",
  "thiserror 2.0.12",
  "tokio",
  "windows-sys 0.59.0",

--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -549,12 +549,13 @@ class DynamicLibrary {
         );
         this.symbols[symbol] = new Function(
           "call",
+          "Uint8Array",
           `return function (${params}) {
             const buffer = new Uint8Array(${structSize});
             call(${params}${parameters.length > 0 ? ", " : ""}buffer);
             return buffer;
           }`,
-        )(call);
+        )(call, Uint8Array);
       }
     }
   }
@@ -573,6 +574,9 @@ function getTurbocallTarget() {
 }
 
 internals.getTurbocallTarget = getTurbocallTarget;
+// Used to test caller-provided struct return views.
+internals.ffiCallPtr = op_ffi_call_ptr;
+internals.ffiCallPtrNonblocking = op_ffi_call_ptr_nonblocking;
 
 return {
   dlopen,

--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -574,9 +574,6 @@ function getTurbocallTarget() {
 }
 
 internals.getTurbocallTarget = getTurbocallTarget;
-// Used to test caller-provided struct return views.
-internals.ffiCallPtr = op_ffi_call_ptr;
-internals.ffiCallPtrNonblocking = op_ffi_call_ptr_nonblocking;
 
 return {
   dlopen,

--- a/ext/ffi/Cargo.toml
+++ b/ext/ffi/Cargo.toml
@@ -33,5 +33,8 @@ tokio.workspace = true
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Globalization", "Win32_System_Diagnostics_Debug"] }
 
+[dev-dependencies]
+sys_traits = { workspace = true, features = ["libc", "real"] }
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_aarch, values("x86_64", "aarch64"))'] }

--- a/ext/ffi/call.rs
+++ b/ext/ffi/call.rs
@@ -453,3 +453,158 @@ pub fn op_ffi_call_ptr(
   // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
   Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+  use std::sync::atomic::AtomicUsize;
+  use std::sync::atomic::Ordering;
+
+  use deno_core::JsRuntime;
+  use deno_core::RuntimeOptions;
+  use deno_permissions::PermissionsContainer;
+  use deno_permissions::RuntimePermissionDescriptorParser;
+
+  use super::op_ffi_call_ptr;
+  use super::op_ffi_call_ptr_nonblocking;
+  use crate::repr::op_ffi_ptr_create;
+
+  deno_core::extension!(
+    test_ffi_call_ops,
+    ops = [
+      op_ffi_call_ptr,
+      op_ffi_call_ptr_nonblocking,
+      op_ffi_ptr_create,
+    ],
+  );
+
+  #[derive(Clone, Copy)]
+  #[repr(C)]
+  struct Rect {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+  }
+
+  static MAKE_RECT_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+  extern "C" fn make_rect(x: f64, y: f64, width: f64, height: f64) -> Rect {
+    MAKE_RECT_CALL_COUNT.fetch_add(1, Ordering::Relaxed);
+    Rect {
+      x,
+      y,
+      width,
+      height,
+    }
+  }
+
+  #[tokio::test]
+  async fn caller_provided_struct_return_views() {
+    MAKE_RECT_CALL_COUNT.store(0, Ordering::Relaxed);
+
+    let mut runtime = JsRuntime::new(RuntimeOptions {
+      extensions: vec![test_ffi_call_ops::init()],
+      ..Default::default()
+    });
+    let parser = Arc::new(RuntimePermissionDescriptorParser::new(
+      sys_traits::impls::RealSys,
+    ));
+    runtime
+      .op_state()
+      .borrow_mut()
+      .put(PermissionsContainer::allow_all(parser));
+
+    let function_pointer = make_rect as *const () as usize;
+    let source = r#"
+      (async () => {
+        const {
+          op_ffi_call_ptr,
+          op_ffi_call_ptr_nonblocking,
+          op_ffi_ptr_create,
+        } = Deno.core.ops;
+        const pointer = op_ffi_ptr_create(__FUNCTION_POINTER__n);
+        const definition = {
+          parameters: ["f64", "f64", "f64", "f64"],
+          result: { struct: ["f64", "f64", "f64", "f64"] },
+        };
+        const fill = 0xee;
+
+        function assertEquals(actual, expected) {
+          if (actual.length !== expected.length) {
+            throw new Error(`length mismatch: ${actual.length} !== ${expected.length}`);
+          }
+          for (let i = 0; i < actual.length; i++) {
+            if (!Object.is(actual[i], expected[i])) {
+              throw new Error(`value mismatch at ${i}: ${actual[i]} !== ${expected[i]}`);
+            }
+          }
+        }
+
+        function assertInvalidBufferError(error) {
+          if (!(error instanceof TypeError)) {
+            throw new Error(`expected TypeError, got ${error?.constructor?.name}`);
+          }
+          const expected =
+            "Invalid FFI struct return buffer: expected at least 32 bytes, got 31";
+          if (error.message !== expected) {
+            throw new Error(`unexpected error: ${error.message}`);
+          }
+        }
+
+        const syncBacking = new Uint8Array(64);
+        syncBacking.fill(fill);
+        const syncOut = new Uint8Array(syncBacking.buffer, 16, 32);
+        op_ffi_call_ptr(pointer, definition, [1, 2, 3, 4], syncOut);
+        assertEquals(syncBacking.subarray(0, 16), new Array(16).fill(fill));
+        assertEquals(
+          new Float64Array(syncBacking.buffer, 16, 4),
+          [1, 2, 3, 4],
+        );
+        assertEquals(syncBacking.subarray(48), new Array(16).fill(fill));
+
+        const asyncBacking = new Uint8Array(64);
+        asyncBacking.fill(fill);
+        const asyncOut = new Uint8Array(asyncBacking.buffer, 16, 32);
+        await op_ffi_call_ptr_nonblocking(
+          pointer,
+          { ...definition, nonblocking: true },
+          [5, 6, 7, 8],
+          asyncOut,
+        );
+        assertEquals(asyncBacking.subarray(0, 16), new Array(16).fill(fill));
+        assertEquals(
+          new Float64Array(asyncBacking.buffer, 16, 4),
+          [5, 6, 7, 8],
+        );
+        assertEquals(asyncBacking.subarray(48), new Array(16).fill(fill));
+
+        const undersizedOut = new Uint8Array(31);
+        try {
+          op_ffi_call_ptr(pointer, definition, [9, 10, 11, 12], undersizedOut);
+          throw new Error("synchronous call accepted an undersized buffer");
+        } catch (error) {
+          assertInvalidBufferError(error);
+        }
+        try {
+          await op_ffi_call_ptr_nonblocking(
+            pointer,
+            { ...definition, nonblocking: true },
+            [9, 10, 11, 12],
+            undersizedOut,
+          );
+          throw new Error("nonblocking call accepted an undersized buffer");
+        } catch (error) {
+          assertInvalidBufferError(error);
+        }
+      })()
+    "#
+    .replace("__FUNCTION_POINTER__", &function_pointer.to_string());
+
+    let promise = runtime.execute_script("ffi_call_test.js", source).unwrap();
+    #[allow(deprecated, reason = "test code")]
+    runtime.resolve_value(promise).await.unwrap();
+
+    assert_eq!(MAKE_RECT_CALL_COUNT.load(Ordering::Relaxed), 2);
+  }
+}

--- a/ext/ffi/call.rs
+++ b/ext/ffi/call.rs
@@ -208,7 +208,7 @@ where
           &symbol.cif,
           &symbol.ptr,
           call_args,
-          out_buffer.unwrap().0,
+          validate_struct_out_buffer(&symbol.cif, out_buffer)?,
         ),
       },
     })
@@ -232,7 +232,7 @@ fn ffi_call(
   parameter_types: &[NativeType],
   result_type: NativeType,
   out_buffer: Option<OutBuffer>,
-) -> FfiValue {
+) -> Result<FfiValue, IRError> {
   let call_args: Vec<Arg> = call_args
     .iter()
     .enumerate()
@@ -244,7 +244,7 @@ fn ffi_call(
 
   // SAFETY: types in the `Cif` match the actual calling convention and
   // types of symbol.
-  unsafe {
+  Ok(unsafe {
     match result_type {
       NativeType::Void => {
         cif.call::<()>(fun_ptr, &call_args);
@@ -291,11 +291,16 @@ fn ffi_call(
         ))
       }
       NativeType::Struct(_) => {
-        ffi_call_rtype_struct(cif, &fun_ptr, call_args, out_buffer.unwrap().0);
+        ffi_call_rtype_struct(
+          cif,
+          &fun_ptr,
+          call_args,
+          validate_struct_out_buffer(cif, out_buffer)?,
+        );
         FfiValue::Null
       }
     }
-  }
+  })
 }
 
 #[op2(stack_trace)]
@@ -349,7 +354,7 @@ where
       .await
       .map_err(CallError::NonblockingCallFailure)?;
     // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
-    Ok(result)
+    Ok(result?)
   })
 }
 
@@ -413,7 +418,7 @@ pub fn op_ffi_call_nonblocking(
       .await
       .map_err(CallError::NonblockingCallFailure)?;
     // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
-    Ok(result)
+    Ok(result?)
   })
 }
 
@@ -444,7 +449,7 @@ pub fn op_ffi_call_ptr(
     &def.parameters,
     def.result.clone(),
     out_buffer_ptr,
-  );
+  )?;
   // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
   Ok(result)
 }

--- a/ext/ffi/call.rs
+++ b/ext/ffi/call.rs
@@ -67,6 +67,18 @@ unsafe fn ffi_call_rtype_struct(
   }
 }
 
+fn validate_struct_out_buffer(
+  cif: &libffi::middle::Cif,
+  out_buffer: Option<OutBuffer>,
+) -> Result<OutBuffer, IRError> {
+  // SAFETY: `Cif::new` prepares a non-null result type that remains owned by
+  // `cif`. libffi populates its ABI size while preparing the CIF.
+  let expected = unsafe { (*(*cif.as_raw_ptr()).rtype).size };
+  out_buffer
+    .ok_or(IRError::MissingStructReturnBuffer)?
+    .validate_size(expected)
+}
+
 // A one-off synchronous FFI call.
 pub(crate) fn ffi_call_sync<'scope>(
   scope: &mut v8::PinScope<'scope, '_>,
@@ -208,7 +220,7 @@ where
           &symbol.cif,
           &symbol.ptr,
           call_args,
-          validate_struct_out_buffer(&symbol.cif, out_buffer)?,
+          validate_struct_out_buffer(&symbol.cif, out_buffer)?.as_ptr(),
         ),
       },
     })
@@ -232,7 +244,7 @@ fn ffi_call(
   parameter_types: &[NativeType],
   result_type: NativeType,
   out_buffer: Option<OutBuffer>,
-) -> Result<FfiValue, IRError> {
+) -> FfiValue {
   let call_args: Vec<Arg> = call_args
     .iter()
     .enumerate()
@@ -244,7 +256,7 @@ fn ffi_call(
 
   // SAFETY: types in the `Cif` match the actual calling convention and
   // types of symbol.
-  Ok(unsafe {
+  unsafe {
     match result_type {
       NativeType::Void => {
         cif.call::<()>(fun_ptr, &call_args);
@@ -295,12 +307,14 @@ fn ffi_call(
           cif,
           &fun_ptr,
           call_args,
-          validate_struct_out_buffer(cif, out_buffer)?,
+          out_buffer
+            .expect("struct return buffer was validated")
+            .as_ptr(),
         );
         FfiValue::Null
       }
     }
-  })
+  }
 }
 
 #[op2(stack_trace)]
@@ -328,11 +342,13 @@ where
     &def.parameters,
     &mut backing_store_holder,
   )?;
-  let out_buffer_ptr = out_buffer_as_ptr_nonblocking(
-    scope,
-    out_buffer,
-    &mut backing_store_holder,
-  )?;
+  let out_buffer =
+    out_buffer_as_ptr_nonblocking(out_buffer, &mut backing_store_holder)?;
+  let out_buffer_ptr = if matches!(&def.result, NativeType::Struct(_)) {
+    Some(validate_struct_out_buffer(&symbol.cif, out_buffer)?)
+  } else {
+    None
+  };
 
   let join_handle = spawn_blocking(move || {
     let PtrSymbol { cif, ptr } = symbol.clone();
@@ -354,7 +370,7 @@ where
       .await
       .map_err(CallError::NonblockingCallFailure)?;
     // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
-    Ok(result?)
+    Ok(result)
   })
 }
 
@@ -386,11 +402,13 @@ pub fn op_ffi_call_nonblocking(
     &symbol.parameter_types,
     &mut backing_store_holder,
   )?;
-  let out_buffer_ptr = out_buffer_as_ptr_nonblocking(
-    scope,
-    out_buffer,
-    &mut backing_store_holder,
-  )?;
+  let out_buffer =
+    out_buffer_as_ptr_nonblocking(out_buffer, &mut backing_store_holder)?;
+  let out_buffer_ptr = if matches!(&symbol.result_type, NativeType::Struct(_)) {
+    Some(validate_struct_out_buffer(&symbol.cif, out_buffer)?)
+  } else {
+    None
+  };
 
   let join_handle = spawn_blocking(move || {
     let Symbol {
@@ -418,7 +436,7 @@ pub fn op_ffi_call_nonblocking(
       .await
       .map_err(CallError::NonblockingCallFailure)?;
     // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
-    Ok(result?)
+    Ok(result)
   })
 }
 
@@ -440,7 +458,12 @@ pub fn op_ffi_call_ptr(
   let symbol = PtrSymbol::new(pointer, &def)?;
   let call_args = ffi_parse_args(scope, parameters, &def.parameters)?;
 
-  let out_buffer_ptr = out_buffer_as_ptr(scope, out_buffer);
+  let out_buffer = out_buffer_as_ptr(out_buffer);
+  let out_buffer_ptr = if matches!(&def.result, NativeType::Struct(_)) {
+    Some(validate_struct_out_buffer(&symbol.cif, out_buffer)?)
+  } else {
+    None
+  };
 
   let result = ffi_call(
     call_args,
@@ -449,7 +472,7 @@ pub fn op_ffi_call_ptr(
     &def.parameters,
     def.result.clone(),
     out_buffer_ptr,
-  )?;
+  );
   // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
   Ok(result)
 }
@@ -541,13 +564,22 @@ mod tests {
           }
         }
 
-        function assertInvalidBufferError(error) {
+        function assertInvalidBufferError(error, actual) {
           if (!(error instanceof TypeError)) {
             throw new Error(`expected TypeError, got ${error?.constructor?.name}`);
           }
           const expected =
-            "Invalid FFI struct return buffer: expected at least 32 bytes, got 31";
+            `Invalid FFI struct return buffer: expected at least 32 bytes, got ${actual}`;
           if (error.message !== expected) {
+            throw new Error(`unexpected error: ${error.message}`);
+          }
+        }
+
+        function assertMissingBufferError(error) {
+          if (!(error instanceof TypeError)) {
+            throw new Error(`expected TypeError, got ${error?.constructor?.name}`);
+          }
+          if (error.message !== "Missing FFI struct return buffer") {
             throw new Error(`unexpected error: ${error.message}`);
           }
         }
@@ -584,7 +616,7 @@ mod tests {
           op_ffi_call_ptr(pointer, definition, [9, 10, 11, 12], undersizedOut);
           throw new Error("synchronous call accepted an undersized buffer");
         } catch (error) {
-          assertInvalidBufferError(error);
+          assertInvalidBufferError(error, 31);
         }
         try {
           await op_ffi_call_ptr_nonblocking(
@@ -595,7 +627,52 @@ mod tests {
           );
           throw new Error("nonblocking call accepted an undersized buffer");
         } catch (error) {
-          assertInvalidBufferError(error);
+          assertInvalidBufferError(error, 31);
+        }
+
+        try {
+          op_ffi_call_ptr(pointer, definition, [9, 10, 11, 12]);
+          throw new Error("synchronous call accepted a missing buffer");
+        } catch (error) {
+          assertMissingBufferError(error);
+        }
+
+        try {
+          await op_ffi_call_ptr_nonblocking(
+            pointer,
+            { ...definition, nonblocking: true },
+            [9, 10, 11, 12],
+          );
+          throw new Error("nonblocking call accepted a missing buffer");
+        } catch (error) {
+          assertMissingBufferError(error);
+        }
+
+        const zeroLengthOut = new Uint8Array(new ArrayBuffer(32), 0, 0);
+        try {
+          op_ffi_call_ptr(
+            pointer,
+            definition,
+            [9, 10, 11, 12],
+            zeroLengthOut,
+          );
+          throw new Error("synchronous call accepted a zero-length buffer");
+        } catch (error) {
+          assertInvalidBufferError(error, 0);
+        }
+
+        const detachedOut = new Uint8Array(32);
+        detachedOut.buffer.transfer();
+        try {
+          await op_ffi_call_ptr_nonblocking(
+            pointer,
+            { ...definition, nonblocking: true },
+            [9, 10, 11, 12],
+            detachedOut,
+          );
+          throw new Error("nonblocking call accepted a detached buffer");
+        } catch (error) {
+          assertInvalidBufferError(error, 0);
         }
       })()
     "#

--- a/ext/ffi/dlfcn.rs
+++ b/ext/ffi/dlfcn.rs
@@ -319,12 +319,9 @@ fn sync_fn_impl<'s>(
   let out_buffer = match data.symbol.result_type {
     NativeType::Struct(_) => {
       let argc = args.length();
-      out_buffer_as_ptr(
-        scope,
-        Some(
-          v8::Local::<v8::TypedArray>::try_from(args.get(argc - 1)).unwrap(),
-        ),
-      )
+      out_buffer_as_ptr(Some(
+        v8::Local::<v8::TypedArray>::try_from(args.get(argc - 1)).unwrap(),
+      ))
     }
     _ => None,
   };
@@ -420,11 +417,110 @@ pub(crate) fn format_error(
 
 #[cfg(test)]
 mod tests {
+  use std::ffi::c_void;
+  use std::sync::atomic::AtomicUsize;
+  use std::sync::atomic::Ordering;
+
+  use deno_core::JsRuntime;
+  use deno_core::RuntimeOptions;
+  use deno_core::v8;
   use serde_json::json;
 
   use super::ForeignFunction;
   use super::ForeignSymbol;
+  use super::make_sync_fn;
   use crate::symbol::NativeType;
+  use crate::symbol::Symbol;
+  use crate::turbocall;
+
+  #[derive(Clone, Copy)]
+  #[repr(C)]
+  struct Rect {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+  }
+
+  static MAKE_RECT_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+  extern "C" fn make_rect(x: f64, y: f64, width: f64, height: f64) -> Rect {
+    MAKE_RECT_CALL_COUNT.fetch_add(1, Ordering::Relaxed);
+    Rect {
+      x,
+      y,
+      width,
+      height,
+    }
+  }
+
+  #[test]
+  fn sync_struct_return_views() {
+    MAKE_RECT_CALL_COUNT.store(0, Ordering::Relaxed);
+
+    let parameter_types = vec![NativeType::F64; 4];
+    let result_type =
+      NativeType::Struct(vec![NativeType::F64; 4].into_boxed_slice());
+    let symbol = Symbol {
+      name: "make_rect".to_string(),
+      cif: libffi::middle::Cif::new(
+        parameter_types
+          .clone()
+          .into_iter()
+          .map(libffi::middle::Type::try_from)
+          .collect::<Result<Vec<_>, _>>()
+          .unwrap(),
+        result_type.clone().try_into().unwrap(),
+      ),
+      ptr: libffi::middle::CodePtr::from_ptr(
+        make_rect as *const () as *const c_void,
+      ),
+      parameter_types,
+      result_type,
+    };
+    assert!(!turbocall::is_compatible(&symbol));
+
+    let mut runtime = JsRuntime::new(RuntimeOptions::default());
+    {
+      deno_core::scope!(scope, runtime);
+      let function = make_sync_fn(scope, Box::new(symbol));
+      let key = v8::String::new(scope, "makeRect").unwrap();
+      let global = scope.get_current_context().global(scope);
+      assert_eq!(global.set(scope, key.into(), function.into()), Some(true));
+    }
+
+    runtime
+      .execute_script(
+        "ffi_sync_call_test.js",
+        r#"
+          const backing = new Uint8Array(64);
+          backing.fill(0xee);
+          const out = new Uint8Array(backing.buffer, 16, 32);
+          makeRect(1, 2, 3, 4, out);
+          const values = new Float64Array(backing.buffer, 16, 4);
+          if (values[0] !== 1 || values[1] !== 2 ||
+              values[2] !== 3 || values[3] !== 4) {
+            throw new Error("unexpected struct result");
+          }
+          if (backing[0] !== 0xee || backing[63] !== 0xee) {
+            throw new Error("write escaped the return view");
+          }
+          try {
+            makeRect(1, 2, 3, 4, new Uint8Array(31));
+            throw new Error("synchronous call accepted an undersized buffer");
+          } catch (error) {
+            const expected =
+              "Invalid FFI struct return buffer: expected at least 32 bytes, got 31";
+            if (!(error instanceof TypeError) || error.message !== expected) {
+              throw error;
+            }
+          }
+        "#,
+      )
+      .unwrap();
+
+    assert_eq!(MAKE_RECT_CALL_COUNT.load(Ordering::Relaxed), 1);
+  }
 
   #[cfg(target_os = "windows")]
   #[test]

--- a/ext/ffi/ir.rs
+++ b/ext/ffi/ir.rs
@@ -80,14 +80,22 @@ pub enum IRError {
     "Resizable backing stores are not supported for nonblocking FFI calls"
   )]
   ResizableBackingStore,
+  #[error(
+    "Invalid FFI struct return buffer: expected at least {expected} bytes, got {actual}"
+  )]
+  InvalidStructReturnBuffer { expected: usize, actual: usize },
   #[error("Invalid FFI function type, expected null, or External")]
   InvalidFunctionType,
 }
 
-pub struct OutBuffer(pub *mut u8);
+#[derive(Clone, Copy)]
+pub struct OutBuffer {
+  ptr: *mut u8,
+  byte_length: usize,
+}
 
-// SAFETY: OutBuffer is allocated by us in 00_ffi.js and is guaranteed to be
-// only used for the purpose of writing return value of structs.
+// SAFETY: synchronous callers keep the TypedArray alive for the duration of the
+// call, while nonblocking callers retain its backing store in a holder.
 unsafe impl Send for OutBuffer {}
 // SAFETY: See above
 unsafe impl Sync for OutBuffer {}
@@ -98,9 +106,18 @@ pub fn out_buffer_as_ptr(
 ) -> Option<OutBuffer> {
   match out_buffer {
     Some(out_buffer) => {
+      let byte_offset = out_buffer.byte_offset();
+      let byte_length = out_buffer.byte_length();
       let ab = out_buffer.buffer(scope).unwrap();
-      ab.data()
-        .map(|non_null| OutBuffer(non_null.as_ptr() as *mut u8))
+      ab.data().map(|non_null| {
+        // SAFETY: `byte_offset` describes this TypedArray view, so it is
+        // within (or one byte past) the backing store allocation.
+        let ptr = unsafe { non_null.as_ptr().add(byte_offset) };
+        OutBuffer {
+          ptr: ptr.cast(),
+          byte_length,
+        }
+      })
     }
     None => None,
   }
@@ -115,15 +132,44 @@ pub fn out_buffer_as_ptr_nonblocking(
 ) -> Result<Option<OutBuffer>, IRError> {
   match out_buffer {
     Some(out_buffer) => {
+      let byte_offset = out_buffer.byte_offset();
+      let byte_length = out_buffer.byte_length();
       let ab = out_buffer.buffer(scope).unwrap();
       holder.push(ab.get_backing_store())?;
-      Ok(
-        ab.data()
-          .map(|non_null| OutBuffer(non_null.as_ptr() as *mut u8)),
-      )
+      Ok(ab.data().map(|non_null| {
+        // SAFETY: `byte_offset` describes this TypedArray view, so it is
+        // within (or one byte past) the backing store allocation.
+        let ptr = unsafe { non_null.as_ptr().add(byte_offset) };
+        OutBuffer {
+          ptr: ptr.cast(),
+          byte_length,
+        }
+      }))
     }
     None => Ok(None),
   }
+}
+
+pub fn validate_struct_out_buffer(
+  cif: &libffi::middle::Cif,
+  out_buffer: Option<OutBuffer>,
+) -> Result<*mut u8, IRError> {
+  // SAFETY: `Cif::new` prepares a non-null result type that remains owned by
+  // `cif`. libffi populates its ABI size while preparing the CIF.
+  let expected = unsafe { (*(*cif.as_raw_ptr()).rtype).size };
+  let Some(out_buffer) = out_buffer else {
+    return Err(IRError::InvalidStructReturnBuffer {
+      expected,
+      actual: 0,
+    });
+  };
+  if out_buffer.byte_length < expected {
+    return Err(IRError::InvalidStructReturnBuffer {
+      expected,
+      actual: out_buffer.byte_length,
+    });
+  }
+  Ok(out_buffer.ptr)
 }
 
 /// Intermediate format for easy translation from NativeType + V8 value

--- a/ext/ffi/ir.rs
+++ b/ext/ffi/ir.rs
@@ -2,6 +2,7 @@
 
 use std::ffi::c_void;
 use std::ptr;
+use std::ptr::NonNull;
 
 use deno_core::v8;
 use libffi::middle::Arg;
@@ -84,13 +85,15 @@ pub enum IRError {
     "Invalid FFI struct return buffer: expected at least {expected} bytes, got {actual}"
   )]
   InvalidStructReturnBuffer { expected: usize, actual: usize },
+  #[error("Missing FFI struct return buffer")]
+  MissingStructReturnBuffer,
   #[error("Invalid FFI function type, expected null, or External")]
   InvalidFunctionType,
 }
 
 #[derive(Clone, Copy)]
 pub struct OutBuffer {
-  ptr: *mut u8,
+  ptr: Option<NonNull<u8>>,
   byte_length: usize,
 }
 
@@ -100,76 +103,57 @@ unsafe impl Send for OutBuffer {}
 // SAFETY: See above
 unsafe impl Sync for OutBuffer {}
 
+impl OutBuffer {
+  pub fn validate_size(self, expected: usize) -> Result<Self, IRError> {
+    if self.byte_length < expected {
+      return Err(IRError::InvalidStructReturnBuffer {
+        expected,
+        actual: self.byte_length,
+      });
+    }
+    self.ptr.ok_or(IRError::InvalidStructReturnBuffer {
+      expected,
+      actual: self.byte_length,
+    })?;
+    Ok(self)
+  }
+
+  pub fn as_ptr(self) -> *mut u8 {
+    self
+      .ptr
+      .expect("struct return buffer was validated")
+      .as_ptr()
+  }
+}
+
 pub fn out_buffer_as_ptr(
-  scope: &mut v8::PinScope<'_, '_>,
   out_buffer: Option<v8::Local<v8::TypedArray>>,
 ) -> Option<OutBuffer> {
-  match out_buffer {
-    Some(out_buffer) => {
-      let byte_offset = out_buffer.byte_offset();
-      let byte_length = out_buffer.byte_length();
-      let ab = out_buffer.buffer(scope).unwrap();
-      ab.data().map(|non_null| {
-        // SAFETY: `byte_offset` describes this TypedArray view, so it is
-        // within (or one byte past) the backing store allocation.
-        let ptr = unsafe { non_null.as_ptr().add(byte_offset) };
-        OutBuffer {
-          ptr: ptr.cast(),
-          byte_length,
-        }
-      })
-    }
-    None => None,
-  }
+  out_buffer.map(|out_buffer| OutBuffer {
+    ptr: NonNull::new(out_buffer.data().cast()),
+    byte_length: out_buffer.byte_length(),
+  })
 }
 
 /// Like `out_buffer_as_ptr` but also returns the backing store reference
 /// to prevent GC from freeing the buffer during nonblocking FFI calls.
 pub fn out_buffer_as_ptr_nonblocking(
-  scope: &mut v8::PinScope<'_, '_>,
   out_buffer: Option<v8::Local<v8::TypedArray>>,
   holder: &mut BackingStoreHolder,
 ) -> Result<Option<OutBuffer>, IRError> {
   match out_buffer {
     Some(out_buffer) => {
-      let byte_offset = out_buffer.byte_offset();
       let byte_length = out_buffer.byte_length();
-      let ab = out_buffer.buffer(scope).unwrap();
-      holder.push(ab.get_backing_store())?;
-      Ok(ab.data().map(|non_null| {
-        // SAFETY: `byte_offset` describes this TypedArray view, so it is
-        // within (or one byte past) the backing store allocation.
-        let ptr = unsafe { non_null.as_ptr().add(byte_offset) };
-        OutBuffer {
-          ptr: ptr.cast(),
-          byte_length,
-        }
+      if let Some(backing_store) = out_buffer.get_backing_store() {
+        holder.push(backing_store)?;
+      }
+      Ok(Some(OutBuffer {
+        ptr: NonNull::new(out_buffer.data().cast()),
+        byte_length,
       }))
     }
     None => Ok(None),
   }
-}
-
-pub fn validate_struct_out_buffer(
-  cif: &libffi::middle::Cif,
-  out_buffer: Option<OutBuffer>,
-) -> Result<*mut u8, IRError> {
-  // SAFETY: `Cif::new` prepares a non-null result type that remains owned by
-  // `cif`. libffi populates its ABI size while preparing the CIF.
-  let expected = unsafe { (*(*cif.as_raw_ptr()).rtype).size };
-  let Some(out_buffer) = out_buffer else {
-    return Err(IRError::InvalidStructReturnBuffer {
-      expected,
-      actual: 0,
-    });
-  };
-  if out_buffer.byte_length < expected {
-    return Err(IRError::InvalidStructReturnBuffer {
-      expected,
-      actual: out_buffer.byte_length,
-    });
-  }
-  Ok(out_buffer.ptr)
 }
 
 /// Intermediate format for easy translation from NativeType + V8 value

--- a/tests/ffi/src/lib.rs
+++ b/tests/ffi/src/lib.rs
@@ -10,8 +10,6 @@
 
 use std::os::raw::c_void;
 use std::sync::Mutex;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -560,22 +558,9 @@ pub struct Rect {
   h: f64,
 }
 
-static MAKE_RECT_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
-
 #[unsafe(no_mangle)]
 pub extern "C" fn make_rect(x: f64, y: f64, w: f64, h: f64) -> Rect {
-  MAKE_RECT_CALL_COUNT.fetch_add(1, Ordering::Relaxed);
   Rect { x, y, w, h }
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn get_make_rect_ptr() -> *const c_void {
-  make_rect as *const c_void
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn get_make_rect_call_count() -> usize {
-  MAKE_RECT_CALL_COUNT.load(Ordering::Relaxed)
 }
 
 #[unsafe(no_mangle)]

--- a/tests/ffi/src/lib.rs
+++ b/tests/ffi/src/lib.rs
@@ -10,6 +10,8 @@
 
 use std::os::raw::c_void;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -558,9 +560,22 @@ pub struct Rect {
   h: f64,
 }
 
+static MAKE_RECT_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
 #[unsafe(no_mangle)]
 pub extern "C" fn make_rect(x: f64, y: f64, w: f64, h: f64) -> Rect {
+  MAKE_RECT_CALL_COUNT.fetch_add(1, Ordering::Relaxed);
   Rect { x, y, w, h }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn get_make_rect_ptr() -> *const c_void {
+  make_rect as *const c_void
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn get_make_rect_call_count() -> usize {
+  MAKE_RECT_CALL_COUNT.load(Ordering::Relaxed)
 }
 
 #[unsafe(no_mangle)]

--- a/tests/ffi/testdata/test.js
+++ b/tests/ffi/testdata/test.js
@@ -833,26 +833,23 @@ function hash() { return dylib.symbols.hash(bytes, bytes.byteLength); };
 
 testOptimized(hash, () => hash(), "hash");
 
-const ffiPermission = await Deno.permissions.revoke({ name: "ffi" });
-assertNotEquals(ffiPermission.state, "granted");
 const originalUint8Array = globalThis.Uint8Array;
 let replacementUint8ArrayCalls = 0;
-let rectAfterPermissionRevoke;
+let rectAfterUint8ArrayOverride;
 try {
-  globalThis.Uint8Array = function (length) {
+  globalThis.Uint8Array = function () {
     replacementUint8ArrayCalls++;
-    const backing = new originalUint8Array(length + 16);
-    return new originalUint8Array(backing.buffer, 16, length);
+    return new originalUint8Array(1);
   };
-  rectAfterPermissionRevoke = dylib.symbols.make_rect(1, 2, 3, 4);
+  rectAfterUint8ArrayOverride = dylib.symbols.make_rect(1, 2, 3, 4);
 } finally {
   globalThis.Uint8Array = originalUint8Array;
 }
 assertEquals(replacementUint8ArrayCalls, 0);
-assertInstanceOf(rectAfterPermissionRevoke, Uint8Array);
-assertEquals(rectAfterPermissionRevoke.byteOffset, 0);
+assertInstanceOf(rectAfterUint8ArrayOverride, Uint8Array);
+assertEquals(rectAfterUint8ArrayOverride.byteOffset, 0);
 assertEquals(
-  Array.from(new Float64Array(rectAfterPermissionRevoke.buffer)),
+  Array.from(new Float64Array(rectAfterUint8ArrayOverride.buffer)),
   [1, 2, 3, 4],
 );
 

--- a/tests/ffi/testdata/test.js
+++ b/tests/ffi/testdata/test.js
@@ -265,6 +265,14 @@ const dylib = Deno.dlopen(libPath, {
     parameters: ["f64", "f64", "f64", "f64"],
     result: { struct: RectNested },
   },
+  get_make_rect_ptr: {
+    parameters: [],
+    result: "pointer",
+  },
+  get_make_rect_call_count: {
+    parameters: [],
+    result: "usize",
+  },
   print_rect: {
     parameters: [{ struct: RectNestedCached }],
     result: "void",
@@ -740,6 +748,99 @@ assertInstanceOf(rect_async, Uint8Array);
 assertEquals(rect_async.length, 4 * 8);
 assertEquals(Array.from(new Float64Array(rect_async.buffer)), [10, 20, 100, 200]);
 
+const makeRectPointer = dylib.symbols.get_make_rect_ptr();
+const makeRectDefinition = {
+  parameters: ["f64", "f64", "f64", "f64"],
+  result: { struct: Rect },
+};
+const { ffiCallPtr, ffiCallPtrNonblocking } = Deno[Deno.internal];
+const shiftedFill = 0xee;
+
+const shiftedSyncBacking = new Uint8Array(64);
+shiftedSyncBacking.fill(shiftedFill);
+const shiftedSyncOut = new Uint8Array(
+  shiftedSyncBacking.buffer,
+  16,
+  4 * 8,
+);
+ffiCallPtr(
+  makeRectPointer,
+  makeRectDefinition,
+  [1, 2, 3, 4],
+  shiftedSyncOut,
+);
+assertEquals(
+  Array.from(shiftedSyncBacking.subarray(0, 16)),
+  new Array(16).fill(shiftedFill),
+);
+assertEquals(
+  Array.from(new Float64Array(shiftedSyncBacking.buffer, 16, 4)),
+  [1, 2, 3, 4],
+);
+assertEquals(
+  Array.from(shiftedSyncBacking.subarray(48)),
+  new Array(16).fill(shiftedFill),
+);
+
+const shiftedAsyncBacking = new Uint8Array(64);
+shiftedAsyncBacking.fill(shiftedFill);
+const shiftedAsyncOut = new Uint8Array(
+  shiftedAsyncBacking.buffer,
+  16,
+  4 * 8,
+);
+await ffiCallPtrNonblocking(
+  makeRectPointer,
+  { ...makeRectDefinition, nonblocking: true },
+  [5, 6, 7, 8],
+  shiftedAsyncOut,
+);
+assertEquals(
+  Array.from(shiftedAsyncBacking.subarray(0, 16)),
+  new Array(16).fill(shiftedFill),
+);
+assertEquals(
+  Array.from(new Float64Array(shiftedAsyncBacking.buffer, 16, 4)),
+  [5, 6, 7, 8],
+);
+assertEquals(
+  Array.from(shiftedAsyncBacking.subarray(48)),
+  new Array(16).fill(shiftedFill),
+);
+
+const callsBeforeUndersizedOut = dylib.symbols.get_make_rect_call_count();
+const undersizedOut = new Uint8Array(4 * 8 - 1);
+assertThrows(
+  () =>
+    ffiCallPtr(
+      makeRectPointer,
+      makeRectDefinition,
+      [9, 10, 11, 12],
+      undersizedOut,
+    ),
+  TypeError,
+  "Invalid FFI struct return buffer: expected at least 32 bytes, got 31",
+);
+assertEquals(
+  dylib.symbols.get_make_rect_call_count(),
+  callsBeforeUndersizedOut,
+);
+await assertRejects(
+  () =>
+    ffiCallPtrNonblocking(
+      makeRectPointer,
+      { ...makeRectDefinition, nonblocking: true },
+      [9, 10, 11, 12],
+      undersizedOut,
+    ),
+  TypeError,
+  "Invalid FFI struct return buffer: expected at least 32 bytes, got 31",
+);
+assertEquals(
+  dylib.symbols.get_make_rect_call_count(),
+  callsBeforeUndersizedOut,
+);
+
 // Test complex, mixed struct returning and passing
 const mixedStruct = dylib.symbols.create_mixed(3, 12.515000343322754, rect_async, Deno.UnsafePointer.create(12456789), new Uint32Array([8, 32]));
 assertEquals(mixedStruct.length, 56);
@@ -832,6 +933,29 @@ const bytes = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 function hash() { return dylib.symbols.hash(bytes, bytes.byteLength); };
 
 testOptimized(hash, () => hash(), "hash");
+
+const ffiPermission = await Deno.permissions.revoke({ name: "ffi" });
+assertNotEquals(ffiPermission.state, "granted");
+const originalUint8Array = globalThis.Uint8Array;
+let replacementUint8ArrayCalls = 0;
+let rectAfterPermissionRevoke;
+try {
+  globalThis.Uint8Array = function (length) {
+    replacementUint8ArrayCalls++;
+    const backing = new originalUint8Array(length + 16);
+    return new originalUint8Array(backing.buffer, 16, length);
+  };
+  rectAfterPermissionRevoke = dylib.symbols.make_rect(1, 2, 3, 4);
+} finally {
+  globalThis.Uint8Array = originalUint8Array;
+}
+assertEquals(replacementUint8ArrayCalls, 0);
+assertInstanceOf(rectAfterPermissionRevoke, Uint8Array);
+assertEquals(rectAfterPermissionRevoke.byteOffset, 0);
+assertEquals(
+  Array.from(new Float64Array(rectAfterPermissionRevoke.buffer)),
+  [1, 2, 3, 4],
+);
 
 (function cleanup() {
   dylib.close();

--- a/tests/ffi/testdata/test.js
+++ b/tests/ffi/testdata/test.js
@@ -265,14 +265,6 @@ const dylib = Deno.dlopen(libPath, {
     parameters: ["f64", "f64", "f64", "f64"],
     result: { struct: RectNested },
   },
-  get_make_rect_ptr: {
-    parameters: [],
-    result: "pointer",
-  },
-  get_make_rect_call_count: {
-    parameters: [],
-    result: "usize",
-  },
   print_rect: {
     parameters: [{ struct: RectNestedCached }],
     result: "void",
@@ -747,99 +739,6 @@ const rect_async = await dylib.symbols.make_rect_async(10, 20, 100, 200);
 assertInstanceOf(rect_async, Uint8Array);
 assertEquals(rect_async.length, 4 * 8);
 assertEquals(Array.from(new Float64Array(rect_async.buffer)), [10, 20, 100, 200]);
-
-const makeRectPointer = dylib.symbols.get_make_rect_ptr();
-const makeRectDefinition = {
-  parameters: ["f64", "f64", "f64", "f64"],
-  result: { struct: Rect },
-};
-const { ffiCallPtr, ffiCallPtrNonblocking } = Deno[Deno.internal];
-const shiftedFill = 0xee;
-
-const shiftedSyncBacking = new Uint8Array(64);
-shiftedSyncBacking.fill(shiftedFill);
-const shiftedSyncOut = new Uint8Array(
-  shiftedSyncBacking.buffer,
-  16,
-  4 * 8,
-);
-ffiCallPtr(
-  makeRectPointer,
-  makeRectDefinition,
-  [1, 2, 3, 4],
-  shiftedSyncOut,
-);
-assertEquals(
-  Array.from(shiftedSyncBacking.subarray(0, 16)),
-  new Array(16).fill(shiftedFill),
-);
-assertEquals(
-  Array.from(new Float64Array(shiftedSyncBacking.buffer, 16, 4)),
-  [1, 2, 3, 4],
-);
-assertEquals(
-  Array.from(shiftedSyncBacking.subarray(48)),
-  new Array(16).fill(shiftedFill),
-);
-
-const shiftedAsyncBacking = new Uint8Array(64);
-shiftedAsyncBacking.fill(shiftedFill);
-const shiftedAsyncOut = new Uint8Array(
-  shiftedAsyncBacking.buffer,
-  16,
-  4 * 8,
-);
-await ffiCallPtrNonblocking(
-  makeRectPointer,
-  { ...makeRectDefinition, nonblocking: true },
-  [5, 6, 7, 8],
-  shiftedAsyncOut,
-);
-assertEquals(
-  Array.from(shiftedAsyncBacking.subarray(0, 16)),
-  new Array(16).fill(shiftedFill),
-);
-assertEquals(
-  Array.from(new Float64Array(shiftedAsyncBacking.buffer, 16, 4)),
-  [5, 6, 7, 8],
-);
-assertEquals(
-  Array.from(shiftedAsyncBacking.subarray(48)),
-  new Array(16).fill(shiftedFill),
-);
-
-const callsBeforeUndersizedOut = dylib.symbols.get_make_rect_call_count();
-const undersizedOut = new Uint8Array(4 * 8 - 1);
-assertThrows(
-  () =>
-    ffiCallPtr(
-      makeRectPointer,
-      makeRectDefinition,
-      [9, 10, 11, 12],
-      undersizedOut,
-    ),
-  TypeError,
-  "Invalid FFI struct return buffer: expected at least 32 bytes, got 31",
-);
-assertEquals(
-  dylib.symbols.get_make_rect_call_count(),
-  callsBeforeUndersizedOut,
-);
-await assertRejects(
-  () =>
-    ffiCallPtrNonblocking(
-      makeRectPointer,
-      { ...makeRectDefinition, nonblocking: true },
-      [9, 10, 11, 12],
-      undersizedOut,
-    ),
-  TypeError,
-  "Invalid FFI struct return buffer: expected at least 32 bytes, got 31",
-);
-assertEquals(
-  dylib.symbols.get_make_rect_call_count(),
-  callsBeforeUndersizedOut,
-);
 
 // Test complex, mixed struct returning and passing
 const mixedStruct = dylib.symbols.create_mixed(3, 12.515000343322754, rect_async, Deno.UnsafePointer.create(12456789), new Uint32Array([8, 32]));


### PR DESCRIPTION
## Summary

- retain the primordial `Uint8Array` constructor in generated synchronous wrappers
- honor typed-array view offsets and validate struct return buffers against the prepared ABI result size
- reject missing, detached, zero-length, and undersized return buffers before native or background-thread dispatch
- cover raw synchronous, pointer-based synchronous, and nonblocking struct-return paths

## Details

Struct return handling now uses `ArrayBufferView::data()`, which includes the view offset, and keeps the view length alongside its pointer. ABI-size validation lives with the FFI call code, happens before `spawn_blocking`, and distinguishes a missing buffer from a supplied buffer with insufficient usable bytes.

Generated synchronous wrappers capture the primordial constructor used elsewhere in the FFI implementation. Missing or unusable buffers now produce a clean `TypeError` instead of reaching an unwrap. Any disagreement between the JavaScript layout calculation and libffi's prepared result size now fails loudly before the native call; this is an intentional compatibility boundary.

## Testing

- `./tools/format.js ext/ffi/00_ffi.js ext/ffi/call.rs ext/ffi/dlfcn.rs ext/ffi/ir.rs tests/ffi/testdata/test.js`
- `cargo test -p deno_ffi`
- `cargo build -p deno`
- `cargo test -p integration_tests --test integration ffi_basic -- --nocapture`
- `./tools/lint.js ext/ffi/00_ffi.js ext/ffi/call.rs ext/ffi/dlfcn.rs ext/ffi/ir.rs tests/ffi/testdata/test.js`
