### PR TITLE
chore(release): handle renamed deno_v8 dep in version bump

### DIFF
--- a/tools/release/01_bump_crate_versions.ts
+++ b/tools/release/01_bump_crate_versions.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env -S deno run -A --lock=tools/deno.lock.json
 // Copyright 2018-2026 the Deno authors. MIT license.
 import { DenoWorkspace } from "./deno_workspace.ts";
-import { $, GitLogOutput, semver } from "./deps.ts";
+import { $, type Crate, GitLogOutput, semver } from "./deps.ts";
+
+// Crates that the root Cargo.toml declares under a key that differs from the
+// crate name (ex. `v8 = { package = "deno_v8", ... }`). The release automation
+// finds dependency entries by matching the crate name at the start of a line,
+// so it can't see these and errors out. Bump them by hand instead.
+const renamedCrates = new Set(["deno_v8"]);
 
 const workspace = await DenoWorkspace.load();
 const repo = workspace.repo;
@@ -57,7 +63,11 @@ denoLibCrate.folderPath.join("version.txt").writeTextSync(cliCrate.version);
 
 // increment the dependency crate versions
 for (const crate of workspace.getCliDependencyCrates()) {
-  await crate.increment("minor");
+  if (renamedCrates.has(crate.name)) {
+    incrementRenamedCrateMinor(crate);
+  } else {
+    await crate.increment("minor");
+  }
 }
 
 // update the lock file
@@ -75,6 +85,51 @@ try {
       "`git log --oneline VERSION_FROM..VERSION_TO` and " +
       "use the output to update Releases.md",
   );
+}
+
+/** Bumps the minor version of a crate that's declared in the root Cargo.toml
+ * under a renamed dependency key. */
+function incrementRenamedCrateMinor(crate: Crate) {
+  const oldVersion = crate.version;
+  const newVersion = semver.format(
+    semver.increment(semver.parse(oldVersion)!, "minor"),
+  );
+  $.logStep(`Setting ${crate.name} to ${newVersion}...`);
+
+  // the dependency entry in the root Cargo.toml
+  updateFileEnsureChange(
+    workspace.repo.folderPath.join("Cargo.toml").toString(),
+    (text) =>
+      text.replace(
+        new RegExp(
+          `^(.*\\bpackage\\s*=\\s*"${crate.name}".*?\\bversion\\s*=\\s*)"[^"]+"`,
+          "m",
+        ),
+        `$1"${newVersion}"`,
+      ),
+  );
+
+  // the crate's own manifest
+  updateFileEnsureChange(
+    crate.manifestPath.toString(),
+    (text) =>
+      text.replace(
+        new RegExp(`^(version\\s*=\\s*)"${oldVersion}"$`, "m"),
+        `$1"${newVersion}"`,
+      ),
+  );
+}
+
+function updateFileEnsureChange(
+  filePath: string,
+  action: (fileText: string) => string,
+) {
+  const originalText = Deno.readTextFileSync(filePath);
+  const newText = action(originalText);
+  if (originalText === newText) {
+    throw new Error(`The file didn't change: ${filePath}`);
+  }
+  Deno.writeTextFileSync(filePath, newText);
 }
 
 async function updateReleasesMd() {


### PR DESCRIPTION
The `version_bump` workflow fails when it reaches `deno_v8`:

    Setting deno_v8 to 0.2.0...
    error: Uncaught (in promise) Error: The file didn't change: cli/Cargo.toml
        at updateFileEnsureChange (jsr:@deno/rust-automation/0.22.2/crate.ts:311)

The root `Cargo.toml` declares the crate under a renamed key —
`v8 = { package = "deno_v8", ... }` — but the release automation locates
version literals with a regex anchored on the crate name at the start of a
line. It therefore misses the root entry, concludes the repo keeps versions in
the member manifests, and falls back to rewriting every dependent's
`Cargo.toml`. In `cli/Cargo.toml` the entry is `v8.workspace = true`, which has
no version literal either, so the helper throws rather than no-op'ing and the
release is blocked.

This special-cases such crates in `01_bump_crate_versions.ts`: a small set of
known renamed crates is bumped by hand, rewriting the version in the root
dependency entry (matched via `package = "<name>"`) and in the crate's own
manifest, and skipping the automation's dependency propagation entirely.

The same commit is already on the `v2.9` branch so the 2.9.5 bump can proceed;
this brings it to `main`.