### PR TITLE
fix(glob): retain valid gitignore rules after parse errors

### DIFF
--- a/libs/config/glob/gitignore.rs
+++ b/libs/config/glob/gitignore.rs
@@ -105,14 +105,22 @@ impl<'a, Sys: FsRead + FsMetadata> GitIgnoreTree<'a, Sys> {
     let parent = dir_path.parent().and_then(|parent| {
       self.get_resolved_git_ignore_inner(parent, Some(dir_path))
     });
+    let gitignore_path = dir_path.join(".gitignore");
     let current = self
       .sys
-      .fs_read_to_string_lossy(dir_path.join(".gitignore"))
+      .fs_read_to_string_lossy(&gitignore_path)
       .ok()
       .and_then(|text| {
         let mut builder = ignore::gitignore::GitignoreBuilder::new(dir_path);
-        for line in text.lines() {
-          builder.add_line(None, line).ok()?;
+        for (line_index, line) in text.lines().enumerate() {
+          if let Err(err) = builder.add_line(None, line) {
+            log::warn!(
+              "Warning: skipping invalid .gitignore pattern at {}:{}: {}",
+              gitignore_path.display(),
+              line_index + 1,
+              err,
+            );
+          }
         }
         // override the gitignore contents to include these paths
         for path in &self.include_paths {
@@ -176,5 +184,46 @@ mod test {
     run_test("/sub_dir/sub_dir/ignore.txt", true);
     run_test("/sub_dir/ignore.txt", false);
     run_test("/ignore.txt", false);
+  }
+
+  #[test]
+  fn git_ignore_tree_keeps_valid_patterns_after_parse_error() {
+    let sys = InMemorySys::default();
+    sys.fs_create_dir_all("/").unwrap();
+    sys
+      .fs_write("/.gitignore", "before.txt\n[\nafter.txt")
+      .unwrap();
+    let mut ignore_tree = GitIgnoreTree::new(&sys, Vec::new());
+
+    for path in ["/before.txt", "/after.txt"] {
+      let path = PathBuf::from(path);
+      let gitignore = ignore_tree
+        .get_resolved_git_ignore_for_file(&path)
+        .unwrap();
+      assert!(gitignore.is_ignored(&path, false), "Path: {}", path.display());
+    }
+  }
+
+  #[test]
+  fn git_ignore_tree_keeps_parent_and_valid_child_patterns() {
+    let sys = InMemorySys::default();
+    sys.fs_create_dir_all("/sub_dir").unwrap();
+    sys.fs_write("/.gitignore", "parent.txt").unwrap();
+    sys
+      .fs_write("/sub_dir/.gitignore", "before.txt\n[\nafter.txt")
+      .unwrap();
+    let mut ignore_tree = GitIgnoreTree::new(&sys, Vec::new());
+
+    for path in [
+      "/sub_dir/parent.txt",
+      "/sub_dir/before.txt",
+      "/sub_dir/after.txt",
+    ] {
+      let path = PathBuf::from(path);
+      let gitignore = ignore_tree
+        .get_resolved_git_ignore_for_file(&path)
+        .unwrap();
+      assert!(gitignore.is_ignored(&path, false), "Path: {}", path.display());
+    }
   }
 }

--- a/libs/config/glob/gitignore.rs
+++ b/libs/config/glob/gitignore.rs
@@ -197,10 +197,13 @@ mod test {
 
     for path in ["/before.txt", "/after.txt"] {
       let path = PathBuf::from(path);
-      let gitignore = ignore_tree
-        .get_resolved_git_ignore_for_file(&path)
-        .unwrap();
-      assert!(gitignore.is_ignored(&path, false), "Path: {}", path.display());
+      let gitignore =
+        ignore_tree.get_resolved_git_ignore_for_file(&path).unwrap();
+      assert!(
+        gitignore.is_ignored(&path, false),
+        "Path: {}",
+        path.display()
+      );
     }
   }
 
@@ -220,10 +223,13 @@ mod test {
       "/sub_dir/after.txt",
     ] {
       let path = PathBuf::from(path);
-      let gitignore = ignore_tree
-        .get_resolved_git_ignore_for_file(&path)
-        .unwrap();
-      assert!(gitignore.is_ignored(&path, false), "Path: {}", path.display());
+      let gitignore =
+        ignore_tree.get_resolved_git_ignore_for_file(&path).unwrap();
+      assert!(
+        gitignore.is_ignored(&path, false),
+        "Path: {}",
+        path.display()
+      );
     }
   }
 }

--- a/tests/specs/publish/dry_run_invalid_gitignore/__test__.jsonc
+++ b/tests/specs/publish/dry_run_invalid_gitignore/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": [
+      "eval",
+      "Deno.writeTextFileSync('.gitignore', 'before.txt\\n[\\nafter.txt')"
+    ],
+    "output": "[WILDCARD]"
+  }, {
+    "args": "publish --dry-run",
+    "output": "publish.out"
+  }]
+}

--- a/tests/specs/publish/dry_run_invalid_gitignore/after.txt
+++ b/tests/specs/publish/dry_run_invalid_gitignore/after.txt
@@ -1,0 +1,1 @@
+not published

--- a/tests/specs/publish/dry_run_invalid_gitignore/before.txt
+++ b/tests/specs/publish/dry_run_invalid_gitignore/before.txt
@@ -1,0 +1,1 @@
+not published

--- a/tests/specs/publish/dry_run_invalid_gitignore/deno.json
+++ b/tests/specs/publish/dry_run_invalid_gitignore/deno.json
@@ -1,0 +1,6 @@
+{
+  "name": "@scope/pkg",
+  "version": "1.0.0",
+  "exports": "./mod.ts",
+  "license": "MIT"
+}

--- a/tests/specs/publish/dry_run_invalid_gitignore/mod.ts
+++ b/tests/specs/publish/dry_run_invalid_gitignore/mod.ts
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/tests/specs/publish/dry_run_invalid_gitignore/publish.out
+++ b/tests/specs/publish/dry_run_invalid_gitignore/publish.out
@@ -1,0 +1,9 @@
+Check [WILDCARD]mod.ts
+Checking for slow types in the public API...
+Check [WILDCARD]mod.ts
+Warning: skipping invalid .gitignore pattern at [WILDCARD].gitignore:2: error parsing glob '[': unclosed character class; missing ']'
+Simulating publish of @scope/pkg@1.0.0 with files:
+   [WILDCARD]deno.json (94B)
+   [WILDCARD]mod.ts (24B)
+   [WILDCARD]published.txt (10B)
+Success Dry run complete

--- a/tests/specs/publish/dry_run_invalid_gitignore/published.txt
+++ b/tests/specs/publish/dry_run_invalid_gitignore/published.txt
@@ -1,0 +1,1 @@
+published


### PR DESCRIPTION
## Summary

- retain valid `.gitignore` patterns when another line cannot be parsed
- identify the malformed file and line in a warning
- cover root, nested, and publish dry-run behavior

## Details

Gitignore loading previously returned no matcher after the first malformed pattern. That discarded valid patterns from the same file, including patterns parsed before the malformed line.

The loader now skips only the malformed line, reports its location, and continues building the matcher from the remaining patterns. Parent-directory matchers continue to compose with nested files as before.

## Validation

- `cargo fmt -p deno_config -- --check`
- `cargo test -p deno_config`
- `cargo test -p specs_tests --test specs publish::dry_run_invalid_gitignore`
- `cargo clippy -p deno_config --all-targets -- -D warnings`
