### PR TITLE
docs(desktop): document showContextMenu coordinate space

### DIFF
--- a/cli/tsc/dts/lib.deno.desktop.d.ts
+++ b/cli/tsc/dts/lib.deno.desktop.d.ts
@@ -621,6 +621,21 @@ declare namespace Deno {
     reload(): void;
 
     setApplicationMenu(menu: MenuItem[]): void;
+    /** Pop up a context menu inside this window.
+     *
+     * `x` and `y` are window-relative CSS pixels with a top-left origin — the
+     * same space as a DOM mouse event's `clientX` / `clientY`, so those can be
+     * forwarded unchanged:
+     *
+     * ```ts
+     * win.addEventListener("mousedown", (e) => {
+     *   if (e.button === 2) win.showContextMenu(e.clientX, e.clientY, menu);
+     * });
+     * ```
+     *
+     * The platform may shift the menu to keep it on screen when it does not
+     * fit below or to the right of that point.
+     */
     showContextMenu(x: number, y: number, menu: MenuItem[]): void;
 
     getNativeWindow(): Deno.UnsafeWindowSurface;


### PR DESCRIPTION
`BrowserWindow.showContextMenu(x, y, menu)` shipped without a doc comment, so the coordinate space of `x`/`y` was left to guesswork. In #36379 the reporter had a genuine backend bug on top of that, but had no way to tell from the type declaration whether the intended arguments were `clientX`/`clientY`, screen coordinates, or something bottom-left-origin — and ended up hard-coding `windowHeight - clientY`.

Documents the actual contract: window-relative CSS pixels with a top-left origin, i.e. a DOM mouse event's `clientX`/`clientY` forward unchanged, with that as the example. Also notes that the platform may shift the menu to keep it on screen.

Docs only — no runtime change. The Y-axis bug from #36379 is a double flip in the laufey macOS backends (they converted to a bottom-left origin even when the content view is flipped, which the WKWebView content view is); fixed in littledivy/laufey#59, and it lands here as a `LAUFEY_VERSION` bump once that's released.
