### PR TITLE
fix(http): truncate streaming responses to content length

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -3945,6 +3945,20 @@ fn abort_raw_response_body(body: &mut ResponseBytesInner) {
   std::mem::take(body).abort();
 }
 
+fn limit_fixed_response_chunk<'a>(
+  chunk: &'a [u8],
+  remaining: &mut Option<u64>,
+) -> (&'a [u8], bool) {
+  let Some(remaining) = remaining else {
+    return (chunk, false);
+  };
+  let write_len = chunk
+    .len()
+    .min(usize::try_from(*remaining).unwrap_or(usize::MAX));
+  *remaining -= write_len as u64;
+  (&chunk[..write_len], *remaining == 0)
+}
+
 struct RawResponseBodyFinishGuard {
   record: Rc<RawHttpRecord>,
   active: bool,
@@ -3991,6 +4005,7 @@ where
     && !raw_response_has_transfer_encoding(&parts))
   .then(|| raw_response_content_length(&parts))
   .flatten();
+  let mut remaining = content_length;
   if context.head {
     conn
       .write_response_with_scratch(
@@ -4036,6 +4051,12 @@ where
       finish.finish(false);
       return Err(error.into());
     }
+  }
+  if remaining == Some(0) {
+    abort_raw_response_body(&mut body);
+    conn.finish_response_with_scratch(scratch, &[]).await?;
+    finish.finish(true);
+    return Ok(());
   }
   loop {
     let event = poll_fn(|cx| {
@@ -4086,12 +4107,12 @@ where
         return Ok(());
       }
       RawResponseBodyEvent::Frame(ResponseStreamResult::NonEmptyBuf(chunk)) => {
+        let (chunk, fixed_body_complete) =
+          limit_fixed_response_chunk(&chunk, &mut remaining);
         let result = if content_length.is_some() {
-          conn.write_response_body_with_scratch(&chunk).await
+          conn.write_response_body_with_scratch(chunk).await
         } else {
-          conn
-            .write_response_chunk_with_scratch(scratch, &chunk)
-            .await
+          conn.write_response_chunk_with_scratch(scratch, chunk).await
         };
         if let Err(error) = result {
           abort_raw_response_body(&mut body);
@@ -4099,6 +4120,12 @@ where
           return Err(error.into());
         }
         finish.record.add_otel_response_size(chunk.len());
+        if fixed_body_complete {
+          abort_raw_response_body(&mut body);
+          conn.finish_response_with_scratch(scratch, &[]).await?;
+          finish.finish(true);
+          return Ok(());
+        }
       }
       RawResponseBodyEvent::Frame(ResponseStreamResult::NoData) => continue,
       RawResponseBodyEvent::Frame(ResponseStreamResult::Error(error)) => {
@@ -4131,6 +4158,7 @@ where
     && !raw_response_has_transfer_encoding(&parts))
   .then(|| raw_response_content_length(&parts))
   .flatten();
+  let mut remaining = content_length;
   if context.head {
     let mut writer = h1::SharedResponseWriter::new(h1::Response {
       version: context.version,
@@ -4184,6 +4212,20 @@ where
     })
     .await
     .inspect_err(|_| abort_raw_response_body(&mut body))?;
+  }
+  if remaining == Some(0) {
+    abort_raw_response_body(&mut body);
+    let mut end = h1::SharedResponseEndWriter::new(&[]);
+    poll_fn(|cx| {
+      let mut conn = conn.borrow_mut();
+      let Some(conn) = conn.as_mut() else {
+        return Poll::Ready(Err(raw_h1_connection_closed()));
+      };
+      conn.poll_finish_response(cx, &mut end)
+    })
+    .await?;
+    finish.finish(true);
+    return Ok(());
   }
   loop {
     let event = poll_fn(|cx| {
@@ -4252,8 +4294,10 @@ where
         return Ok(());
       }
       RawResponseBodyEvent::Frame(ResponseStreamResult::NonEmptyBuf(chunk)) => {
+        let (chunk, fixed_body_complete) =
+          limit_fixed_response_chunk(&chunk, &mut remaining);
         let result = if content_length.is_some() {
-          let mut writer = h1::SharedResponseBodyWriter::new(&chunk);
+          let mut writer = h1::SharedResponseBodyWriter::new(chunk);
           poll_fn(|cx| {
             let mut conn = conn.borrow_mut();
             let Some(conn) = conn.as_mut() else {
@@ -4263,7 +4307,7 @@ where
           })
           .await
         } else {
-          let mut writer = h1::SharedResponseChunkWriter::new(&chunk);
+          let mut writer = h1::SharedResponseChunkWriter::new(chunk);
           poll_fn(|cx| {
             let mut conn = conn.borrow_mut();
             let Some(conn) = conn.as_mut() else {
@@ -4279,6 +4323,20 @@ where
           return Err(error);
         }
         finish.record.add_otel_response_size(chunk.len());
+        if fixed_body_complete {
+          abort_raw_response_body(&mut body);
+          let mut end = h1::SharedResponseEndWriter::new(&[]);
+          poll_fn(|cx| {
+            let mut conn = conn.borrow_mut();
+            let Some(conn) = conn.as_mut() else {
+              return Poll::Ready(Err(raw_h1_connection_closed()));
+            };
+            conn.poll_finish_response(cx, &mut end)
+          })
+          .await?;
+          finish.finish(true);
+          return Ok(());
+        }
       }
       RawResponseBodyEvent::Frame(ResponseStreamResult::NoData) => continue,
       RawResponseBodyEvent::Frame(ResponseStreamResult::Error(error)) => {

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -3986,6 +3986,24 @@ impl Drop for RawResponseBodyFinishGuard {
   }
 }
 
+async fn finish_h1_stream_response_shared<I>(
+  conn: &RawH1ConnectionCell<I>,
+  trailers: &[h1::Header<'_>],
+) -> Result<(), HttpNextError>
+where
+  I: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+  let mut end = h1::SharedResponseEndWriter::new(trailers);
+  poll_fn(|cx| {
+    let mut conn = conn.borrow_mut();
+    let Some(conn) = conn.as_mut() else {
+      return Poll::Ready(Err(raw_h1_connection_closed()));
+    };
+    conn.poll_finish_response(cx, &mut end)
+  })
+  .await
+}
+
 async fn write_h1_stream_response<I>(
   conn: &mut h1::SharedConn<I>,
   scratch: &mut h1::SharedScratch,
@@ -4215,15 +4233,7 @@ where
   }
   if remaining == Some(0) {
     abort_raw_response_body(&mut body);
-    let mut end = h1::SharedResponseEndWriter::new(&[]);
-    poll_fn(|cx| {
-      let mut conn = conn.borrow_mut();
-      let Some(conn) = conn.as_mut() else {
-        return Poll::Ready(Err(raw_h1_connection_closed()));
-      };
-      conn.poll_finish_response(cx, &mut end)
-    })
-    .await?;
+    finish_h1_stream_response_shared(&conn, &[]).await?;
     finish.finish(true);
     return Ok(());
   }
@@ -4281,15 +4291,7 @@ where
         } else {
           trailers.as_slice()
         };
-        let mut end = h1::SharedResponseEndWriter::new(trailers);
-        poll_fn(|cx| {
-          let mut conn = conn.borrow_mut();
-          let Some(conn) = conn.as_mut() else {
-            return Poll::Ready(Err(raw_h1_connection_closed()));
-          };
-          conn.poll_finish_response(cx, &mut end)
-        })
-        .await?;
+        finish_h1_stream_response_shared(&conn, trailers).await?;
         finish.finish(true);
         return Ok(());
       }
@@ -4325,15 +4327,7 @@ where
         finish.record.add_otel_response_size(chunk.len());
         if fixed_body_complete {
           abort_raw_response_body(&mut body);
-          let mut end = h1::SharedResponseEndWriter::new(&[]);
-          poll_fn(|cx| {
-            let mut conn = conn.borrow_mut();
-            let Some(conn) = conn.as_mut() else {
-              return Poll::Ready(Err(raw_h1_connection_closed()));
-            };
-            conn.poll_finish_response(cx, &mut end)
-          })
-          .await?;
+          finish_h1_stream_response_shared(&conn, &[]).await?;
           finish.finish(true);
           return Ok(());
         }

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -3120,14 +3120,30 @@ Deno.test(
 
     const port = (server.addr as Deno.NetAddr).port;
     const encoder = new TextEncoder();
-    async function readToEnd(conn: Deno.Conn): Promise<string> {
+    async function readToEnd(
+      conn: Deno.Conn,
+      pendingRequestBodyAfter?: number,
+    ): Promise<string> {
       const decoder = new TextDecoder();
       let raw = "";
+      let requestBodySent = false;
       while (true) {
         const chunk = new Uint8Array(1024);
         const read = await conn.read(chunk);
         if (read === null) break;
         raw += decoder.decode(chunk.subarray(0, read), { stream: true });
+        const separator = raw.indexOf("\r\n\r\n");
+        if (
+          pendingRequestBodyAfter !== undefined &&
+          !requestBodySent &&
+          separator >= 0 &&
+          raw.length >= separator + 4 + pendingRequestBodyAfter
+        ) {
+          // Keep the body pending until the response is complete so this
+          // exercises the shared writer, then unblock the server's drain.
+          await writeAll(conn, encoder.encode("x"));
+          requestBodySent = true;
+        }
       }
       return raw + decoder.decode();
     }
@@ -3156,7 +3172,10 @@ Deno.test(
     ) {
       const conn = await Deno.connect({ hostname: "127.0.0.1", port });
       await writeAll(conn, encoder.encode(request));
-      const raw = await readToEnd(conn);
+      const raw = await readToEnd(
+        conn,
+        request.startsWith("POST") ? expectedBody.length : undefined,
+      );
       conn.close();
 
       const separator = raw.indexOf("\r\n\r\n");

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -3091,6 +3091,68 @@ createServerLengthTest("fixedResponseKnownEmpty", {
   expectsConnLen: true,
 });
 
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerTruncatesStreamingResponseToContentLength() {
+    const payload = "x".repeat(5_000);
+    const ac = new AbortController();
+    await using server = Deno.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      signal: ac.signal,
+      onListen() {},
+      handler: () => {
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(payload));
+            controller.close();
+          },
+        });
+        return new Response(stream, {
+          headers: { "content-length": "70" },
+        });
+      },
+    });
+
+    const port = (server.addr as Deno.NetAddr).port;
+    // The POST leaves its request body unread so the shared connection writer
+    // takes the same overflow path as the normal GET response writer.
+    for (
+      const request of [
+        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        "POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 1\r\nConnection: close\r\n\r\n",
+      ]
+    ) {
+      const conn = await Deno.connect({ hostname: "127.0.0.1", port });
+      await conn.write(new TextEncoder().encode(request));
+
+      const decoder = new TextDecoder();
+      let raw = "";
+      while (true) {
+        const chunk = new Uint8Array(1024);
+        const read = await conn.read(chunk);
+        if (read === null) break;
+        raw += decoder.decode(chunk.subarray(0, read), { stream: true });
+        const separator = raw.indexOf("\r\n\r\n");
+        if (separator >= 0 && raw.length >= separator + 4 + 70) break;
+      }
+      raw += decoder.decode();
+      conn.close();
+
+      const separator = raw.indexOf("\r\n\r\n");
+      assert(separator > 0);
+      assertStringIncludes(
+        raw.slice(0, separator).toLowerCase(),
+        "content-length: 70",
+      );
+      assertEquals(raw.slice(separator + 4), "x".repeat(70));
+    }
+
+    ac.abort();
+    await server.finished;
+  },
+);
+
 createServerLengthTest("chunkedRespondKnown", {
   headers: { "transfer-encoding": "chunked" },
   body: "foo bar baz",

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -3101,7 +3101,7 @@ Deno.test(
       port: 0,
       signal: ac.signal,
       onListen() {},
-      handler: () => {
+      handler: (request) => {
         const stream = new ReadableStream<Uint8Array>({
           start(controller) {
             controller.enqueue(new TextEncoder().encode(payload));
@@ -3109,23 +3109,18 @@ Deno.test(
           },
         });
         return new Response(stream, {
-          headers: { "content-length": "70" },
+          headers: {
+            "content-length": new URL(request.url).pathname === "/zero"
+              ? "0"
+              : "70",
+          },
         });
       },
     });
 
     const port = (server.addr as Deno.NetAddr).port;
-    // The POST leaves its request body unread so the shared connection writer
-    // takes the same overflow path as the normal GET response writer.
-    for (
-      const request of [
-        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
-        "POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 1\r\nConnection: close\r\n\r\n",
-      ]
-    ) {
-      const conn = await Deno.connect({ hostname: "127.0.0.1", port });
-      await conn.write(new TextEncoder().encode(request));
-
+    const encoder = new TextEncoder();
+    async function readToEnd(conn: Deno.Conn): Promise<string> {
       const decoder = new TextDecoder();
       let raw = "";
       while (true) {
@@ -3133,20 +3128,68 @@ Deno.test(
         const read = await conn.read(chunk);
         if (read === null) break;
         raw += decoder.decode(chunk.subarray(0, read), { stream: true });
-        const separator = raw.indexOf("\r\n\r\n");
-        if (separator >= 0 && raw.length >= separator + 4 + 70) break;
       }
-      raw += decoder.decode();
+      return raw + decoder.decode();
+    }
+
+    // The POST leaves its request body unread so the shared connection writer
+    // takes the same fixed-length path as the normal GET response writer.
+    for (
+      const [request, expectedBody] of [
+        [
+          "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+          "x".repeat(70),
+        ],
+        [
+          "POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 1\r\nConnection: close\r\n\r\n",
+          "x".repeat(70),
+        ],
+        [
+          "GET /zero HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+          "",
+        ],
+        [
+          "POST /zero HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 1\r\nConnection: close\r\n\r\n",
+          "",
+        ],
+      ]
+    ) {
+      const conn = await Deno.connect({ hostname: "127.0.0.1", port });
+      await writeAll(conn, encoder.encode(request));
+      const raw = await readToEnd(conn);
       conn.close();
 
       const separator = raw.indexOf("\r\n\r\n");
       assert(separator > 0);
       assertStringIncludes(
         raw.slice(0, separator).toLowerCase(),
-        "content-length: 70",
+        `content-length: ${expectedBody.length}`,
       );
-      assertEquals(raw.slice(separator + 4), "x".repeat(70));
+      assertEquals(raw.slice(separator + 4), expectedBody);
     }
+
+    const conn = await Deno.connect({ hostname: "127.0.0.1", port });
+    await writeAll(
+      conn,
+      encoder.encode(
+        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n" +
+          "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+      ),
+    );
+    const raw = await readToEnd(conn);
+    conn.close();
+
+    const firstHeaderEnd = raw.indexOf("\r\n\r\n");
+    assert(firstHeaderEnd > 0);
+    const secondResponse = raw.indexOf("HTTP/1.1 200 OK", firstHeaderEnd + 4);
+    assert(secondResponse > firstHeaderEnd);
+    assertEquals(
+      raw.slice(firstHeaderEnd + 4, secondResponse),
+      "x".repeat(70),
+    );
+    const secondHeaderEnd = raw.indexOf("\r\n\r\n", secondResponse);
+    assert(secondHeaderEnd > secondResponse);
+    assertEquals(raw.slice(secondHeaderEnd + 4), "x".repeat(70));
 
     ac.abort();
     await server.finished;


### PR DESCRIPTION
Fixes #36456

## What

- Truncate streaming Deno.serve response chunks to the remaining declared Content-Length.
- Finish the fixed-length response and cancel the excess stream once that length is reached, including zero-length responses.
- Cover both the normal and shared HTTP/1 response writers.
- Verify that truncated fixed-length responses do not corrupt a reused HTTP/1 connection.

## Why

The Deno-owned HTTP/1 path rejected an oversized stream chunk before writing any of it. When the first stream chunk exceeded Content-Length, clients received the response head but zero body bytes. This restores the pre-2.8.3 behavior by writing the valid prefix up to the declared length.

## Validation

- ./tools/format.js --check ext/http/http_next.rs tests/unit/serve_test.ts
- deno lint tests/unit/serve_test.ts
- CARGO_INCREMENTAL=0 cargo clippy -j 2 -p deno_http -F deno_core/quickjs --lib -- -D warnings
- CARGO_INCREMENTAL=0 cargo test -j 2 -p deno_http -F deno_core/quickjs --lib (45 passed)
- CARGO_INCREMENTAL=0 cargo test -j 2 -p deno_http_h1 --lib (83 passed)