### PR TITLE
fix(fs): use a private FsFile constructor token

### DIFF
--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -89,10 +89,10 @@ const {
   ObjectValues,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
+  Symbol,
   SymbolAsyncIterator,
   SymbolDispose,
   SymbolIterator,
-  SymbolFor,
   TypeError,
   Uint32Array,
 } = primordials;
@@ -110,6 +110,8 @@ function lazyStreams() {
     (_streamsImpl = core.loadExtScript("ext:deno_web/06_streams.js"));
 }
 const { pathFromURL } = core.loadExtScript("ext:deno_web/00_infra.js");
+
+const fsFileConstructorKey = Symbol("Deno.internal.FsFile");
 
 function chmodSync(path, mode) {
   op_fs_chmod_sync(pathFromURL(path), mode);
@@ -599,7 +601,7 @@ function openSync(
     options,
   );
 
-  return new FsFile(rid, SymbolFor("Deno.internal.FsFile"));
+  return new FsFile(rid, fsFileConstructorKey);
 }
 
 async function open(
@@ -612,7 +614,7 @@ async function open(
     options,
   );
 
-  return new FsFile(rid, SymbolFor("Deno.internal.FsFile"));
+  return new FsFile(rid, fsFileConstructorKey);
 }
 
 function createSync(path) {
@@ -646,7 +648,7 @@ class FsFile {
       value: rid,
     });
     this.#rid = rid;
-    if (!symbol || symbol !== SymbolFor("Deno.internal.FsFile")) {
+    if (!symbol || symbol !== fsFileConstructorKey) {
       throw new TypeError(
         "'Deno.FsFile' cannot be constructed, use 'Deno.open()' or 'Deno.openSync()' instead",
       );
@@ -983,6 +985,7 @@ return {
   createSync,
   cwd,
   FsFile,
+  fsFileConstructorKey,
   link,
   linkSync,
   lstat,

--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -32,10 +32,11 @@ const {
   PromisePrototypeThen,
   SafePromiseAll,
   Symbol,
-  SymbolFor,
 } = primordials;
 
-const { FsFile } = core.loadExtScript("ext:deno_fs/30_fs.js");
+const { FsFile, fsFileConstructorKey } = core.loadExtScript(
+  "ext:deno_fs/30_fs.js",
+);
 const { readAll } = core.loadExtScript("ext:deno_io/12_io.js");
 const { assert, pathFromURL } = core.loadExtScript("ext:deno_web/00_infra.js");
 const { packageData } = core.loadExtScript("ext:deno_fetch/22_body.js");
@@ -93,20 +94,20 @@ class Process {
     this.pid = res.pid;
 
     if (res.stdinRid && res.stdinRid > 0) {
-      this.stdin = new FsFile(res.stdinRid, SymbolFor("Deno.internal.FsFile"));
+      this.stdin = new FsFile(res.stdinRid, fsFileConstructorKey);
     }
 
     if (res.stdoutRid && res.stdoutRid > 0) {
       this.stdout = new FsFile(
         res.stdoutRid,
-        SymbolFor("Deno.internal.FsFile"),
+        fsFileConstructorKey,
       );
     }
 
     if (res.stderrRid && res.stderrRid > 0) {
       this.stderr = new FsFile(
         res.stderrRid,
-        SymbolFor("Deno.internal.FsFile"),
+        fsFileConstructorKey,
       );
     }
   }

--- a/tests/unit/files_test.ts
+++ b/tests/unit/files_test.ts
@@ -19,6 +19,19 @@ Deno.test(function filesStdioFileDescriptors() {
   assertEquals(Deno.stderr.rid, 2);
 });
 
+Deno.test(function fsFileGlobalSymbolCannotConstruct() {
+  const FsFileCtor = Deno.FsFile as unknown as new (
+    rid: number,
+    token: symbol,
+  ) => Deno.FsFile;
+
+  assertThrows(
+    () => new FsFileCtor(0, Symbol.for("Deno.internal.FsFile")),
+    TypeError,
+    "'Deno.FsFile' cannot be constructed",
+  );
+});
+
 Deno.test(
   { permissions: { read: true } },
   async function filesCopyToStdout() {


### PR DESCRIPTION
## Summary

- replace the globally registered `FsFile` constructor token with a module-private symbol
- share the same private token with file-open and legacy process stdio construction paths
- add regression coverage for the intended illegal-constructor behavior

## Problem

`FsFile` used `Symbol.for()` as its constructor token. The global registry returns the same symbol for a given key, so callers could reproduce the token and bypass the intended direct-construction rejection.

## Validation

- `./tools/format.js ext/fs/30_fs.js ext/process/40_process.js tests/unit/files_test.ts`
- `CARGO_INCREMENTAL=0 cargo build -p deno`
- `CARGO_INCREMENTAL=0 cargo test -p unit_tests --test unit -- files_test`
- `CARGO_INCREMENTAL=0 cargo test -p unit_tests --test unit -- process_test`