### PR TITLE
fix(ext/node): accept string ports in dns.lookupService

### DIFF
--- a/ext/node/polyfills/internal/validators.mjs
+++ b/ext/node/polyfills/internal/validators.mjs
@@ -277,12 +277,12 @@ function validatePort(port, name = "Port", allowZero = true) {
       StringPrototypeTrim(port).length === 0) ||
     +port !== (+port >>> 0) ||
     port > 0xFFFF ||
-    (port === 0 && !allowZero)
+    (+port === 0 && !allowZero)
   ) {
     throw new codes.ERR_SOCKET_BAD_PORT(name, port, allowZero);
   }
 
-  return port;
+  return port | 0;
 }
 
 /**

--- a/tests/unit_node/dns_test.ts
+++ b/tests/unit_node/dns_test.ts
@@ -57,6 +57,25 @@ Deno.test("lookupService promise", async () => {
   assertEquals(typeof defaultImportResult.service, "string");
 });
 
+Deno.test("[node/dns] lookupService accepts string ports", async () => {
+  const stringPort = "80" as unknown as number;
+
+  const callbackResult = await new Promise<LookupServiceResult>(
+    (resolve, reject) => {
+      lookupService("127.0.0.1", stringPort, (err, hostname, service) => {
+        if (err) reject(err);
+        else resolve({ hostname, service });
+      });
+    },
+  );
+  assertEquals(typeof callbackResult.hostname, "string");
+  assertEquals(typeof callbackResult.service, "string");
+
+  const promiseResult = await lookupServicePromise("127.0.0.1", stringPort);
+  assertEquals(typeof promiseResult.hostname, "string");
+  assertEquals(typeof promiseResult.service, "string");
+});
+
 Deno.test("lookupService not found", async () => {
   const address = "10.0.0.0";
 


### PR DESCRIPTION
## Summary

- Normalize validated Node-compatible port inputs before passing them to native ops.
- Preserve `allowZero: false` validation for string zero values.
- Cover both callback and promise `dns.lookupService` APIs with a numeric string port.

Fixes #36537.

## Tests

- `PATH="$PWD/target/debug:$PATH" ./x fmt`
- `PATH="$PWD/target/debug:$PATH" ./x lint-js`
- `target/debug/deno test --config tests/config/deno.json --no-lock --unstable-net -A --filter "lookupService accepts string ports" tests/unit_node/dns_test.ts` (1 passed)
- `cargo test -p unit_node_tests --test unit_node -- unit_node::dgram_test --exact --nocapture` (12 passed)
- `cargo test -p unit_node_tests --test unit_node -- unit_node::net_test --exact --nocapture` (16 passed)
- `cargo test -p unit_node_tests --test unit_node -- --nocapture` (68 of 72 test files passed; the four failures are environment-dependent: `dns_test` and `http_test` see `localhost` as `127.0.1.1`, `os_test` sees a container CPU-count mismatch, and `tls_test` times out reaching an external host)

The new regression test passes both in isolation and within the full `dns_test.ts` run. Running the exact `dns_test.ts` content from base commit `28280d5f` reproduces the same existing `localhost` assertion failure in this environment.

## AI disclosure

Codex assisted with issue analysis, implementation, test preparation, and code review.