### PR TITLE
fix(publish): report when the registry rejects a provenance attestation

### DIFF
--- a/cli/tools/publish/mod.rs
+++ b/cli/tools/publish/mod.rs
@@ -1174,25 +1174,41 @@ async fn publish_package(
       Box::pin(provenance::generate_provenance(http_client, vec![subject]))
         .await?;
 
-    let tlog_entry = &bundle.verification_material.tlog_entries[0];
-    log::info!(
-      "{}",
-      colors::green(format!(
-        "Provenance transparency log available at https://search.sigstore.dev/?logIndex={}",
-        tlog_entry.log_index
-      ))
-    );
+    let log_index = bundle.verification_material.tlog_entries[0].log_index;
+    let transparency_log =
+      format!("https://search.sigstore.dev/?logIndex={log_index}");
 
     // Submit bundle to JSR
     let provenance_url = format!(
       "{}scopes/{}/packages/{}/versions/{}/provenance",
       registry_api_url, package.scope, package.package, package.version
     );
-    http_client
-      .post_json(provenance_url.parse()?, &json!({ "bundle": bundle }))?
-      .header(http::header::AUTHORIZATION, authorization.parse()?)
-      .send()
-      .await?;
+    match submit_provenance_bundle(
+      http_client,
+      &provenance_url,
+      authorization,
+      &bundle,
+    )
+    .await
+    {
+      Ok(()) => log::info!(
+        "{}",
+        colors::green(format!(
+          "Provenance transparency log available at {transparency_log}"
+        ))
+      ),
+      // The version is already published and immutable at this point, so a
+      // registry-side failure must not turn a successful release into a failed
+      // command. Say plainly what did not happen instead.
+      Err(err) => log::warn!(
+        "{} {:#}\n  The package was published, but it will not show a provenance badge.\n  The attestation itself was signed and is in the transparency log at {}",
+        colors::yellow(
+          "Warning: the registry did not accept the provenance attestation:"
+        ),
+        err,
+        transparency_log,
+      ),
+    }
   }
 
   log::info!(
@@ -1308,6 +1324,51 @@ struct ManifestEntry {
 struct VersionManifest {
   manifest: HashMap<String, ManifestEntry>,
   exports: HashMap<String, String>,
+}
+
+/// Submit a signed provenance bundle to the registry, erroring on any response
+/// that is not a success.
+///
+/// The response used to be discarded entirely, so a registry that rejected
+/// every attestation looked identical to one that accepted them: publishes kept
+/// reporting a transparency-log entry and success while no package gained a
+/// provenance badge. That is how jsr-io/jsr#1474 went unnoticed for a month.
+async fn submit_provenance_bundle(
+  http_client: &HttpClient,
+  provenance_url: &str,
+  authorization: &str,
+  bundle: &provenance::ProvenanceBundle,
+) -> Result<(), AnyError> {
+  let response = http_client
+    .post_json(provenance_url.parse()?, &json!({ "bundle": bundle }))?
+    .header(http::header::AUTHORIZATION, authorization.parse()?)
+    .send()
+    .await?;
+
+  let status = response.status();
+  if status.is_success() {
+    return Ok(());
+  }
+
+  // Carried into the error so that a report of this warning is traceable in the
+  // registry's own logs, which is where the reason for a rejection lives.
+  let x_deno_ray = response
+    .headers()
+    .get("x-deno-ray")
+    .and_then(|value| value.to_str().ok())
+    .map(|s| s.to_string());
+
+  // The endpoint answers 204 with an empty body on success, so there is nothing
+  // to deserialize; on failure the body is the registry's JSON error, which
+  // `ApiError` renders as "<message> (<code>)".
+  let body = response.collect().await?.to_bytes();
+  match serde_json::from_slice::<registry::ApiError>(&body) {
+    Ok(mut err) => {
+      err.x_deno_ray = x_deno_ray;
+      Err(err.into())
+    }
+    Err(_) => bail!("{}: {}", status, response_body_snippet(&body)),
+  }
 }
 
 /// Returns a truncated, lossy UTF-8 rendering of a response body for use in

--- a/tests/integration/publish_tests.rs
+++ b/tests/integration/publish_tests.rs
@@ -91,6 +91,31 @@ fn provenance() {
     .assert_matches_file("publish/successful_provenance.out");
 }
 
+/// A registry that rejects the attestation must not fail the publish — the
+/// version is already live and immutable — but it must say so. Regression test
+/// for jsr-io/jsr#1474, where this response was discarded and a registry that
+/// rejected every attestation was indistinguishable from one that accepted
+/// them.
+#[test]
+fn provenance_rejected_by_registry() {
+  let output = TestContextBuilder::new()
+    .use_http_server()
+    .envs(env_vars_for_jsr_provenance_tests())
+    .cwd("publish/provenance_rejected")
+    .build()
+    .new_command()
+    .args("publish")
+    .run();
+  output.assert_exit_code(0);
+  output.assert_matches_file("publish/provenance_rejected.out");
+  // The success line must not claim a transparency-log entry the registry never
+  // accepted.
+  assert_not_contains!(
+    output.combined_output(),
+    "Provenance transparency log available at"
+  );
+}
+
 #[test]
 fn ignores_gitignore() {
   let context = publish_context_builder().build();

--- a/tests/testdata/publish/provenance_rejected.out
+++ b/tests/testdata/publish/provenance_rejected.out
@@ -1,0 +1,9 @@
+Check [WILDCARD]mod.ts
+Checking for slow types in the public API...
+Check [WILDCARD]mod.ts
+Publishing @foo/provenance-fails@1.0.0 ...
+Warning: the registry did not accept the provenance attestation: Internal Server Error (internalServerError)
+  The package was published, but it will not show a provenance badge.
+  The attestation itself was signed and is in the transparency log at https://search.sigstore.dev/?logIndex=42069
+Successfully published @foo/provenance-fails@1.0.0
+Visit http://127.0.0.1:4250/@foo/provenance-fails@1.0.0 for details

--- a/tests/testdata/publish/provenance_rejected/deno.json
+++ b/tests/testdata/publish/provenance_rejected/deno.json
@@ -1,0 +1,10 @@
+{
+  "name": "@foo/provenance-fails",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@std/http": "./std_http.ts"
+  }
+}

--- a/tests/testdata/publish/provenance_rejected/mod.ts
+++ b/tests/testdata/publish/provenance_rejected/mod.ts
@@ -1,0 +1,7 @@
+import http from "@std/http";
+
+export function foobar(): { fileServer(): void } {
+  return {
+    fileServer: http.fileServer,
+  };
+}

--- a/tests/testdata/publish/provenance_rejected/std_http.ts
+++ b/tests/testdata/publish/provenance_rejected/std_http.ts
@@ -1,0 +1,6 @@
+// temp until we get jsr:@std/http in the test server
+export default {
+  fileServer() {
+    console.log("Hi");
+  },
+};

--- a/tests/util/server/servers/jsr_registry.rs
+++ b/tests/util/server/servers/jsr_registry.rs
@@ -143,6 +143,30 @@ async fn registry_server_handler(
       .status(StatusCode::NOT_FOUND)
       .body(UnsyncBoxBody::new(Empty::new()))?;
     return Ok(res);
+  } else if path.starts_with("/api/scopes/") && path.ends_with("/provenance") {
+    // Allow tests to simulate a registry that rejects a provenance attestation
+    // by naming the package "provenance-fails". Publishing itself still
+    // succeeds, which is the case that matters: the version is already live and
+    // immutable by the time the attestation is submitted.
+    //
+    // Consumers of this simulation (rename these fixtures and this match
+    // together):
+    //   - tests/testdata/publish/provenance_rejected
+    if path.contains("/packages/provenance-fails") {
+      let body = serde_json::to_string_pretty(&json!({
+        "code": "internalServerError",
+        "message": "Internal Server Error",
+      }))
+      .unwrap();
+      let res = Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(UnsyncBoxBody::new(Full::from(body)))?;
+      return Ok(res);
+    }
+    let res = Response::builder()
+      .status(StatusCode::NO_CONTENT)
+      .body(UnsyncBoxBody::new(Empty::new()))?;
+    return Ok(res);
   } else if path.starts_with("/api/scopes/") {
     // Allow tests to simulate a publish failure for an individual package by
     // naming the package "publish-fails" (or "publish-fails<n>"), used to


### PR DESCRIPTION
The response to the provenance submission was discarded entirely:

```rust
http_client
  .post_json(provenance_url.parse()?, &json!({ "bundle": bundle }))?
  .header(http::header::AUTHORIZATION, authorization.parse()?)
  .send()
  .await?;          // status never checked
```

So a registry that rejected every attestation was indistinguishable from one that accepted them — `deno publish` printed a transparency-log entry and "Successfully published" either way.

That is how jsr-io/jsr#1474 went unnoticed for a month. JSR compared the attested subject digest against the wrong artifact and returned a 500 for every submission, while publishers saw:

```
Publishing @regseb/metalint@0.22.0 ...
Provenance transparency log available at https://search.sigstore.dev/?logIndex=2276207949
Successfully published @regseb/metalint@0.22.0
```

…and no provenance badge. Six separate packages reported it on that issue before anyone worked out where the failure was.

## What this does

Checks the status and reports a failure.

It **warns rather than failing the command**. The version is already published and immutable by the time the attestation is submitted, so a registry-side hiccup must not turn a successful release into a red build — and the publish cannot be retried anyway, since the version now exists. The output is:

```
Publishing @foo/provenance-fails@1.0.0 ...
Warning: the registry did not accept the provenance attestation: Internal Server Error (internalServerError)
  The package was published, but it will not show a provenance badge.
  The attestation itself was signed and is in the transparency log at https://search.sigstore.dev/?logIndex=42069
Successfully published @foo/provenance-fails@1.0.0
```

The transparency-log line now prints only when the registry accepted the bundle, so the success path no longer claims something that did not happen. The registry's error is surfaced with its `x-deno-ray`, since the reason for a rejection lives in the registry's own logs.

## Tests

- `provenance_rejected_by_registry` — publishing a package whose attestation the mock registry rejects still exits 0, prints the warning, and does not print the transparency-log line.
- The mock registry now answers the provenance endpoint with 204 as JSR does, and rejects it for packages named `provenance-fails` (following the existing `publish-fails` convention).

All 16 publish integration tests and 67 publish spec tests pass locally, including the existing `provenance` test.

## Related

The JSR-side fix for the underlying bug is jsr-io/jsr#1483.
