### PR TITLE
fix(ext/node): report ENODATA for empty DNS hostname

### DIFF
--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -394,12 +394,17 @@ const dnsException = hideStackFrames(function (code, syscall, hostname) {
   // c-ares error code.
   if (typeof code === "number") {
     errno = code;
-    // ENOTFOUND is not a proper POSIX error, but this error has been in place
-    // long enough that it's not practical to remove it.
     if (
+      code === MapPrototypeGet(codeMap, "EAI_NODATA") && hostname === ""
+    ) {
+      errno = undefined;
+      code = "ENODATA";
+    } else if (
       code === MapPrototypeGet(codeMap, "EAI_NODATA") ||
       code === MapPrototypeGet(codeMap, "EAI_NONAME")
     ) {
+      // ENOTFOUND is not a proper POSIX error, but this error has been in place
+      // long enough that it's not practical to remove it.
       code = "ENOTFOUND"; // Fabricated error name.
     } else {
       code = getSystemErrorName(code);

--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -394,17 +394,12 @@ const dnsException = hideStackFrames(function (code, syscall, hostname) {
   // c-ares error code.
   if (typeof code === "number") {
     errno = code;
+    // ENOTFOUND is not a proper POSIX error, but this error has been in place
+    // long enough that it's not practical to remove it.
     if (
-      code === MapPrototypeGet(codeMap, "EAI_NODATA") && hostname === ""
-    ) {
-      errno = undefined;
-      code = "ENODATA";
-    } else if (
       code === MapPrototypeGet(codeMap, "EAI_NODATA") ||
       code === MapPrototypeGet(codeMap, "EAI_NONAME")
     ) {
-      // ENOTFOUND is not a proper POSIX error, but this error has been in place
-      // long enough that it's not practical to remove it.
       code = "ENOTFOUND"; // Fabricated error name.
     } else {
       code = getSystemErrorName(code);

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -324,9 +324,11 @@ class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     // deno-lint-ignore no-explicit-any
     let code: any;
     let ret: Awaited<ReturnType<typeof Deno.resolveDns>>;
+    const servers = this.#servers;
+    const hasCustomServers = servers !== null && servers.length > 0;
 
-    if (this.#servers !== null && this.#servers.length) {
-      for (const server of new SafeArrayIterator(this.#servers)) {
+    if (hasCustomServers) {
+      for (const server of new SafeArrayIterator(servers)) {
         const ipAddr = server[0];
         const port = server[1];
         const resolveOptions = {
@@ -352,6 +354,16 @@ class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
       }
     } else {
       ({ code, ret } = await this.#resolve(query, recordType, null, ttl));
+    }
+
+    if (
+      !hasCustomServers && query === "" &&
+      code === codeMap.get("EAI_NODATA")!
+    ) {
+      // Node's default c-ares resolver passes string ENODATA for this case,
+      // so DNSException leaves errno undefined. Custom servers can answer
+      // NXDOMAIN for the root name and must keep the general error path.
+      code = "ENODATA";
     }
 
     return { code: code!, ret: ret! };

--- a/tests/unit_node/dns_test.ts
+++ b/tests/unit_node/dns_test.ts
@@ -254,15 +254,18 @@ Deno.test("[node/dns] lookup of a missing host reports ENOTFOUND", async () => {
   assertEquals(err.hostname, "nonexistent-host.invalid");
 });
 
-function assertEmptyHostnameResolveError(error: unknown) {
+function assertEmptyHostnameResolveError(
+  error: unknown,
+  syscall: "queryA" | "queryMx",
+) {
   assert(error instanceof Error);
 
   const dnsError = error as ErrnoException;
   assertEquals(dnsError.name, "Error");
-  assertEquals(dnsError.message, "queryA ENODATA");
+  assertEquals(dnsError.message, `${syscall} ENODATA`);
   assertEquals(dnsError.code, "ENODATA");
   assertEquals(dnsError.errno, undefined);
-  assertEquals(dnsError.syscall, "queryA");
+  assertEquals(dnsError.syscall, syscall);
   assertEquals(dnsError.hostname, undefined);
 }
 
@@ -273,7 +276,7 @@ Deno.test(
       dns.resolve("", "A", (error) => resolve(error));
     });
 
-    assertEmptyHostnameResolveError(error);
+    assertEmptyHostnameResolveError(error, "queryA");
   },
 );
 
@@ -285,6 +288,81 @@ Deno.test(
       (error) => error,
     );
 
-    assertEmptyHostnameResolveError(error);
+    assertEmptyHostnameResolveError(error, "queryA");
+  },
+);
+
+Deno.test(
+  "[node/dns] promises.resolve empty hostname as MX reports ENODATA",
+  async () => {
+    const error = await dnsPromises.resolve("", "MX").then(
+      () => undefined,
+      (error) => error,
+    );
+
+    assertEmptyHostnameResolveError(error, "queryMx");
+  },
+);
+
+Deno.test(
+  "[node/dns] resolve of a missing host reports ENOTFOUND",
+  async () => {
+    const error = await dnsPromises.resolve(
+      "nonexistent-host.invalid",
+      "A",
+    ).then(
+      () => undefined,
+      (error) => error,
+    );
+
+    assert(error instanceof Error);
+    const dnsError = error as ErrnoException;
+    assertEquals(
+      dnsError.message,
+      "queryA ENOTFOUND nonexistent-host.invalid",
+    );
+    assertEquals(dnsError.code, "ENOTFOUND");
+    assertEquals(dnsError.syscall, "queryA");
+    assertEquals(dnsError.hostname, "nonexistent-host.invalid");
+  },
+);
+
+Deno.test(
+  "[node/dns] custom resolver preserves NXDOMAIN for empty hostname",
+  async () => {
+    const server = Deno.listenDatagram({
+      transport: "udp",
+      hostname: "127.0.0.1",
+      port: 0,
+    });
+    const { port } = server.addr as Deno.NetAddr;
+    const resolver = new dnsPromises.Resolver();
+    resolver.setServers([`127.0.0.1:${port}`]);
+
+    const responseSent = (async () => {
+      const [request, remoteAddress] = await server.receive();
+      const response = request.slice();
+      response[2] = 0x81;
+      response[3] = 0x83; // Standard recursive response with NXDOMAIN.
+      response.fill(0, 6, 12);
+      await server.send(response, remoteAddress);
+    })();
+
+    try {
+      const error = await resolver.resolve("", "A").then(
+        () => undefined,
+        (error) => error,
+      );
+      await responseSent;
+
+      assert(error instanceof Error);
+      const dnsError = error as ErrnoException;
+      assertEquals(dnsError.message, "queryA ENOTFOUND");
+      assertEquals(dnsError.code, "ENOTFOUND");
+      assertEquals(dnsError.syscall, "queryA");
+      assertEquals(dnsError.hostname, undefined);
+    } finally {
+      server.close();
+    }
   },
 );

--- a/tests/unit_node/dns_test.ts
+++ b/tests/unit_node/dns_test.ts
@@ -253,3 +253,38 @@ Deno.test("[node/dns] lookup of a missing host reports ENOTFOUND", async () => {
   assertEquals(err.syscall, "getaddrinfo");
   assertEquals(err.hostname, "nonexistent-host.invalid");
 });
+
+function assertEmptyHostnameResolveError(error: unknown) {
+  assert(error instanceof Error);
+
+  const dnsError = error as ErrnoException;
+  assertEquals(dnsError.name, "Error");
+  assertEquals(dnsError.message, "queryA ENODATA");
+  assertEquals(dnsError.code, "ENODATA");
+  assertEquals(dnsError.errno, undefined);
+  assertEquals(dnsError.syscall, "queryA");
+  assertEquals(dnsError.hostname, undefined);
+}
+
+Deno.test(
+  "[node/dns] resolve empty hostname callback reports ENODATA",
+  async () => {
+    const error = await new Promise<unknown>((resolve) => {
+      dns.resolve("", "A", (error) => resolve(error));
+    });
+
+    assertEmptyHostnameResolveError(error);
+  },
+);
+
+Deno.test(
+  "[node/dns] promises.resolve empty hostname reports ENODATA",
+  async () => {
+    const error = await dnsPromises.resolve("", "A").then(
+      () => undefined,
+      (error) => error,
+    );
+
+    assertEmptyHostnameResolveError(error);
+  },
+);


### PR DESCRIPTION
Closes #36535

## Summary

- preserve c-ares `ENODATA` for an empty hostname through the default resolver so callback and promise APIs match Node.js without a numeric `errno`
- keep the conversion in the query binding, leaving the shared `dnsException` behavior unchanged for `getaddrinfo` and `getnameinfo`
- cover another record type, keep non-empty missing names on `ENOTFOUND`, and preserve NXDOMAIN from a custom resolver

This intentionally addresses the reported default-resolver case only. Deno still maps query failures through numeric libuv codes, so a non-empty existing name with no records of the requested type may report `ENOTFOUND` with a numeric `errno` instead of Node.js's `ENODATA`. The custom-server path also cannot distinguish NODATA from NXDOMAIN after `Deno.resolveDns` turns both into `NotFound`. Follow-up issue #36561 tracks that wider mismatch.

## Validation

- `./x build`
- `./x verify`
- `target/debug/deno test --config tests/config/deno.json --no-lock --unstable-net -A --no-run tests/unit_node/dns_test.ts`
- 5 focused resolver cases passed
- `./x test-node dns_test`: 14 of 15 passed; the unrelated localhost test failed because this machine resolves `localhost` to `127.0.1.1`

## AI disclosure

Codex assisted with implementation, tests, and verification.
