### PR TITLE
fix(node): treat CJS-shaped .js files as CommonJS when required under type: module

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -2186,6 +2186,17 @@ impl<TGraphContainer: ModuleGraphContainer> NodeRequireLoader
       .is_maybe_cjs_from_require(specifier, media_type)
   }
 
+  fn is_maybe_cjs_from_require_with_source(
+    &self,
+    specifier: &ModuleSpecifier,
+    source: &str,
+  ) -> Result<bool, PackageJsonLoadError> {
+    let media_type = MediaType::from_specifier(specifier);
+    self
+      .cjs_tracker
+      .is_maybe_cjs_from_require_with_source(specifier, media_type, source)
+  }
+
   fn resolve_require_node_module_paths(&self, from: &Path) -> Vec<String> {
     let is_global_resolver_and_from_in_global_cache = self
       .npm_resolver

--- a/cli/rt/Cargo.toml
+++ b/cli/rt/Cargo.toml
@@ -49,7 +49,7 @@ deno_npm.workspace = true
 deno_npmrc.workspace = true
 deno_package_json = { workspace = true, features = ["sync"] }
 deno_path_util.workspace = true
-deno_resolver = { workspace = true, features = ["sync"] }
+deno_resolver = { workspace = true, features = ["deno_ast", "sync"] }
 deno_runtime.workspace = true
 deno_semver.workspace = true
 deno_snapshots.workspace = true

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -1171,6 +1171,18 @@ impl NodeRequireLoader for EmbeddedModuleLoader {
       .cjs_tracker
       .is_maybe_cjs_from_require(specifier, media_type)
   }
+
+  fn is_maybe_cjs_from_require_with_source(
+    &self,
+    specifier: &Url,
+    source: &str,
+  ) -> Result<bool, PackageJsonLoadError> {
+    let media_type = MediaType::from_specifier(specifier);
+    self
+      .shared
+      .cjs_tracker
+      .is_maybe_cjs_from_require_with_source(specifier, media_type, source)
+  }
 }
 
 struct StandaloneModuleLoaderFactory {

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -82,6 +82,16 @@ pub trait NodeRequireLoader {
     specifier: &Url,
   ) -> Result<bool, PackageJsonLoadError>;
 
+  /// Get if a module loaded via `require()` should first be compiled as CJS,
+  /// using the source that was already loaded for compilation.
+  fn is_maybe_cjs_from_require_with_source(
+    &self,
+    specifier: &Url,
+    _source: &str,
+  ) -> Result<bool, PackageJsonLoadError> {
+    self.is_maybe_cjs_from_require(specifier)
+  }
+
   fn resolve_require_node_module_paths(&self, from: &Path) -> Vec<String> {
     default_resolve_require_node_module_paths(from)
   }

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -682,13 +682,16 @@ deno_error::js_error_wrapper!(
 pub fn op_require_is_maybe_cjs(
   state: &mut OpState,
   #[string] filename: &str,
+  #[string] source: &str,
 ) -> Result<bool, JsPackageJsonLoadError> {
   let filename = Path::new(filename);
   let Ok(url) = url_from_file_path(filename) else {
     return Ok(false);
   };
   let loader = state.borrow::<NodeRequireLoaderRc>();
-  loader.is_maybe_cjs_from_require(&url).map_err(Into::into)
+  loader
+    .is_maybe_cjs_from_require_with_source(&url, source)
+    .map_err(Into::into)
 }
 
 #[op2(stack_trace)]

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -2211,7 +2211,9 @@ Module._extensions[".wasm"] = loadESMFromCJS;
 
 function loadMaybeCjs(module, filename) {
   const content = op_require_read_file(filename);
-  const format = op_require_is_maybe_cjs(filename) ? undefined : "module";
+  const format = op_require_is_maybe_cjs(filename, content)
+    ? undefined
+    : "module";
   module._compile(content, filename, format);
 }
 

--- a/libs/resolver/cjs/analyzer/deno_ast.rs
+++ b/libs/resolver/cjs/analyzer/deno_ast.rs
@@ -9,11 +9,13 @@ use deno_ast::ProgramRef;
 use deno_ast::swc::ast::AssignOp;
 use deno_ast::swc::ast::AssignTarget;
 use deno_ast::swc::ast::CallExpr;
+use deno_ast::swc::ast::Decl;
 use deno_ast::swc::ast::Expr;
 use deno_ast::swc::ast::Lit;
 use deno_ast::swc::ast::MemberExpr;
 use deno_ast::swc::ast::MemberProp;
 use deno_ast::swc::ast::ModuleItem;
+use deno_ast::swc::ast::Pat;
 use deno_ast::swc::ast::SimpleAssignTarget;
 use deno_ast::swc::ast::Stmt;
 use deno_error::JsErrorBox;
@@ -22,6 +24,96 @@ use url::Url;
 
 use super::ModuleExportAnalyzer;
 use crate::cache::ParsedSourceCacheRc;
+
+pub fn is_cjs_shaped_source(
+  specifier: &Url,
+  media_type: MediaType,
+  source: &str,
+) -> bool {
+  if media_type != MediaType::JavaScript {
+    return false;
+  }
+  let source = source.strip_prefix('\u{FEFF}').unwrap_or(source);
+  let Ok(parsed_source) = deno_ast::parse_program(deno_ast::ParseParams {
+    specifier: specifier.clone(),
+    text: source.into(),
+    media_type,
+    capture_tokens: false,
+    scope_analysis: false,
+    maybe_syntax: None,
+  }) else {
+    return false;
+  };
+  if !parsed_source.compute_is_script() {
+    return false;
+  }
+
+  match parsed_source.program_ref() {
+    ProgramRef::Module(module) => {
+      let statements = module.body.iter().filter_map(|item| match item {
+        ModuleItem::Stmt(stmt) => Some(stmt),
+        ModuleItem::ModuleDecl(_) => None,
+      });
+      is_cjs_shaped_statements(statements)
+    }
+    ProgramRef::Script(script) => is_cjs_shaped_statements(script.body.iter()),
+  }
+}
+
+fn is_cjs_shaped_statements<'a>(
+  statements: impl Iterator<Item = &'a Stmt>,
+) -> bool {
+  let statements: Vec<_> = statements.collect();
+  if statements.iter().any(|stmt| declares_node_global(stmt)) {
+    return false;
+  }
+  statements.iter().copied().any(is_cjs_shaped_stmt)
+}
+
+fn declares_node_global(stmt: &Stmt) -> bool {
+  let Stmt::Decl(decl) = stmt else {
+    return false;
+  };
+  match decl {
+    Decl::Fn(decl) => is_node_global(&decl.ident.sym),
+    Decl::Class(decl) => is_node_global(&decl.ident.sym),
+    Decl::Var(decl) => decl.decls.iter().any(|declarator| {
+      matches!(
+        &declarator.name,
+        Pat::Ident(binding) if is_node_global(&binding.id.sym)
+      )
+    }),
+    _ => false,
+  }
+}
+
+fn is_node_global(name: &str) -> bool {
+  matches!(name, "require" | "module" | "exports")
+}
+
+fn is_cjs_shaped_stmt(stmt: &Stmt) -> bool {
+  match stmt {
+    Stmt::Expr(expr_stmt) => is_cjs_shaped_expr(&expr_stmt.expr),
+    Stmt::Decl(Decl::Var(var_decl)) => var_decl
+      .decls
+      .iter()
+      .any(|decl| decl.init.as_deref().is_some_and(is_cjs_shaped_expr)),
+    _ => false,
+  }
+}
+
+fn is_cjs_shaped_expr(expr: &Expr) -> bool {
+  if matches!(expr, Expr::Call(call) if matches!(&call.callee, deno_ast::swc::ast::Callee::Expr(callee) if matches!(&**callee, Expr::Ident(ident) if ident.sym == "require")))
+  {
+    return true;
+  }
+  let Expr::Assign(assign) = expr else {
+    return false;
+  };
+  assign.op == AssignOp::Assign
+    && matches!(&assign.left, AssignTarget::Simple(SimpleAssignTarget::Member(member))
+      if is_module_exports_member(member) || exports_member_name(member).is_some())
+}
 
 pub struct DenoAstModuleExportAnalyzer {
   parsed_source_cache: ParsedSourceCacheRc,
@@ -307,5 +399,69 @@ fn call_expr_require_spec(call: &CallExpr) -> Option<String> {
   match arg.expr.as_lit()? {
     Lit::Str(s) => s.value.as_str().map(|s| s.to_string()),
     _ => None,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn is_cjs(source: &str) -> bool {
+    is_cjs_shaped_source(
+      &Url::parse("file:///package/index.js").unwrap(),
+      MediaType::JavaScript,
+      source,
+    )
+  }
+
+  #[test]
+  fn detects_top_level_cjs_shapes() {
+    for source in [
+      "require(\"./dep.js\");",
+      "module.exports = {};",
+      "module.exports.hello = require(\"./dep.js\").hello;",
+      "exports.hello = 1;",
+    ] {
+      assert!(is_cjs(source), "{source}");
+    }
+  }
+
+  #[test]
+  fn ignores_nested_cjs_shapes() {
+    for source in [
+      "function load() { require(\"./dep.js\"); }",
+      "const load = () => { module.exports = {}; }",
+      "class Loader { load() { exports.hello = 1; } }",
+    ] {
+      assert!(!is_cjs(source), "{source}");
+    }
+  }
+
+  #[test]
+  fn ignores_esm_and_textual_matches() {
+    for source in [
+      "export const value = 1;",
+      "import value from \"./dep.js\";",
+      "const text = \"module.exports = 1\";",
+      "// require(\"./dep.js\")",
+      "const text = `exports.value = 1`;",
+      "const require = customRequire; require(\"./dep.js\");",
+      "const module = {}; module.exports = {};",
+      "const exports = {}; exports.value = 1;",
+      "const object = { load() { require(\"./dep.js\"); } };",
+    ] {
+      assert!(!is_cjs(source), "{source}");
+    }
+  }
+
+  #[test]
+  fn handles_bom_parse_errors_and_media_types() {
+    assert!(is_cjs("\u{FEFF}module.exports = 1;"));
+    assert!(!is_cjs("module.exports ="));
+    assert!(!is_cjs_shaped_source(
+      &Url::parse("file:///package/index.ts").unwrap(),
+      MediaType::TypeScript,
+      "module.exports = 1;",
+    ));
   }
 }

--- a/libs/resolver/cjs/analyzer/mod.rs
+++ b/libs/resolver/cjs/analyzer/mod.rs
@@ -25,6 +25,8 @@ mod deno_ast;
 
 #[cfg(feature = "deno_ast")]
 pub use deno_ast::DenoAstModuleExportAnalyzer;
+#[cfg(feature = "deno_ast")]
+pub use deno_ast::is_cjs_shaped_source;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModuleExportsAndReExports {

--- a/libs/resolver/cjs/mod.rs
+++ b/libs/resolver/cjs/mod.rs
@@ -76,6 +76,50 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: FsRead + FsMetadata>
       .map(|mode| mode == ResolutionMode::Require)
   }
 
+  /// Checks whether a file loaded via `require()` should be compiled as
+  /// CommonJS using the source already loaded by the require implementation.
+  /// This only overrides an explicit `"type": "module"` decision for a
+  /// JavaScript file with a positive top-level CommonJS shape.
+  pub fn is_maybe_cjs_from_require_with_source(
+    &self,
+    specifier: &Url,
+    media_type: MediaType,
+    source: &str,
+  ) -> Result<bool, PackageJsonLoadError> {
+    let mode = self
+      .is_cjs_resolver
+      .check_for_require(specifier, media_type)?;
+    if mode == ResolutionMode::Require {
+      return Ok(true);
+    }
+    if media_type != MediaType::JavaScript {
+      return Ok(false);
+    }
+    let Ok(path) = deno_path_util::url_to_file_path(specifier) else {
+      return Ok(false);
+    };
+    let Some(pkg_json) = self
+      .is_cjs_resolver
+      .pkg_json_resolver
+      .get_closest_package_json(&path)?
+    else {
+      return Ok(false);
+    };
+    if pkg_json.typ != "module" || path.extension().is_none() {
+      return Ok(false);
+    }
+
+    #[cfg(feature = "deno_ast")]
+    return Ok(analyzer::is_cjs_shaped_source(
+      specifier, media_type, source,
+    ));
+    #[cfg(not(feature = "deno_ast"))]
+    {
+      let _ = (specifier, source);
+      Ok(false)
+    }
+  }
+
   /// Mark a file as being known CJS or ESM.
   pub fn set_is_known_script(&self, specifier: &Url, is_script: bool) {
     let new_value = if is_script {
@@ -353,6 +397,10 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: FsRead + FsMetadata>
     }
   }
 
+  /// Gets the initial resolution mode for a file loaded via `require()`.
+  /// Ambiguous files in a `"type": "module"` package are initially ESM;
+  /// callers with source available may apply the require-only CJS-shape
+  /// fallback in [`CjsTracker::is_maybe_cjs_from_require_with_source`].
   fn check_for_require(
     &self,
     specifier: &Url,

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/__test__.jsonc
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/__test__.jsonc
@@ -1,0 +1,16 @@
+{
+  "tests": {
+    "require_cjs_shaped": {
+      "args": "run -A require_cjs_shaped.cjs",
+      "output": "require_cjs_shaped.out"
+    },
+    "require_esm": {
+      "args": "run -A require_esm.cjs",
+      "output": "require_esm.out"
+    },
+    "import_esm": {
+      "args": "run -A import_esm.mjs",
+      "output": "import_esm.out"
+    }
+  }
+}

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/cjs-shaped.js
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/cjs-shaped.js
@@ -1,0 +1,1 @@
+module.exports.hello = require("./dep.cjs").hello;

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/dep.cjs
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/dep.cjs
@@ -1,0 +1,1 @@
+exports.hello = "hello from cjs";

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/esm.js
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/esm.js
@@ -1,0 +1,1 @@
+export const value = "hello from esm";

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/import_esm.mjs
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/import_esm.mjs
@@ -1,0 +1,2 @@
+import { value } from "./esm.js";
+console.log(value);

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/import_esm.out
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/import_esm.out
@@ -1,0 +1,1 @@
+hello from esm

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/package.json
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/require_cjs_shaped.cjs
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/require_cjs_shaped.cjs
@@ -1,0 +1,2 @@
+const mod = require("./cjs-shaped.js");
+console.log(mod.hello);

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/require_cjs_shaped.out
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/require_cjs_shaped.out
@@ -1,0 +1,1 @@
+hello from cjs

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/require_esm.cjs
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/require_esm.cjs
@@ -1,0 +1,2 @@
+const mod = require("./esm.js");
+console.log(mod.value);

--- a/tests/specs/node/require_js_package_type_module_cjs_shaped/require_esm.out
+++ b/tests/specs/node/require_js_package_type_module_cjs_shaped/require_esm.out
@@ -1,0 +1,1 @@
+hello from esm


### PR DESCRIPTION
### Summary

`require()` of a `.js` file under `"type": "module"` was unconditionally treated as ESM via `IsCjsResolver::check_for_require`, ignoring file content.

This breaks native-addon wrappers such as:

```js
module.exports.hello = require("./build/Release/addon.node").hello;
```

when they ship CJS-shaped `.js` files under `"type": "module"`.

Node.js handles this case, but Deno threw:

```text
require is not defined
```

### Root Cause

`libs/resolver/cjs/mod.rs:check_for_require` returned `Import` for any `.js` file with an extension under `"type": "module"`.

`op_require_is_maybe_cjs` only received the filename, not the already-loaded source available in `loadMaybeCjs`.

### Solution

Add a require-only, source-aware fallback. This does **not** change the general ESM graph.

* `libs/resolver/cjs/analyzer/deno_ast.rs`

  * Add `is_cjs_shaped_source()`.
  * Requires `compute_is_script() == true`.
  * Detects top-level:

    * `require(...)`
    * `module.exports`
    * `exports.x`
    * `module.exports.x`
  * Uses direct AST inspection rather than regex.
  * Skips functions, classes, arrow functions, and object methods.
  * Ignores comments and strings.
  * Handles top-level shadowing of `require`, `module`, and `exports`.
  * Strips BOM.
  * Returns `false` on parse errors.

* `libs/resolver/cjs/mod.rs`

  * Add `is_maybe_cjs_from_require_with_source()`.
  * Document the behavior of `check_for_require`.
  * Apply the source-aware fallback only for `MediaType::JavaScript` files under `"type": "module"` that have an extension.
  * Do not write the result to `CjsTracker::known`.

* `ext/node/lib.rs`

  * Add the `is_maybe_cjs_from_require_with_source()` trait method with a default fallback.

* `ext/node/ops/require.rs`

  * Update `op_require_is_maybe_cjs(filename, source)` to thread the source through.

* `ext/node/polyfills/01_require.js`

  * Pass `content` from `loadMaybeCjs` to the op.

* `cli/rt/run.rs` and `cli/module_loader.rs`

  * Implement the override via `CjsTracker`.

* `cli/rt/Cargo.toml`

  * Enable the `deno_resolver/deno_ast` feature for `denort`.

`.mjs`, `.cjs`, `.mts`, `.cts`, `.json`, `.wasm`, and extensionless files are unaffected.

### Testing

* Added `tests/specs/node/require_js_package_type_module_cjs_shaped` with three cases:

  * `require_cjs_shaped`
  * `require_esm`
  * `import_esm`
* Verifies that the CJS wrapper works while genuine ESM such as `export const value` remains ESM through both `require()` and `import`.
* Existing specs pass:

  * `require_js_package_no_type`
  * `esm_import_node_addon`
  * `require_esm*`
* `cargo check -p deno_resolver --features deno_ast` passes.

### Checklist

* [x] `cargo fmt` clean
* [x] JS checked with `deno fmt`
* [x] Feature-gated with `#[cfg(feature = "deno_ast")]`
* [x] Non-AST builds return `false`
