### PR TITLE
fix(node_crypto): size cipher updates by byte length

### DIFF
--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -11,6 +11,9 @@ const {
 const {
   ArrayBufferIsView,
   Boolean,
+  DataViewPrototypeGetBuffer,
+  DataViewPrototypeGetByteLength,
+  DataViewPrototypeGetByteOffset,
   Error,
   FunctionPrototypeCall,
   MathFloor,
@@ -26,7 +29,9 @@ const {
   TypeError,
   TypeErrorPrototype,
   TypedArrayPrototypeAt,
+  TypedArrayPrototypeGetBuffer,
   TypedArrayPrototypeGetByteLength,
+  TypedArrayPrototypeGetByteOffset,
   Uint8Array,
 } = primordials;
 const {
@@ -80,6 +85,7 @@ const {
 const {
   isAnyArrayBuffer,
   isArrayBufferView,
+  isTypedArray,
 } = core.loadExtScript("ext:deno_node/internal/util/types.ts");
 const { ERR_CRYPTO_INVALID_STATE, ERR_CRYPTO_UNKNOWN_CIPHER } = core
   .loadExtScript(
@@ -100,6 +106,33 @@ function getTransform() {
 }
 
 const FastBuffer = Buffer[SymbolSpecies];
+
+function getArrayBufferViewParts(
+  view: ArrayBufferView,
+): { buffer: ArrayBufferLike; byteOffset: number; byteLength: number } {
+  if (isTypedArray(view)) {
+    return {
+      buffer: TypedArrayPrototypeGetBuffer(view as Uint8Array),
+      byteOffset: TypedArrayPrototypeGetByteOffset(view as Uint8Array),
+      byteLength: TypedArrayPrototypeGetByteLength(view as Uint8Array),
+    };
+  }
+  return {
+    buffer: DataViewPrototypeGetBuffer(view as DataView),
+    byteOffset: DataViewPrototypeGetByteOffset(view as DataView),
+    byteLength: DataViewPrototypeGetByteLength(view as DataView),
+  };
+}
+
+function getArrayBufferViewByteLength(view: ArrayBufferView): number {
+  const { byteLength } = getArrayBufferViewParts(view);
+  return byteLength;
+}
+
+function toFastBufferView(view: ArrayBufferView): Buffer {
+  const { buffer, byteOffset, byteLength } = getArrayBufferViewParts(view);
+  return new FastBuffer(buffer, byteOffset, byteLength);
+}
 
 function opensslError(code: string, reason: string): NodeError {
   const err = new NodeError(code, reason);
@@ -317,10 +350,13 @@ Cipheriv.prototype.update = function (
   let buf = data;
   if (typeof data === "string") {
     buf = Buffer.from(data, inputEncoding);
+  } else {
+    buf = toFastBufferView(data);
   }
+  const inputByteLength = getArrayBufferViewByteLength(buf);
 
   // Match Node.js/OpenSSL behavior: reject inputs >= INT_MAX bytes
-  if (buf.length >= 2 ** 31 - 1) {
+  if (inputByteLength >= 2 ** 31 - 1) {
     throw new Error("Trying to add data in unsupported state");
   }
 
@@ -343,8 +379,10 @@ Cipheriv.prototype.update = function (
 
   let output: Buffer;
   if (!this._needsBlockCache) {
-    output = Buffer.allocUnsafe(buf.length);
-    op_node_cipheriv_encrypt(this._context, buf, output);
+    output = new FastBuffer(inputByteLength);
+    if (!op_node_cipheriv_encrypt(this._context, buf, output)) {
+      throw new Error("Trying to add data in unsupported state");
+    }
 
     if (outputEncoding !== "buffer") {
       return this._decoder!.write(output);
@@ -359,8 +397,10 @@ Cipheriv.prototype.update = function (
   if (input === null) {
     output = Buffer.alloc(0);
   } else {
-    output = Buffer.allocUnsafe(input.length);
-    op_node_cipheriv_encrypt(this._context, input, output);
+    output = new FastBuffer(input.length);
+    if (!op_node_cipheriv_encrypt(this._context, input, output)) {
+      throw new Error("Trying to add data in unsupported state");
+    }
   }
 
   if (outputEncoding !== "buffer") {
@@ -400,11 +440,15 @@ class BlockModeCache {
     this.#lastChunkIsNonZero = lastChunkIsNotZero;
   }
 
-  add(data: Uint8Array) {
+  add(data: ArrayBufferView) {
+    const { buffer, byteOffset, byteLength } = getArrayBufferViewParts(data);
     const cache = this.cache;
-    this.cache = new Uint8Array(cache.length + data.length);
+    this.cache = new Uint8Array(cache.length + byteLength);
     this.cache.set(cache);
-    this.cache.set(data, cache.length);
+    this.cache.set(
+      new Uint8Array(buffer, byteOffset, byteLength),
+      cache.length,
+    );
   }
 
   /** Gets the chunk of the length of largest multiple of blockSize.
@@ -641,10 +685,13 @@ Decipheriv.prototype.update = function (
   let buf = data;
   if (typeof data === "string") {
     buf = Buffer.from(data, inputEncoding);
+  } else {
+    buf = toFastBufferView(data);
   }
+  const inputByteLength = getArrayBufferViewByteLength(buf);
 
   // Match Node.js/OpenSSL behavior: reject inputs >= INT_MAX bytes
-  if (buf.length >= 2 ** 31 - 1) {
+  if (inputByteLength >= 2 ** 31 - 1) {
     throw new Error("Trying to add data in unsupported state");
   }
 
@@ -667,8 +714,10 @@ Decipheriv.prototype.update = function (
 
   let output;
   if (!this._needsBlockCache) {
-    output = Buffer.allocUnsafe(buf.length);
-    op_node_decipheriv_decrypt(this._context, buf, output);
+    output = new FastBuffer(inputByteLength);
+    if (!op_node_decipheriv_decrypt(this._context, buf, output)) {
+      throw new Error("Trying to add data in unsupported state");
+    }
 
     if (outputEncoding !== "buffer") {
       return this._decoder!.write(output);
@@ -683,7 +732,9 @@ Decipheriv.prototype.update = function (
     output = Buffer.alloc(0);
   } else {
     output = new FastBuffer(input.length);
-    op_node_decipheriv_decrypt(this._context, input, output);
+    if (!op_node_decipheriv_decrypt(this._context, input, output)) {
+      throw new Error("Trying to add data in unsupported state");
+    }
   }
 
   if (outputEncoding !== "buffer") {

--- a/tests/specs/node/crypto_cipheriv_spoofed_length/main.out
+++ b/tests/specs/node/crypto_cipheriv_spoofed_length/main.out
@@ -1,3 +1,3 @@
-encrypt output length: 1
-decrypt output length: 1
+encrypt output length: 1048576
+decrypt output length: 1048576
 Process still alive

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -1238,6 +1238,108 @@ Deno.test({
   },
 });
 
+function viewToBuffer(view: ArrayBufferView): Buffer {
+  return Buffer.from(view.buffer, view.byteOffset, view.byteLength);
+}
+
+Deno.test({
+  name:
+    "Cipheriv/Decipheriv update() uses byteLength for ArrayBufferView inputs",
+  fn() {
+    const key = Buffer.alloc(32, 1);
+
+    const backing = new Uint8Array(64);
+    for (let i = 0; i < backing.length; i++) backing[i] = i;
+
+    const bufferWithSpoofedLength = Buffer.from(backing);
+    Object.defineProperty(bufferWithSpoofedLength, "length", { value: 1 });
+
+    const uint16WithSpoofedLength = new Uint16Array(
+      backing.buffer.slice(0),
+      0,
+      32,
+    );
+    Object.defineProperty(uint16WithSpoofedLength, "length", { value: 1 });
+
+    const dataView = new DataView(backing.buffer, 5, 37);
+
+    for (
+      const input of [
+        bufferWithSpoofedLength,
+        uint16WithSpoofedLength,
+        dataView,
+      ]
+    ) {
+      const plaintext = viewToBuffer(input);
+
+      for (
+        const [algorithm, iv] of [
+          ["aes-256-ctr", Buffer.alloc(16, 2)],
+          ["aes-256-cbc", Buffer.alloc(16, 3)],
+        ] as const
+      ) {
+        const cipher = crypto.createCipheriv(algorithm, key, iv);
+        const encrypted = Buffer.concat([
+          cipher.update(input),
+          cipher.final(),
+        ]);
+
+        const decipher = crypto.createDecipheriv(algorithm, key, iv);
+        const encryptedView = new DataView(
+          encrypted.buffer,
+          encrypted.byteOffset,
+          encrypted.byteLength,
+        );
+        const decrypted = Buffer.concat([
+          decipher.update(encryptedView),
+          decipher.final(),
+        ]);
+
+        assertEquals(decrypted, plaintext, algorithm);
+      }
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "chacha20-poly1305 update() is not affected by Buffer.allocUnsafe override",
+  fn() {
+    const originalAllocUnsafe = Buffer.allocUnsafe;
+    try {
+      Buffer.allocUnsafe = ((_: number) => {
+        return originalAllocUnsafe(1);
+      }) as typeof Buffer.allocUnsafe;
+
+      const key = Buffer.alloc(32, 1);
+      const iv = Buffer.alloc(12, 2);
+      const plaintext = Buffer.alloc(1024, 3);
+
+      const cipher = crypto.createCipheriv("chacha20-poly1305", key, iv, {
+        authTagLength: 16,
+      });
+      const encrypted = Buffer.concat([
+        cipher.update(plaintext),
+        cipher.final(),
+      ]);
+      assertEquals(encrypted.length, plaintext.length);
+      const tag = (cipher as crypto.CipherGCM).getAuthTag();
+
+      const decipher = crypto.createDecipheriv("chacha20-poly1305", key, iv, {
+        authTagLength: 16,
+      });
+      (decipher as crypto.DecipherGCM).setAuthTag(tag);
+      const decrypted = Buffer.concat([
+        decipher.update(encrypted),
+        decipher.final(),
+      ]);
+      assertEquals(decrypted, plaintext);
+    } finally {
+      Buffer.allocUnsafe = originalAllocUnsafe;
+    }
+  },
+});
+
 Deno.test({
   name:
     "Cipheriv/Decipheriv update() leaves stream usable after type-error throw",


### PR DESCRIPTION
## What changed

- Normalize `ArrayBufferView` inputs using their underlying buffer, byte offset, and byte length.
- Allocate cipher update output with the captured `FastBuffer` constructor.
- Keep block-mode caching byte-oriented and handle rejected native updates.
- Cover `Buffer`, multi-byte typed-array, `DataView`, and public allocator replacement cases.
- Align the inherited spoofed-length spec with byte-oriented output sizing.

## Why

Cipher updates consume bytes, while some typed-array properties describe element counts and public `Buffer` allocation methods can be replaced by application code. Depending on those values could size update output incorrectly or produce truncated results for otherwise valid inputs.

## Validation

- `./tools/format.js ext/node/polyfills/internal/crypto/cipher.ts tests/unit_node/crypto/crypto_cipher_test.ts`
- `./tools/lint.js --js`
- `cargo test -p unit_node_tests --test unit_node -- crypto::crypto_cipher_test`
- `dprint check ext/node/polyfills/internal/crypto/cipher.ts tests/unit_node/crypto/crypto_cipher_test.ts`
- `node tests/specs/node/crypto_cipheriv_spoofed_length/main.mjs | diff -u tests/specs/node/crypto_cipheriv_spoofed_length/main.out -`
