### PR TITLE
fix(ci): repair QuickJS Windows builds and CLI parser lint

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -3022,8 +3022,10 @@ jobs:
           try {
             Move-Item target/release/denort.exe target/release/denort.v8.exe
             Move-Item target/release/denort.dll target/release/denort.v8.dll
-            cargo build --release --locked -p denort -p denort_desktop --no-default-features --features quickjs
-            if ($LASTEXITCODE -ne 0) { throw "QuickJS runtime build failed" }
+            cargo build --release --locked -p denort --no-default-features --features quickjs
+            if ($LASTEXITCODE -ne 0) { throw "QuickJS denort build failed" }
+            cargo build --release --locked -p denort_desktop --no-default-features --features quickjs
+            if ($LASTEXITCODE -ne 0) { throw "QuickJS denort_desktop build failed" }
             Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-quickjs-x86_64-pc-windows-msvc.zip
             Get-FileHash target/release/denort-quickjs-x86_64-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-quickjs-x86_64-pc-windows-msvc.zip.sha256sum
             Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-quickjs-x86_64-pc-windows-msvc.zip
@@ -3928,8 +3930,10 @@ jobs:
           try {
             Move-Item target/release/denort.exe target/release/denort.v8.exe
             Move-Item target/release/denort.dll target/release/denort.v8.dll
-            cargo build --release --locked -p denort -p denort_desktop --no-default-features --features quickjs
-            if ($LASTEXITCODE -ne 0) { throw "QuickJS runtime build failed" }
+            cargo build --release --locked -p denort --no-default-features --features quickjs
+            if ($LASTEXITCODE -ne 0) { throw "QuickJS denort build failed" }
+            cargo build --release --locked -p denort_desktop --no-default-features --features quickjs
+            if ($LASTEXITCODE -ne 0) { throw "QuickJS denort_desktop build failed" }
             Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-quickjs-aarch64-pc-windows-msvc.zip
             Get-FileHash target/release/denort-quickjs-aarch64-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-quickjs-aarch64-pc-windows-msvc.zip.sha256sum
             Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-quickjs-aarch64-pc-windows-msvc.zip

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -821,8 +821,10 @@ jobs:
         run: |-
           target/release/deno -A tools/release/create_symcache.ts target/release/deno-x86_64-apple-darwin.symcache
           strip -x -S target/release/deno
-          echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
-          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
+          if [[ "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
+            rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
+          fi
           cd target/release
           shasum -a 256 deno > deno-x86_64-apple-darwin.sha256sum
           zip -r deno-x86_64-apple-darwin.zip deno
@@ -1956,8 +1958,10 @@ jobs:
         run: |-
           target/release/deno -A tools/release/create_symcache.ts target/release/deno-aarch64-apple-darwin.symcache
           strip -x -S target/release/deno
-          echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
-          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
+          if [[ "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
+            rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
+          fi
           cd target/release
           shasum -a 256 deno > deno-aarch64-apple-darwin.sha256sum
           zip -r deno-aarch64-apple-darwin.zip deno

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -6399,7 +6399,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true' && needs.pre_build.outputs.docs_only != 'true'
-    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ubuntu-24.04-arm64-xl'' || ''ubuntu-24.04-arm'' }}'
+    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'') || contains(github.event.pull_request.labels.*.name, ''ci-full'')) && ''ubuntu-24.04-arm64-xl'' || ''ubuntu-24.04-arm'' }}'
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -899,8 +899,12 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               "try {",
               "  Move-Item target/release/denort.exe target/release/denort.v8.exe",
               "  Move-Item target/release/denort.dll target/release/denort.v8.dll",
-              `  cargo build --release --locked -p denort -p denort_desktop --no-default-features --features quickjs`,
-              '  if ($LASTEXITCODE -ne 0) { throw "QuickJS runtime build failed" }',
+              // Both packages produce denort.pdb on Windows. Building them in
+              // one Cargo invocation lets their linkers race to write it.
+              `  cargo build --release --locked -p denort --no-default-features --features quickjs`,
+              '  if ($LASTEXITCODE -ne 0) { throw "QuickJS denort build failed" }',
+              `  cargo build --release --locked -p denort_desktop --no-default-features --features quickjs`,
+              '  if ($LASTEXITCODE -ne 0) { throw "QuickJS denort_desktop build failed" }',
               `  Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-quickjs-${buildItem.arch}-pc-windows-msvc.zip`,
               `  Get-FileHash target/release/denort-quickjs-${buildItem.arch}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-quickjs-${buildItem.arch}-pc-windows-msvc.zip.sha256sum`,
               `  Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.dll -DestinationPath target/release/libdenort-quickjs-${buildItem.arch}-pc-windows-msvc.zip`,

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -799,12 +799,14 @@ const buildJobs = buildItems.map((rawBuildItem) => {
             run: [
               `target/release/deno -A tools/release/create_symcache.ts target/release/deno-${buildItem.arch}-apple-darwin.symcache`,
               "strip -x -S target/release/deno",
-              'echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"',
-              "rcodesign sign target/release/deno " +
+              'if [[ "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == refs/tags/* ]]; then',
+              '  echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"',
+              "  rcodesign sign target/release/deno " +
               "--code-signature-flags=runtime " +
               '--p12-password="$APPLE_CODESIGN_PASSWORD" ' +
               "--p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) " +
               "--entitlements-xml-file=cli/entitlements.plist",
+              "fi",
               "cd target/release",
               `shasum -a 256 deno > deno-${buildItem.arch}-apple-darwin.sha256sum`,
               `zip -r deno-${buildItem.arch}-apple-darwin.zip deno`,

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -58,9 +58,9 @@ const Runners = {
   linuxArmXl: {
     os: "linux",
     arch: "aarch64",
-    runner: isDenoland.and(isMainOrTag).then(ubuntuARMXlRunner).else(
-      ubuntuARMRunner,
-    ),
+    runner: isDenoland.and(isMainOrTag.or(hasCiFullLabel)).then(
+      ubuntuARMXlRunner,
+    ).else(ubuntuARMRunner),
     testRunner: ubuntuARMRunner,
   },
   macosX86: {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11274,7 +11274,7 @@ dependencies = [
 [[package]]
 name = "v8x"
 version = "149.4.0-rc.1"
-source = "git+https://github.com/littledivy/v8x?rev=1fea85fc058544596932b13451bfd26a7b09a208#1fea85fc058544596932b13451bfd26a7b09a208"
+source = "git+https://github.com/littledivy/v8x?rev=d00c139f046807f6cb08a952af070e5cd8b793cc#d00c139f046807f6cb08a952af070e5cd8b793cc"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11273,9 +11273,9 @@ dependencies = [
 
 [[package]]
 name = "v8x"
-version = "149.4.0-rc.3"
+version = "149.4.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692bd87f40ebd8ea56f5f3a0b37bb7f435a7fb1e37c18a29f41b5801e7d92602"
+checksum = "3701ffb3692a24808503d17f758b0a3f688d2c451779247982566b5941033e63"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11273,7 +11273,7 @@ dependencies = [
 
 [[package]]
 name = "v8x"
-version = "149.4.0-rc.1"
+version = "149.4.0-rc.2"
 source = "git+https://github.com/littledivy/v8x?rev=b0359855804a8accee3dedf8d455533f627eb24c#b0359855804a8accee3dedf8d455533f627eb24c"
 dependencies = [
  "bindgen 0.70.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11274,7 +11274,7 @@ dependencies = [
 [[package]]
 name = "v8x"
 version = "149.4.0-rc.1"
-source = "git+https://github.com/littledivy/v8x?rev=598da64e8546424171f8b64ddfe33d385212686c#598da64e8546424171f8b64ddfe33d385212686c"
+source = "git+https://github.com/littledivy/v8x?rev=5be399591ce5d81372bb5bc21046a0b46ce27cc5#5be399591ce5d81372bb5bc21046a0b46ce27cc5"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11273,8 +11273,9 @@ dependencies = [
 
 [[package]]
 name = "v8x"
-version = "149.4.0-rc.2"
-source = "git+https://github.com/littledivy/v8x?rev=b0359855804a8accee3dedf8d455533f627eb24c#b0359855804a8accee3dedf8d455533f627eb24c"
+version = "149.4.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692bd87f40ebd8ea56f5f3a0b37bb7f435a7fb1e37c18a29f41b5801e7d92602"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11274,7 +11274,7 @@ dependencies = [
 [[package]]
 name = "v8x"
 version = "149.4.0-rc.1"
-source = "git+https://github.com/littledivy/v8x?rev=a385bb8f63490fb2ad0095f72a1d355cb394d20e#a385bb8f63490fb2ad0095f72a1d355cb394d20e"
+source = "git+https://github.com/littledivy/v8x?rev=1fea85fc058544596932b13451bfd26a7b09a208#1fea85fc058544596932b13451bfd26a7b09a208"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11274,7 +11274,7 @@ dependencies = [
 [[package]]
 name = "v8x"
 version = "149.4.0-rc.1"
-source = "git+https://github.com/littledivy/v8x?rev=d00c139f046807f6cb08a952af070e5cd8b793cc#d00c139f046807f6cb08a952af070e5cd8b793cc"
+source = "git+https://github.com/littledivy/v8x?rev=2de92428f73d696183fb4f0ecb5c32497285de6d#2de92428f73d696183fb4f0ecb5c32497285de6d"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11274,7 +11274,7 @@ dependencies = [
 [[package]]
 name = "v8x"
 version = "149.4.0-rc.1"
-source = "git+https://github.com/littledivy/v8x?rev=2de92428f73d696183fb4f0ecb5c32497285de6d#2de92428f73d696183fb4f0ecb5c32497285de6d"
+source = "git+https://github.com/littledivy/v8x?rev=598da64e8546424171f8b64ddfe33d385212686c#598da64e8546424171f8b64ddfe33d385212686c"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11274,7 +11274,7 @@ dependencies = [
 [[package]]
 name = "v8x"
 version = "149.4.0-rc.1"
-source = "git+https://github.com/littledivy/v8x?rev=d76331d26b760cff2c222adee6797a5260c103ee#d76331d26b760cff2c222adee6797a5260c103ee"
+source = "git+https://github.com/littledivy/v8x?rev=b0359855804a8accee3dedf8d455533f627eb24c#b0359855804a8accee3dedf8d455533f627eb24c"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11274,7 +11274,7 @@ dependencies = [
 [[package]]
 name = "v8x"
 version = "149.4.0-rc.1"
-source = "git+https://github.com/littledivy/v8x?rev=5be399591ce5d81372bb5bc21046a0b46ce27cc5#5be399591ce5d81372bb5bc21046a0b46ce27cc5"
+source = "git+https://github.com/littledivy/v8x?rev=d76331d26b760cff2c222adee6797a5260c103ee#d76331d26b760cff2c222adee6797a5260c103ee"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11274,8 +11274,7 @@ dependencies = [
 [[package]]
 name = "v8x"
 version = "149.4.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbc26e0dd12c1780f7b57b6ab197c888cf22b63155463b4275984f0afb14cf1"
+source = "git+https://github.com/littledivy/v8x?rev=a385bb8f63490fb2ad0095f72a1d355cb394d20e#a385bb8f63490fb2ad0095f72a1d355cb394d20e"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.9.3",

--- a/libs/cli_parser/src/defs.rs
+++ b/libs/cli_parser/src/defs.rs
@@ -1321,7 +1321,10 @@ pub static TASK_SUBCOMMAND: CommandDef = CommandDef {
       .short('r')
       .long("recursive")
       .set_true(),
-    ArgDef::new("members").long("members").set_true(),
+    ArgDef::new("members")
+      .long("members")
+      .set_true()
+      .conflicts_with(&["recursive", "filter"]),
     ArgDef::new("filter")
       .short('f')
       .long("filter")

--- a/libs/cli_parser/src/tests_full.rs
+++ b/libs/cli_parser/src/tests_full.rs
@@ -5379,6 +5379,7 @@ fn task_subcommand() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5399,6 +5400,7 @@ fn task_subcommand() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5418,6 +5420,7 @@ fn task_subcommand() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5437,6 +5440,7 @@ fn task_subcommand() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: Some("*".to_string()),
         eval: false,
         no_prefix: false,
@@ -5456,6 +5460,7 @@ fn task_subcommand() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: true,
+        members: false,
         filter: Some("*".to_string()),
         eval: false,
         no_prefix: false,
@@ -5475,6 +5480,7 @@ fn task_subcommand() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: true,
+        members: false,
         filter: Some("*".to_string()),
         eval: false,
         no_prefix: false,
@@ -5485,6 +5491,33 @@ fn task_subcommand() {
     }
   );
 
+  let r = flags_from_vec(svec!["deno", "task", "--members", "build"]);
+  assert_eq!(
+    r.unwrap(),
+    Flags {
+      subcommand: DenoSubcommand::Task(TaskFlags {
+        cwd: None,
+        task: Some("build".to_string()),
+        is_run: false,
+        recursive: false,
+        members: true,
+        filter: Some("*".to_string()),
+        eval: false,
+        no_prefix: false,
+        concurrency: None,
+        if_present: false,
+      }),
+      ..Flags::default()
+    }
+  );
+
+  let r = flags_from_vec(svec!["deno", "task", "--members", "-r", "build"]);
+  assert!(r.is_err());
+
+  let r =
+    flags_from_vec(svec!["deno", "task", "--members", "-f", "*", "build"]);
+  assert!(r.is_err());
+
   let r = flags_from_vec(svec!["deno", "task", "--eval", "echo 1"]);
   assert_eq!(
     r.unwrap(),
@@ -5494,6 +5527,7 @@ fn task_subcommand() {
         task: Some("echo 1".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: true,
         no_prefix: false,
@@ -5526,6 +5560,7 @@ fn task_subcommand_jobs() {
           task: Some("build".to_string()),
           is_run: false,
           recursive: false,
+          members: false,
           filter: None,
           eval: false,
           no_prefix: false,
@@ -5565,6 +5600,7 @@ fn task_subcommand_double_hyphen() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5588,6 +5624,7 @@ fn task_subcommand_double_hyphen() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5612,6 +5649,7 @@ fn task_subcommand_double_hyphen_only() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5635,6 +5673,7 @@ fn task_following_arg() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5658,6 +5697,7 @@ fn task_following_double_hyphen_arg() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5682,6 +5722,7 @@ fn task_with_global_flags() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5705,6 +5746,7 @@ fn task_subcommand_empty() {
         task: None,
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5727,6 +5769,7 @@ fn task_subcommand_config() {
         task: None,
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5750,6 +5793,7 @@ fn task_subcommand_config_short() {
         task: None,
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5779,6 +5823,7 @@ fn task_subcommand_env_file() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5805,6 +5850,7 @@ fn task_subcommand_env_file() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,
@@ -5828,6 +5874,7 @@ fn task_subcommand_if_present() {
         task: Some("build".to_string()),
         is_run: false,
         recursive: false,
+        members: false,
         filter: None,
         eval: false,
         no_prefix: false,

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "a385bb8f63490fb2ad0095f72a1d355cb394d20e", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "1fea85fc058544596932b13451bfd26a7b09a208", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "598da64e8546424171f8b64ddfe33d385212686c", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "5be399591ce5d81372bb5bc21046a0b46ce27cc5", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "d00c139f046807f6cb08a952af070e5cd8b793cc", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "2de92428f73d696183fb4f0ecb5c32497285de6d", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "d76331d26b760cff2c222adee6797a5260c103ee", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "b0359855804a8accee3dedf8d455533f627eb24c", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "b0359855804a8accee3dedf8d455533f627eb24c", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.2", git = "https://github.com/littledivy/v8x", rev = "b0359855804a8accee3dedf8d455533f627eb24c", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "a385bb8f63490fb2ad0095f72a1d355cb394d20e", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.3", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.4", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.2", git = "https://github.com/littledivy/v8x", rev = "b0359855804a8accee3dedf8d455533f627eb24c", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.3", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "1fea85fc058544596932b13451bfd26a7b09a208", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "d00c139f046807f6cb08a952af070e5cd8b793cc", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "5be399591ce5d81372bb5bc21046a0b46ce27cc5", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "d76331d26b760cff2c222adee6797a5260c103ee", optional = true, default-features = false }

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -38,4 +38,4 @@ v8_enable_v8_checks = [
 
 [dependencies]
 rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
-v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "2de92428f73d696183fb4f0ecb5c32497285de6d", optional = true, default-features = false }
+v8x_backend = { package = "v8x", version = "=149.4.0-rc.1", git = "https://github.com/littledivy/v8x", rev = "598da64e8546424171f8b64ddfe33d385212686c", optional = true, default-features = false }


### PR DESCRIPTION
## Summary

- use the released v8x 149.4.0-rc.4 crate, containing the Windows target fixes from littledivy/v8x#70 and cached-Cargo checkout recovery from littledivy/v8x#72
- update the ported task parser tests for the new members field
- restore the missing conflicts between `--members` and `--recursive`/`--filter`
- use the XL Linux ARM runner for labeled full-release PR builds
- skip Apple code signing on PR release builds while retaining signing on main and tags

## Root cause

Commit fa9ba06 exposed several v8x defects by enabling QuickJS release artifacts:

- x86_64 mixed WAMR objects built with the dynamic MSVC CRT into Deno binaries built with the static CRT, leaving `__imp_strtok_s` unresolved.
- native ARM64 was misdetected as X86_64 by WAMR; after selecting AARCH64, Visual Studio still routed its assembly through unsupported x86 MASM.
- cached Cargo git checkouts could retain a populated `vendor/rusty_v8` tree without valid submodule metadata. Git for Windows can also retain locks while recovery begins or leave a half-patched worktree after its internal clone retry.
- the crates.io publish job did not initialize the vendored submodules, and Cargo treated `vendor/rusty_v8` as a nested package, so the published rc.3 archive omitted required QuickJS and Rusty V8 sources.

v8x now confines recovery to Cargo-owned checkouts marked by `.cargo-ok`, retries locked cleanup, clears stale lock files, and resets/cleans freshly recovered submodules before applying patches. Normal source checkouts are untouched.

The v8x release workflow now materializes and patches the required submodules, packages them into the crate, extracts the generated archive, and compiles QuickJS from that extracted crate before publishing.

The Linux lint job was also a real failure. The preceding task-members change added a `TaskFlags` field without updating the ported parser test initializers, and the port omitted the conflicts enforced by the main parser.

Repeated Linux ARM full-release shutdowns came from the smaller runner, so `ci-full` release builds now use the same XL ARM runner as main and tags.

Full PR release CI also exposed that macOS packaging attempted Apple signing even though PR secrets are unavailable. PRs now package unsigned artifacts and still build the QuickJS runtimes; main and tag builds retain mandatory signing.

Deno uses the exact crates.io release `v8x = "=149.4.0-rc.4"`; there is no git source or revision override.

## Validation

- `./tools/format.js libs/cli_parser/src/defs.rs libs/cli_parser/src/tests_full.rs`
- `cargo test --locked -p deno_cli_parser --lib --features deno_core/v8 task_subcommand`
- `./tools/lint.js`
- `./tools/lint.js .github/workflows/ci.ts`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo metadata --locked --format-version 1` resolves v8x 149.4.0-rc.4 from the crates.io registry
- `cargo check --locked -p deno_v8 --no-default-features --features quickjs` passes against the downloaded rc.4 crate
- v8x CI on the rc.4 release commit passed the extracted-crate build, Windows x86_64 dynamic/static CRT, native ARM64 static CRT, stale-checkout recovery, and the full engine integration matrix
- labeled full Deno release CI covers Windows, Linux, and macOS artifact builds

Full Windows CI then exposed a separate Cargo output collision: `denort` and `denort_desktop` both emit `denort.pdb`, and building both packages in one Cargo invocation allowed their MSVC linkers to race on the same PDB (`LNK1201`). The Windows QuickJS pre-release step now builds those packages sequentially; Linux and macOS retain the combined build.

The final labeled full-CI run passed all six release builders (Windows x86_64/ARM64, Linux x86_64/ARM64, and macOS x86_64/ARM64), Linux lint, and every downstream check. The two macOS release Node-compat shards that hit the documented `test-http2-ping-settings-heapdump.js` flake passed on rerun.