### PR TITLE
perf(core): use index-based `SafeArrayIterator` in primordials

### DIFF
--- a/libs/core/00_primordials.js
+++ b/libs/core/00_primordials.js
@@ -329,11 +329,35 @@
     return SafeIterator;
   };
 
-  const SafeArrayIterator = createSafeIterator(
-    primordials.ArrayPrototypeSymbolIterator,
-    primordials.ArrayIteratorPrototypeNext,
-  );
+  class SafeArrayIterator {
+    #array;
+    #done = false;
+    #index = 0;
+    constructor(array) {
+      this.#array = array;
+    }
+    next() {
+      if (this.#done) {
+        return { value: undefined, done: true };
+      }
+      const array = this.#array;
+      const index = this.#index;
+      if (index >= array.length) {
+        this.#done = true;
+        return { value: undefined, done: true };
+      }
+      this.#index = index + 1;
+      return { value: array[index], done: false };
+    }
+    [SymbolIterator]() {
+      return this;
+    }
+  }
+  ObjectSetPrototypeOf(SafeArrayIterator.prototype, null);
+  ObjectFreeze(SafeArrayIterator.prototype);
+  ObjectFreeze(SafeArrayIterator);
   primordials.SafeArrayIterator = SafeArrayIterator;
+
   primordials.SafeSetIterator = createSafeIterator(
     primordials.SetPrototypeSymbolIterator,
     primordials.SetIteratorPrototypeNext,

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -2337,6 +2337,51 @@ fn builtin_core_module() {
   runtime.module_map().set_loading_internal_modules(false);
 }
 
+#[test]
+fn safe_array_iterator_remains_done_after_array_grows() {
+  let main_specifier =
+    resolve_url("ext:///safe_array_iterator_test.js").unwrap();
+
+  let source_code = r#"
+    import { primordials } from "ext:core/mod.js";
+
+    const array = [1, 2];
+    const iterator = new primordials.SafeArrayIterator(array);
+
+    for (const value of iterator) {
+      if (value !== 1) throw new Error("unexpected first value");
+      break;
+    }
+
+    const resumed = iterator.next();
+    if (resumed.done || resumed.value !== 2) {
+      throw new Error("iterator did not resume after an early exit");
+    }
+    if (!iterator.next().done) throw new Error("iterator was not exhausted");
+
+    array.push(3);
+    if (!iterator.next().done) {
+      throw new Error("exhausted iterator resumed after the array grew");
+    }
+  "#;
+  let loader = StaticModuleLoader::new([(main_specifier.clone(), source_code)]);
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    module_loader: Some(Rc::new(loader)),
+    ..Default::default()
+  });
+  runtime.module_map().set_loading_internal_modules(true);
+
+  let main_id =
+    futures::executor::block_on(runtime.load_main_es_module(&main_specifier))
+      .unwrap();
+  let receiver = runtime.mod_evaluate(main_id);
+  futures::executor::block_on(runtime.run_event_loop(Default::default()))
+    .unwrap();
+  futures::executor::block_on(receiver).unwrap();
+  runtime.module_map().set_loading_internal_modules(false);
+}
+
 // An internal module that is lazily loaded at runtime gets its imports
 // resolved by the embedder's loader, which in Deno applies the user's import
 // map. Mapping `ext:core/mod.js` used to rewrite internal imports too and


### PR DESCRIPTION
Avoid allocating a real `ArrayIterator` and calling the user-patchable `ArrayIteratorPrototype.next` path. Microbenches show ~1.1–2.7× speedup depending on for-of vs spread call patterns.

Track exhaustion explicitly so an iterator remains done after its backing array grows, matching built-in `ArrayIterator` semantics. Add regression coverage for resuming after an early exit and remaining done after exhaustion.

I used Codex for this implementation.

<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
