### PR TITLE
fix(ext/http): route invalid async responses to onError

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -1043,63 +1043,73 @@ function mapToNativeResponseCallback(context, callback, onError) {
     return undefined;
   }
 
+  function handleOnErrorError(req, span, innerRequest, error) {
+    if (otelState.METRICS_ENABLED) {
+      op_http_metric_handle_otel_error(req);
+    }
+    internals.log(
+      "error",
+      "Exception in onError while handling exception",
+      error,
+    );
+    return finishOrReturnNative(
+      req,
+      span,
+      innerRequest,
+      internalServerError(),
+    );
+  }
+
   function handleError(req, span, innerRequest, error) {
     let response;
     try {
       response = onError(error);
     } catch (error) {
-      if (otelState.METRICS_ENABLED) {
-        op_http_metric_handle_otel_error(req);
-      }
-      internals.log(
-        "error",
-        "Exception in onError while handling exception",
-        error,
-      );
-      response = internalServerError();
+      return handleOnErrorError(req, span, innerRequest, error);
     }
     try {
-      return finishOrReturnMaybePromise(req, span, innerRequest, response);
-    } catch (error) {
-      if (otelState.METRICS_ENABLED) {
-        op_http_metric_handle_otel_error(req);
-      }
-      internals.log(
-        "error",
-        "Exception in onError while handling exception",
-        error,
-      );
-      return finishOrReturnNative(
+      return finishOrReturnMaybePromise(
         req,
         span,
         innerRequest,
-        internalServerError(),
+        response,
+        true,
       );
+    } catch (error) {
+      return handleOnErrorError(req, span, innerRequest, error);
     }
   }
 
-  function finishOrReturnMaybePromise(req, span, innerRequest, response) {
+  function finishOrReturnMaybePromise(
+    req,
+    span,
+    innerRequest,
+    response,
+    isOnErrorResponse = false,
+  ) {
     if (
-      response !== null &&
-      (typeof response === "object" || typeof response === "function") &&
-      typeof response.then === "function"
+      (
+        response !== null &&
+        (typeof response === "object" || typeof response === "function") &&
+        typeof response.then === "function"
+      ) ||
+      (
+        innerRequest?.request !== undefined &&
+        requestHeadersExposed(innerRequest.request)
+      )
     ) {
-      return PromisePrototypeThen(
+      const finished = PromisePrototypeThen(
         PromiseResolve(response),
         (response) =>
           finishOrReturnNative(req, span, innerRequest, response, true),
-        (error) => handleError(req, span, innerRequest, error),
       );
-    }
-    if (
-      innerRequest?.request !== undefined &&
-      requestHeadersExposed(innerRequest.request)
-    ) {
       return PromisePrototypeThen(
-        PromiseResolve(response),
-        (response) =>
-          finishOrReturnNative(req, span, innerRequest, response, true),
-        (error) => handleError(req, span, innerRequest, error),
+        finished,
+        undefined,
+        (error) =>
+          isOnErrorResponse
+            ? handleOnErrorError(req, span, innerRequest, error)
+            : handleError(req, span, innerRequest, error),
       );
     }
     return finishOrReturnNative(req, span, innerRequest, response);

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -5714,9 +5714,10 @@ Deno.test(
 Deno.test(
   { permissions: { net: true, run: true } },
   async function handleServeCallbackReturn() {
-    const deferred = Promise.withResolvers<void>();
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
+    let callbackCount = 0;
+    let errorCount = 0;
 
     await using server = Deno.serve(
       {
@@ -5724,26 +5725,38 @@ Deno.test(
         onListen: onListen(listeningDeferred.resolve),
         signal: ac.signal,
         onError: (error) => {
+          errorCount++;
           assert(error instanceof TypeError);
           assert(
             error.message ===
               "Return value from serve handler must be a response or a promise resolving to a response",
           );
-          deferred.resolve();
           return new Response("Customized Internal Error from onError");
         },
       },
       () => {
         // Trick the typechecker
-        return <Response> <unknown> undefined;
+        const response = <Response> <unknown> undefined;
+        return callbackCount++ === 0 ? response : Promise.resolve(response);
       },
     );
     await listeningDeferred.promise;
-    const respText = await curlRequest([`http://localhost:${servePort}`]);
-    await deferred.promise;
+    const syncRespText = await curlRequest([`http://localhost:${servePort}`]);
+    const asyncRespText = await curlRequest([
+      "--max-time",
+      "2",
+      `http://localhost:${servePort}`,
+    ]);
     ac.abort();
     await server.finished;
-    assert(respText === "Customized Internal Error from onError");
+    assertEquals(errorCount, 2);
+    assertEquals(
+      [syncRespText, asyncRespText],
+      [
+        "Customized Internal Error from onError",
+        "Customized Internal Error from onError",
+      ],
+    );
   },
 );
 


### PR DESCRIPTION
 Fixes #36425.

  Invalid values returned asynchronously from `Deno.serve` handlers were validated inside a promise fulfillment callback, after the rejection handler had already been attached to the original handler promise. The
  resulting `TypeError` therefore bypassed `onError`.

  Attach error handling after response conversion and fall back to the internal 500 response if an asynchronous `onError` result also fails. Extend the existing serve callback test to cover both synchronous and
  asynchronously resolved invalid values.

  Tests:
  - `cargo test -p unit_tests --test unit -- handleServeCallbackReturn`
  - `cargo test -p unit_tests --test unit -- serve`
  - formatting and targeted JS/TS lint checks