### PR TITLE
fix(web): keep MessagePort resource identifiers private

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -30,13 +30,14 @@ const {
   markAsUncloneable: webMarkAsUncloneable,
   MessageChannel,
   MessagePort,
-  MessagePortIdSymbol,
+  getMessagePortId,
   MessagePortPrototype,
   MessagePortReceiveMessageOnPortSymbol,
   nodeWorkerThreadCloseCb,
   refMessagePort,
   serializeJsMessageData,
   serializeMessageData,
+  setMessagePortId,
   unrefParentPort,
 } = core.loadExtScript("ext:deno_web/13_message_port.js");
 const webidl = core.loadExtScript("ext:deno_webidl/00_webidl.js");
@@ -1747,7 +1748,7 @@ function moveMessagePortToContext(
   // Node checks closed-port state before vm.Context to give a clearer
   // error when the port is detached -- order matters for tests in the
   // node_compat suite that pass an empty {} as the context.
-  const portId = port[MessagePortIdSymbol];
+  const portId = getMessagePortId(port);
   if (portId === null) {
     throw new ERR_CLOSED_MESSAGE_PORT();
   }
@@ -1757,7 +1758,7 @@ function moveMessagePortToContext(
   }
   // Take ownership of the port: clear the id on the original so it can no
   // longer be used from this context.
-  port[MessagePortIdSymbol] = null;
+  setMessagePortId(port, null);
 
   // Allocate the wrapper inside the target context so its prototype chain
   // is the target realm's (i.e., `wrapper instanceof Object` in the caller
@@ -1858,7 +1859,9 @@ function receiveMessageOnPort(port: MessagePort): object | undefined {
     throw err;
   }
   port[MessagePortReceiveMessageOnPortSymbol] = true;
-  const data = op_message_port_recv_message_sync(port[MessagePortIdSymbol]);
+  const portId = getMessagePortId(port);
+  if (portId === null) return undefined;
+  const data = op_message_port_recv_message_sync(portId);
   if (data === null) return undefined;
   const message = deserializeJsMessageData(data)[0];
   patchMessagePortIfFound(message);
@@ -2085,13 +2088,14 @@ function webMessagePortToNodeMessagePort(port: MessagePort) {
       // `active: false` after the close event has fired. The underlying
       // resource may already be closed (recv loop saw end-of-stream);
       // swallow any "bad resource id" error from a redundant core.close.
-      if (port[MessagePortIdSymbol] !== null) {
+      const portId = getMessagePortId(port);
+      if (portId !== null) {
         try {
-          core.close(port[MessagePortIdSymbol]);
+          core.close(portId);
         } catch {
           // already closed
         }
-        port[MessagePortIdSymbol] = null;
+        setMessagePortId(port, null);
       }
       port.dispatchEvent(new Event("close"));
     });

--- a/ext/web/13_message_port.js
+++ b/ext/web/13_message_port.js
@@ -34,6 +34,7 @@ const {
   ReflectApply,
   SafeArrayIterator,
   SafeSet,
+  SafeWeakMap,
   StringFromCharCode,
   StringPrototypeCharCodeAt,
   Symbol,
@@ -44,6 +45,8 @@ const {
   TypeError,
   TypeErrorPrototype,
   Uint8Array,
+  WeakMapPrototypeGet,
+  WeakMapPrototypeSet,
 } = primordials;
 const {
   InterruptedPrototype,
@@ -121,8 +124,6 @@ class MessageChannel {
 webidl.configureInterface(MessageChannel);
 const MessageChannelPrototype = MessageChannel.prototype;
 
-const _id = Symbol("id");
-const MessagePortIdSymbol = _id;
 const MessagePortReceiveMessageOnPortSymbol = Symbol(
   "MessagePortReceiveMessageOnPort",
 );
@@ -136,6 +137,39 @@ const refMessagePort = Symbol("refMessagePort");
  * unref/ref on the global message event handler count. */
 const unrefParentPort = Symbol("unrefParentPort");
 
+/** @type {WeakMap<MessagePort, number | null>} */
+const messagePortIds = new SafeWeakMap();
+
+/**
+ * @param {MessagePort} port
+ * @returns {number | null}
+ */
+function getMessagePortId(port) {
+  const id = WeakMapPrototypeGet(messagePortIds, port);
+  if (id === undefined) {
+    throw new TypeError("Illegal invocation");
+  }
+  return id;
+}
+
+/**
+ * @param {MessagePort} port
+ * @param {number | null} id
+ */
+function setMessagePortId(port, id) {
+  WeakMapPrototypeSet(messagePortIds, port, id);
+}
+
+/**
+ * @param {MessagePort} port
+ * @returns {number | null}
+ */
+function takeMessagePortId(port) {
+  const id = getMessagePortId(port);
+  setMessagePortId(port, null);
+  return id;
+}
+
 /**
  * @param {number} id
  * @returns {MessagePort}
@@ -144,7 +178,7 @@ function createMessagePort(id) {
   const port = webidl.createBranded(MessagePort);
   port[core.hostObjectBrand] = "MessagePort";
   setEventTargetData(port);
-  port[_id] = id;
+  setMessagePortId(port, id);
   port[_enabled] = false;
   port[_messageEventListenerCount] = 0;
   port[_refed] = false;
@@ -226,8 +260,6 @@ class _MessagePortBase extends EventTarget {
 }
 
 class MessagePort extends _MessagePortBase {
-  /** @type {number | null} */
-  [_id] = null;
   /** @type {boolean} */
   [_enabled] = false;
   [_refed] = false;
@@ -263,7 +295,8 @@ class MessagePort extends _MessagePortBase {
     webidl.assertBranded(this, MessagePortPrototype);
     const prefix = "Failed to execute 'postMessage' on 'MessagePort'";
     webidl.requiredArguments(arguments.length, 1, prefix);
-    const portClosed = this[_id] === null;
+    const portId = getMessagePortId(this);
+    const portClosed = portId === null;
     // Fast path: no transferables - serialize and send in one shot,
     // bypassing the JsMessageData serde overhead
     if (
@@ -279,10 +312,10 @@ class MessagePort extends _MessagePortBase {
           "DataCloneError",
         );
       }
-      op_message_port_post_message_raw(
-        this[_id],
-        serializeMessageData(message, serializeErrorCb),
-      );
+      const data = serializeMessageData(message, serializeErrorCb);
+      const currentPortId = getMessagePortId(this);
+      if (currentPortId === null) return;
+      op_message_port_post_message_raw(currentPortId, data);
       return;
     }
     message = webidl.converters.any(message);
@@ -325,7 +358,7 @@ class MessagePort extends _MessagePortBase {
       for (let i = 0; i < transfer.length; i++) {
         const t = transfer[i];
         if (ObjectPrototypeIsPrototypeOf(MessagePortPrototype, t)) {
-          if (t[_id] === null) {
+          if (getMessagePortId(t) === null) {
             throw new DOMException(
               "MessagePort in transfer list is already detached",
               "DataCloneError",
@@ -351,7 +384,9 @@ class MessagePort extends _MessagePortBase {
     }
     if (portClosed) return;
     const data = serializeJsMessageData(message, transfer);
-    op_message_port_post_message(this[_id], data);
+    const currentPortId = getMessagePortId(this);
+    if (currentPortId === null) return;
+    op_message_port_post_message(currentPortId, data);
   }
 
   start() {
@@ -360,11 +395,12 @@ class MessagePort extends _MessagePortBase {
     (async () => {
       this[_enabled] = true;
       while (true) {
-        if (this[_id] === null) break;
+        const portId = getMessagePortId(this);
+        if (portId === null) break;
         let data;
         try {
           this[_dataPromise] = op_message_port_recv_message(
-            this[_id],
+            portId,
           );
           if (
             typeof this[nodeWorkerThreadCloseCb] === "function" &&
@@ -455,16 +491,16 @@ class MessagePort extends _MessagePortBase {
         cb();
       });
     }
-    if (this[_id] !== null) {
+    const portId = getMessagePortId(this);
+    if (portId !== null) {
       // Drain any already-queued messages synchronously before closing the
       // resource. Node guarantees that messages sent before the close()
       // call get dispatched even if the receiver closes mid-stream
       // (regression test #22762). Without this, messages buffered after
       // the current async recv resolved but before our handler called
       // close() would be silently dropped.
-      const portId = this[_id];
       try {
-        while (this[_id] === portId) {
+        while (getMessagePortId(this) === portId) {
           const data = op_message_port_recv_message_sync(portId);
           if (data === null) break;
           if (!dispatchPortMessageData(this, data)) break;
@@ -474,9 +510,9 @@ class MessagePort extends _MessagePortBase {
       }
       // The dispatch may have closed the port via a user handler that
       // re-entered close(); only tear down the resource if we still own it.
-      if (this[_id] === portId) {
+      if (getMessagePortId(this) === portId) {
         core.close(portId);
-        this[_id] = null;
+        setMessagePortId(this, null);
         nodeWorkerThreadMaybeInvokeCloseCb(this);
       }
     }
@@ -491,7 +527,7 @@ class MessagePort extends _MessagePortBase {
     return inspect(
       getCreateFilteredInspectProxy()({
         object: {
-          active: this[_id] !== null,
+          active: getMessagePortId(this) !== null,
           refed: this[_refed],
           onmessage: this.onmessage,
           onmessageerror: this.onmessageerror,
@@ -528,8 +564,7 @@ webidl.configureInterface(MessagePort);
 const MessagePortPrototype = MessagePort.prototype;
 
 core.registerTransferableResource("MessagePort", (port) => {
-  const id = port[_id];
-  port[_id] = null;
+  const id = takeMessagePortId(port);
   if (id === null) {
     throw new DOMException(
       "Can not transfer disentangled message port",
@@ -1124,7 +1159,7 @@ return {
   markNotSerializable,
   MessageChannel,
   MessagePort,
-  MessagePortIdSymbol,
+  getMessagePortId,
   MessagePortPrototype,
   MessagePortReceiveMessageOnPortSymbol,
   nodeWorkerThreadCloseCb,
@@ -1143,6 +1178,7 @@ return {
   refMessagePort,
   serializeJsMessageData,
   serializeMessageData,
+  setMessagePortId,
   structuredClone,
   unrefParentPort,
 };

--- a/ext/web/internal.d.ts
+++ b/ext/web/internal.d.ts
@@ -116,7 +116,8 @@ declare module "ext:deno_web/13_message_port.js" {
   }
   const MessageChannel: typeof MessageChannel;
   const MessagePort: typeof MessagePort;
-  const MessagePortIdSymbol: typeof MessagePortIdSymbol;
+  function getMessagePortId(port: MessagePort): number | null;
+  function setMessagePortId(port: MessagePort, id: number | null): void;
   function deserializeJsMessageData(
     messageData: messagePort.MessageData,
   ): [object, object[]];

--- a/tests/unit/message_channel_test.ts
+++ b/tests/unit/message_channel_test.ts
@@ -53,6 +53,86 @@ Deno.test("messagechannel no-transferables ports is empty frozen array", async (
   mc.port2.close();
 });
 
+Deno.test("message port resource is not mutable through own symbols", () => {
+  const { port1, port2 } = new MessageChannel();
+  const other = new MessageChannel();
+
+  try {
+    const idSymbol = Object.getOwnPropertySymbols(port1).find((symbol) =>
+      symbol.description === "id"
+    );
+    if (idSymbol !== undefined) {
+      const mutablePort = port1 as unknown as Record<symbol, unknown>;
+      const mutableOther = other.port1 as unknown as Record<symbol, unknown>;
+      mutablePort[idSymbol] = mutableOther[idSymbol];
+    }
+
+    port1.close();
+    other.port1.postMessage(null);
+  } finally {
+    for (const port of [port1, port2, other.port1, other.port2]) {
+      try {
+        port.close();
+      } catch {
+        // A failed close can leave the substituted wrapper stale.
+      }
+    }
+  }
+});
+
+Deno.test("message port transfer keeps the original resource", async () => {
+  const workerSource = encodeURIComponent(`
+    onmessage = ({ data: port }) => {
+      port.postMessage("worker");
+      port.close();
+      close();
+    };
+  `);
+  const worker = new Worker(`data:application/javascript,${workerSource}`, {
+    type: "module",
+  });
+  const carrier = new MessageChannel();
+  const other = new MessageChannel();
+  const received = Promise.withResolvers<string>();
+
+  worker.onerror = (event) => received.reject(event.error);
+  carrier.port2.onmessage = () => received.resolve("carrier");
+  other.port2.onmessage = () => received.resolve("other");
+
+  try {
+    const idSymbol = Object.getOwnPropertySymbols(carrier.port1).find(
+      (symbol) => symbol.description === "id",
+    );
+    if (idSymbol !== undefined) {
+      const mutableCarrier = carrier.port1 as unknown as Record<
+        symbol,
+        unknown
+      >;
+      const mutableOther = other.port1 as unknown as Record<symbol, unknown>;
+      mutableCarrier[idSymbol] = mutableOther[idSymbol];
+    }
+
+    worker.postMessage(carrier.port1, [carrier.port1]);
+    assertEquals(await received.promise, "carrier");
+  } finally {
+    worker.terminate();
+    for (
+      const port of [
+        carrier.port1,
+        carrier.port2,
+        other.port1,
+        other.port2,
+      ]
+    ) {
+      try {
+        port.close();
+      } catch {
+        // A failed transfer can leave the substituted wrapper stale.
+      }
+    }
+  }
+});
+
 Deno.test("messagechannel primitive fast path", async () => {
   // Primitives take a custom encoding that bypasses V8's structured-clone
   // serializer; verify a representative spread round-trips exactly, including


### PR DESCRIPTION
## Summary

- store `MessagePort` resource identifiers in module-private state
- share the internal accessors with the `node:worker_threads` integration
- cover attempts to replace a port's own-symbol identifier before close and worker transfer

## Why

`MessagePort` previously kept its internal resource identifier in a writable symbol-keyed own property. Changing that property could make later operations or transfers target a different local resource. Module-private state preserves the association between each port wrapper and its resource, while re-reading the state after serialization preserves reentrant close and transfer behavior.

## Testing

- `./tools/format.js ext/node/polyfills/worker_threads.ts ext/web/13_message_port.js ext/web/internal.d.ts tests/unit/message_channel_test.ts`
- `./tools/lint.js --js`
- `cargo build --bin deno`
- `cargo test unit::message_channel_test -- --nocapture`
- `cargo test unit_node::worker_threads_test -- --nocapture`
