### PR TITLE
fix(node_fs): require write permission for fd metadata

### DIFF
--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -156,6 +156,21 @@ fn file_for_fd(
     .ok_or_else(ebadf)
 }
 
+fn check_fd_metadata_write(
+  state: &OpState,
+  file: &Rc<dyn deno_io::fs::File>,
+  api_name: &'static str,
+) -> Result<(), FsError> {
+  if let Some(path) = file.maybe_path() {
+    state.borrow::<PermissionsContainer>().check_open(
+      Cow::Borrowed(path),
+      OpenAccessKind::WriteNoFollow,
+      Some(api_name),
+    )?;
+  }
+  Ok(())
+}
+
 /// When `sync_fs` is enabled, `FileSystemRc` is `Arc` (Send) and we can
 /// offload work to a blocking thread. Otherwise, run inline.
 macro_rules! maybe_spawn_blocking {
@@ -1240,6 +1255,7 @@ pub fn op_node_fs_futimes_sync(
   #[smi] mtime_nanos: u32,
 ) -> Result<(), FsError> {
   let file = file_for_fd(state, fd)?;
+  check_fd_metadata_write(state, &file, "node:fs.futimesSync()")?;
   file.utime_sync(atime_secs, atime_nanos, mtime_secs, mtime_nanos)?;
   Ok(())
 }
@@ -1253,7 +1269,12 @@ pub async fn op_node_fs_futimes(
   #[number] mtime_secs: i64,
   #[smi] mtime_nanos: u32,
 ) -> Result<(), FsError> {
-  let file = file_for_fd(&state.borrow(), fd)?;
+  let file = {
+    let state = state.borrow();
+    let file = file_for_fd(&state, fd)?;
+    check_fd_metadata_write(&state, &file, "node:fs.futimes()")?;
+    file
+  };
   file
     .utime_async(atime_secs, atime_nanos, mtime_secs, mtime_nanos)
     .await?;
@@ -1267,6 +1288,7 @@ pub fn op_node_fs_fchmod_sync(
   #[smi] mode: u32,
 ) -> Result<(), FsError> {
   let file = file_for_fd(state, fd)?;
+  check_fd_metadata_write(state, &file, "node:fs.fchmodSync()")?;
   file.chmod_sync(mode)?;
   Ok(())
 }
@@ -1277,7 +1299,12 @@ pub async fn op_node_fs_fchmod(
   fd: i32,
   #[smi] mode: u32,
 ) -> Result<(), FsError> {
-  let file = file_for_fd(&state.borrow(), fd)?;
+  let file = {
+    let state = state.borrow();
+    let file = file_for_fd(&state, fd)?;
+    check_fd_metadata_write(&state, &file, "node:fs.fchmod()")?;
+    file
+  };
   file.chmod_async(mode).await?;
   Ok(())
 }
@@ -1290,6 +1317,7 @@ pub fn op_node_fs_fchown_sync(
   #[smi] gid: u32,
 ) -> Result<(), FsError> {
   let file = file_for_fd(state, fd)?;
+  check_fd_metadata_write(state, &file, "node:fs.fchownSync()")?;
   file.chown_sync(Some(uid), Some(gid))?;
   Ok(())
 }
@@ -1301,7 +1329,12 @@ pub async fn op_node_fs_fchown(
   #[smi] uid: u32,
   #[smi] gid: u32,
 ) -> Result<(), FsError> {
-  let file = file_for_fd(&state.borrow(), fd)?;
+  let file = {
+    let state = state.borrow();
+    let file = file_for_fd(&state, fd)?;
+    check_fd_metadata_write(&state, &file, "node:fs.fchown()")?;
+    file
+  };
   file.chown_async(Some(uid), Some(gid)).await?;
   Ok(())
 }

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -529,6 +529,108 @@ Deno.test("[node/fs] fchmodSync works", {
   Deno.removeSync(tempFile);
 });
 
+Deno.test({
+  name: "[node/fs] fd metadata ops require write permission",
+  ignore: Deno.build.os === "windows",
+  permissions: { read: true, write: true, run: [Deno.execPath()] },
+  async fn() {
+    const dir = Deno.makeTempDirSync();
+    const target = join(dir, "target.txt");
+    const script = join(dir, "fd_metadata.mjs");
+    const originalTime = new Date(123_456_789_000);
+    const decoder = new TextDecoder();
+
+    try {
+      writeFileSync(target, "data");
+      chmodSync(target, 0o600);
+      Deno.utimeSync(target, originalTime, originalTime);
+      writeFileSync(
+        script,
+        `
+import {
+  closeSync,
+  fchmod,
+  fchmodSync,
+  fchown,
+  fchownSync,
+  futimes,
+  futimesSync,
+  openSync,
+} from "node:fs";
+
+const fd = openSync(Deno.args[0], "r");
+const uid = 0;
+const gid = 0;
+
+function report(name, err) {
+  console.log(
+    name + ":" + (err?.name ?? "ok") + ":" +
+      String(err?.message ?? "").includes("--allow-write")
+  );
+}
+
+function reportSync(name, fn) {
+  try {
+    fn();
+    report(name, undefined);
+  } catch (err) {
+    report(name, err);
+  }
+}
+
+await new Promise((resolve) =>
+  fchmod(fd, 0o777, (err) => {
+    report("fchmod", err);
+    resolve();
+  })
+);
+reportSync("fchmodSync", () => fchmodSync(fd, 0o777));
+await new Promise((resolve) =>
+  fchown(fd, uid, gid, (err) => {
+    report("fchown", err);
+    resolve();
+  })
+);
+reportSync("fchownSync", () => fchownSync(fd, uid, gid));
+await new Promise((resolve) =>
+  futimes(fd, new Date(1), new Date(1), (err) => {
+    report("futimes", err);
+    resolve();
+  })
+);
+reportSync("futimesSync", () =>
+  futimesSync(fd, new Date(1), new Date(1))
+);
+closeSync(fd);
+`,
+      );
+
+      const { code, stdout, stderr } = await new Deno.Command(
+        Deno.execPath(),
+        {
+          args: ["run", `--allow-read=${target}`, script, target],
+          stdout: "piped",
+          stderr: "piped",
+        },
+      ).output();
+      const stdoutText = decoder.decode(stdout);
+      assertEquals(code, 0, decoder.decode(stderr));
+      assert(stdoutText.includes("fchmod:NotCapable:true"));
+      assert(stdoutText.includes("fchmodSync:NotCapable:true"));
+      assert(stdoutText.includes("fchown:NotCapable:true"));
+      assert(stdoutText.includes("fchownSync:NotCapable:true"));
+      assert(stdoutText.includes("futimes:NotCapable:true"));
+      assert(stdoutText.includes("futimesSync:NotCapable:true"));
+
+      const stat = Deno.statSync(target);
+      assertEquals((stat.mode ?? 0) & 0o777, 0o600);
+      assertEquals(stat.mtime?.getTime(), originalTime.getTime());
+    } finally {
+      Deno.removeSync(dir, { recursive: true });
+    }
+  },
+});
+
 Deno.test("[node/fs/promises] lchown works", {
   ignore: Deno.build.os === "windows",
 }, async () => {


### PR DESCRIPTION
## Summary

- require write permission checks before path-backed `node:fs` descriptor metadata updates
- apply the same check to synchronous and asynchronous `fchmod`, `fchown`, and `futimes` operations
- keep pathless descriptor behavior unchanged and add regression coverage for read-only opens

## Why

Path-based metadata operations already use `WriteNoFollow`, but the descriptor variants performed the update after resolving the descriptor without applying the equivalent permission check. This makes the descriptor forms consistent with the rest of the filesystem API.

## Testing

- `./tools/format.js --check`
- `./tools/lint.js`
- `cargo build --bin deno`
- `cargo test -p unit_node_tests --test unit_node -- fs_test`
