### PR TITLE
fix(node): match domain uncaught exception handling

### DIFF
--- a/ext/node/polyfills/domain.ts
+++ b/ext/node/polyfills/domain.ts
@@ -263,6 +263,12 @@ function updateExceptionCapture() {
   }
 }
 
+function clearDomainStack() {
+  stack.length = 0;
+  active = process.domain = null;
+  updateExceptionCapture();
+}
+
 function domainUncaughtExceptionHandler(er) {
   const curDomain = process.domain;
   if (!curDomain || curDomain._disposed) {
@@ -281,22 +287,28 @@ function domainUncaughtExceptionHandler(er) {
     er.domainThrown = true;
   }
 
-  // Remove the errored domain from the stack. This cleans up the entry
-  // left by emitBefore when the callback threw before emitAfter could run.
-  if (stack.length === 1) {
-    active = process.domain = null;
-    stack.length = 0;
-  } else {
-    const idx = ArrayPrototypeLastIndexOf(stack, curDomain);
-    if (idx !== -1) {
-      ArrayPrototypeSplice(stack, idx, 1);
-    }
-    active = process.domain = stack.length > 0 ? stack[stack.length - 1] : null;
+  // Run the error handler outside of its domain, but within its parent.
+  // A domain may have been entered more than once, so remove all adjacent
+  // entries for the currently active domain.
+  while (process.domain === curDomain) {
+    curDomain.exit();
   }
 
-  updateExceptionCapture();
+  try {
+    curDomain.emit("error", er);
+  } catch (handlerError) {
+    // Let the parent domain handle errors thrown by a child domain's handler.
+    // If there is no parent, pass the error on to the process-level handler.
+    if (stack.length > 0) {
+      active = process.domain = stack[stack.length - 1];
+      return domainUncaughtExceptionHandler(handlerError);
+    }
+    throw handlerError;
+  }
 
-  curDomain.emit("error", er);
+  // An uncaught exception ends the current turn. No entered domains should
+  // remain active when unrelated work begins on a later turn.
+  clearDomainStack();
 }
 
 let patched = false;

--- a/ext/node/polyfills/domain.ts
+++ b/ext/node/polyfills/domain.ts
@@ -12,6 +12,7 @@ const { AsyncHook } = core.loadExtScript(
   "ext:deno_node/internal/async_hooks.ts",
 );
 const {
+  ArrayPrototypeEvery,
   ArrayPrototypeIndexOf,
   ArrayPrototypeLastIndexOf,
   ArrayPrototypePush,
@@ -87,6 +88,9 @@ class Domain extends EventEmitter {
     super();
     patchEventEmitter();
     asyncHook.enable();
+
+    this.on("removeListener", updateExceptionCapture);
+    this.on("newListener", updateExceptionCapture);
   }
 
   add(ee) {
@@ -252,24 +256,57 @@ class Domain extends EventEmitter {
 let exceptionCaptureActive = false;
 
 function updateExceptionCapture() {
-  if (stack.length > 0 && !exceptionCaptureActive) {
+  const shouldCapture = !ArrayPrototypeEvery(
+    stack,
+    (domain) => domain.listenerCount("error") === 0,
+  );
+
+  if (shouldCapture && !exceptionCaptureActive) {
     exceptionCaptureActive = true;
     process.setUncaughtExceptionCaptureCallback(
       domainUncaughtExceptionHandler,
     );
-  } else if (stack.length === 0 && exceptionCaptureActive) {
+  } else if (!shouldCapture && exceptionCaptureActive) {
     exceptionCaptureActive = false;
     process.setUncaughtExceptionCaptureCallback(null);
   }
 }
 
-function clearDomainStack() {
+process.on("newListener", (name, listener) => {
+  if (
+    name === "uncaughtException" &&
+    listener !== domainUncaughtExceptionClear
+  ) {
+    // The first uncaughtException listener must clear the domain stack before
+    // user code runs.
+    process.removeListener(name, domainUncaughtExceptionClear);
+    process.prependListener(name, domainUncaughtExceptionClear);
+  }
+});
+
+process.on("removeListener", (name, listener) => {
+  if (
+    name === "uncaughtException" &&
+    listener !== domainUncaughtExceptionClear
+  ) {
+    const listeners = process.listeners("uncaughtException");
+    if (
+      listeners.length === 1 &&
+      listeners[0] === domainUncaughtExceptionClear
+    ) {
+      process.removeListener(name, domainUncaughtExceptionClear);
+    }
+  }
+});
+
+function domainUncaughtExceptionClear() {
   stack.length = 0;
   active = process.domain = null;
   updateExceptionCapture();
 }
 
 function domainUncaughtExceptionHandler(er) {
+  let caught = false;
   const curDomain = process.domain;
   if (!curDomain || curDomain._disposed) {
     // No active domain or domain has been disposed, re-throw
@@ -290,25 +327,42 @@ function domainUncaughtExceptionHandler(er) {
   // Run the error handler outside of its domain, but within its parent.
   // A domain may have been entered more than once, so remove all adjacent
   // entries for the currently active domain.
-  while (process.domain === curDomain) {
+  while (active === curDomain) {
     curDomain.exit();
   }
 
-  try {
-    curDomain.emit("error", er);
-  } catch (handlerError) {
-    // Let the parent domain handle errors thrown by a child domain's handler.
-    // If there is no parent, pass the error on to the process-level handler.
-    if (stack.length > 0) {
-      active = process.domain = stack[stack.length - 1];
-      return domainUncaughtExceptionHandler(handlerError);
+  if (stack.length === 0) {
+    // Without a domain error listener, leave the error for the process-level
+    // uncaughtException handler instead of emitting an error event that throws.
+    if (curDomain.listenerCount("error") > 0) {
+      process.setUncaughtExceptionCaptureCallback(null);
+      try {
+        caught = curDomain.emit("error", er);
+      } finally {
+        updateExceptionCapture();
+      }
     }
-    throw handlerError;
+  } else {
+    try {
+      caught = curDomain.emit("error", er);
+    } catch (handlerError) {
+      // Let the parent domain handle errors thrown by a child domain's handler.
+      // If there is no parent, pass the error on to the process-level handler.
+      updateExceptionCapture();
+      if (stack.length > 0) {
+        active = process.domain = stack[stack.length - 1];
+        caught = domainUncaughtExceptionHandler(handlerError);
+      } else {
+        throw handlerError;
+      }
+    }
   }
 
   // An uncaught exception ends the current turn. No entered domains should
   // remain active when unrelated work begins on a later turn.
-  clearDomainStack();
+  domainUncaughtExceptionClear();
+
+  return caught;
 }
 
 let patched = false;

--- a/tests/unit_node/domain_test.ts
+++ b/tests/unit_node/domain_test.ts
@@ -6,6 +6,34 @@ import domain from "node:domain";
 import { EventEmitter } from "node:events";
 import { assertEquals } from "@std/assert";
 
+const processWithDomain = process as typeof process & {
+  domain: unknown | null;
+};
+
+function assertActiveDomain(expected: unknown | null) {
+  assertEquals(processWithDomain.domain, expected);
+}
+
+function assertNoActiveDomain() {
+  assertActiveDomain(null);
+
+  // Entering and exiting a new domain must not reveal an older stack entry.
+  const probe = domain.create();
+  probe.enter();
+  probe.exit();
+  assertActiveDomain(null);
+}
+
+function checkNoDomainOnLaterTurn() {
+  // Create the promise reaction before entering a domain so the check itself
+  // is not associated with one of the domains being checked.
+  const deferred = Promise.withResolvers<void>();
+  return {
+    check: deferred.promise.then(assertNoActiveDomain),
+    schedule: deferred.resolve,
+  };
+}
+
 Deno.test("should work on throws", async function () {
   const deferred = Promise.withResolvers<void>();
   const d = domain.create();
@@ -109,4 +137,70 @@ Deno.test("intercept should work", async function () {
     // @ts-ignore node:domain types are out of date
   })(new Error("a passed error"), 2, 3);
   await deferred.promise;
+});
+
+Deno.test("handled async errors clear manually entered domains", async () => {
+  const outer = domain.create();
+  const inner = domain.create();
+  const laterTurn = checkNoDomainOnLaterTurn();
+
+  inner.on("error", (error) => {
+    assertEquals(error.message, "inner callback failed");
+    laterTurn.schedule();
+  });
+
+  outer.run(() => {
+    setTimeout(() => {
+      inner.enter();
+      throw new Error("inner callback failed");
+    }, 0);
+  });
+
+  await laterTurn.check;
+});
+
+Deno.test("errors from a nested domain handler reach its parent", async () => {
+  const parent = domain.create();
+  const child = domain.create();
+  const laterTurn = checkNoDomainOnLaterTurn();
+
+  parent.on("error", (error) => {
+    assertEquals(error.message, "child handler failed");
+    assertActiveDomain(null);
+    laterTurn.schedule();
+  });
+  child.on("error", () => {
+    assertActiveDomain(parent);
+    throw new Error("child handler failed");
+  });
+
+  parent.run(() => {
+    setTimeout(() => {
+      child.enter();
+      throw new Error("child callback failed");
+    }, 0);
+  });
+
+  await laterTurn.check;
+});
+
+Deno.test("balanced domain entries preserve their parent", () => {
+  const parent = domain.create();
+  const child = domain.create();
+
+  parent.enter();
+  try {
+    child.enter();
+    try {
+      assertActiveDomain(child);
+    } finally {
+      child.exit();
+    }
+
+    assertActiveDomain(parent);
+  } finally {
+    parent.exit();
+  }
+
+  assertNoActiveDomain();
 });

--- a/tests/unit_node/domain_test.ts
+++ b/tests/unit_node/domain_test.ts
@@ -4,24 +4,24 @@
 
 import domain from "node:domain";
 import { EventEmitter } from "node:events";
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 
 const processWithDomain = process as typeof process & {
-  domain: unknown | null;
+  domain: unknown;
 };
 
-function assertActiveDomain(expected: unknown | null) {
+function assertActiveDomain(expected: unknown) {
   assertEquals(processWithDomain.domain, expected);
 }
 
 function assertNoActiveDomain() {
-  assertActiveDomain(null);
+  assert(processWithDomain.domain == null);
 
   // Entering and exiting a new domain must not reveal an older stack entry.
   const probe = domain.create();
   probe.enter();
   probe.exit();
-  assertActiveDomain(null);
+  assert(processWithDomain.domain == null);
 }
 
 function checkNoDomainOnLaterTurn() {
@@ -32,6 +32,32 @@ function checkNoDomainOnLaterTurn() {
     check: deferred.promise.then(assertNoActiveDomain),
     schedule: deferred.resolve,
   };
+}
+
+async function expectUncaughtException(
+  expectedMessage: string,
+  action: () => void,
+) {
+  const deferred = Promise.withResolvers<void>();
+  process.once("uncaughtException", (error) => {
+    try {
+      assertEquals(error.message, expectedMessage);
+      deferred.resolve();
+    } catch (assertionError) {
+      deferred.reject(assertionError);
+    }
+  });
+
+  action();
+  await deferred.promise;
+}
+
+async function runFatalDomainEval(source: string) {
+  return await new Deno.Command(Deno.execPath(), {
+    args: ["eval", source],
+    stderr: "piped",
+    stdout: "piped",
+  }).output();
 }
 
 Deno.test("should work on throws", async function () {
@@ -166,7 +192,7 @@ Deno.test("errors from a nested domain handler reach its parent", async () => {
 
   parent.on("error", (error) => {
     assertEquals(error.message, "child handler failed");
-    assertActiveDomain(null);
+    assertNoActiveDomain();
     laterTurn.schedule();
   });
   child.on("error", () => {
@@ -182,6 +208,139 @@ Deno.test("errors from a nested domain handler reach its parent", async () => {
   });
 
   await laterTurn.check;
+});
+
+Deno.test("errors from a child without a handler reach its parent", async () => {
+  const parent = domain.create();
+  const child = domain.create();
+  const laterTurn = checkNoDomainOnLaterTurn();
+
+  parent.on("error", (error) => {
+    assertEquals(error.message, "child callback failed");
+    assertNoActiveDomain();
+    laterTurn.schedule();
+  });
+
+  parent.run(() => {
+    setTimeout(() => {
+      child.enter();
+      throw new Error("child callback failed");
+    }, 0);
+  });
+
+  await laterTurn.check;
+});
+
+Deno.test("handled errors clear non-adjacent repeated domains", async () => {
+  const outer = domain.create();
+  const inner = domain.create();
+  const laterTurn = checkNoDomainOnLaterTurn();
+
+  outer.on("error", (error) => {
+    assertEquals(error.message, "re-entered callback failed");
+    assertActiveDomain(inner);
+    laterTurn.schedule();
+  });
+
+  setTimeout(() => {
+    outer.enter();
+    inner.enter();
+    outer.enter();
+    throw new Error("re-entered callback failed");
+  }, 0);
+
+  await laterTurn.check;
+});
+
+Deno.test("errors traverse three nested domain handlers", async () => {
+  const grandparent = domain.create();
+  const parent = domain.create();
+  const child = domain.create();
+  const laterTurn = checkNoDomainOnLaterTurn();
+
+  grandparent.on("error", (error) => {
+    assertEquals(error.message, "parent handler failed");
+    assertNoActiveDomain();
+    laterTurn.schedule();
+  });
+  parent.on("error", (error) => {
+    assertEquals(error.message, "child handler failed");
+    assertActiveDomain(grandparent);
+    throw new Error("parent handler failed");
+  });
+  child.on("error", (error) => {
+    assertEquals(error.message, "child callback failed");
+    assertActiveDomain(parent);
+    throw new Error("child handler failed");
+  });
+
+  setTimeout(() => {
+    grandparent.enter();
+    parent.enter();
+    child.enter();
+    throw new Error("child callback failed");
+  }, 0);
+
+  await laterTurn.check;
+});
+
+Deno.test("top-level domains without handlers reach uncaughtException", async () => {
+  const topLevel = domain.create();
+
+  await expectUncaughtException("top-level callback failed", () => {
+    topLevel.run(() => {
+      setTimeout(() => {
+        throw new Error("top-level callback failed");
+      }, 0);
+    });
+  });
+
+  assertNoActiveDomain();
+});
+
+Deno.test("errors from top-level domain handlers remain fatal", async () => {
+  const output = await runFatalDomainEval(`
+    import domain from "node:domain";
+    const topLevel = domain.create();
+    topLevel.on("error", () => {
+      throw new Error("top-level handler failed");
+    });
+    topLevel.run(() => {
+      setTimeout(() => {
+        throw new Error("top-level callback failed");
+      }, 0);
+    });
+  `);
+
+  assert(!output.success);
+  assert(
+    new TextDecoder().decode(output.stderr).includes(
+      "top-level handler failed",
+    ),
+  );
+});
+
+Deno.test("disposed domains rethrow uncaught errors", async () => {
+  const output = await runFatalDomainEval(`
+    import domain from "node:domain";
+    const parent = domain.create();
+    const disposed = domain.create();
+    parent.on("error", () => console.log("parent handled"));
+    setTimeout(() => {
+      parent.enter();
+      disposed.enter();
+      disposed.dispose();
+      throw new Error("disposed callback failed");
+    }, 0);
+  `);
+
+  assert(!output.success);
+  assertEquals(new TextDecoder().decode(output.stdout), "");
+  assert(
+    new TextDecoder().decode(output.stderr).includes(
+      "disposed callback failed",
+    ),
+  );
 });
 
 Deno.test("balanced domain entries preserve their parent", () => {


### PR DESCRIPTION
## Summary

- route uncaught errors from child domains without an `error` listener, and errors thrown by nested domain handlers, to the parent domain
- let top-level domains without an `error` listener reach `process.on("uncaughtException")`, while preserving fatal top-level handler throws
- clear the complete domain stack after handled uncaught errors and keep exception capture aligned with domain listener changes

## Context

The compatibility layer installed its exception capture callback for every entered domain and always emitted `error` from the active domain. This diverged from Node in several related cases: a child without a listener could crash instead of reaching its parent, a top-level domain without a listener could bypass `uncaughtException`, and handled errors could leave parent domains active on a later turn.

This ports the Node top-level/nested handler split, listener-aware capture, process-level cleanup hook, parent recursion, and end-of-turn stack cleanup without changing balanced `run()`, `enter()`, and `exit()` behavior.

## Validation

- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_DEV_SPLIT_DEBUGINFO=off cargo build -p deno -p test_server -j 2`
- `target/debug/deno test --import-map ../deno/import_map.json --no-lock --allow-all tests/unit_node/domain_test.ts` (14 passed)
- `target/debug/deno lint ext/node/polyfills/domain.ts tests/unit_node/domain_test.ts`
- `dprint check ext/node/polyfills/domain.ts tests/unit_node/domain_test.ts`
- Node v26.7.0 parity repros for a no-listener child, non-adjacent re-entry, three nested throwing handlers, and top-level process/fatal paths
