### PR TITLE
fix(node): validate Brotli encoder operations

### DIFF
--- a/ext/node/ops/zlib/mod.rs
+++ b/ext/node/ops/zlib/mod.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use brotli::enc::StandardAlloc;
 use brotli::enc::encode::BrotliEncoderDestroyInstance;
 use brotli::enc::encode::BrotliEncoderOperation;
+use brotli::enc::encode::BrotliEncoderParameter;
 use brotli::enc::encode::BrotliEncoderStateStruct;
 use brotli::ffi;
 use deno_core::op2;
@@ -611,15 +612,49 @@ unsafe impl deno_core::GarbageCollected for BrotliEncoder {
   }
 }
 
-fn encoder_param(i: u32) -> brotli::enc::encode::BrotliEncoderParameter {
-  const _: () = {
-    assert!(
-      std::mem::size_of::<brotli::enc::encode::BrotliEncoderParameter>()
-        == std::mem::size_of::<u32>(),
-    );
-  };
-  // SAFETY: `i` is a valid u32 value that corresponds to a BrotliEncoderParameter.
-  unsafe { std::mem::transmute(i) }
+fn encoder_param(i: usize) -> Option<BrotliEncoderParameter> {
+  use BrotliEncoderParameter::*;
+
+  Some(match i {
+    0 => BROTLI_PARAM_MODE,
+    1 => BROTLI_PARAM_QUALITY,
+    2 => BROTLI_PARAM_LGWIN,
+    3 => BROTLI_PARAM_LGBLOCK,
+    4 => BROTLI_PARAM_DISABLE_LITERAL_CONTEXT_MODELING,
+    5 => BROTLI_PARAM_SIZE_HINT,
+    6 => BROTLI_PARAM_LARGE_WINDOW,
+    150 => BROTLI_PARAM_Q9_5,
+    151 => BROTLI_METABLOCK_CALLBACK,
+    152 => BROTLI_PARAM_STRIDE_DETECTION_QUALITY,
+    153 => BROTLI_PARAM_HIGH_ENTROPY_DETECTION_QUALITY,
+    154 => BROTLI_PARAM_LITERAL_BYTE_SCORE,
+    155 => BROTLI_PARAM_CDF_ADAPTATION_DETECTION,
+    156 => BROTLI_PARAM_PRIOR_BITMASK_DETECTION,
+    157 => BROTLI_PARAM_SPEED,
+    158 => BROTLI_PARAM_SPEED_MAX,
+    159 => BROTLI_PARAM_CM_SPEED,
+    160 => BROTLI_PARAM_CM_SPEED_MAX,
+    161 => BROTLI_PARAM_SPEED_LOW,
+    162 => BROTLI_PARAM_SPEED_LOW_MAX,
+    164 => BROTLI_PARAM_CM_SPEED_LOW,
+    165 => BROTLI_PARAM_CM_SPEED_LOW_MAX,
+    166 => BROTLI_PARAM_AVOID_DISTANCE_PREFIX_SEARCH,
+    167 => BROTLI_PARAM_CATABLE,
+    168 => BROTLI_PARAM_APPENDABLE,
+    169 => BROTLI_PARAM_MAGIC_NUMBER,
+    171 => BROTLI_PARAM_FAVOR_EFFICIENCY,
+    _ => return None,
+  })
+}
+
+fn encoder_operation(i: u8) -> Result<BrotliEncoderOperation, JsErrorBox> {
+  match i {
+    0 => Ok(BrotliEncoderOperation::BROTLI_OPERATION_PROCESS),
+    1 => Ok(BrotliEncoderOperation::BROTLI_OPERATION_FLUSH),
+    2 => Ok(BrotliEncoderOperation::BROTLI_OPERATION_FINISH),
+    3 => Ok(BrotliEncoderOperation::BROTLI_OPERATION_EMIT_METADATA),
+    _ => Err(JsErrorBox::type_error("invalid Brotli operation")),
+  }
 }
 
 #[op2]
@@ -637,6 +672,10 @@ impl BrotliEncoder {
     #[buffer] params: &[u32],
     #[scoped] callback: v8::Global<v8::Function>,
   ) -> bool {
+    if params.len() > usize::from(u8::MAX) + 1 {
+      return false;
+    }
+
     let inst = {
       let mut state = BrotliEncoderStateStruct::new(StandardAlloc::default());
 
@@ -644,7 +683,10 @@ impl BrotliEncoder {
         if value == 0xFFFFFFFF {
           continue; // Skip setting the parameter, same as C API.
         }
-        if !state.set_parameter(encoder_param(i as u32), value) {
+        let Some(parameter) = encoder_param(i) else {
+          return false;
+        };
+        if !state.set_parameter(parameter, value) {
           return false;
         }
       }
@@ -682,18 +724,18 @@ impl BrotliEncoder {
     #[smi] out_len: u32,
     #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
+    let operation = encoder_operation(flush)?;
     let input_slice = slice_input(input, in_off, in_len)?;
     let output_slice = slice_output(out, out_off, out_len)?;
 
     let mut avail_in = in_len as usize;
     let mut avail_out = out_len as usize;
-    // SAFETY: `inst`, `next_in`, `next_out`, `avail_in`, and `avail_out` are valid pointers.
-    let callback = unsafe {
+    let callback = {
       let mut ctx = self.ctx.borrow_mut();
       let ctx = ctx.as_mut().expect("BrotliEncoder not initialized");
 
       ctx.inst.compress_stream(
-        std::mem::transmute::<u8, BrotliEncoderOperation>(flush),
+        operation,
         &mut avail_in,
         input_slice,
         &mut 0,
@@ -729,6 +771,7 @@ impl BrotliEncoder {
     #[smi] out_len: u32,
     #[buffer] write_result: &mut [u32],
   ) -> Result<(), JsErrorBox> {
+    let operation = encoder_operation(flush)?;
     let input_slice = slice_input(input, in_off, in_len)?;
     let output_slice = slice_output(out, out_off, out_len)?;
 
@@ -737,20 +780,17 @@ impl BrotliEncoder {
 
     let mut avail_in = in_len as usize;
     let mut avail_out = out_len as usize;
-    // SAFETY: `inst`, `next_in`, `next_out`, `avail_in`, and `avail_out` are valid pointers.
-    unsafe {
-      ctx.inst.compress_stream(
-        std::mem::transmute::<u8, BrotliEncoderOperation>(flush),
-        &mut avail_in,
-        input_slice,
-        &mut 0,
-        &mut avail_out,
-        output_slice,
-        &mut 0,
-        &mut None,
-        &mut |_, _, _, _| (),
-      );
-    };
+    ctx.inst.compress_stream(
+      operation,
+      &mut avail_in,
+      input_slice,
+      &mut 0,
+      &mut avail_out,
+      output_slice,
+      &mut 0,
+      &mut None,
+      &mut |_, _, _, _| (),
+    );
 
     if write_result.len() >= 2 {
       write_result[0] = avail_out as u32;
@@ -1484,6 +1524,39 @@ pub fn op_zlib_crc32(#[buffer] data: &[u8], value: u32) -> u32 {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn brotli_encoder_operation_values() {
+    assert!(matches!(
+      encoder_operation(0),
+      Ok(BrotliEncoderOperation::BROTLI_OPERATION_PROCESS)
+    ));
+    assert!(matches!(
+      encoder_operation(1),
+      Ok(BrotliEncoderOperation::BROTLI_OPERATION_FLUSH)
+    ));
+    assert!(matches!(
+      encoder_operation(2),
+      Ok(BrotliEncoderOperation::BROTLI_OPERATION_FINISH)
+    ));
+    assert!(matches!(
+      encoder_operation(3),
+      Ok(BrotliEncoderOperation::BROTLI_OPERATION_EMIT_METADATA)
+    ));
+    for operation in 4..=u8::MAX {
+      assert!(encoder_operation(operation).is_err());
+    }
+  }
+
+  #[test]
+  fn brotli_encoder_parameter_values() {
+    for parameter in [0, 6, 150, 162, 164, 171] {
+      assert!(encoder_param(parameter).is_some());
+    }
+    for parameter in [7, 149, 163, 170, 172, 256] {
+      assert!(encoder_param(parameter).is_none());
+    }
+  }
 
   #[test]
   fn zlib_start_write() {

--- a/tests/unit_node/zlib_test.ts
+++ b/tests/unit_node/zlib_test.ts
@@ -529,3 +529,56 @@ Deno.test("brotli writeSync rejects out-of-range offsets", () => {
   // The in-range window still works.
   writeSync(0, input.length, 0, output.length);
 });
+
+Deno.test("Brotli encoder validates direct handle operations", () => {
+  const input = Buffer.alloc(0);
+  const output = Buffer.allocUnsafe(1024);
+  const operations = [
+    constants.BROTLI_OPERATION_PROCESS,
+    constants.BROTLI_OPERATION_FLUSH,
+    constants.BROTLI_OPERATION_FINISH,
+    constants.BROTLI_OPERATION_EMIT_METADATA,
+  ];
+
+  for (const operation of operations) {
+    // deno-lint-ignore no-explicit-any
+    const handle = (createBrotliCompress() as any)._handle;
+    handle.writeSync(
+      operation,
+      input,
+      0,
+      input.length,
+      output,
+      0,
+      output.length,
+    );
+  }
+
+  const invalidOperation = constants.BROTLI_OPERATION_EMIT_METADATA + 1;
+  for (const method of ["writeSync", "write"] as const) {
+    // deno-lint-ignore no-explicit-any
+    const handle = (createBrotliCompress() as any)._handle;
+    assertThrows(
+      () =>
+        handle[method](
+          invalidOperation,
+          input,
+          0,
+          input.length,
+          output,
+          0,
+          output.length,
+        ),
+      TypeError,
+      "invalid Brotli operation",
+    );
+  }
+});
+
+Deno.test("Brotli encoder rejects oversized direct init parameters", () => {
+  // deno-lint-ignore no-explicit-any
+  const handle = (createBrotliCompress() as any)._handle;
+  const params = new Uint32Array(257);
+  params.fill(0xffffffff);
+  assertEquals(handle.init(params, () => {}), false);
+});


### PR DESCRIPTION
## What this changes

- validate Brotli encoder operation values before passing them to the encoder
- map supported parameter indices explicitly and reject oversized parameter arrays
- add direct-handle regression coverage for synchronous and asynchronous operations and initialization

## Why

The low-level Brotli handle accepted arbitrary numeric operation and parameter values. Unsupported values should produce normal JavaScript errors or initialization failures instead of being interpreted as encoder enum values.

## Validation

- `cargo test -p deno_node --features deno_core/v8 brotli_encoder_ --lib`
- `cargo test -p unit_node_tests --test unit_node -- zlib_test`
- `cargo clippy -p deno_node --features deno_core/v8 --lib -- -D warnings`