### PR TITLE
fix(npm): validate package names used in cache paths

### DIFF
--- a/cli/tools/publish/unfurl.rs
+++ b/cli/tools/publish/unfurl.rs
@@ -588,6 +588,9 @@ impl<TSys: SpecifierUnfurlerSys> SpecifierUnfurler<TSys> {
               | PackageJsonDepValueParseErrorKind::JsrRequiresScope {
                 ..
               }
+              | PackageJsonDepValueParseErrorKind::InvalidNpmPackageName {
+                ..
+              }
               | PackageJsonDepValueParseErrorKind::EmptyName => {
                 log::warn!(
                   "Ignoring failed to resolve package.json dependency. {:#}",

--- a/libs/cache_dir/npm.rs
+++ b/libs/cache_dir/npm.rs
@@ -109,14 +109,13 @@ impl NpmCacheDir {
   }
 
   pub fn package_name_folder(&self, name: &str, registry_url: &Url) -> PathBuf {
-    let dir = self.registry_folder(registry_url);
+    let mut dir = self.registry_folder(registry_url);
     if name.to_lowercase() != name || !is_safe_package_name_path(name) {
       let encoded_name = mixed_case_package_name_encode(name);
       // Using the encoded directory may have a collision with an actual package name
       // so prefix it with an underscore since npm packages can't start with that
       dir.join(format!("_{encoded_name}"))
     } else {
-      let mut dir = dir;
       // ensure backslashes are used on windows
       for part in name.split('/') {
         dir = dir.join(part);
@@ -207,10 +206,41 @@ impl NpmCacheDir {
 }
 
 fn is_safe_package_name_path(name: &str) -> bool {
-  fn is_safe_component(value: &str) -> bool {
+  fn is_safe_component(value: &str, is_scope: bool) -> bool {
+    // Windows device names remain reserved when followed by an extension.
+    let stem = value.split('.').next().unwrap_or(value);
+    let is_windows_device_name = !is_scope
+      && matches!(
+        stem,
+        "con"
+          | "prn"
+          | "aux"
+          | "nul"
+          | "com1"
+          | "com2"
+          | "com3"
+          | "com4"
+          | "com5"
+          | "com6"
+          | "com7"
+          | "com8"
+          | "com9"
+          | "lpt1"
+          | "lpt2"
+          | "lpt3"
+          | "lpt4"
+          | "lpt5"
+          | "lpt6"
+          | "lpt7"
+          | "lpt8"
+          | "lpt9"
+      );
+
     !value.is_empty()
       && value != "."
       && value != ".."
+      && !value.ends_with('.')
+      && !is_windows_device_name
       && value.bytes().all(|byte| {
         byte.is_ascii_alphanumeric()
           || matches!(
@@ -225,10 +255,10 @@ fn is_safe_package_name_path(name: &str) -> bool {
       return false;
     };
     !package.contains('/')
-      && is_safe_component(scope)
-      && is_safe_component(package)
+      && is_safe_component(scope, true)
+      && is_safe_component(package, false)
   } else {
-    !name.contains('/') && is_safe_component(name)
+    !name.contains('/') && is_safe_component(name, false)
   }
 }
 
@@ -423,6 +453,13 @@ mod test {
       "package//name",
       "@scope/../package",
       "MiXeD/../package",
+      "package.",
+      "@scope./package",
+      "@scope/package.",
+      "con",
+      "con.txt",
+      "nul",
+      "lpt1",
     ] {
       assert_eq!(
         cache.package_name_folder(name, &registry_url),
@@ -438,6 +475,10 @@ mod test {
     assert_eq!(
       cache.package_name_folder("@scope/package", &registry_url),
       registry_dir.join("@scope").join("package"),
+    );
+    assert_eq!(
+      cache.package_name_folder("@con/package", &registry_url),
+      registry_dir.join("@con").join("package"),
     );
   }
 

--- a/libs/cache_dir/npm.rs
+++ b/libs/cache_dir/npm.rs
@@ -109,13 +109,14 @@ impl NpmCacheDir {
   }
 
   pub fn package_name_folder(&self, name: &str, registry_url: &Url) -> PathBuf {
-    let mut dir = self.registry_folder(registry_url);
-    if name.to_lowercase() != name {
+    let dir = self.registry_folder(registry_url);
+    if name.to_lowercase() != name || !is_safe_package_name_path(name) {
       let encoded_name = mixed_case_package_name_encode(name);
       // Using the encoded directory may have a collision with an actual package name
       // so prefix it with an underscore since npm packages can't start with that
       dir.join(format!("_{encoded_name}"))
     } else {
+      let mut dir = dir;
       // ensure backslashes are used on windows
       for part in name.split('/') {
         dir = dir.join(part);
@@ -202,6 +203,32 @@ impl NpmCacheDir {
       version: version.to_string(),
       copy_index,
     })
+  }
+}
+
+fn is_safe_package_name_path(name: &str) -> bool {
+  fn is_safe_component(value: &str) -> bool {
+    !value.is_empty()
+      && value != "."
+      && value != ".."
+      && value.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric()
+          || matches!(
+            byte,
+            b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')'
+          )
+      })
+  }
+
+  if let Some(scoped_name) = name.strip_prefix('@') {
+    let Some((scope, package)) = scoped_name.split_once('/') else {
+      return false;
+    };
+    !package.contains('/')
+      && is_safe_component(scope)
+      && is_safe_component(package)
+  } else {
+    !name.contains('/') && is_safe_component(name)
   }
 }
 
@@ -367,6 +394,50 @@ mod test {
         .join("registry.npmjs.org")
         .join("_ib2hs4dfomxuuu2pjy")
         .join("2.1.5"),
+    );
+  }
+
+  #[test]
+  fn should_confine_unsafe_package_names() {
+    let sys = sys_traits::impls::InMemorySys::default();
+    let root_dir = if cfg!(windows) {
+      PathBuf::from("C:\\cache")
+    } else {
+      PathBuf::from("/cache")
+    };
+    sys.fs_create_dir_all(&root_dir).unwrap();
+    let registry_url = Url::parse("https://registry.npmjs.org/").unwrap();
+    let cache =
+      NpmCacheDir::new(&sys, root_dir.clone(), vec![registry_url.clone()]);
+    let registry_dir = root_dir.join("registry.npmjs.org");
+
+    for name in [
+      ".",
+      "..",
+      "../other/package",
+      "..\\other\\package",
+      "/absolute",
+      "C:\\absolute",
+      "C:relative",
+      "package/name",
+      "package//name",
+      "@scope/../package",
+      "MiXeD/../package",
+    ] {
+      assert_eq!(
+        cache.package_name_folder(name, &registry_url),
+        registry_dir.join(format!("_{}", mixed_case_package_name_encode(name))),
+        "{name}",
+      );
+    }
+
+    assert_eq!(
+      cache.package_name_folder("package", &registry_url),
+      registry_dir.join("package"),
+    );
+    assert_eq!(
+      cache.package_name_folder("@scope/package", &registry_url),
+      registry_dir.join("@scope").join("package"),
     );
   }
 

--- a/libs/npm/registry.rs
+++ b/libs/npm/registry.rs
@@ -641,6 +641,8 @@ To work around this, you can use a package.json and install the dependencies via
   /// in the published package tarball. We silently skip them.
   #[error("Unsupported local dependency: {specifier}")]
   LocalDependency { specifier: String },
+  #[error(transparent)]
+  InvalidPackageName(#[from] deno_package_json::InvalidNpmPackageNameError),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -1113,6 +1115,7 @@ fn parse_dep_entry_name_and_raw_version<'a>(
       specifier: version_req.to_string(),
     })
   } else {
+    deno_package_json::validate_npm_package_name(name)?;
     Ok((name, version_req))
   }
 }
@@ -2411,6 +2414,24 @@ mod test {
       let (name, version) =
         parse_dep_entry_name_and_raw_version(&key, &value).unwrap();
       assert_eq!((name, version), expected_result);
+    }
+  }
+
+  #[test]
+  fn test_parse_dep_entry_rejects_invalid_package_names() {
+    for value in [
+      "npm:../package@1",
+      "npm:package/name@1",
+      "npm:package\\name@1",
+      "npm:C:\\package@1",
+      "npm:@scope/../package@1",
+    ] {
+      let err = parse_dep_entry_name_and_raw_version("alias", value)
+        .expect_err(value);
+      assert!(
+        matches!(err, NpmDependencyEntryErrorSource::InvalidPackageName(_)),
+        "{value}: {err}",
+      );
     }
   }
 

--- a/libs/npm/registry.rs
+++ b/libs/npm/registry.rs
@@ -1008,6 +1008,15 @@ impl NpmPackageVersionInfo {
       match parse_dep_entry_inner(key_value, kind) {
         Ok(entry) => Ok(Some(entry)),
         Err(NpmDependencyEntryErrorSource::LocalDependency { .. }) => Ok(None),
+        Err(NpmDependencyEntryErrorSource::InvalidPackageName(err)) => {
+          log::warn!(
+            "Ignoring invalid npm dependency name {:?} in {:?}@{}.",
+            err.name,
+            parent_nv.0,
+            parent_nv.1,
+          );
+          Ok(None)
+        }
         Err(source) => Err(Box::new(NpmDependencyEntryError {
           parent_nv: PackageNv {
             name: parent_nv.0.into(),
@@ -1085,6 +1094,7 @@ fn parse_dep_entry_name_and_raw_version<'a>(
   key: &'a str,
   value: &'a str,
 ) -> Result<(&'a str, &'a str), NpmDependencyEntryErrorSource> {
+  deno_package_json::validate_npm_package_name(key)?;
   let (name, version_req) =
     if let Some(package_and_version) = value.strip_prefix("npm:") {
       if let Some((name, version)) = package_and_version.rsplit_once('@') {
@@ -2419,18 +2429,19 @@ mod test {
 
   #[test]
   fn test_parse_dep_entry_rejects_invalid_package_names() {
-    for value in [
-      "npm:../package@1",
-      "npm:package/name@1",
-      "npm:package\\name@1",
-      "npm:C:\\package@1",
-      "npm:@scope/../package@1",
+    for (key, value) in [
+      ("alias", "npm:../package@1"),
+      ("alias", "npm:package/name@1"),
+      ("alias", "npm:package\\name@1"),
+      ("alias", "npm:C:\\package@1"),
+      ("alias", "npm:@scope/../package@1"),
+      ("../alias", "npm:package@1"),
     ] {
-      let err =
-        parse_dep_entry_name_and_raw_version("alias", value).expect_err(value);
+      let err = parse_dep_entry_name_and_raw_version(key, value)
+        .expect_err(&format!("{key}: {value}"));
       assert!(
         matches!(err, NpmDependencyEntryErrorSource::InvalidPackageName(_)),
-        "{value}: {err}",
+        "{key}: {value}: {err}",
       );
     }
   }
@@ -2508,6 +2519,21 @@ mod test {
       assert_eq!(entries.len(), 1);
       assert_eq!(entries[0].bare_specifier.as_str(), "a");
     }
+  }
+
+  #[test]
+  fn invalid_dep_names_as_entries_are_skipped() {
+    let deps = NpmPackageVersionInfo {
+      dependencies: HashMap::from([
+        ("a".into(), "^1.0.0".into()),
+        ("../invalid-key".into(), "^1.0.0".into()),
+        ("invalid-target".into(), "npm:../target@1".into()),
+      ]),
+      ..Default::default()
+    };
+    let entries = deps.dependencies_as_entries("pkg-name").unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].bare_specifier.as_str(), "a");
   }
 
   #[test]

--- a/libs/npm/registry.rs
+++ b/libs/npm/registry.rs
@@ -2426,8 +2426,8 @@ mod test {
       "npm:C:\\package@1",
       "npm:@scope/../package@1",
     ] {
-      let err = parse_dep_entry_name_and_raw_version("alias", value)
-        .expect_err(value);
+      let err =
+        parse_dep_entry_name_and_raw_version("alias", value).expect_err(value);
       assert!(
         matches!(err, NpmDependencyEntryErrorSource::InvalidPackageName(_)),
         "{value}: {err}",

--- a/libs/npm_installer/lib.rs
+++ b/libs/npm_installer/lib.rs
@@ -445,6 +445,7 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmInstallerSys>
     for err in self.npm_install_deps_provider.pkg_json_dep_errors() {
       match err.source.as_kind() {
         deno_package_json::PackageJsonDepValueParseErrorKind::JsrRequiresScope { .. } |
+        deno_package_json::PackageJsonDepValueParseErrorKind::InvalidNpmPackageName { .. } |
         deno_package_json::PackageJsonDepValueParseErrorKind::VersionReq { .. } => {
           return Err(Box::new(err.clone()).into());
         }

--- a/libs/package_json/lib.rs
+++ b/libs/package_json/lib.rs
@@ -119,6 +119,59 @@ pub enum PackageJsonDepValueParseErrorKind {
   #[class(type)]
   #[error("Package name must not be empty")]
   EmptyName,
+  #[class(inherit)]
+  #[error(transparent)]
+  InvalidNpmPackageName(#[from] InvalidNpmPackageNameError),
+}
+
+#[derive(Debug, Clone, Error, JsError, PartialEq, Eq)]
+#[class(type)]
+#[error("Invalid npm package name '{name}'")]
+pub struct InvalidNpmPackageNameError {
+  pub name: String,
+}
+
+/// Validates an npm package name using npm's compatibility rules for existing
+/// packages. In particular, legacy mixed-case package names remain valid.
+pub fn validate_npm_package_name(
+  name: &str,
+) -> Result<(), InvalidNpmPackageNameError> {
+  fn is_url_friendly_component(value: &str) -> bool {
+    !value.is_empty()
+      && value.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric()
+          || matches!(
+            byte,
+            b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')'
+          )
+      })
+  }
+
+  let is_valid = !name.is_empty()
+    && !name.starts_with(['.', '-', '_'])
+    && name.trim() == name
+    && !matches!(name.to_ascii_lowercase().as_str(), "node_modules" | "favicon.ico")
+    && if let Some(scoped_name) = name.strip_prefix('@') {
+      let Some((scope, package)) = scoped_name.split_once('/') else {
+        return Err(InvalidNpmPackageNameError {
+          name: name.to_string(),
+        });
+      };
+      !package.contains('/')
+        && !package.starts_with('.')
+        && is_url_friendly_component(scope)
+        && is_url_friendly_component(package)
+    } else {
+      !name.contains('/') && is_url_friendly_component(name)
+    };
+
+  if is_valid {
+    Ok(())
+  } else {
+    Err(InvalidNpmPackageNameError {
+      name: name.to_string(),
+    })
+  }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -217,6 +270,8 @@ impl PackageJsonDepValue {
       if name.is_empty() {
         return Err(PackageJsonDepValueParseErrorKind::EmptyName.into_box());
       }
+      validate_npm_package_name(&name)
+        .map_err(|err| PackageJsonDepValueParseErrorKind::from(err).into_box())?;
       match VersionReq::parse_from_npm(version_req) {
         Ok(version_req) => {
           Ok(PackageJsonDepValue::Req(PackageReq { name, version_req }))
@@ -230,6 +285,8 @@ impl PackageJsonDepValue {
     if key.is_empty() {
       return Err(PackageJsonDepValueParseErrorKind::EmptyName.into_box());
     }
+    validate_npm_package_name(key)
+      .map_err(|err| PackageJsonDepValueParseErrorKind::from(err).into_box())?;
 
     if let Some((scheme, value)) = value.split_once(':') {
       match scheme {
@@ -317,6 +374,9 @@ fn parse_workspace_dep_value(
         && !name.is_empty()
         && !range.is_empty()
       {
+        validate_npm_package_name(name).map_err(|err| {
+          PackageJsonDepValueParseErrorKind::from(err).into_box()
+        })?;
         Ok((Some(name.into()), parse_workspace_req(range)?))
       } else {
         Err(bare_err)
@@ -938,6 +998,86 @@ mod test {
     .unwrap();
 
     assert!(package_json.exports.is_none());
+  }
+
+  #[test]
+  fn validates_npm_package_names() {
+    for name in [
+      "package",
+      "package-name",
+      "package.name",
+      "legacy_Package",
+      "@scope/package",
+      "@Legacy-Scope/Package",
+    ] {
+      assert_eq!(validate_npm_package_name(name), Ok(()), "{name}");
+    }
+
+    for name in [
+      "",
+      ".",
+      "..",
+      "./package",
+      "../package",
+      "/package",
+      "package/name",
+      "package//name",
+      "package\\name",
+      "C:\\package",
+      "C:package",
+      "@scope",
+      "@scope/",
+      "@/package",
+      "@scope/.",
+      "@scope/..",
+      "@scope/package/extra",
+      "-package",
+      "_package",
+      "node_modules",
+      "favicon.ico",
+      "package name",
+      "påckage",
+    ] {
+      assert_eq!(
+        validate_npm_package_name(name),
+        Err(InvalidNpmPackageNameError {
+          name: name.to_string()
+        }),
+        "{name}",
+      );
+    }
+  }
+
+  #[test]
+  fn validates_package_json_npm_alias_names() {
+    assert_eq!(
+      PackageJsonDepValue::parse("alias", "npm:package@^1").unwrap(),
+      PackageJsonDepValue::Req(PackageReq::from_str("package@^1").unwrap()),
+    );
+    assert_eq!(
+      PackageJsonDepValue::parse("alias", "npm:@scope/package@^1").unwrap(),
+      PackageJsonDepValue::Req(
+        PackageReq::from_str("@scope/package@^1").unwrap()
+      ),
+    );
+
+    let err =
+      PackageJsonDepValue::parse("alias", "npm:../package@1").unwrap_err();
+    assert_eq!(
+      err.into_kind(),
+      PackageJsonDepValueParseErrorKind::InvalidNpmPackageName(
+        InvalidNpmPackageNameError {
+          name: "../package".to_string()
+        }
+      )
+    );
+
+    let err =
+      PackageJsonDepValue::parse("../alias", "catalog:").unwrap_err();
+    assert!(matches!(
+      err.as_kind(),
+      PackageJsonDepValueParseErrorKind::InvalidNpmPackageName(_)
+    ));
   }
 
   fn get_local_package_json_version_reqs_for_tests(

--- a/libs/package_json/lib.rs
+++ b/libs/package_json/lib.rs
@@ -132,7 +132,10 @@ pub struct InvalidNpmPackageNameError {
 }
 
 /// Validates an npm package name using npm's compatibility rules for existing
-/// packages. In particular, legacy mixed-case package names remain valid.
+/// packages. Legacy mixed-case, special-character, and over-214-character
+/// names remain valid because npm treats them as publication warnings. Scoped
+/// package components starting with `.` are rejected, matching npm's scoped
+/// package handling.
 pub fn validate_npm_package_name(
   name: &str,
 ) -> Result<(), InvalidNpmPackageNameError> {
@@ -1016,6 +1019,11 @@ mod test {
     ] {
       assert_eq!(validate_npm_package_name(name), Ok(()), "{name}");
     }
+
+    // npm's 214-character publication limit remains a warning for legacy
+    // packages, so it is accepted by these compatibility rules.
+    let legacy_long_name = "a".repeat(215);
+    assert_eq!(validate_npm_package_name(&legacy_long_name), Ok(()));
 
     for name in [
       "",

--- a/libs/package_json/lib.rs
+++ b/libs/package_json/lib.rs
@@ -150,7 +150,10 @@ pub fn validate_npm_package_name(
   let is_valid = !name.is_empty()
     && !name.starts_with(['.', '-', '_'])
     && name.trim() == name
-    && !matches!(name.to_ascii_lowercase().as_str(), "node_modules" | "favicon.ico")
+    && !matches!(
+      name.to_ascii_lowercase().as_str(),
+      "node_modules" | "favicon.ico"
+    )
     && if let Some(scoped_name) = name.strip_prefix('@') {
       let Some((scope, package)) = scoped_name.split_once('/') else {
         return Err(InvalidNpmPackageNameError {
@@ -270,8 +273,9 @@ impl PackageJsonDepValue {
       if name.is_empty() {
         return Err(PackageJsonDepValueParseErrorKind::EmptyName.into_box());
       }
-      validate_npm_package_name(&name)
-        .map_err(|err| PackageJsonDepValueParseErrorKind::from(err).into_box())?;
+      validate_npm_package_name(&name).map_err(|err| {
+        PackageJsonDepValueParseErrorKind::from(err).into_box()
+      })?;
       match VersionReq::parse_from_npm(version_req) {
         Ok(version_req) => {
           Ok(PackageJsonDepValue::Req(PackageReq { name, version_req }))
@@ -1072,8 +1076,7 @@ mod test {
       )
     );
 
-    let err =
-      PackageJsonDepValue::parse("../alias", "catalog:").unwrap_err();
+    let err = PackageJsonDepValue::parse("../alias", "catalog:").unwrap_err();
     assert!(matches!(
       err.as_kind(),
       PackageJsonDepValueParseErrorKind::InvalidNpmPackageName(_)

--- a/tests/specs/npm/package_json_alias_names/__test__.jsonc
+++ b/tests/specs/npm/package_json_alias_names/__test__.jsonc
@@ -1,0 +1,38 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_DIR": "$PWD/deno_dir"
+  },
+  "tests": {
+    "invalid_alias_name": {
+      "cwd": "invalid",
+      "steps": [
+        {
+          "args": "install --no-lock",
+          "output": "invalid.out",
+          "exitCode": 1
+        },
+        {
+          "args": [
+            "eval",
+            "let exists = true; try { Deno.statSync('../deno_dir/npm/outside/registry.json'); } catch (error) { if (error instanceof Deno.errors.NotFound) exists = false; else throw error; } console.log(exists);"
+          ],
+          "output": "false\n"
+        }
+      ]
+    },
+    "valid_alias_names": {
+      "cwd": "valid",
+      "steps": [
+        {
+          "args": "install --quiet --no-lock",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run --quiet --no-lock main.js",
+          "output": "ok 3\n"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/npm/package_json_alias_names/invalid.out
+++ b/tests/specs/npm/package_json_alias_names/invalid.out
@@ -1,0 +1,5 @@
+error: Failed to install 'alias'
+    at [WILDCARD]/package.json
+
+Caused by:
+    Invalid npm package name '../outside'

--- a/tests/specs/npm/package_json_alias_names/invalid/package.json
+++ b/tests/specs/npm/package_json_alias_names/invalid/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "alias": "npm:../outside@1"
+  }
+}

--- a/tests/specs/npm/package_json_alias_names/valid/main.js
+++ b/tests/specs/npm/package_json_alias_names/valid/main.js
@@ -1,0 +1,4 @@
+import chalk from "unscoped-alias";
+import { add } from "scoped-alias";
+
+console.log(chalk.green("ok"), add(1, 2));

--- a/tests/specs/npm/package_json_alias_names/valid/package.json
+++ b/tests/specs/npm/package_json_alias_names/valid/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "unscoped-alias": "npm:chalk@5",
+    "scoped-alias": "npm:@denotest/add@1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

- validate user-authored package dependency and alias names using npm-compatible legacy rules
- validate both dependency keys and alias targets from registry metadata, warning and skipping malformed entries
- keep cache path construction independently confined with reversible encoding
- cover Windows reserved device names and trailing-dot path aliases

## Details

Malformed package aliases could produce unexpected cache paths because the cache mapping joined raw slash-separated name components. User-authored package names are rejected during dependency parsing, before registry lookup or cache identity construction. Malformed transitive registry dependencies are ignored with a warning so legacy third-party metadata does not fail the entire resolution.

The cache mapper independently routes any name that is unsafe to represent as path components through the existing reversible encoding, including traversal forms, Windows reserved device names, and trailing-dot aliases. Legacy mixed-case and other npm-compatible existing package names remain supported.

## Tests

- `./tools/format.js --check libs/cache_dir/npm.rs libs/npm/registry.rs libs/package_json/lib.rs`
- `cargo test -p deno_package_json -p deno_cache_dir -p deno_npm`
- `cargo clippy -p deno_package_json -p deno_cache_dir -p deno_npm -p deno_npm_installer --all-targets -- -D warnings`
- `cargo build -p deno -p test_server`
- `cargo test -p specs_tests --test specs npm::package_json_alias_names`
- existing npm alias, mixed-case package-name, and invalid-package-name specs
