### PR TITLE
fix(process): validate whitespace-only loader environment values

### DIFF
--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -1434,7 +1434,6 @@ fn get_requires_allow_all_env_vars(env: &RunEnv) -> Vec<&str> {
 
   fn is_empty(value: &OsString) -> bool {
     value.is_empty()
-      || value.to_str().map(|v| v.trim().is_empty()).unwrap_or(false)
   }
 
   let mut found_envs = env

--- a/tests/unit/command_test.ts
+++ b/tests/unit/command_test.ts
@@ -767,6 +767,30 @@ Deno.test(
 );
 
 Deno.test(
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { run: [Deno.execPath()], read: true },
+  },
+  function commandLoaderEnvValueValidation() {
+    for (const name of ["LD_PRELOAD", "DYLD_INSERT_LIBRARIES"]) {
+      const command = (value: string) =>
+        new Deno.Command(Deno.execPath(), {
+          args: ["eval", ""],
+          clearEnv: true,
+          env: { [name]: value },
+        });
+
+      assertEquals(command("").outputSync().success, true);
+      assertThrows(
+        () => command("\t").outputSync(),
+        Deno.errors.NotCapable,
+        name,
+      );
+    }
+  },
+);
+
+Deno.test(
   { permissions: { run: true, read: true } },
   function commandSyncEnv() {
     const { stdout } = new Deno.Command(Deno.execPath(), {


### PR DESCRIPTION
Scoped subprocess validation now treats loader environment values as absent only when they are exactly empty. Previously, trimming the value for this decision allowed whitespace-only values to skip validation even though the original value was still passed unchanged to the child process.

Exactly empty values retain their existing behavior, and ordinary command environment handling is unchanged. The focused command test covers both `LD_` and `DYLD_` names on non-Windows platforms.

Validation:

- `./tools/format.js --check ext/process/lib.rs tests/unit/command_test.ts`
- `cargo fmt --check --package deno_process`
- `CARGO_INCREMENTAL=0 cargo build -p deno --bin deno`
- `CARGO_INCREMENTAL=0 cargo test -p unit_tests --test unit -- command_test`
- `CARGO_INCREMENTAL=0 cargo clippy -p deno_process --all-targets --features deno_core/v8 -- -D warnings`
