### PR TITLE
fix(web): avoid inspecting getters on Event subclass prototypes

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -176,7 +176,7 @@ class Event {
     return inspect(
       getCreateFilteredInspectProxy()({
         object: this,
-        evaluate: ObjectPrototypeIsPrototypeOf(EventPrototype, this),
+        evaluate: this[_attributes] !== undefined,
         keys: EVENT_PROPS,
       }),
       inspectOptions,

--- a/tests/unit/event_test.ts
+++ b/tests/unit/event_test.ts
@@ -155,6 +155,12 @@ Deno.test(function inspectEvent() {
     // check a substring because one property is a timestamp
     `Event {\n  bubbles: false,\n  cancelable: false,`,
   );
+
+  class SubclassedEvent extends Event {}
+  assertStringIncludes(
+    Deno.inspect(SubclassedEvent.prototype),
+    "bubbles: [Getter]",
+  );
 });
 
 Deno.test(function removeEventListenerWithEmptyObjectOptions() {


### PR DESCRIPTION
## Summary

- only evaluate `Event` inspection getters when the receiver has initialized event attributes
- preserve getter descriptors when inspecting subclass prototype objects
- add regression coverage for inspecting an `Event` subclass prototype

Fixes #36508.

## Verification

- `./x verify`
- confirmed the issue reproducer throws on Deno 2.9.2 before this change

The focused unit-test build was also attempted locally, but the full Deno binary build exceeded the available disk space; CI should execute the added regression test.

## AI disclosure

This contribution was prepared with AI assistance and manually verified through diff review, repository formatting/lint checks, and reproduction of the original failure.
