### PR TITLE
fix(loader): require explicit access for network file imports

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -510,7 +510,7 @@ impl ModuleGraphCreator {
   ) -> Result<deno_graph::ModuleGraph, AnyError> {
     let mut cache = self
       .module_graph_builder
-      .create_graph_loader_with_root_permissions();
+      .create_graph_loader_with_root_permissions(&roots);
     self
       .create_graph_with_loader(graph_kind, roots, &mut cache, npm_caching)
       .await
@@ -597,7 +597,7 @@ impl ModuleGraphCreator {
 
     let loader = self
       .module_graph_builder
-      .create_graph_loader_with_root_permissions();
+      .create_graph_loader_with_root_permissions(&roots);
     let publish_loader = PublishLoader(loader);
     let mut graph = self
       .create_graph_with_options(CreateGraphOptions {
@@ -906,11 +906,19 @@ impl ModuleGraphBuilder {
 
     let _clear_guard = self.progress_bar.deferred_keep_initialize_alive();
     let analyzer = self.module_info_cache.as_module_analyzer();
+    let file_roots = if options.is_dynamic {
+      Vec::new()
+    } else {
+      match &request {
+        BuildGraphRequest::Roots(roots, _) => roots.clone(),
+        BuildGraphRequest::Reload(_) => graph.roots.iter().cloned().collect(),
+      }
+    };
     let mut loader = match options.loader {
       Some(loader) => LoaderRef::Borrowed(loader),
-      None => {
-        LoaderRef::Owned(self.create_graph_loader_with_root_permissions())
-      }
+      None => LoaderRef::Owned(
+        self.create_graph_loader_with_root_permissions(&file_roots),
+      ),
     };
     let jsx_import_source_config_resolver =
       JsxImportSourceConfigResolver::from_compiler_options_resolver(
@@ -1201,10 +1209,12 @@ impl ModuleGraphBuilder {
   /// Creates the default loader used for creating a graph.
   pub fn create_graph_loader_with_root_permissions(
     &self,
+    roots: &[ModuleSpecifier],
   ) -> CliDenoGraphLoader {
-    self.create_graph_loader_with_permissions(
+    self.create_graph_loader_with_permissions_and_roots(
       self.root_permissions_container.clone(),
       None,
+      roots,
     )
   }
 
@@ -1213,6 +1223,19 @@ impl ModuleGraphBuilder {
     permissions: PermissionsContainer,
     file_permission_api_name: Option<&'static str>,
   ) -> CliDenoGraphLoader {
+    self.create_graph_loader_with_permissions_and_roots(
+      permissions,
+      file_permission_api_name,
+      &[],
+    )
+  }
+
+  fn create_graph_loader_with_permissions_and_roots(
+    &self,
+    permissions: PermissionsContainer,
+    file_permission_api_name: Option<&'static str>,
+    roots: &[ModuleSpecifier],
+  ) -> CliDenoGraphLoader {
     CliDenoGraphLoader::new(
       self.file_fetcher.clone(),
       self.global_http_cache.clone(),
@@ -1220,6 +1243,11 @@ impl ModuleGraphBuilder {
       self.sys.clone(),
       deno_resolver::file_fetcher::DenoGraphLoaderOptions {
         file_header_overrides: self.cli_options.resolve_file_header_overrides(),
+        file_roots: roots
+          .iter()
+          .filter(|specifier| specifier.scheme() == "file")
+          .cloned()
+          .collect(),
         permissions: Some(permissions),
         file_permission_api_name,
         reporter: self.load_reporter.clone(),

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -413,7 +413,7 @@ impl LanguageServer {
       let module_graph_builder = factory.module_graph_builder().await?;
       let module_graph_creator = factory.module_graph_creator().await?;
       let mut inner_loader =
-        module_graph_builder.create_graph_loader_with_root_permissions();
+        module_graph_builder.create_graph_loader_with_root_permissions(&[]);
       let mut loader = crate::lsp::documents::OpenDocumentsGraphLoader {
         inner_loader: &mut inner_loader,
         open_modules: &open_modules,

--- a/cli/tools/info.rs
+++ b/cli/tools/info.rs
@@ -165,8 +165,10 @@ pub async fn info(
       }
     };
 
-    let mut loader =
-      module_graph_builder.create_graph_loader_with_root_permissions();
+    let mut loader = module_graph_builder
+      .create_graph_loader_with_root_permissions(std::slice::from_ref(
+        &specifier,
+      ));
     loader.enable_loading_cache_info(); // for displaying the cache information
     let graph = module_graph_creator
       .create_graph_with_loader(

--- a/libs/resolver/file_fetcher.rs
+++ b/libs/resolver/file_fetcher.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use boxed_error::Boxed;
@@ -30,6 +31,7 @@ use deno_graph::source::LoaderChecksum;
 use deno_permissions::CheckSpecifierKind;
 use deno_permissions::PermissionCheckError;
 use deno_permissions::PermissionsContainer;
+use deno_permissions::is_windows_network_file_url;
 use futures::FutureExt;
 use futures::future::LocalBoxFuture;
 use http::header;
@@ -445,6 +447,9 @@ pub type GraphLoaderReporterRc =
 
 pub struct DenoGraphLoaderOptions {
   pub file_header_overrides: HashMap<Url, HashMap<String, String>>,
+  /// File roots explicitly selected by the host application. These roots may
+  /// be loaded without read permission, including from a network filesystem.
+  pub file_roots: HashSet<Url>,
   /// Whether to include npm package sources in the graph.
   ///
   /// Generally we don't do this for performance reasons because we
@@ -454,6 +459,20 @@ pub struct DenoGraphLoaderOptions {
   /// Uses `check_open` with this API name for dynamic local-file loads.
   pub file_permission_api_name: Option<&'static str>,
   pub reporter: Option<GraphLoaderReporterRc>,
+}
+
+fn check_specifier_kind(
+  file_roots: &HashSet<Url>,
+  specifier: &Url,
+  was_dynamic_root: bool,
+) -> CheckSpecifierKind {
+  if was_dynamic_root {
+    CheckSpecifierKind::Dynamic
+  } else if file_roots.contains(specifier) {
+    CheckSpecifierKind::StaticRoot
+  } else {
+    CheckSpecifierKind::Static
+  }
 }
 
 #[sys_traits::auto_impl]
@@ -470,6 +489,11 @@ pub struct DenoGraphLoader<
   THttpClient: HttpClient,
 > {
   file_header_overrides: HashMap<Url, HashMap<String, String>>,
+  #[allow(
+    clippy::disallowed_types,
+    reason = "immutable roots are shared across loader futures"
+  )]
+  file_roots: deno_maybe_sync::MaybeArc<HashSet<Url>>,
   #[allow(
     clippy::disallowed_types,
     reason = "Arc is needed for source content"
@@ -505,6 +529,7 @@ impl<
       in_npm_pkg_checker,
       sys,
       file_header_overrides: options.file_header_overrides,
+      file_roots: deno_maybe_sync::new_rc(options.file_roots),
       permissions: options.permissions,
       file_permission_api_name: options.file_permission_api_name,
       cache_info_enabled: false,
@@ -562,9 +587,10 @@ impl<
     Result<Option<TStrategy::Response>, deno_graph::source::LoadError>,
   > {
     let file_fetcher = self.file_fetcher.clone();
+    let file_roots = self.file_roots.clone();
     let permissions = self.permissions.clone();
     let file_permission_api_name = self.file_permission_api_name;
-    let is_statically_analyzable = !options.was_dynamic_root;
+    let was_dynamic_root = options.was_dynamic_root;
 
     async move {
       let maybe_cache_setting = match options.cache_setting {
@@ -585,11 +611,11 @@ impl<
           &specifier,
           match (&permissions, file_permission_api_name) {
             (Some(permissions), file_permission_api_name) => {
-              let kind = if is_statically_analyzable {
-                CheckSpecifierKind::Static
-              } else {
-                CheckSpecifierKind::Dynamic
-              };
+              let kind = check_specifier_kind(
+                &file_roots,
+                &specifier,
+                was_dynamic_root,
+              );
               match file_permission_api_name {
                 Some(api_name) => {
                   FetchPermissionsOptionRef::RestrictedWithFileApiName(
@@ -684,6 +710,9 @@ impl<
   }
 
   fn get_cache_info(&self, specifier: &Url) -> Option<CacheInfo> {
+    if is_windows_network_file_url(specifier) {
+      return None;
+    }
     let local = self.get_local_path(specifier)?;
     if self.sys.fs_is_file_no_err(&local) {
       Some(CacheInfo { local: Some(local) })
@@ -699,6 +728,7 @@ impl<
   ) -> LoadFuture {
     let specifier = if specifier.scheme() == "file"
       && specifier.path().contains("/node_modules/")
+      && !is_windows_network_file_url(specifier)
     {
       // The specifier might be in a completely different symlinked tree than
       // what the node_modules url is in (ex. `/my-project-1/node_modules`
@@ -904,15 +934,29 @@ fn validate_scheme(specifier: &Url) -> Result<(), UnsupportedSchemeError> {
 #[cfg(test)]
 mod test {
   use std::collections::HashMap;
+  use std::ffi::OsStr;
+  use std::ffi::OsString;
+  use std::io;
+  use std::path::Path;
   use std::path::PathBuf;
+  use std::time::SystemTime;
+  use std::time::UNIX_EPOCH;
 
   use deno_cache_dir::file_fetcher::CacheSetting;
   use deno_cache_dir::file_fetcher::NullBlobStore;
   use deno_cache_dir::file_fetcher::SendError;
   use deno_cache_dir::file_fetcher::SendResponse;
+  use deno_cache_dir::memory::MemoryHttpCache;
   use deno_graph::source::CacheSetting as LoaderCacheSetting;
   use deno_graph::source::LoadResponse;
   use deno_graph::source::Loader;
+  use deno_permissions::Permissions;
+  use deno_permissions::RuntimePermissionDescriptorParser;
+  use sys_traits::BaseEnvVar;
+  use sys_traits::BaseFsMetadata;
+  use sys_traits::BaseFsOpen;
+  use sys_traits::OpenOptions;
+  use sys_traits::SystemTimeNow;
   use sys_traits::impls::InMemorySys;
   use url::Url;
 
@@ -932,6 +976,112 @@ mod test {
       _headers: http::HeaderMap,
     ) -> Result<SendResponse, SendError> {
       Err(SendError::NotFound)
+    }
+  }
+
+  #[derive(Debug, Clone, Copy)]
+  struct NoFileSystemSys;
+
+  impl BaseEnvVar for NoFileSystemSys {
+    fn base_env_var_os(&self, _key: &OsStr) -> Option<OsString> {
+      None
+    }
+  }
+
+  impl BaseFsMetadata for NoFileSystemSys {
+    type Metadata = <InMemorySys as BaseFsMetadata>::Metadata;
+
+    fn base_fs_metadata(&self, path: &Path) -> io::Result<Self::Metadata> {
+      panic!("unexpected metadata access: {path:?}")
+    }
+
+    fn base_fs_symlink_metadata(
+      &self,
+      path: &Path,
+    ) -> io::Result<Self::Metadata> {
+      panic!("unexpected symlink metadata access: {path:?}")
+    }
+  }
+
+  impl BaseFsOpen for NoFileSystemSys {
+    type File = <InMemorySys as BaseFsOpen>::File;
+
+    fn base_fs_open(
+      &self,
+      path: &Path,
+      _options: &OpenOptions,
+    ) -> io::Result<Self::File> {
+      panic!("unexpected file open: {path:?}")
+    }
+  }
+
+  impl SystemTimeNow for NoFileSystemSys {
+    fn sys_time_now(&self) -> SystemTime {
+      UNIX_EPOCH
+    }
+  }
+
+  fn fetch_options() -> FetchNoFollowOptions<'static> {
+    FetchNoFollowOptions {
+      local: Default::default(),
+      maybe_auth: None,
+      maybe_accept: None,
+      maybe_cache_setting: None,
+      maybe_checksum: None,
+    }
+  }
+
+  #[test]
+  #[allow(
+    clippy::disallowed_types,
+    reason = "PermissionsContainer requires Arc"
+  )]
+  fn rejected_file_import_does_not_access_file_system() {
+    let file_fetcher = PermissionedFileFetcher::new(
+      NullBlobStore,
+      deno_maybe_sync::new_rc(MemoryHttpCache::default()),
+      TestHttpClient,
+      deno_maybe_sync::new_rc(crate::loader::MemoryFiles::default()),
+      NoFileSystemSys,
+      PermissionedFileFetcherOptions {
+        allow_remote: false,
+        cache_setting: CacheSetting::Use,
+      },
+    );
+    let parser = RuntimePermissionDescriptorParser::new(
+      InMemorySys::new_with_cwd(get_cwd()),
+    );
+    let permissions = PermissionsContainer::new(
+      std::sync::Arc::new(parser),
+      Permissions::none_without_prompt(),
+    );
+    let specifier = Url::parse("file://server/share/dependency.ts").unwrap();
+    let mut pool = futures::executor::LocalPool::new();
+
+    for kind in [CheckSpecifierKind::Static, CheckSpecifierKind::Dynamic] {
+      let err = pool
+        .run_until(file_fetcher.fetch_no_follow(
+          &specifier,
+          FetchPermissionsOptionRef::Restricted(&permissions, kind),
+          fetch_options(),
+        ))
+        .unwrap_err();
+      assert!(matches!(
+        err.into_kind(),
+        FetchNoFollowErrorKind::PermissionCheck(_)
+      ));
+
+      let err = pool
+        .run_until(file_fetcher.ensure_cached_no_follow(
+          &specifier,
+          FetchPermissionsOptionRef::Restricted(&permissions, kind),
+          fetch_options(),
+        ))
+        .unwrap_err();
+      assert!(matches!(
+        err.into_kind(),
+        FetchNoFollowErrorKind::PermissionCheck(_)
+      ));
     }
   }
 
@@ -973,6 +1123,7 @@ mod test {
       sys,
       DenoGraphLoaderOptions {
         file_header_overrides: HashMap::new(),
+        file_roots: HashSet::new(),
         permissions: None,
         file_permission_api_name: None,
         reporter: None,
@@ -988,6 +1139,31 @@ mod test {
       cache_setting: LoaderCacheSetting::Use,
       maybe_checksum: None,
     }
+  }
+
+  #[test]
+  fn file_root_permission_kinds() {
+    let root = Url::parse("file:///project/main.ts").unwrap();
+    let literal_dynamic_dependency =
+      Url::parse("file:///project/dependency.ts").unwrap();
+    let file_roots = HashSet::from([root.clone()]);
+
+    // An explicitly selected entrypoint keeps its host-provided authority.
+    assert_eq!(
+      check_specifier_kind(&file_roots, &root, false),
+      CheckSpecifierKind::StaticRoot,
+    );
+    // Static imports and analyzable dynamic imports are graph dependencies.
+    assert_eq!(
+      check_specifier_kind(&file_roots, &literal_dynamic_dependency, false),
+      CheckSpecifierKind::Static,
+    );
+    // Computed dynamic imports are checked at runtime, even if they resolve to
+    // the original entrypoint.
+    assert_eq!(
+      check_specifier_kind(&file_roots, &root, true),
+      CheckSpecifierKind::Dynamic,
+    );
   }
 
   #[test]

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -3880,8 +3880,34 @@ impl Permissions {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum CheckSpecifierKind {
+  /// A graph root explicitly selected by the host application.
+  StaticRoot,
   Static,
   Dynamic,
+}
+
+fn has_windows_network_path_prefix(path: &Path) -> bool {
+  let bytes = path.as_os_str().as_encoded_bytes();
+  let is_separator = |byte| matches!(byte, b'/' | b'\\');
+  if bytes.starts_with(br"\\?\")
+    && bytes.len() >= 7
+    && bytes[4].is_ascii_alphabetic()
+    && bytes[5] == b':'
+    && bytes[6] == b'\\'
+  {
+    return false;
+  }
+  bytes.len() >= 2 && is_separator(bytes[0]) && is_separator(bytes[1])
+}
+
+fn is_windows_network_path(path: &Path) -> bool {
+  cfg!(windows) && has_windows_network_path_prefix(path)
+}
+
+pub fn is_windows_network_file_url(specifier: &Url) -> bool {
+  specifier.scheme() == "file"
+    && url_to_file_path(specifier)
+      .is_ok_and(|path| is_windows_network_path(&path))
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
@@ -4130,31 +4156,34 @@ impl PermissionsContainer {
     let mut inner = self.inner.lock();
     match specifier.scheme() {
       "file" => {
+        let path = url_to_file_path(specifier).map_err(|_| {
+          PermissionCheckError::InvalidFilePath(specifier.clone())
+        })?;
+        let is_windows_network_path = is_windows_network_path(&path);
+
         if inner.read.is_allow_all() {
-          if kind != CheckSpecifierKind::Static {
+          if kind == CheckSpecifierKind::Dynamic || is_windows_network_path {
             write_audit(ReadQueryDescriptor::flag_name(), specifier);
           }
 
           return Ok(());
         }
-        if kind == CheckSpecifierKind::Static {
+        if kind != CheckSpecifierKind::Dynamic
+          && (kind == CheckSpecifierKind::StaticRoot
+            || !is_windows_network_path)
+        {
           return Ok(());
         }
 
-        match url_to_file_path(specifier) {
-          Ok(path) => inner
-            .read
-            .check(
-              // a file: specifier will always go to absolute
-              &PathQueryDescriptor::new_known_absolute(Cow::Owned(path))
-                .into_read(),
-              Some("import()"),
-            )
-            .map_err(ignored_to_not_found),
-          Err(_) => {
-            Err(PermissionCheckError::InvalidFilePath(specifier.clone()))
-          }
-        }
+        inner
+          .read
+          .check(
+            // a file: specifier will always go to absolute
+            &PathQueryDescriptor::new_known_absolute(Cow::Owned(path))
+              .into_read(),
+            Some("import()"),
+          )
+          .map_err(ignored_to_not_found)
       }
       "data" => Ok(()),
       "blob" => Ok(()),
@@ -6320,6 +6349,21 @@ mod tests {
 
     if cfg!(target_os = "windows") {
       fixtures.push((
+        Url::parse("file://server/share/entry.ts").unwrap(),
+        CheckSpecifierKind::StaticRoot,
+        true,
+      ));
+      fixtures.push((
+        Url::parse("file://server/share/dependency.ts").unwrap(),
+        CheckSpecifierKind::Static,
+        false,
+      ));
+      fixtures.push((
+        Url::parse("file://server/share/dependency.ts").unwrap(),
+        CheckSpecifierKind::Dynamic,
+        false,
+      ));
+      fixtures.push((
         Url::parse("file:///C:/a/mod.ts").unwrap(),
         CheckSpecifierKind::Dynamic,
         true,
@@ -6360,6 +6404,84 @@ mod tests {
         specifier,
       );
     }
+  }
+
+  #[test]
+  fn windows_network_path_prefixes() {
+    for path in [
+      r"\\server\share\module.ts",
+      r"//server/share/module.ts",
+      r"/\server/share/module.ts",
+      r"\\?\UNC\server\share\module.ts",
+    ] {
+      assert!(has_windows_network_path_prefix(Path::new(path)), "{path}");
+    }
+
+    for path in [
+      r"C:\project\module.ts",
+      r"\\?\C:\project\module.ts",
+      r"\project\module.ts",
+      r"/project/module.ts",
+    ] {
+      assert!(!has_windows_network_path_prefix(Path::new(path)), "{path}");
+    }
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn windows_file_url_path_classification() {
+    for specifier in [
+      "file://server/share/module.ts",
+      r"file:\\server\share\module.ts",
+      "file:////server/share/module.ts",
+      "file:///%2Fserver/share/module.ts",
+      "file:///%5Cserver/share/module.ts",
+      "file:///%2F%2Fserver/share/module.ts",
+    ] {
+      let path = url_to_file_path(&Url::parse(specifier).unwrap()).unwrap();
+      assert!(is_windows_network_path(&path), "{specifier}: {path:?}");
+    }
+
+    for specifier in [
+      "file:///C:/project/module.ts",
+      "file://localhost/C:/project/module.ts",
+    ] {
+      let path = url_to_file_path(&Url::parse(specifier).unwrap()).unwrap();
+      assert!(!is_windows_network_path(&path), "{specifier}: {path:?}");
+    }
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn exact_unc_read_descriptor_allows_network_file_import() {
+    set_prompter(Box::new(TestPrompter));
+    let parser = TestPermissionDescriptorParser;
+    let perms = Permissions::from_options(
+      &parser,
+      &PermissionsOptions {
+        allow_read: Some(svec![r"\\server\share\allowed.ts"]),
+        ..Default::default()
+      },
+    )
+    .unwrap();
+    let perms = PermissionsContainer::new(Arc::new(parser), perms);
+
+    assert!(
+      perms
+        .check_specifier(
+          &Url::parse("file://server/share/allowed.ts").unwrap(),
+          CheckSpecifierKind::Static,
+        )
+        .is_ok()
+    );
+    assert!(
+      perms
+        .check_specifier(
+          &Url::parse("file://server/share/other.ts").unwrap(),
+          CheckSpecifierKind::Static,
+        )
+        .is_err()
+    );
   }
 
   #[test]


### PR DESCRIPTION
This changes Windows file-module loading to distinguish local paths from paths backed by a network filesystem after URL-to-path conversion.

Local static imports and statically analyzable dynamic imports keep their existing permission behavior. Network file dependencies now require matching read access, while an explicitly selected file entrypoint retains its root provenance. Loader cache inspection and `node_modules` canonicalization avoid touching these paths before that decision.

Tests cover hosted, hostless, encoded, and mixed-separator file URL forms; local drive and `localhost` forms; exact read descriptors; static roots and dependencies; computed dynamic loads; and rejection before metadata or file-open operations.

Validation:

- `./tools/format.js --check cli/graph_util.rs cli/lsp/language_server.rs cli/tools/info.rs libs/resolver/file_fetcher.rs runtime/permissions/lib.rs`
- `cargo fmt --check --package deno_permissions --package deno_resolver --package deno`
- `cargo test -p deno_permissions`
- `cargo test -p deno_resolver -p deno_cache_dir --features deno_resolver/graph file_fetcher::test::`
- `cargo clippy -p deno --bin deno -- -D warnings`
- `cargo check -p deno_permissions --tests --target x86_64-pc-windows-msvc`
- `cargo check -p deno_resolver -p deno_cache_dir --features deno_resolver/graph --tests --target x86_64-pc-windows-msvc`
