### PR TITLE
fix(ext/node): require sys permission for inspector.open

### DIFF
--- a/ext/node/ops/inspector.rs
+++ b/ext/node/ops/inspector.rs
@@ -97,9 +97,12 @@ pub fn op_inspector_open(
   let port = port.unwrap_or(DEFAULT_PORT);
   let addr = SocketAddr::new(host_ip, port);
 
-  state
-    .borrow_mut::<PermissionsContainer>()
-    .check_net(&(host_ip.to_string(), Some(port)), "inspector.open")?;
+  {
+    let permissions = state.borrow_mut::<PermissionsContainer>();
+    permissions.check_sys("inspector", "inspector.open")?;
+    permissions
+      .check_net(&(host_ip.to_string(), Some(port)), "inspector.open")?;
+  }
 
   let server =
     create_inspector_server(addr, "deno", InspectPublishUid::default())?;

--- a/tests/unit/inspector_test.ts
+++ b/tests/unit/inspector_test.ts
@@ -2406,6 +2406,26 @@ Deno.test("inspector_node_runtime_api_url", async () => {
   );
 });
 
+Deno.test("inspector_node_open_requires_sys_permission", async () => {
+  const script =
+    'import inspector from "node:inspector"; inspector.open(0, "127.0.0.1", false); console.log("opened"); inspector.close();';
+  const scriptUrl = `data:application/javascript,${encodeURIComponent(script)}`;
+
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--no-config", "--quiet", "--allow-net", scriptUrl],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { success, stdout, stderr } = await command.output();
+  assert(!success);
+  assertEquals(new TextDecoder().decode(stdout), "");
+  assertStringIncludes(
+    new TextDecoder().decode(stderr),
+    'Requires sys access to "inspector"',
+  );
+});
+
 // Regression test for https://github.com/denoland/deno/issues/30176.
 // `console.group(label)` must emit a paired `log` event so Chrome DevTools
 // renders the label inside the group container; otherwise the group appears


### PR DESCRIPTION
## Summary

- require `--allow-sys=inspector` before `node:inspector.open()` starts an inspector listener
- retain the existing network permission check for the selected bind address
- add regression coverage for a process with network access but without inspector system access

## Details

The companion `inspector.url()` and `inspector.Session.connect()` APIs already require the inspector system permission. `inspector.open()` only applied the network binding check, which made permission behavior inconsistent across the API entry points. This change makes `open()` apply both relevant checks.

## Validation

- `./tools/format.js`
- `cargo fmt --all -- --check`
- `cargo check -p deno_node --features deno_core/v8`
- `cargo clippy -p deno_node --features deno_core/v8`
- focused `inspector_node_open_requires_sys_permission` unit test
- explicit `inspector.open()` smoke test with both permissions granted
