### PR TITLE
fix(cache): combine duplicate headers for Vary matching

### DIFF
--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -431,6 +431,9 @@ pub fn vary_header_matches(
   };
   let headers = get_headers_from_vary_header(vary_header);
   for header in headers {
+    if header == "*" {
+      return false;
+    }
     let query_header = get_header(&header, query_request_headers);
     let cached_header = get_header(&header, cached_request_headers);
     if query_header != cached_header {
@@ -442,31 +445,74 @@ pub fn vary_header_matches(
 
 #[test]
 fn test_vary_header_matches() {
+  let headers = |headers: &[(&str, &str)]| {
+    headers
+      .iter()
+      .map(|(name, value)| ((*name).into(), (*value).into()))
+      .collect::<Vec<(ByteString, ByteString)>>()
+  };
+
   let vary_header = ByteString::from("accept-encoding");
-  let query_request_headers = vec![(
-    ByteString::from("accept-encoding"),
-    ByteString::from("gzip"),
-  )];
-  let cached_request_headers = vec![(
-    ByteString::from("accept-encoding"),
-    ByteString::from("gzip"),
-  )];
+  let query_request_headers = headers(&[("accept-encoding", "gzip")]);
+  let cached_request_headers = headers(&[("accept-encoding", "gzip")]);
   assert!(vary_header_matches(
     &vary_header,
     &query_request_headers,
     &cached_request_headers
   ));
-  let vary_header = ByteString::from("accept-encoding");
-  let query_request_headers = vec![(
-    ByteString::from("accept-encoding"),
-    ByteString::from("gzip"),
-  )];
-  let cached_request_headers =
-    vec![(ByteString::from("accept-encoding"), ByteString::from("br"))];
+
+  let query_request_headers = headers(&[("accept-encoding", "gzip")]);
+  let cached_request_headers = headers(&[("accept-encoding", "br")]);
   assert!(!vary_header_matches(
     &vary_header,
     &query_request_headers,
     &cached_request_headers
+  ));
+
+  let vary_header = ByteString::from("x-example");
+  let cached_request_headers =
+    headers(&[("X-Example", "first"), ("x-example", "cached")]);
+  let matching_query_headers =
+    headers(&[("x-example", "first"), ("X-EXAMPLE", "cached")]);
+  assert!(vary_header_matches(
+    &vary_header,
+    &matching_query_headers,
+    &cached_request_headers,
+  ));
+
+  for query_request_headers in [
+    headers(&[("x-example", "first"), ("x-example", "query")]),
+    headers(&[("x-example", "cached"), ("x-example", "first")]),
+    headers(&[("x-example", "first")]),
+  ] {
+    assert!(!vary_header_matches(
+      &vary_header,
+      &query_request_headers,
+      &cached_request_headers,
+    ));
+  }
+
+  let no_headers = headers(&[]);
+  assert!(vary_header_matches(&vary_header, &no_headers, &no_headers,));
+  assert!(!vary_header_matches(
+    &vary_header,
+    &headers(&[("x-example", "present")]),
+    &no_headers,
+  ));
+  assert!(!vary_header_matches(
+    &ByteString::from("*"),
+    &no_headers,
+    &no_headers,
+  ));
+
+  let response_headers =
+    headers(&[("vary", "accept-language"), ("Vary", "x-example")]);
+  let vary_header = get_header("vary", &response_headers).unwrap();
+  assert_eq!(vary_header, ByteString::from("accept-language, x-example"));
+  assert!(!vary_header_matches(
+    &vary_header,
+    &headers(&[("accept-language", "en"), ("x-example", "query")]),
+    &headers(&[("accept-language", "en"), ("x-example", "cached")]),
   ));
 }
 
@@ -486,21 +532,32 @@ fn test_get_headers_from_vary_header() {
   assert_eq!(headers, vec!["accept-encoding", "user-agent"]);
 }
 
-/// Get value for the header with the given name.
+/// Get the combined value for headers with the given name.
+///
+/// This follows Fetch's header-list get algorithm: matching values are joined
+/// in their original order with `, ` separators.
 pub fn get_header(
   name: &str,
   headers: &[(ByteString, ByteString)],
 ) -> Option<ByteString> {
-  headers
-    .iter()
-    .find(|(k, _)| {
-      if let Ok(k) = std::str::from_utf8(k) {
-        k.eq_ignore_ascii_case(name)
-      } else {
-        false
+  let mut combined: Option<Vec<u8>> = None;
+  for (header_name, value) in headers {
+    let Ok(header_name) = std::str::from_utf8(header_name) else {
+      continue;
+    };
+    if !header_name.eq_ignore_ascii_case(name) {
+      continue;
+    }
+
+    match &mut combined {
+      Some(combined) => {
+        combined.extend_from_slice(b", ");
+        combined.extend_from_slice(value);
       }
-    })
-    .map(|(_, v)| v.to_owned())
+      None => combined = Some(value.to_vec()),
+    }
+  }
+  combined.map(ByteString::from)
 }
 
 #[test]
@@ -518,9 +575,10 @@ fn test_get_header() {
       ByteString::from("vary"),
       ByteString::from("accept-encoding"),
     ),
+    (ByteString::from("Accept-Encoding"), ByteString::from("br")),
   ];
   let value = get_header("accept-encoding", &headers);
-  assert_eq!(value, Some(ByteString::from("gzip")));
+  assert_eq!(value, Some(ByteString::from("gzip, br")));
   let value = get_header("content-type", &headers);
   assert_eq!(value, Some(ByteString::from("application/json")));
   let value = get_header("vary", &headers);

--- a/ext/cache/lscache.rs
+++ b/ext/cache/lscache.rs
@@ -111,7 +111,7 @@ impl LscBackend {
     );
     let mut headers = HeaderMap::new();
     for hdr in &request_response.request_headers {
-      headers.insert(
+      headers.append(
         HeaderName::from_bytes(
           &[REQHDR_PREFIX.as_bytes(), &hdr.0[..]].concat(),
         )?,
@@ -125,7 +125,7 @@ impl LscBackend {
       if hdr.0[..] == b"content-encoding"[..] {
         return Err(CacheError::ContentEncodingNotAllowed);
       }
-      headers.insert(
+      headers.append(
         HeaderName::from_bytes(&hdr.0[..])?,
         HeaderValue::from_bytes(&hdr.1[..])?,
       );
@@ -196,9 +196,9 @@ impl LscBackend {
     // From https://w3c.github.io/ServiceWorker/#request-matches-cached-item-algorithm
     // If there's Vary header in the response, ensure all the
     // headers of the cached request match the query request.
-    if let Some(vary_header) = res.headers().get(&VARY)
+    if let Some(vary_header) = get_header_from_map(VARY.as_str(), res.headers())
       && !vary_header_matches(
-        vary_header.as_bytes(),
+        &vary_header,
         &request.request_headers,
         res.headers(),
       )
@@ -319,7 +319,7 @@ impl deno_core::Resource for LscBackend {
 }
 
 fn vary_header_matches(
-  vary_header: &[u8],
+  vary_header: &ByteString,
   query_request_headers: &[(ByteString, ByteString)],
   cached_headers: &HeaderMap,
 ) -> bool {
@@ -329,6 +329,9 @@ fn vary_header_matches(
   };
   let headers = get_headers_from_vary_header(vary_header);
   for header in headers {
+    if header == "*" {
+      return false;
+    }
     // Ignoring `accept-encoding` is safe because we refuse to cache responses
     // with `content-encoding`
     if header == "accept-encoding" {
@@ -336,14 +339,22 @@ fn vary_header_matches(
     }
     let lookup_key = format!("{}{}", REQHDR_PREFIX, header);
     let query_header = get_header(&header, query_request_headers);
-    let cached_header = cached_headers.get(&lookup_key);
-    if query_header.as_ref().map(|x| &x[..])
-      != cached_header.as_ref().map(|x| x.as_bytes())
-    {
+    let cached_header = get_header_from_map(&lookup_key, cached_headers);
+    if query_header != cached_header {
       return false;
     }
   }
   true
+}
+
+fn get_header_from_map(name: &str, headers: &HeaderMap) -> Option<ByteString> {
+  let mut values = headers.get_all(name).iter();
+  let mut combined = values.next()?.as_bytes().to_vec();
+  for value in values {
+    combined.extend_from_slice(b", ");
+    combined.extend_from_slice(value.as_bytes());
+  }
+  Some(combined.into())
 }
 
 fn build_cache_object_key(cache_name: &[u8], request_url: &[u8]) -> String {
@@ -352,4 +363,54 @@ fn build_cache_object_key(cache_name: &[u8], request_url: &[u8]) -> String {
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(cache_name),
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(request_url),
   )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn lsc_vary_header_matches_combined_values() {
+    let mut cached_headers = HeaderMap::new();
+    cached_headers.append(
+      "x-lsc-meta-reqhdr-x-example",
+      HeaderValue::from_static("first"),
+    );
+    cached_headers.append(
+      "x-lsc-meta-reqhdr-x-example",
+      HeaderValue::from_static("cached"),
+    );
+
+    let query_headers = vec![
+      ("X-Example".into(), "first".into()),
+      ("x-example".into(), "cached".into()),
+    ];
+    assert!(vary_header_matches(
+      &"x-example".into(),
+      &query_headers,
+      &cached_headers,
+    ));
+
+    let query_headers = vec![
+      ("x-example".into(), "first".into()),
+      ("x-example".into(), "query".into()),
+    ];
+    assert!(!vary_header_matches(
+      &"x-example".into(),
+      &query_headers,
+      &cached_headers,
+    ));
+  }
+
+  #[test]
+  fn lsc_combines_repeated_vary_fields() {
+    let mut headers = HeaderMap::new();
+    headers.append(VARY, HeaderValue::from_static("accept-language"));
+    headers.append(VARY, HeaderValue::from_static("x-example"));
+
+    assert_eq!(
+      get_header_from_map(VARY.as_str(), &headers),
+      Some("accept-language, x-example".into()),
+    );
+  }
 }

--- a/tests/unit/cache_api_test.ts
+++ b/tests/unit/cache_api_test.ts
@@ -195,6 +195,53 @@ Deno.test(async function cacheApi() {
   assertFalse(await caches.has(cacheName));
 });
 
+Deno.test(async function cacheVaryUsesCombinedHeaderValues() {
+  const cacheName = "cache-vary-combined-values";
+  await caches.delete(cacheName);
+  const cache = await caches.open(cacheName);
+  const url = "https://example.com/vary-combined-values";
+
+  const cachedRequest = new Request(url, {
+    headers: [
+      ["x-unchanged", "same"],
+      ["x-example", "first"],
+      ["X-Example", "cached"],
+    ],
+  });
+  await cache.put(
+    cachedRequest,
+    new Response("cached response", {
+      headers: [
+        ["Vary", "x-unchanged"],
+        ["vary", "x-example"],
+      ],
+    }),
+  );
+
+  const matchingRequest = new Request(url, {
+    headers: [
+      ["x-unchanged", "same"],
+      ["x-example", "first"],
+      ["x-example", "cached"],
+    ],
+  });
+  assertEquals(
+    await (await cache.match(matchingRequest))?.text(),
+    "cached response",
+  );
+
+  const differentRequest = new Request(url, {
+    headers: [
+      ["x-unchanged", "same"],
+      ["x-example", "first"],
+      ["x-example", "query"],
+    ],
+  });
+  assertEquals(await cache.match(differentRequest), undefined);
+
+  await caches.delete(cacheName);
+});
+
 Deno.test(async function cacheStorageMatch() {
   const names = ["match-a", "match-b", "match-c"];
   for (const name of names) {


### PR DESCRIPTION
## Summary

- make `Vary: *` cache entries never match in both the SQLite and remote cache backends
- compare the combined value of every request header named by `Vary`, preserving value order
- preserve repeated request and response headers in remote cache metadata, including repeated `Vary` fields

## Details

Cache matching previously compared only the first tuple for a repeated request
header. That differed from Fetch header-list semantics, where all matching values
are joined in their original order with `, ` separators.

`Vary: *` was also treated like a missing request header: neither request had a
header named `*`, so the two missing values compared equal and the cached
response matched. Both cache matchers now return no match for `Vary: *`.

The remote cache backend also used replacement insertion while constructing its
HTTP metadata, which discarded earlier repeated request and response fields. It
now appends those fields and combines repeated values in insertion order during
matching. This also ensures every field named across repeated `Vary` headers is
checked.

Coverage includes matching and mismatching combined values, value order, missing
values, repeated `Vary` fields, `Vary: *`, and Cache API behavior.

## Validation

- `cargo test -p deno_cache --features deno_core/v8`
- `cargo test -p unit_tests --test unit -- cache_api_test`
- `cargo clippy -p deno_cache --all-targets --features deno_core/v8 -- -D warnings`
- `./tools/format.js --check`
- `./tools/lint.js --js`
