### PR TITLE
fix(process): reject NULs in Windows arguments

### DIFF
--- a/runtime/subprocess_windows/src/lib.rs
+++ b/runtime/subprocess_windows/src/lib.rs
@@ -485,7 +485,6 @@ impl Command {
       cwd: self.cwd.as_deref().map(Cow::Borrowed),
       stdio,
     })
-    .map_err(|err| std::io::Error::other(err.to_string()))
     .map(|process| Child {
       inner: FusedChild::Child(ChildDropGuard {
         inner: process,

--- a/runtime/subprocess_windows/src/process.rs
+++ b/runtime/subprocess_windows/src/process.rs
@@ -352,6 +352,10 @@ fn make_program_args(
   args: &[&OsStr],
   verbatim_arguments: bool,
 ) -> Result<WCString, std::io::Error> {
+  for arg in args {
+    ensure_no_nuls(arg)?;
+  }
+
   let mut dst_len = 0;
   let mut temp_buffer_len = 0;
 
@@ -1652,5 +1656,32 @@ mod tests {
     let verbatim_arguments = false;
     let result = make_program_args(&args, verbatim_arguments).unwrap();
     assert_eq!(result, WCString::new("hello world \"\\\"hello world\\\"\""));
+  }
+
+  fn assert_make_program_args_rejects_nuls(verbatim_arguments: bool) {
+    for nul_index in 0..3 {
+      // Keep an argument after the invalid one so an embedded terminator
+      // cannot silently discard the rest of a verbatim command line.
+      let mut args = [
+        OsStr::new("program"),
+        OsStr::new("before"),
+        OsStr::new("must-not-be-dropped"),
+      ];
+      args[nul_index] = OsStr::new("invalid\0argument");
+
+      let error = make_program_args(&args, verbatim_arguments).unwrap_err();
+      assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+      assert_eq!(error.to_string(), "nul byte found in provided data");
+    }
+  }
+
+  #[test]
+  fn test_make_program_args_rejects_nuls() {
+    assert_make_program_args_rejects_nuls(false);
+  }
+
+  #[test]
+  fn test_make_program_args_verbatim_rejects_nuls() {
+    assert_make_program_args_rejects_nuls(true);
   }
 }

--- a/runtime/subprocess_windows/src/tests.rs
+++ b/runtime/subprocess_windows/src/tests.rs
@@ -1,3 +1,21 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-// TODO
+use std::ffi::OsStr;
+use std::io;
+
+use crate::Command;
+
+#[test]
+fn spawn_rejects_nuls_in_arguments() {
+  for verbatim_arguments in [false, true] {
+    let mut command = Command::new(std::env::current_exe().unwrap());
+    command
+      .arg(OsStr::new("invalid\0argument"))
+      .arg("must-not-be-dropped")
+      .verbatim_arguments(verbatim_arguments);
+
+    let error = command.spawn().err().unwrap();
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(error.to_string(), "nul byte found in provided data");
+  }
+}


### PR DESCRIPTION
## Summary

- Validate every Windows process argument for internal NUL code units before constructing the command line.
- Apply the same validation to normal quoted and verbatim argument modes.
- Preserve `InvalidInput` through the public `Command::spawn()` boundary.
- Add Windows unit coverage for every argument position and the public spawn API, including an invalid argument followed by a trailing argument.

## Rationale

Windows command lines are NUL-terminated. Allowing an embedded NUL into command-line construction can truncate an argument or prevent later arguments from reaching the child process. Invalid arguments now return `InvalidInput` through the public spawn API before command-line construction, while all representable arguments retain their existing quoting behavior.

## Tests

- `./tools/format.js`
- `cargo test -p deno_subprocess_windows`
- `cargo check -p deno_subprocess_windows --all-targets`
- `cargo xwin test --target x86_64-pc-windows-msvc -p deno_subprocess_windows --no-run`
- `cargo xwin check --target x86_64-pc-windows-msvc -p deno_subprocess_windows --all-targets`
- `cargo xwin clippy --target x86_64-pc-windows-msvc -p deno_subprocess_windows --all-targets -- -D warnings`
