### PR TITLE
fix(ext/crypto): preserve RSA-OAEP label bytes

### DIFF
--- a/ext/crypto/decrypt.rs
+++ b/ext/crypto/decrypt.rs
@@ -22,13 +22,6 @@ use ctr::Ctr64BE;
 use ctr::Ctr128BE;
 use ctr::cipher::StreamCipher;
 use rsa::pkcs1::DecodeRsaPrivateKey;
-use sha1::Sha1;
-use sha2::Sha256;
-use sha2::Sha384;
-use sha2::Sha512;
-use sha3::Sha3_256;
-use sha3::Sha3_384;
-use sha3::Sha3_512;
 
 use crate::shared::*;
 
@@ -85,45 +78,7 @@ pub(crate) fn decrypt_rsa_oaep(
   let key = key.as_rsa_private_key()?;
 
   let private_key = rsa::RsaPrivateKey::from_pkcs1_der(key)?;
-  let label = Some(String::from_utf8_lossy(&label).to_string());
-
-  let padding = match hash {
-    ShaHash::Sha1 => rsa::Oaep {
-      digest: Box::<Sha1>::default(),
-      mgf_digest: Box::<Sha1>::default(),
-      label,
-    },
-    ShaHash::Sha256 => rsa::Oaep {
-      digest: Box::<Sha256>::default(),
-      mgf_digest: Box::<Sha256>::default(),
-      label,
-    },
-    ShaHash::Sha384 => rsa::Oaep {
-      digest: Box::<Sha384>::default(),
-      mgf_digest: Box::<Sha384>::default(),
-      label,
-    },
-    ShaHash::Sha512 => rsa::Oaep {
-      digest: Box::<Sha512>::default(),
-      mgf_digest: Box::<Sha512>::default(),
-      label,
-    },
-    ShaHash::Sha3_256 => rsa::Oaep {
-      digest: Box::<Sha3_256>::default(),
-      mgf_digest: Box::<Sha3_256>::default(),
-      label,
-    },
-    ShaHash::Sha3_384 => rsa::Oaep {
-      digest: Box::<Sha3_384>::default(),
-      mgf_digest: Box::<Sha3_384>::default(),
-      label,
-    },
-    ShaHash::Sha3_512 => rsa::Oaep {
-      digest: Box::<Sha3_512>::default(),
-      mgf_digest: Box::<Sha3_512>::default(),
-      label,
-    },
-  };
+  let padding = rsa_oaep_padding(hash, &label);
 
   private_key
     .decrypt(padding, data)

--- a/ext/crypto/encrypt.rs
+++ b/ext/crypto/encrypt.rs
@@ -23,13 +23,6 @@ use ctr::Ctr64BE;
 use ctr::Ctr128BE;
 use rand::rngs::OsRng;
 use rsa::pkcs1::DecodeRsaPublicKey;
-use sha1::Sha1;
-use sha2::Sha256;
-use sha2::Sha384;
-use sha2::Sha512;
-use sha3::Sha3_256;
-use sha3::Sha3_384;
-use sha3::Sha3_512;
 
 use crate::shared::*;
 
@@ -77,49 +70,11 @@ pub(crate) fn encrypt_rsa_oaep(
   label: Vec<u8>,
   data: &[u8],
 ) -> Result<Vec<u8>, EncryptError> {
-  let label = String::from_utf8_lossy(&label).to_string();
-
   let public_key = key.as_rsa_public_key()?;
   let public_key = rsa::RsaPublicKey::from_pkcs1_der(&public_key)
     .map_err(|_| SharedError::FailedDecodePublicKey)?;
   let mut rng = OsRng;
-  let padding = match hash {
-    ShaHash::Sha1 => rsa::Oaep {
-      digest: Box::<Sha1>::default(),
-      mgf_digest: Box::<Sha1>::default(),
-      label: Some(label),
-    },
-    ShaHash::Sha256 => rsa::Oaep {
-      digest: Box::<Sha256>::default(),
-      mgf_digest: Box::<Sha256>::default(),
-      label: Some(label),
-    },
-    ShaHash::Sha384 => rsa::Oaep {
-      digest: Box::<Sha384>::default(),
-      mgf_digest: Box::<Sha384>::default(),
-      label: Some(label),
-    },
-    ShaHash::Sha512 => rsa::Oaep {
-      digest: Box::<Sha512>::default(),
-      mgf_digest: Box::<Sha512>::default(),
-      label: Some(label),
-    },
-    ShaHash::Sha3_256 => rsa::Oaep {
-      digest: Box::<Sha3_256>::default(),
-      mgf_digest: Box::<Sha3_256>::default(),
-      label: Some(label),
-    },
-    ShaHash::Sha3_384 => rsa::Oaep {
-      digest: Box::<Sha3_384>::default(),
-      mgf_digest: Box::<Sha3_384>::default(),
-      label: Some(label),
-    },
-    ShaHash::Sha3_512 => rsa::Oaep {
-      digest: Box::<Sha3_512>::default(),
-      mgf_digest: Box::<Sha3_512>::default(),
-      label: Some(label),
-    },
-  };
+  let padding = rsa_oaep_padding(hash, &label);
   let encrypted = public_key
     .encrypt(&mut rng, padding, data)
     .map_err(|_| EncryptError::Failed)?;

--- a/ext/crypto/shared.rs
+++ b/ext/crypto/shared.rs
@@ -12,6 +12,14 @@ use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::pkcs1::EncodeRsaPublicKey;
 use serde::Deserialize;
 use serde::Serialize;
+use sha1::Sha1;
+use sha2::Digest;
+use sha2::Sha256;
+use sha2::Sha384;
+use sha2::Sha512;
+use sha3::Sha3_256;
+use sha3::Sha3_384;
+use sha3::Sha3_512;
 
 pub const RSA_ENCRYPTION_OID: const_oid::ObjectIdentifier =
   const_oid::ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
@@ -39,6 +47,34 @@ pub enum ShaHash {
   Sha3_384,
   #[serde(rename = "SHA3-512")]
   Sha3_512,
+}
+
+fn rsa_oaep_padding_for_digest<D>(label: &[u8]) -> rsa::Oaep
+where
+  D: Digest + sha2::digest::DynDigest + Default + Send + Sync + 'static,
+{
+  let mut digest = D::default();
+  Digest::update(&mut digest, label);
+
+  // `rsa::Oaep` only accepts string labels. Preloading the label bytes into
+  // the label digest and passing an empty label preserves arbitrary bytes.
+  rsa::Oaep {
+    digest: Box::new(digest),
+    mgf_digest: Box::<D>::default(),
+    label: None,
+  }
+}
+
+pub(crate) fn rsa_oaep_padding(hash: ShaHash, label: &[u8]) -> rsa::Oaep {
+  match hash {
+    ShaHash::Sha1 => rsa_oaep_padding_for_digest::<Sha1>(label),
+    ShaHash::Sha256 => rsa_oaep_padding_for_digest::<Sha256>(label),
+    ShaHash::Sha384 => rsa_oaep_padding_for_digest::<Sha384>(label),
+    ShaHash::Sha512 => rsa_oaep_padding_for_digest::<Sha512>(label),
+    ShaHash::Sha3_256 => rsa_oaep_padding_for_digest::<Sha3_256>(label),
+    ShaHash::Sha3_384 => rsa_oaep_padding_for_digest::<Sha3_384>(label),
+    ShaHash::Sha3_512 => rsa_oaep_padding_for_digest::<Sha3_512>(label),
+  }
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]

--- a/tests/unit/webcrypto_test.ts
+++ b/tests/unit/webcrypto_test.ts
@@ -154,6 +154,62 @@ Deno.test(async function testEncryptDecrypt() {
   }
 });
 
+Deno.test(async function testRsaOaepLabelBytes() {
+  const subtle = globalThis.crypto.subtle;
+  const keyPair = await subtle.generateKey(
+    {
+      name: "RSA-OAEP",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["encrypt", "decrypt"],
+  );
+  const data = new TextEncoder().encode("Secret Message");
+  const labels = [
+    new Uint8Array([0x80]),
+    new Uint8Array([0x81]),
+    new TextEncoder().encode("ordinary label"),
+  ];
+  const cipherTexts: ArrayBuffer[] = [];
+
+  for (const label of labels) {
+    const cipherText = await subtle.encrypt(
+      { name: "RSA-OAEP", label },
+      keyPair.publicKey,
+      data,
+    );
+    cipherTexts.push(cipherText);
+
+    const decrypted = await subtle.decrypt(
+      { name: "RSA-OAEP", label },
+      keyPair.privateKey,
+      cipherText,
+    );
+    assertEquals(new Uint8Array(decrypted), data);
+  }
+
+  await assertRejects(
+    () =>
+      subtle.decrypt(
+        { name: "RSA-OAEP", label: labels[1] },
+        keyPair.privateKey,
+        cipherTexts[0],
+      ),
+    DOMException,
+  );
+  await assertRejects(
+    () =>
+      subtle.decrypt(
+        { name: "RSA-OAEP", label: labels[0] },
+        keyPair.privateKey,
+        cipherTexts[1],
+      ),
+    DOMException,
+  );
+});
+
 Deno.test(async function testGenerateRSAKey() {
   const subtle = globalThis.crypto.subtle;
   assert(subtle);


### PR DESCRIPTION
## Summary

- preserve arbitrary `BufferSource` bytes in RSA-OAEP labels
- use the same byte-preserving padding construction for encryption and decryption
- cover binary-label round trips and mismatched labels in WebCrypto unit tests

## Details

The pinned `rsa` crate represents OAEP labels as strings. Converting a WebCrypto label through UTF-8 can therefore change its bytes before the label hash is computed.

This change preloads the exact label bytes into the OAEP label digest and supplies an empty backend label. The separate MGF digest remains pristine. As a result, binary labels, ordinary text labels, and empty labels all follow the byte-oriented WebCrypto semantics without changing the dependency.

## Validation

- `./tools/format.js ext/crypto/shared.rs ext/crypto/encrypt.rs ext/crypto/decrypt.rs tests/unit/webcrypto_test.ts`
- `./x test-unit webcrypto`
- `./x build`
- manual Deno/Node RSA-OAEP interoperability check with a binary label
