### PR TITLE
fix(ext/tls): avoid panic for mismatched client certificate and key

### DIFF
--- a/ext/tls/lib.rs
+++ b/ext/tls/lib.rs
@@ -316,8 +316,7 @@ pub fn create_client_config(
     // or client cert".
     let mut client = match maybe_cert_chain_and_key {
       TlsKeys::Static(TlsKey(cert_chain, private_key)) => client_config
-        .with_client_auth_cert(cert_chain, private_key.clone_key())
-        .expect("invalid client key or certificate"),
+        .with_client_auth_cert(cert_chain, private_key.clone_key())?,
       TlsKeys::Null => client_config.with_no_client_auth(),
       TlsKeys::Resolver(_) => unimplemented!(),
     };
@@ -350,8 +349,7 @@ pub fn create_client_config(
 
   let mut client = match maybe_cert_chain_and_key {
     TlsKeys::Static(TlsKey(cert_chain, private_key)) => client_config
-      .with_client_auth_cert(cert_chain, private_key.clone_key())
-      .expect("invalid client key or certificate"),
+      .with_client_auth_cert(cert_chain, private_key.clone_key())?,
     TlsKeys::Null => client_config.with_no_client_auth(),
     TlsKeys::Resolver(_) => unimplemented!(),
   };

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -1561,6 +1561,23 @@ Deno.test(
 );
 
 Deno.test(
+  { permissions: { read: true } },
+  function createHttpClientMismatchedCertAndKey() {
+    assertThrows(
+      () =>
+        Deno.createHttpClient({
+          cert: Deno.readTextFileSync(
+            "tests/testdata/tls/localhost.crt",
+          ),
+          key: Deno.readTextFileSync("tests/testdata/tls/RootCA.key"),
+        }),
+      TypeError,
+      "keys may not be consistent: KeyMismatch",
+    );
+  },
+);
+
+Deno.test(
   { permissions: { read: true, net: true } },
   async function fetchCustomClientPrivateKey(): Promise<
     void


### PR DESCRIPTION
## Summary

- Propagate the `rustls` validation error when a client certificate and private key do not match instead of panicking through `.expect()`.
- Apply the error propagation to both client configuration paths in `create_client_config()`.
- Add a regression test verifying that `Deno.createHttpClient()` throws a `TypeError` for mismatched credentials.

The validation error is now surfaced through the existing `TlsError` conversion path:

```text
TypeError: keys may not be consistent: KeyMismatch
```

This prevents invalid user-provided TLS credentials from terminating the Deno process.

## Testing

- Reproduced the original panic with the official Deno 2.9.4 Windows binary.
- Verified that the patched runtime returns `TypeError: keys may not be consistent: KeyMismatch` without printing the Deno panic banner.
- Targeted runtime regression test: 1 passed, 139 filtered out.
- `cargo check -p deno_tls --features deno_core/quickjs`
- `cargo test -p deno_tls --features deno_core/quickjs` — 3 passed; 1 doctest ignored.
- `cargo clippy -p deno_tls --features deno_core/quickjs -- -D warnings`
- `cargo fmt --all -- --check`
- Targeted dprint check for `tests/unit/fetch_test.ts`
- Deno lint for `tests/unit/fetch_test.ts`
- `git diff --check`

A full default V8-based Windows build could not be completed because Windows Developer Mode is disabled, preventing `rusty_v8` from creating its required symbolic links.

AI assistance: OpenAI Codex was used only to review the patch and test results.

Fixes #36380
