### PR TITLE
fix(net): check permissions for multicast membership

### DIFF
--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -55,6 +55,22 @@ pub fn check_unix_socket_path<'a>(
   Ok(checked)
 }
 
+/// Checks access to a multicast group using the UDP socket's bound port.
+///
+/// The group is already an IP address, but both checks are required: the
+/// first applies the requested host-and-port grant, while the second preserves
+/// IP deny rules that also apply after name resolution.
+pub fn check_multicast_membership_permission(
+  permissions: &mut deno_permissions::PermissionsContainer,
+  group: std::net::IpAddr,
+  port: u16,
+  api_name: &str,
+) -> Result<(), deno_permissions::PermissionCheckError> {
+  permissions.check_net(&(group.to_string(), Some(port)), api_name)?;
+  permissions.check_net_resolved(&group, port, api_name)?;
+  Ok(())
+}
+
 pub(crate) fn is_unix_socket_abstract_path(path: &std::path::Path) -> bool {
   #[cfg(any(target_os = "android", target_os = "linux"))]
   {

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -347,6 +347,17 @@ pub async fn op_net_join_multi_v4_udp(
   let addr = Ipv4Addr::from_str(address.as_str())?;
   let interface_addr = Ipv4Addr::from_str(multi_interface.as_str())?;
 
+  let port = socket.local_addr()?.port();
+  {
+    let mut state = state.borrow_mut();
+    crate::check_multicast_membership_permission(
+      state.borrow_mut::<PermissionsContainer>(),
+      std::net::IpAddr::V4(addr),
+      port,
+      "Deno.DatagramConn.joinMulticastV4()",
+    )?;
+  }
+
   socket.join_multicast_v4(addr, interface_addr)?;
 
   Ok(())
@@ -367,6 +378,17 @@ pub async fn op_net_join_multi_v6_udp(
   let socket = RcRef::map(&resource, |r| &r.socket).borrow().await;
 
   let addr = Ipv6Addr::from_str(address.as_str())?;
+
+  let port = socket.local_addr()?.port();
+  {
+    let mut state = state.borrow_mut();
+    crate::check_multicast_membership_permission(
+      state.borrow_mut::<PermissionsContainer>(),
+      std::net::IpAddr::V6(addr),
+      port,
+      "Deno.DatagramConn.joinMulticastV6()",
+    )?;
+  }
 
   socket.join_multicast_v6(&addr, multi_interface)?;
 

--- a/ext/node/ops/udp.rs
+++ b/ext/node/ops/udp.rs
@@ -135,6 +135,14 @@ pub fn op_node_udp_join_multi_v4(
     .transpose()?
     .unwrap_or(Ipv4Addr::UNSPECIFIED);
 
+  let port = resource.socket.local_addr()?.port();
+  deno_net::check_multicast_membership_permission(
+    state.borrow_mut::<PermissionsContainer>(),
+    std::net::IpAddr::V4(addr),
+    port,
+    "dgram.addMembership()",
+  )?;
+
   resource.socket.join_multicast_v4(addr, iface)?;
   Ok(())
 }
@@ -274,6 +282,13 @@ pub fn op_node_udp_join_multi_v6(
 
   let addr = Ipv6Addr::from_str(address)?;
   let iface = resolve_ipv6_interface(interface_addr.as_deref())?;
+  let port = resource.socket.local_addr()?.port();
+  deno_net::check_multicast_membership_permission(
+    state.borrow_mut::<PermissionsContainer>(),
+    std::net::IpAddr::V6(addr),
+    port,
+    "dgram.addMembership()",
+  )?;
   resource.socket.join_multicast_v6(&addr, iface)?;
   Ok(())
 }

--- a/tests/unit/net_test.ts
+++ b/tests/unit/net_test.ts
@@ -650,6 +650,81 @@ Deno.test(
 );
 
 Deno.test(
+  { permissions: { net: true, write: true, run: true } },
+  async function netUdpMulticastMembershipChecksGroupPermission() {
+    const reservation = Deno.listenDatagram({
+      hostname: "0.0.0.0",
+      port: 0,
+      transport: "udp",
+    });
+    assert(reservation.addr.transport === "udp");
+    const port = reservation.addr.port;
+    reservation.close();
+
+    const scriptPath = Deno.makeTempFileSync({ suffix: ".js" });
+    Deno.writeTextFileSync(
+      scriptPath,
+      `
+      const listener = Deno.listenDatagram({
+        hostname: "0.0.0.0",
+        port: ${port},
+        transport: "udp",
+        reuseAddress: true,
+      });
+      try {
+        const membership = await listener.joinMulticastV4(
+          "224.0.0.114",
+          "0.0.0.0",
+        );
+        console.log("MEMBERSHIP_RESULT:JOINED");
+        membership.leave();
+      } catch (error) {
+        console.log(
+          error instanceof Deno.errors.NotCapable
+            ? "NOT_CAPABLE"
+            : "MEMBERSHIP_RESULT:" + error.name,
+        );
+      } finally {
+        listener.close();
+      }
+      `,
+    );
+
+    const run = (permissionArgs: string[]) =>
+      execCode3(Deno.execPath(), [
+        "run",
+        "--unstable-net",
+        "--no-prompt",
+        ...permissionArgs,
+        scriptPath,
+      ]).finished();
+
+    try {
+      const [deniedStatus, deniedOutput] = await run([
+        `--allow-net=0.0.0.0:${port}`,
+      ]);
+      assertEquals(deniedStatus, 0);
+      assertStringIncludes(deniedOutput, "NOT_CAPABLE");
+
+      const scopedGrant = `--allow-net=0.0.0.0:${port},224.0.0.114:${port}`;
+      const [allowedStatus, allowedOutput] = await run([scopedGrant]);
+      assertEquals(allowedStatus, 0);
+      assertStringIncludes(allowedOutput, "MEMBERSHIP_RESULT:");
+      assert(!allowedOutput.includes("NOT_CAPABLE"));
+
+      const [explicitlyDeniedStatus, explicitlyDeniedOutput] = await run([
+        scopedGrant,
+        `--deny-net=224.0.0.114:${port}`,
+      ]);
+      assertEquals(explicitlyDeniedStatus, 0);
+      assertStringIncludes(explicitlyDeniedOutput, "NOT_CAPABLE");
+    } finally {
+      Deno.removeSync(scriptPath);
+    }
+  },
+);
+
+Deno.test(
   { permissions: { net: true }, ignore: true },
   async function netUdpSendReceiveMulticastv4() {
     const alice = Deno.listenDatagram({

--- a/tests/unit_node/dgram_test.ts
+++ b/tests/unit_node/dgram_test.ts
@@ -274,6 +274,75 @@ socket.on("error", (err) => {
   }
 });
 
+Deno.test("[node/dgram] addMembership checks group permission", {
+  permissions: { write: true, run: true, net: true },
+}, async () => {
+  const reservation = Deno.listenDatagram({
+    hostname: "0.0.0.0",
+    port: 0,
+    transport: "udp",
+  });
+  assert(reservation.addr.transport === "udp");
+  const port = reservation.addr.port;
+  reservation.close();
+
+  const tempFile = Deno.makeTempFileSync({ suffix: ".ts" });
+  Deno.writeTextFileSync(
+    tempFile,
+    `import dgram from "node:dgram";
+const socket = dgram.createSocket({ type: "udp4", reuseAddr: true });
+socket.bind(${port}, "0.0.0.0", () => {
+  try {
+    socket.addMembership("224.0.0.114");
+    console.log("JOINED");
+    socket.dropMembership("224.0.0.114");
+  } catch (error) {
+    console.log("ADD_ERROR:" + (error.code ?? error.name));
+  } finally {
+    socket.close();
+  }
+});
+`,
+  );
+
+  const run = async (allowNet: string) => {
+    const { success, stdout, stderr } = await new Deno.Command(
+      Deno.execPath(),
+      {
+        args: ["run", "--no-prompt", allowNet, tempFile],
+        stdout: "piped",
+        stderr: "piped",
+      },
+    ).output();
+    return {
+      success,
+      output: new TextDecoder().decode(stdout) +
+        new TextDecoder().decode(stderr),
+    };
+  };
+
+  try {
+    const denied = await run(`--allow-net=0.0.0.0:${port}`);
+    assert(denied.success, denied.output);
+    assert(
+      denied.output.includes("ADD_ERROR:") &&
+        !denied.output.includes("JOINED"),
+      `Membership should have been blocked, but got: ${denied.output}`,
+    );
+
+    const allowed = await run(
+      `--allow-net=0.0.0.0:${port},224.0.0.114:${port}`,
+    );
+    assert(allowed.success, allowed.output);
+    assert(
+      allowed.output.includes("JOINED"),
+      `Membership should have been allowed, but got: ${allowed.output}`,
+    );
+  } finally {
+    Deno.removeSync(tempFile);
+  }
+});
+
 Deno.test("[node/dgram] large recvBufferSize and sendBufferSize do not throw", async () => {
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   const socket = createSocket({


### PR DESCRIPTION
## Summary

- check multicast membership against the group address and bound UDP port
- apply the same behavior to `Deno.DatagramConn` and `node:dgram` for IPv4 and IPv6
- keep leave operations unchanged

## Details

A UDP socket's bind check only covers the local address. Joining a multicast group previously did not consult the group-and-port network permission, so bind-only configurations could still request membership in another group.

The check uses the parsed, normalized group address and the socket's actual bound port. It also applies resolved-IP deny rules consistently with other network operations.

## Tests

- `cargo check -p deno --lib`
- `cargo test -p unit_tests --test unit -- net_test`
- `cargo test -p unit_node_tests --test unit_node -- dgram_test`
- `cargo clippy -p deno --lib -- -D warnings`
- `./tools/format.js ext/net/lib.rs ext/net/ops.rs ext/node/ops/udp.rs tests/unit/net_test.ts tests/unit_node/dgram_test.ts`
