### PR TITLE
fix(npm): skip rewriting unchanged bin shims to avoid Windows os error 32

### DIFF
--- a/libs/npm_installer/bin_entries.rs
+++ b/libs/npm_installer/bin_entries.rs
@@ -20,6 +20,7 @@ use sys_traits::FsFileSetPermissions;
 use sys_traits::FsMetadata;
 use sys_traits::FsMetadataValue;
 use sys_traits::FsOpen;
+use sys_traits::FsRead;
 use sys_traits::FsReadLink;
 use sys_traits::FsRemoveFile;
 use sys_traits::FsSymlinkFile;
@@ -402,6 +403,7 @@ pub trait SetupBinEntrySys:
   + FsCreateDirAll
   + FsMetadata
   + FsReadLink
+  + FsRead
 {
 }
 

--- a/libs/npm_installer/bin_entries/windows_shim.rs
+++ b/libs/npm_installer/bin_entries/windows_shim.rs
@@ -25,6 +25,7 @@ use std::path::PathBuf;
 
 use sys_traits::FsMetadata;
 use sys_traits::FsOpen;
+use sys_traits::FsRead;
 use sys_traits::FsWrite;
 use sys_traits::PathsInErrorsExt;
 
@@ -297,7 +298,7 @@ impl ShimData {
 }
 
 pub fn set_up_bin_shim<'a>(
-  sys: &(impl FsOpen + FsWrite + FsMetadata),
+  sys: &(impl FsOpen + FsWrite + FsMetadata + FsRead),
   package: &'a deno_npm::NpmResolutionPackage,
   extra: &'a deno_npm::NpmPackageExtraInfo,
   bin_name: &'a str,
@@ -339,8 +340,26 @@ pub fn set_up_bin_shim<'a>(
   let shebang = resolve_shebang(sys.as_ref(), &target_file);
   let shim = ShimData::new(rel_target.to_string_lossy(), shebang);
 
-  let write_shim =
-    |path: PathBuf, contents: &str| sys.fs_write(&path, contents);
+  let write_shim = |path: PathBuf, contents: &str| -> std::io::Result<()> {
+    if let Ok(existing) = sys.fs_read(&path) {
+      if existing == contents.as_bytes() {
+        return Ok(());
+      }
+    }
+    // retry on Windows sharing violation (os error 32) when another deno process holds the file
+    let mut last_err = None;
+    for _ in 0..3 {
+      match sys.fs_write(&path, contents) {
+        Ok(()) => return Ok(()),
+        Err(e) if e.raw_os_error() == Some(32) => {
+          last_err = Some(e);
+          std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        Err(e) => return Err(e),
+      }
+    }
+    Err(last_err.unwrap())
+  };
 
   write_shim(shim_path.with_extension("cmd"), &shim.generate_cmd())?;
   write_shim(shim_path.clone(), &shim.generate_sh())?;

--- a/libs/npm_installer/bin_entries/windows_shim.rs
+++ b/libs/npm_installer/bin_entries/windows_shim.rs
@@ -33,6 +33,8 @@ use crate::bin_entries::EntrySetupOutcome;
 use crate::bin_entries::bin_script_stays_in_package;
 use crate::bin_entries::relative_path;
 
+const ERROR_SHARING_VIOLATION: i32 = 32;
+
 // note: parts of logic and pretty much all of the shims ported from https://github.com/npm/cmd-shim
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct Shebang {
@@ -351,7 +353,7 @@ pub fn set_up_bin_shim<'a>(
     for _ in 0..3 {
       match sys.fs_write(&path, contents) {
         Ok(()) => return Ok(()),
-        Err(e) if e.raw_os_error() == Some(32) => {
+        Err(e) if e.raw_os_error() == Some(ERROR_SHARING_VIOLATION) => {
           last_err = Some(e);
           std::thread::sleep(std::time::Duration::from_millis(10));
         }


### PR DESCRIPTION
Fixes #36423

Concurrent deno check/run/test/task all rewrite 147 bin shims in node_modules/.bin even when contents are unchanged. On Windows concurrent LSP plus dev server plus test regularly collide with os error 32 sharing violation.

This change reads the existing file before writing and skips the write when the new content is byte-identical. When a sharing violation does occur it retries up to 3 times with a short backoff before failing. The trait bound now includes FsRead so the existing file can be compared without changing public behaviour.

Assisted-by: Codex