### PR TITLE
feat: add compression support for 'text/x-component' content type

### DIFF
--- a/ext/http/compressible.rs
+++ b/ext/http/compressible.rs
@@ -609,6 +609,7 @@ static CONTENT_TYPES: phf::Set<&'static [u8]> = phf_set! {
   b"text/uri-list",
   b"text/vcard",
   b"text/vtt",
+  b"text/x-component",
   b"text/x-gwt-rpc",
   b"text/x-jquery-tmpl",
   b"text/x-markdown",
@@ -653,5 +654,7 @@ mod tests {
     assert!(is_content_compressible("application/json"));
     assert!(is_content_compressible("text/plain;charset=UTF-8"));
     assert!(is_content_compressible("text/PlAIn; charset=utf-8"));
+    assert!(is_content_compressible("text/x-component"));
+    assert!(is_content_compressible("text/X-Component; charset=utf-8"));
   }
 }


### PR DESCRIPTION
Adding support for react server component content type into the compression list