### PR TITLE
fix(lsp): validate JSR package names before metadata lookup

### DIFF
--- a/cli/jsr.rs
+++ b/cli/jsr.rs
@@ -9,6 +9,7 @@ use deno_graph::packages::JsrPackageInfo;
 use deno_graph::packages::JsrPackageVersionInfo;
 use deno_graph::packages::JsrPackageVersionResolver;
 use deno_graph::packages::JsrVersionResolver;
+use deno_semver::jsr::JsrPackageReqReference;
 use deno_semver::package::PackageName;
 use deno_semver::package::PackageNv;
 use deno_semver::package::PackageReq;
@@ -16,6 +17,73 @@ use deno_semver::package::PackageReq;
 use crate::args::jsr_url;
 use crate::file_fetcher::CliFileFetcher;
 use crate::npm::PackageInfoLoadError;
+
+fn is_valid_jsr_name_part(part: &str, max_len: usize) -> bool {
+  (2..=max_len).contains(&part.len())
+    && part
+      .bytes()
+      .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == b'-')
+    && !part.starts_with('-')
+    && !part.ends_with('-')
+    && !part.contains("--")
+}
+
+// Keep these constraints in sync with JSR's `ScopedPackageName` validation.
+fn parse_jsr_package_name(name: &str) -> Option<(&str, &str)> {
+  let req_ref =
+    JsrPackageReqReference::from_str(&format!("jsr:{name}")).ok()?;
+  if req_ref.sub_path().is_some() || req_ref.req().name != name {
+    return None;
+  }
+
+  let (scope, package) = name.split_once('/')?;
+  let scope_name = scope.strip_prefix('@')?;
+  if !is_valid_jsr_name_part(scope_name, 20)
+    || !is_valid_jsr_name_part(package, 32)
+  {
+    return None;
+  }
+  Some((scope, package))
+}
+
+pub(crate) fn is_valid_jsr_package_name(name: &str) -> bool {
+  parse_jsr_package_name(name).is_some()
+}
+
+fn jsr_package_metadata_url(
+  registry_url: &deno_core::url::Url,
+  name: &str,
+  file_name: &str,
+) -> Option<deno_core::url::Url> {
+  let (scope, package) = parse_jsr_package_name(name)?;
+  let mut url = registry_url.clone();
+  url.set_query(None);
+  url.set_fragment(None);
+  let mut path = url.path_segments_mut().ok()?;
+  path
+    .pop_if_empty()
+    .push(scope)
+    .push(package)
+    .push(file_name);
+  drop(path);
+  Some(url)
+}
+
+pub(crate) fn jsr_package_meta_url(
+  name: &str,
+) -> Option<deno_core::url::Url> {
+  jsr_package_metadata_url(jsr_url(), name, "meta.json")
+}
+
+pub(crate) fn jsr_package_version_meta_url(
+  nv: &PackageNv,
+) -> Option<deno_core::url::Url> {
+  jsr_package_metadata_url(
+    jsr_url(),
+    &nv.name,
+    &format!("{}_meta.json", nv.version),
+  )
+}
 
 /// This is similar to a subset of `JsrCacheResolver` which fetches rather than
 /// just reads the cache. Keep in sync!
@@ -130,7 +198,7 @@ impl JsrFetchResolver {
   }
 
   fn meta_url(&self, name: &str) -> Option<deno_core::url::Url> {
-    jsr_url().join(&format!("{}/meta.json", name)).ok()
+    jsr_package_meta_url(name)
   }
 
   pub async fn package_info(&self, name: &str) -> Option<Arc<JsrPackageInfo>> {
@@ -186,9 +254,7 @@ impl JsrFetchResolver {
       return info.value().clone();
     }
     let fetch_package_version_info = || async {
-      let meta_url = jsr_url()
-        .join(&format!("{}/{}_meta.json", &nv.name, &nv.version))
-        .ok()?;
+      let meta_url = jsr_package_version_meta_url(nv)?;
       let file_fetcher = self.file_fetcher.clone();
       let file = file_fetcher
         .fetch_bypass_permissions(&meta_url)
@@ -218,4 +284,54 @@ pub fn partial_jsr_package_version_info_from_slice(
     module_graph_2: None,
     lockfile_checksum: None,
   })
+}
+
+#[cfg(test)]
+mod tests {
+  use deno_core::url::Url;
+
+  use super::*;
+
+  #[test]
+  fn jsr_package_metadata_url_uses_registry_path() {
+    let registry_url = Url::parse(
+      "https://registry.example:8443/jsr/root/?source=config#fragment",
+    )
+    .unwrap();
+    let url = jsr_package_metadata_url(
+      &registry_url,
+      "@std/assert",
+      "meta.json",
+    )
+    .unwrap();
+    assert_eq!(
+      url.as_str(),
+      "https://registry.example:8443/jsr/root/@std/assert/meta.json"
+    );
+    assert_eq!(url.origin(), registry_url.origin());
+  }
+
+  #[test]
+  fn jsr_package_metadata_url_rejects_invalid_names() {
+    let registry_url = Url::parse("https://registry.example/").unwrap();
+    for name in [
+      "http:127.0.0.1:8000?action=delete",
+      "https://example.com/package",
+      "//example.com/package",
+      "@scope/package?query",
+      "@scope/package#fragment",
+      "@scope/../package",
+      "@scope/..",
+      "@scope/%2e%2e",
+      "@scope/package/extra",
+      "@scope/package:extra",
+      "@scope\\package",
+    ] {
+      assert_eq!(
+        jsr_package_metadata_url(&registry_url, name, "meta.json"),
+        None,
+        "accepted invalid package name {name:?}"
+      );
+    }
+  }
 }

--- a/cli/jsr.rs
+++ b/cli/jsr.rs
@@ -69,9 +69,7 @@ fn jsr_package_metadata_url(
   Some(url)
 }
 
-pub(crate) fn jsr_package_meta_url(
-  name: &str,
-) -> Option<deno_core::url::Url> {
+pub(crate) fn jsr_package_meta_url(name: &str) -> Option<deno_core::url::Url> {
   jsr_package_metadata_url(jsr_url(), name, "meta.json")
 }
 
@@ -298,12 +296,9 @@ mod tests {
       "https://registry.example:8443/jsr/root/?source=config#fragment",
     )
     .unwrap();
-    let url = jsr_package_metadata_url(
-      &registry_url,
-      "@std/assert",
-      "meta.json",
-    )
-    .unwrap();
+    let url =
+      jsr_package_metadata_url(&registry_url, "@std/assert", "meta.json")
+        .unwrap();
     assert_eq!(
       url.as_str(),
       "https://registry.example:8443/jsr/root/@std/assert/meta.json"

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -45,6 +45,7 @@ use super::search::PackageSearchApi;
 use super::text::LineIndex;
 use super::tsc;
 use crate::jsr::JsrFetchResolver;
+use crate::jsr::is_valid_jsr_package_name;
 use crate::lsp::registries::DocumentationCompletionItemData;
 use crate::util::env::resolve_cwd;
 use crate::util::path::is_importable_ext;
@@ -625,6 +626,9 @@ async fn get_jsr_completions(
   if let Some(v_index) = parse_bare_specifier_version_index(bare_specifier) {
     let package_name = &bare_specifier[..v_index];
     let v_prefix = &bare_specifier[(v_index + 1)..];
+    if !is_valid_jsr_package_name(package_name) {
+      return None;
+    }
 
     let versions = jsr_search_api.versions(package_name).await.ok()?;
     let items = versions
@@ -1510,6 +1514,33 @@ mod tests {
         ],
       }
     );
+  }
+
+  #[tokio::test]
+  async fn test_get_jsr_completions_rejects_invalid_package_names() {
+    let range = lsp::Range::default();
+    let referrer = ModuleSpecifier::parse("file:///referrer.ts").unwrap();
+    for package_name in [
+      "http:127.0.0.1:8000?action=delete",
+      "@scope/package?query",
+      "@scope/package#fragment",
+      "@scope/..",
+      "@scope/%2e%2e",
+      "@scope/package:extra",
+    ] {
+      let jsr_search_api = TestPackageSearchApi::default()
+        .with_package_version(package_name, "1.0.0", &[]);
+      let actual = get_jsr_completions(
+        &referrer,
+        &format!("jsr:{package_name}@"),
+        &range,
+        None,
+        &jsr_search_api,
+        None,
+      )
+      .await;
+      assert_eq!(actual, None, "accepted invalid package name {package_name:?}");
+    }
   }
 
   #[tokio::test]

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -1539,7 +1539,10 @@ mod tests {
         None,
       )
       .await;
-      assert_eq!(actual, None, "accepted invalid package name {package_name:?}");
+      assert_eq!(
+        actual, None,
+        "accepted invalid package name {package_name:?}"
+      );
     }
   }
 

--- a/cli/lsp/jsr.rs
+++ b/cli/lsp/jsr.rs
@@ -29,6 +29,8 @@ use crate::args::jsr_url;
 use crate::file_fetcher::CliFileFetcher;
 use crate::file_fetcher::TextDecodedFile;
 use crate::jsr::JsrFetchResolver;
+use crate::jsr::jsr_package_meta_url;
+use crate::jsr::jsr_package_version_meta_url;
 use crate::jsr::partial_jsr_package_version_info_from_slice;
 use crate::sys::CliSys;
 
@@ -304,7 +306,7 @@ impl JsrCacheResolver {
       return info.value().clone();
     }
     let read_cached_package_info = || {
-      let meta_url = jsr_url().join(&format!("{}/meta.json", name)).ok()?;
+      let meta_url = jsr_package_meta_url(name)?;
       let meta_bytes = read_cached_url(&meta_url, &self.cache)?;
       serde_json::from_slice::<JsrPackageInfo>(&meta_bytes).ok()
     };
@@ -321,9 +323,7 @@ impl JsrCacheResolver {
       return info.value().clone();
     }
     let read_cached_package_version_info = || {
-      let meta_url = jsr_url()
-        .join(&format!("{}/{}_meta.json", &nv.name, &nv.version))
-        .ok()?;
+      let meta_url = jsr_package_version_meta_url(nv)?;
       let meta_bytes = read_cached_url(&meta_url, &self.cache)?;
       partial_jsr_package_version_info_from_slice(&meta_bytes).ok()
     };


### PR DESCRIPTION
This validates JSR package names before LSP version metadata lookups and constructs metadata URLs from URL path segments.

Previously, version completion passed raw package-like text into `Url::join()`. Malformed input could therefore be interpreted as a different URL instead of a path beneath the configured registry. The live and cache-backed resolvers also maintained separate URL construction logic.

This change:

- checks names against the JSR scoped-package grammar before requesting version metadata
- centralizes package and version metadata URL construction for the live and cache-backed resolvers
- appends encoded path segments while preserving configured registry origins and path prefixes
- adds regression coverage for malformed URL-shaped, query, fragment, and traversal-like names

Validation:

- `./tools/format.js --check cli/jsr.rs cli/lsp/jsr.rs cli/lsp/completions.rs`
- `cargo test -p deno --lib jsr::tests::`
- `cargo test -p deno --lib lsp::completions::tests::test_get_jsr_completions`
- `cargo clippy -p deno --lib --tests -- -D warnings`
