### PR TITLE
fix: upgrade deno_task_shell to 0.33.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3460,9 +3460,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.33.0"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd069c87eb3cdc25e9898fe633a07ec7f20218e92ad3e7eccab3db324764d4fb"
+checksum = "8ac466d733d16a8ab5268b7e83a407289b25060a8f96dadc5cb96232a67c5282"
 dependencies = [
  "bitflags 2.9.3",
  "deno_path_util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_path_util = "=0.6.4"
 deno_semver = "=0.10.1"
-deno_task_shell = "=0.33.0"
+deno_task_shell = "=0.33.3"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"


### PR DESCRIPTION
Picks up three releases since 0.33.0. `deno task` now understands shell-style
`#` comments, accepts reserved words such as `if` and `then` in argument
position, and lets a backslash escape the operator characters `;`, `&`, `|`,
`<` and `>` in an unquoted word so that `deno task foo \; bar` passes the
semicolon through as an argument instead of splitting the command. On the
built-in command side, `cp -r dir/. dest` now copies the directory contents
the way GNU cp does rather than the directory itself.

There are no API changes, so this is a version bump and a lockfile update.

Fixes #36401