### PR TITLE
fix(bundle): avoid esbuild protocol deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4539,9 +4539,9 @@ checksum = "31ae425815400e5ed474178a7a22e275a9687086a12ca63ec793ff292d8fdae8"
 
 [[package]]
 name = "esbuild_client"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec79be0f4b20864729b38953ad77c7f347e436a7532c5f332dce9736aa4b5c"
+checksum = "4aad340fec9a377656190d6fbf205d589c322484c6a1d37ebbf328fe6f541720"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -128,7 +128,7 @@ dprint-plugin-json.workspace = true
 dprint-plugin-jupyter.workspace = true
 dprint-plugin-markdown.workspace = true
 dprint-plugin-typescript.workspace = true
-esbuild_client = { version = "0.7.1", features = ["serde"] }
+esbuild_client = { version = "0.7.2", features = ["serde"] }
 faster-hex.workspace = true
 fastwebsockets.workspace = true
 # If you disable the default __vendored_zlib_ng feature above, you _must_ be able to link against `-lz`.


### PR DESCRIPTION
## Summary

- update `esbuild_client` from 0.7.1 to 0.7.2
- include the protocol deadlock fix from denoland/esbuild_client#18

## Root cause

The esbuild protocol reader and writer share one select loop and communicate through bounded channels. Under load, packet forwarding could wait for the packet handler while the handler waited inline for response-channel capacity, leaving each side dependent on the other.

`esbuild_client` 0.7.2 moves `ping` and `on-start` response delivery out of the packet-dispatch path, breaking that circular wait while preserving bounded queues.

Fixes #36417.

## Validation

- `./tools/format.js --check Cargo.lock cli/Cargo.toml`
- `cargo build -p deno --bin deno`
- `./x test-spec 'specs::bundle::'` (65 tests)
