### PR TITLE
test: isolate package imports specs

### DIFF
--- a/tests/specs/npm/pkg_json_imports/__test__.jsonc
+++ b/tests/specs/npm/pkg_json_imports/__test__.jsonc
@@ -1,4 +1,5 @@
 {
+  "tempDir": true,
   "tests": {
     "check": {
       "args": "check main.ts",
@@ -40,7 +41,6 @@
       "output": "run.out"
     },
     "compile": {
-      "tempDir": true,
       "steps": [{
         "args": "compile --no-check --output bin main.ts",
         "output": "[WILDCARD]"
@@ -51,7 +51,6 @@
       }]
     },
     "compile_node_modules_dir_auto": {
-      "tempDir": true,
       "steps": [{
         "args": "compile --node-modules-dir=auto --no-check --output bin main.ts",
         "output": "[WILDCARD]"
@@ -62,7 +61,6 @@
       }]
     },
     "compile_node_modules_dir_none": {
-      "tempDir": true,
       "steps": [{
         "args": "compile --node-modules-dir=none --no-check --output bin main.ts",
         "output": "[WILDCARD]"


### PR DESCRIPTION
## Summary

- run every `pkg_json_imports` spec case in its own temporary directory
- remove the now-redundant per-compile `tempDir` settings

## Root cause

The Windows specs shard intermittently copied the generated `.deno` tree from the shared source fixture while sibling cases were modifying it. This caused the copy to observe `@types/node/sea.d.ts` after it had disappeared and fail with `os error 2`.

Applying `tempDir` to the whole test group keeps generated npm state out of the shared fixture directory and prevents the race.

Original failure: https://github.com/denoland/deno/actions/runs/30955671376/job/92151292617

## Validation

- `./tools/format.js --check`
- `./tools/lint.js`
- `cargo build -p deno -p test_server`
- `cargo build -p denort`
- `target/debug/deno run -A tools/download_tsc.ts`
- `cargo test -p specs_tests --test specs specs::npm::pkg_json_imports -- --nocapture` (12 passed)

