### PR TITLE
fix(node_crypto): apply RFC 7748 scalar decoding for X448

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,9 +2375,9 @@ dependencies = [
  "ctr",
  "curve25519-dalek",
  "deno_core",
+ "deno_crypto_provider",
  "deno_error",
  "ecdsa",
- "ed448-goldilocks",
  "elliptic-curve 0.13.8",
  "fips203",
  "fips205",
@@ -2397,6 +2397,7 @@ dependencies = [
  "sha3 0.10.8",
  "signature 2.2.0",
  "spki 0.7.3",
+ "subtle",
  "thiserror 2.0.12",
  "tiny-keccak",
  "tokio",
@@ -2409,6 +2410,7 @@ name = "deno_crypto_provider"
 version = "0.51.0"
 dependencies = [
  "aws-lc-sys",
+ "ed448-goldilocks",
 ]
 
 [[package]]

--- a/ext/crypto/Cargo.toml
+++ b/ext/crypto/Cargo.toml
@@ -25,9 +25,9 @@ const-oid.workspace = true
 ctr.workspace = true
 curve25519-dalek.workspace = true
 deno_core.workspace = true
+deno_crypto_provider.workspace = true
 deno_error.workspace = true
 ecdsa.workspace = true
-ed448-goldilocks = { workspace = true }
 elliptic-curve = { workspace = true, features = ["std", "pem", "arithmetic"] }
 fips203 = { workspace = true, features = ["ml-kem-512", "ml-kem-768", "ml-kem-1024"] }
 fips205.workspace = true
@@ -47,6 +47,7 @@ sha2.workspace = true
 sha3.workspace = true
 signature.workspace = true
 spki.workspace = true
+subtle.workspace = true
 thiserror.workspace = true
 tiny-keccak = { workspace = true, features = ["k12", "kmac"] }
 tokio.workspace = true

--- a/ext/crypto/x448.rs
+++ b/ext/crypto/x448.rs
@@ -1,15 +1,11 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
-use ed448_goldilocks::EdwardsScalar;
-use ed448_goldilocks::MontgomeryPoint;
-use ed448_goldilocks::elliptic_curve::bigint::U448;
-use ed448_goldilocks::elliptic_curve::scalar::FromUintUnchecked;
-use ed448_goldilocks::subtle::ConstantTimeEq;
 use rand::RngCore;
 use rand::rngs::OsRng;
 use spki::der::Encode;
 use spki::der::asn1::BitString;
+use subtle::ConstantTimeEq;
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum X448Error {
@@ -24,23 +20,6 @@ pub enum X448Error {
   Der(#[from] spki::der::Error),
 }
 
-/// The X448 function from RFC 7748: decode and clamp the scalar `k`
-/// (section 5) and perform the Montgomery ladder against the point `u`.
-///
-/// The clamped scalar has its top bit (bit 447) set, so it exceeds the
-/// Ed448 group order. It must therefore be used verbatim rather than
-/// reduced mod order (which `EdwardsScalar::from_bytes_mod_order` does)
-/// or the derived point is wrong. See denoland/deno#35155.
-fn x448(k: &[u8; 56], u: MontgomeryPoint) -> MontgomeryPoint {
-  // decodeScalar448 (RFC 7748, section 5).
-  let mut scalar_bytes = *k;
-  scalar_bytes[0] &= 252;
-  scalar_bytes[55] |= 128;
-  let scalar =
-    EdwardsScalar::from_uint_unchecked(U448::from_le_slice(&scalar_bytes));
-  &u * &scalar
-}
-
 /// Generate a random 56-byte X448 private scalar into `pkey` and write the
 /// corresponding 56-byte Montgomery-form public key into `pubkey`. Called
 /// from the cppgc X448 generate-key path in `subtle_generate_key.rs`.
@@ -50,11 +29,14 @@ pub fn generate_x448_keypair(pkey: &mut [u8], pubkey: &mut [u8]) {
 
   // x448(pkey, 5)
   let pkey: &[u8; 56] = (&*pkey).try_into().expect("Expected byteLength 56");
-  let point = x448(pkey, MontgomeryPoint::GENERATOR);
-  pubkey.copy_from_slice(&point.0);
+  let point = deno_crypto_provider::x448::x448(
+    pkey,
+    &deno_crypto_provider::x448::BASE_POINT,
+  );
+  pubkey.copy_from_slice(&point);
 }
 
-static MONTGOMERY_IDENTITY: MontgomeryPoint = MontgomeryPoint([0; 56]);
+static MONTGOMERY_IDENTITY: [u8; 56] = [0; 56];
 
 /// Compute the X448 shared secret from a raw 56-byte private key `k`
 /// and 56-byte peer public key `u`, writing into `secret`. Returns
@@ -70,12 +52,12 @@ pub(crate) fn x448_derive_bits(
   let u: [u8; 56] = u.try_into().map_err(|_| X448Error::InvalidKeyLength)?;
 
   // x448(k, u)
-  let point = x448(&k, MontgomeryPoint(u));
+  let point = deno_crypto_provider::x448::x448(&k, &u);
   if point.ct_eq(&MONTGOMERY_IDENTITY).unwrap_u8() == 1 {
     return Ok(true);
   }
 
-  secret.copy_from_slice(&point.0);
+  secret.copy_from_slice(&point);
   Ok(false)
 }
 
@@ -89,8 +71,11 @@ pub(crate) fn x448_public_key(private_key: &[u8]) -> Result<String, X448Error> {
     .try_into()
     .map_err(|_| X448Error::InvalidKeyLength)?;
   // x448(pkey, 5), identical derivation to generate_x448_keypair.
-  let point = x448(&private_key, MontgomeryPoint::GENERATOR);
-  Ok(BASE64_URL_SAFE_NO_PAD.encode(point.0))
+  let point = deno_crypto_provider::x448::x448(
+    &private_key,
+    &deno_crypto_provider::x448::BASE_POINT,
+  );
+  Ok(BASE64_URL_SAFE_NO_PAD.encode(point))
 }
 
 pub(crate) fn export_spki_x448(pubkey: &[u8]) -> Result<Vec<u8>, X448Error> {
@@ -117,49 +102,4 @@ pub(crate) fn export_pkcs8_x448(pkey: &[u8]) -> Result<Vec<u8>, X448Error> {
   let mut buf = Vec::new();
   pk_info.encode_to_vec(&mut buf)?;
   Ok(buf)
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  fn from_hex(s: &str) -> Vec<u8> {
-    (0..s.len())
-      .step_by(2)
-      .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
-      .collect()
-  }
-
-  #[test]
-  fn x448_public_key_from_scalar() {
-    // Test vector from denoland/deno#35155.
-    let scalar = from_hex(
-      "27a4354608f3bdd38f1f5af305f3e0682efe4e25808249d8fcb55927f6a9f446b8dc1d0a2c3b8cb133a5673b59a6d55ce754ec0c9a555401",
-    );
-    let expected = from_hex(
-      "145d083ea7a6379dbb32dcbd8aff4c206ea5d069b75e96c6dd2a3e38f441471ac97adca641fdad66685a96f32b7c3e064635fab3cc89234e",
-    );
-
-    let scalar: [u8; 56] = scalar.try_into().unwrap();
-    let point = x448(&scalar, MontgomeryPoint::GENERATOR);
-    assert_eq!(point.0.as_slice(), expected.as_slice());
-  }
-
-  #[test]
-  fn x448_rfc7748_ecdh() {
-    // RFC 7748 section 5.2 X448 test vector.
-    let scalar = from_hex(
-      "3d262fddf9ec8e88495266fea19a34d28882acef045104d0d1aae121700a779c984c24f8cdd78fbff44943eba368f54b29259a4f1c600ad3",
-    );
-    let u = from_hex(
-      "06fce640fa3487bfda5f6cf2d5263f8aad88334cbd07437f020f08f9814dc031ddbdc38c19c6da2583fa5429db94ada18aa7a7fb4ef8a086",
-    );
-    let expected = from_hex(
-      "ce3e4ff95a60dc6697da1db1d85e6afbdf79b50a2412d7546d5f239fe14fbaadeb445fc66a01b0779d98223961111e21766282f73dd96b6f",
-    );
-    let scalar: [u8; 56] = scalar.try_into().unwrap();
-    let u: [u8; 56] = u.try_into().unwrap();
-    let point = x448(&scalar, MontgomeryPoint(u));
-    assert_eq!(point.0.as_slice(), expected.as_slice());
-  }
 }

--- a/ext/node_crypto/keys.rs
+++ b/ext/node_crypto/keys.rs
@@ -245,13 +245,11 @@ impl AsymmetricPrivateKey {
         AsymmetricPublicKey::Ed25519(key.verifying_key())
       }
       AsymmetricPrivateKey::X448(key) => {
-        let mut scalar_bytes = [0u8; 57];
-        scalar_bytes[..56].copy_from_slice(&key[..56]);
-        let scalar = ed448_goldilocks::EdwardsScalar::from_bytes_mod_order(
-          &scalar_bytes.into(),
+        let point = deno_crypto_provider::x448::x448(
+          key,
+          &deno_crypto_provider::x448::BASE_POINT,
         );
-        let point = &ed448_goldilocks::MontgomeryPoint::GENERATOR * &scalar;
-        AsymmetricPublicKey::X448(point.0)
+        AsymmetricPublicKey::X448(point)
       }
       AsymmetricPrivateKey::Ed448(key) => {
         AsymmetricPublicKey::Ed448(key.verifying_key())

--- a/ext/node_crypto/lib.rs
+++ b/ext/node_crypto/lib.rs
@@ -1799,17 +1799,11 @@ pub fn op_node_diffie_hellman(
       AsymmetricPrivateKey::X448(private),
       AsymmetricPublicKey::X448(public),
     ) => {
-      let mut scalar_bytes = [0u8; 57];
-      scalar_bytes[..56].copy_from_slice(&private[..56]);
-      let scalar = ed448_goldilocks::EdwardsScalar::from_bytes_mod_order(
-        &scalar_bytes.into(),
-      );
-      let point = ed448_goldilocks::MontgomeryPoint(*public);
-      let shared = &point * &scalar;
-      if shared.0.iter().all(|b| *b == 0) {
+      let shared = deno_crypto_provider::x448::x448(private, public);
+      if shared.iter().all(|b| *b == 0) {
         return Err(DiffieHellmanError::FailedDuringDerivation);
       }
-      shared.0.to_vec().into_boxed_slice()
+      shared.to_vec().into_boxed_slice()
     }
     (AsymmetricPrivateKey::Dh(private), AsymmetricPublicKey::Dh(public)) => {
       // Compare DH parameters by integer value, not byte encoding,

--- a/libs/crypto/Cargo.toml
+++ b/libs/crypto/Cargo.toml
@@ -13,3 +13,4 @@ path = "lib.rs"
 
 [dependencies]
 aws-lc-sys.workspace = true
+ed448-goldilocks.workspace = true

--- a/libs/crypto/lib.rs
+++ b/libs/crypto/lib.rs
@@ -7,3 +7,4 @@
 
 mod ffi;
 pub mod spki;
+pub mod x448;

--- a/libs/crypto/x448.rs
+++ b/libs/crypto/x448.rs
@@ -1,0 +1,69 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+use ed448_goldilocks::EdwardsScalar;
+use ed448_goldilocks::MontgomeryPoint;
+use ed448_goldilocks::elliptic_curve::bigint::U448;
+use ed448_goldilocks::elliptic_curve::scalar::FromUintUnchecked;
+
+pub const BASE_POINT: [u8; 56] = {
+  let mut point = [0; 56];
+  point[0] = 5;
+  point
+};
+
+/// The X448 function from RFC 7748: decode and clamp the scalar `k`
+/// (section 5) and perform the Montgomery ladder against the point `u`.
+///
+/// The clamped scalar has its top bit (bit 447) set, so it exceeds the
+/// Ed448 group order. It must therefore be used verbatim rather than
+/// reduced mod order.
+pub fn x448(k: &[u8; 56], u: &[u8; 56]) -> [u8; 56] {
+  // decodeScalar448 (RFC 7748, section 5).
+  let mut scalar_bytes = *k;
+  scalar_bytes[0] &= 252;
+  scalar_bytes[55] |= 128;
+  let scalar =
+    EdwardsScalar::from_uint_unchecked(U448::from_le_slice(&scalar_bytes));
+  (&MontgomeryPoint(*u) * &scalar).0
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn from_hex<const N: usize>(value: &str) -> [u8; N] {
+    let bytes: Vec<_> = (0..value.len())
+      .step_by(2)
+      .map(|i| u8::from_str_radix(&value[i..i + 2], 16).unwrap())
+      .collect();
+    bytes.try_into().unwrap()
+  }
+
+  #[test]
+  fn public_key_from_scalar() {
+    let scalar = from_hex(
+      "27a4354608f3bdd38f1f5af305f3e0682efe4e25808249d8fcb55927f6a9f446b8dc1d0a2c3b8cb133a5673b59a6d55ce754ec0c9a555401",
+    );
+    let expected = from_hex(
+      "145d083ea7a6379dbb32dcbd8aff4c206ea5d069b75e96c6dd2a3e38f441471ac97adca641fdad66685a96f32b7c3e064635fab3cc89234e",
+    );
+
+    assert_eq!(x448(&scalar, &BASE_POINT), expected);
+  }
+
+  #[test]
+  fn rfc7748_ecdh() {
+    // RFC 7748 section 5.2 X448 test vector.
+    let scalar = from_hex(
+      "3d262fddf9ec8e88495266fea19a34d28882acef045104d0d1aae121700a779c984c24f8cdd78fbff44943eba368f54b29259a4f1c600ad3",
+    );
+    let u = from_hex(
+      "06fce640fa3487bfda5f6cf2d5263f8aad88334cbd07437f020f08f9814dc031ddbdc38c19c6da2583fa5429db94ada18aa7a7fb4ef8a086",
+    );
+    let expected = from_hex(
+      "ce3e4ff95a60dc6697da1db1d85e6afbdf79b50a2412d7546d5f239fe14fbaadeb445fc66a01b0779d98223961111e21766282f73dd96b6f",
+    );
+
+    assert_eq!(x448(&scalar, &u), expected);
+  }
+}

--- a/tests/unit_node/crypto/crypto_key_test.ts
+++ b/tests/unit_node/crypto/crypto_key_test.ts
@@ -9,6 +9,7 @@ import {
   createSecretKey,
   createSign,
   createVerify,
+  diffieHellman,
   generateKeyPair,
   generateKeyPairSync,
   KeyObject,
@@ -43,11 +44,91 @@ const generateKeyPairAsync = promisify(
 
 const testDir = new URL(".", import.meta.url);
 
+function x448PrivateKey(raw: Buffer): KeyObject {
+  const pkcs8 = Buffer.concat([
+    Buffer.from("3046020100300506032b656f043a0438", "hex"),
+    raw,
+  ]);
+  return createPrivateKey({ key: pkcs8, format: "der", type: "pkcs8" });
+}
+
+function x448PublicKey(raw: Buffer): KeyObject {
+  const spki = Buffer.concat([
+    Buffer.from("3042300506032b656f033900", "hex"),
+    raw,
+  ]);
+  return createPublicKey({ key: spki, format: "der", type: "spki" });
+}
+
+function x448RawPublicKey(key: KeyObject): Buffer {
+  const spki = Buffer.from(key.export({ format: "der", type: "spki" }));
+  return spki.subarray(-56);
+}
+
 const pemBuffer = Buffer.from(
   await Deno.readTextFile(
     new URL("../testdata/x509.pem", import.meta.url),
   ),
 );
+
+Deno.test("X448 imported private key derives RFC 7748 values", () => {
+  const privateKey = x448PrivateKey(Buffer.from(
+    "27a4354608f3bdd38f1f5af305f3e0682efe4e25808249d8fcb55927f6a9f446b8dc1d0a2c3b8cb133a5673b59a6d55ce754ec0c9a555401",
+    "hex",
+  ));
+  assertEquals(
+    x448RawPublicKey(createPublicKey(privateKey)).toString("hex"),
+    "145d083ea7a6379dbb32dcbd8aff4c206ea5d069b75e96c6dd2a3e38f441471ac97adca641fdad66685a96f32b7c3e064635fab3cc89234e",
+  );
+
+  const rfcPrivateKey = x448PrivateKey(Buffer.from(
+    "3d262fddf9ec8e88495266fea19a34d28882acef045104d0d1aae121700a779c984c24f8cdd78fbff44943eba368f54b29259a4f1c600ad3",
+    "hex",
+  ));
+  const rfcPublicKey = x448PublicKey(Buffer.from(
+    "06fce640fa3487bfda5f6cf2d5263f8aad88334cbd07437f020f08f9814dc031ddbdc38c19c6da2583fa5429db94ada18aa7a7fb4ef8a086",
+    "hex",
+  ));
+  assertEquals(
+    diffieHellman({
+      privateKey: rfcPrivateKey,
+      publicKey: rfcPublicKey,
+    }).toString("hex"),
+    "ce3e4ff95a60dc6697da1db1d85e6afbdf79b50a2412d7546d5f239fe14fbaadeb445fc66a01b0779d98223961111e21766282f73dd96b6f",
+  );
+});
+
+Deno.test("X448 generated peers derive the same secret", () => {
+  const alice = generateKeyPairSync("x448");
+  const bob = generateKeyPairSync("x448");
+  const aliceSecret = diffieHellman({
+    privateKey: alice.privateKey,
+    publicKey: bob.publicKey,
+  });
+  const bobSecret = diffieHellman({
+    privateKey: bob.privateKey,
+    publicKey: alice.publicKey,
+  });
+  assertEquals(aliceSecret, bobSecret);
+});
+
+Deno.test("X448 rejects low-order public keys", () => {
+  const privateKey = x448PrivateKey(Buffer.alloc(56, 42));
+  const pMinusOne = Buffer.alloc(56, 0xff);
+  pMinusOne[0] = 0xfe;
+  pMinusOne[28] = 0xfe;
+
+  for (
+    const rawPublicKey of [
+      Buffer.alloc(56),
+      Buffer.from([1, ...Buffer.alloc(55)]),
+      pMinusOne,
+    ]
+  ) {
+    const publicKey = x448PublicKey(rawPublicKey);
+    assertThrows(() => diffieHellman({ privateKey, publicKey }));
+  }
+});
 
 Deno.test({
   name: "create secret key",


### PR DESCRIPTION
## Summary

- share the RFC 7748 X448 operation between WebCrypto and Node crypto
- apply X448 scalar decoding when deriving Node-compatible public keys and shared secrets
- retain rejection of low-order public keys

## Problem

The Node crypto paths converted 56-byte X448 private keys by reducing them modulo the Ed448 group order. RFC 7748 instead requires clearing the scalar's two least-significant bits and setting its most-significant bit before scalar multiplication.

As a result, imported X448 private keys could derive different public keys and shared secrets in Deno than in Node/OpenSSL. Both Node crypto paths now use the same RFC 7748 implementation as WebCrypto.

## Tests

- RFC 7748 public-key and shared-secret vectors
- imported PKCS#8 key compatibility with Node/OpenSSL
- generated peer agreement
- low-order public-key rejection
- focused Rust unit tests, Node crypto unit test, clippy, formatting, and TypeScript lint
