### PR TITLE
fix(ext/node): don't error on RST after a complete HTTP response

### DIFF
--- a/ext/node/polyfills/_http_client.js
+++ b/ext/node/polyfills/_http_client.js
@@ -1102,15 +1102,26 @@ function socketErrorListener(err) {
     // Retry on stale keepalive socket before emitting error
     if (maybeRetryRequest(req, socket)) return;
 
-    // End OTel span on error
-    const span = req[kOtelSpan];
-    if (span) {
-      updateSpanFromError(span, err);
-      span.end();
-      req[kOtelSpan] = null;
+    // The whole response already arrived before the transport error did, e.g.
+    // a server that sends RST immediately after a complete response. Node
+    // never surfaces this: the message completes and the socket is released to
+    // the agent before the reset is processed, so the error lands on the freed
+    // socket and is discarded. Here the error can instead arrive in the window
+    // between the last body chunk and the response's 'end', which would fail a
+    // request that actually succeeded. Tear the socket down quietly and let
+    // 'end' (already queued by the parser's push(null)) complete the response.
+    // The span is left alone so responseOnEnd ends it normally.
+    if (!(req.res && req.res.complete)) {
+      // End OTel span on error
+      const span = req[kOtelSpan];
+      if (span) {
+        updateSpanFromError(span, err);
+        span.end();
+        req[kOtelSpan] = null;
+      }
+      socket._hadError = true;
+      emitErrorEvent(req, err);
     }
-    socket._hadError = true;
-    emitErrorEvent(req, err);
   }
 
   const parser = socket.parser;

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -3787,3 +3787,54 @@ Deno.test(
     await promise;
   },
 );
+
+// A server that resets the connection immediately after writing a complete
+// response must not fail the request: Node releases the socket to the agent
+// before the reset is processed, so the error is discarded and the response is
+// delivered normally. Regression test for a spurious ECONNRESET emitted in the
+// window between the last body chunk and the response's "end".
+Deno.test("[node/http] RST right after a complete response is not an error", async () => {
+  const server = net.createServer((socket) => {
+    socket.on("data", () => {
+      socket.write(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok",
+      );
+      socket.resetAndDestroy();
+    });
+    socket.on("error", () => {});
+  });
+
+  const port = await new Promise<number>((resolve) => {
+    server.listen(0, () => resolve((server.address() as AddressInfo).port));
+  });
+
+  const agent = new http.Agent({ keepAlive: true });
+  const errors: string[] = [];
+
+  const status = await new Promise<number>((resolve, reject) => {
+    const req = http.request(
+      { port, host: "127.0.0.1", method: "GET", path: "/", agent },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          assertEquals(Buffer.concat(chunks).toString(), "ok");
+          resolve(res.statusCode!);
+        });
+        res.on("error", reject);
+      },
+    );
+    req.on("error", (e: NodeJS.ErrnoException) => {
+      errors.push(e.code ?? e.message);
+      reject(e);
+    });
+    req.end();
+  });
+
+  assertEquals(status, 200);
+  assertEquals(errors, []);
+
+  agent.destroy();
+  server.close();
+  await new Promise((resolve) => server.on("close", resolve));
+});


### PR DESCRIPTION
A server that sends RST immediately after writing a complete HTTP response
caused a spurious ECONNRESET on the ClientRequest, so a request whose
response had already fully arrived was reported as failed. Node never
surfaces this: the message completes and the socket is released to the agent
before the reset is processed, so the error lands on an already-freed socket
and is discarded. In Deno the error can instead arrive in the window between
the last body chunk and the response's 'end'.

The error is now suppressed when the response is already complete, letting
the 'end' the parser has already queued finish the response. The OTel span is
left alone so responseOnEnd ends it normally rather than marking a successful
request as errored.