### PR TITLE
fix(pack): exclude existing package.json from assets

### DIFF
--- a/cli/tools/pack/mod.rs
+++ b/cli/tools/pack/mod.rs
@@ -474,10 +474,12 @@ fn collect_asset_files(
       excluded.insert(p);
     }
   }
-  // The source config file is replaced by the generated package.json.
+  // The source config file and any existing package.json are replaced by the
+  // generated package.json.
   if let Ok(p) = package.config_file.specifier.to_file_path() {
     excluded.insert(p);
   }
+  excluded.insert(package_dir.join("package.json"));
   // README/LICENSE are added by `collect_readme_license_files`.
   for file in readme_license_files {
     excluded.insert(package_dir.join(&file.relative_path));

--- a/tests/specs/pack/package_json_content/__test__.jsonc
+++ b/tests/specs/pack/package_json_content/__test__.jsonc
@@ -4,13 +4,13 @@
     "pack_package_json_content": {
       "steps": [{
         "args": "pack",
-        "output": "[WILDCARD]✓[WILDCARD]test-pkg-json-1.0.0.tgz[WILDCARD]"
+        "output": "[WILDCARD]0 assets collected[WILDCARD]✓[WILDCARD]test-pkg-json-1.0.0.tgz[WILDCARD]"
       }, {
         "if": "unix",
         "commandName": "bash",
         "args": [
           "-c",
-          "tar -xzf test-pkg-json-1.0.0.tgz && cat package/package.json && echo"
+          "test \"$(tar -tzf test-pkg-json-1.0.0.tgz | grep -c '^package/package.json$')\" -eq 1 && tar -xzf test-pkg-json-1.0.0.tgz && cat package/package.json && echo"
         ],
         "output": "package_json.out"
       }]

--- a/tests/specs/pack/package_json_content/package.json
+++ b/tests/specs/pack/package_json_content/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "source-package-json",
+  "private": true
+}


### PR DESCRIPTION
Fixes #36387.

When `deno pack` collects non-module assets, it now excludes a root `package.json` because the pack pipeline already writes a generated `package.json` to the same tar path. This prevents tarballs from containing two entries named `package/package.json`.

The existing package JSON spec fixture now includes a source `package.json` and verifies both that it is not counted as an asset and that the archive contains exactly one generated package JSON entry.

### Verification

- `CARGO_INCREMENTAL=0 cargo test -p specs_tests --test specs package_json_content -- --nocapture` — 1 test passed
- `./tools/lint.js cli/tools/pack/mod.rs` — passed
- `cargo fmt --check -p deno` — passed
- `target/debug/deno fmt --check tests/specs/pack/package_json_content/__test__.jsonc tests/specs/pack/package_json_content/package.json` — checked 2 files
