### PR TITLE
fix(compile): skip symlinked node_modules roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6138,6 +6138,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "junction",
  "lazy-regex",
  "nix 0.30.1",
  "os_pipe",

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -1472,10 +1472,13 @@ impl<'a> DenoCompileBinaryWriter<'a> {
           let mut entries = entries.filter_map(|e| e.ok()).collect::<Vec<_>>();
           entries.sort_by_cached_key(|entry| entry.file_name()); // determinism
           for entry in entries {
-            let path = entry.path();
-            if !path.is_dir() {
+            let Ok(file_type) = entry.file_type() else {
+              continue;
+            };
+            if !file_type.is_dir() {
               continue;
             }
+            let path = entry.path();
             if path.ends_with("node_modules") {
               builder.add_dir_recursive(&path)?;
             } else {

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -1472,13 +1472,25 @@ impl<'a> DenoCompileBinaryWriter<'a> {
           let mut entries = entries.filter_map(|e| e.ok()).collect::<Vec<_>>();
           entries.sort_by_cached_key(|entry| entry.file_name()); // determinism
           for entry in entries {
+            let path = entry.path();
             let Ok(file_type) = entry.file_type() else {
               continue;
             };
             if !file_type.is_dir() {
+              if file_type.is_symlink() && path.ends_with("node_modules") {
+                let path_display = path.to_string_lossy();
+                let path_display =
+                  crate::util::console::escape_terminal_control_chars(
+                    &path_display,
+                  );
+                log::warn!(
+                  "{} Skipping linked node_modules directory during automatic workspace discovery.\n    Path: {}",
+                  crate::colors::yellow("Warning"),
+                  path_display
+                );
+              }
               continue;
             }
-            let path = entry.path();
             if path.ends_with("node_modules") {
               builder.add_dir_recursive(&path)?;
             } else {

--- a/cli/standalone/native_addons.rs
+++ b/cli/standalone/native_addons.rs
@@ -220,10 +220,13 @@ fn find_byonm_native_addon_packages(
       continue;
     };
     for entry in entries.flatten() {
-      let path = entry.path();
-      if !path.is_dir() {
+      let Ok(file_type) = entry.file_type() else {
+        continue;
+      };
+      if !file_type.is_dir() {
         continue;
       }
+      let path = entry.path();
       if path.file_name() == Some(OsStr::new("node_modules")) {
         node_modules_dirs.push_back(path);
       } else {
@@ -329,5 +332,51 @@ mod tests {
     let found = find_byonm_native_addon_packages(root);
     assert_eq!(found.len(), 1);
     assert_eq!(found[0].folder, nested);
+  }
+
+  #[test]
+  fn byonm_skips_linked_workspace_paths() {
+    let tmp = test_util::TempDir::new();
+    let workspace = tmp.path().join("workspace").to_path_buf();
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let linked_root_target =
+      tmp.path().join("linked_root_target").to_path_buf();
+    touch(&linked_root_target.join("pkg/addon.node"));
+    tmp.symlink_dir(&linked_root_target, workspace.join("node_modules"));
+
+    let linked_intermediate_target =
+      tmp.path().join("linked_intermediate_target").to_path_buf();
+    touch(&linked_intermediate_target.join("node_modules/pkg/addon.node"));
+    tmp.symlink_dir(
+      &linked_intermediate_target,
+      workspace.join("packages/linked"),
+    );
+
+    let real_pkg = workspace.join("packages/real/node_modules/pkg");
+    touch(&real_pkg.join("addon.node"));
+
+    let found = find_byonm_native_addon_packages(&workspace);
+    assert_eq!(
+      found.len(),
+      1,
+      "linked workspace paths must not participate in automatic discovery"
+    );
+    assert_eq!(found[0].folder, real_pkg);
+  }
+
+  #[test]
+  fn byonm_follows_package_link_in_real_node_modules() {
+    let tmp = test_util::TempDir::new();
+    let workspace = tmp.path().join("workspace").to_path_buf();
+    let package_target = tmp.path().join("package_target").to_path_buf();
+    touch(&package_target.join("addon.node"));
+
+    let package_link = workspace.join("node_modules/pkg");
+    tmp.symlink_dir(&package_target, &package_link);
+
+    let found = find_byonm_native_addon_packages(&workspace);
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].folder, package_link);
   }
 }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -60,3 +60,6 @@ zeromq.workspace = true
 
 [target.'cfg(unix)'.dev-dependencies]
 nix.workspace = true
+
+[target.'cfg(windows)'.dev-dependencies]
+junction.workspace = true

--- a/tests/integration/compile_tests.rs
+++ b/tests/integration/compile_tests.rs
@@ -1022,6 +1022,74 @@ Embedded Files
 }
 
 #[test]
+fn compile_byonm_skips_symlinked_node_modules_roots() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  let project_dir = temp_dir.path().join("project");
+  project_dir.join("main.ts").write("console.log('ok');");
+  project_dir
+    .join("package.json")
+    .write(r#"{ "name": "compile-byonm-test", "private": true }"#);
+
+  const TOP_LEVEL_SENTINEL: &[u8] = b"top-level-linked-node-modules-sentinel";
+  const NESTED_SENTINEL: &[u8] = b"nested-linked-node-modules-sentinel";
+  const REAL_SENTINEL: &[u8] = b"real-node-modules-sentinel";
+
+  let top_level_target = temp_dir.path().join("top_level_target");
+  top_level_target
+    .join("sentinel.txt")
+    .write(TOP_LEVEL_SENTINEL);
+  temp_dir.symlink_dir(&top_level_target, project_dir.join("node_modules"));
+
+  let nested_target = temp_dir.path().join("nested_target");
+  nested_target.join("sentinel.txt").write(NESTED_SENTINEL);
+  temp_dir.symlink_dir(
+    &nested_target,
+    project_dir.join("packages/nested/node_modules"),
+  );
+
+  project_dir
+    .join("packages/real/node_modules/pkg/sentinel.txt")
+    .write(REAL_SENTINEL);
+
+  let binary_path = project_dir.join(if cfg!(windows) {
+    "compiled.exe"
+  } else {
+    "compiled"
+  });
+  context
+    .new_command()
+    .current_dir(&project_dir)
+    .args("compile --output compiled main.ts")
+    .run()
+    .assert_exit_code(0)
+    .skip_output_check();
+
+  let binary = binary_path.read_to_bytes_if_exists().unwrap();
+  assert!(
+    binary
+      .windows(REAL_SENTINEL.len())
+      .any(|window| window == REAL_SENTINEL)
+  );
+  assert!(
+    !binary
+      .windows(TOP_LEVEL_SENTINEL.len())
+      .any(|window| window == TOP_LEVEL_SENTINEL)
+  );
+  assert!(
+    !binary
+      .windows(NESTED_SENTINEL.len())
+      .any(|window| window == NESTED_SENTINEL)
+  );
+
+  context
+    .new_command()
+    .name(binary_path)
+    .run()
+    .assert_matches_text("ok\n");
+}
+
+#[test]
 fn dynamic_imports_tmp_lit() {
   let context = TestContextBuilder::new().build();
   let dir = context.temp_dir();

--- a/tests/integration/compile_tests.rs
+++ b/tests/integration/compile_tests.rs
@@ -5,6 +5,7 @@ use test_util::eprintln;
 use test_util::test;
 use util::TestContext;
 use util::TestContextBuilder;
+use util::assert_contains;
 use util::assert_not_contains;
 use util::testdata_path;
 
@@ -1033,7 +1034,11 @@ fn compile_byonm_skips_symlinked_node_modules_roots() {
 
   const TOP_LEVEL_SENTINEL: &[u8] = b"top-level-linked-node-modules-sentinel";
   const NESTED_SENTINEL: &[u8] = b"nested-linked-node-modules-sentinel";
+  const INTERMEDIATE_SENTINEL: &[u8] =
+    b"linked-intermediate-node-modules-sentinel";
   const REAL_SENTINEL: &[u8] = b"real-node-modules-sentinel";
+  #[cfg(windows)]
+  const JUNCTION_SENTINEL: &[u8] = b"junction-node-modules-sentinel";
 
   let top_level_target = temp_dir.path().join("top_level_target");
   top_level_target
@@ -1048,6 +1053,24 @@ fn compile_byonm_skips_symlinked_node_modules_roots() {
     project_dir.join("packages/nested/node_modules"),
   );
 
+  let intermediate_target = temp_dir.path().join("intermediate_target");
+  intermediate_target
+    .join("node_modules/sentinel.txt")
+    .write(INTERMEDIATE_SENTINEL);
+  temp_dir
+    .symlink_dir(&intermediate_target, project_dir.join("packages/linked"));
+
+  #[cfg(windows)]
+  {
+    let junction_target = temp_dir.path().join("junction_target");
+    junction_target
+      .join("sentinel.txt")
+      .write(JUNCTION_SENTINEL);
+    let junction_path = project_dir.join("packages/junction/node_modules");
+    junction_path.parent().unwrap().create_dir_all();
+    junction::create(&junction_target, &junction_path).unwrap();
+  }
+
   project_dir
     .join("packages/real/node_modules/pkg/sentinel.txt")
     .write(REAL_SENTINEL);
@@ -1057,29 +1080,55 @@ fn compile_byonm_skips_symlinked_node_modules_roots() {
   } else {
     "compiled"
   });
-  context
+  let output = context
     .new_command()
     .current_dir(&project_dir)
     .args("compile --output compiled main.ts")
-    .run()
-    .assert_exit_code(0)
-    .skip_output_check();
+    .run();
+  output.assert_exit_code(0);
+  assert_contains!(
+    output.combined_output(),
+    "Warning Skipping linked node_modules directory during automatic workspace discovery."
+  );
+  assert_contains!(
+    output.combined_output(),
+    &format!(
+      "    Path: {}",
+      project_dir.canonicalize().join("node_modules")
+    )
+  );
 
   let binary = binary_path.read_to_bytes_if_exists().unwrap();
   assert!(
     binary
       .windows(REAL_SENTINEL.len())
-      .any(|window| window == REAL_SENTINEL)
+      .any(|window| window == REAL_SENTINEL),
+    "real node_modules root was not embedded"
   );
   assert!(
     !binary
       .windows(TOP_LEVEL_SENTINEL.len())
-      .any(|window| window == TOP_LEVEL_SENTINEL)
+      .any(|window| window == TOP_LEVEL_SENTINEL),
+    "top-level linked node_modules root was embedded"
   );
   assert!(
     !binary
       .windows(NESTED_SENTINEL.len())
-      .any(|window| window == NESTED_SENTINEL)
+      .any(|window| window == NESTED_SENTINEL),
+    "nested linked node_modules root was embedded"
+  );
+  assert!(
+    !binary
+      .windows(INTERMEDIATE_SENTINEL.len())
+      .any(|window| window == INTERMEDIATE_SENTINEL),
+    "linked intermediate directory was traversed"
+  );
+  #[cfg(windows)]
+  assert!(
+    !binary
+      .windows(JUNCTION_SENTINEL.len())
+      .any(|window| window == JUNCTION_SENTINEL),
+    "junction node_modules root was embedded"
   );
 
   context


### PR DESCRIPTION
## Summary

- make automatic BYONM workspace discovery inspect directory entries without following links
- keep real `node_modules` directories in the compiled VFS
- cover top-level and nested linked roots alongside a real nested root

## Motivation

The BYONM workspace scan used `Path::is_dir()`, which follows directory links while looking for `node_modules`. This could cause compile output to contain files from a link target that was not itself a directory entry in the workspace traversal.

Using `DirEntry::file_type()` keeps automatic discovery aligned with the workspace layout. VFS handling for paths explicitly reached through the module graph or configured includes is unchanged.

## Tests

- `cargo build --bin deno --bin denort`
- `cargo test -p integration_tests --test integration -- compile::compile_byonm_skips_symlinked_node_modules_roots`
- `cargo build --bin test_server`
- `cargo test -p integration_tests --test integration -- compile::compile_node_modules_symlink_`
- `./tools/format.js cli/standalone/binary.rs tests/integration/compile_tests.rs`
- `./tools/lint.js`
