### PR TITLE
fix(node): preserve v8 deserializer view offsets

### DIFF
--- a/ext/node/ops/v8.rs
+++ b/ext/node/ops/v8.rs
@@ -693,6 +693,7 @@ pub fn op_v8_write_value(
 
 struct DeserBuffer {
   ptr: Option<NonNull<u8>>,
+  len: usize,
   // Hold onto backing store to keep the underlying buffer
   // alive while we hold a reference to it.
   _backing_store: v8::SharedRef<v8::BackingStore>,
@@ -775,7 +776,7 @@ pub fn op_v8_new_deserializer(
     (
       // SAFETY: the len is valid, from v8, and the data_ptr is valid (as above)
       unsafe { std::slice::from_raw_parts(data_ptr.cast_const().cast(), len) },
-      Some(data.cast()),
+      NonNull::new(data_ptr),
     )
   } else {
     (&[] as &[u8], None::<NonNull<u8>>)
@@ -796,6 +797,7 @@ pub fn op_v8_new_deserializer(
     buf: DeserBuffer {
       _backing_store: backing_store,
       ptr: buf_ptr,
+      len,
     },
   })
 }
@@ -844,16 +846,31 @@ pub fn op_v8_read_header(
 pub fn op_v8_read_raw_bytes(
   #[cppgc] deser: &Deserializer,
   #[number] length: usize,
-) -> usize {
-  let Some(buf_ptr) = deser.buf.ptr else {
-    return 0;
+) -> isize {
+  let Some(buf) = deser.inner.read_raw_bytes(length) else {
+    return -1;
   };
-  if let Some(buf) = deser.inner.read_raw_bytes(length) {
-    let ptr = buf.as_ptr();
-    (ptr as usize) - (buf_ptr.as_ptr() as usize)
-  } else {
-    0
+  let Some(buf_ptr) = deser.buf.ptr else {
+    return if length == 0 && buf.is_empty() && deser.buf.len == 0 {
+      0
+    } else {
+      -1
+    };
+  };
+
+  let Some(offset) =
+    (buf.as_ptr() as usize).checked_sub(buf_ptr.as_ptr() as usize)
+  else {
+    return -1;
+  };
+  let Some(end) = offset.checked_add(buf.len()) else {
+    return -1;
+  };
+  if end > deser.buf.len {
+    return -1;
   }
+
+  isize::try_from(offset).unwrap_or(-1)
 }
 
 #[op2(fast)]

--- a/ext/node/polyfills/v8.ts
+++ b/ext/node/polyfills/v8.ts
@@ -419,7 +419,11 @@ class Deserializer {
     );
   }
   _readRawBytes(length: number): number {
-    return op_v8_read_raw_bytes(this[kHandle], length);
+    const offset = op_v8_read_raw_bytes(this[kHandle], length);
+    if (offset < 0) {
+      throw new Error("ReadRawBytes() failed");
+    }
+    return offset;
   }
   getWireFormatVersion(): number {
     return op_v8_get_wire_format_version(this[kHandle]);
@@ -643,7 +647,7 @@ class DefaultDeserializer extends Deserializer {
     const bufferCopy = Buffer.allocUnsafe(byteLength);
     Buffer.from(
       getViewBuffer(view),
-      byteOffset,
+      offset,
       byteLength,
     ).copy(bufferCopy);
     return new ctor(

--- a/tests/unit_node/v8_test.ts
+++ b/tests/unit_node/v8_test.ts
@@ -112,12 +112,21 @@ Deno.test({
       payload.copy(wrapped, prefixLength);
       wrapped.fill(0x99, prefixLength + payload.length);
 
-      const sliced = wrapped.subarray(
-        prefixLength,
-        prefixLength + payload.length,
-      );
+      const views = [
+        wrapped.subarray(
+          prefixLength,
+          prefixLength + payload.length,
+        ),
+        new DataView(
+          wrapped.buffer,
+          wrapped.byteOffset + prefixLength,
+          payload.length,
+        ),
+      ];
 
-      assertEquals(v8.deserialize(sliced), value);
+      for (const view of views) {
+        assertEquals(v8.deserialize(view), value);
+      }
     }
   },
 });

--- a/tests/unit_node/v8_test.ts
+++ b/tests/unit_node/v8_test.ts
@@ -99,6 +99,50 @@ Deno.test({
 });
 
 Deno.test({
+  name: "deserialize host objects from nonzero-offset views",
+  fn() {
+    const cases = [
+      { prefixLength: 8, value: Buffer.from([1, 2, 3, 4]) },
+      { prefixLength: 2, value: new Uint16Array([0x0102, 0x0304]) },
+    ];
+
+    for (const { prefixLength, value } of cases) {
+      const payload = v8.serialize(value);
+      const wrapped = Buffer.alloc(prefixLength + payload.length + 16, 0x44);
+      payload.copy(wrapped, prefixLength);
+      wrapped.fill(0x99, prefixLength + payload.length);
+
+      const sliced = wrapped.subarray(
+        prefixLength,
+        prefixLength + payload.length,
+      );
+
+      assertEquals(v8.deserialize(sliced), value);
+    }
+  },
+});
+
+Deno.test({
+  name: "deserialize throws when host object raw bytes are truncated",
+  fn() {
+    const payload = v8.serialize(Buffer.from([1, 2, 3, 4]));
+    assertThrows(
+      () => v8.deserialize(payload.subarray(0, payload.length - 1)),
+      Error,
+      "ReadRawBytes() failed",
+    );
+  },
+});
+
+Deno.test({
+  name: "Deserializer.readRawBytes accepts an empty read at offset zero",
+  fn() {
+    const deserializer = new v8.Deserializer(Buffer.alloc(0));
+    assertEquals(deserializer.readRawBytes(0), Buffer.alloc(0));
+  },
+});
+
+Deno.test({
   name: "Deserializer keeps delegate alive across GC",
   fn() {
     v8.setFlagsFromString("--expose_gc");


### PR DESCRIPTION
## Summary

- compute raw-byte positions relative to the supplied ArrayBufferView
- reject failed or out-of-range raw-byte reads
- apply the view offset consistently when constructing host-object views
- cover nonzero-offset, truncated, and empty-input cases

## Problem

The deserializer initialized V8 with bytes from the supplied view but calculated returned positions from the start of the underlying ArrayBuffer. The JavaScript layer then added the view offset again, so host objects deserialized from slices could use the wrong bytes. Failed raw-byte reads also returned zero, making them indistinguishable from a valid offset at the beginning of the view.

## Validation

- ./tools/format.js ext/node/ops/v8.rs ext/node/polyfills/v8.ts tests/unit_node/v8_test.ts
- ./tools/lint.js --js ext/node/polyfills/v8.ts tests/unit_node/v8_test.ts
- cargo check -p deno_node --features deno_core/v8
- cargo build --bin deno
- cargo build -p test_server
- cargo test -p unit_node_tests --test unit_node v8_test -- --nocapture