### PR TITLE
fix(desktop): run Vite-based HMR dev servers inside the desktop runtime

### DIFF
--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -1214,7 +1214,7 @@ laufey::main!(|| {
       && (env::var("NODE_CHANNEL_FD").is_ok()
         || env::var("NEXT_PRIVATE_WORKER").is_ok()));
   if is_worker {
-    run_headless_worker();
+    run_on_runtime_thread(run_headless_worker);
     return;
   }
 
@@ -1336,40 +1336,44 @@ laufey::main!(|| {
     }
   }
 
-  let rt = tokio::runtime::Builder::new_current_thread()
-    .enable_all()
-    .build()
-    .unwrap();
+  // Everything above must stay on this (still effectively single-threaded)
+  // loader thread — see the setenv comment. The runtime itself moves to a
+  // dedicated thread with a real stack; the loader thread just parks in
+  // `join` (inside `run_on_runtime_thread`) until the app exits.
+  run_on_runtime_thread(move || {
+    let rt = deno_runtime::tokio_util::create_basic_runtime();
 
-  rt.block_on(async {
-    log::debug!("[desktop] run_desktop starting");
-    match run_desktop(update_rolled_back, desktop_serve_port, data).await {
-      Ok(()) => log::debug!("[desktop] run_desktop completed OK"),
-      Err(error) => {
-        // A failure raised while the app's main module was still loading or
-        // first evaluating is tagged `DesktopStartupError` (see
-        // `denort::run`). It carries its own pre-formatted message.
-        let startup = error.downcast_ref::<denort::run::DesktopStartupError>();
-        let error_string = match startup {
-          Some(startup) => startup.message.clone(),
-          None => match js_error_downcast_ref(&error) {
-            Some(js_error) => format_js_error(js_error, None),
-            None => format!("{:?}", error),
-          },
-        };
-        let message = error_string.trim_start_matches("error: ");
-        log::error!("{}: {}", colors::red_bold("error"), message);
-        let is_startup = startup.is_some();
-        // A `DesktopStartupError` wraps the formatted message rather than the
-        // original `JsError`, so only consult `js_error_downcast_ref` for the
-        // untagged (post-load) case.
-        let is_js_error =
-          !is_startup && js_error_downcast_ref(&error).is_some();
-        if should_show_native_error_dialog(is_startup, is_js_error) {
-          laufey::alert("Application Error", message);
+    rt.block_on(async {
+      log::debug!("[desktop] run_desktop starting");
+      match run_desktop(update_rolled_back, desktop_serve_port, data).await {
+        Ok(()) => log::debug!("[desktop] run_desktop completed OK"),
+        Err(error) => {
+          // A failure raised while the app's main module was still loading or
+          // first evaluating is tagged `DesktopStartupError` (see
+          // `denort::run`). It carries its own pre-formatted message.
+          let startup =
+            error.downcast_ref::<denort::run::DesktopStartupError>();
+          let error_string = match startup {
+            Some(startup) => startup.message.clone(),
+            None => match js_error_downcast_ref(&error) {
+              Some(js_error) => format_js_error(js_error, None),
+              None => format!("{:?}", error),
+            },
+          };
+          let message = error_string.trim_start_matches("error: ");
+          log::error!("{}: {}", colors::red_bold("error"), message);
+          let is_startup = startup.is_some();
+          // A `DesktopStartupError` wraps the formatted message rather than the
+          // original `JsError`, so only consult `js_error_downcast_ref` for the
+          // untagged (post-load) case.
+          let is_js_error =
+            !is_startup && js_error_downcast_ref(&error).is_some();
+          if should_show_native_error_dialog(is_startup, is_js_error) {
+            laufey::alert("Application Error", message);
+          }
         }
       }
-    }
+    });
   });
 });
 
@@ -1389,6 +1393,31 @@ fn should_show_native_error_dialog(
   is_startup || !is_js_error
 }
 
+/// Stack size for the thread the Deno runtime runs on. Laufey invokes
+/// `laufey_runtime_start` on its RuntimeLoader thread, which gets the
+/// platform-default stack for secondary threads — only 512KB on macOS.
+/// That is far too small for the runtime: synchronous module parsing (swc)
+/// alone recurses past it on real-world module graphs (e.g. a SvelteKit
+/// dev server's graph) and kills the process with SIGBUS. 8MB matches the
+/// headroom the CLI gets from the OS main thread.
+const RUNTIME_THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+/// Run `f` to completion on a dedicated thread with a stack large enough
+/// for the Deno runtime (see `RUNTIME_THREAD_STACK_SIZE`), keeping the
+/// calling (loader) thread parked until it finishes.
+fn run_on_runtime_thread<F: FnOnce() + Send + 'static>(f: F) {
+  let thread = std::thread::Builder::new()
+    .name("deno-desktop-runtime".to_string())
+    .stack_size(RUNTIME_THREAD_STACK_SIZE)
+    .spawn(f)
+    .expect("failed to spawn desktop runtime thread");
+  if thread.join().is_err() {
+    // The runtime thread panicked. The panic hook normally exits the
+    // process itself; this is a backstop in case it returned.
+    deno_runtime::exit(1);
+  }
+}
+
 /// Run as a headless worker (no Laufey window). Used when a framework dev
 /// server forks child processes that re-execute this dylib.
 fn run_headless_worker() {
@@ -1398,10 +1427,7 @@ fn run_headless_worker() {
     .install_default()
     .unwrap();
 
-  let rt = tokio::runtime::Builder::new_current_thread()
-    .enable_all()
-    .build()
-    .unwrap();
+  let rt = deno_runtime::tokio_util::create_basic_runtime();
 
   rt.block_on(async {
     let args: Vec<_> = env::args_os().collect();
@@ -1435,9 +1461,13 @@ fn run_headless_worker() {
 
     let sys = if data.metadata.self_extracting.is_some() {
       // VFS should already be extracted by the parent process.
-      // In dev mode, keep the source directory as CWD (inherited from parent).
-      // In production mode, set CWD to extraction directory.
-      if env::var("DENO_DESKTOP_DEV_URL").is_err() {
+      // In dev mode (external dev server via DENO_DESKTOP_DEV_URL or
+      // in-runtime dev server via DENO_DESKTOP_FRAMEWORK_DEV), keep the
+      // source directory as CWD (inherited from parent). In production
+      // mode, set CWD to extraction directory.
+      if env::var("DENO_DESKTOP_DEV_URL").is_err()
+        && env::var("DENO_DESKTOP_FRAMEWORK_DEV").is_err()
+      {
         let _ = std::env::set_current_dir(&data.root_path);
       }
       denort::file_system::DenoRtSys::new_self_extracting(data.vfs.clone())
@@ -1688,7 +1718,17 @@ async fn run_desktop(
 
   // Framework dev servers handle their own HMR via websocket.
   // For non-framework apps, V8-level HMR reloads the webview.
-  let is_framework_dev = env::var("DENO_DESKTOP_DEV_URL").is_ok();
+  //
+  // Two framework-dev shapes exist (see `run_desktop_hmr` in
+  // cli/tools/desktop.rs):
+  // - DENO_DESKTOP_DEV_URL: the CLI spawned an external dev-server process
+  //   and parsed its URL; navigate there directly.
+  // - DENO_DESKTOP_FRAMEWORK_DEV: the embedded entrypoint boots the dev
+  //   server inside this runtime on the desktop serve port (so server code
+  //   keeps `Deno.desktop`, #35899); use the regular serve-port poll.
+  let external_dev_url = env::var("DENO_DESKTOP_DEV_URL").ok();
+  let is_framework_dev = external_dev_url.is_some()
+    || env::var("DENO_DESKTOP_FRAMEWORK_DEV").is_ok();
 
   // In dev mode, restore CWD to the source directory so the framework
   // dev server watches the original source files, not the extracted VFS.
@@ -1837,8 +1877,9 @@ async fn run_desktop(
   // Run the Deno runtime and Laufey event loop concurrently.
   // We spawn the runtime first, wait for the server to be ready,
   // then navigate the webview.
-  let url = env::var("DENO_DESKTOP_DEV_URL")
-    .unwrap_or_else(|_| format!("http://127.0.0.1:{}", desktop_serve_port));
+  let poll_serve_port = external_dev_url.is_none();
+  let url = external_dev_url
+    .unwrap_or_else(|| format!("http://127.0.0.1:{}", desktop_serve_port));
   log::debug!("[desktop] starting runtime and laufey event loop");
   let run_fut =
     denort::run::run_with_options(Arc::new(sys.clone()), sys, data, run_opts);
@@ -1883,7 +1924,7 @@ async fn run_desktop(
     }
 
     let id = initial_window_id_for_navigate.load(Ordering::Acquire);
-    if !is_framework_dev {
+    if poll_serve_port {
       let mut server_ready = false;
       for i in 0..60 {
         if let Ok(mut stream) =

--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -323,10 +323,25 @@ async fn compile_desktop(
   let desktop_entrypoint_file = if desktop_flags.source_file == "." {
     let cwd = &detection_cwd;
     if let Some(detection) = detected_framework.as_ref() {
-      let use_framework_hmr =
-        desktop_flags.hmr && detection.hmr_command.is_some();
+      let use_framework_hmr = desktop_flags.hmr
+        && (detection.hmr_entrypoint_code().is_some()
+          || detection.hmr_command.is_some());
       let entrypoint_code = if use_framework_hmr {
-        NOOP_ENTRYPOINT.to_string()
+        match detection.hmr_entrypoint_code() {
+          Some(code) => {
+            // The generated dev shim imports the framework's dev-server API
+            // (e.g. Vite's); type-checking it would demand the project ship
+            // `@types/node` and checks nothing user-authored, so skip it.
+            flags.type_check_mode = TypeCheckMode::None;
+            // The dev server used to run as an unsandboxed `deno task dev`
+            // subprocess; now that it runs inside the desktop runtime, keep
+            // that behavior — a sandboxed Vite immediately dies on env reads
+            // (e.g. NAPI_RS_WASI_FLAVOR from its napi loader).
+            flags.permissions.allow_all = true;
+            code.to_string()
+          }
+          None => NOOP_ENTRYPOINT.to_string(),
+        }
       } else {
         detection.entrypoint_code.clone()
       };
@@ -1325,7 +1340,20 @@ async fn run_desktop_hmr(
     cmd.env("DENO_DESKTOP_HMR", &source_abs);
   }
 
+  // In-runtime framework dev: the compiled entrypoint boots the framework's
+  // dev server inside the desktop runtime (see `hmr_entrypoint_code`), so
+  // server-side code keeps access to `Deno.desktop` (#35899). Signal
+  // rt_desktop to restore CWD to the source dir and leave hot reloading to
+  // the framework; the webview finds the server via the regular
+  // DENO_SERVE_ADDRESS poll, so no external process and no URL scraping.
+  let in_runtime_dev = desktop_flags.hmr
+    && framework.is_some_and(|f| f.hmr_entrypoint_code().is_some());
+  if in_runtime_dev {
+    cmd.env("DENO_DESKTOP_FRAMEWORK_DEV", "1");
+  }
+
   let _dev_server_child = if desktop_flags.hmr
+    && !in_runtime_dev
     && let Some(fw) = framework
     && let Some(dev_cmd) = &fw.hmr_command
   {

--- a/cli/tools/framework.rs
+++ b/cli/tools/framework.rs
@@ -31,7 +31,47 @@ pub struct FrameworkDetection {
   pub hmr_command: Option<Vec<String>>,
 }
 
+/// Entrypoint compiled for `deno desktop --hmr` on projects whose dev command
+/// is plain `vite dev`: it boots the project's own Vite dev server through
+/// Vite's JS API *inside* the desktop runtime, so server-side code (SvelteKit
+/// endpoints, Vite SSR handlers) keeps access to `Deno.desktop` — matching the
+/// compiled app, where the server also runs in the desktop runtime (#35899).
+///
+/// The runtime publishes `DENO_SERVE_ADDRESS` before user code runs and the
+/// webview polls-then-navigates to that port. Binding Vite to it explicitly
+/// (rather than relying on the node:http listen override alone) keeps the
+/// port Vite believes it serves on — `printUrls`, HMR websocket origin — in
+/// agreement with where it actually listens.
+const VITE_DEV_ENTRYPOINT: &str = r#"// @ts-nocheck
+import { createServer } from "vite";
+const addr = Deno.env.get("DENO_SERVE_ADDRESS") ?? "";
+const match = addr.match(/^tcp:(.+):(\d+)$/);
+const server = await createServer({
+  server: match
+    ? { host: match[1], port: Number(match[2]), strictPort: true }
+    : {},
+});
+await server.listen();
+server.printUrls();
+"#;
+
 impl FrameworkDetection {
+  /// Entrypoint that boots the framework's dev server *inside* the desktop
+  /// runtime for `deno desktop --hmr`, so server-side code keeps access to
+  /// `Deno.desktop` (#35899). `None` means `--hmr` falls back to spawning
+  /// `hmr_command` as a separate plain-Deno process, where desktop APIs are
+  /// unavailable to server code.
+  pub fn hmr_entrypoint_code(&self) -> Option<&'static str> {
+    match self.name {
+      // Both run plain `vite dev` as their dev task; boot the same server
+      // through Vite's JS API so it lives inside the desktop runtime. The
+      // wrapper dev CLIs (`nuxi dev`, `vinxi dev`, `react-router dev`,
+      // Fresh's dev.ts) are not plain Vite and keep the external path.
+      "Vite" | "SvelteKit" => Some(VITE_DEV_ENTRYPOINT),
+      _ => None,
+    }
+  }
+
   /// Directories (relative to the project root) where the framework keeps
   /// static assets like favicons. Used to auto-detect a desktop app icon
   /// when the user didn't supply `--icon`.
@@ -947,9 +987,12 @@ mod tests {
     let det = detect_framework(dir.path()).unwrap().unwrap();
     assert_eq!(det.name, "Nuxt");
     assert_eq!(det.include_paths, vec![".output"]);
+    // Nuxt runs a Vite-based dev server, so `deno desktop --hmr` is
+    // supported — but `nuxi dev` is not plain `vite dev`, so it keeps the
+    // external dev-server process rather than the in-runtime dev entrypoint.
+    assert!(det.hmr_entrypoint_code().is_none());
     let cmd = det.build_command.unwrap();
     assert_eq!(cmd[1..], vec!["task", "build"]);
-    // Nuxt runs a Vite-based dev server, so `deno desktop --hmr` is supported.
     let hmr = det.hmr_command.unwrap();
     assert_eq!(hmr[1..], vec!["task", "dev"]);
   }
@@ -1055,6 +1098,14 @@ mod tests {
     assert_eq!(det.name, "SvelteKit");
     assert!(det.entrypoint_code.contains("build/index.js"));
     assert_eq!(det.include_paths, vec!["build/client"]);
+    // SvelteKit's dev command is plain `vite dev`, so `--hmr` boots the dev
+    // server inside the desktop runtime and server-side endpoints keep
+    // `Deno.desktop` (#35899).
+    assert!(
+      det
+        .hmr_entrypoint_code()
+        .is_some_and(|code| code.contains("createServer"))
+    );
   }
 
   #[test]
@@ -1394,9 +1445,17 @@ mod tests {
     // binary is reproducible.
     assert!(det.entrypoint_code.contains("jsr:@std/http@^1/file-server"));
     assert_eq!(det.include_paths, vec!["dist"]);
+    // A plain Vite SPA (e.g. the Vue template) supports `deno desktop --hmr`.
+    // Vite's dev command is plain `vite dev`, so `--hmr` boots the dev server
+    // inside the desktop runtime and server code keeps the desktop APIs
+    // (#35899).
+    assert!(
+      det
+        .hmr_entrypoint_code()
+        .is_some_and(|code| code.contains("createServer"))
+    );
     let cmd = det.build_command.unwrap();
     assert_eq!(cmd[1..], vec!["task", "build"]);
-    // A plain Vite SPA (e.g. the Vue template) supports `deno desktop --hmr`.
     let hmr = det.hmr_command.unwrap();
     assert_eq!(hmr[1..], vec!["task", "dev"]);
   }


### PR DESCRIPTION
Fixes #35899

## Problem

With `deno desktop --hmr` on a framework project, the dev server was spawned as a plain `deno task dev` subprocess. Server-side code (SvelteKit endpoints, Vite SSR handlers) therefore had no access to the desktop APIs (`Deno.BrowserWindow` / `Deno.Tray` / `Deno.Dock`) — inconsistent with the compiled app, where the server entrypoint runs inside the desktop runtime. Verified with a SvelteKit endpoint probing the globals: `{"hasBrowserWindow":false}` under `--hmr`, `true` in the built app.

## Fix

For frameworks whose dev command is plain `vite dev` (Vite, SvelteKit), `--hmr` now compiles a generated dev entrypoint that boots the project's own Vite dev server through Vite's JS API (`createServer()`) **inside the desktop runtime**, bound to the `DENO_SERVE_ADDRESS` port the webview already polls and navigates to (`DENO_DESKTOP_FRAMEWORK_DEV=1` signals rt_desktop to restore CWD to the source dir and leave hot reloading to the framework).

Side benefit: the external-process path — parsing the dev server's stdout for the `Local:` URL with a 15s timeout (#35910's failure mode) — is no longer used for these frameworks. The generated shim is compiled with `--no-check` semantics (nothing user-authored in it) and allow-all permissions, matching the previously-unsandboxed `deno task dev` subprocess.

Wrapper dev CLIs that aren't plain Vite (`nuxi dev`, `vinxi dev`, `react-router dev`, Fresh) keep the existing external-process behavior for now.

## Latent crash this surfaced (fixed too)

Booting a real dev server in-runtime made the runtime parse a much bigger module graph, which exposed that laufey invokes `laufey_runtime_start` on its `RuntimeLoader` C++ thread — which gets the platform-default *secondary*-thread stack, only **512KB on macOS**. Synchronous swc parsing of SvelteKit's graph overflows it and kills the process with SIGBUS (`KERN_PROTECTION_FAILURE` in the stack guard region, ~220 swc parser frames). This can plausibly also kill *production* desktop apps with big server bundles.

The runtime (and headless forked workers) now run on a dedicated 8MB-stack thread, and the tokio runtime is built via `tokio_util::create_basic_runtime()` so blocking-pool threads get the established stack sizes as well.

## Verification (macOS, debug build + rebuilt `denort_desktop` dylib)

- SvelteKit (adapter-node, `sv create` scaffold) with an `/api` endpoint probing globals: `{"hasDeno":true,"hasBrowserWindow":true,"hasTray":true,"hasDock":true}` under `--hmr`; page HTML serves; no SIGBUS.
- Plain Vite React SPA with a `configureServer` middleware probe: same result, and editing `src/App.jsx` triggers `[vite] hmr update /src/App.jsx` (file watching from the restored CWD works).
- `cargo test -p deno --lib framework::` — 71 passed.
- `tools/format.js` clean; `tools/lint.js --rs` clean (JS lint fails only on untracked local scratch files unrelated to this PR).