### PR TITLE
fix(node): check reads during require resolution

### DIFF
--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -410,13 +410,7 @@ pub fn op_require_stat<TSys: ExtNodeSys + 'static>(
   #[string] path: &str,
 ) -> Result<i32, JsErrorBox> {
   let path = Cow::Borrowed(Path::new(path));
-  let path = if path.ends_with("node_modules") {
-    // skip stat permission checks for node_modules directories
-    // because they're noisy and it's fine
-    path
-  } else {
-    ensure_read_permission(state, path)?
-  };
+  let path = ensure_read_permission(state, path)?;
   let sys = state.borrow::<TSys>();
   if let Ok(metadata) = sys.fs_metadata(&path) {
     if metadata.file_type().is_file() {
@@ -696,17 +690,21 @@ pub fn op_require_is_maybe_cjs(
 pub fn op_require_read_package_scope<TSys: ExtNodeSys + 'static>(
   state: &mut OpState,
   #[string] package_json_path: &str,
-) -> Option<PackageJsonRc> {
-  let pkg_json_resolver = state.borrow::<PackageJsonResolverRc<TSys>>();
+) -> Result<Option<PackageJsonRc>, JsErrorBox> {
   let package_json_path = Path::new(package_json_path);
   if package_json_path.file_name() != Some("package.json".as_ref()) {
     // permissions: do not allow reading a non-package.json file
-    return None;
+    return Ok(None);
   }
-  pkg_json_resolver
-    .load_package_json(package_json_path)
-    .ok()
-    .flatten()
+  let package_json_path =
+    ensure_read_permission(state, Cow::Borrowed(package_json_path))?;
+  let pkg_json_resolver = state.borrow::<PackageJsonResolverRc<TSys>>();
+  Ok(
+    pkg_json_resolver
+      .load_package_json(&package_json_path)
+      .ok()
+      .flatten(),
+  )
 }
 
 #[op2(stack_trace)]

--- a/tests/unit_node/module_test.ts
+++ b/tests/unit_node/module_test.ts
@@ -217,6 +217,108 @@ Deno.test("[node/module findPackageJSON] absolute specifiers use closest package
   }
 });
 
+Deno.test("[node/module require.resolve] checks runtime-selected node_modules paths", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const nodeModulesDir = path.join(tempDir, "project", "node_modules");
+    await Deno.mkdir(nodeModulesDir, { recursive: true });
+    await Deno.writeTextFile(
+      path.join(nodeModulesDir, "package.json"),
+      '{"main":"runtime-selected-entry.js"}',
+    );
+
+    const childPath = path.join(tempDir, "resolve.mjs");
+    await Deno.writeTextFile(
+      childPath,
+      `
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+try {
+  require.resolve(${JSON.stringify(nodeModulesDir + path.sep)});
+  console.error("unexpected success");
+  Deno.exit(1);
+} catch (error) {
+  if (!(error instanceof Error) || error.name !== "NotCapable") {
+    console.error(error);
+    Deno.exit(2);
+  }
+  if (String(error).includes("runtime-selected-entry.js")) {
+    console.error(error);
+    Deno.exit(3);
+  }
+}
+`,
+    );
+
+    const command = new Deno.Command(Deno.execPath(), {
+      args: ["run", childPath],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { code, stdout, stderr } = await command.output();
+    assertEquals(
+      code,
+      0,
+      new TextDecoder().decode(stdout) + new TextDecoder().decode(stderr),
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("[node/module findPackageJSON] checks package metadata reads", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(
+      path.join(tempDir, "package.json"),
+      '{"name":"runtime-selected-package"}',
+    );
+    await Deno.writeTextFile(
+      path.join(tempDir, "static-entry.mjs"),
+      "export const value = 1;",
+    );
+
+    const childPath = path.join(tempDir, "find-package.mjs");
+    await Deno.writeTextFile(
+      childPath,
+      `
+import { findPackageJSON } from "node:module";
+import { value } from "./static-entry.mjs";
+
+if (value !== 1) Deno.exit(1);
+try {
+  findPackageJSON(import.meta.resolve("./static-entry.mjs"));
+  console.error("unexpected success");
+  Deno.exit(2);
+} catch (error) {
+  if (
+    !(error instanceof Error) || error.name !== "NotCapable" ||
+    !String(error).includes("package.json")
+  ) {
+    console.error(error);
+    Deno.exit(3);
+  }
+}
+`,
+    );
+
+    const command = new Deno.Command(Deno.execPath(), {
+      args: ["run", childPath],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { code, stdout, stderr } = await command.output();
+    assertEquals(
+      code,
+      0,
+      new TextDecoder().decode(stdout) + new TextDecoder().decode(stderr),
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
 // https://github.com/denoland/deno/issues/24902
 Deno.test("[node/module register] is a function", () => {
   assertEquals(register("foo"), undefined);


### PR DESCRIPTION
This routes filesystem stats and package metadata reads performed by runtime Node require resolution through Deno's existing read-policy helper.

The helper already preserves module-graph and managed npm reads, while runtime-selected paths now follow the same policy as other Node require operations. Read-check failures for package metadata are propagated instead of being treated as a missing package file.

Tests cover runtime-selected node_modules directories, package metadata lookups involving a statically loaded module, and existing managed npm require resolution behavior.

Validation:
- ./tools/format.js --check
- cargo fmt --check
- ./tools/lint.js --js
- cargo build --bin deno
- cargo test -p unit_node_tests --test unit_node module_test -- --nocapture
- cargo test -p specs_tests --test specs npm::require_resolve_ -- --nocapture