### PR TITLE
fix(fmt): update lax-markup to 0.3.2, lax-css and lax-sql to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6370,15 +6370,6 @@ dependencies = [
 
 [[package]]
 name = "lax-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59154ddba1bc6fa3d3e9ef0190dbecbac0cbbdc87b8d28e4437f8ff9c70b8d24"
-dependencies = [
- "dprint-core",
-]
-
-[[package]]
-name = "lax-core"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e9266de41ab34dbeb7b0176a6430b1091f1fa7f4dd9f7ccf3e430a9c5a6789"
@@ -6388,13 +6379,13 @@ dependencies = [
 
 [[package]]
 name = "lax-css"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03894b80c51cf9a758f8bbecdc1b74a36032ce4624cf2a3b0f2ed378e2627b01"
+checksum = "c964e0b1c58e6a38762c707d7b5f7a78ab4efab65d3e6c4ab2031deb8f65229e"
 dependencies = [
  "anyhow",
  "dprint-core",
- "lax-core 0.1.2",
+ "lax-core",
  "serde",
 ]
 
@@ -6406,19 +6397,19 @@ checksum = "0b6f67a7a729b68c4b8e6f45315b0777fdf9618cfd569d4551d14d0906b93306"
 dependencies = [
  "anyhow",
  "dprint-core",
- "lax-core 0.3.0",
+ "lax-core",
  "serde",
 ]
 
 [[package]]
 name = "lax-sql"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68eb5374e8216c43b6a467e1613c25c5c669c46143829db3c870cf903a9c2a69"
+checksum = "e2cca919c19f0e32e8a9fe410e087fc71e4a5ce7a843f939967c643e7881981f"
 dependencies = [
  "anyhow",
  "dprint-core",
- "lax-core 0.1.2",
+ "lax-core",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6378,6 +6378,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lax-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e9266de41ab34dbeb7b0176a6430b1091f1fa7f4dd9f7ccf3e430a9c5a6789"
+dependencies = [
+ "dprint-core",
+]
+
+[[package]]
 name = "lax-css"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6385,19 +6394,19 @@ checksum = "03894b80c51cf9a758f8bbecdc1b74a36032ce4624cf2a3b0f2ed378e2627b01"
 dependencies = [
  "anyhow",
  "dprint-core",
- "lax-core",
+ "lax-core 0.1.2",
  "serde",
 ]
 
 [[package]]
 name = "lax-markup"
-version = "0.2.5"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57349e8fdb68f5fd322a16ec4311e1ecbc7d0b3419a9efb089bba3c45011a553"
+checksum = "0b6f67a7a729b68c4b8e6f45315b0777fdf9618cfd569d4551d14d0906b93306"
 dependencies = [
  "anyhow",
  "dprint-core",
- "lax-core",
+ "lax-core 0.3.0",
  "serde",
 ]
 
@@ -6409,7 +6418,7 @@ checksum = "68eb5374e8216c43b6a467e1613c25c5c669c46143829db3c870cf903a9c2a69"
 dependencies = [
  "anyhow",
  "dprint-core",
- "lax-core",
+ "lax-core 0.1.2",
  "serde",
 ]
 
@@ -6550,7 +6559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,7 @@ dunce = "1.0.5"
 env_logger = { version = "=0.11.6", default-features = false, features = ["regex"] }
 imara-diff = "=0.2.0"
 lax-css = "=0.2.4"
-lax-markup = "=0.2.5"
+lax-markup = "=0.3.2"
 lax-sql = "=0.2.1"
 libsui = "=0.16.4"
 object = { version = "0.36.3", default-features = false, features = ["read_core", "pe"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,9 +373,9 @@ dprint-plugin-typescript = "=0.96.1"
 dunce = "1.0.5"
 env_logger = { version = "=0.11.6", default-features = false, features = ["regex"] }
 imara-diff = "=0.2.0"
-lax-css = "=0.2.4"
+lax-css = "=0.3.0"
 lax-markup = "=0.3.2"
-lax-sql = "=0.2.1"
+lax-sql = "=0.3.0"
 libsui = "=0.16.4"
 object = { version = "0.36.3", default-features = false, features = ["read_core", "pe"] }
 open = "5.0.1"

--- a/tests/specs/fmt/svelte_top_level_block/__test__.jsonc
+++ b/tests/specs/fmt/svelte_top_level_block/__test__.jsonc
@@ -1,0 +1,20 @@
+{
+  "tempDir": true,
+  "tests": {
+    // a Svelte block at the top level used to pin the whole file, so nothing
+    // in it was formatted at all, not even the script body
+    "top_level_block_does_not_skip_the_file": {
+      "args": "fmt --unstable-component badly_formatted.svelte",
+      "output": "[WILDLINE]badly_formatted.svelte\nChecked 1 file\n"
+    },
+    "idempotent": {
+      "steps": [{
+        "args": "fmt --unstable-component badly_formatted.svelte",
+        "output": "[WILDCARD]"
+      }, {
+        "args": "fmt --unstable-component --check badly_formatted.svelte",
+        "output": "Checked 1 file\n"
+      }]
+    }
+  }
+}

--- a/tests/specs/fmt/svelte_top_level_block/badly_formatted.svelte
+++ b/tests/specs/fmt/svelte_top_level_block/badly_formatted.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+		import foo from "./foo.ts";
+
+
+
+
+</script>
+
+{#if foo}
+	bar
+{/if}


### PR DESCRIPTION
A Svelte block or a bare interpolation at the top level of a component made
`deno fmt --unstable-component` skip the whole file, script body included.
The title of the issue says the template has to begin with a conditional,
but the trigger is broader: any `{#if}`, `{#each}` or even a plain
`{count}` outside an element does it, and it reproduces in plain HTML too.
lax-markup pinned whitespace sensitive node lists by emitting the entire
source verbatim, so one unpinnable text run turned formatting off for every
element in the file. It now keeps the gaps between nodes byte for byte
while each element still formats its own interior.

The bump also carries a fix for interpolated tag names such as
`<h{{ level }}>`, whose close tag was being regenerated as `</h>`, and a
forward port of the mustache control tag handling that had been released as
0.2.5 off a branch and never merged upstream. lax-css and lax-sql move to
0.3.0 in the same go so the lockfile carries a single lax-core.

Closes #36389