### PR TITLE
fix(ext/node): close accepted idle HTTP sockets

### DIFF
--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -196,7 +196,7 @@ const _kOnTimeout = HTTPParser.kOnTimeout | 0;
 class ConnectionsList {
   constructor() {
     this._all = new SafeSet();
-    this._active = new SafeMap(); // socket -> { headersCompleted, startTime, req }
+    this._active = new SafeMap(); // socket -> { hasActiveRequest, headersCompleted, startTime, req }
   }
 
   add(socket) {
@@ -208,8 +208,9 @@ class ConnectionsList {
     this._active.delete(socket);
   }
 
-  pushActive(socket) {
+  pushActive(socket, hasActiveRequest = false) {
     this._active.set(socket, {
+      hasActiveRequest,
       headersCompleted: false,
       startTime: performance.now(),
       req: null,
@@ -704,7 +705,7 @@ function onParserMessageBegin(server, socket) {
   const connections = server[kConnectionsKey];
   if (connections) {
     connections.popActive(socket);
-    connections.pushActive(socket);
+    connections.pushActive(socket, true);
   }
 }
 
@@ -1621,11 +1622,14 @@ Server.prototype.closeIdleConnections = function closeIdleConnections() {
   const connections = this[kConnectionsKey];
   if (connections) {
     for (const socket of new SafeSetIterator(connections._all)) {
-      // A socket is idle if it completed a request-response cycle and
-      // currently has no active HTTP response being written. Sockets
-      // that have never finished a response (e.g. still receiving
-      // headers) are not idle.
-      if (!socket._httpMessage && socket._httpMessageDetached) {
+      const active = connections._active.get(socket);
+      // A socket is idle if it completed a request-response cycle, or it
+      // accepted a connection that has not started an HTTP request. Sockets
+      // with a request in progress (e.g. still receiving headers) are not idle.
+      if (
+        !socket._httpMessage &&
+        (socket._httpMessageDetached || !active?.hasActiveRequest)
+      ) {
         socket.destroy();
       }
     }

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1665,6 +1665,46 @@ Deno.test("[node/http] server closeIdleConnections shutdown", async () => {
   await promise;
 });
 
+Deno.test("[node/http] server close shuts down an accepted idle socket", async () => {
+  const server = http.createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("unexpected server address");
+  }
+
+  const socket = net.connect(address.port, "127.0.0.1");
+  socket.on("error", () => {});
+  await once(socket, "connect");
+
+  const serverClosed = once(server, "close");
+  const socketClosed = once(socket, "close");
+  const { promise: closeCallback, resolve: resolveCloseCallback } = Promise
+    .withResolvers<void>();
+  const { promise: timeout, reject: rejectTimeout } = Promise.withResolvers<
+    never
+  >();
+  const timeoutId = setTimeout(
+    () => rejectTimeout(new Error("server.close() did not close idle socket")),
+    500,
+  );
+
+  try {
+    server.close(resolveCloseCallback);
+    await Promise.race([
+      Promise.all([closeCallback, socketClosed]),
+      timeout,
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
+    socket.destroy();
+    server.closeAllConnections();
+    await serverClosed;
+  }
+});
+
 Deno.test("[node/http] client closing a streaming response doesn't terminate server", async () => {
   let interval: NodeJS.Timeout;
   const server = http.createServer((req, res) => {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1681,8 +1681,8 @@ Deno.test("[node/http] server close shuts down an accepted idle socket", async (
 
   const serverClosed = once(server, "close");
   const socketClosed = once(socket, "close");
-  const { promise: closeCallback, resolve: resolveCloseCallback } = Promise
-    .withResolvers<void>();
+  const { promise: closeCallback, resolve: resolveCloseCallback, reject } =
+    Promise.withResolvers<void>();
   const { promise: timeout, reject: rejectTimeout } = Promise.withResolvers<
     never
   >();
@@ -1692,7 +1692,13 @@ Deno.test("[node/http] server close shuts down an accepted idle socket", async (
   );
 
   try {
-    server.close(resolveCloseCallback);
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolveCloseCallback();
+      }
+    });
     await Promise.race([
       Promise.all([closeCallback, socketClosed]),
       timeout,


### PR DESCRIPTION
## Summary

- Close accepted `node:http` sockets that have not begun an HTTP request when the server closes.
- Preserve sockets with a request in progress, including while headers are being received.
- Add a raw-TCP regression test for the close callback and client socket closure.

Related to #36513.

## Validation

- `deno fmt --check ext/node/polyfills/_http_server.js tests/unit_node/http_test.ts`
- `deno lint tests/unit_node/http_test.ts`
- `git diff --check`
- Runtime validation is delegated to CI.

## AI assistance

I used AI assistance to develop this contribution. I have reviewed the changes and take responsibility for them.