### PR TITLE
fix(fs): require write permission for creating opens

### DIFF
--- a/ext/fs/interface.rs
+++ b/ext/fs/interface.rs
@@ -14,6 +14,7 @@ use deno_maybe_sync::MaybeSend;
 use deno_maybe_sync::MaybeSync;
 use deno_permissions::CheckedPath;
 use deno_permissions::CheckedPathBuf;
+use deno_permissions::OpenAccessKind;
 use serde::Deserialize;
 
 #[derive(FromV8, Default, Debug, Clone, Copy)]
@@ -67,6 +68,23 @@ impl OpenOptions {
       mode,
     }
   }
+
+  pub fn access_kind(&self) -> OpenAccessKind {
+    // If neither write access mode is set, the file is opened for reading.
+    // This also covers read-only opens that carry creation flags.
+    let read = self.read || (!self.write && !self.append);
+    let write = self.write
+      || self.append
+      || self.create
+      || self.create_new
+      || self.truncate;
+
+    match (read, write) {
+      (true, true) => OpenAccessKind::ReadWrite,
+      (false, true) => OpenAccessKind::Write,
+      (true, false) | (false, false) => OpenAccessKind::Read,
+    }
+  }
 }
 
 impl From<i32> for OpenOptions {
@@ -108,17 +126,56 @@ impl From<i32> for OpenOptions {
       options.custom_flags = Some(flags);
     }
 
-    if !options.append
-      && !options.create
-      && !options.create_new
-      && !options.read
-      && !options.truncate
-      && !options.write
-    {
+    // O_RDONLY is zero, so no explicit access-mode bit remains to detect.
+    // Other flags, such as O_CREAT, do not change that read access mode.
+    if !options.read && !options.write {
       options.read = true;
     }
 
     Self { ..options }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn read_only_create_flags_require_read_and_write_access() {
+    let options = OpenOptions::from(libc::O_RDONLY | libc::O_CREAT);
+
+    assert!(options.read);
+    assert!(options.create);
+    assert_eq!(options.access_kind(), OpenAccessKind::ReadWrite);
+  }
+
+  #[test]
+  fn every_mutating_option_requires_write_access() {
+    for options in [
+      OpenOptions {
+        create: true,
+        ..Default::default()
+      },
+      OpenOptions {
+        create_new: true,
+        ..OpenOptions::read()
+      },
+      OpenOptions {
+        truncate: true,
+        ..OpenOptions::read()
+      },
+    ] {
+      assert_eq!(options.access_kind(), OpenAccessKind::ReadWrite);
+    }
+  }
+
+  #[test]
+  fn ordinary_read_and_write_access_are_unchanged() {
+    assert_eq!(OpenOptions::read().access_kind(), OpenAccessKind::Read);
+    assert_eq!(
+      OpenOptions::write(false, false, false, None).access_kind(),
+      OpenAccessKind::Write
+    );
   }
 }
 

--- a/ext/fs/ops.rs
+++ b/ext/fs/ops.rs
@@ -112,16 +112,6 @@ impl Resource for ReadDirResource {
   }
 }
 
-fn open_options_to_access_kind(open_options: &OpenOptions) -> OpenAccessKind {
-  let read = open_options.read;
-  let write = open_options.write || open_options.append;
-  match (read, write) {
-    (true, true) => OpenAccessKind::ReadWrite,
-    (false, true) => OpenAccessKind::Write,
-    (true, false) | (false, false) => OpenAccessKind::Read,
-  }
-}
-
 #[op2]
 #[string]
 pub fn op_fs_cwd(state: &mut OpState) -> Result<String, FsOpsError> {
@@ -213,7 +203,7 @@ pub fn op_fs_open_sync(
     .borrow_mut::<deno_permissions::PermissionsContainer>()
     .check_open(
       Cow::Borrowed(path),
-      open_options_to_access_kind(&options),
+      options.access_kind(),
       Some("Deno.openSync()"),
     )?;
   let file = fs.open_sync(&path, options).context_path("open", &path)?;
@@ -244,7 +234,7 @@ pub async fn op_fs_open_async(
         .borrow_mut::<deno_permissions::PermissionsContainer>()
         .check_open(
           Cow::Owned(path),
-          open_options_to_access_kind(&options),
+          options.access_kind(),
           Some("Deno.open()"),
         )?,
     )
@@ -1552,7 +1542,7 @@ pub fn op_fs_read_file_sync(
     .borrow::<deno_permissions::PermissionsContainer>()
     .check_open(
       Cow::Borrowed(path),
-      open_options_to_access_kind(&options),
+      options.access_kind(),
       Some("Deno.readFileSync()"),
     )?;
 
@@ -1586,7 +1576,7 @@ pub async fn op_fs_read_file_async(
       .borrow::<deno_permissions::PermissionsContainer>()
       .check_open(
         Cow::Owned(path),
-        open_options_to_access_kind(&options),
+        options.access_kind(),
         Some("Deno.readFile()"),
       )?;
     (state.borrow::<FileSystemRc>().clone(), cancel_handle, path)

--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -351,16 +351,6 @@ fn get_open_options(flags: i32, mode: Option<u32>) -> OpenOptions {
   options
 }
 
-fn open_options_to_access_kind(open_options: &OpenOptions) -> OpenAccessKind {
-  let read = open_options.read;
-  let write = open_options.write || open_options.append || open_options.create;
-  match (read, write) {
-    (true, true) => OpenAccessKind::ReadWrite,
-    (false, true) => OpenAccessKind::Write,
-    (true, false) | (false, false) => OpenAccessKind::Read,
-  }
-}
-
 #[op2(fast, stack_trace)]
 #[smi]
 pub fn op_node_open_sync(
@@ -375,7 +365,7 @@ pub fn op_node_open_sync(
   let fs = state.borrow::<FileSystemRc>().clone();
   let path = state.borrow_mut::<PermissionsContainer>().check_open(
     Cow::Borrowed(path),
-    open_options_to_access_kind(&options),
+    options.access_kind(),
     Some("node:fs.openSync"),
   )?;
 
@@ -438,7 +428,7 @@ pub async fn op_node_open(
       state.borrow::<FileSystemRc>().clone(),
       state.borrow_mut::<PermissionsContainer>().check_open(
         Cow::Owned(path),
-        open_options_to_access_kind(&options),
+        options.access_kind(),
         Some("node:fs.open"),
       )?,
     )

--- a/tests/unit/files_test.ts
+++ b/tests/unit/files_test.ts
@@ -10,6 +10,43 @@ import { copy } from "@std/io/copy";
 
 // Note tests for Deno.FsFile.setRaw is in integration tests.
 
+function changingCreateOptions(): Deno.OpenOptions {
+  let writeReads = 0;
+  return {
+    read: false,
+    create: true,
+    get write() {
+      // Validation reads this getter twice before the op converts the options.
+      writeReads++;
+      return writeReads <= 2;
+    },
+  };
+}
+
+Deno.test(
+  { permissions: { read: true, write: false } },
+  function openSyncChangingOptionsChecksConvertedAccess() {
+    const path = `open_sync_changing_options_${crypto.randomUUID()}`;
+
+    assertThrows(
+      () => Deno.openSync(path, changingCreateOptions()),
+      Deno.errors.NotCapable,
+    );
+  },
+);
+
+Deno.test(
+  { permissions: { read: true, write: false } },
+  async function openChangingOptionsChecksConvertedAccess() {
+    const path = `open_changing_options_${crypto.randomUUID()}`;
+
+    await assertRejects(
+      () => Deno.open(path, changingCreateOptions()),
+      Deno.errors.NotCapable,
+    );
+  },
+);
+
 Deno.test(function filesStdioFileDescriptors() {
   // @ts-ignore `Deno.stdin.rid` was soft-removed in Deno 2.
   assertEquals(Deno.stdin.rid, 0);

--- a/tests/unit_node/_fs/_fs_open_test.ts
+++ b/tests/unit_node/_fs/_fs_open_test.ts
@@ -613,3 +613,20 @@ Deno.test({
     Deno.removeSync(file);
   },
 });
+
+Deno.test({
+  name: "open with numeric flag `O_RDONLY | O_CREAT` requires read access",
+  permissions: { read: false, write: true },
+  async fn() {
+    const file = "tests/testdata/assets/hello.txt";
+
+    assertThrows(
+      () => openSync(file, O_RDONLY | O_CREAT),
+      Deno.errors.NotCapable,
+    );
+    await assertRejects(
+      () => openPromise(file, O_RDONLY | O_CREAT),
+      Deno.errors.NotCapable,
+    );
+  },
+});

--- a/tests/unit_node/_fs/_fs_readFile_test.ts
+++ b/tests/unit_node/_fs/_fs_readFile_test.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
+import { O_CREAT, O_RDONLY } from "node:constants";
 import { existsSync, promises, readFile, readFileSync } from "node:fs";
 import * as path from "@std/path";
 import {
@@ -14,6 +15,96 @@ import { Buffer } from "node:buffer";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testData = path.resolve(moduleDir, "testdata", "hello.txt");
+const permissionTestDir = Deno.makeTempDirSync();
+const readCreateOptions = {
+  flag: O_RDONLY | O_CREAT,
+} as unknown as { flag: string };
+const readOnlyOptions = {
+  flag: O_RDONLY,
+} as unknown as { flag: string };
+
+Deno.test({
+  name: "fs.readFileSync requires write access when flags may create",
+  permissions: { read: true, write: false },
+  fn() {
+    const filePath = path.join(permissionTestDir, "sync_read_only.txt");
+
+    assertThrows(
+      () => readFileSync(filePath, readCreateOptions),
+      Deno.errors.NotCapable,
+    );
+    assertEquals(existsSync(filePath), false);
+  },
+});
+
+Deno.test({
+  name: "fs.promises.readFile requires write access when flags may create",
+  permissions: { read: true, write: false },
+  async fn() {
+    const filePath = path.join(permissionTestDir, "async_read_only.txt");
+
+    await assertRejects(
+      () => readFilePromise(filePath, readCreateOptions),
+      Deno.errors.NotCapable,
+    );
+    assertEquals(existsSync(filePath), false);
+  },
+});
+
+Deno.test({
+  name: "fs.readFile requires read access when flags may create",
+  permissions: { read: false, write: true },
+  async fn() {
+    assertThrows(
+      () => readFileSync(testData, readCreateOptions),
+      Deno.errors.NotCapable,
+    );
+    await assertRejects(
+      () => readFilePromise(testData, readCreateOptions),
+      Deno.errors.NotCapable,
+    );
+  },
+});
+
+Deno.test({
+  name: "fs.readFile with read-only flags only requires read access",
+  permissions: { read: true, write: false },
+  async fn() {
+    assertEquals(
+      readFileSync(testData, readOnlyOptions).toString(),
+      "hello world",
+    );
+    assertEquals(
+      (await readFilePromise(testData, readOnlyOptions)).toString(),
+      "hello world",
+    );
+  },
+});
+
+Deno.test({
+  name: "fs.readFile can read and create when both accesses are granted",
+  permissions: { read: true, write: true },
+  async fn() {
+    const tempDir = Deno.makeTempDirSync();
+    try {
+      const syncPath = path.join(tempDir, "sync.txt");
+      const asyncPath = path.join(tempDir, "async.txt");
+
+      assertEquals(
+        readFileSync(syncPath, readCreateOptions).length,
+        0,
+      );
+      assertEquals(
+        (await readFilePromise(asyncPath, readCreateOptions)).length,
+        0,
+      );
+      assertEquals(existsSync(syncPath), true);
+      assertEquals(existsSync(asyncPath), true);
+    } finally {
+      Deno.removeSync(tempDir, { recursive: true });
+    }
+  },
+});
 
 Deno.test("readFileSuccess", async function () {
   const data = await new Promise((res, rej) => {


### PR DESCRIPTION
## Summary

- preserve read access when numeric flags combine O_RDONLY with creation flags
- derive file-open permission checks from one shared access classification across core and Node fs operations
- account for create, create-new, and truncate as write-producing options

## Details

A read-only access mode can be combined with creation flags. Flag conversion previously treated recognized modifiers as suppressing the implicit O_RDONLY mode, while the core and Node paths used different write classifications. As a result, an operation that may create a file could be checked as read-only, or an operation that will read could be checked as write-only.

The shared classification now keeps the O_RDONLY read intent while requiring write access for options that may mutate a path. Ordinary read-only and write-only opens retain their existing checks.

## Tests

- cargo test -p deno_core -p deno_fs --features deno_core/v8 --lib interface::tests
- cargo test -p unit_node_tests --test unit_node -- _fs_readFile
- cargo test -p unit_node_tests --test unit_node -- _fs_open
- cargo test -p unit_tests --test unit -- files_test
- cargo clippy -p deno_core -p deno_fs -p deno_node --features deno_core/v8 --lib -- -D warnings