### PR TITLE
fix(ext/napi): align Unix uv_poll with libuv semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10329,6 +10329,7 @@ dependencies = [
 name = "test_napi"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "libuv-sys-lite",
  "napi_sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10374,6 +10374,7 @@ dependencies = [
 name = "test_napi"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "libuv-sys-lite",
  "napi_sys",
 ]

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -620,8 +620,13 @@ pub struct Env {
   pub async_hooks_after: v8::Global<v8::Function>,
   pub async_hooks_destroy: v8::Global<v8::Function>,
   pub next_async_id: i64,
+  // Models libuv's uv__fd_exists registry by recording which handle has an
+  // active I/O watcher for each fd. Only poll handles currently participate
+  // here, while libuv uses the registry for other I/O watcher types as well.
+  // Addons must stop or close a poll handle before closing its fd; otherwise a
+  // reused fd number can remain registered and cause an unexpected UV_EEXIST.
   #[cfg(unix)]
-  active_poll_fds: HashMap<i32, usize>,
+  fd_watchers: HashMap<i32, usize>,
 }
 
 unsafe impl Send for Env {}
@@ -657,7 +662,7 @@ impl Env {
       async_hooks_destroy,
       next_async_id: 1,
       #[cfg(unix)]
-      active_poll_fds: HashMap::new(),
+      fd_watchers: HashMap::new(),
       shared: std::ptr::null_mut(),
       open_handle_scopes: 0,
       open_callback_scopes: 0,
@@ -875,24 +880,31 @@ fn drain_gc_finalizers(
   }
 
   #[cfg(unix)]
-  pub(crate) fn try_acquire_poll_fd(
+  pub(crate) fn get_fd_watcher(&self, fd: i32) -> Option<usize> {
+    self.fd_watchers.get(&fd).copied()
+  }
+
+  // Registration is idempotent for the same watcher and refuses to replace a
+  // different watcher already registered for the fd.
+  #[cfg(unix)]
+  pub(crate) fn register_fd_watcher(
     &mut self,
     fd: i32,
-    poll_addr: usize,
+    watcher_addr: usize,
   ) -> bool {
-    match self.active_poll_fds.get(&fd) {
-      Some(owner) if *owner != poll_addr => false,
-      _ => {
-        self.active_poll_fds.insert(fd, poll_addr);
+    match self.fd_watchers.get(&fd) {
+      Some(current) => *current == watcher_addr,
+      None => {
+        self.fd_watchers.insert(fd, watcher_addr);
         true
       }
     }
   }
 
   #[cfg(unix)]
-  pub(crate) fn release_poll_fd(&mut self, fd: i32, poll_addr: usize) {
-    if self.active_poll_fds.get(&fd) == Some(&poll_addr) {
-      self.active_poll_fds.remove(&fd);
+  pub(crate) fn unregister_fd_watcher(&mut self, fd: i32, watcher_addr: usize) {
+    if self.fd_watchers.get(&fd) == Some(&watcher_addr) {
+      self.fd_watchers.remove(&fd);
     }
   }
 }

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -620,6 +620,8 @@ pub struct Env {
   pub async_hooks_after: v8::Global<v8::Function>,
   pub async_hooks_destroy: v8::Global<v8::Function>,
   pub next_async_id: i64,
+  #[cfg(unix)]
+  active_poll_fds: HashMap<i32, usize>,
 }
 
 unsafe impl Send for Env {}
@@ -654,6 +656,8 @@ impl Env {
       async_hooks_after,
       async_hooks_destroy,
       next_async_id: 1,
+      #[cfg(unix)]
+      active_poll_fds: HashMap::new(),
       shared: std::ptr::null_mut(),
       open_handle_scopes: 0,
       open_callback_scopes: 0,
@@ -867,6 +871,28 @@ fn drain_gc_finalizers(
     // Backstop for a throw that escaped without being recorded.
     if let Some(exception) = tc.exception() {
       report_finalizer_exception(tc, exception);
+    }
+  }
+
+  #[cfg(unix)]
+  pub(crate) fn try_acquire_poll_fd(
+    &mut self,
+    fd: i32,
+    poll_addr: usize,
+  ) -> bool {
+    match self.active_poll_fds.get(&fd) {
+      Some(owner) if *owner != poll_addr => false,
+      _ => {
+        self.active_poll_fds.insert(fd, poll_addr);
+        true
+      }
+    }
+  }
+
+  #[cfg(unix)]
+  pub(crate) fn release_poll_fd(&mut self, fd: i32, poll_addr: usize) {
+    if self.active_poll_fds.get(&fd) == Some(&poll_addr) {
+      self.active_poll_fds.remove(&fd);
     }
   }
 }

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -497,12 +497,12 @@ impl Drop for NapiState {
       crate::js_native_api::detach_external_string_env(*env_ptr);
     }
 
-    // Invalidate each Env's poll owner before addon cleanup hooks run, so
+    // Invalidate each Env's poll scope before addon cleanup hooks run, so
     // queued readiness cannot invoke addon callbacks during cleanup. The
-    // worker identifies the owner only by token.
+    // worker identifies handles and scopes only by numeric token and scope ID.
     #[cfg(unix)]
     for env_ptr in &self.env_ptrs {
-      unsafe { (*(*env_ptr)).poll_owner.invalidate() };
+      unsafe { (*(*env_ptr)).poll_scope.invalidate() };
     }
 
     let hooks = {
@@ -635,7 +635,7 @@ pub struct Env {
   #[cfg(unix)]
   pub(crate) uv_loop_liveness: Arc<deno_core::uv_compat::UvLoopLiveness>,
   #[cfg(unix)]
-  pub(crate) poll_owner: deno_core::uv_compat::UvPollOwner,
+  pub(crate) poll_scope: deno_core::uv_compat::UvPollScope,
 }
 
 unsafe impl Send for Env {}
@@ -660,7 +660,7 @@ impl Env {
     external_ops_tracker: ExternalOpsTracker,
     #[cfg(unix)] uv_loop: *mut deno_core::uv_compat::uv_loop_t,
     #[cfg(unix)] uv_loop_liveness: Arc<deno_core::uv_compat::UvLoopLiveness>,
-    #[cfg(unix)] poll_owner: deno_core::uv_compat::UvPollOwner,
+    #[cfg(unix)] poll_scope: deno_core::uv_compat::UvPollScope,
   ) -> Self {
     Self {
       isolate_ptr,
@@ -678,7 +678,7 @@ impl Env {
       #[cfg(unix)]
       uv_loop_liveness,
       #[cfg(unix)]
-      poll_owner,
+      poll_scope,
       shared: std::ptr::null_mut(),
       open_handle_scopes: 0,
       open_callback_scopes: 0,
@@ -996,12 +996,14 @@ fn op_napi_open<'scope>(
   }
 
   // Unix uv_poll forwards to the backing libuv-compatible loop.
-  // `poll_owner` and `uv_loop_liveness` cover independent teardown orders:
-  // the owner suppresses queued callbacks after this Env begins cleanup while
-  // the loop remains live; liveness prevents Env cleanup from accessing a loop
-  // already in teardown.
+  // `poll_scope` and `uv_loop_liveness` cover either teardown order:
+  // the poll scope suppresses queued callbacks during N-API teardown while
+  // the loop is still live; the liveness guard serializes loop-state access
+  // with loop teardown, waiting for in-flight operations and making later
+  // `uv_loop_operation_guard` calls return `None` once teardown invalidates
+  // liveness.
   #[cfg(unix)]
-  let (uv_loop, uv_loop_liveness, poll_owner) = {
+  let (uv_loop, uv_loop_liveness, poll_scope) = {
     let op_state = op_state.borrow();
     let uv_loop = &**op_state.borrow::<Box<deno_core::uv_compat::UvLoop>>()
       as *const deno_core::uv_compat::UvLoop
@@ -1009,7 +1011,7 @@ fn op_napi_open<'scope>(
     (
       uv_loop,
       unsafe { deno_core::uv_compat::uv_loop_liveness(uv_loop) },
-      unsafe { deno_core::uv_compat::new_poll_owner(uv_loop) },
+      unsafe { deno_core::uv_compat::new_poll_scope(uv_loop) },
     )
   };
 
@@ -1071,7 +1073,7 @@ fn op_napi_open<'scope>(
     #[cfg(unix)]
     uv_loop_liveness,
     #[cfg(unix)]
-    poll_owner,
+    poll_scope,
   );
   env.shared = Box::into_raw(Box::new(env_shared));
   // Track the EnvShared pointer so we can call instance data finalize

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -978,19 +978,6 @@ fn op_napi_open<'scope>(
     )
   };
 
-  #[cfg(unix)]
-  let (uv_loop, uv_loop_liveness, poll_owner) = {
-    let op_state = op_state.borrow();
-    let uv_loop = &**op_state.borrow::<Box<deno_core::uv_compat::UvLoop>>()
-      as *const deno_core::uv_compat::UvLoop
-      as *mut deno_core::uv_compat::uv_loop_t;
-    (
-      uv_loop,
-      unsafe { deno_core::uv_compat::uv_loop_liveness(uv_loop) },
-      unsafe { deno_core::uv_compat::new_poll_owner(uv_loop) },
-    )
-  };
-
   // Register the uv_compat loop so that our libuv-ABI `uv_timer_*`
   // polyfills bridge onto Deno's event loop instead of degrading to
   // no-ops. The loop pointer is opaque to addons — they only pass it
@@ -1006,6 +993,24 @@ fn op_napi_open<'scope>(
       crate::uv::register_default_uv_loop(loop_ptr);
     }
   }
+
+  // Unix uv_poll forwards to the backing libuv-compatible loop.
+  // `poll_owner` and `uv_loop_liveness` cover independent teardown orders:
+  // the owner suppresses queued callbacks after this Env begins cleanup while
+  // the loop remains live; liveness prevents Env cleanup from accessing a loop
+  // already in teardown.
+  #[cfg(unix)]
+  let (uv_loop, uv_loop_liveness, poll_owner) = {
+    let op_state = op_state.borrow();
+    let uv_loop = &**op_state.borrow::<Box<deno_core::uv_compat::UvLoop>>()
+      as *const deno_core::uv_compat::UvLoop
+      as *mut deno_core::uv_compat::uv_loop_t;
+    (
+      uv_loop,
+      unsafe { deno_core::uv_compat::uv_loop_liveness(uv_loop) },
+      unsafe { deno_core::uv_compat::new_poll_owner(uv_loop) },
+    )
+  };
 
   // Use per-isolate Private keys (like Node.js) so that objects wrapped by one
   // addon can be unwrapped by another. Lazily create on first addon load.

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -497,8 +497,9 @@ impl Drop for NapiState {
       crate::js_native_api::detach_external_string_env(*env_ptr);
     }
 
-    // Suppress queued core-poll callbacks before addon cleanup hooks can stop
-    // or close their ABI handles. The worker knows only the owner token.
+    // Invalidate each Env's poll owner before addon cleanup hooks run, so
+    // queued readiness cannot invoke addon callbacks during cleanup. The
+    // worker identifies the owner only by token.
     #[cfg(unix)]
     for env_ptr in &self.env_ptrs {
       unsafe { (*(*env_ptr)).poll_owner.invalidate() };

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -39,6 +39,8 @@ use std::path::Path;
 use std::path::PathBuf;
 pub use std::ptr;
 use std::rc::Rc;
+#[cfg(unix)]
+use std::sync::Arc;
 use std::thread_local;
 
 use deno_core::ExternalOpsTracker;
@@ -495,6 +497,13 @@ impl Drop for NapiState {
       crate::js_native_api::detach_external_string_env(*env_ptr);
     }
 
+    // Suppress queued core-poll callbacks before addon cleanup hooks can stop
+    // or close their ABI handles. The worker knows only the owner token.
+    #[cfg(unix)]
+    for env_ptr in &self.env_ptrs {
+      unsafe { (*(*env_ptr)).poll_owner.invalidate() };
+    }
+
     let hooks = {
       let h = self.env_cleanup_hooks.borrow_mut();
       h.clone()
@@ -620,13 +629,12 @@ pub struct Env {
   pub async_hooks_after: v8::Global<v8::Function>,
   pub async_hooks_destroy: v8::Global<v8::Function>,
   pub next_async_id: i64,
-  // Models libuv's uv__fd_exists registry by recording which handle has an
-  // active I/O watcher for each fd. Only poll handles currently participate
-  // here, while libuv uses the registry for other I/O watcher types as well.
-  // Addons must stop or close a poll handle before closing its fd; otherwise a
-  // reused fd number can remain registered and cause an unexpected UV_EEXIST.
   #[cfg(unix)]
-  fd_watchers: HashMap<i32, usize>,
+  pub(crate) uv_loop: *mut deno_core::uv_compat::uv_loop_t,
+  #[cfg(unix)]
+  pub(crate) uv_loop_liveness: Arc<deno_core::uv_compat::UvLoopLiveness>,
+  #[cfg(unix)]
+  pub(crate) poll_owner: deno_core::uv_compat::UvPollOwner,
 }
 
 unsafe impl Send for Env {}
@@ -649,6 +657,9 @@ impl Env {
     cleanup_hooks: Rc<RefCell<Vec<(napi_cleanup_hook, *mut c_void)>>>,
     ref_tracker: Rc<RefCell<RefTracker>>,
     external_ops_tracker: ExternalOpsTracker,
+    #[cfg(unix)] uv_loop: *mut deno_core::uv_compat::uv_loop_t,
+    #[cfg(unix)] uv_loop_liveness: Arc<deno_core::uv_compat::UvLoopLiveness>,
+    #[cfg(unix)] poll_owner: deno_core::uv_compat::UvPollOwner,
   ) -> Self {
     Self {
       isolate_ptr,
@@ -662,7 +673,11 @@ impl Env {
       async_hooks_destroy,
       next_async_id: 1,
       #[cfg(unix)]
-      fd_watchers: HashMap::new(),
+      uv_loop,
+      #[cfg(unix)]
+      uv_loop_liveness,
+      #[cfg(unix)]
+      poll_owner,
       shared: std::ptr::null_mut(),
       open_handle_scopes: 0,
       open_callback_scopes: 0,
@@ -878,35 +893,6 @@ fn drain_gc_finalizers(
       report_finalizer_exception(tc, exception);
     }
   }
-
-  #[cfg(unix)]
-  pub(crate) fn get_fd_watcher(&self, fd: i32) -> Option<usize> {
-    self.fd_watchers.get(&fd).copied()
-  }
-
-  // Registration is idempotent for the same watcher and refuses to replace a
-  // different watcher already registered for the fd.
-  #[cfg(unix)]
-  pub(crate) fn register_fd_watcher(
-    &mut self,
-    fd: i32,
-    watcher_addr: usize,
-  ) -> bool {
-    match self.fd_watchers.get(&fd) {
-      Some(current) => *current == watcher_addr,
-      None => {
-        self.fd_watchers.insert(fd, watcher_addr);
-        true
-      }
-    }
-  }
-
-  #[cfg(unix)]
-  pub(crate) fn unregister_fd_watcher(&mut self, fd: i32, watcher_addr: usize) {
-    if self.fd_watchers.get(&fd) == Some(&watcher_addr) {
-      self.fd_watchers.remove(&fd);
-    }
-  }
 }
 
 fn report_finalizer_exception(
@@ -992,6 +978,19 @@ fn op_napi_open<'scope>(
     )
   };
 
+  #[cfg(unix)]
+  let (uv_loop, uv_loop_liveness, poll_owner) = {
+    let op_state = op_state.borrow();
+    let uv_loop = &**op_state.borrow::<Box<deno_core::uv_compat::UvLoop>>()
+      as *const deno_core::uv_compat::UvLoop
+      as *mut deno_core::uv_compat::uv_loop_t;
+    (
+      uv_loop,
+      unsafe { deno_core::uv_compat::uv_loop_liveness(uv_loop) },
+      unsafe { deno_core::uv_compat::new_poll_owner(uv_loop) },
+    )
+  };
+
   // Register the uv_compat loop so that our libuv-ABI `uv_timer_*`
   // polyfills bridge onto Deno's event loop instead of degrading to
   // no-ops. The loop pointer is opaque to addons — they only pass it
@@ -1061,6 +1060,12 @@ fn op_napi_open<'scope>(
     cleanup_hooks,
     ref_tracker,
     external_ops_tracker,
+    #[cfg(unix)]
+    uv_loop,
+    #[cfg(unix)]
+    uv_loop_liveness,
+    #[cfg(unix)]
+    poll_owner,
   );
   env.shared = Box::into_raw(Box::new(env_shared));
   // Track the EnvShared pointer so we can call instance data finalize

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -502,6 +502,8 @@ pub struct Env {
   pub async_hooks_after: v8::Global<v8::Function>,
   pub async_hooks_destroy: v8::Global<v8::Function>,
   pub next_async_id: i64,
+  #[cfg(unix)]
+  active_poll_fds: HashMap<i32, usize>,
 }
 
 unsafe impl Send for Env {}
@@ -535,6 +537,8 @@ impl Env {
       async_hooks_after,
       async_hooks_destroy,
       next_async_id: 1,
+      #[cfg(unix)]
+      active_poll_fds: HashMap::new(),
       shared: std::ptr::null_mut(),
       open_handle_scopes: 0,
       open_callback_scopes: 0,
@@ -643,6 +647,28 @@ impl Env {
     let mut tracker = self.ref_tracker.borrow_mut();
     if let Some(pos) = tracker.iter().rposition(|f| f.data == data) {
       tracker.remove(pos);
+    }
+  }
+
+  #[cfg(unix)]
+  pub(crate) fn try_acquire_poll_fd(
+    &mut self,
+    fd: i32,
+    poll_addr: usize,
+  ) -> bool {
+    match self.active_poll_fds.get(&fd) {
+      Some(owner) if *owner != poll_addr => false,
+      _ => {
+        self.active_poll_fds.insert(fd, poll_addr);
+        true
+      }
+    }
+  }
+
+  #[cfg(unix)]
+  pub(crate) fn release_poll_fd(&mut self, fd: i32, poll_addr: usize) {
+    if self.active_poll_fds.get(&fd) == Some(&poll_addr) {
+      self.active_poll_fds.remove(&fd);
     }
   }
 }

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -971,7 +971,7 @@ unsafe extern "C" fn uv_poll_init_socket(
       // liveness is invalidated, teardown no longer dispatches registry
       // pointers.
       let _ = Box::into_raw(bridge_box);
-      return 0;
+      0
     }
 
     #[cfg(windows)]
@@ -1044,7 +1044,7 @@ unsafe extern "C" fn uv_poll_start(
           (&mut *(*poll).r#loop).external_ops_tracker.ref_op();
         }
       }
-      return 0;
+      0
     }
 
     #[cfg(windows)]
@@ -1128,7 +1128,7 @@ unsafe extern "C" fn uv_poll_stop(poll: *mut uv_poll_t) -> c_int {
         0
       };
       napi_poll_mark_stopped(poll);
-      return result;
+      result
     }
     #[cfg(windows)]
     {
@@ -1953,7 +1953,13 @@ mod tests {
     let core_loop = runtime
       .uv_loop_ptr()
       .expect("N-API-enabled JsRuntime should have a uv loop");
-    let (sender, cleanup_hooks, ref_tracker, external_ops_tracker) = {
+    let (
+      sender,
+      gc_finalizer_spawner,
+      cleanup_hooks,
+      ref_tracker,
+      external_ops_tracker,
+    ) = {
       let op_state = runtime.op_state();
       let op_state = op_state.borrow();
       let napi_state = op_state.borrow::<NapiState>();
@@ -1961,6 +1967,7 @@ mod tests {
         op_state
           .borrow::<deno_core::V8CrossThreadTaskSpawner>()
           .clone(),
+        op_state.borrow::<deno_core::V8TaskSpawner>().clone(),
         napi_state.env_cleanup_hooks.clone(),
         napi_state.ref_tracker.clone(),
         op_state.external_ops_tracker.clone(),
@@ -1994,6 +2001,7 @@ mod tests {
         v8::Global::new(scope, callback),
         v8::Global::new(scope, callback),
         sender,
+        gc_finalizer_spawner,
         cleanup_hooks,
         ref_tracker,
         external_ops_tracker,

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -26,6 +26,8 @@ fn assert_ok(res: c_int) -> c_int {
 }
 
 use std::ffi::c_int;
+#[cfg(unix)]
+use std::ffi::c_short;
 
 use js_native_api::napi_create_string_utf8;
 use node_api::napi_create_async_work;
@@ -959,6 +961,72 @@ const UV_DISCONNECT: c_int = 4;
 #[cfg(unix)]
 const UV_PRIORITIZED: c_int = 8;
 
+#[cfg(unix)]
+fn uv_events_to_poll_events(events: c_int) -> c_short {
+  let mut poll_events = 0;
+  if events & UV_READABLE != 0 {
+    poll_events |= libc::POLLIN;
+  }
+  if events & UV_WRITABLE != 0 {
+    poll_events |= libc::POLLOUT;
+  }
+  if events & UV_PRIORITIZED != 0 {
+    poll_events |= libc::POLLPRI;
+  }
+  // POLLRDHUP is only available on these targets. Elsewhere, omitting
+  // UV_DISCONNECT is fine: libuv treats it as an optional shutdown
+  // optimization.
+  #[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "illumos",
+  ))]
+  if events & UV_DISCONNECT != 0 {
+    poll_events |= libc::POLLRDHUP;
+  }
+  poll_events
+}
+
+#[cfg(unix)]
+fn poll_revents_to_uv_callback_args(
+  revents: c_short,
+  requested_events: c_int,
+) -> (c_int, c_int) {
+  let mut cb_events = 0;
+  if revents & libc::POLLIN != 0 {
+    cb_events |= UV_READABLE;
+  }
+  if revents & libc::POLLOUT != 0 {
+    cb_events |= UV_WRITABLE;
+  }
+  if revents & libc::POLLPRI != 0 {
+    cb_events |= UV_PRIORITIZED;
+  }
+  #[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "illumos",
+  ))]
+  if revents & libc::POLLRDHUP != 0 {
+    cb_events |= UV_DISCONNECT;
+  }
+
+  if revents & libc::POLLNVAL != 0
+    || (revents & libc::POLLERR != 0 && revents & libc::POLLPRI == 0)
+  {
+    return (uv_compat::UV_EBADF, 0);
+  }
+  if revents & (libc::POLLERR | libc::POLLHUP) != 0 {
+    // libuv reports the interests that can make progress on an error or
+    // hangup, even when poll(2) returned no ordinary readiness bits.
+    cb_events |= requested_events
+      & (UV_READABLE | UV_WRITABLE | UV_DISCONNECT | UV_PRIORITIZED);
+  }
+  (0, cb_events)
+}
+
 #[unsafe(no_mangle)]
 unsafe extern "C" fn uv_poll_start(
   poll: *mut uv_poll_t,
@@ -1004,28 +1072,7 @@ unsafe extern "C" fn uv_poll_start(
     std::thread::spawn(move || {
       let poll = poll_ptr.take() as *mut uv_poll_t;
       let cb = cb.unwrap();
-      let mut poll_events = 0;
-      if events & UV_READABLE != 0 {
-        poll_events |= libc::POLLIN;
-      }
-      if events & UV_WRITABLE != 0 {
-        poll_events |= libc::POLLOUT;
-      }
-      if events & UV_PRIORITIZED != 0 {
-        poll_events |= libc::POLLPRI;
-      }
-      // POLLRDHUP is only available on these targets. Elsewhere, omitting
-      // UV_DISCONNECT is fine: libuv treats it as an optional shutdown
-      // optimization.
-      #[cfg(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "illumos",
-      ))]
-      if events & UV_DISCONNECT != 0 {
-        poll_events |= libc::POLLRDHUP;
-      }
+      let poll_events = uv_events_to_poll_events(events);
 
       while bridge.active.load(Ordering::Acquire) {
         let mut fds = libc::pollfd {
@@ -1037,50 +1084,22 @@ unsafe extern "C" fn uv_poll_start(
         if result == 0 {
           continue;
         }
-        let mut cb_status = 0;
-        if result < 0 {
+        let poll_error = if result < 0 {
           let code = std::io::Error::last_os_error()
             .raw_os_error()
             .unwrap_or(libc::EIO);
           if code == libc::EINTR {
             continue;
           }
-          cb_status = -code;
-        }
-        let mut cb_events = 0;
-        if result > 0 {
-          if fds.revents & libc::POLLIN != 0 {
-            cb_events |= UV_READABLE;
-          }
-          if fds.revents & libc::POLLOUT != 0 {
-            cb_events |= UV_WRITABLE;
-          }
-          if fds.revents & libc::POLLPRI != 0 {
-            cb_events |= UV_PRIORITIZED;
-          }
-          #[cfg(any(
-            target_os = "linux",
-            target_os = "android",
-            target_os = "freebsd",
-            target_os = "illumos",
-          ))]
-          if fds.revents & libc::POLLRDHUP != 0 {
-            cb_events |= UV_DISCONNECT;
-          }
-
-          if fds.revents & libc::POLLNVAL != 0
-            || (fds.revents & libc::POLLERR != 0
-              && fds.revents & libc::POLLPRI == 0)
-          {
-            cb_status = uv_compat::UV_EBADF;
-            cb_events = 0;
-          } else if fds.revents & (libc::POLLERR | libc::POLLHUP) != 0 {
-            // libuv reports the interests that can make progress on an error
-            // or hangup, even when poll(2) returned no ordinary readiness bits.
-            cb_events |= events
-              & (UV_READABLE | UV_WRITABLE | UV_DISCONNECT | UV_PRIORITIZED);
-          }
-        }
+          Some(code)
+        } else {
+          None
+        };
+        let (cb_status, cb_events) = if let Some(code) = poll_error {
+          (-code, 0)
+        } else {
+          poll_revents_to_uv_callback_args(fds.revents, events)
+        };
         if !bridge.active.load(Ordering::Acquire) {
           break;
         }
@@ -1874,6 +1893,39 @@ mod tests {
     assert!(
       std::mem::size_of::<u32>()
         <= std::mem::size_of::<libuv_sys_lite::uv_cond_t>()
+    );
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn uv_events_translate_to_poll_events() {
+    assert_eq!(
+      uv_events_to_poll_events(UV_READABLE | UV_WRITABLE | UV_PRIORITIZED),
+      libc::POLLIN | libc::POLLOUT | libc::POLLPRI
+    );
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn poll_revents_translate_to_uv_callback_args() {
+    assert_eq!(
+      poll_revents_to_uv_callback_args(
+        libc::POLLIN | libc::POLLOUT,
+        UV_READABLE | UV_WRITABLE | UV_DISCONNECT
+      ),
+      (0, UV_READABLE | UV_WRITABLE)
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLPRI, UV_PRIORITIZED),
+      (0, UV_PRIORITIZED)
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLHUP, UV_READABLE),
+      (0, UV_READABLE)
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLERR, UV_READABLE),
+      (uv_compat::UV_EBADF, 0)
     );
   }
 

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -548,8 +548,6 @@ struct PollBridge {
   active: AtomicBool,
   #[cfg(unix)]
   fd: c_int,
-  #[cfg(unix)]
-  cb: uv_poll_cb,
 }
 
 #[cfg(unix)]
@@ -871,6 +869,44 @@ unsafe extern "C" fn uv_idle_stop(_idle: *mut uv_idle_t) -> c_int {
   0
 }
 
+#[cfg(unix)]
+unsafe fn fcntl_retry_on_eintr(
+  fd: c_int,
+  cmd: c_int,
+  arg: c_int,
+) -> Result<c_int, c_int> {
+  loop {
+    let result = unsafe { libc::fcntl(fd, cmd, arg) };
+    if result != -1 {
+      return Ok(result);
+    }
+    let code = std::io::Error::last_os_error()
+      .raw_os_error()
+      .unwrap_or(libc::EINVAL);
+    if code != libc::EINTR {
+      return Err(code);
+    }
+  }
+}
+
+#[cfg(unix)]
+unsafe fn set_fd_nonblocking(fd: c_int) -> c_int {
+  // F_GETFL ignores the variadic argument, so this 0 placeholder is harmless.
+  let flags = match unsafe { fcntl_retry_on_eintr(fd, libc::F_GETFL, 0) } {
+    Ok(flags) => flags,
+    Err(code) => return -code,
+  };
+  if flags & libc::O_NONBLOCK != 0 {
+    return 0;
+  }
+  match unsafe {
+    fcntl_retry_on_eintr(fd, libc::F_SETFL, flags | libc::O_NONBLOCK)
+  } {
+    Ok(_) => 0,
+    Err(code) => -code,
+  }
+}
+
 #[unsafe(no_mangle)]
 unsafe extern "C" fn uv_poll_init_socket(
   r#loop: *mut uv_loop_t,
@@ -878,6 +914,13 @@ unsafe extern "C" fn uv_poll_init_socket(
   fd: uv_os_sock_t,
 ) -> c_int {
   unsafe {
+    #[cfg(unix)]
+    {
+      let result = set_fd_nonblocking(fd);
+      if result != 0 {
+        return result;
+      }
+    }
     let data = (*poll).data;
     std::ptr::write_bytes(poll.cast::<u8>(), 0, UV_POLL_SIZE);
     addr_of_mut!((*poll).data).write(data);
@@ -890,8 +933,6 @@ unsafe extern "C" fn uv_poll_init_socket(
       active: AtomicBool::new(false),
       #[cfg(unix)]
       fd,
-      #[cfg(unix)]
-      cb: None,
     });
     #[cfg(windows)]
     let _ = fd;
@@ -909,6 +950,15 @@ unsafe extern "C" fn uv_poll_init(
   unsafe { uv_poll_init_socket(r#loop, poll, fd as uv_os_sock_t) }
 }
 
+#[cfg(unix)]
+const UV_READABLE: c_int = 1;
+#[cfg(unix)]
+const UV_WRITABLE: c_int = 2;
+#[cfg(unix)]
+const UV_DISCONNECT: c_int = 4;
+#[cfg(unix)]
+const UV_PRIORITIZED: c_int = 8;
+
 #[unsafe(no_mangle)]
 unsafe extern "C" fn uv_poll_start(
   poll: *mut uv_poll_t,
@@ -918,37 +968,65 @@ unsafe extern "C" fn uv_poll_start(
   unsafe {
     let bridge_ptr = (*poll).bridge;
     if bridge_ptr.is_null() {
-      return -1;
+      return uv_compat::UV_EINVAL;
+    }
+    #[cfg(unix)]
+    if cb.is_none() && events != 0 {
+      return uv_compat::UV_EINVAL;
+    }
+    let env = &mut *(*poll).r#loop;
+    #[cfg(unix)]
+    if !env.try_acquire_poll_fd((&*bridge_ptr).fd, poll as usize) {
+      return uv_compat::UV_EEXIST;
+    }
+    if events == 0 {
+      return uv_poll_stop(poll);
     }
 
     (&*bridge_ptr).active.store(false, Ordering::Release);
     if !(*poll).active {
       (*poll).active = true;
       if (*poll).refed {
-        (&mut *(*poll).r#loop).external_ops_tracker.ref_op();
+        env.external_ops_tracker.ref_op();
       }
     }
     let bridge = Arc::new(PollBridge {
       active: AtomicBool::new(true),
       #[cfg(unix)]
       fd: (&*bridge_ptr).fd,
-      #[cfg(unix)]
-      cb,
     });
     *bridge_ptr = bridge;
     #[cfg(unix)]
     let bridge = Arc::clone(&*bridge_ptr);
-    let sender = (&mut *(*poll).r#loop).async_work_sender.clone();
+    let sender = env.async_work_sender.clone();
     let poll_ptr = SendPtr(poll as *const uv_poll_t);
     #[cfg(unix)]
     std::thread::spawn(move || {
+      let poll = poll_ptr.take() as *mut uv_poll_t;
+      let cb = cb.unwrap();
       let mut poll_events = 0;
-      if events & 1 != 0 {
+      if events & UV_READABLE != 0 {
         poll_events |= libc::POLLIN;
       }
-      if events & 2 != 0 {
+      if events & UV_WRITABLE != 0 {
         poll_events |= libc::POLLOUT;
       }
+      if events & UV_PRIORITIZED != 0 {
+        poll_events |= libc::POLLPRI;
+      }
+      // POLLRDHUP is only available on these targets. Elsewhere, omitting
+      // UV_DISCONNECT is fine: libuv treats it as an optional shutdown
+      // optimization.
+      #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "illumos",
+      ))]
+      if events & UV_DISCONNECT != 0 {
+        poll_events |= libc::POLLRDHUP;
+      }
+
       while bridge.active.load(Ordering::Acquire) {
         let mut fds = libc::pollfd {
           fd: bridge.fd,
@@ -956,20 +1034,70 @@ unsafe extern "C" fn uv_poll_start(
           revents: 0,
         };
         let result = libc::poll(&mut fds, 1, 10);
-        if result <= 0 {
+        if result == 0 {
           continue;
         }
-        if !bridge.active.swap(false, Ordering::AcqRel) {
+        let mut cb_status = 0;
+        if result < 0 {
+          let code = std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or(libc::EIO);
+          if code == libc::EINTR {
+            continue;
+          }
+          cb_status = -code;
+        }
+        let mut cb_events = 0;
+        if result > 0 {
+          if fds.revents & libc::POLLIN != 0 {
+            cb_events |= UV_READABLE;
+          }
+          if fds.revents & libc::POLLOUT != 0 {
+            cb_events |= UV_WRITABLE;
+          }
+          if fds.revents & libc::POLLPRI != 0 {
+            cb_events |= UV_PRIORITIZED;
+          }
+          #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd",
+            target_os = "illumos",
+          ))]
+          if fds.revents & libc::POLLRDHUP != 0 {
+            cb_events |= UV_DISCONNECT;
+          }
+
+          if fds.revents & libc::POLLNVAL != 0
+            || (fds.revents & libc::POLLERR != 0
+              && fds.revents & libc::POLLPRI == 0)
+          {
+            cb_status = uv_compat::UV_EBADF;
+            cb_events = 0;
+          } else if fds.revents & (libc::POLLERR | libc::POLLHUP) != 0 {
+            // libuv reports the interests that can make progress on an error
+            // or hangup, even when poll(2) returned no ordinary readiness bits.
+            cb_events |= events
+              & (UV_READABLE | UV_WRITABLE | UV_DISCONNECT | UV_PRIORITIZED);
+          }
+        }
+        if !bridge.active.load(Ordering::Acquire) {
           break;
         }
-        if let Some(cb) = bridge.cb {
-          let poll_ptr = SendPtr(poll_ptr.take());
-          sender.spawn(move |_| {
-            let poll = poll_ptr.take() as *mut uv_poll_t;
-            cb(poll, 0, events);
-          });
-        }
-        break;
+        let bridge = Arc::clone(&bridge);
+        let poll_ptr = SendPtr(poll as *const uv_poll_t);
+        // Waiting for the loop-thread callback provides back-pressure for
+        // level-triggered fds. Re-polling earlier can flood the loop queue.
+        sender.spawn_blocking(move |_| {
+          if !bridge.active.load(Ordering::Acquire) {
+            return;
+          }
+          let poll = poll_ptr.take() as *mut uv_poll_t;
+          if cb_status != 0 {
+            uv_poll_stop(poll);
+          }
+          cb(poll, cb_status, cb_events);
+        });
       }
     });
     #[cfg(windows)]
@@ -994,13 +1122,7 @@ unsafe fn uv_poll_close(poll: *mut uv_poll_t) {
     if bridge_ptr.is_null() {
       return;
     }
-    (&*bridge_ptr).active.store(false, Ordering::Release);
-    if (*poll).active {
-      (*poll).active = false;
-      if (*poll).refed {
-        (&mut *(*poll).r#loop).external_ops_tracker.unref_op();
-      }
-    }
+    uv_poll_stop(poll);
     drop(Box::from_raw(bridge_ptr));
     (*poll).bridge = std::ptr::null_mut();
   }
@@ -1017,6 +1139,8 @@ unsafe extern "C" fn uv_poll_stop(poll: *mut uv_poll_t) -> c_int {
       return 0;
     }
     (&*bridge_ptr).active.store(false, Ordering::Release);
+    #[cfg(unix)]
+    (&mut *(*poll).r#loop).release_poll_fd((&*bridge_ptr).fd, poll as usize);
     if (*poll).active {
       (*poll).active = false;
       if (*poll).refed {

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -11,6 +11,10 @@ use std::time::Instant;
 
 use deno_core::parking_lot::Mutex;
 use deno_core::uv_compat;
+#[cfg(unix)]
+use deno_core::uv_compat::{
+  UV_DISCONNECT, UV_PRIORITIZED, UV_READABLE, UV_WRITABLE,
+};
 
 use crate::util::SendPtr;
 use crate::*;
@@ -954,15 +958,6 @@ unsafe extern "C" fn uv_poll_init(
 ) -> c_int {
   unsafe { uv_poll_init_socket(r#loop, poll, fd as uv_os_sock_t) }
 }
-
-#[cfg(unix)]
-const UV_READABLE: c_int = 1;
-#[cfg(unix)]
-const UV_WRITABLE: c_int = 2;
-#[cfg(unix)]
-const UV_DISCONNECT: c_int = 4;
-#[cfg(unix)]
-const UV_PRIORITIZED: c_int = 8;
 
 #[cfg(unix)]
 fn uv_events_to_poll_events(events: c_int) -> c_short {

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -551,9 +551,10 @@ struct PollBridge {
 
 // Heap-allocated bridge owned by the N-API layer after Box::into_raw transfers
 // it out of this initializer. It cannot live in the addon's fixed-size
-// `uv_poll_t`, whose libuv layout must stay intact. `inner` is first so a core
-// callback can cast its handle pointer back to this bridge; the aggregate
-// worker receives numeric state only and never an addon pointer.
+// `uv_poll_t`, whose libuv layout must stay intact. `inner` is first so
+// `napi_poll_trampoline` and `napi_poll_stopped` can cast their handle pointer
+// back to this bridge. The poll worker receives numeric state only and never
+// an addon pointer.
 #[cfg(unix)]
 #[repr(C)]
 struct NapiPollBridge {
@@ -602,8 +603,6 @@ unsafe fn napi_poll_mark_stopped(poll: *mut uv_poll_t) {
   unsafe {
     if (*poll).active {
       (*poll).active = false;
-      // The active transition is shared by explicit stop, terminal errors,
-      // and close. Gate the unref here so those paths balance one reference.
       if (*poll).refed {
         (&mut *(*poll).r#loop).external_ops_tracker.unref_op();
       }
@@ -966,10 +965,10 @@ unsafe extern "C" fn uv_poll_init_socket(
       addr_of_mut!((*poll).bridge).write(bridge);
       addr_of_mut!((*poll).active).write(false);
       addr_of_mut!((*poll).refed).write(true);
-      // Core stores a non-owning `inner` pointer in its registry. Normal close
-      // removes that registry entry before freeing this Box. After loop
-      // liveness is invalidated, teardown no longer dispatches registry
-      // pointers.
+      // UvLoopInner's poll-handle registry keeps a non-owning pointer to
+      // `inner`. Normal close unregisters it before freeing this Box. Once
+      // loop liveness is invalidated, the loop no longer dispatches that
+      // handle.
       let _ = Box::into_raw(bridge_box);
       0
     }
@@ -1089,10 +1088,9 @@ unsafe fn uv_poll_close(poll: *mut uv_poll_t) {
     #[cfg(unix)]
     {
       let env = &*(*poll).r#loop;
-      // While this guard succeeds, close removes the core registry before
-      // freeing the bridge. If teardown already invalidated the loop, core
-      // owns remaining registry and worker teardown and will not dispatch this
-      // bridge again.
+      // With the guard held, close unregisters the handle from UvLoopInner's
+      // poll registry before freeing the bridge. Once loop liveness is
+      // invalidated, the loop no longer dispatches that handle.
       if let Some(_guard) =
         uv_compat::uv_loop_operation_guard(&env.uv_loop_liveness)
       {
@@ -1940,8 +1938,7 @@ mod tests {
         "no queued poll callback may reach addon storage during teardown"
       );
 
-      // This is the same production ABI cleanup path used by uv_close in the
-      // native fixture: stop the core bridge, balance its ref, then free it.
+      // Exercise the same production ABI cleanup path as the native fixture.
       uv_poll_close(cleanup.poll);
       drop(Box::from_raw(cleanup.poll));
       cleanup.storage_freed.store(true, Ordering::SeqCst);

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -945,7 +945,7 @@ unsafe extern "C" fn uv_poll_init_socket(
         env.uv_loop,
         addr_of_mut!((*bridge).inner),
         fd,
-        env.poll_owner.clone(),
+        env.poll_scope.clone(),
       );
       if result != 0 {
         return result;
@@ -1920,9 +1920,9 @@ mod tests {
 
       let bridge = (*cleanup.poll).bridge;
       assert!(!bridge.is_null(), "cleanup owns an armed N-API poll bridge");
-      // NapiState invalidates every Env owner before it runs addon hooks.
+      // NapiState invalidates each Env's poll scope before running addon hooks.
       // The rejected restart verifies this hook observes that invalidation.
-      // Loop dispatch uses the same owner state to discard any readiness.
+      // Loop dispatch consults the same poll-scope state to discard readiness.
       assert_eq!(
         uv_compat::uv_poll_start(
           addr_of_mut!((*bridge).inner),
@@ -1930,7 +1930,7 @@ mod tests {
           Some(napi_poll_trampoline),
         ),
         uv_compat::UV_ECANCELED,
-        "cleanup must observe its Env poll owner invalidated"
+        "cleanup must observe that its Env poll scope was invalidated"
       );
       assert_eq!(
         cleanup.callback_count.load(Ordering::SeqCst),
@@ -1972,10 +1972,10 @@ mod tests {
     };
 
     let isolate_ptr = unsafe { runtime.v8_isolate().as_raw_isolate_ptr() };
-    let (uv_loop_liveness, poll_owner) = unsafe {
+    let (uv_loop_liveness, poll_scope) = unsafe {
       (
         uv_compat::uv_loop_liveness(uv_loop),
-        uv_compat::new_poll_owner(uv_loop),
+        uv_compat::new_poll_scope(uv_loop),
       )
     };
     let env_ptr = {
@@ -2004,7 +2004,7 @@ mod tests {
         external_ops_tracker,
         uv_loop,
         uv_loop_liveness,
-        poll_owner,
+        poll_scope,
       );
       env.shared = Box::into_raw(Box::new(EnvShared::new(
         napi_wrap,
@@ -2103,7 +2103,8 @@ mod tests {
             .recv()
             .expect("host dropped the teardown request sender");
           // Move and drop the extension's actual NapiState. Its production Drop
-          // implementation invalidates Env owners and invokes this hook.
+          // implementation invalidates each Env's poll scope before invoking
+          // this hook.
           let napi_state = runtime.op_state().borrow_mut().take::<NapiState>();
           drop(napi_state);
           assert_eq!(cleanup_count.load(Ordering::SeqCst), 1);

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -1950,7 +1950,7 @@ mod tests {
 
   #[cfg(unix)]
   unsafe fn new_test_napi_env(runtime: &mut deno_core::JsRuntime) -> *mut Env {
-    let core_loop = runtime
+    let uv_loop = runtime
       .uv_loop_ptr()
       .expect("N-API-enabled JsRuntime should have a uv loop");
     let (
@@ -1977,8 +1977,8 @@ mod tests {
     let isolate_ptr = unsafe { runtime.v8_isolate().as_raw_isolate_ptr() };
     let (uv_loop_liveness, poll_owner) = unsafe {
       (
-        uv_compat::uv_loop_liveness(core_loop),
-        uv_compat::new_poll_owner(core_loop),
+        uv_compat::uv_loop_liveness(uv_loop),
+        uv_compat::new_poll_owner(uv_loop),
       )
     };
     let env_ptr = {
@@ -2005,7 +2005,7 @@ mod tests {
         cleanup_hooks,
         ref_tracker,
         external_ops_tracker,
-        core_loop,
+        uv_loop,
         uv_loop_liveness,
         poll_owner,
       );

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -11,10 +11,6 @@ use std::time::Instant;
 
 use deno_core::parking_lot::Mutex;
 use deno_core::uv_compat;
-#[cfg(unix)]
-use deno_core::uv_compat::{
-  UV_DISCONNECT, UV_PRIORITIZED, UV_READABLE, UV_WRITABLE,
-};
 
 use crate::util::SendPtr;
 use crate::*;
@@ -30,8 +26,6 @@ fn assert_ok(res: c_int) -> c_int {
 }
 
 use std::ffi::c_int;
-#[cfg(unix)]
-use std::ffi::c_short;
 
 use js_native_api::napi_create_string_utf8;
 use node_api::napi_create_async_work;
@@ -550,10 +544,22 @@ struct uv_idle_t {
   idle_cb: uv_idle_cb,
 }
 
+#[cfg(windows)]
 struct PollBridge {
   active: AtomicBool,
-  #[cfg(unix)]
-  fd: c_int,
+}
+
+// Heap-allocated bridge owned by the N-API layer after Box::into_raw transfers
+// it out of this initializer. It cannot live in the addon's fixed-size
+// `uv_poll_t`, whose libuv layout must stay intact. `inner` is first so a core
+// callback can cast its handle pointer back to this bridge; the aggregate
+// worker receives numeric state only and never an addon pointer.
+#[cfg(unix)]
+#[repr(C)]
+struct NapiPollBridge {
+  inner: uv_compat::uv_poll_t,
+  napi_handle: *mut uv_poll_t,
+  user_cb: uv_poll_cb,
 }
 
 #[cfg(unix)]
@@ -575,17 +581,60 @@ struct uv_poll_t {
       - size_of::<Option<uv_close_cb>>())
       / size_of::<usize>()
   }],
+  #[cfg(unix)]
+  bridge: *mut NapiPollBridge,
+  #[cfg(windows)]
   bridge: *mut Arc<PollBridge>,
   active: bool,
   refed: bool,
   _padding: [MaybeUninit<usize>; const {
     (UV_POLL_SIZE
       - 96
-      - size_of::<*mut Arc<PollBridge>>()
+      - size_of::<*mut c_void>()
       - size_of::<bool>()
       - size_of::<bool>())
       / size_of::<usize>()
   }],
+}
+
+#[cfg(unix)]
+unsafe fn napi_poll_mark_stopped(poll: *mut uv_poll_t) {
+  unsafe {
+    if (*poll).active {
+      (*poll).active = false;
+      // The active transition is shared by explicit stop, terminal errors,
+      // and close. Gate the unref here so those paths balance one reference.
+      if (*poll).refed {
+        (&mut *(*poll).r#loop).external_ops_tracker.unref_op();
+      }
+    }
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn napi_poll_trampoline(
+  inner: *mut uv_compat::uv_poll_t,
+  status: c_int,
+  events: c_int,
+) {
+  unsafe {
+    let bridge = inner.cast::<NapiPollBridge>();
+    let napi_handle = (*bridge).napi_handle;
+    if status != 0 {
+      napi_poll_mark_stopped(napi_handle);
+    }
+    if let Some(cb) = (*bridge).user_cb {
+      cb(napi_handle, status, events);
+    }
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn napi_poll_stopped(inner: *mut uv_compat::uv_poll_t) {
+  unsafe {
+    let bridge = inner.cast::<NapiPollBridge>();
+    napi_poll_mark_stopped((*bridge).napi_handle);
+  }
 }
 
 #[cfg(unix)]
@@ -875,44 +924,6 @@ unsafe extern "C" fn uv_idle_stop(_idle: *mut uv_idle_t) -> c_int {
   0
 }
 
-#[cfg(unix)]
-unsafe fn fcntl_retry_on_eintr(
-  fd: c_int,
-  cmd: c_int,
-  arg: c_int,
-) -> Result<c_int, c_int> {
-  loop {
-    let result = unsafe { libc::fcntl(fd, cmd, arg) };
-    if result != -1 {
-      return Ok(result);
-    }
-    let code = std::io::Error::last_os_error()
-      .raw_os_error()
-      .unwrap_or(libc::EINVAL);
-    if code != libc::EINTR {
-      return Err(code);
-    }
-  }
-}
-
-#[cfg(unix)]
-unsafe fn set_fd_nonblocking(fd: c_int) -> c_int {
-  // F_GETFL ignores the variadic argument, so this 0 placeholder is harmless.
-  let flags = match unsafe { fcntl_retry_on_eintr(fd, libc::F_GETFL, 0) } {
-    Ok(flags) => flags,
-    Err(code) => return -code,
-  };
-  if flags & libc::O_NONBLOCK != 0 {
-    return 0;
-  }
-  match unsafe {
-    fcntl_retry_on_eintr(fd, libc::F_SETFL, flags | libc::O_NONBLOCK)
-  } {
-    Ok(_) => 0,
-    Err(code) => -code,
-  }
-}
-
 #[unsafe(no_mangle)]
 unsafe extern "C" fn uv_poll_init_socket(
   r#loop: *mut uv_loop_t,
@@ -922,31 +933,65 @@ unsafe extern "C" fn uv_poll_init_socket(
   unsafe {
     #[cfg(unix)]
     {
-      if (&*r#loop).get_fd_watcher(fd).is_some() {
-        return uv_compat::UV_EEXIST;
-      }
-      let result = set_fd_nonblocking(fd);
+      let env = &*r#loop;
+      let Some(_guard) =
+        uv_compat::uv_loop_operation_guard(&env.uv_loop_liveness)
+      else {
+        return uv_compat::UV_ECANCELED;
+      };
+      let mut bridge_box: Box<MaybeUninit<NapiPollBridge>> =
+        Box::new(MaybeUninit::zeroed());
+      let bridge = bridge_box.as_mut_ptr();
+      let result = uv_compat::uv_poll_init(
+        env.uv_loop,
+        addr_of_mut!((*bridge).inner),
+        fd,
+        env.poll_owner.clone(),
+      );
       if result != 0 {
         return result;
       }
+      addr_of_mut!((*bridge).napi_handle).write(poll);
+      addr_of_mut!((*bridge).user_cb).write(None);
+      uv_compat::uv_poll_set_stop_callback(
+        addr_of_mut!((*bridge).inner),
+        Some(napi_poll_stopped),
+      );
+
+      let data = (*poll).data;
+      std::ptr::write_bytes(poll.cast::<u8>(), 0, UV_POLL_SIZE);
+      addr_of_mut!((*poll).data).write(data);
+      addr_of_mut!((*poll).r#loop).write(r#loop);
+      addr_of_mut!((*poll).r#type).write(uv_handle_type::UV_POLL);
+      addr_of_mut!((*poll).bridge).write(bridge);
+      addr_of_mut!((*poll).active).write(false);
+      addr_of_mut!((*poll).refed).write(true);
+      // Core stores a non-owning `inner` pointer in its registry. Normal close
+      // removes that registry entry before freeing this Box. After loop
+      // liveness is invalidated, teardown no longer dispatches registry
+      // pointers.
+      let _ = Box::into_raw(bridge_box);
+      return 0;
     }
-    let data = (*poll).data;
-    std::ptr::write_bytes(poll.cast::<u8>(), 0, UV_POLL_SIZE);
-    addr_of_mut!((*poll).data).write(data);
-    addr_of_mut!((*poll).r#loop).write(r#loop);
-    addr_of_mut!((*poll).r#type).write(uv_handle_type::UV_POLL);
-    addr_of_mut!((*poll).bridge).write(std::ptr::null_mut());
-    addr_of_mut!((*poll).active).write(false);
-    addr_of_mut!((*poll).refed).write(true);
-    let bridge = Arc::new(PollBridge {
-      active: AtomicBool::new(false),
-      #[cfg(unix)]
-      fd,
-    });
+
     #[cfg(windows)]
-    let _ = fd;
-    addr_of_mut!((*poll).bridge).write(Box::into_raw(Box::new(bridge)));
+    {
+      let data = (*poll).data;
+      std::ptr::write_bytes(poll.cast::<u8>(), 0, UV_POLL_SIZE);
+      addr_of_mut!((*poll).data).write(data);
+      addr_of_mut!((*poll).r#loop).write(r#loop);
+      addr_of_mut!((*poll).r#type).write(uv_handle_type::UV_POLL);
+      addr_of_mut!((*poll).bridge).write(std::ptr::null_mut());
+      addr_of_mut!((*poll).active).write(false);
+      addr_of_mut!((*poll).refed).write(true);
+      let bridge = Arc::new(PollBridge {
+        active: AtomicBool::new(false),
+      });
+      let _ = fd;
+      addr_of_mut!((*poll).bridge).write(Box::into_raw(Box::new(bridge)));
+    }
   }
+  #[cfg(windows)]
   0
 }
 
@@ -957,80 +1002,6 @@ unsafe extern "C" fn uv_poll_init(
   fd: c_int,
 ) -> c_int {
   unsafe { uv_poll_init_socket(r#loop, poll, fd as uv_os_sock_t) }
-}
-
-#[cfg(unix)]
-fn uv_events_to_poll_events(events: c_int) -> c_short {
-  let mut poll_events = 0;
-  if events & UV_READABLE != 0 {
-    poll_events |= libc::POLLIN;
-  }
-  if events & UV_WRITABLE != 0 {
-    poll_events |= libc::POLLOUT;
-  }
-  if events & UV_PRIORITIZED != 0 {
-    poll_events |= libc::POLLPRI;
-  }
-  // POLLRDHUP is only available on these targets. Elsewhere, omitting
-  // UV_DISCONNECT is fine: libuv treats it as an optional shutdown
-  // optimization.
-  #[cfg(any(
-    target_os = "linux",
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "illumos",
-  ))]
-  if events & UV_DISCONNECT != 0 {
-    poll_events |= libc::POLLRDHUP;
-  }
-  poll_events
-}
-
-#[cfg(unix)]
-fn poll_revents_to_uv_callback_args(
-  revents: c_short,
-  requested_events: c_int,
-) -> (c_int, c_int) {
-  let mut cb_events = 0;
-  if revents & libc::POLLIN != 0 {
-    cb_events |= UV_READABLE;
-  }
-  if revents & libc::POLLOUT != 0 {
-    cb_events |= UV_WRITABLE;
-  }
-  if revents & libc::POLLPRI != 0 {
-    cb_events |= UV_PRIORITIZED;
-  }
-  #[cfg(any(
-    target_os = "linux",
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "illumos",
-  ))]
-  if revents & libc::POLLRDHUP != 0 {
-    cb_events |= UV_DISCONNECT;
-  }
-
-  // Closing an active descriptor without first stopping its poll handle is
-  // invalid libuv usage. A later poll(2) call may return POLLNVAL. Although
-  // libuv's event backends do not surface it, we report it as UV_EBADF. The
-  // error path stops the poll handle and removes its fd registration.
-  if revents & libc::POLLNVAL != 0 {
-    return (uv_compat::UV_EBADF, 0);
-  }
-  // libuv treats POLLERR | POLLPRI as prioritized readiness. Linux and
-  // FreeBSD sysfs/kernfs polling reports this combination, unlike TCP OOB
-  // messages, so only POLLERR without POLLPRI is an EBADF error.
-  if revents & libc::POLLERR != 0 && revents & libc::POLLPRI == 0 {
-    return (uv_compat::UV_EBADF, 0);
-  }
-  // libuv reports the interests that can make progress on an error or hangup,
-  // even when poll(2) returned no ordinary readiness bits.
-  if revents & (libc::POLLERR | libc::POLLHUP) != 0 {
-    cb_events |= requested_events
-      & (UV_READABLE | UV_WRITABLE | UV_DISCONNECT | UV_PRIORITIZED);
-  }
-  (0, cb_events)
 }
 
 #[unsafe(no_mangle)]
@@ -1044,94 +1015,56 @@ unsafe extern "C" fn uv_poll_start(
     if bridge_ptr.is_null() {
       return uv_compat::UV_EINVAL;
     }
+
     #[cfg(unix)]
-    if let Some(watcher) = (&*(*poll).r#loop).get_fd_watcher((&*bridge_ptr).fd)
     {
-      if watcher != poll as usize {
-        return uv_compat::UV_EEXIST;
+      let env = &*(*poll).r#loop;
+      let Some(_guard) =
+        uv_compat::uv_loop_operation_guard(&env.uv_loop_liveness)
+      else {
+        return uv_compat::UV_ECANCELED;
+      };
+      let result = uv_compat::uv_poll_start(
+        addr_of_mut!((*bridge_ptr).inner),
+        events,
+        cb.map(|_| {
+          napi_poll_trampoline
+            as unsafe extern "C" fn(*mut uv_compat::uv_poll_t, c_int, c_int)
+        }),
+      );
+      if result != 0 {
+        return result;
       }
-    }
-    #[cfg(unix)]
-    if cb.is_none() && events != 0 {
-      return uv_compat::UV_EINVAL;
-    }
-    if events == 0 {
-      return uv_poll_stop(poll);
+      (*bridge_ptr).user_cb = cb;
+      if events == 0 {
+        napi_poll_mark_stopped(poll);
+      } else if !(*poll).active {
+        (*poll).active = true;
+        if (*poll).refed {
+          (&mut *(*poll).r#loop).external_ops_tracker.ref_op();
+        }
+      }
+      return 0;
     }
 
-    (&*bridge_ptr).active.store(false, Ordering::Release);
-    if !(*poll).active {
-      (*poll).active = true;
-      if (*poll).refed {
-        (&mut *(*poll).r#loop).external_ops_tracker.ref_op();
-      }
-    }
-    let bridge = Arc::new(PollBridge {
-      active: AtomicBool::new(true),
-      #[cfg(unix)]
-      fd: (&*bridge_ptr).fd,
-    });
-    *bridge_ptr = bridge;
-    #[cfg(unix)]
-    (&mut *(*poll).r#loop)
-      .register_fd_watcher((&*bridge_ptr).fd, poll as usize);
-    #[cfg(unix)]
-    let bridge = Arc::clone(&*bridge_ptr);
-    let sender = (&mut *(*poll).r#loop).async_work_sender.clone();
-    let poll_ptr = SendPtr(poll as *const uv_poll_t);
-    #[cfg(unix)]
-    std::thread::spawn(move || {
-      let poll = poll_ptr.take() as *mut uv_poll_t;
-      let cb = cb.unwrap();
-      let poll_events = uv_events_to_poll_events(events);
-
-      while bridge.active.load(Ordering::Acquire) {
-        let mut fds = libc::pollfd {
-          fd: bridge.fd,
-          events: poll_events,
-          revents: 0,
-        };
-        let result = libc::poll(&mut fds, 1, 10);
-        if result == 0 {
-          continue;
-        }
-        let poll_error = if result < 0 {
-          let code = std::io::Error::last_os_error()
-            .raw_os_error()
-            .unwrap_or(libc::EIO);
-          if code == libc::EINTR {
-            continue;
-          }
-          Some(code)
-        } else {
-          None
-        };
-        let (cb_status, cb_events) = if let Some(code) = poll_error {
-          (-code, 0)
-        } else {
-          poll_revents_to_uv_callback_args(fds.revents, events)
-        };
-        if !bridge.active.load(Ordering::Acquire) {
-          break;
-        }
-        let bridge = Arc::clone(&bridge);
-        let poll_ptr = SendPtr(poll as *const uv_poll_t);
-        // Waiting for the loop-thread callback provides back-pressure for
-        // level-triggered fds. Re-polling earlier can flood the loop queue.
-        sender.spawn_blocking(move |_| {
-          if !bridge.active.load(Ordering::Acquire) {
-            return;
-          }
-          let poll = poll_ptr.take() as *mut uv_poll_t;
-          if cb_status != 0 {
-            uv_poll_stop(poll);
-          }
-          cb(poll, cb_status, cb_events);
-        });
-      }
-    });
     #[cfg(windows)]
     {
+      if events == 0 {
+        return uv_poll_stop(poll);
+      }
+      (&*bridge_ptr).active.store(false, Ordering::Release);
+      if !(*poll).active {
+        (*poll).active = true;
+        if (*poll).refed {
+          (&mut *(*poll).r#loop).external_ops_tracker.ref_op();
+        }
+      }
+      let bridge = Arc::new(PollBridge {
+        active: AtomicBool::new(true),
+      });
+      *bridge_ptr = bridge;
+      let sender = (&mut *(*poll).r#loop).async_work_sender.clone();
+      let poll_ptr = SendPtr(poll as *const uv_poll_t);
       if let Some(cb) = cb {
         sender.spawn(move |_| {
           let poll = poll_ptr.take() as *mut uv_poll_t;
@@ -1140,6 +1073,7 @@ unsafe extern "C" fn uv_poll_start(
       }
     }
   }
+  #[cfg(windows)]
   0
 }
 
@@ -1152,6 +1086,21 @@ unsafe fn uv_poll_close(poll: *mut uv_poll_t) {
     if bridge_ptr.is_null() {
       return;
     }
+    #[cfg(unix)]
+    {
+      let env = &*(*poll).r#loop;
+      // While this guard succeeds, close removes the core registry before
+      // freeing the bridge. If teardown already invalidated the loop, core
+      // owns remaining registry and worker teardown and will not dispatch this
+      // bridge again.
+      if let Some(_guard) =
+        uv_compat::uv_loop_operation_guard(&env.uv_loop_liveness)
+      {
+        uv_compat::uv_poll_close(addr_of_mut!((*bridge_ptr).inner));
+      }
+      napi_poll_mark_stopped(poll);
+    }
+    #[cfg(windows)]
     uv_poll_stop(poll);
     drop(Box::from_raw(bridge_ptr));
     (*poll).bridge = std::ptr::null_mut();
@@ -1168,17 +1117,31 @@ unsafe extern "C" fn uv_poll_stop(poll: *mut uv_poll_t) -> c_int {
     if bridge_ptr.is_null() {
       return 0;
     }
-    (&*bridge_ptr).active.store(false, Ordering::Release);
     #[cfg(unix)]
-    (&mut *(*poll).r#loop)
-      .unregister_fd_watcher((&*bridge_ptr).fd, poll as usize);
-    if (*poll).active {
-      (*poll).active = false;
-      if (*poll).refed {
-        (&mut *(*poll).r#loop).external_ops_tracker.unref_op();
+    {
+      let env = &*(*poll).r#loop;
+      let result = if let Some(_guard) =
+        uv_compat::uv_loop_operation_guard(&env.uv_loop_liveness)
+      {
+        uv_compat::uv_poll_stop(addr_of_mut!((*bridge_ptr).inner))
+      } else {
+        0
+      };
+      napi_poll_mark_stopped(poll);
+      return result;
+    }
+    #[cfg(windows)]
+    {
+      (&*bridge_ptr).active.store(false, Ordering::Release);
+      if (*poll).active {
+        (*poll).active = false;
+        if (*poll).refed {
+          (&mut *(*poll).r#loop).external_ops_tracker.unref_op();
+        }
       }
     }
   }
+  #[cfg(windows)]
   0
 }
 
@@ -1266,6 +1229,13 @@ unsafe extern "C" fn uv_ref(handle: *mut uv_handle_t) {
           if (*handle).active {
             (&mut *(*handle).r#loop).external_ops_tracker.ref_op();
           }
+          #[cfg(unix)]
+          if !(*handle).bridge.is_null() {
+            let liveness = &(*(*handle).r#loop).uv_loop_liveness;
+            if let Some(_guard) = uv_compat::uv_loop_operation_guard(liveness) {
+              uv_compat::uv_ref(addr_of_mut!((*(*handle).bridge).inner).cast());
+            }
+          }
         }
       }
       uv_handle_type::UV_TIMER => {
@@ -1308,6 +1278,15 @@ unsafe extern "C" fn uv_unref(handle: *mut uv_handle_t) {
           (*handle).refed = false;
           if (*handle).active {
             (&mut *(*handle).r#loop).external_ops_tracker.unref_op();
+          }
+          #[cfg(unix)]
+          if !(*handle).bridge.is_null() {
+            let liveness = &(*(*handle).r#loop).uv_loop_liveness;
+            if let Some(_guard) = uv_compat::uv_loop_operation_guard(liveness) {
+              uv_compat::uv_unref(
+                addr_of_mut!((*(*handle).bridge).inner).cast(),
+              );
+            }
           }
         }
       }
@@ -1909,64 +1888,244 @@ mod tests {
   }
 
   #[cfg(unix)]
-  #[test]
-  fn uv_events_translate_to_poll_events() {
-    assert_eq!(
-      uv_events_to_poll_events(UV_READABLE | UV_WRITABLE | UV_PRIORITIZED),
-      libc::POLLIN | libc::POLLOUT | libc::POLLPRI
-    );
-    #[cfg(any(
-      target_os = "linux",
-      target_os = "android",
-      target_os = "freebsd",
-      target_os = "illumos",
-    ))]
-    assert_eq!(uv_events_to_poll_events(UV_DISCONNECT), libc::POLLRDHUP);
+  struct ActiveNapiPollCleanup {
+    poll: *mut uv_poll_t,
+    _read_fd: std::os::fd::OwnedFd,
+    _write_fd: std::os::fd::OwnedFd,
+    callback_count: Arc<std::sync::atomic::AtomicUsize>,
+    cleanup_count: Arc<std::sync::atomic::AtomicUsize>,
+    storage_freed: Arc<AtomicBool>,
+  }
+
+  #[cfg(unix)]
+  unsafe extern "C" fn active_napi_poll_callback(
+    poll: *mut uv_poll_t,
+    _status: c_int,
+    _events: c_int,
+  ) {
+    unsafe {
+      let callback_count =
+        &*((*poll).data.cast::<std::sync::atomic::AtomicUsize>());
+      callback_count.fetch_add(1, Ordering::SeqCst);
+    }
+  }
+
+  #[cfg(unix)]
+  unsafe extern "C" fn cleanup_active_napi_poll(data: *mut c_void) {
+    unsafe {
+      let cleanup = Box::from_raw(data.cast::<ActiveNapiPollCleanup>());
+      assert_eq!(
+        cleanup.cleanup_count.fetch_add(1, Ordering::SeqCst),
+        0,
+        "NapiState must run each environment cleanup hook once"
+      );
+
+      let bridge = (*cleanup.poll).bridge;
+      assert!(!bridge.is_null(), "cleanup owns an armed N-API poll bridge");
+      // NapiState invalidates every Env owner before it runs addon hooks.
+      // The rejected restart verifies this hook observes that invalidation.
+      // Loop dispatch uses the same owner state to discard any readiness.
+      assert_eq!(
+        uv_compat::uv_poll_start(
+          addr_of_mut!((*bridge).inner),
+          uv_compat::UV_READABLE,
+          Some(napi_poll_trampoline),
+        ),
+        uv_compat::UV_ECANCELED,
+        "cleanup must observe its Env poll owner invalidated"
+      );
+      assert_eq!(
+        cleanup.callback_count.load(Ordering::SeqCst),
+        0,
+        "no queued poll callback may reach addon storage during teardown"
+      );
+
+      // This is the same production ABI cleanup path used by uv_close in the
+      // native fixture: stop the core bridge, balance its ref, then free it.
+      uv_poll_close(cleanup.poll);
+      drop(Box::from_raw(cleanup.poll));
+      cleanup.storage_freed.store(true, Ordering::SeqCst);
+    }
+  }
+
+  #[cfg(unix)]
+  unsafe fn new_test_napi_env(runtime: &mut deno_core::JsRuntime) -> *mut Env {
+    let core_loop = runtime
+      .uv_loop_ptr()
+      .expect("N-API-enabled JsRuntime should have a uv loop");
+    let (sender, cleanup_hooks, ref_tracker, external_ops_tracker) = {
+      let op_state = runtime.op_state();
+      let op_state = op_state.borrow();
+      let napi_state = op_state.borrow::<NapiState>();
+      (
+        op_state
+          .borrow::<deno_core::V8CrossThreadTaskSpawner>()
+          .clone(),
+        napi_state.env_cleanup_hooks.clone(),
+        napi_state.ref_tracker.clone(),
+        op_state.external_ops_tracker.clone(),
+      )
+    };
+
+    let isolate_ptr = unsafe { runtime.v8_isolate().as_raw_isolate_ptr() };
+    let (uv_loop_liveness, poll_owner) = unsafe {
+      (
+        uv_compat::uv_loop_liveness(core_loop),
+        uv_compat::new_poll_owner(core_loop),
+      )
+    };
+    let env_ptr = {
+      deno_core::scope!(scope, runtime);
+      let context = scope.get_current_context();
+      let global = context.global(scope);
+      let callback =
+        deno_core::JsRuntime::eval::<v8::Function>(scope, "()=>{}")
+          .expect("test callback must compile");
+      let napi_wrap = v8::Global::new(scope, v8::Private::new(scope, None));
+      let type_tag = v8::Global::new(scope, v8::Private::new(scope, None));
+      let mut env = Env::new(
+        isolate_ptr,
+        v8::Global::new(scope, context),
+        v8::Global::new(scope, global),
+        v8::Global::new(scope, callback),
+        v8::Global::new(scope, callback),
+        v8::Global::new(scope, callback),
+        v8::Global::new(scope, callback),
+        v8::Global::new(scope, callback),
+        v8::Global::new(scope, callback),
+        sender,
+        cleanup_hooks,
+        ref_tracker,
+        external_ops_tracker,
+        core_loop,
+        uv_loop_liveness,
+        poll_owner,
+      );
+      env.shared = Box::into_raw(Box::new(EnvShared::new(
+        napi_wrap,
+        type_tag,
+        "test-napi-env\\0".to_owned(),
+      )));
+      Box::into_raw(Box::new(env))
+    };
+    let op_state = runtime.op_state();
+    let mut op_state = op_state.borrow_mut();
+    let napi_state = op_state.borrow_mut::<NapiState>();
+    napi_state
+      .env_shared_ptrs
+      .push(unsafe { (*env_ptr).shared });
+    napi_state.env_ptrs.push(env_ptr);
+    env_ptr
   }
 
   #[cfg(unix)]
   #[test]
-  fn poll_revents_translate_to_uv_callback_args() {
-    assert_eq!(
-      poll_revents_to_uv_callback_args(
-        libc::POLLIN | libc::POLLOUT,
-        UV_READABLE | UV_WRITABLE | UV_DISCONNECT
-      ),
-      (0, UV_READABLE | UV_WRITABLE)
-    );
-    assert_eq!(
-      poll_revents_to_uv_callback_args(libc::POLLPRI, UV_PRIORITIZED),
-      (0, UV_PRIORITIZED)
-    );
-    assert_eq!(
-      poll_revents_to_uv_callback_args(libc::POLLHUP, UV_READABLE),
-      (0, UV_READABLE)
-    );
-    assert_eq!(
-      poll_revents_to_uv_callback_args(libc::POLLERR, UV_READABLE),
-      (uv_compat::UV_EBADF, 0)
-    );
-    assert_eq!(
-      poll_revents_to_uv_callback_args(
-        libc::POLLERR | libc::POLLPRI,
-        UV_PRIORITIZED
-      ),
-      (0, UV_PRIORITIZED)
-    );
-    assert_eq!(
-      poll_revents_to_uv_callback_args(libc::POLLNVAL, UV_READABLE),
-      (uv_compat::UV_EBADF, 0)
-    );
-    #[cfg(any(
-      target_os = "linux",
-      target_os = "android",
-      target_os = "freebsd",
-      target_os = "illumos",
-    ))]
-    assert_eq!(
-      poll_revents_to_uv_callback_args(libc::POLLRDHUP, UV_DISCONNECT),
-      (0, UV_DISCONNECT)
-    );
+  fn active_napi_poll_teardown_joins_runtime_thread() {
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+    use std::os::fd::OwnedFd;
+    use std::time::Duration;
+
+    const REPETITIONS: usize = 10;
+    const WATCHDOG: Duration = Duration::from_secs(10);
+
+    for unref in [false, true] {
+      for _ in 0..REPETITIONS {
+        let (armed_sender, armed_receiver) = std::sync::mpsc::sync_channel(0);
+        let (teardown_sender, teardown_receiver) =
+          std::sync::mpsc::sync_channel(0);
+        let (unwound_sender, unwound_receiver) =
+          std::sync::mpsc::sync_channel(0);
+        let worker = std::thread::spawn(move || {
+          let mut fds = [-1; 2];
+          assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+          let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+          let write_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+          let mut runtime =
+            deno_core::JsRuntime::new(deno_core::RuntimeOptions {
+              extensions: vec![crate::deno_napi::init(None)],
+              ..Default::default()
+            });
+          let env = unsafe { new_test_napi_env(&mut runtime) };
+          let callback_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+          let cleanup_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+          let storage_freed = Arc::new(AtomicBool::new(false));
+          let poll_ptr: *mut uv_poll_t =
+            Box::into_raw(Box::new(MaybeUninit::<uv_poll_t>::zeroed())).cast();
+
+          unsafe {
+            addr_of_mut!((*poll_ptr).data)
+              .write(Arc::as_ptr(&callback_count).cast_mut().cast());
+            assert_eq!(
+              uv_poll_init(env.cast(), poll_ptr, read_fd.as_raw_fd()),
+              0
+            );
+            assert_eq!(
+              uv_poll_start(
+                poll_ptr,
+                uv_compat::UV_READABLE,
+                Some(active_napi_poll_callback),
+              ),
+              0
+            );
+            if unref {
+              uv_unref(poll_ptr.cast());
+            }
+            assert_eq!(
+              libc::write(write_fd.as_raw_fd(), b"x".as_ptr().cast(), 1),
+              1
+            );
+          }
+          unsafe {
+            (*env).add_cleanup_hook(
+              cleanup_active_napi_poll,
+              Box::into_raw(Box::new(ActiveNapiPollCleanup {
+                poll: poll_ptr,
+                _read_fd: read_fd,
+                _write_fd: write_fd,
+                callback_count: callback_count.clone(),
+                cleanup_count: cleanup_count.clone(),
+                storage_freed: storage_freed.clone(),
+              }))
+              .cast(),
+            );
+          }
+          armed_sender
+            .send(())
+            .expect("host stopped waiting before arming");
+
+          teardown_receiver
+            .recv()
+            .expect("host dropped the teardown request sender");
+          // Move and drop the extension's actual NapiState. Its production Drop
+          // implementation invalidates Env owners and invokes this hook.
+          let napi_state = runtime.op_state().borrow_mut().take::<NapiState>();
+          drop(napi_state);
+          assert_eq!(cleanup_count.load(Ordering::SeqCst), 1);
+          assert!(storage_freed.load(Ordering::SeqCst));
+          unsafe {
+            let shared = (*env).shared;
+            drop(Box::from_raw(env));
+            drop(Box::from_raw(shared));
+          }
+          drop(runtime);
+          unwound_sender
+            .send(())
+            .expect("host stopped waiting for runtime teardown");
+        });
+
+        armed_receiver
+          .recv_timeout(WATCHDOG)
+          .expect("poll fixture did not arm before the watchdog");
+        teardown_sender
+          .send(())
+          .expect("runtime worker stopped before teardown request");
+        unwound_receiver
+          .recv_timeout(WATCHDOG)
+          .expect("runtime teardown did not complete before the watchdog");
+        worker.join().expect("runtime worker thread panicked");
+      }
+    }
   }
 
   // Drives the uv_sem_* / uv_thread_* polyfills the way a native addon

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -918,6 +918,9 @@ unsafe extern "C" fn uv_poll_init_socket(
   unsafe {
     #[cfg(unix)]
     {
+      if (&*r#loop).get_fd_watcher(fd).is_some() {
+        return uv_compat::UV_EEXIST;
+      }
       let result = set_fd_nonblocking(fd);
       if result != 0 {
         return result;
@@ -1039,14 +1042,15 @@ unsafe extern "C" fn uv_poll_start(
       return uv_compat::UV_EINVAL;
     }
     #[cfg(unix)]
-    if cb.is_none() && events != 0 {
-      return uv_compat::UV_EINVAL;
+    if let Some(watcher) = (&*(*poll).r#loop).get_fd_watcher((&*bridge_ptr).fd)
+    {
+      if watcher != poll as usize {
+        return uv_compat::UV_EEXIST;
+      }
     }
     #[cfg(unix)]
-    if !(&mut *(*poll).r#loop)
-      .try_acquire_poll_fd((&*bridge_ptr).fd, poll as usize)
-    {
-      return uv_compat::UV_EEXIST;
+    if cb.is_none() && events != 0 {
+      return uv_compat::UV_EINVAL;
     }
     if events == 0 {
       return uv_poll_stop(poll);
@@ -1065,6 +1069,9 @@ unsafe extern "C" fn uv_poll_start(
       fd: (&*bridge_ptr).fd,
     });
     *bridge_ptr = bridge;
+    #[cfg(unix)]
+    (&mut *(*poll).r#loop)
+      .register_fd_watcher((&*bridge_ptr).fd, poll as usize);
     #[cfg(unix)]
     let bridge = Arc::clone(&*bridge_ptr);
     let sender = (&mut *(*poll).r#loop).async_work_sender.clone();
@@ -1160,7 +1167,8 @@ unsafe extern "C" fn uv_poll_stop(poll: *mut uv_poll_t) -> c_int {
     }
     (&*bridge_ptr).active.store(false, Ordering::Release);
     #[cfg(unix)]
-    (&mut *(*poll).r#loop).release_poll_fd((&*bridge_ptr).fd, poll as usize);
+    (&mut *(*poll).r#loop)
+      .unregister_fd_watcher((&*bridge_ptr).fd, poll as usize);
     if (*poll).active {
       (*poll).active = false;
       if (*poll).refed {

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -1016,14 +1016,22 @@ fn poll_revents_to_uv_callback_args(
     cb_events |= UV_DISCONNECT;
   }
 
-  if revents & libc::POLLNVAL != 0
-    || (revents & libc::POLLERR != 0 && revents & libc::POLLPRI == 0)
-  {
+  // Closing an active descriptor without first stopping its poll handle is
+  // invalid libuv usage. A later poll(2) call may return POLLNVAL. Although
+  // libuv's event backends do not surface it, we report it as UV_EBADF. The
+  // error path stops the poll handle and removes its fd registration.
+  if revents & libc::POLLNVAL != 0 {
     return (uv_compat::UV_EBADF, 0);
   }
+  // libuv treats POLLERR | POLLPRI as prioritized readiness. Linux and
+  // FreeBSD sysfs/kernfs polling reports this combination, unlike TCP OOB
+  // messages, so only POLLERR without POLLPRI is an EBADF error.
+  if revents & libc::POLLERR != 0 && revents & libc::POLLPRI == 0 {
+    return (uv_compat::UV_EBADF, 0);
+  }
+  // libuv reports the interests that can make progress on an error or hangup,
+  // even when poll(2) returned no ordinary readiness bits.
   if revents & (libc::POLLERR | libc::POLLHUP) != 0 {
-    // libuv reports the interests that can make progress on an error or
-    // hangup, even when poll(2) returned no ordinary readiness bits.
     cb_events |= requested_events
       & (UV_READABLE | UV_WRITABLE | UV_DISCONNECT | UV_PRIORITIZED);
   }
@@ -1912,6 +1920,13 @@ mod tests {
       uv_events_to_poll_events(UV_READABLE | UV_WRITABLE | UV_PRIORITIZED),
       libc::POLLIN | libc::POLLOUT | libc::POLLPRI
     );
+    #[cfg(any(
+      target_os = "linux",
+      target_os = "android",
+      target_os = "freebsd",
+      target_os = "illumos",
+    ))]
+    assert_eq!(uv_events_to_poll_events(UV_DISCONNECT), libc::POLLRDHUP);
   }
 
   #[cfg(unix)]
@@ -1935,6 +1950,27 @@ mod tests {
     assert_eq!(
       poll_revents_to_uv_callback_args(libc::POLLERR, UV_READABLE),
       (uv_compat::UV_EBADF, 0)
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(
+        libc::POLLERR | libc::POLLPRI,
+        UV_PRIORITIZED
+      ),
+      (0, UV_PRIORITIZED)
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLNVAL, UV_READABLE),
+      (uv_compat::UV_EBADF, 0)
+    );
+    #[cfg(any(
+      target_os = "linux",
+      target_os = "android",
+      target_os = "freebsd",
+      target_os = "illumos",
+    ))]
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLRDHUP, UV_DISCONNECT),
+      (0, UV_DISCONNECT)
     );
   }
 

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -1042,9 +1042,10 @@ unsafe extern "C" fn uv_poll_start(
     if cb.is_none() && events != 0 {
       return uv_compat::UV_EINVAL;
     }
-    let env = &mut *(*poll).r#loop;
     #[cfg(unix)]
-    if !env.try_acquire_poll_fd((&*bridge_ptr).fd, poll as usize) {
+    if !(&mut *(*poll).r#loop)
+      .try_acquire_poll_fd((&*bridge_ptr).fd, poll as usize)
+    {
       return uv_compat::UV_EEXIST;
     }
     if events == 0 {
@@ -1055,7 +1056,7 @@ unsafe extern "C" fn uv_poll_start(
     if !(*poll).active {
       (*poll).active = true;
       if (*poll).refed {
-        env.external_ops_tracker.ref_op();
+        (&mut *(*poll).r#loop).external_ops_tracker.ref_op();
       }
     }
     let bridge = Arc::new(PollBridge {
@@ -1066,7 +1067,7 @@ unsafe extern "C" fn uv_poll_start(
     *bridge_ptr = bridge;
     #[cfg(unix)]
     let bridge = Arc::clone(&*bridge_ptr);
-    let sender = env.async_work_sender.clone();
+    let sender = (&mut *(*poll).r#loop).async_work_sender.clone();
     let poll_ptr = SendPtr(poll as *const uv_poll_t);
     #[cfg(unix)]
     std::thread::spawn(move || {

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -49,6 +49,11 @@ const UV_HANDLE_ACTIVE: u32 = 1 << 0;
 const UV_HANDLE_REF: u32 = 1 << 1;
 const UV_HANDLE_CLOSING: u32 = 1 << 2;
 
+pub const UV_READABLE: c_int = 1;
+pub const UV_WRITABLE: c_int = 2;
+pub const UV_DISCONNECT: c_int = 4;
+pub const UV_PRIORITIZED: c_int = 8;
+
 // libuv-compatible error codes (negative errno values on unix,
 // which vary depending on platform, fixed values on windows).
 macro_rules! uv_errno {

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -78,6 +78,10 @@ uv_errno!(UV_ECONNRESET, libc::ECONNRESET, -4077);
 uv_errno!(UV_ECONNABORTED, libc::ECONNABORTED, -4079);
 uv_errno!(UV_ETIMEDOUT, libc::ETIMEDOUT, -4039);
 uv_errno!(UV_EACCES, libc::EACCES, -4092);
+uv_errno!(UV_EEXIST, libc::EEXIST, -4075);
+uv_errno!(UV_EFAULT, libc::EFAULT, -4074);
+uv_errno!(UV_EIO, libc::EIO, -4070);
+uv_errno!(UV_ENOMEM, libc::ENOMEM, -4057);
 pub const UV_EOF: i32 = -4095;
 
 pub fn uv_error_message(err: c_int) -> Option<&'static CStr> {
@@ -100,6 +104,10 @@ pub fn uv_error_message(err: c_int) -> Option<&'static CStr> {
     x if x == UV_ECONNABORTED => c"software caused connection abort",
     x if x == UV_ETIMEDOUT => c"connection timed out",
     x if x == UV_EACCES => c"permission denied",
+    x if x == UV_EEXIST => c"file already exists",
+    x if x == UV_EFAULT => c"bad address in system call argument",
+    x if x == UV_EIO => c"i/o error",
+    x if x == UV_ENOMEM => c"not enough memory",
     x if x == UV_EOF => c"end of file",
     _ => return None,
   };

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -77,6 +77,10 @@ uv_errno!(UV_ECONNRESET, libc::ECONNRESET, -4077);
 uv_errno!(UV_ECONNABORTED, libc::ECONNABORTED, -4079);
 uv_errno!(UV_ETIMEDOUT, libc::ETIMEDOUT, -4039);
 uv_errno!(UV_EACCES, libc::EACCES, -4092);
+uv_errno!(UV_EEXIST, libc::EEXIST, -4075);
+uv_errno!(UV_EFAULT, libc::EFAULT, -4074);
+uv_errno!(UV_EIO, libc::EIO, -4070);
+uv_errno!(UV_ENOMEM, libc::ENOMEM, -4057);
 pub const UV_EOF: i32 = -4095;
 
 pub fn uv_error_message(err: c_int) -> Option<&'static CStr> {
@@ -99,6 +103,10 @@ pub fn uv_error_message(err: c_int) -> Option<&'static CStr> {
     x if x == UV_ECONNABORTED => c"software caused connection abort",
     x if x == UV_ETIMEDOUT => c"connection timed out",
     x if x == UV_EACCES => c"permission denied",
+    x if x == UV_EEXIST => c"file already exists",
+    x if x == UV_EFAULT => c"bad address in system call argument",
+    x if x == UV_EIO => c"i/o error",
+    x if x == UV_ENOMEM => c"not enough memory",
     x if x == UV_EOF => c"end of file",
     _ => return None,
   };

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -272,20 +272,17 @@ pub struct uv_check_t {
 #[cfg(unix)]
 pub type uv_poll_cb = unsafe extern "C" fn(*mut uv_poll_t, c_int, c_int);
 
-/// An owner can suppress readiness for all poll handles created for one
-/// embedding scope.
+/// A poll scope groups handles created by one embedding context, such as an
+/// N-API Env, and can invalidate them together.
 ///
-/// Invalidation removes matching worker watches and rejects queued readiness
-/// and new starts. Loop-side handle state and fd ownership remain until each
-/// handle is stopped or closed. The worker sees only this numeric owner id; it
-/// never retains an addon or ABI-handle pointer.
-///
-/// Unlike `UvLoopLiveness`, invalidation is limited to this owner's poll
-/// handles and does not guard access to loop-associated state.
+/// Invalidating it removes matching worker watches and causes the loop to
+/// discard queued readiness and reject new starts. Loop-side handle state and
+/// fd ownership remain until each handle is stopped or closed. The worker sees
+/// only this numeric scope ID; it never retains an addon or ABI-handle pointer.
 #[cfg(unix)]
 #[derive(Clone)]
-pub struct UvPollOwner {
-  id: u64,
+pub struct UvPollScope {
+  scope_id: u64,
   live: Arc<AtomicBool>,
   control: Weak<poll::PollControl>,
 }
@@ -331,11 +328,11 @@ pub fn uv_loop_operation_guard(
 }
 
 #[cfg(unix)]
-impl UvPollOwner {
+impl UvPollScope {
   pub fn invalidate(&self) {
     self.live.store(false, Ordering::Release);
     if let Some(control) = self.control.upgrade() {
-      control.stop_owner(self.id);
+      control.stop_scope(self.scope_id);
     }
   }
 }
@@ -359,7 +356,7 @@ pub struct uv_poll_t {
   internal_requested_events: c_int,
   internal_cb: Option<uv_poll_cb>,
   internal_stop_cb: Option<unsafe extern "C" fn(*mut uv_poll_t)>,
-  internal_owner: Option<UvPollOwner>,
+  internal_scope: Option<UvPollScope>,
 }
 
 pub type uv_timer_cb = unsafe extern "C" fn(*mut uv_timer_t);
@@ -403,7 +400,7 @@ pub(crate) struct UvLoopInner {
   #[cfg(unix)]
   next_poll_token: Cell<u64>,
   #[cfg(unix)]
-  next_poll_owner: Cell<u64>,
+  next_poll_scope_id: Cell<u64>,
   waker: RefCell<Option<Waker>>,
   closing_handles: RefCell<VecDeque<(*mut uv_handle_t, Option<uv_close_cb>)>>,
   time_origin: Instant,
@@ -443,7 +440,7 @@ impl UvLoopInner {
       #[cfg(unix)]
       next_poll_token: Cell::new(1),
       #[cfg(unix)]
-      next_poll_owner: Cell::new(1),
+      next_poll_scope_id: Cell::new(1),
       waker: RefCell::new(None),
       closing_handles: RefCell::new(VecDeque::with_capacity(16)),
       time_origin: origin,
@@ -582,13 +579,13 @@ impl UvLoopInner {
       let handle = unsafe { &**handle_ptr };
       if handle.flags & UV_HANDLE_ACTIVE != 0
         && handle.flags & UV_HANDLE_REF != 0
-        // Owner invalidation is an Env-scoped close signal. The handle can
+        // Scope invalidation is an Env-scoped close signal. The handle can
         // remain allocated until its bridge processes close, but it must not
-        // keep this runtime alive after that owner is gone.
+        // keep this runtime alive after that scope is gone.
         && handle
-          .internal_owner
+          .internal_scope
           .as_ref()
-          .is_some_and(|owner| owner.live.load(Ordering::Acquire))
+          .is_some_and(|scope| scope.live.load(Ordering::Acquire))
       {
         return true;
       }
@@ -1104,9 +1101,9 @@ impl UvLoopInner {
             || handle.internal_generation != ready.generation
             || handle.flags & UV_HANDLE_ACTIVE == 0
             || !handle
-              .internal_owner
+              .internal_scope
               .as_ref()
-              .is_some_and(|owner| owner.live.load(Ordering::Acquire))
+              .is_some_and(|scope| scope.live.load(Ordering::Acquire))
           {
             None
           } else {
@@ -1147,9 +1144,9 @@ impl UvLoopInner {
             && handle.internal_generation == ready.generation
             && handle.flags & UV_HANDLE_ACTIVE != 0
             && handle
-              .internal_owner
+              .internal_scope
               .as_ref()
-              .is_some_and(|owner| owner.live.load(Ordering::Acquire))
+              .is_some_and(|scope| scope.live.load(Ordering::Acquire))
         })
       };
       if should_rearm
@@ -1300,18 +1297,19 @@ pub unsafe fn uv_loop_get_inner_ptr(
   unsafe { (*loop_).internal as *const std::ffi::c_void }
 }
 
-/// Create an invalidation owner for poll handles registered with `loop_`.
+/// Create a poll scope that can invalidate poll handles registered with
+/// `loop_`.
 ///
 /// ### Safety
 /// `loop_` must be a valid loop initialized by `uv_loop_init`.
 #[cfg(unix)]
-pub unsafe fn new_poll_owner(loop_: *mut uv_loop_t) -> UvPollOwner {
+pub unsafe fn new_poll_scope(loop_: *mut uv_loop_t) -> UvPollScope {
   // SAFETY: Caller guarantees loop_ is initialized.
   let inner = unsafe { get_inner(loop_) };
-  let id = inner.next_poll_owner.get();
-  inner.next_poll_owner.set(id.wrapping_add(1));
-  UvPollOwner {
-    id,
+  let scope_id = inner.next_poll_scope_id.get();
+  inner.next_poll_scope_id.set(scope_id.wrapping_add(1));
+  UvPollScope {
+    scope_id,
     live: Arc::new(AtomicBool::new(true)),
     control: inner.poll_driver.borrow().control(),
   }
@@ -1333,7 +1331,7 @@ pub unsafe fn uv_poll_init(
   loop_: *mut uv_loop_t,
   handle: *mut uv_poll_t,
   fd: c_int,
-  owner: UvPollOwner,
+  scope: UvPollScope,
 ) -> c_int {
   // SAFETY: Caller guarantees loop_ and handle are valid.
   let inner = unsafe { get_inner(loop_) };
@@ -1362,7 +1360,7 @@ pub unsafe fn uv_poll_init(
         internal_requested_events: 0,
         internal_cb: None,
         internal_stop_cb: None,
-        internal_owner: Some(owner),
+        internal_scope: Some(scope),
       },
     );
   }
@@ -1401,10 +1399,10 @@ pub unsafe fn uv_poll_start(
   }
   // SAFETY: An initialized poll handle always records its initialized loop.
   let inner = unsafe { get_inner(handle_ref.loop_) };
-  let Some(owner) = handle_ref.internal_owner.as_ref() else {
+  let Some(scope) = handle_ref.internal_scope.as_ref() else {
     return UV_EINVAL;
   };
-  if !owner.live.load(Ordering::Acquire) {
+  if !scope.live.load(Ordering::Acquire) {
     return UV_ECANCELED;
   }
 
@@ -1430,7 +1428,7 @@ pub unsafe fn uv_poll_start(
   let watch = poll::PollWatch {
     token: handle_ref.internal_token,
     generation,
-    owner: owner.id,
+    scope_id: scope.scope_id,
     fd: handle_ref.internal_fd,
     poll_events: poll::uv_events_to_poll_events(events),
   };
@@ -1439,7 +1437,7 @@ pub unsafe fn uv_poll_start(
   // This leaves fd ownership unpublished during upsert, which is safe because
   // uv_poll_start and upsert run synchronously and non-reentrantly on the loop
   // thread. Reserve the fd before upsert if either assumption changes.
-  if let Err(errno) = inner.poll_driver.borrow_mut().upsert(watch, &owner.live)
+  if let Err(errno) = inner.poll_driver.borrow_mut().upsert(watch, &scope.live)
   {
     return -errno;
   }
@@ -1494,7 +1492,7 @@ pub unsafe fn uv_poll_close(handle: *mut uv_poll_t) {
   unsafe {
     (*handle).flags |= UV_HANDLE_CLOSING;
     (*handle).flags &= !(UV_HANDLE_ACTIVE | UV_HANDLE_REF);
-    (*handle).internal_owner = None;
+    (*handle).internal_scope = None;
   }
 }
 

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -279,6 +279,9 @@ pub type uv_poll_cb = unsafe extern "C" fn(*mut uv_poll_t, c_int, c_int);
 /// and new starts. Loop-side handle state and fd ownership remain until each
 /// handle is stopped or closed. The worker sees only this numeric owner id; it
 /// never retains an addon or ABI-handle pointer.
+///
+/// Unlike `UvLoopLiveness`, invalidation is limited to this owner's poll
+/// handles and does not guard access to loop-associated state.
 #[cfg(unix)]
 #[derive(Clone)]
 pub struct UvPollOwner {
@@ -288,6 +291,11 @@ pub struct UvPollOwner {
 }
 
 #[cfg(unix)]
+/// Coordinates access to loop-associated state with loop teardown.
+///
+/// `uv_loop_operation_guard` holds this mutex during an operation. Teardown
+/// takes the same mutex before invalidating the token, so it waits for
+/// in-flight operations and later guards return `None`.
 pub struct UvLoopLiveness {
   live: AtomicBool,
   lock: Mutex<()>,
@@ -1079,9 +1087,7 @@ impl UvLoopInner {
     }
   }
 
-  /// Drain exactly one worker-ready snapshot and invoke callbacks on the
-  /// loop thread. No registry borrow survives a callback: it may close or
-  /// restart the same handle, including through a higher-level ABI bridge.
+  /// Dispatch the poll worker's currently queued readiness on the loop thread.
   #[cfg(unix)]
   unsafe fn run_poll_io(&self) -> bool {
     let ready = self.poll_driver.borrow().drain_ready();
@@ -1089,6 +1095,8 @@ impl UvLoopInner {
 
     for ready in ready {
       let snapshot = unsafe {
+        // Keep the registry borrow scoped to this block so the callback can
+        // close or restart the handle.
         let handles = self.poll_handles.borrow();
         if let Some(handle_ptr) = handles.get(&ready.token) {
           let handle = &mut **handle_ptr;
@@ -1292,9 +1300,9 @@ pub unsafe fn uv_loop_get_inner_ptr(
   unsafe { (*loop_).internal as *const std::ffi::c_void }
 }
 
-/// Create an invalidation owner for core poll handles on `loop_`.
+/// Create an invalidation owner for poll handles registered with `loop_`.
 ///
-/// # Safety
+/// ### Safety
 /// `loop_` must be a valid loop initialized by `uv_loop_init`.
 #[cfg(unix)]
 pub unsafe fn new_poll_owner(loop_: *mut uv_loop_t) -> UvPollOwner {
@@ -1311,17 +1319,14 @@ pub unsafe fn new_poll_owner(loop_: *mut uv_loop_t) -> UvPollOwner {
 
 /// Returns the shared operation/lifetime token for an initialized uv loop.
 ///
-/// # Safety
-///
+/// ### Safety
 /// `loop_` must point to a live initialized loop.
 #[cfg(unix)]
 pub unsafe fn uv_loop_liveness(loop_: *mut uv_loop_t) -> Arc<UvLoopLiveness> {
   unsafe { get_inner(loop_) }.liveness.clone()
 }
 
-/// Initialize a Unix poll handle managed by the core loop.
-///
-/// # Safety
+/// ### Safety
 /// `loop_` must be initialized and `handle` must be valid writable storage.
 #[cfg(unix)]
 pub unsafe fn uv_poll_init(
@@ -1367,8 +1372,7 @@ pub unsafe fn uv_poll_init(
 
 /// Install a loop-thread notification invoked whenever a poll handle stops.
 ///
-/// # Safety
-///
+/// ### Safety
 /// `handle` must be a live initialized poll handle.
 #[cfg(unix)]
 pub unsafe fn uv_poll_set_stop_callback(
@@ -1378,9 +1382,9 @@ pub unsafe fn uv_poll_set_stop_callback(
   unsafe { (*handle).internal_stop_cb = callback };
 }
 
-/// Start or update a core poll handle.
+/// Start or update a poll handle.
 ///
-/// # Safety
+/// ### Safety
 /// `handle` must have been initialized by `uv_poll_init` and remain valid.
 #[cfg(unix)]
 pub unsafe fn uv_poll_start(
@@ -1432,6 +1436,9 @@ pub unsafe fn uv_poll_start(
   };
   // Commit loop state only after lazy worker startup accepts the watch, so a
   // failure leaves an existing registration, generation, and fd owner intact.
+  // This leaves fd ownership unpublished during upsert, which is safe because
+  // uv_poll_start and upsert run synchronously and non-reentrantly on the loop
+  // thread. Reserve the fd before upsert if either assumption changes.
   if let Err(errno) = inner.poll_driver.borrow_mut().upsert(watch, &owner.live)
   {
     return -errno;
@@ -1447,9 +1454,10 @@ pub unsafe fn uv_poll_start(
   0
 }
 
-/// Stop a core poll handle and invalidate its currently queued generation.
+/// Stop a poll handle and invalidate queued readiness for its current
+/// generation.
 ///
-/// # Safety
+/// ### Safety
 /// `handle` must have been initialized by `uv_poll_init` and remain valid.
 #[cfg(unix)]
 pub unsafe fn uv_poll_stop(handle: *mut uv_poll_t) -> c_int {
@@ -1466,9 +1474,7 @@ pub unsafe fn uv_poll_stop(handle: *mut uv_poll_t) -> c_int {
   0
 }
 
-/// Remove a core poll handle from its loop registry.
-///
-/// # Safety
+/// ### Safety
 /// `handle` must have been initialized by `uv_poll_init` and remain valid.
 #[cfg(unix)]
 pub unsafe fn uv_poll_close(handle: *mut uv_poll_t) {

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -3,6 +3,8 @@
 // Drop-in replacement for libuv integrated with deno_core's event loop.
 
 mod pipe;
+#[cfg(unix)]
+mod poll;
 mod stream;
 mod tcp;
 mod tty;
@@ -20,6 +22,16 @@ use std::ffi::CStr;
 use std::ffi::c_int;
 use std::ffi::c_void;
 use std::sync::Arc;
+#[cfg(unix)]
+use std::sync::Mutex;
+#[cfg(unix)]
+use std::sync::MutexGuard;
+#[cfg(unix)]
+use std::sync::Weak;
+#[cfg(unix)]
+use std::sync::atomic::AtomicBool;
+#[cfg(unix)]
+use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Waker;
 use std::time::Duration;
@@ -39,6 +51,7 @@ pub enum uv_handle_type {
   UV_PREPARE = 3,
   UV_CHECK = 4,
   UV_NAMED_PIPE = 7,
+  UV_POLL = 8,
   UV_TCP = 12,
   UV_TTY = 13,
   UV_UDP = 15,
@@ -250,6 +263,91 @@ pub struct uv_check_t {
   cb: Option<unsafe extern "C" fn(*mut uv_check_t)>,
 }
 
+#[cfg(unix)]
+pub type uv_poll_cb = unsafe extern "C" fn(*mut uv_poll_t, c_int, c_int);
+
+/// An owner can suppress readiness for all poll handles created for one
+/// embedding scope.
+///
+/// Invalidation removes matching worker watches and rejects queued readiness
+/// and new starts. Loop-side handle state and fd ownership remain until each
+/// handle is stopped or closed. The worker sees only this numeric owner id; it
+/// never retains an addon or ABI-handle pointer.
+#[cfg(unix)]
+#[derive(Clone)]
+pub struct UvPollOwner {
+  id: u64,
+  live: Arc<AtomicBool>,
+  control: Weak<poll::PollControl>,
+}
+
+#[cfg(unix)]
+pub struct UvLoopLiveness {
+  live: AtomicBool,
+  lock: Mutex<()>,
+}
+
+#[cfg(unix)]
+impl UvLoopLiveness {
+  fn new() -> Self {
+    Self {
+      live: AtomicBool::new(true),
+      lock: Mutex::new(()),
+    }
+  }
+  fn invalidate(&self) {
+    let _guard = self.lock.lock().unwrap_or_else(|p| p.into_inner());
+    self.live.store(false, Ordering::Release);
+  }
+}
+
+#[cfg(unix)]
+/// Prevents loop teardown while the caller accesses loop-associated external
+/// state. Returns `None` once teardown has begun; callers must hold the guard
+/// for their entire operation.
+pub fn uv_loop_operation_guard(
+  liveness: &UvLoopLiveness,
+) -> Option<MutexGuard<'_, ()>> {
+  let guard = liveness.lock.lock().unwrap_or_else(|p| p.into_inner());
+  if liveness.live.load(Ordering::Acquire) {
+    Some(guard)
+  } else {
+    None
+  }
+}
+
+#[cfg(unix)]
+impl UvPollOwner {
+  pub fn invalidate(&self) {
+    self.live.store(false, Ordering::Release);
+    if let Some(control) = self.control.upgrade() {
+      control.stop_owner(self.id);
+    }
+  }
+}
+
+/// Caller storage containing this handle must remain valid until
+/// `uv_poll_close` removes it from the loop registry or loop teardown
+/// invalidates `UvLoopLiveness`.
+#[cfg(unix)]
+#[repr(C)]
+pub struct uv_poll_t {
+  pub r#type: uv_handle_type,
+  pub loop_: *mut uv_loop_t,
+  pub data: *mut c_void,
+  pub flags: u32,
+  // The token identifies this handle without sharing its ABI pointer with the
+  // worker. The generation identifies its current start/update, so readiness
+  // queued for an older watch can be discarded after stop or restart.
+  internal_token: u64,
+  internal_generation: u64,
+  internal_fd: c_int,
+  internal_events: c_int,
+  internal_cb: Option<uv_poll_cb>,
+  internal_stop_cb: Option<unsafe extern "C" fn(*mut uv_poll_t)>,
+  internal_owner: Option<UvPollOwner>,
+}
+
 pub type uv_timer_cb = unsafe extern "C" fn(*mut uv_timer_t);
 pub type uv_idle_cb = unsafe extern "C" fn(*mut uv_idle_t);
 pub type uv_prepare_cb = unsafe extern "C" fn(*mut uv_prepare_t);
@@ -267,6 +365,8 @@ struct TimerKey {
 }
 
 pub(crate) struct UvLoopInner {
+  #[cfg(unix)]
+  liveness: Arc<UvLoopLiveness>,
   timers: RefCell<BTreeSet<TimerKey>>,
   next_timer_id: Cell<u64>,
   timer_handles: RefCell<HashMap<u64, *mut uv_timer_t>>,
@@ -276,6 +376,20 @@ pub(crate) struct UvLoopInner {
   tcp_handles: RefCell<Vec<*mut uv_tcp_t>>,
   pipe_handles: RefCell<Vec<*mut uv_pipe_t>>,
   tty_handles: RefCell<Vec<*mut uv_tty_t>>,
+  #[cfg(unix)]
+  poll_driver: RefCell<poll::PollDriver>,
+  #[cfg(unix)]
+  poll_handles: RefCell<HashMap<u64, *mut uv_poll_t>>,
+  // Mirrors libuv's loop-wide uv__fd_exists duplicate-fd registry rather than
+  // poll-local ownership. Only poll handles participate today. An entry
+  // reserves its raw fd until stop or close; closing the fd first can let OS
+  // reuse make a later setup fail with UV_EEXIST.
+  #[cfg(unix)]
+  fd_watchers: RefCell<HashMap<c_int, u64>>,
+  #[cfg(unix)]
+  next_poll_token: Cell<u64>,
+  #[cfg(unix)]
+  next_poll_owner: Cell<u64>,
   waker: RefCell<Option<Waker>>,
   closing_handles: RefCell<VecDeque<(*mut uv_handle_t, Option<uv_close_cb>)>>,
   time_origin: Instant,
@@ -291,7 +405,12 @@ pub(crate) struct UvLoopInner {
 impl UvLoopInner {
   fn new() -> Self {
     let origin = Instant::now();
+    let shared = waker::LoopShared::new();
+    #[cfg(unix)]
+    let poll_driver = poll::PollDriver::new(shared.clone());
     Self {
+      #[cfg(unix)]
+      liveness: Arc::new(UvLoopLiveness::new()),
       timers: RefCell::new(BTreeSet::new()),
       next_timer_id: Cell::new(1),
       timer_handles: RefCell::new(HashMap::with_capacity(16)),
@@ -301,11 +420,21 @@ impl UvLoopInner {
       tcp_handles: RefCell::new(Vec::with_capacity(8)),
       pipe_handles: RefCell::new(Vec::with_capacity(4)),
       tty_handles: RefCell::new(Vec::with_capacity(4)),
+      #[cfg(unix)]
+      poll_driver: RefCell::new(poll_driver),
+      #[cfg(unix)]
+      poll_handles: RefCell::new(HashMap::with_capacity(4)),
+      #[cfg(unix)]
+      fd_watchers: RefCell::new(HashMap::with_capacity(4)),
+      #[cfg(unix)]
+      next_poll_token: Cell::new(1),
+      #[cfg(unix)]
+      next_poll_owner: Cell::new(1),
       waker: RefCell::new(None),
       closing_handles: RefCell::new(VecDeque::with_capacity(16)),
       time_origin: origin,
       cached_time_ms: Cell::new(0),
-      shared: waker::LoopShared::new(),
+      shared,
     }
   }
 
@@ -429,6 +558,23 @@ impl UvLoopInner {
       let handle = unsafe { &**handle_ptr };
       if handle.flags & UV_HANDLE_ACTIVE != 0
         && handle.flags & UV_HANDLE_REF != 0
+      {
+        return true;
+      }
+    }
+    #[cfg(unix)]
+    for handle_ptr in self.poll_handles.borrow().values() {
+      // SAFETY: Poll pointers are retained by their C caller until uv_close.
+      let handle = unsafe { &**handle_ptr };
+      if handle.flags & UV_HANDLE_ACTIVE != 0
+        && handle.flags & UV_HANDLE_REF != 0
+        // Owner invalidation is an Env-scoped close signal. The handle can
+        // remain allocated until its bridge processes close, but it must not
+        // keep this runtime alive after that owner is gone.
+        && handle
+          .internal_owner
+          .as_ref()
+          .is_some_and(|owner| owner.live.load(Ordering::Acquire))
       {
         return true;
       }
@@ -682,6 +828,13 @@ impl UvLoopInner {
         any_work |= unsafe { tty::poll_tty_handle(tty_ptr, &mut cx) };
       }
 
+      #[cfg(unix)]
+      {
+        // Preserve one-pass I/O ordering: tokio-backed TCP/pipe/TTY callbacks
+        // run before worker-driven poll callbacks.
+        any_work |= unsafe { self.run_poll_io() };
+      }
+
       any_work
     }
   }
@@ -890,6 +1043,127 @@ impl UvLoopInner {
       (*handle).flags &= !UV_HANDLE_ACTIVE;
     }
   }
+
+  #[cfg(unix)]
+  unsafe fn stop_poll(&self, handle: *mut uv_poll_t) {
+    // SAFETY: Caller guarantees handle is valid and initialized.
+    let handle_ref = unsafe { &mut *handle };
+    let generation = handle_ref.internal_generation;
+    handle_ref.internal_generation = generation.wrapping_add(1);
+    handle_ref.flags &= !UV_HANDLE_ACTIVE;
+    handle_ref.internal_events = 0;
+    handle_ref.internal_cb = None;
+
+    // Release fd ownership before notifying the embedding: its stop hook or a
+    // subsequent error callback may synchronously install a replacement.
+    let mut watchers = self.fd_watchers.borrow_mut();
+    if watchers
+      .get(&handle_ref.internal_fd)
+      .is_some_and(|token| *token == handle_ref.internal_token)
+    {
+      watchers.remove(&handle_ref.internal_fd);
+    }
+    drop(watchers);
+    self
+      .poll_driver
+      .borrow()
+      .stop(handle_ref.internal_token, generation);
+    if let Some(callback) = handle_ref.internal_stop_cb {
+      unsafe { callback(handle) };
+    }
+  }
+
+  /// Drain exactly one worker-ready snapshot and invoke callbacks on the
+  /// loop thread. No registry borrow survives a callback: it may close or
+  /// restart the same handle, including through a higher-level ABI bridge.
+  #[cfg(unix)]
+  unsafe fn run_poll_io(&self) -> bool {
+    let ready = self.poll_driver.borrow().drain_ready();
+    let mut any_work = false;
+
+    for ready in ready {
+      let snapshot = unsafe {
+        let handles = self.poll_handles.borrow();
+        if let Some(handle_ptr) = handles.get(&ready.token) {
+          let handle = &mut **handle_ptr;
+          if handle.internal_token != ready.token
+            || handle.internal_generation != ready.generation
+            || handle.flags & UV_HANDLE_ACTIVE == 0
+            || !handle
+              .internal_owner
+              .as_ref()
+              .is_some_and(|owner| owner.live.load(Ordering::Acquire))
+          {
+            None
+          } else {
+            let (status, events) = if ready.status != 0 {
+              (ready.status, 0)
+            } else {
+              poll::poll_revents_to_uv_callback_args(
+                ready.revents,
+                handle.internal_events,
+              )
+            };
+            handle
+              .internal_cb
+              .map(|callback| (*handle_ptr, callback, status, events))
+          }
+        } else {
+          None
+        }
+      };
+      let Some((handle_ptr, callback, status, events)) = snapshot else {
+        continue;
+      };
+
+      if status != 0 {
+        // Stop first so the poll callback can install a replacement watch.
+        unsafe { self.stop_poll(handle_ptr) };
+      }
+      // SAFETY: Callback and pointer were copied while the registry entry was
+      // live. The C caller keeps the handle valid until its close callback.
+      unsafe { callback(handle_ptr, status, events) };
+      any_work = true;
+
+      let should_rearm = unsafe {
+        let handles = self.poll_handles.borrow();
+        handles.get(&ready.token).is_some_and(|handle_ptr| {
+          let handle = &**handle_ptr;
+          handle.internal_token == ready.token
+            && handle.internal_generation == ready.generation
+            && handle.flags & UV_HANDLE_ACTIVE != 0
+            && handle
+              .internal_owner
+              .as_ref()
+              .is_some_and(|owner| owner.live.load(Ordering::Acquire))
+        })
+      };
+      if should_rearm
+        && self
+          .poll_driver
+          .borrow()
+          .rearm(ready.token, ready.generation)
+          .is_err()
+      {
+        // The worker has entered a terminal state after this callback was
+        // delivered. It cannot accept the rearm, so release loop ownership
+        // instead of leaving a referenced but unserviceable handle alive.
+        unsafe { self.stop_poll(handle_ptr) };
+      }
+    }
+
+    any_work
+  }
+}
+
+#[cfg(unix)]
+impl Drop for UvLoopInner {
+  fn drop(&mut self) {
+    self.liveness.invalidate();
+    // Join before the token registry and LoopShared are dropped. The worker
+    // only owns tokens, but it can still wake LoopShared while shutting down.
+    self.poll_driver.get_mut().shutdown();
+  }
 }
 
 /// ### Safety
@@ -1010,6 +1284,206 @@ pub unsafe fn uv_loop_get_inner_ptr(
 ) -> *const std::ffi::c_void {
   // SAFETY: Caller guarantees loop_ is valid and was initialized by uv_loop_init.
   unsafe { (*loop_).internal as *const std::ffi::c_void }
+}
+
+/// Create an invalidation owner for core poll handles on `loop_`.
+///
+/// # Safety
+/// `loop_` must be a valid loop initialized by `uv_loop_init`.
+#[cfg(unix)]
+pub unsafe fn new_poll_owner(loop_: *mut uv_loop_t) -> UvPollOwner {
+  // SAFETY: Caller guarantees loop_ is initialized.
+  let inner = unsafe { get_inner(loop_) };
+  let id = inner.next_poll_owner.get();
+  inner.next_poll_owner.set(id.wrapping_add(1));
+  UvPollOwner {
+    id,
+    live: Arc::new(AtomicBool::new(true)),
+    control: inner.poll_driver.borrow().control(),
+  }
+}
+
+/// Returns the shared operation/lifetime token for an initialized uv loop.
+///
+/// # Safety
+///
+/// `loop_` must point to a live initialized loop.
+#[cfg(unix)]
+pub unsafe fn uv_loop_liveness(loop_: *mut uv_loop_t) -> Arc<UvLoopLiveness> {
+  unsafe { get_inner(loop_) }.liveness.clone()
+}
+
+/// Initialize a Unix poll handle managed by the core loop.
+///
+/// # Safety
+/// `loop_` must be initialized and `handle` must be valid writable storage.
+#[cfg(unix)]
+pub unsafe fn uv_poll_init(
+  loop_: *mut uv_loop_t,
+  handle: *mut uv_poll_t,
+  fd: c_int,
+  owner: UvPollOwner,
+) -> c_int {
+  // SAFETY: Caller guarantees loop_ and handle are valid.
+  let inner = unsafe { get_inner(loop_) };
+  // Match libuv's uv__fd_exists check before changing descriptor flags or
+  // registering this handle. An active watch owns its fd for this loop.
+  if inner.fd_watchers.borrow().contains_key(&fd) {
+    return UV_EEXIST;
+  }
+  if let Err(errno) = poll::set_fd_nonblocking(fd) {
+    return -errno;
+  }
+  let token = inner.next_poll_token.get();
+  inner.next_poll_token.set(token.wrapping_add(1));
+  // SAFETY: handle is valid writable storage supplied by the caller.
+  unsafe {
+    std::ptr::write(
+      handle,
+      uv_poll_t {
+        r#type: uv_handle_type::UV_POLL,
+        loop_,
+        data: std::ptr::null_mut(),
+        flags: UV_HANDLE_REF,
+        internal_token: token,
+        internal_generation: 0,
+        internal_fd: fd,
+        internal_events: 0,
+        internal_cb: None,
+        internal_stop_cb: None,
+        internal_owner: Some(owner),
+      },
+    );
+  }
+  inner.poll_handles.borrow_mut().insert(token, handle);
+  0
+}
+
+/// Install a loop-thread notification invoked whenever a poll handle stops.
+///
+/// # Safety
+///
+/// `handle` must be a live initialized poll handle.
+#[cfg(unix)]
+pub unsafe fn uv_poll_set_stop_callback(
+  handle: *mut uv_poll_t,
+  callback: Option<unsafe extern "C" fn(*mut uv_poll_t)>,
+) {
+  unsafe { (*handle).internal_stop_cb = callback };
+}
+
+/// Start or update a core poll handle.
+///
+/// # Safety
+/// `handle` must have been initialized by `uv_poll_init` and remain valid.
+#[cfg(unix)]
+pub unsafe fn uv_poll_start(
+  handle: *mut uv_poll_t,
+  events: c_int,
+  cb: Option<uv_poll_cb>,
+) -> c_int {
+  const VALID_EVENTS: c_int =
+    UV_READABLE | UV_WRITABLE | UV_DISCONNECT | UV_PRIORITIZED;
+  // SAFETY: Caller guarantees handle is valid and initialized.
+  let handle_ref = unsafe { &mut *handle };
+  if handle_ref.flags & UV_HANDLE_CLOSING != 0 || events & !VALID_EVENTS != 0 {
+    return UV_EINVAL;
+  }
+  // SAFETY: An initialized poll handle always records its initialized loop.
+  let inner = unsafe { get_inner(handle_ref.loop_) };
+  let Some(owner) = handle_ref.internal_owner.as_ref() else {
+    return UV_EINVAL;
+  };
+  if !owner.live.load(Ordering::Acquire) {
+    return UV_ECANCELED;
+  }
+
+  // libuv validates fd ownership before treating a zero mask as stop.
+  if inner
+    .fd_watchers
+    .borrow()
+    .get(&handle_ref.internal_fd)
+    .is_some_and(|token| *token != handle_ref.internal_token)
+  {
+    return UV_EEXIST;
+  }
+  // libuv stores a null callback without validation and would later invoke it
+  // during event dispatch. Reject it synchronously instead.
+  if events != 0 && cb.is_none() {
+    return UV_EINVAL;
+  }
+  if events == 0 {
+    return unsafe { uv_poll_stop(handle) };
+  }
+
+  let generation = handle_ref.internal_generation.wrapping_add(1);
+  let watch = poll::PollWatch {
+    token: handle_ref.internal_token,
+    generation,
+    owner: owner.id,
+    fd: handle_ref.internal_fd,
+    events: poll::uv_events_to_poll_events(events),
+  };
+  // Commit loop state only after lazy worker startup accepts the watch, so a
+  // failure leaves an existing registration, generation, and fd owner intact.
+  if let Err(errno) = inner.poll_driver.borrow_mut().upsert(watch, &owner.live)
+  {
+    return -errno;
+  }
+  handle_ref.internal_generation = generation;
+  handle_ref.internal_events = events;
+  handle_ref.internal_cb = cb;
+  handle_ref.flags |= UV_HANDLE_ACTIVE;
+  inner
+    .fd_watchers
+    .borrow_mut()
+    .insert(handle_ref.internal_fd, handle_ref.internal_token);
+  0
+}
+
+/// Stop a core poll handle and invalidate its currently queued generation.
+///
+/// # Safety
+/// `handle` must have been initialized by `uv_poll_init` and remain valid.
+#[cfg(unix)]
+pub unsafe fn uv_poll_stop(handle: *mut uv_poll_t) -> c_int {
+  // SAFETY: Caller guarantees handle is valid and initialized.
+  let loop_ = unsafe { (*handle).loop_ };
+  if loop_.is_null() || unsafe { (*loop_).internal.is_null() } {
+    // SAFETY: handle is valid per this function's contract.
+    unsafe { (*handle).flags &= !UV_HANDLE_ACTIVE };
+    return 0;
+  }
+  // SAFETY: loop_ is initialized while its internal pointer is non-null.
+  let inner = unsafe { get_inner(loop_) };
+  unsafe { inner.stop_poll(handle) };
+  0
+}
+
+/// Remove a core poll handle from its loop registry.
+///
+/// # Safety
+/// `handle` must have been initialized by `uv_poll_init` and remain valid.
+#[cfg(unix)]
+pub unsafe fn uv_poll_close(handle: *mut uv_poll_t) {
+  // SAFETY: Caller guarantees handle is valid and initialized.
+  let loop_ = unsafe { (*handle).loop_ };
+  if !loop_.is_null() && unsafe { !(*loop_).internal.is_null() } {
+    // SAFETY: loop_ is initialized while its internal pointer is non-null.
+    let inner = unsafe { get_inner(loop_) };
+    unsafe { inner.stop_poll(handle) };
+    // SAFETY: handle remains valid until its caller completes close handling.
+    inner
+      .poll_handles
+      .borrow_mut()
+      .remove(&unsafe { (*handle).internal_token });
+  }
+  // SAFETY: handle is valid per this function's contract.
+  unsafe {
+    (*handle).flags |= UV_HANDLE_CLOSING;
+    (*handle).flags &= !(UV_HANDLE_ACTIVE | UV_HANDLE_REF);
+    (*handle).internal_owner = None;
+  }
 }
 
 /// ### Safety
@@ -1506,6 +1980,10 @@ pub unsafe extern "C" fn uv_close(
       }
       uv_handle_type::UV_NAMED_PIPE => {
         inner.stop_pipe(handle as *mut uv_pipe_t);
+      }
+      #[cfg(unix)]
+      uv_handle_type::UV_POLL => {
+        uv_poll_close(handle as *mut uv_poll_t);
       }
       _ => {}
     }

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -100,6 +100,9 @@ uv_errno!(UV_EEXIST, libc::EEXIST, -4075);
 uv_errno!(UV_EFAULT, libc::EFAULT, -4074);
 uv_errno!(UV_EIO, libc::EIO, -4070);
 uv_errno!(UV_ENOMEM, libc::ENOMEM, -4057);
+uv_errno!(UV_EMFILE, libc::EMFILE, -4066);
+uv_errno!(UV_ENFILE, libc::ENFILE, -4061);
+uv_errno!(UV_ENOSYS, libc::ENOSYS, -4054);
 pub const UV_EOF: i32 = -4095;
 
 pub fn uv_error_message(err: c_int) -> Option<&'static CStr> {
@@ -126,6 +129,9 @@ pub fn uv_error_message(err: c_int) -> Option<&'static CStr> {
     x if x == UV_EFAULT => c"bad address in system call argument",
     x if x == UV_EIO => c"i/o error",
     x if x == UV_ENOMEM => c"not enough memory",
+    x if x == UV_EMFILE => c"too many open files",
+    x if x == UV_ENFILE => c"file table overflow",
+    x if x == UV_ENOSYS => c"function not implemented",
     x if x == UV_EOF => c"end of file",
     _ => return None,
   };

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -348,7 +348,7 @@ pub struct uv_poll_t {
   internal_token: u64,
   internal_generation: u64,
   internal_fd: c_int,
-  internal_events: c_int,
+  internal_requested_events: c_int,
   internal_cb: Option<uv_poll_cb>,
   internal_stop_cb: Option<unsafe extern "C" fn(*mut uv_poll_t)>,
   internal_owner: Option<UvPollOwner>,
@@ -429,9 +429,9 @@ impl UvLoopInner {
       #[cfg(unix)]
       poll_driver: RefCell::new(poll_driver),
       #[cfg(unix)]
-      poll_handles: RefCell::new(HashMap::with_capacity(4)),
+      poll_handles: RefCell::new(HashMap::new()),
       #[cfg(unix)]
-      fd_watchers: RefCell::new(HashMap::with_capacity(4)),
+      fd_watchers: RefCell::new(HashMap::new()),
       #[cfg(unix)]
       next_poll_token: Cell::new(1),
       #[cfg(unix)]
@@ -1057,7 +1057,7 @@ impl UvLoopInner {
     let generation = handle_ref.internal_generation;
     handle_ref.internal_generation = generation.wrapping_add(1);
     handle_ref.flags &= !UV_HANDLE_ACTIVE;
-    handle_ref.internal_events = 0;
+    handle_ref.internal_requested_events = 0;
     handle_ref.internal_cb = None;
 
     // Release fd ownership before notifying the embedding: its stop hook or a
@@ -1107,7 +1107,7 @@ impl UvLoopInner {
             } else {
               poll::poll_revents_to_uv_callback_args(
                 ready.revents,
-                handle.internal_events,
+                handle.internal_requested_events,
               )
             };
             handle
@@ -1354,7 +1354,7 @@ pub unsafe fn uv_poll_init(
         internal_token: token,
         internal_generation: 0,
         internal_fd: fd,
-        internal_events: 0,
+        internal_requested_events: 0,
         internal_cb: None,
         internal_stop_cb: None,
         internal_owner: Some(owner),
@@ -1428,7 +1428,7 @@ pub unsafe fn uv_poll_start(
     generation,
     owner: owner.id,
     fd: handle_ref.internal_fd,
-    events: poll::uv_events_to_poll_events(events),
+    poll_events: poll::uv_events_to_poll_events(events),
   };
   // Commit loop state only after lazy worker startup accepts the watch, so a
   // failure leaves an existing registration, generation, and fd owner intact.
@@ -1437,7 +1437,7 @@ pub unsafe fn uv_poll_start(
     return -errno;
   }
   handle_ref.internal_generation = generation;
-  handle_ref.internal_events = events;
+  handle_ref.internal_requested_events = events;
   handle_ref.internal_cb = cb;
   handle_ref.flags |= UV_HANDLE_ACTIVE;
   inner

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -1362,48 +1362,6 @@ mod tests {
 
   #[cfg(not(miri))] // needs I/O
   #[test]
-  fn poll_owner_invalidation_does_not_blacklist_reused_id() {
-    let (first_read, _first_write) = pipe();
-    let (second_read, _second_write) = pipe();
-    let shared = LoopShared::new();
-    let mut driver = PollDriver::new(shared);
-    let first_owner_live = AtomicBool::new(true);
-    let second_owner_live = AtomicBool::new(true);
-
-    driver
-      .upsert(
-        PollWatch {
-          token: 1,
-          generation: 1,
-          owner: 7,
-          fd: first_read.as_raw_fd(),
-          events: libc::POLLIN,
-        },
-        &first_owner_live,
-      )
-      .unwrap();
-    driver.control.stop_owner(7);
-
-    assert!(
-      driver
-        .upsert(
-          PollWatch {
-            token: 2,
-            generation: 1,
-            owner: 7,
-            fd: second_read.as_raw_fd(),
-            events: libc::POLLIN,
-          },
-          &second_owner_live,
-        )
-        .is_ok()
-    );
-
-    driver.shutdown();
-  }
-
-  #[cfg(not(miri))] // needs I/O
-  #[test]
   fn one_worker_for_many_handles() {
     const HANDLE_COUNT: usize = 64;
 

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -785,6 +785,9 @@ mod tests {
 
   #[test]
   fn uv_events_translate_to_poll_events() {
+    assert_eq!(uv_events_to_poll_events(UV_READABLE), libc::POLLIN);
+    assert_eq!(uv_events_to_poll_events(UV_WRITABLE), libc::POLLOUT);
+    assert_eq!(uv_events_to_poll_events(UV_PRIORITIZED), libc::POLLPRI);
     assert_eq!(
       uv_events_to_poll_events(UV_READABLE | UV_WRITABLE | UV_PRIORITIZED),
       libc::POLLIN | libc::POLLOUT | libc::POLLPRI,
@@ -810,6 +813,18 @@ mod tests {
   #[test]
   fn poll_revents_translate_to_uv_callback_args() {
     assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLIN, UV_READABLE),
+      (0, UV_READABLE),
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLOUT, UV_WRITABLE),
+      (0, UV_WRITABLE),
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLPRI, UV_PRIORITIZED),
+      (0, UV_PRIORITIZED),
+    );
+    assert_eq!(
       poll_revents_to_uv_callback_args(
         libc::POLLIN | libc::POLLOUT | libc::POLLPRI,
         UV_READABLE | UV_WRITABLE | UV_DISCONNECT | UV_PRIORITIZED,
@@ -826,6 +841,13 @@ mod tests {
         UV_PRIORITIZED,
       ),
       (0, UV_PRIORITIZED),
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(
+        libc::POLLERR | libc::POLLPRI,
+        UV_READABLE | UV_PRIORITIZED,
+      ),
+      (0, UV_READABLE | UV_PRIORITIZED),
     );
     assert_eq!(
       poll_revents_to_uv_callback_args(
@@ -849,7 +871,7 @@ mod tests {
       target_os = "illumos",
     ))]
     assert_eq!(
-      poll_revents_to_uv_callback_args(libc::POLLRDHUP, UV_READABLE),
+      poll_revents_to_uv_callback_args(libc::POLLRDHUP, UV_DISCONNECT),
       (0, UV_DISCONNECT),
     );
   }

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -424,8 +424,8 @@ pub(crate) fn poll_revents_to_uv_callback_args(
   if revents & libc::POLLNVAL != 0 {
     return (super::UV_EBADF, 0);
   }
-  // libuv preserves POLLERR | POLLPRI as prioritized readiness. Linux and
-  // FreeBSD sysfs/kernfs use that combination, so it is not an EBADF error.
+  // libuv treats POLLERR as UV_EBADF only when POLLPRI is absent because
+  // sysfs/GPIO polling can return POLLERR | POLLPRI.
   if revents & libc::POLLERR != 0 && revents & libc::POLLPRI == 0 {
     return (super::UV_EBADF, 0);
   }

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -1202,7 +1202,12 @@ mod tests {
     let wake_count = Arc::new(AtomicUsize::new(0));
     let waker = Waker::from(Arc::new(WakeCounter(wake_count.clone())));
     let mut cx = Context::from_waker(&waker);
-    let _ = runtime.poll_event_loop(&mut cx, PollEventLoopOptions::default());
+    assert!(
+      runtime
+        .poll_event_loop(&mut cx, PollEventLoopOptions::default())
+        .is_pending(),
+      "event loop should be pending before owner invalidation"
+    );
     wake_count.store(0, Ordering::SeqCst);
 
     std::thread::spawn(move || owner.invalidate())

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -43,7 +43,7 @@ pub(crate) struct PollWatch {
   // Embedding scope whose teardown stops all of its watches together.
   pub owner: u64,
   pub fd: c_int,
-  pub events: c_short,
+  pub poll_events: c_short,
 }
 
 // Worker-to-loop handoff: the worker has disarmed this token/generation, and
@@ -242,8 +242,8 @@ impl PollDriver {
       state
         .control_read
         .as_ref()
-        .map(AsRawFd::as_raw_fd)
-        .unwrap_or(-1)
+        .expect("control pipe must be initialized")
+        .as_raw_fd()
     };
 
     // `control_fd` borrows `state.control_read`. The `Arc<PollControl>` moved
@@ -468,15 +468,15 @@ fn worker_loop(control: Arc<PollControl>, control_fd: c_int) {
       events: libc::POLLIN,
       revents: 0,
     }];
-    let mut captured = Vec::new();
+    let mut snapshot = Vec::new();
     for worker_watch in watches.values() {
       if worker_watch.armed {
         fds.push(libc::pollfd {
           fd: worker_watch.watch.fd,
-          events: worker_watch.watch.events,
+          events: worker_watch.watch.poll_events,
           revents: 0,
         });
-        captured
+        snapshot
           .push((worker_watch.watch.token, worker_watch.watch.generation));
       }
     }
@@ -487,8 +487,10 @@ fn worker_loop(control: Arc<PollControl>, control_fd: c_int) {
     let poll_result = default_poll(&mut fds, -1);
 
     match poll_result {
-      Ok(_) => {
+      Ok(num_ready_fds) => {
+        let mut remaining = num_ready_fds as usize;
         if fds[0].revents != 0 {
+          remaining -= 1;
           drain_control_fd(control_fd);
           // Commands may replace or stop watches captured by this poll, so
           // apply them first. Generation and armed checks prevent an old
@@ -500,11 +502,15 @@ fn worker_loop(control: Arc<PollControl>, control_fd: c_int) {
         }
 
         let mut ready = Vec::new();
-        for (index, (token, generation)) in captured.into_iter().enumerate() {
+        for (index, (token, generation)) in snapshot.into_iter().enumerate() {
+          if remaining == 0 {
+            break;
+          }
           let revents = fds[index + 1].revents;
           if revents == 0 {
             continue;
           }
+          remaining -= 1;
           if let Some(worker_watch) = watches.get_mut(&token)
             && worker_watch.armed
             && worker_watch.watch.generation == generation
@@ -840,7 +846,7 @@ mod tests {
       generation,
       owner: 999,
       fd,
-      events: libc::POLLIN,
+      poll_events: libc::POLLIN,
     }
   }
 

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -444,11 +444,15 @@ pub(crate) fn poll_revents_to_uv_callback_args(
     cb_events |= super::UV_DISCONNECT;
   }
 
-  // Closing an active poll fd is invalid libuv usage. When poll(2) detects it
-  // as POLLNVAL, report terminal UV_EBADF so loop dispatch stops the handle
-  // and releases its raw-fd ownership. This cleanup is best-effort, however:
-  // fd-number reuse can occur before POLLNVAL is observed, in which case the
-  // worker cannot distinguish the replacement descriptor from the original.
+  // Closing a poll fd while its handle is active is invalid libuv usage. Libuv
+  // permits, but does not guarantee, an error callback in that case: epoll and
+  // kqueue can silently discard a closed fd, and libuv's poll(2) backend
+  // filters out POLLNVAL. Our poll(2) driver can observe POLLNVAL, so report it
+  // once as terminal UV_EBADF to stop the handle and release its raw-fd
+  // ownership. This is backend-specific defensive cleanup, not a portable
+  // libuv guarantee. It is still best-effort because fd-number reuse can occur
+  // first, leaving the worker unable to distinguish the replacement descriptor
+  // from the original.
   if revents & libc::POLLNVAL != 0 {
     return (super::UV_EBADF, 0);
   }

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -1,21 +1,22 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-// Unix uv_poll driver.
-//
-// Each UvLoopInner lazily creates one worker and joins it during loop drop.
-// The worker aggregates all armed descriptors in poll(..., -1), so a control
-// pipe is needed to interrupt that otherwise indefinite wait for updates and
-// shutdown. Its commands and ready records contain numeric state only; addon
-// pointers stay on the loop thread.
-//
-// An owner groups watches created by one embedding scope, such as an N-API
-// Env. During teardown, invalidation makes the loop reject queued readiness
-// and new starts, and StopOwner removes its worker watches.
-//
-// A ready watch remains disarmed while readiness is outstanding. That
-// back-pressure prevents a level-ready fd from flooding loop work while other
-// handles remain pollable. The loop validates owner and generation before
-// dispatch and again before rearming, discarding stale records.
+//! Unix uv_poll driver.
+//!
+//! Each UvLoopInner lazily creates one worker and joins it during loop drop.
+//! The worker aggregates all armed descriptors in poll(..., -1), so a control
+//! pipe is needed to interrupt that otherwise indefinite wait for updates and
+//! shutdown. Its commands and ready records contain numeric state only; addon
+//! pointers stay on the loop thread.
+//!
+//! A poll scope groups watches created by one embedding context, such as an
+//! N-API Env. During teardown, invalidation makes the loop discard queued
+//! readiness and queues StopScope to remove the scope's worker watches.
+//!
+//! A ready watch remains disarmed while readiness is outstanding. That
+//! back-pressure prevents a level-ready fd from flooding loop work while other
+//! handles remain pollable. The loop validates scope liveness, token,
+//! generation, and active state before dispatch and again before rearming,
+//! discarding stale records.
 
 use std::collections::HashMap;
 use std::collections::VecDeque;
@@ -40,14 +41,14 @@ pub(crate) struct PollWatch {
   pub token: u64,
   // Version of this handle's watch. Stop and restart make older work stale.
   pub generation: u64,
-  // Embedding scope whose teardown stops all of its watches together.
-  pub owner: u64,
+  // ID of the embedding scope whose teardown stops all of its watches together.
+  pub scope_id: u64,
   pub fd: c_int,
   pub poll_events: c_short,
 }
 
 // Worker-to-loop handoff: the worker has disarmed this token/generation, and
-// the loop validates its current handle and owner before the ABI callback.
+// the loop validates the handle's scope liveness before the ABI callback.
 // `status` is zero for readiness or a negative worker errno; successful
 // records carry raw poll(2) `revents` for loop-side libuv translation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -62,7 +63,7 @@ enum PollCommand {
   Upsert(PollWatch),
   Stop { token: u64, generation: u64 },
   Rearm { token: u64, generation: u64 },
-  StopOwner { owner: u64 },
+  StopScope { scope_id: u64 },
   Shutdown,
 }
 
@@ -174,14 +175,14 @@ impl PollDriver {
   pub(crate) fn upsert(
     &mut self,
     watch: PollWatch,
-    owner_live: &AtomicBool,
+    scope_live: &AtomicBool,
   ) -> Result<(), c_int> {
     self.start_worker()?;
     #[cfg(test)]
     if let Some(hook) = &self.upsert_hook {
       hook.wait();
     }
-    self.upsert_command(watch, owner_live)
+    self.upsert_command(watch, scope_live)
   }
 
   pub(crate) fn stop(&self, token: u64, generation: u64) {
@@ -288,7 +289,7 @@ impl PollDriver {
   fn upsert_command(
     &self,
     watch: PollWatch,
-    owner_live: &AtomicBool,
+    scope_live: &AtomicBool,
   ) -> Result<(), c_int> {
     let mut state = lock_state(&self.control);
     if let Some(errno) = state.permanent_failure {
@@ -298,8 +299,8 @@ impl PollDriver {
       return Err(libc::ECANCELED);
     }
     // The command mutex makes either ordering safe: invalidation follows an
-    // already queued upsert with StopOwner, while a later upsert sees false.
-    if !owner_live.load(Ordering::Acquire) {
+    // already queued upsert with StopScope, while a later upsert sees false.
+    if !scope_live.load(Ordering::Acquire) {
       return Err(libc::ECANCELED);
     }
     state.commands.push_back(PollCommand::Upsert(watch));
@@ -309,13 +310,15 @@ impl PollDriver {
 }
 
 impl PollControl {
-  pub(crate) fn stop_owner(&self, owner: u64) {
+  pub(crate) fn stop_scope(&self, scope_id: u64) {
     let mut state = lock_state(self);
     if !state.shutdown && state.permanent_failure.is_none() {
-      state.commands.push_back(PollCommand::StopOwner { owner });
+      state
+        .commands
+        .push_back(PollCommand::StopScope { scope_id });
       signal_control(&state);
     }
-    // Owner invalidation can race with a terminal worker error. Wake the loop
+    // Scope invalidation can race with a terminal worker error. Wake the loop
     // even when no command can be queued so it observes the invalidation.
     self.shared.loop_waker.wake();
   }
@@ -575,8 +578,8 @@ fn process_command_queue(
           watch.armed = true;
         }
       }
-      PollCommand::StopOwner { owner } => {
-        watches.retain(|_, watch| watch.watch.owner != owner)
+      PollCommand::StopScope { scope_id } => {
+        watches.retain(|_, watch| watch.watch.scope_id != scope_id)
       }
       PollCommand::Shutdown => return true,
     }
@@ -753,7 +756,7 @@ mod tests {
   use crate::uv_compat::*;
 
   const DEADLINE: Duration = Duration::from_secs(5);
-  static OWNER_LIVE: AtomicBool = AtomicBool::new(true);
+  static SCOPE_LIVE: AtomicBool = AtomicBool::new(true);
 
   #[test]
   fn uv_events_translate_to_poll_events() {
@@ -844,7 +847,7 @@ mod tests {
     PollWatch {
       token,
       generation,
-      owner: 999,
+      scope_id: 1,
       fd,
       poll_events: libc::POLLIN,
     }
@@ -993,14 +996,14 @@ mod tests {
     });
     let mut first_handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
     let mut second_handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
-    let owner = unsafe { new_poll_owner(loop_) };
+    let scope = unsafe { new_poll_scope(loop_) };
     unsafe {
       assert_eq!(
         uv_poll_init(
           loop_,
           first_handle.as_mut_ptr(),
           first_read.as_raw_fd(),
-          owner.clone(),
+          scope.clone(),
         ),
         0
       );
@@ -1009,7 +1012,7 @@ mod tests {
           loop_,
           second_handle.as_mut_ptr(),
           second_read.as_raw_fd(),
-          owner,
+          scope,
         ),
         0
       );
@@ -1067,7 +1070,7 @@ mod tests {
           loop_,
           handle.as_mut_ptr(),
           read_fd.as_raw_fd(),
-          new_poll_owner(loop_)
+          new_poll_scope(loop_)
         ),
         0
       );
@@ -1107,7 +1110,7 @@ mod tests {
           loop_,
           handle.as_mut_ptr(),
           read_fd.as_raw_fd(),
-          new_poll_owner(loop_)
+          new_poll_scope(loop_)
         ),
         0
       );
@@ -1131,11 +1134,11 @@ mod tests {
 
   #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
-  async fn poll_owner_invalidation_suppresses_queued_callback() {
+  async fn poll_scope_invalidation_suppresses_queued_callback() {
     let (read_fd, write_fd) = pipe();
     let mut runtime = JsRuntime::new(Default::default());
     let loop_ = runtime_loop(&runtime);
-    let owner = unsafe { new_poll_owner(loop_) };
+    let scope = unsafe { new_poll_scope(loop_) };
     let state = Box::new(PollCallbackState {
       calls: Cell::new(0),
     });
@@ -1146,7 +1149,7 @@ mod tests {
           loop_,
           handle.as_mut_ptr(),
           read_fd.as_raw_fd(),
-          owner.clone()
+          scope.clone()
         ),
         0
       );
@@ -1160,7 +1163,7 @@ mod tests {
     write_byte(&write_fd);
     wait_for_queued_ready(loop_).await;
 
-    owner.invalidate();
+    scope.invalidate();
     tick(&mut runtime).await;
     assert_eq!(state.calls.get(), 0);
 
@@ -1169,11 +1172,11 @@ mod tests {
 
   #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
-  async fn poll_owner_invalidation_wakes_a_pending_loop() {
+  async fn poll_scope_invalidation_wakes_a_pending_loop() {
     let (read_fd, _write_fd) = pipe();
     let mut runtime = JsRuntime::new(Default::default());
     let loop_ = runtime_loop(&runtime);
-    let owner = unsafe { new_poll_owner(loop_) };
+    let scope = unsafe { new_poll_scope(loop_) };
     let mut handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
     unsafe {
       assert_eq!(
@@ -1181,7 +1184,7 @@ mod tests {
           loop_,
           handle.as_mut_ptr(),
           read_fd.as_raw_fd(),
-          owner.clone()
+          scope.clone()
         ),
         0
       );
@@ -1198,30 +1201,30 @@ mod tests {
       runtime
         .poll_event_loop(&mut cx, PollEventLoopOptions::default())
         .is_pending(),
-      "event loop should be pending before owner invalidation"
+      "event loop should be pending before scope invalidation"
     );
     wake_count.store(0, Ordering::SeqCst);
 
-    std::thread::spawn(move || owner.invalidate())
+    std::thread::spawn(move || scope.invalidate())
       .join()
-      .expect("owner invalidation thread panicked");
+      .expect("scope invalidation thread panicked");
 
     assert!(
       wake_count.load(Ordering::SeqCst) > 0,
-      "owner invalidation must wake the pending event loop"
+      "scope invalidation must wake the pending event loop"
     );
     assert!(
       runtime
         .poll_event_loop(&mut cx, PollEventLoopOptions::default())
         .is_ready(),
-      "invalidated owner must not keep a refed poll handle alive"
+      "invalidated scope must not keep a refed poll handle alive"
     );
     unsafe { uv_poll_close(handle.as_mut_ptr()) };
   }
 
   #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
-  async fn poll_start_rejects_owner_invalidated_at_upsert_boundary() {
+  async fn poll_start_rejects_scope_invalidated_at_upsert_boundary() {
     let (read_fd, _write_fd) = pipe();
     let runtime = JsRuntime::new(Default::default());
     let loop_ = runtime_loop(&runtime);
@@ -1238,13 +1241,13 @@ mod tests {
         },
       );
 
-    let owner = unsafe { new_poll_owner(loop_) };
-    let owner_for_invalidator = owner.clone();
+    let scope = unsafe { new_poll_scope(loop_) };
+    let scope_for_invalidator = scope.clone();
     let invalidator = std::thread::spawn(move || {
       entered_receiver
         .recv_timeout(DEADLINE)
         .expect("start did not reach the upsert boundary");
-      owner_for_invalidator.invalidate();
+      scope_for_invalidator.invalidate();
       release_sender
         .send(())
         .expect("start did not wait for the invalidation");
@@ -1252,7 +1255,7 @@ mod tests {
     let mut handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
     unsafe {
       assert_eq!(
-        uv_poll_init(loop_, handle.as_mut_ptr(), read_fd.as_raw_fd(), owner),
+        uv_poll_init(loop_, handle.as_mut_ptr(), read_fd.as_raw_fd(), scope),
         0
       );
       assert_eq!(
@@ -1318,7 +1321,7 @@ mod tests {
           loop_,
           handle.as_mut_ptr(),
           read_fd.as_raw_fd(),
-          new_poll_owner(loop_)
+          new_poll_scope(loop_)
         ),
         0
       );
@@ -1364,7 +1367,7 @@ mod tests {
     let loop_ = runtime_loop(&runtime);
     let mut pipes = Vec::with_capacity(HANDLE_COUNT);
     let mut handles = Vec::with_capacity(HANDLE_COUNT);
-    let owner = unsafe { new_poll_owner(loop_) };
+    let scope = unsafe { new_poll_scope(loop_) };
     for _ in 0..HANDLE_COUNT {
       pipes.push(pipe());
       handles.push(std::mem::MaybeUninit::<uv_poll_t>::uninit());
@@ -1377,7 +1380,7 @@ mod tests {
             loop_,
             handle.as_mut_ptr(),
             read_fd.as_raw_fd(),
-            owner.clone(),
+            scope.clone(),
           ),
           0
         );
@@ -1425,13 +1428,13 @@ mod tests {
     );
 
     driver
-      .upsert(watch(1, read_a.as_raw_fd()), &OWNER_LIVE)
+      .upsert(watch(1, read_a.as_raw_fd()), &SCOPE_LIVE)
       .unwrap();
     second_poll_entered
       .recv_timeout(DEADLINE)
       .expect("worker did not begin its indefinite poll before timeout");
     driver
-      .upsert(watch(2, read_b.as_raw_fd()), &OWNER_LIVE)
+      .upsert(watch(2, read_b.as_raw_fd()), &SCOPE_LIVE)
       .unwrap();
     write_byte(&write_b);
 
@@ -1446,7 +1449,7 @@ mod tests {
     let shared = LoopShared::new();
     let mut driver = PollDriver::new(shared);
     driver
-      .upsert(watch(1, read_fd.as_raw_fd()), &OWNER_LIVE)
+      .upsert(watch(1, read_fd.as_raw_fd()), &SCOPE_LIVE)
       .unwrap();
 
     write_byte(&write_fd);
@@ -1481,7 +1484,7 @@ mod tests {
     );
 
     driver
-      .upsert(watch(1, old_read.as_raw_fd()), &OWNER_LIVE)
+      .upsert(watch(1, old_read.as_raw_fd()), &SCOPE_LIVE)
       .unwrap();
     second_poll_entered
       .recv_timeout(DEADLINE)
@@ -1491,7 +1494,7 @@ mod tests {
     driver
       .upsert(
         watch_with_generation(1, 2, new_read.as_raw_fd()),
-        &OWNER_LIVE,
+        &SCOPE_LIVE,
       )
       .unwrap();
     write_byte(&new_write);
@@ -1528,10 +1531,10 @@ mod tests {
     );
 
     driver
-      .upsert(watch(1, read_a.as_raw_fd()), &OWNER_LIVE)
+      .upsert(watch(1, read_a.as_raw_fd()), &SCOPE_LIVE)
       .unwrap();
     driver
-      .upsert(watch(2, read_b.as_raw_fd()), &OWNER_LIVE)
+      .upsert(watch(2, read_b.as_raw_fd()), &SCOPE_LIVE)
       .unwrap();
     barrier.wait();
 
@@ -1555,7 +1558,7 @@ mod tests {
       ]
     );
     assert_eq!(
-      driver.upsert(watch(3, read_a.as_raw_fd()), &OWNER_LIVE),
+      driver.upsert(watch(3, read_a.as_raw_fd()), &SCOPE_LIVE),
       Err(libc::EIO)
     );
     assert!(driver.drain_ready().is_empty());
@@ -1584,7 +1587,7 @@ mod tests {
     );
     let control = driver.control.clone();
     let upsert = std::thread::spawn(move || {
-      driver.upsert(watch(1, read_fd.as_raw_fd()), &OWNER_LIVE)
+      driver.upsert(watch(1, read_fd.as_raw_fd()), &SCOPE_LIVE)
     });
 
     entered_receiver
@@ -1616,7 +1619,7 @@ mod tests {
     let shared = LoopShared::new();
     let mut driver = PollDriver::new(shared);
     driver
-      .upsert(watch(1, read_fd.as_raw_fd()), &OWNER_LIVE)
+      .upsert(watch(1, read_fd.as_raw_fd()), &SCOPE_LIVE)
       .unwrap();
 
     let (shutdown_complete, shutdown_done) = mpsc::sync_channel(1);

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -329,21 +329,33 @@ impl Drop for PollDriver {
 
 fn control_pipe() -> Result<(OwnedFd, OwnedFd), c_int> {
   let mut fds = [0; 2];
-  if unsafe { libc::pipe(fds.as_mut_ptr()) } == -1 {
-    return Err(last_errno());
+  #[cfg(target_os = "linux")]
+  {
+    // Atomically set CLOEXEC to avoid a concurrent fork/exec inheritance race.
+    if unsafe {
+      libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC | libc::O_NONBLOCK)
+    } == -1
+    {
+      return Err(last_errno());
+    }
+    let read = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+    let write = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+    Ok((read, write))
   }
-  let read = unsafe { OwnedFd::from_raw_fd(fds[0]) };
-  let write = unsafe { OwnedFd::from_raw_fd(fds[1]) };
-  configure_control_fd(read.as_raw_fd())?;
-  configure_control_fd(write.as_raw_fd())?;
-  Ok((read, write))
-}
-
-fn configure_control_fd(fd: c_int) -> Result<(), c_int> {
-  set_fd_nonblocking(fd)?;
-  let flags = fcntl_retry(fd, libc::F_GETFD, 0)?;
-  fcntl_retry(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC)?;
-  Ok(())
+  #[cfg(not(target_os = "linux"))]
+  {
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } == -1 {
+      return Err(last_errno());
+    }
+    let read = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+    let write = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+    for fd in fds {
+      set_fd_nonblocking(fd)?;
+      let flags = fcntl_retry(fd, libc::F_GETFD, 0)?;
+      fcntl_retry(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC)?;
+    }
+    Ok((read, write))
+  }
 }
 
 pub(crate) fn set_fd_nonblocking(fd: c_int) -> Result<(), c_int> {

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -71,6 +71,9 @@ enum PollCommand {
 type PollFn =
   Arc<dyn Fn(&mut [libc::pollfd], c_int) -> Result<c_int, c_int> + Send + Sync>;
 
+#[cfg(test)]
+type JoinFn = Box<dyn FnOnce(JoinHandle<()>) + Send>;
+
 struct PollControlState {
   commands: VecDeque<PollCommand>,
   ready: VecDeque<PollReady>,
@@ -103,6 +106,8 @@ pub(crate) struct PollDriver {
   worker_starts: usize,
   #[cfg(test)]
   upsert_hook: Option<PollUpsertHook>,
+  #[cfg(test)]
+  join: Option<JoinFn>,
 }
 
 #[cfg(test)]
@@ -146,6 +151,8 @@ impl PollDriver {
       worker_starts: 0,
       #[cfg(test)]
       upsert_hook: None,
+      #[cfg(test)]
+      join: None,
     }
   }
 
@@ -169,6 +176,17 @@ impl PollDriver {
   ) -> Self {
     let mut driver = Self::new_with_poll_for_test(shared, poll);
     driver.upsert_hook = Some(upsert_hook);
+    driver
+  }
+
+  #[cfg(test)]
+  pub(crate) fn new_with_poll_and_join_for_test(
+    shared: Arc<LoopShared>,
+    poll: PollFn,
+    join: JoinFn,
+  ) -> Self {
+    let mut driver = Self::new_with_poll_for_test(shared, poll);
+    driver.join = Some(join);
     driver
   }
 
@@ -217,6 +235,13 @@ impl PollDriver {
       }
     }
     if let Some(worker) = self.worker.take() {
+      #[cfg(test)]
+      if let Some(join) = self.join.take() {
+        join(worker);
+      } else {
+        let _ = worker.join();
+      }
+      #[cfg(not(test))]
       let _ = worker.join();
     }
   }
@@ -1616,20 +1641,76 @@ mod tests {
   #[test]
   fn shutdown_joins_worker() {
     let (read_fd, _write_fd) = pipe();
+    let (poll_entered_sender, poll_entered_receiver) = mpsc::sync_channel(1);
+    let (release_poll_sender, release_poll_receiver) = mpsc::sync_channel(0);
+    let release_poll_receiver = Arc::new(Mutex::new(release_poll_receiver));
+    let release_poll_receiver_for_worker = release_poll_receiver.clone();
+    let (poll_returned_sender, poll_returned_receiver) = mpsc::sync_channel(1);
+    let (join_began_sender, join_began_receiver) = mpsc::sync_channel(1);
+    let (join_returned_sender, join_returned_receiver) = mpsc::sync_channel(1);
+    let poll_started = Arc::new(AtomicBool::new(false));
+    let poll_started_for_worker = poll_started.clone();
     let shared = LoopShared::new();
-    let mut driver = PollDriver::new(shared);
+    let mut driver = PollDriver::new_with_poll_and_join_for_test(
+      shared,
+      Arc::new(move |fds, timeout| {
+        if !poll_started_for_worker.swap(true, Ordering::SeqCst) {
+          let _ = poll_entered_sender.send(());
+          let _ = release_poll_receiver_for_worker
+            .lock()
+            .unwrap()
+            .recv_timeout(DEADLINE);
+        }
+        let result = default_poll(fds, timeout);
+        let _ = poll_returned_sender.try_send(());
+        result
+      }),
+      Box::new(move |worker| {
+        let _ = join_began_sender.send(());
+        let _ = worker.join();
+        let _ = join_returned_sender.send(());
+      }),
+    );
     driver
       .upsert(watch(1, read_fd.as_raw_fd()), &SCOPE_LIVE)
       .unwrap();
+    poll_entered_receiver
+      .recv_timeout(DEADLINE)
+      .expect("poll worker did not enter the injected poll");
 
     let (shutdown_complete, shutdown_done) = mpsc::sync_channel(1);
+    let control = driver.control.clone();
     let shutdown = std::thread::spawn(move || {
       driver.shutdown();
       let _ = shutdown_complete.send(());
     });
+
+    // Wait until shutdown has started synchronously joining the worker while
+    // the worker is still blocked in the injected poll.
+    let deadline = Instant::now() + DEADLINE;
+    while !lock_state(&control).shutdown {
+      assert!(
+        Instant::now() < deadline,
+        "shutdown did not request worker termination within {DEADLINE:?}"
+      );
+      std::thread::yield_now();
+    }
+    join_began_receiver
+      .recv_timeout(DEADLINE)
+      .expect("shutdown did not begin joining the worker");
+
+    release_poll_sender
+      .send(())
+      .expect("poll worker release receiver disconnected");
+    poll_returned_receiver
+      .recv_timeout(DEADLINE)
+      .expect("poll worker did not return from the injected poll");
+    join_returned_receiver
+      .recv_timeout(DEADLINE)
+      .expect("shutdown join did not return after the poll worker exited");
     shutdown_done
       .recv_timeout(DEADLINE)
-      .expect("shutdown did not join promptly");
+      .expect("shutdown did not complete after the poll worker returned");
     assert!(shutdown.join().is_ok(), "shutdown thread panicked");
   }
 }

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -1133,6 +1133,44 @@ mod tests {
 
   #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
+  async fn poll_owner_invalidation_suppresses_queued_callback() {
+    let (read_fd, write_fd) = pipe();
+    let mut runtime = JsRuntime::new(Default::default());
+    let loop_ = runtime_loop(&runtime);
+    let owner = unsafe { new_poll_owner(loop_) };
+    let state = Box::new(PollCallbackState {
+      calls: Cell::new(0),
+    });
+    let mut handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
+    unsafe {
+      assert_eq!(
+        uv_poll_init(
+          loop_,
+          handle.as_mut_ptr(),
+          read_fd.as_raw_fd(),
+          owner.clone()
+        ),
+        0
+      );
+      (*handle.as_mut_ptr()).data =
+        (&*state as *const PollCallbackState).cast_mut().cast();
+      assert_eq!(
+        uv_poll_start(handle.as_mut_ptr(), UV_READABLE, Some(count_callback)),
+        0
+      );
+    }
+    write_byte(&write_fd);
+    wait_for_queued_ready(loop_).await;
+
+    owner.invalidate();
+    tick(&mut runtime).await;
+    assert_eq!(state.calls.get(), 0);
+
+    unsafe { uv_poll_close(handle.as_mut_ptr()) };
+  }
+
+  #[cfg(not(miri))] // needs I/O
+  #[tokio::test(flavor = "current_thread")]
   async fn poll_owner_invalidation_wakes_a_pending_loop() {
     let (read_fd, _write_fd) = pipe();
     let mut runtime = JsRuntime::new(Default::default());

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -960,6 +960,7 @@ mod tests {
       .expect("JsRuntime should have a uv loop")
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
   async fn poll_callback_back_pressure_is_handle_local() {
     let (first_read, first_write) = pipe();
@@ -1040,6 +1041,7 @@ mod tests {
     };
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
   async fn poll_restart_invalidates_queued_generation() {
     let (read_fd, write_fd) = pipe();
@@ -1079,6 +1081,7 @@ mod tests {
     unsafe { uv_poll_close(handle.as_mut_ptr()) };
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
   async fn poll_stop_suppresses_queued_callback() {
     let (read_fd, write_fd) = pipe();
@@ -1116,6 +1119,7 @@ mod tests {
     unsafe { uv_poll_close(handle.as_mut_ptr()) };
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
   async fn poll_owner_invalidation_wakes_a_pending_loop() {
     let (read_fd, _write_fd) = pipe();
@@ -1159,6 +1163,7 @@ mod tests {
     unsafe { uv_poll_close(handle.as_mut_ptr()) };
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
   async fn poll_start_rejects_owner_invalidated_at_upsert_boundary() {
     let (read_fd, _write_fd) = pipe();
@@ -1211,6 +1216,7 @@ mod tests {
     invalidator.join().expect("invalidation thread panicked");
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[tokio::test(flavor = "current_thread")]
   async fn poll_permanent_failure_after_callback_releases_pending_handle() {
     let (read_fd, _write_fd) = pipe();
@@ -1293,6 +1299,7 @@ mod tests {
     unsafe { uv_poll_close(handle.as_mut_ptr()) };
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[test]
   fn poll_owner_invalidation_does_not_blacklist_reused_id() {
     let (first_read, _first_write) = pipe();
@@ -1334,6 +1341,7 @@ mod tests {
     driver.shutdown();
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[test]
   fn one_worker_for_many_handles() {
     const HANDLE_COUNT: usize = 64;
@@ -1383,6 +1391,7 @@ mod tests {
     drop(runtime);
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[test]
   fn control_interrupts_indefinite_poll() {
     let (read_a, _write_a) = pipe();
@@ -1416,6 +1425,7 @@ mod tests {
     driver.shutdown();
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[test]
   fn ready_watch_waits_for_rearm() {
     let (read_fd, write_fd) = pipe();
@@ -1434,6 +1444,7 @@ mod tests {
     driver.shutdown();
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[test]
   fn stop_discards_old_generation() {
     let (old_read, old_write) = pipe();
@@ -1486,6 +1497,7 @@ mod tests {
     driver.shutdown();
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[test]
   fn permanent_poll_error_fails_all_watches_once() {
     let (read_a, _write_a) = pipe();
@@ -1536,6 +1548,7 @@ mod tests {
     driver.shutdown();
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[test]
   fn upsert_reports_failure_if_poll_fails_before_command_enqueue() {
     let (read_fd, _write_fd) = pipe();
@@ -1582,6 +1595,7 @@ mod tests {
     );
   }
 
+  #[cfg(not(miri))] // needs I/O
   #[test]
   fn shutdown_joins_worker() {
     let (read_fd, _write_fd) = pipe();

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -1471,17 +1471,51 @@ mod tests {
   #[test]
   fn ready_watch_waits_for_rearm() {
     let (read_fd, write_fd) = pipe();
+    let (disarmed_sender, disarmed_receiver) = mpsc::channel();
+    let (rearmed_sender, rearmed_receiver) = mpsc::channel();
+    let first_ready = Arc::new(AtomicBool::new(false));
+    let first_ready_for_poll = first_ready.clone();
+    let watched_fd = read_fd.as_raw_fd();
     let shared = LoopShared::new();
-    let mut driver = PollDriver::new(shared);
+    let mut driver = PollDriver::new_with_poll_for_test(
+      shared,
+      Arc::new(move |fds, timeout| {
+        let includes_watched_fd =
+          fds.iter().any(|poll_fd| poll_fd.fd == watched_fd);
+        if first_ready_for_poll.load(Ordering::Acquire) {
+          if includes_watched_fd {
+            let _ = rearmed_sender.send(());
+          } else {
+            let _ = disarmed_sender.send(());
+          }
+        }
+
+        let result = default_poll(fds, timeout);
+        if !first_ready_for_poll.load(Ordering::Acquire)
+          && result.is_ok()
+          && fds
+            .iter()
+            .any(|poll_fd| poll_fd.fd == watched_fd && poll_fd.revents != 0)
+        {
+          first_ready_for_poll.store(true, Ordering::Release);
+        }
+        result
+      }),
+    );
     driver
       .upsert(watch(1, read_fd.as_raw_fd()), &SCOPE_LIVE)
       .unwrap();
 
     write_byte(&write_fd);
     assert_eq!(wait_for_ready(&driver, 1).len(), 1);
-    assert!(driver.drain_ready().is_empty());
+    disarmed_receiver
+      .recv_timeout(DEADLINE)
+      .expect("worker did not poll without the ready watch");
 
     assert_eq!(driver.rearm(1, 1), Ok(()));
+    rearmed_receiver
+      .recv_timeout(DEADLINE)
+      .expect("worker did not poll with the rearmed watch");
     assert_eq!(wait_for_ready(&driver, 1).len(), 1);
     driver.shutdown();
   }

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -1,0 +1,1604 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Unix uv_poll driver.
+//
+// Each UvLoopInner lazily creates one worker and joins it during loop drop.
+// The worker aggregates all armed descriptors in poll(..., -1), so a control
+// pipe is needed to interrupt that otherwise indefinite wait for updates and
+// shutdown. Its commands and ready records contain numeric state only; addon
+// pointers stay on the loop thread.
+//
+// An owner groups watches created by one embedding scope, such as an N-API
+// Env. During teardown, invalidation makes the loop reject queued readiness
+// and new starts, and StopOwner removes its worker watches.
+//
+// A ready watch remains disarmed while readiness is outstanding. That
+// back-pressure prevents a level-ready fd from flooding loop work while other
+// handles remain pollable. The loop validates owner and generation before
+// dispatch and again before rearming, discarding stale records.
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::ffi::c_int;
+use std::ffi::c_short;
+use std::os::fd::AsRawFd;
+use std::os::fd::FromRawFd;
+use std::os::fd::OwnedFd;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
+use std::sync::Weak;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::thread::JoinHandle;
+
+use super::waker::LoopShared;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PollWatch {
+  // Stable handle identity. The worker uses this instead of an ABI pointer.
+  pub token: u64,
+  // Version of this handle's watch. Stop and restart make older work stale.
+  pub generation: u64,
+  // Embedding scope whose teardown stops all of its watches together.
+  pub owner: u64,
+  pub fd: c_int,
+  pub events: c_short,
+}
+
+// Worker-to-loop handoff: the worker has disarmed this token/generation, and
+// the loop validates its current handle and owner before the ABI callback.
+// `status` is zero for readiness or a negative worker errno; successful
+// records carry raw poll(2) `revents` for loop-side libuv translation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PollReady {
+  pub token: u64,
+  pub generation: u64,
+  pub status: c_int,
+  pub revents: c_short,
+}
+
+enum PollCommand {
+  Upsert(PollWatch),
+  Stop { token: u64, generation: u64 },
+  Rearm { token: u64, generation: u64 },
+  StopOwner { owner: u64 },
+  Shutdown,
+}
+
+#[cfg(test)]
+type PollFn =
+  Arc<dyn Fn(&mut [libc::pollfd], c_int) -> Result<c_int, c_int> + Send + Sync>;
+
+struct PollControlState {
+  commands: VecDeque<PollCommand>,
+  ready: VecDeque<PollReady>,
+  permanent_failure: Option<c_int>,
+  shutdown: bool,
+  control_read: Option<OwnedFd>,
+  control_write: Option<OwnedFd>,
+}
+
+pub(crate) struct PollControl {
+  state: Mutex<PollControlState>,
+  shared: Arc<LoopShared>,
+  // Syscall injection is test-only. Production calls `default_poll` directly
+  // so each loop avoids an Arc allocation and dynamic dispatch in its worker.
+  #[cfg(test)]
+  poll: PollFn,
+}
+
+struct WorkerWatch {
+  watch: PollWatch,
+  // Cleared when readiness is queued; matching Rearm after the callback makes
+  // the fd pollable again.
+  armed: bool,
+}
+
+pub(crate) struct PollDriver {
+  control: Arc<PollControl>,
+  worker: Option<JoinHandle<()>>,
+  #[cfg(test)]
+  worker_starts: usize,
+  #[cfg(test)]
+  upsert_hook: Option<PollUpsertHook>,
+}
+
+#[cfg(test)]
+pub(crate) struct PollUpsertHook {
+  entered_sender: std::sync::mpsc::SyncSender<()>,
+  release_receiver: std::sync::mpsc::Receiver<()>,
+}
+
+#[cfg(test)]
+impl PollUpsertHook {
+  fn wait(&self) {
+    self
+      .entered_sender
+      .send(())
+      .expect("upsert hook entered receiver disconnected");
+    self
+      .release_receiver
+      .recv()
+      .expect("upsert hook release sender disconnected");
+  }
+}
+
+impl PollDriver {
+  pub(crate) fn new(shared: Arc<LoopShared>) -> Self {
+    Self {
+      control: Arc::new(PollControl {
+        state: Mutex::new(PollControlState {
+          commands: VecDeque::new(),
+          ready: VecDeque::new(),
+          permanent_failure: None,
+          shutdown: false,
+          control_read: None,
+          control_write: None,
+        }),
+        shared,
+        #[cfg(test)]
+        poll: Arc::new(default_poll),
+      }),
+      worker: None,
+      #[cfg(test)]
+      worker_starts: 0,
+      #[cfg(test)]
+      upsert_hook: None,
+    }
+  }
+
+  #[cfg(test)]
+  pub(crate) fn new_with_poll_for_test(
+    shared: Arc<LoopShared>,
+    poll: PollFn,
+  ) -> Self {
+    let mut driver = Self::new(shared);
+    Arc::get_mut(&mut driver.control)
+      .expect("a new poll driver has the only PollControl reference")
+      .poll = poll;
+    driver
+  }
+
+  #[cfg(test)]
+  pub(crate) fn new_with_poll_and_upsert_hook_for_test(
+    shared: Arc<LoopShared>,
+    poll: PollFn,
+    upsert_hook: PollUpsertHook,
+  ) -> Self {
+    let mut driver = Self::new_with_poll_for_test(shared, poll);
+    driver.upsert_hook = Some(upsert_hook);
+    driver
+  }
+
+  pub(crate) fn upsert(
+    &mut self,
+    watch: PollWatch,
+    owner_live: &AtomicBool,
+  ) -> Result<(), c_int> {
+    self.start_worker()?;
+    #[cfg(test)]
+    if let Some(hook) = &self.upsert_hook {
+      hook.wait();
+    }
+    self.upsert_command(watch, owner_live)
+  }
+
+  pub(crate) fn stop(&self, token: u64, generation: u64) {
+    // This is best-effort after terminal failure or shutdown: the worker will
+    // not poll addon fds again, and callers separately invalidate the loop-side
+    // generation to suppress queued records.
+    let _ = self.command(PollCommand::Stop { token, generation });
+  }
+
+  pub(crate) fn rearm(&self, token: u64, generation: u64) -> Result<(), c_int> {
+    self.command(PollCommand::Rearm { token, generation })
+  }
+
+  pub(crate) fn control(&self) -> Weak<PollControl> {
+    Arc::downgrade(&self.control)
+  }
+
+  pub(crate) fn drain_ready(&self) -> VecDeque<PollReady> {
+    std::mem::take(&mut lock_state(&self.control).ready)
+  }
+
+  pub(crate) fn shutdown(&mut self) {
+    {
+      let mut state = lock_state(&self.control);
+      if !state.shutdown {
+        state.shutdown = true;
+        state.permanent_failure.get_or_insert(libc::ECANCELED);
+        if self.worker.is_some() {
+          state.commands.push_back(PollCommand::Shutdown);
+          signal_control(&state);
+        }
+      }
+    }
+    if let Some(worker) = self.worker.take() {
+      let _ = worker.join();
+    }
+  }
+
+  fn start_worker(&mut self) -> Result<(), c_int> {
+    if self.worker.is_some() {
+      let state = lock_state(&self.control);
+      return state.permanent_failure.map_or(Ok(()), Err);
+    }
+
+    let control_fd = {
+      let mut state = lock_state(&self.control);
+      if let Some(errno) = state.permanent_failure {
+        return Err(errno);
+      }
+      if state.shutdown {
+        return Err(libc::ECANCELED);
+      }
+      if state.control_read.is_none() {
+        let (read, write) = control_pipe()?;
+        state.control_read = Some(read);
+        state.control_write = Some(write);
+      }
+      state
+        .control_read
+        .as_ref()
+        .map(AsRawFd::as_raw_fd)
+        .unwrap_or(-1)
+    };
+
+    // `control_fd` borrows `state.control_read`. The `Arc<PollControl>` moved
+    // into the worker keeps the `OwnedFd` alive; `shutdown` joins it first.
+    let control = self.control.clone();
+    match std::thread::Builder::new()
+      .name("uv-poll".to_owned())
+      .spawn(move || worker_loop(control, control_fd))
+    {
+      Ok(worker) => {
+        self.worker = Some(worker);
+        #[cfg(test)]
+        {
+          self.worker_starts += 1;
+        }
+        Ok(())
+      }
+      Err(err) => {
+        let errno = err.raw_os_error().unwrap_or(libc::EAGAIN);
+        let mut state = lock_state(&self.control);
+        state.permanent_failure = Some(errno);
+        state.control_read = None;
+        state.control_write = None;
+        Err(errno)
+      }
+    }
+  }
+
+  fn command(&self, command: PollCommand) -> Result<(), c_int> {
+    let mut state = lock_state(&self.control);
+    if let Some(errno) = state.permanent_failure {
+      return Err(errno);
+    }
+    if state.shutdown {
+      return Err(libc::ECANCELED);
+    }
+    state.commands.push_back(command);
+    signal_control(&state);
+    Ok(())
+  }
+
+  fn upsert_command(
+    &self,
+    watch: PollWatch,
+    owner_live: &AtomicBool,
+  ) -> Result<(), c_int> {
+    let mut state = lock_state(&self.control);
+    if let Some(errno) = state.permanent_failure {
+      return Err(errno);
+    }
+    if state.shutdown {
+      return Err(libc::ECANCELED);
+    }
+    // The command mutex makes either ordering safe: invalidation follows an
+    // already queued upsert with StopOwner, while a later upsert sees false.
+    if !owner_live.load(Ordering::Acquire) {
+      return Err(libc::ECANCELED);
+    }
+    state.commands.push_back(PollCommand::Upsert(watch));
+    signal_control(&state);
+    Ok(())
+  }
+}
+
+impl PollControl {
+  pub(crate) fn stop_owner(&self, owner: u64) {
+    let mut state = lock_state(self);
+    if !state.shutdown && state.permanent_failure.is_none() {
+      state.commands.push_back(PollCommand::StopOwner { owner });
+      signal_control(&state);
+    }
+    // Owner invalidation can race with a terminal worker error. Wake the loop
+    // even when no command can be queued so it observes the invalidation.
+    self.shared.loop_waker.wake();
+  }
+}
+
+impl Drop for PollDriver {
+  fn drop(&mut self) {
+    self.shutdown();
+  }
+}
+
+fn control_pipe() -> Result<(OwnedFd, OwnedFd), c_int> {
+  let mut fds = [0; 2];
+  if unsafe { libc::pipe(fds.as_mut_ptr()) } == -1 {
+    return Err(last_errno());
+  }
+  let read = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+  let write = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+  configure_control_fd(read.as_raw_fd())?;
+  configure_control_fd(write.as_raw_fd())?;
+  Ok((read, write))
+}
+
+fn configure_control_fd(fd: c_int) -> Result<(), c_int> {
+  set_fd_nonblocking(fd)?;
+  let flags = fcntl_retry(fd, libc::F_GETFD, 0)?;
+  fcntl_retry(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC)?;
+  Ok(())
+}
+
+pub(crate) fn set_fd_nonblocking(fd: c_int) -> Result<(), c_int> {
+  let flags = fcntl_retry(fd, libc::F_GETFL, 0)?;
+  if flags & libc::O_NONBLOCK == 0 {
+    fcntl_retry(fd, libc::F_SETFL, flags | libc::O_NONBLOCK)?;
+  }
+  Ok(())
+}
+
+pub(crate) fn uv_events_to_poll_events(events: c_int) -> c_short {
+  let mut poll_events = 0;
+  if events & super::UV_READABLE != 0 {
+    poll_events |= libc::POLLIN;
+  }
+  if events & super::UV_WRITABLE != 0 {
+    poll_events |= libc::POLLOUT;
+  }
+  if events & super::UV_PRIORITIZED != 0 {
+    poll_events |= libc::POLLPRI;
+  }
+  // POLLRDHUP is only available on these targets. Elsewhere, omitting
+  // UV_DISCONNECT is fine: libuv treats it as an optional shutdown
+  // optimization.
+  #[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "illumos",
+  ))]
+  if events & super::UV_DISCONNECT != 0 {
+    poll_events |= libc::POLLRDHUP;
+  }
+  poll_events
+}
+
+pub(crate) fn poll_revents_to_uv_callback_args(
+  revents: c_short,
+  requested_events: c_int,
+) -> (c_int, c_int) {
+  let mut cb_events = 0;
+  if revents & libc::POLLIN != 0 {
+    cb_events |= super::UV_READABLE;
+  }
+  if revents & libc::POLLOUT != 0 {
+    cb_events |= super::UV_WRITABLE;
+  }
+  if revents & libc::POLLPRI != 0 {
+    cb_events |= super::UV_PRIORITIZED;
+  }
+  #[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "illumos",
+  ))]
+  if revents & libc::POLLRDHUP != 0 {
+    cb_events |= super::UV_DISCONNECT;
+  }
+
+  // Closing an active poll fd is invalid libuv usage. When poll(2) detects it
+  // as POLLNVAL, report terminal UV_EBADF so loop dispatch stops the handle
+  // and releases its raw-fd ownership. This cleanup is best-effort, however:
+  // fd-number reuse can occur before POLLNVAL is observed, in which case the
+  // worker cannot distinguish the replacement descriptor from the original.
+  if revents & libc::POLLNVAL != 0 {
+    return (super::UV_EBADF, 0);
+  }
+  // libuv preserves POLLERR | POLLPRI as prioritized readiness. Linux and
+  // FreeBSD sysfs/kernfs use that combination, so it is not an EBADF error.
+  if revents & libc::POLLERR != 0 && revents & libc::POLLPRI == 0 {
+    return (super::UV_EBADF, 0);
+  }
+  // On error or hangup, libuv mixes in the requested interests so the
+  // appropriate read or write callback can run even without a readiness bit.
+  if revents & (libc::POLLERR | libc::POLLHUP) != 0 {
+    cb_events |= requested_events
+      & (super::UV_READABLE
+        | super::UV_WRITABLE
+        | super::UV_DISCONNECT
+        | super::UV_PRIORITIZED);
+  }
+  (0, cb_events)
+}
+
+fn fcntl_retry(
+  fd: c_int,
+  command: c_int,
+  argument: c_int,
+) -> Result<c_int, c_int> {
+  loop {
+    // Getter commands such as F_GETFL ignore the variadic third argument,
+    // so passing a placeholder value such as 0 is safe.
+    let result = unsafe { libc::fcntl(fd, command, argument) };
+    if result != -1 {
+      return Ok(result);
+    }
+    let errno = last_errno();
+    if errno != libc::EINTR {
+      return Err(errno);
+    }
+  }
+}
+
+fn worker_loop(control: Arc<PollControl>, control_fd: c_int) {
+  let mut watches: HashMap<u64, WorkerWatch> = HashMap::new();
+  loop {
+    let mut fds = vec![libc::pollfd {
+      fd: control_fd,
+      events: libc::POLLIN,
+      revents: 0,
+    }];
+    let mut captured = Vec::new();
+    for worker_watch in watches.values() {
+      if worker_watch.armed {
+        fds.push(libc::pollfd {
+          fd: worker_watch.watch.fd,
+          events: worker_watch.watch.events,
+          revents: 0,
+        });
+        captured
+          .push((worker_watch.watch.token, worker_watch.watch.generation));
+      }
+    }
+
+    #[cfg(test)]
+    let poll_result = (control.poll)(&mut fds, -1);
+    #[cfg(not(test))]
+    let poll_result = default_poll(&mut fds, -1);
+
+    match poll_result {
+      Ok(_) => {
+        if fds[0].revents != 0 {
+          drain_control_fd(control_fd);
+          // Commands may replace or stop watches captured by this poll, so
+          // apply them first. Generation and armed checks prevent an old
+          // snapshot from disarming a replacement or queuing readiness for a
+          // stopped watch.
+          if process_commands(&control, &mut watches) {
+            return;
+          }
+        }
+
+        let mut ready = Vec::new();
+        for (index, (token, generation)) in captured.into_iter().enumerate() {
+          let revents = fds[index + 1].revents;
+          if revents == 0 {
+            continue;
+          }
+          if let Some(worker_watch) = watches.get_mut(&token)
+            && worker_watch.armed
+            && worker_watch.watch.generation == generation
+          {
+            worker_watch.armed = false;
+            ready.push(PollReady {
+              token,
+              generation,
+              status: 0,
+              revents,
+            });
+          }
+        }
+        push_ready(&control, ready);
+      }
+      Err(errno) => {
+        drain_control_fd(control_fd);
+        let commands = fail_and_take_commands(&control, errno);
+        if process_command_queue(commands, &mut watches) {
+          return;
+        }
+        fail_watches(&control, &mut watches, errno);
+        service_shutdown(&control, control_fd, &mut watches);
+        return;
+      }
+    }
+  }
+}
+
+fn process_commands(
+  control: &PollControl,
+  watches: &mut HashMap<u64, WorkerWatch>,
+) -> bool {
+  let commands = {
+    let mut state = lock_state(control);
+    std::mem::take(&mut state.commands)
+  };
+  process_command_queue(commands, watches)
+}
+
+fn process_command_queue(
+  commands: VecDeque<PollCommand>,
+  watches: &mut HashMap<u64, WorkerWatch>,
+) -> bool {
+  for command in commands {
+    match command {
+      PollCommand::Upsert(watch) => {
+        watches.insert(watch.token, WorkerWatch { watch, armed: true });
+      }
+      PollCommand::Stop { token, generation } => {
+        if watches
+          .get(&token)
+          .is_some_and(|watch| watch.watch.generation == generation)
+        {
+          watches.remove(&token);
+        }
+      }
+      PollCommand::Rearm { token, generation } => {
+        if let Some(watch) = watches.get_mut(&token)
+          && watch.watch.generation == generation
+        {
+          watch.armed = true;
+        }
+      }
+      PollCommand::StopOwner { owner } => {
+        watches.retain(|_, watch| watch.watch.owner != owner)
+      }
+      PollCommand::Shutdown => return true,
+    }
+  }
+  false
+}
+
+fn fail_and_take_commands(
+  control: &PollControl,
+  errno: c_int,
+) -> VecDeque<PollCommand> {
+  let mut state = lock_state(control);
+  // An aggregate poll failure cannot be attributed to one watch, so the worker
+  // becomes terminal. Commands accepted before it apply first: stops suppress
+  // errors, upserts join the one-time fanout, and Shutdown exits immediately.
+  state.permanent_failure.get_or_insert(errno);
+  std::mem::take(&mut state.commands)
+}
+
+fn fail_watches(
+  control: &PollControl,
+  watches: &mut HashMap<u64, WorkerWatch>,
+  errno: c_int,
+) {
+  // Only armed watches need an error record. A disarmed watch has queued
+  // readiness; if it remains current through dispatch, Rearm sees
+  // permanent_failure and the loop stops the handle.
+  let mut ready = Vec::new();
+  for watch in watches.values_mut() {
+    if watch.armed {
+      watch.armed = false;
+      ready.push(PollReady {
+        token: watch.watch.token,
+        generation: watch.watch.generation,
+        status: -errno,
+        revents: 0,
+      });
+    }
+  }
+  push_ready(control, ready);
+}
+
+fn service_shutdown(
+  control: &PollControl,
+  control_fd: c_int,
+  watches: &mut HashMap<u64, WorkerWatch>,
+) {
+  // A terminal poll failure has already reported each armed watch. From here
+  // service only the control pipe until Shutdown arrives, rather than touching
+  // addon fds again or leaving a worker that loop drop cannot join.
+  loop {
+    let mut fd = libc::pollfd {
+      fd: control_fd,
+      events: libc::POLLIN,
+      revents: 0,
+    };
+    match default_poll(std::slice::from_mut(&mut fd), -1) {
+      Ok(_) => {
+        drain_control_fd(control_fd);
+        if process_commands(control, watches) {
+          return;
+        }
+      }
+      Err(_) => return,
+    }
+  }
+}
+
+fn push_ready(control: &PollControl, ready: Vec<PollReady>) {
+  if ready.is_empty() {
+    return;
+  }
+  lock_state(control).ready.extend(ready);
+  control.shared.loop_waker.wake();
+}
+
+fn drain_control_fd(fd: c_int) {
+  let mut bytes = [0_u8; 64];
+  loop {
+    let result =
+      unsafe { libc::read(fd, bytes.as_mut_ptr().cast(), bytes.len()) };
+    if result > 0 {
+      continue;
+    }
+    if result == -1 && last_errno() == libc::EINTR {
+      continue;
+    }
+    return;
+  }
+}
+
+fn signal_control(state: &PollControlState) {
+  let Some(fd) = state.control_write.as_ref().map(AsRawFd::as_raw_fd) else {
+    return;
+  };
+  loop {
+    let result = unsafe { libc::write(fd, b"x".as_ptr().cast(), 1) };
+    if result == 1 {
+      return;
+    }
+    if result == -1 {
+      let errno = last_errno();
+      if errno == libc::EINTR {
+        continue;
+      }
+      if errno == libc::EAGAIN || errno == libc::EWOULDBLOCK {
+        // A full nonblocking pipe already holds a wakeup byte. Dropping this
+        // byte deliberately coalesces updates; the worker drains the pipe and
+        // then takes the whole command queue under the same mutex.
+        return;
+      }
+    }
+    return;
+  }
+}
+
+fn default_poll(
+  fds: &mut [libc::pollfd],
+  timeout: c_int,
+) -> Result<c_int, c_int> {
+  loop {
+    let result = unsafe {
+      libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, timeout)
+    };
+    if result >= 0 {
+      return Ok(result);
+    }
+    let errno = last_errno();
+    if errno != libc::EINTR {
+      return Err(errno);
+    }
+  }
+}
+
+fn last_errno() -> c_int {
+  std::io::Error::last_os_error()
+    .raw_os_error()
+    .unwrap_or(libc::EIO)
+}
+
+fn lock_state(control: &PollControl) -> MutexGuard<'_, PollControlState> {
+  control
+    .state
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+  // Pure translation tests pin libuv mask semantics. Driver tests use injection
+  // for state-machine and concurrency edges; end-to-end addon coverage lives
+  // in tests/napi.
+  use std::cell::Cell;
+  use std::future::poll_fn;
+  use std::os::fd::AsRawFd;
+  use std::os::fd::FromRawFd;
+  use std::os::fd::OwnedFd;
+  use std::sync::Arc;
+  use std::sync::Barrier;
+  use std::sync::atomic::AtomicBool;
+  use std::sync::atomic::AtomicUsize;
+  use std::sync::atomic::Ordering;
+  use std::sync::mpsc;
+  use std::task::Context;
+  use std::task::Wake;
+  use std::task::Waker;
+  use std::time::Duration;
+  use std::time::Instant;
+
+  use super::*;
+  use crate::JsRuntime;
+  use crate::PollEventLoopOptions;
+  use crate::uv_compat::waker::LoopShared;
+  use crate::uv_compat::*;
+
+  const DEADLINE: Duration = Duration::from_secs(5);
+  static OWNER_LIVE: AtomicBool = AtomicBool::new(true);
+
+  #[test]
+  fn uv_events_translate_to_poll_events() {
+    assert_eq!(
+      uv_events_to_poll_events(UV_READABLE | UV_WRITABLE | UV_PRIORITIZED),
+      libc::POLLIN | libc::POLLOUT | libc::POLLPRI,
+    );
+
+    #[cfg(any(
+      target_os = "linux",
+      target_os = "android",
+      target_os = "freebsd",
+      target_os = "illumos",
+    ))]
+    assert_eq!(uv_events_to_poll_events(UV_DISCONNECT), libc::POLLRDHUP);
+
+    #[cfg(not(any(
+      target_os = "linux",
+      target_os = "android",
+      target_os = "freebsd",
+      target_os = "illumos",
+    )))]
+    assert_eq!(uv_events_to_poll_events(UV_DISCONNECT), 0);
+  }
+
+  #[test]
+  fn poll_revents_translate_to_uv_callback_args() {
+    assert_eq!(
+      poll_revents_to_uv_callback_args(
+        libc::POLLIN | libc::POLLOUT | libc::POLLPRI,
+        UV_READABLE | UV_WRITABLE | UV_DISCONNECT | UV_PRIORITIZED,
+      ),
+      (0, UV_READABLE | UV_WRITABLE | UV_PRIORITIZED),
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLERR, UV_READABLE),
+      (UV_EBADF, 0),
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(
+        libc::POLLERR | libc::POLLPRI,
+        UV_PRIORITIZED,
+      ),
+      (0, UV_PRIORITIZED),
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(
+        libc::POLLHUP,
+        UV_READABLE | UV_WRITABLE | UV_PRIORITIZED | UV_DISCONNECT,
+      ),
+      (
+        0,
+        UV_READABLE | UV_WRITABLE | UV_PRIORITIZED | UV_DISCONNECT,
+      ),
+    );
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLNVAL, UV_READABLE),
+      (UV_EBADF, 0),
+    );
+
+    #[cfg(any(
+      target_os = "linux",
+      target_os = "android",
+      target_os = "freebsd",
+      target_os = "illumos",
+    ))]
+    assert_eq!(
+      poll_revents_to_uv_callback_args(libc::POLLRDHUP, UV_READABLE),
+      (0, UV_DISCONNECT),
+    );
+  }
+
+  fn pipe() -> (OwnedFd, OwnedFd) {
+    let mut fds = [0; 2];
+    assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+    unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+  }
+
+  fn watch(token: u64, fd: c_int) -> PollWatch {
+    watch_with_generation(token, 1, fd)
+  }
+
+  fn watch_with_generation(
+    token: u64,
+    generation: u64,
+    fd: c_int,
+  ) -> PollWatch {
+    PollWatch {
+      token,
+      generation,
+      owner: 999,
+      fd,
+      events: libc::POLLIN,
+    }
+  }
+
+  fn write_byte(fd: &OwnedFd) {
+    assert_eq!(
+      unsafe { libc::write(fd.as_raw_fd(), b"x".as_ptr().cast(), 1) },
+      1
+    );
+  }
+
+  fn wait_for_ready(driver: &PollDriver, count: usize) -> Vec<PollReady> {
+    let deadline = Instant::now() + DEADLINE;
+    let mut ready = Vec::new();
+    while ready.len() < count {
+      ready.extend(driver.drain_ready());
+      if ready.len() >= count {
+        return ready;
+      }
+      assert!(
+        Instant::now() < deadline,
+        "poll readiness did not arrive within {DEADLINE:?}"
+      );
+      std::thread::yield_now();
+    }
+    ready
+  }
+
+  async fn tick(runtime: &mut JsRuntime) {
+    poll_fn(|cx| {
+      let _ = runtime.poll_event_loop(cx, PollEventLoopOptions::default());
+      std::task::Poll::Ready(())
+    })
+    .await;
+  }
+
+  async fn wait_for_queued_ready(loop_: *mut uv_loop_t) {
+    wait_for_queued_ready_count(loop_, 1).await;
+  }
+
+  async fn wait_for_queued_ready_count(loop_: *mut uv_loop_t, count: usize) {
+    let deadline = Instant::now() + DEADLINE;
+    loop {
+      let ready_count = unsafe {
+        let driver = super::super::get_inner(loop_).poll_driver.borrow();
+        lock_state(&driver.control).ready.len()
+      };
+      if ready_count >= count {
+        return;
+      }
+      assert!(
+        Instant::now() < deadline,
+        "poll readiness did not queue within {DEADLINE:?}"
+      );
+      tokio::task::yield_now().await;
+    }
+  }
+
+  struct PollCallbackState {
+    calls: Cell<usize>,
+  }
+
+  struct FailureCallbackState {
+    calls: Cell<usize>,
+    status: Cell<c_int>,
+    stopped: Cell<bool>,
+    loop_: *mut uv_loop_t,
+    release_failure: mpsc::SyncSender<()>,
+  }
+
+  struct WakeCounter(Arc<AtomicUsize>);
+
+  impl Wake for WakeCounter {
+    fn wake(self: Arc<Self>) {
+      self.0.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+      self.0.fetch_add(1, Ordering::SeqCst);
+    }
+  }
+
+  unsafe extern "C" fn count_callback(
+    handle: *mut uv_poll_t,
+    _: c_int,
+    _: c_int,
+  ) {
+    // SAFETY: Tests install a valid PollCallbackState in handle.data.
+    let state = unsafe { &*((*handle).data as *const PollCallbackState) };
+    state.calls.set(state.calls.get() + 1);
+  }
+
+  unsafe extern "C" fn noop_callback(_: *mut uv_poll_t, _: c_int, _: c_int) {}
+
+  unsafe extern "C" fn poll_stopped_callback(handle: *mut uv_poll_t) {
+    let state = unsafe { &*((*handle).data as *const FailureCallbackState) };
+    state.stopped.set(true);
+  }
+
+  unsafe extern "C" fn failure_callback(
+    handle: *mut uv_poll_t,
+    status: c_int,
+    _: c_int,
+  ) {
+    // SAFETY: Tests install a valid FailureCallbackState in handle.data.
+    let state = unsafe { &*((*handle).data as *const FailureCallbackState) };
+    state.calls.set(state.calls.get() + 1);
+    state.status.set(status);
+    state
+      .release_failure
+      .send(())
+      .expect("worker did not wait for callback completion");
+
+    let deadline = Instant::now() + DEADLINE;
+    while unsafe {
+      let driver = super::super::get_inner(state.loop_).poll_driver.borrow();
+      lock_state(&driver.control).permanent_failure.is_none()
+    } {
+      assert!(
+        Instant::now() < deadline,
+        "worker did not record its permanent failure within {DEADLINE:?}"
+      );
+      std::thread::yield_now();
+    }
+  }
+
+  fn runtime_loop(runtime: &JsRuntime) -> *mut uv_loop_t {
+    runtime
+      .uv_loop_ptr()
+      .expect("JsRuntime should have a uv loop")
+  }
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn poll_callback_back_pressure_is_handle_local() {
+    let (first_read, first_write) = pipe();
+    let (second_read, second_write) = pipe();
+    let mut runtime = JsRuntime::new(Default::default());
+    let loop_ = runtime_loop(&runtime);
+    let first_state = Box::new(PollCallbackState {
+      calls: Cell::new(0),
+    });
+    let second_state = Box::new(PollCallbackState {
+      calls: Cell::new(0),
+    });
+    let mut first_handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
+    let mut second_handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
+    let owner = unsafe { new_poll_owner(loop_) };
+    unsafe {
+      assert_eq!(
+        uv_poll_init(
+          loop_,
+          first_handle.as_mut_ptr(),
+          first_read.as_raw_fd(),
+          owner.clone(),
+        ),
+        0
+      );
+      assert_eq!(
+        uv_poll_init(
+          loop_,
+          second_handle.as_mut_ptr(),
+          second_read.as_raw_fd(),
+          owner,
+        ),
+        0
+      );
+      (*first_handle.as_mut_ptr()).data = (&*first_state
+        as *const PollCallbackState)
+        .cast_mut()
+        .cast();
+      (*second_handle.as_mut_ptr()).data = (&*second_state
+        as *const PollCallbackState)
+        .cast_mut()
+        .cast();
+      assert_eq!(
+        uv_poll_start(
+          first_handle.as_mut_ptr(),
+          UV_READABLE,
+          Some(count_callback)
+        ),
+        0
+      );
+      assert_eq!(
+        uv_poll_start(
+          second_handle.as_mut_ptr(),
+          UV_READABLE,
+          Some(count_callback)
+        ),
+        0
+      );
+    }
+    write_byte(&first_write);
+    wait_for_queued_ready(loop_).await;
+    write_byte(&second_write);
+    wait_for_queued_ready_count(loop_, 2).await;
+    let deadline = Instant::now() + DEADLINE;
+    while second_state.calls.get() != 1 {
+      tick(&mut runtime).await;
+      assert!(
+        Instant::now() < deadline,
+        "poll callback did not arrive within {DEADLINE:?}"
+      );
+      tokio::task::yield_now().await;
+    }
+    assert_eq!(first_state.calls.get(), 1);
+    assert_eq!(second_state.calls.get(), 1);
+    unsafe {
+      uv_poll_close(first_handle.as_mut_ptr());
+      uv_poll_close(second_handle.as_mut_ptr());
+    };
+  }
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn poll_restart_invalidates_queued_generation() {
+    let (read_fd, write_fd) = pipe();
+    let mut runtime = JsRuntime::new(Default::default());
+    let loop_ = runtime_loop(&runtime);
+    let state = Box::new(PollCallbackState {
+      calls: Cell::new(0),
+    });
+    let mut handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
+    unsafe {
+      assert_eq!(
+        uv_poll_init(
+          loop_,
+          handle.as_mut_ptr(),
+          read_fd.as_raw_fd(),
+          new_poll_owner(loop_)
+        ),
+        0
+      );
+      (*handle.as_mut_ptr()).data =
+        (&*state as *const PollCallbackState).cast_mut().cast();
+      assert_eq!(
+        uv_poll_start(handle.as_mut_ptr(), UV_READABLE, Some(count_callback)),
+        0
+      );
+    }
+    write_byte(&write_fd);
+    wait_for_queued_ready(loop_).await;
+    unsafe {
+      assert_eq!(
+        uv_poll_start(handle.as_mut_ptr(), UV_WRITABLE, Some(count_callback)),
+        0
+      );
+    }
+    tick(&mut runtime).await;
+    assert_eq!(state.calls.get(), 0);
+    unsafe { uv_poll_close(handle.as_mut_ptr()) };
+  }
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn poll_stop_suppresses_queued_callback() {
+    let (read_fd, write_fd) = pipe();
+    let mut runtime = JsRuntime::new(Default::default());
+    let loop_ = runtime_loop(&runtime);
+    let state = Box::new(PollCallbackState {
+      calls: Cell::new(0),
+    });
+    let mut handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
+    unsafe {
+      assert_eq!(
+        uv_poll_init(
+          loop_,
+          handle.as_mut_ptr(),
+          read_fd.as_raw_fd(),
+          new_poll_owner(loop_)
+        ),
+        0
+      );
+      (*handle.as_mut_ptr()).data =
+        (&*state as *const PollCallbackState).cast_mut().cast();
+      assert_eq!(
+        uv_poll_start(handle.as_mut_ptr(), UV_READABLE, Some(count_callback)),
+        0
+      );
+    }
+    write_byte(&write_fd);
+    wait_for_queued_ready(loop_).await;
+    unsafe {
+      assert_eq!(uv_poll_stop(handle.as_mut_ptr()), 0);
+    }
+    tick(&mut runtime).await;
+    assert_eq!(state.calls.get(), 0);
+
+    unsafe { uv_poll_close(handle.as_mut_ptr()) };
+  }
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn poll_owner_invalidation_wakes_a_pending_loop() {
+    let (read_fd, _write_fd) = pipe();
+    let mut runtime = JsRuntime::new(Default::default());
+    let loop_ = runtime_loop(&runtime);
+    let owner = unsafe { new_poll_owner(loop_) };
+    let mut handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
+    unsafe {
+      assert_eq!(
+        uv_poll_init(
+          loop_,
+          handle.as_mut_ptr(),
+          read_fd.as_raw_fd(),
+          owner.clone()
+        ),
+        0
+      );
+      assert_eq!(
+        uv_poll_start(handle.as_mut_ptr(), UV_READABLE, Some(noop_callback)),
+        0
+      );
+    }
+
+    let wake_count = Arc::new(AtomicUsize::new(0));
+    let waker = Waker::from(Arc::new(WakeCounter(wake_count.clone())));
+    let mut cx = Context::from_waker(&waker);
+    let _ = runtime.poll_event_loop(&mut cx, PollEventLoopOptions::default());
+    wake_count.store(0, Ordering::SeqCst);
+
+    std::thread::spawn(move || owner.invalidate())
+      .join()
+      .expect("owner invalidation thread panicked");
+
+    assert_eq!(wake_count.load(Ordering::SeqCst), 1);
+    assert!(
+      runtime
+        .poll_event_loop(&mut cx, PollEventLoopOptions::default())
+        .is_ready(),
+      "invalidated owner must not keep a refed poll handle alive"
+    );
+    unsafe { uv_poll_close(handle.as_mut_ptr()) };
+  }
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn poll_start_rejects_owner_invalidated_at_upsert_boundary() {
+    let (read_fd, _write_fd) = pipe();
+    let runtime = JsRuntime::new(Default::default());
+    let loop_ = runtime_loop(&runtime);
+    let (entered_sender, entered_receiver) = mpsc::sync_channel(0);
+    let (release_sender, release_receiver) = mpsc::sync_channel(0);
+    let inner = unsafe { super::super::get_inner(loop_) };
+    *inner.poll_driver.borrow_mut() =
+      PollDriver::new_with_poll_and_upsert_hook_for_test(
+        inner.shared.clone(),
+        Arc::new(default_poll),
+        PollUpsertHook {
+          entered_sender,
+          release_receiver,
+        },
+      );
+
+    let owner = unsafe { new_poll_owner(loop_) };
+    let owner_for_invalidator = owner.clone();
+    let invalidator = std::thread::spawn(move || {
+      entered_receiver
+        .recv_timeout(DEADLINE)
+        .expect("start did not reach the upsert boundary");
+      owner_for_invalidator.invalidate();
+      release_sender
+        .send(())
+        .expect("start did not wait for the invalidation");
+    });
+    let mut handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
+    unsafe {
+      assert_eq!(
+        uv_poll_init(loop_, handle.as_mut_ptr(), read_fd.as_raw_fd(), owner),
+        0
+      );
+      assert_eq!(
+        uv_poll_start(handle.as_mut_ptr(), UV_READABLE, Some(noop_callback)),
+        UV_ECANCELED
+      );
+      assert_eq!(uv_is_active(handle.as_ptr().cast()), 0);
+      assert!(
+        !inner
+          .fd_watchers
+          .borrow()
+          .contains_key(&read_fd.as_raw_fd()),
+        "rejected start must not claim fd ownership"
+      );
+      uv_poll_close(handle.as_mut_ptr());
+    }
+    invalidator.join().expect("invalidation thread panicked");
+  }
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn poll_permanent_failure_after_callback_releases_pending_handle() {
+    let (read_fd, _write_fd) = pipe();
+    let mut runtime = JsRuntime::new(Default::default());
+    let loop_ = runtime_loop(&runtime);
+    let (release_failure, failure_release) = mpsc::sync_channel(0);
+    let ready_once = Arc::new(AtomicBool::new(false));
+    let ready_once_for_worker = ready_once.clone();
+    let failure_release_for_worker = Arc::new(Mutex::new(failure_release));
+    let failure_release_for_worker = failure_release_for_worker.clone();
+    let inner = unsafe { super::super::get_inner(loop_) };
+    *inner.poll_driver.borrow_mut() = PollDriver::new_with_poll_for_test(
+      inner.shared.clone(),
+      Arc::new(move |fds, timeout| {
+        if fds.len() > 1 && !ready_once_for_worker.swap(true, Ordering::SeqCst)
+        {
+          fds[1].revents = libc::POLLIN;
+          return Ok(1);
+        }
+        if ready_once_for_worker.load(Ordering::SeqCst) {
+          failure_release_for_worker
+            .lock()
+            .unwrap()
+            .recv_timeout(DEADLINE)
+            .expect("callback did not release permanent failure");
+          return Err(libc::EIO);
+        }
+        default_poll(fds, timeout)
+      }),
+    );
+
+    let state = Box::new(FailureCallbackState {
+      calls: Cell::new(0),
+      status: Cell::new(-1),
+      stopped: Cell::new(false),
+      loop_,
+      release_failure,
+    });
+    let mut handle = std::mem::MaybeUninit::<uv_poll_t>::uninit();
+    unsafe {
+      assert_eq!(
+        uv_poll_init(
+          loop_,
+          handle.as_mut_ptr(),
+          read_fd.as_raw_fd(),
+          new_poll_owner(loop_)
+        ),
+        0
+      );
+      (*handle.as_mut_ptr()).data =
+        (&*state as *const FailureCallbackState).cast_mut().cast();
+      uv_poll_set_stop_callback(
+        handle.as_mut_ptr(),
+        Some(poll_stopped_callback),
+      );
+      assert_eq!(
+        uv_poll_start(handle.as_mut_ptr(), UV_READABLE, Some(failure_callback)),
+        0
+      );
+    }
+    wait_for_queued_ready(loop_).await;
+    tick(&mut runtime).await;
+
+    assert_eq!(state.calls.get(), 1);
+    assert_eq!(state.status.get(), 0);
+    assert!(
+      state.stopped.get(),
+      "terminal rearm failure must notify bridges"
+    );
+    assert_eq!(unsafe { uv_is_active(handle.as_ptr().cast()) }, 0);
+    assert!(
+      !inner
+        .fd_watchers
+        .borrow()
+        .contains_key(&read_fd.as_raw_fd()),
+      "failed rearm must release fd ownership"
+    );
+    tick(&mut runtime).await;
+    assert_eq!(state.calls.get(), 1, "failure must not redeliver callback");
+    unsafe { uv_poll_close(handle.as_mut_ptr()) };
+  }
+
+  #[test]
+  fn poll_owner_invalidation_does_not_blacklist_reused_id() {
+    let (first_read, _first_write) = pipe();
+    let (second_read, _second_write) = pipe();
+    let shared = LoopShared::new();
+    let mut driver = PollDriver::new(shared);
+    let first_owner_live = AtomicBool::new(true);
+    let second_owner_live = AtomicBool::new(true);
+
+    driver
+      .upsert(
+        PollWatch {
+          token: 1,
+          generation: 1,
+          owner: 7,
+          fd: first_read.as_raw_fd(),
+          events: libc::POLLIN,
+        },
+        &first_owner_live,
+      )
+      .unwrap();
+    driver.control.stop_owner(7);
+
+    assert!(
+      driver
+        .upsert(
+          PollWatch {
+            token: 2,
+            generation: 1,
+            owner: 7,
+            fd: second_read.as_raw_fd(),
+            events: libc::POLLIN,
+          },
+          &second_owner_live,
+        )
+        .is_ok()
+    );
+
+    driver.shutdown();
+  }
+
+  #[test]
+  fn one_worker_for_many_handles() {
+    const HANDLE_COUNT: usize = 64;
+
+    let runtime = JsRuntime::new(Default::default());
+    let loop_ = runtime_loop(&runtime);
+    let mut pipes = Vec::with_capacity(HANDLE_COUNT);
+    let mut handles = Vec::with_capacity(HANDLE_COUNT);
+    let owner = unsafe { new_poll_owner(loop_) };
+    for _ in 0..HANDLE_COUNT {
+      pipes.push(pipe());
+      handles.push(std::mem::MaybeUninit::<uv_poll_t>::uninit());
+    }
+
+    for ((read_fd, _write_fd), handle) in pipes.iter().zip(handles.iter_mut()) {
+      unsafe {
+        assert_eq!(
+          uv_poll_init(
+            loop_,
+            handle.as_mut_ptr(),
+            read_fd.as_raw_fd(),
+            owner.clone(),
+          ),
+          0
+        );
+        assert_eq!(
+          uv_poll_start(handle.as_mut_ptr(), UV_READABLE, Some(noop_callback)),
+          0
+        );
+      }
+    }
+
+    let worker_starts = unsafe {
+      super::super::get_inner(loop_)
+        .poll_driver
+        .borrow()
+        .worker_starts
+    };
+    assert_eq!(worker_starts, 1);
+
+    for handle in &mut handles {
+      unsafe {
+        assert_eq!(uv_poll_stop(handle.as_mut_ptr()), 0);
+        uv_poll_close(handle.as_mut_ptr());
+      }
+    }
+    drop(runtime);
+  }
+
+  #[test]
+  fn control_interrupts_indefinite_poll() {
+    let (read_a, _write_a) = pipe();
+    let (read_b, write_b) = pipe();
+    let (entered_second_poll, second_poll_entered) = mpsc::sync_channel(0);
+    let poll_calls = Arc::new(AtomicUsize::new(0));
+    let poll_calls_for_worker = poll_calls.clone();
+    let shared = LoopShared::new();
+    let mut driver = PollDriver::new_with_poll_for_test(
+      shared,
+      Arc::new(move |fds, timeout| {
+        if poll_calls_for_worker.fetch_add(1, Ordering::SeqCst) == 1 {
+          let _ = entered_second_poll.send(());
+        }
+        default_poll(fds, timeout)
+      }),
+    );
+
+    driver
+      .upsert(watch(1, read_a.as_raw_fd()), &OWNER_LIVE)
+      .unwrap();
+    second_poll_entered
+      .recv_timeout(DEADLINE)
+      .expect("worker did not begin its indefinite poll within {DEADLINE:?}");
+    driver
+      .upsert(watch(2, read_b.as_raw_fd()), &OWNER_LIVE)
+      .unwrap();
+    write_byte(&write_b);
+
+    assert_eq!(wait_for_ready(&driver, 1)[0].token, 2);
+    driver.shutdown();
+  }
+
+  #[test]
+  fn ready_watch_waits_for_rearm() {
+    let (read_fd, write_fd) = pipe();
+    let shared = LoopShared::new();
+    let mut driver = PollDriver::new(shared);
+    driver
+      .upsert(watch(1, read_fd.as_raw_fd()), &OWNER_LIVE)
+      .unwrap();
+
+    write_byte(&write_fd);
+    assert_eq!(wait_for_ready(&driver, 1).len(), 1);
+    assert!(driver.drain_ready().is_empty());
+
+    assert_eq!(driver.rearm(1, 1), Ok(()));
+    assert_eq!(wait_for_ready(&driver, 1).len(), 1);
+    driver.shutdown();
+  }
+
+  #[test]
+  fn stop_discards_old_generation() {
+    let (old_read, old_write) = pipe();
+    let (new_read, new_write) = pipe();
+    let (entered_second_poll, second_poll_entered) = mpsc::sync_channel(0);
+    let barrier = Arc::new(Barrier::new(2));
+    let poll_barrier = barrier.clone();
+    let poll_calls = Arc::new(AtomicUsize::new(0));
+    let poll_calls_for_worker = poll_calls.clone();
+    let shared = LoopShared::new();
+    let mut driver = PollDriver::new_with_poll_for_test(
+      shared,
+      Arc::new(move |fds, timeout| {
+        if poll_calls_for_worker.fetch_add(1, Ordering::SeqCst) == 1 {
+          let _ = entered_second_poll.send(());
+          poll_barrier.wait();
+        }
+        default_poll(fds, timeout)
+      }),
+    );
+
+    driver
+      .upsert(watch(1, old_read.as_raw_fd()), &OWNER_LIVE)
+      .unwrap();
+    second_poll_entered
+      .recv_timeout(DEADLINE)
+      .expect("worker did not begin its second poll within {DEADLINE:?}");
+    write_byte(&old_write);
+    driver.stop(1, 1);
+    driver
+      .upsert(
+        watch_with_generation(1, 2, new_read.as_raw_fd()),
+        &OWNER_LIVE,
+      )
+      .unwrap();
+    write_byte(&new_write);
+    barrier.wait();
+
+    let ready = wait_for_ready(&driver, 1);
+    assert_eq!(
+      ready,
+      vec![PollReady {
+        token: 1,
+        generation: 2,
+        status: 0,
+        revents: libc::POLLIN
+      }]
+    );
+    assert!(driver.drain_ready().is_empty());
+    driver.shutdown();
+  }
+
+  #[test]
+  fn permanent_poll_error_fails_all_watches_once() {
+    let (read_a, _write_a) = pipe();
+    let (read_b, _write_b) = pipe();
+    let barrier = Arc::new(Barrier::new(2));
+    let poll_barrier = barrier.clone();
+    let shared = LoopShared::new();
+    let mut driver = PollDriver::new_with_poll_for_test(
+      shared,
+      Arc::new(move |_, _| {
+        poll_barrier.wait();
+        Err(libc::EIO)
+      }),
+    );
+
+    driver
+      .upsert(watch(1, read_a.as_raw_fd()), &OWNER_LIVE)
+      .unwrap();
+    driver
+      .upsert(watch(2, read_b.as_raw_fd()), &OWNER_LIVE)
+      .unwrap();
+    barrier.wait();
+
+    let mut ready = wait_for_ready(&driver, 2);
+    ready.sort_by_key(|ready| ready.token);
+    assert_eq!(
+      ready,
+      vec![
+        PollReady {
+          token: 1,
+          generation: 1,
+          status: -libc::EIO,
+          revents: 0
+        },
+        PollReady {
+          token: 2,
+          generation: 1,
+          status: -libc::EIO,
+          revents: 0
+        },
+      ]
+    );
+    assert_eq!(
+      driver.upsert(watch(3, read_a.as_raw_fd()), &OWNER_LIVE),
+      Err(libc::EIO)
+    );
+    assert!(driver.drain_ready().is_empty());
+    driver.shutdown();
+  }
+
+  #[test]
+  fn upsert_reports_failure_if_poll_fails_before_command_enqueue() {
+    let (read_fd, _write_fd) = pipe();
+    let (entered_sender, entered_receiver) = mpsc::sync_channel(0);
+    let (release_sender, release_receiver) = mpsc::sync_channel(0);
+    let failure_barrier = Arc::new(Barrier::new(2));
+    let poll_barrier = failure_barrier.clone();
+    let shared = LoopShared::new();
+    let mut driver = PollDriver::new_with_poll_and_upsert_hook_for_test(
+      shared,
+      Arc::new(move |_, _| {
+        poll_barrier.wait();
+        Err(libc::EIO)
+      }),
+      PollUpsertHook {
+        entered_sender,
+        release_receiver,
+      },
+    );
+    let control = driver.control.clone();
+    let upsert = std::thread::spawn(move || {
+      driver.upsert(watch(1, read_fd.as_raw_fd()), &OWNER_LIVE)
+    });
+
+    entered_receiver
+      .recv_timeout(DEADLINE)
+      .expect("upsert did not reach the command boundary within {DEADLINE:?}");
+    failure_barrier.wait();
+    let deadline = Instant::now() + DEADLINE;
+    while lock_state(&control).permanent_failure != Some(libc::EIO) {
+      assert!(
+        Instant::now() < deadline,
+        "poll failure was not recorded within {DEADLINE:?}"
+      );
+      std::thread::yield_now();
+    }
+    release_sender
+      .send(())
+      .expect("upsert did not wait for release");
+
+    assert_eq!(
+      upsert.join().expect("upsert thread panicked"),
+      Err(libc::EIO)
+    );
+  }
+
+  #[test]
+  fn shutdown_joins_worker() {
+    let (read_fd, _write_fd) = pipe();
+    let shared = LoopShared::new();
+    let mut driver = PollDriver::new(shared);
+    driver
+      .upsert(watch(1, read_fd.as_raw_fd()), &OWNER_LIVE)
+      .unwrap();
+
+    let (shutdown_complete, shutdown_done) = mpsc::sync_channel(1);
+    let shutdown = std::thread::spawn(move || {
+      driver.shutdown();
+      let _ = shutdown_complete.send(());
+    });
+    shutdown_done
+      .recv_timeout(DEADLINE)
+      .expect("shutdown did not join promptly");
+    assert!(shutdown.join().is_ok(), "shutdown thread panicked");
+  }
+}

--- a/libs/core/uv_compat/poll.rs
+++ b/libs/core/uv_compat/poll.rs
@@ -1042,15 +1042,7 @@ mod tests {
     wait_for_queued_ready(loop_).await;
     write_byte(&second_write);
     wait_for_queued_ready_count(loop_, 2).await;
-    let deadline = Instant::now() + DEADLINE;
-    while second_state.calls.get() != 1 {
-      tick(&mut runtime).await;
-      assert!(
-        Instant::now() < deadline,
-        "poll callback did not arrive within {DEADLINE:?}"
-      );
-      tokio::task::yield_now().await;
-    }
+    tick(&mut runtime).await;
     assert_eq!(first_state.calls.get(), 1);
     assert_eq!(second_state.calls.get(), 1);
     unsafe {
@@ -1214,7 +1206,10 @@ mod tests {
       .join()
       .expect("owner invalidation thread panicked");
 
-    assert_eq!(wake_count.load(Ordering::SeqCst), 1);
+    assert!(
+      wake_count.load(Ordering::SeqCst) > 0,
+      "owner invalidation must wake the pending event loop"
+    );
     assert!(
       runtime
         .poll_event_loop(&mut cx, PollEventLoopOptions::default())
@@ -1362,8 +1357,8 @@ mod tests {
 
   #[cfg(not(miri))] // needs I/O
   #[test]
-  fn one_worker_for_many_handles() {
-    const HANDLE_COUNT: usize = 64;
+  fn one_worker_is_shared_by_multiple_handles() {
+    const HANDLE_COUNT: usize = 4;
 
     let runtime = JsRuntime::new(Default::default());
     let loop_ = runtime_loop(&runtime);
@@ -1434,7 +1429,7 @@ mod tests {
       .unwrap();
     second_poll_entered
       .recv_timeout(DEADLINE)
-      .expect("worker did not begin its indefinite poll within {DEADLINE:?}");
+      .expect("worker did not begin its indefinite poll before timeout");
     driver
       .upsert(watch(2, read_b.as_raw_fd()), &OWNER_LIVE)
       .unwrap();
@@ -1490,7 +1485,7 @@ mod tests {
       .unwrap();
     second_poll_entered
       .recv_timeout(DEADLINE)
-      .expect("worker did not begin its second poll within {DEADLINE:?}");
+      .expect("worker did not begin its second poll before timeout");
     write_byte(&old_write);
     driver.stop(1, 1);
     driver
@@ -1594,7 +1589,7 @@ mod tests {
 
     entered_receiver
       .recv_timeout(DEADLINE)
-      .expect("upsert did not reach the command boundary within {DEADLINE:?}");
+      .expect("upsert did not reach the command boundary before timeout");
     failure_barrier.wait();
     let deadline = Instant::now() + DEADLINE;
     while lock_state(&control).permanent_failure != Some(libc::EIO) {

--- a/libs/core/uv_compat/tests.rs
+++ b/libs/core/uv_compat/tests.rs
@@ -47,6 +47,20 @@ async fn loop_init_and_close() {
   }
 }
 
+#[cfg(unix)]
+#[test]
+fn loop_liveness_expires_before_post_drop_poll_cleanup() {
+  let mut uninit = Box::<uv_loop_t>::new_uninit();
+  let liveness = unsafe {
+    assert_ok(uv_loop_init(uninit.as_mut_ptr().cast()));
+    uv_loop_liveness(uninit.as_mut_ptr().cast())
+  };
+  assert!(uv_loop_operation_guard(&liveness).is_some());
+  let uv_loop = Box::into_raw(uninit).cast::<uv_loop_t>();
+  unsafe { drop(Box::from_raw(uv_loop)) };
+  assert!(uv_loop_operation_guard(&liveness).is_none());
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn uv_now_returns_nonzero_after_delay() {
   run_test(async |_runtime, uv_loop| {

--- a/tests/napi/Cargo.toml
+++ b/tests/napi/Cargo.toml
@@ -13,5 +13,6 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+libc.workspace = true
 libuv-sys-lite.workspace = true
 napi_sys.workspace = true

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -1364,35 +1364,6 @@ extern "C" fn test_uv_poll_reports_actual_writable_events(
 }
 
 #[cfg(unix)]
-extern "C" fn test_uv_poll_reports_prioritized_events(
-  env: napi_env,
-  info: napi_callback_info,
-) -> napi_value {
-  unsafe {
-    // TCP out-of-band data produces POLLPRI on the peer, exercising the
-    // POLLPRI-to-UV_PRIORITIZED translation.
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let client =
-      std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
-    let (server, _) = listener.accept().unwrap();
-    assert_eq!(
-      libc::send(client.as_raw_fd(), c"x".as_ptr().cast(), 1, libc::MSG_OOB),
-      1
-    );
-    let state = new_poll_test_with_fds(
-      env,
-      poll_callback_arg(env, info),
-      server.into(),
-      client.into(),
-    );
-    let prioritized = libuv_sys_lite::uv_poll_event::UV_PRIORITIZED.0 as i32;
-    poll_test_expect(state, 0, prioritized, true, false);
-    poll_test_start(state, prioritized, Some(poll_expected_cb));
-  }
-  null_mut()
-}
-
-#[cfg(unix)]
 extern "C" fn test_uv_poll_dispatches_hangup_only(
   env: napi_env,
   info: napi_callback_info,
@@ -1415,44 +1386,6 @@ extern "C" fn test_uv_poll_dispatches_hangup_only(
     let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
     poll_test_expect(state, 0, readable, true, false);
     poll_test_start(state, readable, Some(poll_expected_cb));
-  }
-  null_mut()
-}
-
-#[cfg(unix)]
-extern "C" fn test_uv_poll_error_reports_ebadf_and_stops(
-  env: napi_env,
-  info: napi_callback_info,
-) -> napi_value {
-  unsafe {
-    let mut fds = [0; 2];
-    assert_eq!(pipe(fds.as_mut_ptr()), 0);
-    let reader = OwnedFd::from_raw_fd(fds[0]);
-    let writer = OwnedFd::from_raw_fd(fds[1]);
-    drop(reader);
-    // POLLERR is reported independently of the requested mask. Because this
-    // watch requests only readable events, a pipe write end without a reader
-    // produces an error-only result. It must invoke the callback with UV_EBADF,
-    // deactivate the handle, and not enter a retry loop.
-    let placeholder: OwnedFd = File::open("/dev/null").unwrap().into();
-    let state = new_poll_test_with_fds(
-      env,
-      poll_callback_arg(env, info),
-      writer,
-      placeholder,
-    );
-    poll_test_expect(
-      state,
-      libuv_sys_lite::uv_errno_t::UV_EBADF.0,
-      0,
-      false,
-      true,
-    );
-    poll_test_start(
-      state,
-      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
-      Some(poll_expected_cb),
-    );
   }
   null_mut()
 }
@@ -1823,11 +1756,7 @@ unsupported_poll_test!(test_uv_poll_init_sets_nonblocking);
 #[cfg(not(unix))]
 unsupported_poll_test!(test_uv_poll_reports_actual_writable_events);
 #[cfg(not(unix))]
-unsupported_poll_test!(test_uv_poll_reports_prioritized_events);
-#[cfg(not(unix))]
 unsupported_poll_test!(test_uv_poll_dispatches_hangup_only);
-#[cfg(not(unix))]
-unsupported_poll_test!(test_uv_poll_error_reports_ebadf_and_stops);
 #[cfg(not(unix))]
 unsupported_poll_test!(test_uv_poll_invalid_fd_reports_ebadf);
 #[cfg(not(unix))]
@@ -1870,18 +1799,8 @@ pub fn init(env: napi_env, exports: napi_value) {
     ),
     napi_new_property!(
       env,
-      "test_uv_poll_reports_prioritized_events",
-      test_uv_poll_reports_prioritized_events
-    ),
-    napi_new_property!(
-      env,
       "test_uv_poll_dispatches_hangup_only",
       test_uv_poll_dispatches_hangup_only
-    ),
-    napi_new_property!(
-      env,
-      "test_uv_poll_error_reports_ebadf_and_stops",
-      test_uv_poll_error_reports_ebadf_and_stops
     ),
     napi_new_property!(
       env,

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -1,6 +1,8 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 #[cfg(unix)]
+use std::ffi::c_void;
+#[cfg(unix)]
 use std::fs::File;
 use std::mem::MaybeUninit;
 #[cfg(unix)]
@@ -12,6 +14,8 @@ use std::os::fd::OwnedFd;
 use std::ptr;
 use std::ptr::addr_of_mut;
 use std::ptr::null_mut;
+#[cfg(unix)]
+use std::sync::mpsc;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -1080,7 +1084,8 @@ struct PollTest {
   // Keeps the JavaScript completion callback alive across asynchronous work.
   callback: napi_ref,
   poll: *mut libuv_sys_lite::uv_poll_t,
-  // Starts as the watchdog, then some scenarios reuse it as a settle timer.
+  // Starts as the watchdog; unrelated fixtures may reuse it for a settle
+  // window after first stopping it.
   timer: *mut libuv_sys_lite::uv_timer_t,
   poll_fd: OwnedFd,
   other_fd: OwnedFd,
@@ -1093,6 +1098,205 @@ struct PollTest {
   expected_events: i32,
   expected_active: bool,
   settle_after_callback: bool,
+}
+
+#[cfg(unix)]
+struct MultiPollTest {
+  env: napi_env,
+  callback: napi_ref,
+  first_poll: *mut libuv_sys_lite::uv_poll_t,
+  second_poll: *mut libuv_sys_lite::uv_poll_t,
+  timer: *mut libuv_sys_lite::uv_timer_t,
+  first_reader: OwnedFd,
+  first_writer: OwnedFd,
+  second_reader: OwnedFd,
+  // Keeps the helper's raw descriptor valid until its rendezvous write and
+  // acknowledgement complete during the first callback.
+  _second_writer: OwnedFd,
+  first_ready: mpsc::SyncSender<()>,
+  second_write_result: mpsc::Receiver<isize>,
+  first_callback_count: usize,
+  second_callback_count: usize,
+  first_callback_returned: bool,
+  closing: bool,
+  passed: bool,
+  closed_handles: usize,
+}
+
+#[cfg(unix)]
+unsafe fn multi_poll_test_finish(state: *mut MultiPollTest, passed: bool) {
+  unsafe {
+    // Either poll callback or the timeout may finish first. Once closing has
+    // begun, retain a late failure without scheduling duplicate closes.
+    if (*state).closing {
+      (*state).passed &= passed;
+      return;
+    }
+    (*state).closing = true;
+    (*state).passed &= passed;
+    assert_eq!(libuv_sys_lite::uv_poll_stop((*state).first_poll), 0);
+    assert_eq!(libuv_sys_lite::uv_poll_stop((*state).second_poll), 0);
+    assert_eq!(libuv_sys_lite::uv_timer_stop((*state).timer), 0);
+    libuv_sys_lite::uv_close(
+      (*state).first_poll.cast(),
+      Some(multi_poll_test_close_cb),
+    );
+    libuv_sys_lite::uv_close(
+      (*state).second_poll.cast(),
+      Some(multi_poll_test_close_cb),
+    );
+    libuv_sys_lite::uv_close(
+      (*state).timer.cast(),
+      Some(multi_poll_test_close_cb),
+    );
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn multi_poll_test_close_cb(
+  handle: *mut libuv_sys_lite::uv_handle_t,
+) {
+  unsafe {
+    let state = (*handle).data.cast::<MultiPollTest>();
+    (*state).closed_handles += 1;
+    // libuv may invoke these three close callbacks in any order. The last one
+    // owns reporting the result and freeing state after every handle closes.
+    if (*state).closed_handles != 3 {
+      return;
+    }
+
+    let mut js_cb = null_mut();
+    assert_napi_ok!(napi_get_reference_value(
+      (*state).env,
+      (*state).callback,
+      &mut js_cb
+    ));
+    let mut global = null_mut();
+    assert_napi_ok!(napi_get_global((*state).env, &mut global));
+    let mut passed = null_mut();
+    assert_napi_ok!(napi_get_boolean(
+      (*state).env,
+      (*state).passed,
+      &mut passed
+    ));
+    let mut result = null_mut();
+    assert_napi_ok!(napi_call_function(
+      (*state).env,
+      global,
+      js_cb,
+      1,
+      &passed,
+      &mut result,
+    ));
+    assert_napi_ok!(napi_delete_reference((*state).env, (*state).callback));
+
+    let _ = Box::from_raw((*state).first_poll);
+    let _ = Box::from_raw((*state).second_poll);
+    let _ = Box::from_raw((*state).timer);
+    let _ = Box::from_raw(state);
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn multi_poll_test_timeout(
+  timer: *mut libuv_sys_lite::uv_timer_t,
+) {
+  unsafe {
+    multi_poll_test_finish((*timer).data.cast(), false);
+  }
+}
+
+#[cfg(unix)]
+unsafe fn new_multi_poll_test(
+  env: napi_env,
+  callback: napi_value,
+) -> *mut MultiPollTest {
+  unsafe {
+    let mut first_fds = [0; 2];
+    let mut second_fds = [0; 2];
+    assert_eq!(libc::pipe(first_fds.as_mut_ptr()), 0);
+    assert_eq!(libc::pipe(second_fds.as_mut_ptr()), 0);
+    let first_reader = OwnedFd::from_raw_fd(first_fds[0]);
+    let first_writer = OwnedFd::from_raw_fd(first_fds[1]);
+    let second_reader = OwnedFd::from_raw_fd(second_fds[0]);
+    let second_writer = OwnedFd::from_raw_fd(second_fds[1]);
+    let (first_ready, wait_for_first) = mpsc::sync_channel(0);
+    let (second_was_written, second_write_result) = mpsc::sync_channel(1);
+    let second_writer_fd = second_writer.as_raw_fd();
+    std::thread::spawn(move || {
+      if wait_for_first.recv().is_ok() {
+        let written = libc::write(second_writer_fd, b"x".as_ptr().cast(), 1);
+        let _ = second_was_written.send(written);
+      }
+    });
+
+    let first_poll = Box::into_raw(Box::new(MaybeUninit::<
+      libuv_sys_lite::uv_poll_t,
+    >::zeroed()))
+    .cast();
+    let second_poll = Box::into_raw(Box::new(MaybeUninit::<
+      libuv_sys_lite::uv_poll_t,
+    >::zeroed()))
+    .cast();
+    let timer = Box::into_raw(Box::new(MaybeUninit::<
+      libuv_sys_lite::uv_timer_t,
+    >::zeroed()))
+    .cast();
+    let mut loop_ = null_mut();
+    assert_napi_ok!(napi_get_uv_event_loop(env, &mut loop_));
+    let mut callback_ref = null_mut();
+    assert_napi_ok!(napi_create_reference(env, callback, 1, &mut callback_ref));
+    let state = Box::into_raw(Box::new(MultiPollTest {
+      env,
+      callback: callback_ref,
+      first_poll,
+      second_poll,
+      timer,
+      first_reader,
+      first_writer,
+      second_reader,
+      _second_writer: second_writer,
+      first_ready,
+      second_write_result,
+      first_callback_count: 0,
+      second_callback_count: 0,
+      first_callback_returned: false,
+      closing: false,
+      passed: true,
+      closed_handles: 0,
+    }));
+
+    assert_eq!(
+      libuv_sys_lite::uv_poll_init(
+        loop_.cast(),
+        first_poll,
+        (*state).first_reader.as_raw_fd(),
+      ),
+      0
+    );
+    assert_eq!(
+      libuv_sys_lite::uv_poll_init(
+        loop_.cast(),
+        second_poll,
+        (*state).second_reader.as_raw_fd(),
+      ),
+      0
+    );
+    assert_eq!(libuv_sys_lite::uv_timer_init(loop_.cast(), timer), 0);
+    libuv_sys_lite::uv_handle_set_data(first_poll.cast(), state.cast());
+    libuv_sys_lite::uv_handle_set_data(second_poll.cast(), state.cast());
+    libuv_sys_lite::uv_handle_set_data(timer.cast(), state.cast());
+    assert_eq!(
+      libuv_sys_lite::uv_timer_start(
+        timer,
+        Some(multi_poll_test_timeout),
+        10_000,
+        0,
+      ),
+      0
+    );
+    state
+  }
 }
 
 #[cfg(unix)]
@@ -1131,8 +1335,8 @@ unsafe extern "C" fn poll_test_close_cb(
       return;
     }
 
-    // uv_close() completes asynchronously; only then can the shared state be
-    // released and JavaScript told that this test has settled.
+    // Free shared state and resolve JavaScript only after both close callbacks
+    // have run.
     let mut js_cb = null_mut();
     assert_napi_ok!(napi_get_reference_value(
       (*state).env,
@@ -1185,6 +1389,97 @@ unsafe fn new_poll_test(env: napi_env, callback: napi_value) -> *mut PollTest {
 }
 
 #[cfg(unix)]
+struct ActivePollForTeardown {
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  _reader: OwnedFd,
+  _writer: OwnedFd,
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn active_poll_for_teardown_callback(
+  _poll: *mut libuv_sys_lite::uv_poll_t,
+  _status: i32,
+  _events: i32,
+) {
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn active_poll_for_teardown_cleanup(data: *mut c_void) {
+  unsafe {
+    // NapiState::drop invalidates this Env's poll owner before calling cleanup
+    // hooks, so a queued core readiness entry cannot reach this bridge after
+    // the addon-owned poll storage is released below.
+    let state = Box::from_raw(data.cast::<ActivePollForTeardown>());
+    libuv_sys_lite::uv_close(state.poll.cast(), None);
+    let _ = Box::from_raw(state.poll);
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_leave_active(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  let (args, argc, _) = napi_get_callback_info!(env, info, 1);
+  assert_eq!(argc, 1);
+
+  unsafe {
+    let mut unref = false;
+    assert_napi_ok!(napi_get_value_bool(env, args[0], &mut unref));
+
+    let mut fds = [0; 2];
+    assert_eq!(libc::pipe(fds.as_mut_ptr()), 0);
+    let reader = OwnedFd::from_raw_fd(fds[0]);
+    let writer = OwnedFd::from_raw_fd(fds[1]);
+    let poll = Box::into_raw(Box::new(
+      MaybeUninit::<libuv_sys_lite::uv_poll_t>::zeroed(),
+    ))
+    .cast();
+    let state = Box::into_raw(Box::new(ActivePollForTeardown {
+      poll,
+      _reader: reader,
+      _writer: writer,
+    }));
+    let mut loop_ = null_mut();
+    assert_napi_ok!(napi_get_uv_event_loop(env, &mut loop_));
+    assert_eq!(
+      libuv_sys_lite::uv_poll_init(
+        loop_.cast(),
+        poll,
+        (*state)._reader.as_raw_fd(),
+      ),
+      0
+    );
+    libuv_sys_lite::uv_handle_set_data(poll.cast(), state.cast());
+    assert_eq!(
+      libuv_sys_lite::uv_poll_start(
+        poll,
+        libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+        Some(active_poll_for_teardown_callback),
+      ),
+      0
+    );
+    // Exercise teardown both with and without this active poll keeping the
+    // loop alive.
+    if unref {
+      libuv_sys_lite::uv_unref(poll.cast());
+    }
+    // Leave this ready poll and its storage to the environment cleanup hook.
+    assert_eq!(
+      libc::write((*state)._writer.as_raw_fd(), b"x".as_ptr().cast(), 1),
+      1
+    );
+    assert_napi_ok!(napi_add_env_cleanup_hook(
+      env,
+      Some(active_poll_for_teardown_cleanup),
+      state.cast(),
+    ));
+  }
+
+  null_mut()
+}
+
+#[cfg(unix)]
 unsafe fn new_poll_test_with_fds(
   env: napi_env,
   callback: napi_value,
@@ -1204,6 +1499,8 @@ unsafe fn new_poll_test_with_fds(
     .cast();
     let mut callback_ref = null_mut();
     assert_napi_ok!(napi_create_reference(env, callback, 1, &mut callback_ref));
+    let mut loop_ = null_mut();
+    assert_napi_ok!(napi_get_uv_event_loop(env, &mut loop_));
 
     let state = Box::into_raw(Box::new(PollTest {
       env,
@@ -1223,8 +1520,6 @@ unsafe fn new_poll_test_with_fds(
       settle_after_callback: false,
     }));
 
-    let mut loop_ = null_mut();
-    assert_napi_ok!(napi_get_uv_event_loop(env, &mut loop_));
     assert_eq!(
       libuv_sys_lite::uv_poll_init(
         loop_.cast(),
@@ -1604,6 +1899,226 @@ extern "C" fn test_uv_poll_does_not_flood_callbacks(
 }
 
 #[cfg(unix)]
+unsafe extern "C" fn multi_poll_first_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<MultiPollTest>();
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    (*state).first_callback_count += 1;
+    (*state).passed &=
+      (*state).first_callback_count == 1 && status == 0 && events == readable;
+    if (*state).first_ready.send(()).is_err() {
+      multi_poll_test_finish(state, false);
+      return;
+    }
+
+    // The helper writes only after this callback begins and acknowledges the
+    // write before it returns, proving the second descriptor is ready here.
+    // The second callback then verifies it dispatches after this flag is set.
+    if !matches!((*state).second_write_result.recv(), Ok(1)) {
+      multi_poll_test_finish(state, false);
+      return;
+    }
+    assert_eq!(libuv_sys_lite::uv_poll_stop(poll), 0);
+    (*state).first_callback_returned = true;
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn multi_poll_second_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<MultiPollTest>();
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    (*state).second_callback_count += 1;
+    (*state).passed &= (*state).first_callback_returned
+      && (*state).second_callback_count == 1
+      && status == 0
+      && events == readable;
+    multi_poll_test_finish(state, (*state).passed);
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_delivers_two_fds(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let state = new_multi_poll_test(env, poll_callback_arg(env, info));
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    assert_eq!(
+      libuv_sys_lite::uv_poll_start(
+        (*state).first_poll,
+        readable,
+        Some(multi_poll_first_cb),
+      ),
+      0
+    );
+    assert_eq!(
+      libuv_sys_lite::uv_poll_start(
+        (*state).second_poll,
+        readable,
+        Some(multi_poll_second_cb),
+      ),
+      0
+    );
+    assert_eq!(
+      libc::write((*state).first_writer.as_raw_fd(), b"x".as_ptr().cast(), 1,),
+      1
+    );
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_self_stop_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    (*state).poll_callback_count += 1;
+    (*state).passed &=
+      (*state).poll_callback_count == 1 && status == 0 && events == readable;
+    assert_eq!(libuv_sys_lite::uv_poll_stop(poll), 0);
+    poll_test_finish(state, (*state).passed);
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_self_stops(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let state = new_poll_test(env, poll_callback_arg(env, info));
+    poll_test_write(state);
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_self_stop_cb),
+    );
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_self_restarted_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    let writable = libuv_sys_lite::uv_poll_event::UV_WRITABLE.0 as i32;
+    (*state).poll_callback_count += 1;
+    // Two writable callbacks prove the replacement watch remains active after
+    // its first delivery.
+    (*state).passed &= (*state).poll_callback_count > 1
+      && (*state).poll_callback_count <= 3
+      && status == 0
+      && events == writable;
+    if (*state).poll_callback_count == 3 {
+      assert_eq!(libuv_sys_lite::uv_poll_stop(poll), 0);
+      poll_test_finish(state, (*state).passed);
+    }
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_self_restart_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    let writable = libuv_sys_lite::uv_poll_event::UV_WRITABLE.0 as i32;
+    (*state).poll_callback_count += 1;
+    (*state).passed &=
+      (*state).poll_callback_count == 1 && status == 0 && events == readable;
+    // Keep the original byte unread while requesting writable so the
+    // replacement runs while the original readiness remains.
+    assert_eq!(
+      libuv_sys_lite::uv_poll_start(
+        poll,
+        writable,
+        Some(poll_self_restarted_cb)
+      ),
+      0
+    );
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_restarts_in_callback(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let (client, server) = std::os::unix::net::UnixStream::pair().unwrap();
+    let state = new_poll_test_with_fds(
+      env,
+      poll_callback_arg(env, info),
+      client.into(),
+      server.into(),
+    );
+    poll_test_write(state);
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_self_restart_cb),
+    );
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_self_close_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    (*state).poll_callback_count += 1;
+    (*state).passed &=
+      (*state).poll_callback_count == 1 && status == 0 && events == readable;
+    (*state).poll_closed = true;
+    libuv_sys_lite::uv_close(poll.cast(), Some(poll_test_close_cb));
+    poll_test_finish(state, (*state).passed);
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_closes_in_callback(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let state = new_poll_test(env, poll_callback_arg(env, info));
+    poll_test_write(state);
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_self_close_cb),
+    );
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
 unsafe extern "C" fn poll_restarted_cb(
   poll: *mut libuv_sys_lite::uv_poll_t,
   status: i32,
@@ -1835,6 +2350,16 @@ unsupported_poll_test!(test_uv_poll_restart_replaces_watch);
 unsupported_poll_test!(test_uv_poll_allows_one_active_handle_per_fd);
 #[cfg(not(unix))]
 unsupported_poll_test!(test_uv_poll_close_suppresses_ready_callback);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_delivers_two_fds);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_self_stops);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_restarts_in_callback);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_closes_in_callback);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_leave_active);
 
 pub fn init(env: napi_env, exports: napi_value) {
   let properties = &[
@@ -1905,6 +2430,27 @@ pub fn init(env: napi_env, exports: napi_value) {
       env,
       "test_uv_poll_close_suppresses_ready_callback",
       test_uv_poll_close_suppresses_ready_callback
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_delivers_two_fds",
+      test_uv_poll_delivers_two_fds
+    ),
+    napi_new_property!(env, "test_uv_poll_self_stops", test_uv_poll_self_stops),
+    napi_new_property!(
+      env,
+      "test_uv_poll_leave_active",
+      test_uv_poll_leave_active
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_restarts_in_callback",
+      test_uv_poll_restarts_in_callback
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_closes_in_callback",
+      test_uv_poll_closes_in_callback
     ),
   ];
 

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -1734,10 +1734,12 @@ extern "C" fn test_uv_poll_invalid_fd_reports_ebadf(
 ) -> napi_value {
   unsafe {
     let state = new_poll_test(env, poll_callback_arg(env, info));
-    // Closing an fd after uv_poll_init is invalid libuv usage. Real libuv may
-    // abort on Linux rather than deliver a callback, but poll(2) can return
-    // POLLNVAL here. This compatibility layer defensively reports it once as
-    // UV_EBADF and stops.
+    // Closing an fd after uv_poll_init is invalid libuv usage, and libuv does
+    // not guarantee an error callback. This test pins a defensive property of
+    // our current poll(2) driver: when it observes POLLNVAL, the compatibility
+    // layer reports UV_EBADF once and stops the handle. A future epoll, kqueue,
+    // or other backend that silently discards closed descriptors may remove or
+    // relax this test instead of synthesizing a stronger guarantee than libuv.
     //
     // Replace the reader before closing it so cleanup cannot close a later
     // descriptor that reuses the same fd.

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -1407,8 +1407,8 @@ unsafe extern "C" fn active_poll_for_teardown_callback(
 unsafe extern "C" fn active_poll_for_teardown_cleanup(data: *mut c_void) {
   unsafe {
     // NapiState::drop invalidates this Env's poll owner before calling cleanup
-    // hooks, so a queued core readiness entry cannot reach this bridge after
-    // the addon-owned poll storage is released below.
+    // hooks, so queued poll readiness cannot reach this bridge after the
+    // addon-owned poll storage is released below.
     let state = Box::from_raw(data.cast::<ActivePollForTeardown>());
     libuv_sys_lite::uv_close(state.poll.cast(), None);
     let _ = Box::from_raw(state.poll);

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -1655,15 +1655,27 @@ extern "C" fn test_uv_poll_allows_one_active_handle_per_fd(
     libuv_sys_lite::uv_handle_set_data(second.cast(), state.cast());
     let start_zero =
       libuv_sys_lite::uv_poll_start((*state).poll, 0, Some(poll_stale_cb));
+    let start_zero_null = libuv_sys_lite::uv_poll_start((*state).poll, 0, None);
     let first_start = libuv_sys_lite::uv_poll_start(
       (*state).poll,
       readable,
       Some(poll_stale_cb),
     );
+    let first_start_null =
+      libuv_sys_lite::uv_poll_start((*state).poll, readable, None);
+    let third = Box::into_raw(Box::new(
+      MaybeUninit::<libuv_sys_lite::uv_poll_t>::zeroed(),
+    ))
+    .cast();
+    let late_init = libuv_sys_lite::uv_poll_init(loop_.cast(), third, fd);
     let conflicting_start =
       libuv_sys_lite::uv_poll_start(second, readable, Some(poll_stale_cb));
     let conflicting_start_zero =
       libuv_sys_lite::uv_poll_start(second, 0, Some(poll_stale_cb));
+    let conflicting_start_zero_null =
+      libuv_sys_lite::uv_poll_start(second, 0, None);
+    let conflicting_start_null =
+      libuv_sys_lite::uv_poll_start(second, readable, None);
     let first_stop = libuv_sys_lite::uv_poll_stop((*state).poll);
     let second_start =
       libuv_sys_lite::uv_poll_start(second, readable, Some(poll_stale_cb));
@@ -1671,14 +1683,24 @@ extern "C" fn test_uv_poll_allows_one_active_handle_per_fd(
 
     let passed = second_init == 0
       && start_zero == 0
+      && start_zero_null == 0
       && first_start == 0
+      && first_start_null == libuv_sys_lite::uv_errno_t::UV_EINVAL.0
+      && late_init == libuv_sys_lite::uv_errno_t::UV_EEXIST.0
       && conflicting_start == libuv_sys_lite::uv_errno_t::UV_EEXIST.0
       && conflicting_start_zero == libuv_sys_lite::uv_errno_t::UV_EEXIST.0
+      && conflicting_start_zero_null == libuv_sys_lite::uv_errno_t::UV_EEXIST.0
+      && conflicting_start_null == libuv_sys_lite::uv_errno_t::UV_EEXIST.0
       && first_stop == 0
       && second_start == 0
       && second_stop == 0;
 
     libuv_sys_lite::uv_close(second.cast(), Some(duplicate_poll_close_cb));
+    if late_init == 0 {
+      libuv_sys_lite::uv_close(third.cast(), Some(duplicate_poll_close_cb));
+    } else {
+      let _ = Box::from_raw(third);
+    }
     poll_test_finish(state, passed);
   }
   null_mut()

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -1406,7 +1406,7 @@ unsafe extern "C" fn active_poll_for_teardown_callback(
 #[cfg(unix)]
 unsafe extern "C" fn active_poll_for_teardown_cleanup(data: *mut c_void) {
   unsafe {
-    // NapiState::drop invalidates this Env's poll owner before calling cleanup
+    // NapiState::drop invalidates this Env's poll scope before calling cleanup
     // hooks, so queued poll readiness cannot reach this bridge after the
     // addon-owned poll storage is released below.
     let state = Box::from_raw(data.cast::<ActivePollForTeardown>());

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -1386,6 +1386,52 @@ extern "C" fn test_uv_poll_dispatches_hangup_only(
   null_mut()
 }
 
+#[cfg(target_os = "linux")]
+extern "C" fn test_uv_poll_reports_disconnect(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let mut fds = [0; 2];
+    assert_eq!(
+      libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr(),),
+      0
+    );
+    let poll_socket = OwnedFd::from_raw_fd(fds[0]);
+    let peer_socket = OwnedFd::from_raw_fd(fds[1]);
+    let state = new_poll_test_with_fds(
+      env,
+      poll_callback_arg(env, info),
+      poll_socket,
+      peer_socket,
+    );
+    let disconnect = libuv_sys_lite::uv_poll_event::UV_DISCONNECT.0 as i32;
+    poll_test_expect(state, 0, disconnect, true, false);
+    poll_test_start(state, disconnect, Some(poll_expected_cb));
+
+    // Linux reports POLLRDHUP when the peer closes its write side. Other Unix
+    // poll backends do not guarantee an equivalent raw event, so the JavaScript
+    // test runs this production-path assertion on Linux only.
+    assert_eq!(
+      libc::shutdown((*state).other_fd.as_raw_fd(), libc::SHUT_WR),
+      0
+    );
+  }
+  null_mut()
+}
+
+#[cfg(not(target_os = "linux"))]
+extern "C" fn test_uv_poll_reports_disconnect(
+  env: napi_env,
+  _info: napi_callback_info,
+) -> napi_value {
+  let mut undefined = null_mut();
+  unsafe {
+    assert_napi_ok!(napi_get_undefined(env, &mut undefined));
+  }
+  undefined
+}
+
 #[cfg(unix)]
 extern "C" fn test_uv_poll_invalid_fd_reports_ebadf(
   env: napi_env,
@@ -1819,6 +1865,11 @@ pub fn init(env: napi_env, exports: napi_value) {
       env,
       "test_uv_poll_dispatches_hangup_only",
       test_uv_poll_dispatches_hangup_only
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_reports_disconnect",
+      test_uv_poll_reports_disconnect
     ),
     napi_new_property!(
       env,

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -15,12 +15,6 @@ use std::ptr::null_mut;
 use std::time::Duration;
 use std::time::Instant;
 
-#[cfg(unix)]
-unsafe extern "C" {
-  fn pipe(fds: *mut i32) -> i32;
-  fn write(fd: i32, buffer: *const std::ffi::c_void, count: usize) -> isize;
-}
-
 use libuv_sys_lite::uv_async_init;
 use libuv_sys_lite::uv_async_t;
 use libuv_sys_lite::uv_close;
@@ -1051,7 +1045,7 @@ extern "C" fn test_uv_poll_init_sets_nonblocking(
     let mut loop_ = null_mut();
     assert_napi_ok!(napi_get_uv_event_loop(env, &mut loop_));
     let mut fds = [0; 2];
-    assert_eq!(pipe(fds.as_mut_ptr()), 0);
+    assert_eq!(libc::pipe(fds.as_mut_ptr()), 0);
     let poll_fd = OwnedFd::from_raw_fd(fds[0]);
     let _other_fd = OwnedFd::from_raw_fd(fds[1]);
     let flags = libc::fcntl(poll_fd.as_raw_fd(), libc::F_GETFL);
@@ -1183,7 +1177,7 @@ unsafe fn new_poll_test(env: napi_env, callback: napi_value) -> *mut PollTest {
   unsafe {
     // Create the usual pipe fixture: poll its read end and write to its peer.
     let mut fds = [0; 2];
-    assert_eq!(pipe(fds.as_mut_ptr()), 0);
+    assert_eq!(libc::pipe(fds.as_mut_ptr()), 0);
     let reader = OwnedFd::from_raw_fd(fds[0]);
     let writer = OwnedFd::from_raw_fd(fds[1]);
     new_poll_test_with_fds(env, callback, reader, writer)
@@ -1268,7 +1262,7 @@ unsafe fn poll_test_start(
 unsafe fn poll_test_write(state: *mut PollTest) {
   unsafe {
     assert_eq!(
-      write((*state).other_fd.as_raw_fd(), b"x".as_ptr().cast(), 1),
+      libc::write((*state).other_fd.as_raw_fd(), b"x".as_ptr().cast(), 1),
       1
     );
   }
@@ -1346,7 +1340,7 @@ extern "C" fn test_uv_poll_reports_actual_writable_events(
 ) -> napi_value {
   unsafe {
     let mut fds = [0; 2];
-    assert_eq!(pipe(fds.as_mut_ptr()), 0);
+    assert_eq!(libc::pipe(fds.as_mut_ptr()), 0);
     let reader = OwnedFd::from_raw_fd(fds[0]);
     let writer = OwnedFd::from_raw_fd(fds[1]);
     let state =
@@ -1370,7 +1364,7 @@ extern "C" fn test_uv_poll_dispatches_hangup_only(
 ) -> napi_value {
   unsafe {
     let mut fds = [0; 2];
-    assert_eq!(pipe(fds.as_mut_ptr()), 0);
+    assert_eq!(libc::pipe(fds.as_mut_ptr()), 0);
     let reader = OwnedFd::from_raw_fd(fds[0]);
     let writer = OwnedFd::from_raw_fd(fds[1]);
     drop(writer);

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -1237,7 +1237,9 @@ unsafe fn new_poll_test_with_fds(
     libuv_sys_lite::uv_handle_set_data(poll.cast(), state.cast());
     libuv_sys_lite::uv_handle_set_data(timer.cast(), state.cast());
     assert_eq!(
-      libuv_sys_lite::uv_timer_start(timer, Some(poll_test_timeout), 1000, 0),
+      // This failure-only watchdog leaves the short settle timers below
+      // unchanged while providing enough margin for loaded CI workers.
+      libuv_sys_lite::uv_timer_start(timer, Some(poll_test_timeout), 10_000, 0),
       0
     );
     state

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -1,11 +1,25 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+#[cfg(unix)]
+use std::fs::File;
 use std::mem::MaybeUninit;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+#[cfg(unix)]
+use std::os::fd::OwnedFd;
 use std::ptr;
 use std::ptr::addr_of_mut;
 use std::ptr::null_mut;
 use std::time::Duration;
 use std::time::Instant;
+
+#[cfg(unix)]
+unsafe extern "C" {
+  fn pipe(fds: *mut i32) -> i32;
+  fn write(fd: i32, buffer: *const std::ffi::c_void, count: usize) -> isize;
+}
 
 use libuv_sys_lite::uv_async_init;
 use libuv_sys_lite::uv_async_t;
@@ -1028,6 +1042,807 @@ extern "C" fn test_uv_cond_broadcast(
   undefined
 }
 
+#[cfg(unix)]
+extern "C" fn test_uv_poll_init_sets_nonblocking(
+  env: napi_env,
+  _info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let mut loop_ = null_mut();
+    assert_napi_ok!(napi_get_uv_event_loop(env, &mut loop_));
+    let mut fds = [0; 2];
+    assert_eq!(pipe(fds.as_mut_ptr()), 0);
+    let poll_fd = OwnedFd::from_raw_fd(fds[0]);
+    let _other_fd = OwnedFd::from_raw_fd(fds[1]);
+    let flags = libc::fcntl(poll_fd.as_raw_fd(), libc::F_GETFL);
+    assert_ne!(flags, -1);
+    assert_eq!(flags & libc::O_NONBLOCK, 0);
+
+    let mut poll = MaybeUninit::<libuv_sys_lite::uv_poll_t>::zeroed();
+    assert_eq!(
+      libuv_sys_lite::uv_poll_init(
+        loop_.cast(),
+        poll.as_mut_ptr(),
+        poll_fd.as_raw_fd(),
+      ),
+      0
+    );
+    let flags = libc::fcntl(poll_fd.as_raw_fd(), libc::F_GETFL);
+    assert_ne!(flags, -1);
+    assert_ne!(flags & libc::O_NONBLOCK, 0);
+    libuv_sys_lite::uv_close(poll.as_mut_ptr().cast(), None);
+  }
+
+  let mut undefined = null_mut();
+  unsafe {
+    assert_napi_ok!(napi_get_undefined(env, &mut undefined));
+  }
+  undefined
+}
+
+#[cfg(unix)]
+struct PollTest {
+  env: napi_env,
+  // Keeps the JavaScript completion callback alive across asynchronous work.
+  callback: napi_ref,
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  // Starts as the watchdog, then some scenarios reuse it as a settle timer.
+  timer: *mut libuv_sys_lite::uv_timer_t,
+  poll_fd: OwnedFd,
+  other_fd: OwnedFd,
+  poll_callback_count: usize,
+  closing: bool,
+  poll_closed: bool,
+  passed: bool,
+  closed_handles: usize,
+  expected_status: i32,
+  expected_events: i32,
+  expected_active: bool,
+  settle_after_callback: bool,
+}
+
+#[cfg(unix)]
+unsafe fn poll_test_finish(state: *mut PollTest, passed: bool) {
+  unsafe {
+    // All exit paths converge here so the watchdog and ordinary assertions use
+    // the same idempotent cleanup sequence.
+    if (*state).closing {
+      // A callback after cleanup has begun is a test failure. Preserve the
+      // failure without closing either handle twice.
+      (*state).passed &= passed;
+      return;
+    }
+    (*state).closing = true;
+    (*state).passed &= passed;
+    if !(*state).poll_closed {
+      assert_eq!(libuv_sys_lite::uv_poll_stop((*state).poll), 0);
+    }
+    assert_eq!(libuv_sys_lite::uv_timer_stop((*state).timer), 0);
+    if !(*state).poll_closed {
+      (*state).poll_closed = true;
+      libuv_sys_lite::uv_close((*state).poll.cast(), Some(poll_test_close_cb));
+    }
+    libuv_sys_lite::uv_close((*state).timer.cast(), Some(poll_test_close_cb));
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_test_close_cb(
+  handle: *mut libuv_sys_lite::uv_handle_t,
+) {
+  unsafe {
+    let state = (*handle).data.cast::<PollTest>();
+    (*state).closed_handles += 1;
+    if (*state).closed_handles != 2 {
+      return;
+    }
+
+    // uv_close() completes asynchronously; only then can the shared state be
+    // released and JavaScript told that this test has settled.
+    let mut js_cb = null_mut();
+    assert_napi_ok!(napi_get_reference_value(
+      (*state).env,
+      (*state).callback,
+      &mut js_cb
+    ));
+    let mut global = null_mut();
+    assert_napi_ok!(napi_get_global((*state).env, &mut global));
+    let mut passed = null_mut();
+    assert_napi_ok!(napi_get_boolean(
+      (*state).env,
+      (*state).passed,
+      &mut passed
+    ));
+    let mut result = null_mut();
+    assert_napi_ok!(napi_call_function(
+      (*state).env,
+      global,
+      js_cb,
+      1,
+      &passed,
+      &mut result,
+    ));
+    assert_napi_ok!(napi_delete_reference((*state).env, (*state).callback));
+
+    let _ = Box::from_raw((*state).poll);
+    let _ = Box::from_raw((*state).timer);
+    let _ = Box::from_raw(state);
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_test_timeout(timer: *mut libuv_sys_lite::uv_timer_t) {
+  unsafe {
+    let state = (*timer).data.cast::<PollTest>();
+    poll_test_finish(state, false);
+  }
+}
+
+#[cfg(unix)]
+unsafe fn new_poll_test(env: napi_env, callback: napi_value) -> *mut PollTest {
+  unsafe {
+    // Create the usual pipe fixture: poll its read end and write to its peer.
+    let mut fds = [0; 2];
+    assert_eq!(pipe(fds.as_mut_ptr()), 0);
+    let reader = OwnedFd::from_raw_fd(fds[0]);
+    let writer = OwnedFd::from_raw_fd(fds[1]);
+    new_poll_test_with_fds(env, callback, reader, writer)
+  }
+}
+
+#[cfg(unix)]
+unsafe fn new_poll_test_with_fds(
+  env: napi_env,
+  callback: napi_value,
+  poll_fd: OwnedFd,
+  other_fd: OwnedFd,
+) -> *mut PollTest {
+  unsafe {
+    // The fixture owns both descriptors until its two libuv handles finish
+    // closing, including for tests that provide sockets instead of a pipe.
+    let poll = Box::into_raw(Box::new(
+      MaybeUninit::<libuv_sys_lite::uv_poll_t>::zeroed(),
+    ))
+    .cast();
+    let timer = Box::into_raw(Box::new(MaybeUninit::<
+      libuv_sys_lite::uv_timer_t,
+    >::zeroed()))
+    .cast();
+    let mut callback_ref = null_mut();
+    assert_napi_ok!(napi_create_reference(env, callback, 1, &mut callback_ref));
+
+    let state = Box::into_raw(Box::new(PollTest {
+      env,
+      callback: callback_ref,
+      poll,
+      timer,
+      poll_fd,
+      other_fd,
+      poll_callback_count: 0,
+      closing: false,
+      poll_closed: false,
+      passed: true,
+      closed_handles: 0,
+      expected_status: 0,
+      expected_events: 0,
+      expected_active: false,
+      settle_after_callback: false,
+    }));
+
+    let mut loop_ = null_mut();
+    assert_napi_ok!(napi_get_uv_event_loop(env, &mut loop_));
+    assert_eq!(
+      libuv_sys_lite::uv_poll_init(
+        loop_.cast(),
+        poll,
+        (*state).poll_fd.as_raw_fd()
+      ),
+      0
+    );
+    assert_eq!(libuv_sys_lite::uv_timer_init(loop_.cast(), timer), 0);
+    libuv_sys_lite::uv_handle_set_data(poll.cast(), state.cast());
+    libuv_sys_lite::uv_handle_set_data(timer.cast(), state.cast());
+    assert_eq!(
+      libuv_sys_lite::uv_timer_start(timer, Some(poll_test_timeout), 1000, 0),
+      0
+    );
+    state
+  }
+}
+
+#[cfg(unix)]
+unsafe fn poll_test_start(
+  state: *mut PollTest,
+  events: i32,
+  callback: libuv_sys_lite::uv_poll_cb,
+) {
+  unsafe {
+    assert_eq!(
+      libuv_sys_lite::uv_poll_start((*state).poll, events, callback),
+      0
+    );
+  }
+}
+
+#[cfg(unix)]
+unsafe fn poll_test_write(state: *mut PollTest) {
+  unsafe {
+    assert_eq!(
+      write((*state).other_fd.as_raw_fd(), b"x".as_ptr().cast(), 1),
+      1
+    );
+  }
+}
+
+#[cfg(unix)]
+unsafe fn poll_test_start_timer(
+  state: *mut PollTest,
+  callback: libuv_sys_lite::uv_timer_cb,
+  timeout: u64,
+) {
+  unsafe {
+    // Reuse the watchdog timer for short post-condition windows after first
+    // stopping it; this avoids introducing another handle to clean up.
+    assert_eq!(
+      libuv_sys_lite::uv_timer_start((*state).timer, callback, timeout, 0),
+      0
+    );
+  }
+}
+
+#[cfg(unix)]
+unsafe fn poll_test_expect(
+  state: *mut PollTest,
+  status: i32,
+  events: i32,
+  active: bool,
+  settle_after_callback: bool,
+) {
+  unsafe {
+    (*state).expected_status = status;
+    (*state).expected_events = events;
+    (*state).expected_active = active;
+    (*state).settle_after_callback = settle_after_callback;
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_expected_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    (*state).poll_callback_count += 1;
+    let active = libuv_sys_lite::uv_is_active(poll.cast()) != 0;
+    (*state).passed &= (*state).poll_callback_count == 1
+      && status == (*state).expected_status
+      && events == (*state).expected_events
+      && (*state).expected_active == active;
+
+    if (*state).settle_after_callback {
+      assert_eq!(libuv_sys_lite::uv_timer_stop((*state).timer), 0);
+      poll_test_start_timer(state, Some(poll_stop_settle_cb), 100);
+    } else {
+      poll_test_finish(state, (*state).passed);
+    }
+  }
+}
+
+#[cfg(unix)]
+fn poll_callback_arg(env: napi_env, info: napi_callback_info) -> napi_value {
+  // Poll tests receive one `done` Promise resolver, which the fixture retains
+  // until asynchronous cleanup has completed.
+  let (args, argc, _) = napi_get_callback_info!(env, info, 1);
+  assert_eq!(argc, 1);
+  args[0]
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_reports_actual_writable_events(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let mut fds = [0; 2];
+    assert_eq!(pipe(fds.as_mut_ptr()), 0);
+    let reader = OwnedFd::from_raw_fd(fds[0]);
+    let writer = OwnedFd::from_raw_fd(fds[1]);
+    let state =
+      new_poll_test_with_fds(env, poll_callback_arg(env, info), writer, reader);
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    let writable = libuv_sys_lite::uv_poll_event::UV_WRITABLE.0 as i32;
+    // A pipe's write end produces POLLOUT but not POLLIN. Requesting both bits
+    // distinguishes actual readiness from the requested mask. Expecting
+    // UV_WRITABLE (2) verifies that POLLOUT (4 on supported Unix targets) is
+    // translated to the libuv value.
+    poll_test_expect(state, 0, writable, true, false);
+    poll_test_start(state, readable | writable, Some(poll_expected_cb));
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_reports_prioritized_events(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    // TCP out-of-band data produces POLLPRI on the peer, exercising the
+    // POLLPRI-to-UV_PRIORITIZED translation.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let client =
+      std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    let (server, _) = listener.accept().unwrap();
+    assert_eq!(
+      libc::send(client.as_raw_fd(), c"x".as_ptr().cast(), 1, libc::MSG_OOB),
+      1
+    );
+    let state = new_poll_test_with_fds(
+      env,
+      poll_callback_arg(env, info),
+      server.into(),
+      client.into(),
+    );
+    let prioritized = libuv_sys_lite::uv_poll_event::UV_PRIORITIZED.0 as i32;
+    poll_test_expect(state, 0, prioritized, true, false);
+    poll_test_start(state, prioritized, Some(poll_expected_cb));
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_dispatches_hangup_only(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let mut fds = [0; 2];
+    assert_eq!(pipe(fds.as_mut_ptr()), 0);
+    let reader = OwnedFd::from_raw_fd(fds[0]);
+    let writer = OwnedFd::from_raw_fd(fds[1]);
+    drop(writer);
+    // poll(2) reports POLLHUP independently of the requested mask. libuv
+    // surfaces the requested readable interest so the consumer can observe EOF.
+    let placeholder: OwnedFd = File::open("/dev/null").unwrap().into();
+    let state = new_poll_test_with_fds(
+      env,
+      poll_callback_arg(env, info),
+      reader,
+      placeholder,
+    );
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    poll_test_expect(state, 0, readable, true, false);
+    poll_test_start(state, readable, Some(poll_expected_cb));
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_error_reports_ebadf_and_stops(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let mut fds = [0; 2];
+    assert_eq!(pipe(fds.as_mut_ptr()), 0);
+    let reader = OwnedFd::from_raw_fd(fds[0]);
+    let writer = OwnedFd::from_raw_fd(fds[1]);
+    drop(reader);
+    // POLLERR is reported independently of the requested mask. Because this
+    // watch requests only readable events, a pipe write end without a reader
+    // produces an error-only result. It must invoke the callback with UV_EBADF,
+    // deactivate the handle, and not enter a retry loop.
+    let placeholder: OwnedFd = File::open("/dev/null").unwrap().into();
+    let state = new_poll_test_with_fds(
+      env,
+      poll_callback_arg(env, info),
+      writer,
+      placeholder,
+    );
+    poll_test_expect(
+      state,
+      libuv_sys_lite::uv_errno_t::UV_EBADF.0,
+      0,
+      false,
+      true,
+    );
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_expected_cb),
+    );
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_invalid_fd_reports_ebadf(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let state = new_poll_test(env, poll_callback_arg(env, info));
+    // Closing an fd after uv_poll_init is invalid libuv usage. Real libuv may
+    // abort on Linux rather than deliver a callback, but poll(2) can return
+    // POLLNVAL here. This compatibility layer defensively reports it once as
+    // UV_EBADF and stops.
+    //
+    // Replace the reader before closing it so cleanup cannot close a later
+    // descriptor that reuses the same fd.
+    let placeholder: OwnedFd = File::open("/dev/null").unwrap().into();
+    drop(std::mem::replace(&mut (*state).poll_fd, placeholder));
+    poll_test_expect(
+      state,
+      libuv_sys_lite::uv_errno_t::UV_EBADF.0,
+      0,
+      false,
+      false,
+    );
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_expected_cb),
+    );
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_level_triggered_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    (*state).passed &= status == 0 && events == readable;
+    (*state).poll_callback_count += 1;
+    // Leave the byte unread. libuv polling is level-triggered, so the same
+    // readiness must produce another callback without another uv_poll_start().
+    if (*state).poll_callback_count == 2 {
+      poll_test_finish(state, (*state).passed);
+    }
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_repeats_while_readable(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let state = new_poll_test(env, poll_callback_arg(env, info));
+    poll_test_write(state);
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_level_triggered_cb),
+    );
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_stop_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  _status: i32,
+  _events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    // If this callback runs after uv_poll_stop(), cancellation failed.
+    (*state).passed = false;
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_stop_settle_cb(
+  timer: *mut libuv_sys_lite::uv_timer_t,
+) {
+  unsafe {
+    poll_test_finish((*timer).data.cast(), true);
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_arm_then_stop_cb(
+  timer: *mut libuv_sys_lite::uv_timer_t,
+) {
+  unsafe {
+    let state = (*timer).data.cast::<PollTest>();
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_stop_cb),
+    );
+    // Keep the loop thread occupied long enough for the poll worker to observe
+    // readiness and queue its callback. The task queue exposes no test-visible
+    // latch, so this generous scheduling window is the closest public-API
+    // approximation of a pending callback. stop must suppress that callback.
+    std::thread::sleep(Duration::from_millis(100));
+    assert_eq!(libuv_sys_lite::uv_poll_stop((*state).poll), 0);
+    poll_test_start_timer(state, Some(poll_stop_settle_cb), 100);
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_stop_suppresses_ready_callback(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let state = new_poll_test(env, poll_callback_arg(env, info));
+    poll_test_write(state);
+    assert_eq!(libuv_sys_lite::uv_timer_stop((*state).timer), 0);
+    poll_test_start_timer(state, Some(poll_arm_then_stop_cb), 0);
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_no_flood_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    (*state).poll_callback_count += 1;
+    if (*state).poll_callback_count != 1 {
+      // Leave cleanup to the settle timer installed by the first callback.
+      // Several callbacks may already be queued by the implementation under
+      // test, so freeing shared state here would make the test itself racy.
+      (*state).passed = false;
+      assert_eq!(libuv_sys_lite::uv_poll_stop(poll), 0);
+      return;
+    }
+
+    // Keep the loop-thread callback busy while the fd remains level-ready.
+    // A poll worker may not enqueue successors until this callback returns.
+    std::thread::sleep(Duration::from_millis(100));
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+    (*state).passed = status == 0 && events == readable;
+    assert_eq!(libuv_sys_lite::uv_poll_stop(poll), 0);
+    assert_eq!(libuv_sys_lite::uv_timer_stop((*state).timer), 0);
+    poll_test_start_timer(state, Some(poll_stop_settle_cb), 100);
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_does_not_flood_callbacks(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let state = new_poll_test(env, poll_callback_arg(env, info));
+    poll_test_write(state);
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_no_flood_cb),
+    );
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_restarted_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  status: i32,
+  events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    let writable = libuv_sys_lite::uv_poll_event::UV_WRITABLE.0 as i32;
+    (*state).passed &= status == 0 && events == writable;
+    (*state).poll_callback_count += 1;
+    // Requiring two callbacks also proves the replacement watch remains armed.
+    if (*state).poll_callback_count == 2 {
+      poll_test_finish(state, (*state).passed);
+    }
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_stale_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  _status: i32,
+  _events: i32,
+) {
+  unsafe {
+    poll_test_finish((*poll).data.cast(), false);
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_restart_replaces_watch(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let (client, server) = std::os::unix::net::UnixStream::pair().unwrap();
+    let state = new_poll_test_with_fds(
+      env,
+      poll_callback_arg(env, info),
+      client.into(),
+      server.into(),
+    );
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_stale_cb),
+    );
+    // Restarting replaces the callback and event mask atomically from the
+    // addon's perspective; callbacks belonging to the previous watch must not
+    // run. The socket is writable, while no data makes it readable.
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_WRITABLE.0 as i32,
+      Some(poll_restarted_cb),
+    );
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn duplicate_poll_close_cb(
+  handle: *mut libuv_sys_lite::uv_handle_t,
+) {
+  unsafe {
+    let _ = Box::from_raw(handle.cast::<libuv_sys_lite::uv_poll_t>());
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_allows_one_active_handle_per_fd(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let state = new_poll_test(env, poll_callback_arg(env, info));
+    let second = Box::into_raw(Box::new(MaybeUninit::<
+      libuv_sys_lite::uv_poll_t,
+    >::zeroed()))
+    .cast();
+    let mut loop_ = null_mut();
+    assert_napi_ok!(napi_get_uv_event_loop(env, &mut loop_));
+    let fd = (*state).poll_fd.as_raw_fd();
+    let readable = libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32;
+
+    // libuv permits multiple initialized poll handles for an fd, but only one
+    // may actively poll it at a time. Exclusivity ends immediately when the
+    // active handle stops.
+    let second_init = libuv_sys_lite::uv_poll_init(loop_.cast(), second, fd);
+    if second_init != 0 {
+      // A failed init leaves the handle uninitialized, so uv_close() would not
+      // be valid. Free its storage and report the contract failure directly.
+      let _ = Box::from_raw(second);
+      poll_test_finish(state, false);
+      return null_mut();
+    }
+    libuv_sys_lite::uv_handle_set_data(second.cast(), state.cast());
+    let start_zero =
+      libuv_sys_lite::uv_poll_start((*state).poll, 0, Some(poll_stale_cb));
+    let first_start = libuv_sys_lite::uv_poll_start(
+      (*state).poll,
+      readable,
+      Some(poll_stale_cb),
+    );
+    let conflicting_start =
+      libuv_sys_lite::uv_poll_start(second, readable, Some(poll_stale_cb));
+    let conflicting_start_zero =
+      libuv_sys_lite::uv_poll_start(second, 0, Some(poll_stale_cb));
+    let first_stop = libuv_sys_lite::uv_poll_stop((*state).poll);
+    let second_start =
+      libuv_sys_lite::uv_poll_start(second, readable, Some(poll_stale_cb));
+    let second_stop = libuv_sys_lite::uv_poll_stop(second);
+
+    let passed = second_init == 0
+      && start_zero == 0
+      && first_start == 0
+      && conflicting_start == libuv_sys_lite::uv_errno_t::UV_EEXIST.0
+      && conflicting_start_zero == libuv_sys_lite::uv_errno_t::UV_EEXIST.0
+      && first_stop == 0
+      && second_start == 0
+      && second_stop == 0;
+
+    libuv_sys_lite::uv_close(second.cast(), Some(duplicate_poll_close_cb));
+    poll_test_finish(state, passed);
+  }
+  null_mut()
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_after_close_cb(
+  poll: *mut libuv_sys_lite::uv_poll_t,
+  _status: i32,
+  _events: i32,
+) {
+  unsafe {
+    let state = (*poll).data.cast::<PollTest>();
+    (*state).passed = false;
+  }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn poll_arm_then_close_cb(
+  timer: *mut libuv_sys_lite::uv_timer_t,
+) {
+  unsafe {
+    let state = (*timer).data.cast::<PollTest>();
+    poll_test_start(
+      state,
+      libuv_sys_lite::uv_poll_event::UV_READABLE.0 as i32,
+      Some(poll_after_close_cb),
+    );
+    // As in the stop test, use a generous scheduling window because the task
+    // queue exposes no test-visible latch. uv_close() must invalidate the
+    // callback expected to be in transit.
+    std::thread::sleep(Duration::from_millis(100));
+    (*state).poll_closed = true;
+    libuv_sys_lite::uv_close((*state).poll.cast(), Some(poll_test_close_cb));
+    poll_test_start_timer(state, Some(poll_stop_settle_cb), 100);
+  }
+}
+
+#[cfg(unix)]
+extern "C" fn test_uv_poll_close_suppresses_ready_callback(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  unsafe {
+    let state = new_poll_test(env, poll_callback_arg(env, info));
+    poll_test_write(state);
+    assert_eq!(libuv_sys_lite::uv_timer_stop((*state).timer), 0);
+    poll_test_start_timer(state, Some(poll_arm_then_close_cb), 0);
+  }
+  null_mut()
+}
+
+#[cfg(not(unix))]
+macro_rules! unsupported_poll_test {
+  ($name:ident) => {
+    extern "C" fn $name(
+      env: napi_env,
+      _info: napi_callback_info,
+    ) -> napi_value {
+      let mut undefined = null_mut();
+      unsafe {
+        assert_napi_ok!(napi_get_undefined(env, &mut undefined));
+      }
+      undefined
+    }
+  };
+}
+
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_init_sets_nonblocking);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_reports_actual_writable_events);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_reports_prioritized_events);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_dispatches_hangup_only);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_error_reports_ebadf_and_stops);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_invalid_fd_reports_ebadf);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_repeats_while_readable);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_stop_suppresses_ready_callback);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_does_not_flood_callbacks);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_restart_replaces_watch);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_allows_one_active_handle_per_fd);
+#[cfg(not(unix))]
+unsupported_poll_test!(test_uv_poll_close_suppresses_ready_callback);
+
 pub fn init(env: napi_env, exports: napi_value) {
   let properties = &[
     napi_new_property!(env, "test_uv_async", test_uv_async),
@@ -1043,6 +1858,66 @@ pub fn init(env: napi_env, exports: napi_value) {
     napi_new_property!(env, "test_uv_threads", test_uv_threads),
     napi_new_property!(env, "test_uv_cond", test_uv_cond),
     napi_new_property!(env, "test_uv_cond_broadcast", test_uv_cond_broadcast),
+    napi_new_property!(
+      env,
+      "test_uv_poll_init_sets_nonblocking",
+      test_uv_poll_init_sets_nonblocking
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_reports_actual_writable_events",
+      test_uv_poll_reports_actual_writable_events
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_reports_prioritized_events",
+      test_uv_poll_reports_prioritized_events
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_dispatches_hangup_only",
+      test_uv_poll_dispatches_hangup_only
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_error_reports_ebadf_and_stops",
+      test_uv_poll_error_reports_ebadf_and_stops
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_invalid_fd_reports_ebadf",
+      test_uv_poll_invalid_fd_reports_ebadf
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_repeats_while_readable",
+      test_uv_poll_repeats_while_readable
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_stop_suppresses_ready_callback",
+      test_uv_poll_stop_suppresses_ready_callback
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_does_not_flood_callbacks",
+      test_uv_poll_does_not_flood_callbacks
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_restart_replaces_watch",
+      test_uv_poll_restart_replaces_watch
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_allows_one_active_handle_per_fd",
+      test_uv_poll_allows_one_active_handle_per_fd
+    ),
+    napi_new_property!(
+      env,
+      "test_uv_poll_close_suppresses_ready_callback",
+      test_uv_poll_close_suppresses_ready_callback
+    ),
   ];
 
   assert_napi_ok!(napi_define_properties(

--- a/tests/napi/uv_test.js
+++ b/tests/napi/uv_test.js
@@ -173,6 +173,17 @@ uvPollTest("napi uv poll dispatches hangup-only readiness", (done) => {
   uv.test_uv_poll_dispatches_hangup_only(done);
 });
 
+Deno.test({
+  name: "napi uv poll reports peer disconnect",
+  ignore: Deno.build.os !== "linux",
+  async fn() {
+    const passed = await new Promise((resolve) => {
+      uv.test_uv_poll_reports_disconnect(resolve);
+    });
+    assertEquals(passed, true);
+  },
+});
+
 uvPollTest("napi uv poll reports invalid fd error", (done) => {
   uv.test_uv_poll_invalid_fd_reports_ebadf(done);
 });

--- a/tests/napi/uv_test.js
+++ b/tests/napi/uv_test.js
@@ -211,3 +211,19 @@ uvPollTest("napi uv poll allows one active handle per fd", (done) => {
 uvPollTest("napi uv poll close suppresses subsequent callback", (done) => {
   uv.test_uv_poll_close_suppresses_ready_callback(done);
 });
+
+uvPollTest("napi uv poll delivers two independent fds", (done) => {
+  uv.test_uv_poll_delivers_two_fds(done);
+});
+
+uvPollTest("napi uv poll callback can stop itself", (done) => {
+  uv.test_uv_poll_self_stops(done);
+});
+
+uvPollTest("napi uv poll callback can restart itself", (done) => {
+  uv.test_uv_poll_restarts_in_callback(done);
+});
+
+uvPollTest("napi uv poll callback can close itself", (done) => {
+  uv.test_uv_poll_closes_in_callback(done);
+});

--- a/tests/napi/uv_test.js
+++ b/tests/napi/uv_test.js
@@ -147,3 +147,64 @@ Deno.test({
     uv.test_uv_cond_broadcast();
   },
 });
+
+function uvPollTest(name, run) {
+  Deno.test({
+    name,
+    ignore: Deno.build.os === "windows",
+    fn: async () => {
+      const passed = await new Promise((resolve) => run(resolve));
+      assertEquals(passed, true);
+    },
+  });
+}
+
+Deno.test({
+  name: "napi uv poll init sets fd nonblocking",
+  ignore: Deno.build.os === "windows",
+  fn: () => uv.test_uv_poll_init_sets_nonblocking(),
+});
+
+uvPollTest("napi uv poll reports actual writable events", (done) => {
+  uv.test_uv_poll_reports_actual_writable_events(done);
+});
+
+uvPollTest("napi uv poll reports prioritized events", (done) => {
+  uv.test_uv_poll_reports_prioritized_events(done);
+});
+
+uvPollTest("napi uv poll dispatches hangup-only readiness", (done) => {
+  uv.test_uv_poll_dispatches_hangup_only(done);
+});
+
+uvPollTest("napi uv poll reports error-only result and stops", (done) => {
+  uv.test_uv_poll_error_reports_ebadf_and_stops(done);
+});
+
+uvPollTest("napi uv poll reports invalid fd error", (done) => {
+  uv.test_uv_poll_invalid_fd_reports_ebadf(done);
+});
+
+uvPollTest("napi uv poll repeats while fd remains readable", (done) => {
+  uv.test_uv_poll_repeats_while_readable(done);
+});
+
+uvPollTest("napi uv poll stop suppresses subsequent callback", (done) => {
+  uv.test_uv_poll_stop_suppresses_ready_callback(done);
+});
+
+uvPollTest("napi uv poll applies callback back-pressure", (done) => {
+  uv.test_uv_poll_does_not_flood_callbacks(done);
+});
+
+uvPollTest("napi uv poll restart replaces active watch", (done) => {
+  uv.test_uv_poll_restart_replaces_watch(done);
+});
+
+uvPollTest("napi uv poll allows one active handle per fd", (done) => {
+  uv.test_uv_poll_allows_one_active_handle_per_fd(done);
+});
+
+uvPollTest("napi uv poll close suppresses subsequent callback", (done) => {
+  uv.test_uv_poll_close_suppresses_ready_callback(done);
+});

--- a/tests/napi/uv_test.js
+++ b/tests/napi/uv_test.js
@@ -169,16 +169,8 @@ uvPollTest("napi uv poll reports actual writable events", (done) => {
   uv.test_uv_poll_reports_actual_writable_events(done);
 });
 
-uvPollTest("napi uv poll reports prioritized events", (done) => {
-  uv.test_uv_poll_reports_prioritized_events(done);
-});
-
 uvPollTest("napi uv poll dispatches hangup-only readiness", (done) => {
   uv.test_uv_poll_dispatches_hangup_only(done);
-});
-
-uvPollTest("napi uv poll reports error-only result and stops", (done) => {
-  uv.test_uv_poll_error_reports_ebadf_and_stops(done);
 });
 
 uvPollTest("napi uv poll reports invalid fd error", (done) => {

--- a/tests/napi/uv_test.js
+++ b/tests/napi/uv_test.js
@@ -132,3 +132,64 @@ Deno.test({
     uv.test_uv_cond_broadcast();
   },
 });
+
+function uvPollTest(name, run) {
+  Deno.test({
+    name,
+    ignore: Deno.build.os === "windows",
+    fn: async () => {
+      const passed = await new Promise((resolve) => run(resolve));
+      assertEquals(passed, true);
+    },
+  });
+}
+
+Deno.test({
+  name: "napi uv poll init sets fd nonblocking",
+  ignore: Deno.build.os === "windows",
+  fn: () => uv.test_uv_poll_init_sets_nonblocking(),
+});
+
+uvPollTest("napi uv poll reports actual writable events", (done) => {
+  uv.test_uv_poll_reports_actual_writable_events(done);
+});
+
+uvPollTest("napi uv poll reports prioritized events", (done) => {
+  uv.test_uv_poll_reports_prioritized_events(done);
+});
+
+uvPollTest("napi uv poll dispatches hangup-only readiness", (done) => {
+  uv.test_uv_poll_dispatches_hangup_only(done);
+});
+
+uvPollTest("napi uv poll reports error-only result and stops", (done) => {
+  uv.test_uv_poll_error_reports_ebadf_and_stops(done);
+});
+
+uvPollTest("napi uv poll reports invalid fd error", (done) => {
+  uv.test_uv_poll_invalid_fd_reports_ebadf(done);
+});
+
+uvPollTest("napi uv poll repeats while fd remains readable", (done) => {
+  uv.test_uv_poll_repeats_while_readable(done);
+});
+
+uvPollTest("napi uv poll stop suppresses subsequent callback", (done) => {
+  uv.test_uv_poll_stop_suppresses_ready_callback(done);
+});
+
+uvPollTest("napi uv poll applies callback back-pressure", (done) => {
+  uv.test_uv_poll_does_not_flood_callbacks(done);
+});
+
+uvPollTest("napi uv poll restart replaces active watch", (done) => {
+  uv.test_uv_poll_restart_replaces_watch(done);
+});
+
+uvPollTest("napi uv poll allows one active handle per fd", (done) => {
+  uv.test_uv_poll_allows_one_active_handle_per_fd(done);
+});
+
+uvPollTest("napi uv poll close suppresses subsequent callback", (done) => {
+  uv.test_uv_poll_close_suppresses_ready_callback(done);
+});

--- a/tests/napi/worker_termination_test.js
+++ b/tests/napi/worker_termination_test.js
@@ -2,6 +2,58 @@
 
 import { assertEquals } from "./common.js";
 
+function waitForMessage(worker, expected) {
+  return new Promise((resolve, reject) => {
+    worker.onmessage = (event) => {
+      if (event.data === expected) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `expected worker message ${JSON.stringify(expected)}, got ${
+              JSON.stringify(event.data)
+            }`,
+          ),
+        );
+      }
+    };
+    worker.onerror = (event) => {
+      event.preventDefault();
+      reject(event.error ?? new Error(event.message));
+    };
+  });
+}
+
+async function testActivePollTerminationProtocol(message) {
+  const worker = new Worker(
+    new URL("./worker_termination_worker.js", import.meta.url),
+    { type: "module" },
+  );
+  await waitForMessage(worker, "ready");
+  worker.postMessage(message);
+  await waitForMessage(worker, "armed");
+  // The worker sends "armed" only after registering cleanup for the ready
+  // active poll. This test exercises that protocol but does not await shutdown.
+  worker.terminate();
+}
+
+// Unix-only: this fixture uses POSIX pipes through the Unix poll bridge.
+Deno.test({
+  name: "napi uv poll worker termination arms a refed poll",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    await testActivePollTerminationProtocol("arm_refed_poll");
+  },
+});
+
+Deno.test({
+  name: "napi uv poll worker termination arms an unrefed poll",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    await testActivePollTerminationProtocol("arm_unrefed_poll");
+  },
+});
+
 Deno.test("napi addon survives worker termination", async () => {
   // Spawn a worker that loads the NAPI addon and does work.
   // Terminate it and verify no crash occurs.

--- a/tests/napi/worker_termination_test.js
+++ b/tests/napi/worker_termination_test.js
@@ -32,8 +32,10 @@ async function testActivePollTerminationProtocol(message) {
   await waitForMessage(worker, "ready");
   worker.postMessage(message);
   await waitForMessage(worker, "armed");
-  // The worker sends "armed" only after registering cleanup for the ready
-  // active poll. This test exercises that protocol but does not await shutdown.
+  // This is end-to-end smoke coverage for Web Worker termination. The worker
+  // sends "armed" only after registering cleanup for the ready active poll,
+  // but this API cannot observe runtime destruction. The Rust unit test
+  // `active_napi_poll_teardown_joins_runtime_thread` separately waits for it.
   worker.terminate();
 }
 
@@ -41,6 +43,8 @@ async function testActivePollTerminationProtocol(message) {
 Deno.test({
   name: "napi uv poll worker termination arms a refed poll",
   ignore: Deno.build.os === "windows",
+  sanitizeOps: true,
+  sanitizeResources: true,
   async fn() {
     await testActivePollTerminationProtocol("arm_refed_poll");
   },
@@ -49,6 +53,8 @@ Deno.test({
 Deno.test({
   name: "napi uv poll worker termination arms an unrefed poll",
   ignore: Deno.build.os === "windows",
+  sanitizeOps: true,
+  sanitizeResources: true,
   async fn() {
     await testActivePollTerminationProtocol("arm_unrefed_poll");
   },

--- a/tests/napi/worker_termination_worker.js
+++ b/tests/napi/worker_termination_worker.js
@@ -14,4 +14,12 @@ self.onmessage = (e) => {
     lib.test_external_buffer();
     self.postMessage("created");
   }
+  if (e.data === "arm_refed_poll") {
+    lib.test_uv_poll_leave_active(false);
+    self.postMessage("armed");
+  }
+  if (e.data === "arm_unrefed_poll") {
+    lib.test_uv_poll_leave_active(true);
+    self.postMessage("armed");
+  }
 };


### PR DESCRIPTION
Fixes #36317

Align the Unix N-API uv_poll compatibility implementation more closely with libuv.

- Set descriptors to non-blocking mode during `uv_poll_init`.
- Translate `pollfd.revents` readiness into `UV_READABLE`, `UV_WRITABLE`, `UV_PRIORITIZED`, and, where `POLLRDHUP` is available, `UV_DISCONNECT`.
- Handle `POLLHUP`, `POLLERR`, and `POLLNVAL`, reporting the requested events or `UV_EBADF` as appropriate and stopping after an error callback.
- Preserve level-triggered polling while waiting for each loop-thread callback to finish before polling again, preventing callback flooding.
- Retry `poll(2)` when interrupted and report other genuine polling failures instead of entering a hot retry loop.
- Reject a second active poll handle for the same descriptor with `UV_EEXIST`.
- Extend `uv_strerror` messages for additional errors exposed by this path.
- Add Unix N-API regression tests for the updated poll behavior.

## Testing

Tested locally on Linux:

```sh
./x verify
cargo build -p deno
cargo build -p test_napi
./target/debug/deno test \
  --allow-read --allow-env --allow-ffi \
  --v8-flags=--expose-gc --config ./tests/config/deno.json --no-lock \
  --filter 'napi uv poll' \
  ./tests/napi/uv_test.js
```

At present, the suite takes more than 30 seconds to complete. This is likely due to #36454 and is unrelated to the `uv_poll` implementation. I expect it to complete in about a second once that timer issue is resolved.

## AI disclosure
This PR was developed with assistance from OpenAI Codex. I reviewed and validated all changes.