### PR TITLE
fix(fetch): require an initial multipart boundary

### DIFF
--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -462,67 +462,66 @@ class MultipartParser {
   }
 
   /**
-   * @returns {{ type: 1 | 2, headerStart: number } | null}
+   * @param {number} index
+   * @returns {{ type: 1 | 2, nextIndex: number } | null}
    */
-  #findInitialDelimiter() {
-    for (let index = 0; index < this.body.length; index++) {
-      const isLineStart = index === 0 ||
-        (this.body[index - 2] === CR && this.body[index - 1] === LF);
-      if (!isLineStart || !this.#matchesBoundary(index)) {
-        continue;
-      }
+  #matchDelimiter(index) {
+    if (!this.#matchesBoundary(index)) {
+      return null;
+    }
 
-      let suffixIndex = index + this.boundaryChars.length;
-      /** @type {1 | 2} */
-      let type = 1;
-      if (
-        this.body[suffixIndex] === DASH &&
-        this.body[suffixIndex + 1] === DASH
-      ) {
-        type = 2;
-        suffixIndex += 2;
-      }
+    let suffixIndex = index + this.boundaryChars.length;
+    /** @type {1 | 2} */
+    let type = 1;
+    if (
+      this.body[suffixIndex] === DASH &&
+      this.body[suffixIndex + 1] === DASH
+    ) {
+      type = 2;
+      suffixIndex += 2;
+    }
 
-      while (
-        this.body[suffixIndex] === SPACE || this.body[suffixIndex] === TAB
-      ) {
-        suffixIndex++;
-      }
+    // RFC 2046 section 5.1.1 requires receivers to accept transport
+    // padding on every boundary delimiter line.
+    while (
+      this.body[suffixIndex] === SPACE || this.body[suffixIndex] === TAB
+    ) {
+      suffixIndex++;
+    }
 
-      if (type === 2 && suffixIndex === this.body.length) {
-        return { type, headerStart: suffixIndex };
-      }
-      if (
-        this.body[suffixIndex] === CR && this.body[suffixIndex + 1] === LF
-      ) {
-        return { type, headerStart: suffixIndex + 2 };
-      }
+    if (type === 2 && suffixIndex === this.body.length) {
+      return { type, nextIndex: suffixIndex };
+    }
+    if (
+      this.body[suffixIndex] === CR && this.body[suffixIndex + 1] === LF
+    ) {
+      return { type, nextIndex: suffixIndex + 2 };
     }
 
     return null;
   }
 
   /**
-   * @param {number} index
-   * @returns {0 | 1 | 2}
+   * @returns {{ type: 1 | 2, headerStart: number } | null}
    */
-  #delimiterType(index) {
-    if (!this.#matchesBoundary(index)) {
-      return 0;
+  #findInitialDelimiter() {
+    // RFC 2046 section 5.1.1 requires receivers to ignore the preamble.
+    // Only consider boundary delimiters at the start of a line so that
+    // boundary-looking bytes within the preamble are not accepted.
+    for (let index = 0; index < this.body.length; index++) {
+      const isLineStart = index === 0 ||
+        (this.body[index - 2] === CR && this.body[index - 1] === LF);
+      if (!isLineStart) {
+        continue;
+      }
+
+      const delimiter = this.#matchDelimiter(index);
+      if (delimiter !== null) {
+        return { type: delimiter.type, headerStart: delimiter.nextIndex };
+      }
     }
 
-    const suffixIndex = index + this.boundaryChars.length;
-    if (this.body[suffixIndex] === CR && this.body[suffixIndex + 1] === LF) {
-      return 1;
-    }
-    if (
-      this.body[suffixIndex] === DASH &&
-      this.body[suffixIndex + 1] === DASH
-    ) {
-      return 2;
-    }
-
-    return 0;
+    return null;
   }
 
   /**
@@ -567,8 +566,8 @@ class MultipartParser {
         }
       } else if (state === 2) {
         if (isNewLine) {
-          const delimiterType = this.#delimiterType(i + 1);
-          if (delimiterType === 0) {
+          const delimiter = this.#matchDelimiter(i + 1);
+          if (delimiter === null) {
             continue;
           }
 
@@ -605,13 +604,13 @@ class MultipartParser {
             }
           }
 
-          if (delimiterType === 2) {
+          if (delimiter.type === 2) {
             break;
           }
 
           state = 1;
-          i += this.boundaryChars.length + 2; // Skip boundary + trailing \r\n
-          headerStart = i + 1;
+          headerStart = delimiter.nextIndex;
+          i = headerStart - 1;
         }
       }
     }

--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -388,6 +388,8 @@ const CRLF = "\r\n";
 const LF = StringPrototypeCodePointAt(CRLF, 1);
 const CR = StringPrototypeCodePointAt(CRLF, 0);
 const DASH = StringPrototypeCodePointAt("-", 0);
+const SPACE = StringPrototypeCodePointAt(" ", 0);
+const TAB = StringPrototypeCodePointAt("\t", 0);
 const MAX_MULTIPART_PART_HEADER_SIZE = 16 * 1024;
 const MAX_MULTIPART_PART_HEADER_COUNT = 128;
 
@@ -411,9 +413,8 @@ class MultipartParser {
       );
     }
 
-    this.boundary = `--${boundary}`;
     this.body = body;
-    this.boundaryChars = core.encode(this.boundary);
+    this.boundaryChars = core.encode(`--${boundary}`);
   }
 
   /**
@@ -448,13 +449,66 @@ class MultipartParser {
 
   /**
    * @param {number} index
+   * @returns {boolean}
+   */
+  #matchesBoundary(index) {
+    for (let i = 0; i < this.boundaryChars.length; i++) {
+      if (this.body[index + i] !== this.boundaryChars[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * @returns {{ type: 1 | 2, headerStart: number } | null}
+   */
+  #findInitialDelimiter() {
+    for (let index = 0; index < this.body.length; index++) {
+      const isLineStart = index === 0 ||
+        (this.body[index - 2] === CR && this.body[index - 1] === LF);
+      if (!isLineStart || !this.#matchesBoundary(index)) {
+        continue;
+      }
+
+      let suffixIndex = index + this.boundaryChars.length;
+      /** @type {1 | 2} */
+      let type = 1;
+      if (
+        this.body[suffixIndex] === DASH &&
+        this.body[suffixIndex + 1] === DASH
+      ) {
+        type = 2;
+        suffixIndex += 2;
+      }
+
+      while (
+        this.body[suffixIndex] === SPACE || this.body[suffixIndex] === TAB
+      ) {
+        suffixIndex++;
+      }
+
+      if (type === 2 && suffixIndex === this.body.length) {
+        return { type, headerStart: suffixIndex };
+      }
+      if (
+        this.body[suffixIndex] === CR && this.body[suffixIndex + 1] === LF
+      ) {
+        return { type, headerStart: suffixIndex + 2 };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * @param {number} index
    * @returns {0 | 1 | 2}
    */
   #delimiterType(index) {
-    for (let i = 0; i < this.boundaryChars.length; i++) {
-      if (this.body[index + i] !== this.boundaryChars[i]) {
-        return 0;
-      }
+    if (!this.#matchesBoundary(index)) {
+      return 0;
     }
 
     const suffixIndex = index + this.boundaryChars.length;
@@ -475,38 +529,27 @@ class MultipartParser {
    * @returns {FormData}
    */
   parse() {
-    // To have fields body must be at least 2 boundaries + \r\n + --
-    // on the last boundary.
-    if (this.body.length < (this.boundary.length * 2) + 4) {
-      const decodedBody = core.decode(this.body);
-      const lastBoundary = this.boundary + "--";
-      // check if it's an empty valid form data
-      if (
-        decodedBody === lastBoundary ||
-        decodedBody === lastBoundary + "\r\n"
-      ) {
-        return new FormData();
-      }
+    const initialDelimiter = this.#findInitialDelimiter();
+    if (initialDelimiter === null) {
       throw new TypeError("Unable to parse body as form data");
     }
 
     const formData = new FormData();
+    if (initialDelimiter.type === 2) {
+      return formData;
+    }
+
     let headerText = "";
-    let headerStart = 0;
-    let state = 0;
+    let headerStart = initialDelimiter.headerStart;
+    let state = 1;
     let fileStart = 0;
 
-    for (let i = 0; i < this.body.length; i++) {
+    for (let i = headerStart; i < this.body.length; i++) {
       const byte = this.body[i];
       const prevByte = this.body[i - 1];
       const isNewLine = byte === LF && prevByte === CR;
 
-      if (state === 0 && isNewLine) {
-        state = 1;
-        headerStart = i + 1;
-      } else if (
-        state === 1
-      ) {
+      if (state === 1) {
         const headerByteLength = i - headerStart + 1;
         if (headerByteLength > MAX_MULTIPART_PART_HEADER_SIZE) {
           throw new TypeError("Multipart part headers are too large");

--- a/tests/unit/body_test.ts
+++ b/tests/unit/body_test.ts
@@ -191,6 +191,102 @@ Deno.test(async function bodyMultipartFormDataEmptyFilenameIsFile() {
   assertEquals(await fileWithContents.text(), "file contents");
 });
 
+Deno.test(async function bodyMultipartFormDataInitialBoundaryAtStart() {
+  const boundary = "AaB03x";
+  const payload = [
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="field"',
+    "",
+    "value",
+    `--${boundary}--`,
+  ].join("\r\n");
+
+  const body = buildBody(
+    new TextEncoder().encode(payload),
+    new Headers({
+      "Content-Type": `multipart/form-data; boundary=${boundary}`,
+    }),
+  );
+
+  const formData = await body.formData();
+  assertEquals(formData.get("field"), "value");
+});
+
+Deno.test(async function bodyMultipartFormDataIgnoresPreamble() {
+  const boundary = "AaB03x";
+  const payload = [
+    "multipart preamble",
+    'Content-Disposition: form-data; name="preamble"',
+    "",
+    "not a field",
+    `--${boundary}\t `,
+    'Content-Disposition: form-data; name="field"',
+    "",
+    "value",
+    `--${boundary}--`,
+  ].join("\r\n");
+
+  const body = buildBody(
+    new TextEncoder().encode(payload),
+    new Headers({
+      "Content-Type": `multipart/form-data; boundary=${boundary}`,
+    }),
+  );
+
+  const formData = await body.formData();
+  assertEquals(formData.get("preamble"), null);
+  assertEquals(formData.get("field"), "value");
+});
+
+Deno.test(async function bodyMultipartFormDataInitialClosingBoundaryIsEmpty() {
+  const boundary = "AaB03x";
+  const payloads = [
+    `--${boundary}--`,
+    `--${boundary}--\r\n`,
+    `preamble\r\n--${boundary}--\r\nepilogue`,
+    `--${boundary}-- \t\r\n`,
+  ];
+
+  for (const payload of payloads) {
+    const body = buildBody(
+      new TextEncoder().encode(payload),
+      new Headers({
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+      }),
+    );
+
+    const formData = await body.formData();
+    assertEquals([...formData], []);
+  }
+});
+
+Deno.test(async function bodyMultipartFormDataRejectsInvalidInitialBoundary() {
+  const boundary = "AaB03x";
+  const payloads = [
+    "",
+    "multipart preamble",
+    `--${boundary.slice(0, -1)}\r\n`,
+    `--${boundary}-\r\n`,
+    `--${boundary}extra\r\n`,
+    `--${boundary} \tinvalid\r\n`,
+  ];
+
+  for (const payload of payloads) {
+    const body = buildBody(
+      new TextEncoder().encode(payload),
+      new Headers({
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+      }),
+    );
+
+    await assertRejects(
+      () => body.formData(),
+      TypeError,
+      "Unable to parse body as form data",
+    );
+  }
+});
+
 Deno.test(
   { permissions: { net: true } },
   async function bodyURLEncodedFormData() {

--- a/tests/unit/body_test.ts
+++ b/tests/unit/body_test.ts
@@ -238,6 +238,33 @@ Deno.test(async function bodyMultipartFormDataIgnoresPreamble() {
   assertEquals(formData.get("field"), "value");
 });
 
+Deno.test(async function bodyMultipartFormDataAcceptsTransportPadding() {
+  const boundary = "AaB03x";
+  const payload = [
+    `--${boundary} \t`,
+    'Content-Disposition: form-data; name="first"',
+    "",
+    "one",
+    `--${boundary}\t `,
+    'Content-Disposition: form-data; name="second"',
+    "",
+    "two",
+    `--${boundary}-- \t`,
+    "epilogue",
+  ].join("\r\n");
+
+  const body = buildBody(
+    new TextEncoder().encode(payload),
+    new Headers({
+      "Content-Type": `multipart/form-data; boundary=${boundary}`,
+    }),
+  );
+
+  const formData = await body.formData();
+  assertEquals(formData.get("first"), "one");
+  assertEquals(formData.get("second"), "two");
+});
+
 Deno.test(async function bodyMultipartFormDataInitialClosingBoundaryIsEmpty() {
   const boundary = "AaB03x";
   const payloads = [
@@ -269,6 +296,7 @@ Deno.test(async function bodyMultipartFormDataRejectsInvalidInitialBoundary() {
     `--${boundary}-\r\n`,
     `--${boundary}extra\r\n`,
     `--${boundary} \tinvalid\r\n`,
+    `x--${boundary}\r\n`,
   ];
 
   for (const payload of payloads) {
@@ -460,6 +488,7 @@ Deno.test(
       "",
       "before",
       `--${boundary}x`,
+      `--${boundary}--x`,
       "after",
       `--${boundary}--`,
     ].join("\r\n");
@@ -474,7 +503,10 @@ Deno.test(
     const formData = await body.formData();
     const file = formData.get("file");
     assert(file instanceof File);
-    assertEquals(await file.text(), `before\r\n--${boundary}x\r\nafter`);
+    assertEquals(
+      await file.text(),
+      `before\r\n--${boundary}x\r\n--${boundary}--x\r\nafter`,
+    );
   },
 );
 


### PR DESCRIPTION
## Summary

- begin multipart parsing only after a valid initial boundary delimiter line
- ignore multipart preambles and accept RFC 2046 transport padding on opening, part, and closing delimiters
- share delimiter validation so malformed boundary-prefix lines remain part content
- handle an initial closing delimiter as an empty form and reject bodies without a valid opener
- cover initial, preamble, padding, closing, partial, non-line-start, and malformed boundary cases

## Context

The multipart parser previously entered header parsing at the first CRLF in the body without first recognizing the declared boundary. This could make preamble bytes appear as part metadata and allowed malformed opening delimiter lines to initialize parsing.

The parser now searches line starts for the exact declared delimiter before reading part headers. A shared matcher validates opening, part, and closing delimiter lines consistently, including RFC 2046 transport padding, while preserving boundary-prefix lines as part content.

## Validation

- `./tools/format.js --check ext/fetch/21_formdata.js tests/unit/body_test.ts`
- `./tools/lint.js --js`
- focused exact-source parser assertions for delimiter padding, preambles, non-line-start delimiters, and boundary-prefix content
