### PR TITLE
fix(node/crypto): preserve binary key export passphrases

### DIFF
--- a/ext/node/polyfills/internal/crypto/keys.ts
+++ b/ext/node/polyfills/internal/crypto/keys.ts
@@ -939,8 +939,7 @@ class PrivateKeyObject extends AsymmetricKeyObject {
         this[kHandle],
         type,
         cipher ?? null,
-        // deno-lint-ignore deno-internal/prefer-primordials -- Buffer.prototype.toString has no primordial
-        passphrase != null ? passphrase.toString() : null,
+        passphrase ?? null,
       );
     } else {
       return Buffer.from(
@@ -948,8 +947,7 @@ class PrivateKeyObject extends AsymmetricKeyObject {
           this[kHandle],
           type,
           cipher ?? null,
-          // deno-lint-ignore deno-internal/prefer-primordials -- Buffer.prototype.toString has no primordial
-          passphrase != null ? passphrase.toString() : null,
+          passphrase ?? null,
         ),
       );
     }

--- a/ext/node/polyfills/internal/crypto/keys.ts
+++ b/ext/node/polyfills/internal/crypto/keys.ts
@@ -19,8 +19,10 @@ const {
   ObjectPrototypeIsPrototypeOf,
   StringPrototypeStartsWith,
   SymbolToStringTag,
+  TypedArrayPrototypeGetBuffer,
   TypeError,
   TypedArrayPrototypeGetByteLength,
+  TypedArrayPrototypeGetByteOffset,
   Uint8Array,
 } = primordials;
 
@@ -465,7 +467,16 @@ function parseKeyEncoding(
   }
 
   if (passphrase !== undefined) {
-    passphrase = getArrayBufferOrView(passphrase, "key.passphrase", encoding);
+    const view = getArrayBufferOrView(
+      passphrase,
+      "key.passphrase",
+      encoding,
+    );
+    passphrase = new Uint8Array(
+      TypedArrayPrototypeGetBuffer(view),
+      TypedArrayPrototypeGetByteOffset(view),
+      TypedArrayPrototypeGetByteLength(view),
+    );
   }
 
   return {

--- a/ext/node_crypto/keys.rs
+++ b/ext/node_crypto/keys.rs
@@ -4046,7 +4046,7 @@ pub fn op_node_export_private_key_pem(
   #[cppgc] handle: &KeyObjectHandle,
   #[string] typ: &str,
   #[string] cipher: Option<String>,
-  #[string] passphrase: Option<String>,
+  #[buffer] passphrase: Option<&[u8]>,
 ) -> Result<String, ExportPrivateKeyPemError> {
   let private_key = handle
     .as_private_key()
@@ -4060,24 +4060,15 @@ pub fn op_node_export_private_key_pem(
     _ => unreachable!("export_der would have errored"),
   };
 
-  match (&cipher, &passphrase) {
+  match (&cipher, passphrase) {
     (Some(cipher), Some(passphrase)) => {
       // Node.js uses PKCS#8 EncryptedPrivateKeyInfo for `pkcs8` exports with
       // a cipher (label "ENCRYPTED PRIVATE KEY"); for `pkcs1`/`sec1` it uses
       // the legacy OpenSSL PEM encryption format with Proc-Type/DEK-Info.
       if typ == "pkcs8" {
-        return encrypt_pkcs8_private_key_pem(
-          &data,
-          cipher,
-          passphrase.as_bytes(),
-        );
+        return encrypt_pkcs8_private_key_pem(&data, cipher, passphrase);
       }
-      return encrypt_private_key_pem(
-        label,
-        &data,
-        cipher,
-        passphrase.as_bytes(),
-      );
+      return encrypt_private_key_pem(label, &data, cipher, passphrase);
     }
     (Some(_), None) | (None, Some(_)) => {
       return Err(ExportPrivateKeyPemError::MissingCipherOrPassphrase);
@@ -4202,20 +4193,19 @@ pub fn op_node_export_private_key_der(
   #[cppgc] handle: &KeyObjectHandle,
   #[string] typ: &str,
   #[string] cipher: Option<String>,
-  #[string] passphrase: Option<String>,
+  #[buffer] passphrase: Option<&[u8]>,
 ) -> Result<Box<[u8]>, ExportPrivateKeyDerError> {
   let private_key = handle
     .as_private_key()
     .ok_or(AsymmetricPrivateKeyDerError::KeyIsNotAsymmetricPrivateKey)?;
   let data = private_key.export_der(typ)?;
 
-  match (&cipher, &passphrase) {
+  match (&cipher, passphrase) {
     (Some(cipher), Some(passphrase)) => {
       if typ != "pkcs8" {
         return Err(ExportPrivateKeyDerError::EncryptionRequiresPkcs8);
       }
-      let encrypted =
-        encrypt_private_key_pkcs8_der(&data, cipher, passphrase.as_bytes())?;
+      let encrypted = encrypt_private_key_pkcs8_der(&data, cipher, passphrase)?;
       Ok(encrypted.into_boxed_slice())
     }
     (Some(_), None) | (None, Some(_)) => {

--- a/tests/unit_node/crypto/crypto_key_test.ts
+++ b/tests/unit_node/crypto/crypto_key_test.ts
@@ -789,6 +789,90 @@ Deno.test("generateKeyPair promisify", async () => {
   assert(privateKey.startsWith("-----BEGIN ENCRYPTED PRIVATE KEY-----"));
 });
 
+Deno.test("private key export preserves passphrase bytes", async (t) => {
+  const { privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+  const expected = privateKey.export({ type: "pkcs8", format: "der" });
+  const bytes = [0xff, 0xfe, 0x80, 0x61, 0xc3];
+  const passphrases: [string, () => unknown][] = [
+    ["Buffer", () => Buffer.from(bytes)],
+    ["Uint8Array", () => new Uint8Array(bytes)],
+    ["ArrayBuffer", () => new Uint8Array(bytes).buffer],
+    [
+      "DataView",
+      () => {
+        const data = new Uint8Array([0, ...bytes, 0]);
+        return new DataView(data.buffer, 1, bytes.length);
+      },
+    ],
+    ["string", () => "pässphrase"],
+  ];
+
+  for (const format of ["pem", "der"] as const) {
+    for (const [name, createPassphrase] of passphrases) {
+      await t.step(`${format} ${name}`, () => {
+        const passphrase = createPassphrase();
+        const encrypted = privateKey.export({
+          type: "pkcs8",
+          format,
+          cipher: "aes-256-cbc",
+          passphrase,
+        } as any);
+        const imported = createPrivateKey({
+          key: encrypted,
+          type: "pkcs8",
+          format,
+          passphrase,
+        } as any);
+        assertEquals(
+          imported.export({ type: "pkcs8", format: "der" }),
+          expected,
+        );
+      });
+    }
+  }
+});
+
+Deno.test("private key export validates passphrase options", () => {
+  const { privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+
+  for (const passphrase of [undefined, null, 1, {}, true]) {
+    const error = assertThrows(
+      () =>
+        privateKey.export({
+          type: "pkcs8",
+          format: "pem",
+          cipher: "aes-256-cbc",
+          passphrase,
+        } as any),
+      TypeError,
+      "options.passphrase",
+    );
+    assertEquals(
+      (error as Error & { code: string }).code,
+      "ERR_INVALID_ARG_VALUE",
+    );
+  }
+
+  const error = assertThrows(
+    () =>
+      privateKey.export({
+        type: "pkcs8",
+        format: "pem",
+        passphrase: "secret",
+      } as any),
+    TypeError,
+    "options.cipher",
+  );
+  assertEquals(
+    (error as Error & { code: string }).code,
+    "ERR_INVALID_ARG_VALUE",
+  );
+});
+
 Deno.test("RSA export private JWK", function () {
   // @ts-ignore @types/node broken
   const { privateKey, publicKey } = generateKeyPairSync("rsa", {

--- a/tests/unit_node/crypto/crypto_key_test.ts
+++ b/tests/unit_node/crypto/crypto_key_test.ts
@@ -795,16 +795,21 @@ Deno.test("private key export preserves passphrase bytes", async (t) => {
   });
   const expected = privateKey.export({ type: "pkcs8", format: "der" });
   const bytes = [0xff, 0xfe, 0x80, 0x61, 0xc3];
-  const passphrases: [string, () => unknown][] = [
-    ["Buffer", () => Buffer.from(bytes)],
-    ["Uint8Array", () => new Uint8Array(bytes)],
-    ["ArrayBuffer", () => new Uint8Array(bytes).buffer],
+  const passphrases: [
+    string,
+    () => unknown,
+    readonly number[] | string,
+  ][] = [
+    ["Buffer", () => Buffer.from(bytes), bytes],
+    ["Uint8Array", () => new Uint8Array(bytes), bytes],
+    ["ArrayBuffer", () => new Uint8Array(bytes).buffer, bytes],
     [
       "DataView",
       () => {
         const data = new Uint8Array([0, ...bytes, 0]);
         return new DataView(data.buffer, 1, bytes.length);
       },
+      bytes,
     ],
     [
       "Int8Array",
@@ -813,6 +818,7 @@ Deno.test("private key export preserves passphrase bytes", async (t) => {
         const passphrase = new Int8Array(data.buffer, 1, bytes.length);
         return passphrase;
       },
+      bytes,
     ],
     [
       "Uint16Array",
@@ -822,6 +828,7 @@ Deno.test("private key export preserves passphrase bytes", async (t) => {
         const passphrase = new Uint16Array(data.buffer, 2, 2);
         return passphrase;
       },
+      [0xff, 0xfe, 0x80, 0xc3],
     ],
     [
       "Float32Array",
@@ -831,14 +838,16 @@ Deno.test("private key export preserves passphrase bytes", async (t) => {
         const passphrase = new Float32Array(data.buffer, 4, 1);
         return passphrase;
       },
+      [0xff, 0xfe, 0x80, 0xc3],
     ],
-    ["string", () => "pässphrase"],
+    ["string", () => "pässphrase", "pässphrase"],
   ];
 
   for (const format of ["pem", "der"] as const) {
-    for (const [name, createPassphrase] of passphrases) {
+    for (const [name, createPassphrase, expectedPassphrase] of passphrases) {
       await t.step(`${format} ${name}`, () => {
         const passphrase = createPassphrase();
+        const expectedPassphraseBytes = Buffer.from(expectedPassphrase);
         const encrypted = privateKey.export({
           type: "pkcs8",
           format,
@@ -849,15 +858,45 @@ Deno.test("private key export preserves passphrase bytes", async (t) => {
           key: encrypted,
           type: "pkcs8",
           format,
-          passphrase,
+          passphrase: expectedPassphraseBytes,
         } as any);
         assertEquals(
           imported.export({ type: "pkcs8", format: "der" }),
           expected,
         );
+
+        const importedWithOriginalView = createPrivateKey({
+          key: encrypted,
+          type: "pkcs8",
+          format,
+          passphrase,
+        } as any);
+        assertEquals(
+          importedWithOriginalView.export({ type: "pkcs8", format: "der" }),
+          expected,
+        );
       });
     }
   }
+
+  await t.step("pem sec1 Buffer", () => {
+    const passphrase = Buffer.from(bytes);
+    const encrypted = privateKey.export({
+      type: "sec1",
+      format: "pem",
+      cipher: "aes-256-cbc",
+      passphrase,
+    });
+    const imported = createPrivateKey({
+      key: encrypted,
+      format: "pem",
+      passphrase,
+    });
+    assertEquals(
+      imported.export({ type: "pkcs8", format: "der" }),
+      expected,
+    );
+  });
 });
 
 Deno.test("private key export validates passphrase options", () => {

--- a/tests/unit_node/crypto/crypto_key_test.ts
+++ b/tests/unit_node/crypto/crypto_key_test.ts
@@ -806,6 +806,32 @@ Deno.test("private key export preserves passphrase bytes", async (t) => {
         return new DataView(data.buffer, 1, bytes.length);
       },
     ],
+    [
+      "Int8Array",
+      () => {
+        const data = new Uint8Array([0, ...bytes, 0]);
+        const passphrase = new Int8Array(data.buffer, 1, bytes.length);
+        return passphrase;
+      },
+    ],
+    [
+      "Uint16Array",
+      () => {
+        const data = new Uint8Array(8);
+        data.set([0xff, 0xfe, 0x80, 0xc3], 2);
+        const passphrase = new Uint16Array(data.buffer, 2, 2);
+        return passphrase;
+      },
+    ],
+    [
+      "Float32Array",
+      () => {
+        const data = new Uint8Array(12);
+        data.set([0xff, 0xfe, 0x80, 0xc3], 4);
+        const passphrase = new Float32Array(data.buffer, 4, 1);
+        return passphrase;
+      },
+    ],
     ["string", () => "pässphrase"],
   ];
 


### PR DESCRIPTION
## Summary

- preserve normalized passphrase bytes when exporting encrypted private keys
- normalize every accepted passphrase view to its exact byte range before native PEM and PKCS#8 DER export
- add interoperability-style byte-range, legacy PEM, and validation coverage for Node-compatible passphrase types

## Details

`KeyObject#export()` normalized passphrases to byte views but converted them to strings before calling native encryption. Binary inputs could therefore use different bytes than supplied.

The native exporters now accept the normalized bytes directly. Passphrase parsing also converts accepted typed-array views to a byte-oriented `Uint8Array` using the backing buffer, byte offset, and byte length. This preserves non-UTF-8 data and offset view boundaries while ordinary string inputs remain UTF-8 encoded.

The tests cover Buffer values containing non-UTF-8 bytes, Uint8Array, ArrayBuffer, offset DataView and typed-array views (`Int8Array`, `Uint16Array`, and `Float32Array`), and ordinary strings across PKCS#8 PEM and DER exports. Offset views are checked against independent exact-byte passphrases, and coverage also includes legacy SEC1 PEM encryption and invalid option behavior.

## Tests

- `./tools/format.js --check`
- `./tools/lint.js --js`
- `cargo fmt --check`
- `cargo check -p deno_node_crypto --features deno_core/v8`
- `RUSTC_WRAPPER= cargo build --bin deno`
- `./target/debug/deno test --config tests/config/deno.json --no-lock --unstable-net -A --parallel tests/unit_node/crypto/crypto_key_test.ts`
