### PR TITLE
refactor(cli): replace single-method flag ext traits with free functions

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -63,41 +63,35 @@ fn join_paths(allowlist: &[String], d: &str) -> String {
     .join(d)
 }
 
-pub trait FileFlagsExt {
-  fn as_file_patterns(&self, base: &Path) -> Result<FilePatterns, AnyError>;
-}
-
-impl FileFlagsExt for FileFlags {
-  fn as_file_patterns(&self, base: &Path) -> Result<FilePatterns, AnyError> {
-    Ok(FilePatterns {
-      include: if self.include.is_empty() {
-        None
-      } else {
-        Some(PathOrPatternSet::from_include_relative_path_or_patterns(
-          base,
-          &self.include,
-        )?)
-      },
-      exclude: PathOrPatternSet::from_exclude_relative_path_or_patterns(
+/// Resolve a subcommand's include/ignore globs against `base`.
+pub fn resolve_file_patterns(
+  files: &FileFlags,
+  base: &Path,
+) -> Result<FilePatterns, AnyError> {
+  Ok(FilePatterns {
+    include: if files.include.is_empty() {
+      None
+    } else {
+      Some(PathOrPatternSet::from_include_relative_path_or_patterns(
         base,
-        &self.ignore,
-      )?,
-      base: base.to_path_buf(),
-    })
-  }
+        &files.include,
+      )?)
+    },
+    exclude: PathOrPatternSet::from_exclude_relative_path_or_patterns(
+      base,
+      &files.ignore,
+    )?,
+    base: base.to_path_buf(),
+  })
 }
 
-pub trait CompileFlagsExt {
-  fn resolve_target(&self) -> String;
-}
-
-impl CompileFlagsExt for CompileFlags {
-  fn resolve_target(&self) -> String {
-    self
-      .target
-      .clone()
-      .unwrap_or_else(|| env!("TARGET").to_string())
-  }
+/// The `--target` triple for `deno compile`, defaulting to the triple this
+/// binary was built for.
+pub fn resolve_compile_target(flags: &CompileFlags) -> String {
+  flags
+    .target
+    .clone()
+    .unwrap_or_else(|| env!("TARGET").to_string())
 }
 
 fn npm_system_info_from_env() -> NpmSystemInfo {
@@ -109,84 +103,74 @@ fn npm_system_info_from_env() -> NpmSystemInfo {
   }
 }
 
-pub trait DenoSubcommandExt {
-  fn npm_system_info(&self) -> NpmSystemInfo;
-}
-
-impl DenoSubcommandExt for DenoSubcommand {
-  fn npm_system_info(&self) -> NpmSystemInfo {
-    match self {
-      DenoSubcommand::Compile(CompileFlags {
-        target: Some(target),
-        ..
-      })
-      | DenoSubcommand::Desktop(DesktopFlags {
-        target: Some(target),
-        ..
-      }) => {
-        // the values of NpmSystemInfo align with the possible values for the
-        // `arch` and `platform` fields of Node.js' `process` global:
-        // https://nodejs.org/api/process.html
-        match target.as_str() {
-          "aarch64-apple-darwin" => NpmSystemInfo {
-            os: "darwin".into(),
-            cpu: "arm64".into(),
-          },
-          "aarch64-unknown-linux-gnu" => NpmSystemInfo {
-            os: "linux".into(),
-            cpu: "arm64".into(),
-          },
-          "x86_64-apple-darwin" => NpmSystemInfo {
-            os: "darwin".into(),
-            cpu: "x64".into(),
-          },
-          "x86_64-unknown-linux-gnu" => NpmSystemInfo {
-            os: "linux".into(),
-            cpu: "x64".into(),
-          },
-          "x86_64-pc-windows-msvc" => NpmSystemInfo {
-            os: "win32".into(),
-            cpu: "x64".into(),
-          },
-          value => {
-            log::warn!(
-              concat!(
-                "Not implemented npm system info for target '{}'. Using current ",
-                "system default. This may impact architecture specific dependencies."
-              ),
-              value,
-            );
-            NpmSystemInfo::default()
-          }
+/// The npm platform/arch a subcommand should resolve packages for. `compile`
+/// and `desktop` follow their `--target`; `install` follows `--os`/`--arch`;
+/// everything else uses the current system.
+pub fn npm_system_info(subcommand: &DenoSubcommand) -> NpmSystemInfo {
+  match subcommand {
+    DenoSubcommand::Compile(CompileFlags {
+      target: Some(target),
+      ..
+    })
+    | DenoSubcommand::Desktop(DesktopFlags {
+      target: Some(target),
+      ..
+    }) => {
+      // the values of NpmSystemInfo align with the possible values for the
+      // `arch` and `platform` fields of Node.js' `process` global:
+      // https://nodejs.org/api/process.html
+      match target.as_str() {
+        "aarch64-apple-darwin" => NpmSystemInfo {
+          os: "darwin".into(),
+          cpu: "arm64".into(),
+        },
+        "aarch64-unknown-linux-gnu" => NpmSystemInfo {
+          os: "linux".into(),
+          cpu: "arm64".into(),
+        },
+        "x86_64-apple-darwin" => NpmSystemInfo {
+          os: "darwin".into(),
+          cpu: "x64".into(),
+        },
+        "x86_64-unknown-linux-gnu" => NpmSystemInfo {
+          os: "linux".into(),
+          cpu: "x64".into(),
+        },
+        "x86_64-pc-windows-msvc" => NpmSystemInfo {
+          os: "win32".into(),
+          cpu: "x64".into(),
+        },
+        value => {
+          log::warn!(
+            concat!(
+              "Not implemented npm system info for target '{}'. Using current ",
+              "system default. This may impact architecture specific dependencies."
+            ),
+            value,
+          );
+          NpmSystemInfo::default()
         }
       }
-      DenoSubcommand::Install(InstallFlags::Local(
-        _,
-        NpmInstallTargetFlags { os, arch },
-      )) => {
-        let default = npm_system_info_from_env();
-        NpmSystemInfo {
-          os: os.as_deref().unwrap_or(&default.os).into(),
-          cpu: arch.as_deref().unwrap_or(&default.cpu).into(),
-        }
-      }
-      _ => npm_system_info_from_env(),
     }
+    DenoSubcommand::Install(InstallFlags::Local(
+      _,
+      NpmInstallTargetFlags { os, arch },
+    )) => {
+      let default = npm_system_info_from_env();
+      NpmSystemInfo {
+        os: os.as_deref().unwrap_or(&default.os).into(),
+        cpu: arch.as_deref().unwrap_or(&default.cpu).into(),
+      }
+    }
+    _ => npm_system_info_from_env(),
   }
 }
 
-pub trait TypeCheckModeExt {
-  fn as_graph_kind(&self) -> GraphKind;
-}
-
-impl TypeCheckModeExt for TypeCheckMode {
-  /// Gets the corresponding module `GraphKind` that should be created
-  /// for the current `TypeCheckMode`.
-  fn as_graph_kind(&self) -> GraphKind {
-    match self.is_true() {
-      true => GraphKind::All,
-      false => GraphKind::CodeOnly,
-    }
+/// The module `GraphKind` that should be created for a `TypeCheckMode`.
+pub fn graph_kind(mode: TypeCheckMode) -> GraphKind {
+  match mode.is_true() {
+    true => GraphKind::All,
+    false => GraphKind::CodeOnly,
   }
 }
 
@@ -989,7 +973,7 @@ mod tests {
       ))
     );
     assert_eq!(
-      flags.subcommand.npm_system_info(),
+      npm_system_info(&flags.subcommand),
       NpmSystemInfo {
         os: "linux".into(),
         cpu: "arm64".into(),
@@ -1015,7 +999,7 @@ mod tests {
         },
       ))
     );
-    let sys_info = flags.subcommand.npm_system_info();
+    let sys_info = npm_system_info(&flags.subcommand);
     assert_eq!(sys_info.os.as_str(), "win32");
   }
 

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -629,7 +629,7 @@ impl CliOptions {
       // they rewrite.
       DenoSubcommand::Outdated(_) => GraphKind::All,
       DenoSubcommand::Remove(_) => GraphKind::All,
-      _ => self.type_check_mode().as_graph_kind(),
+      _ => graph_kind(self.type_check_mode()),
     }
   }
 
@@ -658,7 +658,7 @@ impl CliOptions {
   }
 
   pub fn npm_system_info(&self) -> NpmSystemInfo {
-    self.sub_command().npm_system_info()
+    npm_system_info(self.sub_command())
   }
 
   /// Resolve the specifier for a specified import map.
@@ -987,7 +987,7 @@ impl CliOptions {
     fmt_flags: &FmtFlags,
   ) -> Result<Vec<(WorkspaceDirectoryRc, FmtOptions)>, AnyError> {
     let cli_arg_patterns =
-      fmt_flags.files.as_file_patterns(self.initial_cwd())?;
+      resolve_file_patterns(&fmt_flags.files, self.initial_cwd())?;
     let member_configs = self
       .workspace()
       .resolve_fmt_config_for_members(&cli_arg_patterns)?;
@@ -1021,7 +1021,7 @@ impl CliOptions {
     lint_flags: &LintFlags,
   ) -> Result<Vec<(WorkspaceDirectoryRc, LintOptions)>, AnyError> {
     let cli_arg_patterns =
-      lint_flags.files.as_file_patterns(self.initial_cwd())?;
+      resolve_file_patterns(&lint_flags.files, self.initial_cwd())?;
     let member_configs = self
       .workspace()
       .resolve_lint_config_for_members(&cli_arg_patterns)?;
@@ -1060,7 +1060,7 @@ impl CliOptions {
     test_flags: &TestFlags,
   ) -> Result<Vec<(WorkspaceDirectoryRc, TestOptions)>, AnyError> {
     let cli_arg_patterns =
-      test_flags.files.as_file_patterns(self.initial_cwd())?;
+      resolve_file_patterns(&test_flags.files, self.initial_cwd())?;
     let workspace_dir_configs = self
       .workspace()
       .resolve_test_config_for_members(&cli_arg_patterns)?;
@@ -1084,7 +1084,7 @@ impl CliOptions {
     bench_flags: &BenchFlags,
   ) -> Result<Vec<(WorkspaceDirectoryRc, BenchOptions)>, AnyError> {
     let cli_arg_patterns =
-      bench_flags.files.as_file_patterns(self.initial_cwd())?;
+      resolve_file_patterns(&bench_flags.files, self.initial_cwd())?;
     let workspace_dir_configs = self
       .workspace()
       .resolve_bench_config_for_members(&cli_arg_patterns)?;

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -66,11 +66,11 @@ use crate::args::CliLockfile;
 use crate::args::CliOptions;
 use crate::args::ConfigFlag;
 use crate::args::DenoSubcommand;
-use crate::args::DenoSubcommandExt;
 use crate::args::Flags;
 use crate::args::FlagsExt;
 use crate::args::InstallFlags;
 use crate::args::InstallFlagsLocal;
+use crate::args::npm_system_info;
 use crate::cache::Caches;
 use crate::cache::CodeCache;
 use crate::cache::DenoDir;
@@ -1432,7 +1432,7 @@ impl CliFactory {
             node_resolver::analyze::NodeCodeTranslatorMode::ModuleLoader
           },
           node_resolution_cache: Some(Arc::new(NodeResolutionThreadLocalCache)),
-          npm_system_info: self.flags.subcommand.npm_system_info(),
+          npm_system_info: npm_system_info(&self.flags.subcommand),
           specified_import_map: Some(Box::new(CliSpecifiedImportMapProvider {
             cli_options: options.clone(),
             eszip_module_loader_provider: self

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -59,8 +59,8 @@ use sys_traits::FsMetadata;
 use crate::args::CliLockfile;
 use crate::args::CliOptions;
 use crate::args::DenoSubcommand;
-use crate::args::TypeCheckModeExt;
 use crate::args::config_to_deno_graph_workspace_member;
+use crate::args::graph_kind;
 use crate::args::jsr_url;
 use crate::cache;
 use crate::cache::GlobalHttpCache;
@@ -699,7 +699,7 @@ impl ModuleGraphCreator {
     &self,
     roots: Vec<ModuleSpecifier>,
   ) -> Result<Arc<deno_graph::ModuleGraph>, AnyError> {
-    let graph_kind = self.options.type_check_mode().as_graph_kind();
+    let graph_kind = graph_kind(self.options.type_check_mode());
 
     let graph = self
       .create_graph_with_options(CreateGraphOptions {

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -69,9 +69,9 @@ use sys_traits::FsRead;
 use super::virtual_fs::output_vfs;
 use crate::args::CliOptions;
 use crate::args::CompileFlags;
-use crate::args::CompileFlagsExt;
 use crate::args::JavaScriptEngine;
 use crate::args::get_default_v8_flags;
+use crate::args::resolve_compile_target;
 use crate::cache::DenoDir;
 use crate::file_fetcher::CliFileFetcher;
 use crate::http_util::HttpClientProvider;
@@ -417,7 +417,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       self.get_base_binary(options.compile_flags).await?;
 
     if options.compile_flags.no_terminal {
-      let target = options.compile_flags.resolve_target();
+      let target = resolve_compile_target(options.compile_flags);
       if !target.contains("windows") {
         bail!(
           "The `--no-terminal` flag is only available when targeting Windows (current: {})",
@@ -428,7 +428,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
         .context("Setting windows binary to GUI.")?;
     }
     if options.compile_flags.icon.is_some() {
-      let target = options.compile_flags.resolve_target();
+      let target = resolve_compile_target(options.compile_flags);
       // Desktop builds handle icons during app bundle packaging.
       if !target.contains("windows") && !self.is_desktop {
         bail!(
@@ -475,7 +475,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       });
     }
 
-    let target = compile_flags.resolve_target();
+    let target = resolve_compile_target(compile_flags);
     let binary_name =
       runtime_archive_name("denort", &compile_flags.engine, &target);
 
@@ -538,7 +538,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       });
     }
 
-    let target = compile_flags.resolve_target();
+    let target = resolve_compile_target(compile_flags);
     let lib_ext = if target.contains("darwin") {
       "dylib"
     } else if target.contains("windows") {
@@ -1622,7 +1622,7 @@ fn write_binary_bytes(
   data_section_bytes: Vec<u8>,
   compile_flags: &CompileFlags,
 ) -> Result<(), AnyError> {
-  let target = compile_flags.resolve_target();
+  let target = resolve_compile_target(compile_flags);
   if target.contains("linux") {
     libsui::Elf::new(&original_bin).append(
       "d3n0l4nd",

--- a/cli/tools/bench/mod.rs
+++ b/cli/tools/bench/mod.rs
@@ -37,7 +37,7 @@ use tokio::sync::mpsc::unbounded_channel;
 use crate::args::BenchFlags;
 use crate::args::CliOptions;
 use crate::args::Flags;
-use crate::args::TypeCheckModeExt;
+use crate::args::graph_kind;
 use crate::colors;
 use crate::display::write_json_to_stdout;
 use crate::factory::CliFactory;
@@ -556,7 +556,7 @@ pub async fn run_benchmarks_with_watch(
 
         let _ = watcher_communicator.watch_paths(cli_options.watch_paths());
 
-        let graph_kind = cli_options.type_check_mode().as_graph_kind();
+        let graph_kind = graph_kind(cli_options.type_check_mode());
         let module_graph_creator = factory.module_graph_creator().await?;
         let members_with_bench_options =
           cli_options.resolve_bench_options_for_members(&bench_flags)?;

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -10,7 +10,7 @@ use deno_terminal::colors;
 use crate::args::CheckFlags;
 use crate::args::Flags;
 use crate::args::SyncTypesFlags;
-use crate::args::TypeCheckModeExt;
+use crate::args::graph_kind;
 use crate::factory::CliFactory;
 use crate::graph_util::GraphRootsValidOptions;
 use crate::tsc::Diagnostics;
@@ -102,7 +102,7 @@ async fn native_check(
     log::warn!("{} No matching files found.", colors::yellow("Warning"));
     return Ok(());
   }
-  let graph_kind = cli_options.type_check_mode().as_graph_kind();
+  let graph_kind = graph_kind(cli_options.type_check_mode());
   let imports = factory
     .module_graph_builder()
     .await?

--- a/cli/tools/pack/mod.rs
+++ b/cli/tools/pack/mod.rs
@@ -18,9 +18,9 @@ use deno_graph::ModuleGraph;
 use deno_terminal::colors;
 
 use crate::args::CliOptions;
-use crate::args::FileFlagsExt;
 use crate::args::Flags;
 use crate::args::PackFlags;
+use crate::args::resolve_file_patterns;
 use crate::factory::CliFactory;
 use crate::graph_util::CreatePublishGraphOptions;
 use crate::sys::CliSys;
@@ -290,7 +290,7 @@ fn collect_graph_modules(
   let mut paths = Vec::new();
 
   // Create file patterns from pack_flags
-  let file_patterns = pack_flags.files.as_file_patterns(package_dir)?;
+  let file_patterns = resolve_file_patterns(&pack_flags.files, package_dir)?;
 
   for module in graph.modules() {
     if let Module::Js(js_module) = module {
@@ -462,7 +462,7 @@ fn collect_asset_files(
   // The `--ignore`/`--exclude` CLI flags filter graph modules in
   // `collect_graph_modules`; apply the same patterns to assets so e.g.
   // `pack --ignore=tests/**` also drops asset files under `tests/`.
-  let cli_patterns = pack_flags.files.as_file_patterns(&package_dir)?;
+  let cli_patterns = resolve_file_patterns(&pack_flags.files, &package_dir)?;
 
   // Absolute paths that are already represented elsewhere in the tarball
   // and must not be packed again as raw assets.

--- a/cli/tools/pm/approve_scripts.rs
+++ b/cli/tools/pm/approve_scripts.rs
@@ -22,8 +22,8 @@ use jsonc_parser::json;
 
 use super::CacheTopLevelDepsOptions;
 use crate::args::ApproveScriptsFlags;
-use crate::args::DenoSubcommandExt;
 use crate::args::Flags;
+use crate::args::npm_system_info;
 use crate::factory::CliFactory;
 use crate::npm::CliNpmResolver;
 use crate::tools::pm::ConfigKind;
@@ -87,7 +87,7 @@ pub async fn approve_scripts(
     let npm_resolver = factory.npm_resolver().await?;
     let candidates = find_script_candidates(
       npm_resolver,
-      &flags.subcommand.npm_system_info(),
+      &npm_system_info(&flags.subcommand),
       &allow_list,
       &deny_reqs,
     )?;

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -69,7 +69,7 @@ use crate::args::CliOptions;
 use crate::args::Flags;
 use crate::args::TestFlags;
 use crate::args::TestReporterConfig;
-use crate::args::TypeCheckModeExt;
+use crate::args::graph_kind;
 use crate::colors;
 use crate::display;
 use crate::factory::CliFactory;
@@ -2316,7 +2316,7 @@ async fn filter_specifiers_by_changed(
   // mode uses, where the cost is amortized across reruns; for a one-shot
   // `--changed`/`--related` run it's an extra graph build we accept for now to
   // keep the filtering self-contained.
-  let graph_kind = cli_options.type_check_mode().as_graph_kind();
+  let graph_kind = graph_kind(cli_options.type_check_mode());
   let module_graph_creator = factory.module_graph_creator().await?;
   let graph_roots = specifiers_with_mode
     .iter()
@@ -2555,7 +2555,7 @@ pub async fn run_tests_with_watch(
           cli_options.resolve_workspace_test_options(&test_flags);
 
         let _ = watcher_communicator.watch_paths(cli_options.watch_paths());
-        let graph_kind = cli_options.type_check_mode().as_graph_kind();
+        let graph_kind = graph_kind(cli_options.type_check_mode());
         let log_level = cli_options.log_level();
         let cli_options = cli_options.clone();
         let module_graph_creator = factory.module_graph_creator().await?;


### PR DESCRIPTION
Stacked on #36489 -- please merge that first; this targets its branch so
the diff stays reviewable.

Splitting the flag types into `deno_cli_parser` left their behavior
behind in the CLI, and the orphan rule meant every method needed an
extension trait to hang off a foreign type. Four of those traits carried
exactly one method each, so `as_file_patterns`, `resolve_target`,
`npm_system_info` and `as_graph_kind` cost four public traits plus a
trait import at every call site. They become plain free functions.

`FlagsExt` stays a trait -- five cohesive methods on the central `Flags`
type, where method syntax earns its keep. Moving any of this into
`deno_cli_parser` instead was not an option: `resolve_target` needs the
CLI's build-time `TARGET`, `npm_system_info` reads an environment
variable the parser crate's clippy config forbids, and `as_graph_kind`
and `otel_config` need deno_graph and deno_telemetry, neither of which
it depends on.