### PR TITLE
fix(ext/node): throw ERR_INVALID_ARG_VALUE for falsy dns.lookup hostname

### DIFF
--- a/ext/node/polyfills/dns.ts
+++ b/ext/node/polyfills/dns.ts
@@ -268,17 +268,11 @@ function lookup(
   }
 
   if (!hostname) {
-    if (all) {
-      nextTick(callback as LookupCallback, null, []);
-    } else {
-      nextTick(
-        callback as LookupCallback,
-        null,
-        null,
-        family === 6 ? 6 : 4,
-      );
-    }
-    return {};
+    throw new ERR_INVALID_ARG_VALUE(
+      "hostname",
+      hostname,
+      "must be a non-empty string",
+    );
   }
 
   const matchedFamily = isIP(hostname);

--- a/ext/node/polyfills/internal/dns/promises.ts
+++ b/ext/node/polyfills/internal/dns/promises.ts
@@ -114,11 +114,15 @@ function createLookupPromise(
 ): Promise<void | LookupAddress | LookupAddress[]> {
   return new Promise((resolve, reject) => {
     if (!hostname) {
-      throw new ERR_INVALID_ARG_VALUE(
-        "hostname",
-        hostname,
-        "must be a non-empty string",
+      reject(
+        new ERR_INVALID_ARG_VALUE(
+          "hostname",
+          hostname,
+          "must be a non-empty string",
+        ),
       );
+
+      return;
     }
 
     const matchedFamily = isIP(hostname);

--- a/ext/node/polyfills/internal/dns/promises.ts
+++ b/ext/node/polyfills/internal/dns/promises.ts
@@ -114,12 +114,11 @@ function createLookupPromise(
 ): Promise<void | LookupAddress | LookupAddress[]> {
   return new Promise((resolve, reject) => {
     if (!hostname) {
-      if (all) {
-        resolve([]);
-      } else {
-        resolve({ address: null, family: family === 6 ? 6 : 4 });
-      }
-      return;
+      throw new ERR_INVALID_ARG_VALUE(
+        "hostname",
+        hostname,
+        "must be a non-empty string",
+      );
     }
 
     const matchedFamily = isIP(hostname);

--- a/tests/unit_node/dns_test.ts
+++ b/tests/unit_node/dns_test.ts
@@ -1,5 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { assert, assertEquals, assertRejects, assertThrows, fail } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertThrows,
+  fail,
+} from "@std/assert";
 import dns, { getDefaultResultOrder, lookupService } from "node:dns";
 import dnsPromises, {
   getDefaultResultOrder as getDefaultResultOrderPromise,

--- a/tests/unit_node/dns_test.ts
+++ b/tests/unit_node/dns_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { assert, assertEquals, fail } from "@std/assert";
+import { assert, assertEquals, assertRejects, assertThrows, fail } from "@std/assert";
 import dns, { getDefaultResultOrder, lookupService } from "node:dns";
 import dnsPromises, {
   getDefaultResultOrder as getDefaultResultOrderPromise,
@@ -163,78 +163,33 @@ Deno.test("[node/dns] lookup uses the system resolver / hosts file", async () =>
   );
 });
 
-// Regression test for https://github.com/denoland/deno/issues/34801
-// `dns.lookup` must follow Node.js behavior when `hostname` is falsy
-// (undefined / null / empty string): the callback is invoked with
-// (null, null, family) instead of throwing synchronously.
-Deno.test("[node/dns] lookup with falsy hostname invokes callback", async () => {
+// Regression test for https://github.com/denoland/deno/issues/36378
+// Node.js moved the falsy-hostname case of `dns.lookup` to end-of-life
+// (nodejs/node a5f9ca1f, Node v25+): `undefined`, `null` and `""` now
+// throw ERR_INVALID_ARG_VALUE synchronously instead of invoking the
+// callback with (null, null, family).
+Deno.test("[node/dns] lookup with falsy hostname throws", () => {
   for (const hostname of [undefined, null, ""]) {
-    const result = await new Promise<
-      { error: unknown; address: unknown; family: unknown }
-    >((resolve) => {
-      // deno-lint-ignore no-explicit-any
-      dns.lookup(hostname as any, (error, address, family) => {
-        resolve({ error, address, family });
-      });
-    });
-    assertEquals(result, { error: null, address: null, family: 4 });
+    assertThrows(
+      () => {
+        // deno-lint-ignore no-explicit-any
+        dns.lookup(hostname as any, () => {});
+      },
+      TypeError,
+      "must be a non-empty string",
+    );
   }
-
-  // family argument is honored when 6.
-  const result6 = await new Promise<
-    { error: unknown; address: unknown; family: unknown }
-  >((resolve) => {
-    dns.lookup(
-      // deno-lint-ignore no-explicit-any
-      undefined as any,
-      6,
-      (error, address, family) => resolve({ error, address, family }),
-    );
-  });
-  assertEquals(result6, { error: null, address: null, family: 6 });
-
-  // options.family = 6
-  const resultOpt6 = await new Promise<
-    { error: unknown; address: unknown; family: unknown }
-  >((resolve) => {
-    dns.lookup(
-      // deno-lint-ignore no-explicit-any
-      undefined as any,
-      { family: 6 },
-      (error, address, family) => resolve({ error, address, family }),
-    );
-  });
-  assertEquals(resultOpt6, { error: null, address: null, family: 6 });
-
-  // options.all = true returns an empty array via the callback.
-  const resultAll = await new Promise<
-    { error: unknown; addresses: unknown }
-  >((resolve) => {
-    dns.lookup(
-      // deno-lint-ignore no-explicit-any
-      undefined as any,
-      { all: true },
-      // deno-lint-ignore no-explicit-any
-      (error, addresses: any) => resolve({ error, addresses }),
-    );
-  });
-  assertEquals(resultAll, { error: null, addresses: [] });
 });
 
-Deno.test("[node/dns] promises.lookup with falsy hostname resolves", async () => {
+Deno.test("[node/dns] promises.lookup with falsy hostname rejects", async () => {
   for (const hostname of [undefined, null, ""]) {
-    // deno-lint-ignore no-explicit-any
-    const result = await lookupPromise(hostname as any);
-    assertEquals(result as unknown, { address: null, family: 4 });
+    await assertRejects(
+      // deno-lint-ignore no-explicit-any
+      () => lookupPromise(hostname as any),
+      TypeError,
+      "must be a non-empty string",
+    );
   }
-
-  // deno-lint-ignore no-explicit-any
-  const result6 = await lookupPromise(undefined as any, { family: 6 });
-  assertEquals(result6 as unknown, { address: null, family: 6 });
-
-  // deno-lint-ignore no-explicit-any
-  const resultAll = await lookupPromise(undefined as any, { all: true });
-  assertEquals(resultAll, []);
 });
 
 // Regression test for https://github.com/denoland/deno/issues/25927


### PR DESCRIPTION
Node.js moved the falsy-hostname case of `dns.lookup` to end-of-life (nodejs/node a5f9ca1f, Node v25+): `undefined`, `null` and `""` now throw `ERR_INVALID_ARG_VALUE` synchronously instead of invoking the callback with `(null, null, family)`. Deno's current behavior (callbacks/resolves with a null address) matches the deprecated pre-v25 path.

Root cause: both `lookup` in ext/node/polyfills/dns.ts and `createLookupPromise` in ext/node/polyfills/internal/dns/promises.ts treat a falsy hostname as "no host given" and synthesize a null address. Node's `if (!hostname) throw` (lib/dns.js:202) applies to both the callback and the promise APIs.

Fix: throw `ERR_INVALID_ARG_VALUE` with the same message as Node in both paths, and update the regression tests (added for #34801) to assert the throw/rejection. No internal consumers relied on the old behavior: `net.connect` always defaults the host to "localhost" before calling lookup.

Closes #36378

## Verification

- Behavior simulation against the edited code: lookup("")/null/undefined all throw `ERR_INVALID_ARG_VALUE` ("must be a non-empty string"), lookup("localhost") unaffected, same for dns/promises (rejects)
- Both changed files pass a TypeScript syntax check
- `net`/`dgram` callers verified to never pass a falsy hostname

AI disclosure: an automated coding agent assisted with drafting this PR (analysis, code, tests) and running verification. All changes were reviewed and approved by a human before submission.
