### PR TITLE
fix(lsp): use indexed line mapping for coverage

### DIFF
--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -3,6 +3,8 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -16,6 +18,7 @@ use deno_core::futures::StreamExt;
 use deno_core::futures::future;
 use deno_core::futures::stream;
 use deno_core::parking_lot::RwLock;
+use deno_core::serde_json;
 use deno_core::unsync::spawn;
 use deno_core::unsync::spawn_blocking;
 use deno_runtime::deno_permissions::Permissions;
@@ -32,6 +35,7 @@ use super::server::TestServerTests;
 use crate::args::DenoSubcommand;
 use crate::args::flags_from_vec;
 use crate::args::parallelism_count;
+use crate::cdp;
 use crate::factory::CliFactory;
 use crate::lsp::client::Client;
 use crate::lsp::client::TestingNotification;
@@ -229,6 +233,15 @@ impl TestRun {
   /// If being executed, cancel the test.
   pub fn cancel(&self) {
     self.token.cancel();
+  }
+
+  /// Returns the coverage directory path if coverage mode is enabled.
+  pub fn coverage_dir(&self) -> Option<PathBuf> {
+    if self.kind == lsp_custom::TestRunKind::Coverage {
+      Some(std::env::temp_dir().join(format!("deno_lsp_coverage_{}", self.id)))
+    } else {
+      None
+    }
   }
 
   /// Execute the tests, dispatching progress notifications to the client.
@@ -522,6 +535,27 @@ impl TestRun {
 
     result??;
 
+    // If coverage mode is enabled, collect and send coverage data
+    if let Some(coverage_dir) = self.coverage_dir() {
+      match collect_coverage_from_dir(&coverage_dir) {
+        Ok(files) => {
+          if !files.is_empty() {
+            client.send_test_notification(TestingNotification::Coverage(
+              lsp_custom::CoverageNotificationParams { id: self.id, files },
+            ));
+          }
+        }
+        Err(err) => {
+          lsp_log!("Failed to collect coverage data: {}", err);
+        }
+      }
+
+      // Clean up coverage directory
+      if let Err(err) = fs::remove_dir_all(&coverage_dir) {
+        lsp_log!("Failed to clean up coverage directory: {}", err);
+      }
+    }
+
     Ok(())
   }
 
@@ -560,6 +594,11 @@ impl TestRun {
       && !args.contains(&Cow::Borrowed("--inspect-brk"))
     {
       args.push(Cow::Borrowed("--inspect"));
+    }
+    if self.kind == lsp_custom::TestRunKind::Coverage
+      && let Some(coverage_dir) = self.coverage_dir()
+    {
+      args.push(Cow::Owned(format!("--coverage={}", coverage_dir.display())));
     }
     // Inherit `--env-file` paths from the `test` task in deno.json when the
     // user hasn't already supplied one via `deno.testing.args`. Without this,
@@ -672,6 +711,131 @@ fn extract_env_files_from_command(command: &str) -> Vec<String> {
 
 fn is_shell_command_separator(token: &str) -> bool {
   matches!(token, "&&" | "||" | ";" | "|")
+}
+
+/// Builds byte offsets for the start of each source line.
+fn build_line_starts(source: &str) -> Vec<usize> {
+  let mut starts = vec![0usize];
+  for (i, byte) in source.bytes().enumerate() {
+    if byte == b'\n' {
+      starts.push(i + 1);
+    }
+  }
+  starts
+}
+
+/// Converts a byte offset to a 1-indexed line using binary search.
+fn offset_to_line(starts: &[usize], offset: usize) -> u32 {
+  match starts.binary_search(&offset) {
+    Ok(index) => (index + 1) as u32,
+    Err(index) => index as u32,
+  }
+}
+
+/// Collects V8 coverage JSON files from a directory and builds per-file
+/// coverage summaries.
+fn collect_coverage_from_dir(
+  coverage_dir: &Path,
+) -> Result<Vec<lsp_custom::FileCoverage>, AnyError> {
+  let mut file_coverages: HashMap<String, (Vec<u32>, Vec<u32>, u32, u32)> =
+    HashMap::new();
+
+  if !coverage_dir.exists() {
+    return Ok(Vec::new());
+  }
+
+  for entry in fs::read_dir(coverage_dir)? {
+    let entry = entry?;
+    let path = entry.path();
+    if path.extension().and_then(|s| s.to_str()) == Some("json") {
+      let content = fs::read_to_string(&path)?;
+      if let Ok(script_coverage) =
+        serde_json::from_str::<cdp::ScriptCoverage>(&content)
+      {
+        // Skip internal/test files
+        if script_coverage.url.starts_with("ext:")
+          || script_coverage.url.starts_with("data:")
+          || script_coverage.url.ends_with("__anonymous__")
+          || script_coverage.url.ends_with("$deno$test.mjs")
+        {
+          continue;
+        }
+
+        let line_starts = if script_coverage.url.starts_with("file://") {
+          let file_path = script_coverage
+            .url
+            .strip_prefix("file://")
+            .unwrap_or(&script_coverage.url);
+          fs::read_to_string(file_path)
+            .ok()
+            .map(|s| build_line_starts(&s))
+        } else {
+          None
+        };
+
+        let Some(ref line_starts) = line_starts else {
+          continue;
+        };
+
+        let mut line_hits: HashMap<u32, i64> = HashMap::new();
+        for function in &script_coverage.functions {
+          for range in &function.ranges {
+            let start_line =
+              offset_to_line(line_starts, range.start_char_offset);
+            let end_line = offset_to_line(line_starts, range.end_char_offset);
+
+            for line in start_line..=end_line {
+              let count = line_hits.entry(line).or_insert(0);
+              if range.count > 0 {
+                *count += range.count;
+              }
+            }
+          }
+        }
+
+        let entry = file_coverages
+          .entry(script_coverage.url.clone())
+          .or_insert_with(|| (Vec::new(), Vec::new(), 0, 0));
+
+        for (line, count) in line_hits {
+          if count > 0 {
+            if !entry.0.contains(&line) {
+              entry.0.push(line);
+              entry.2 += 1; // covered count
+            }
+          } else if !entry.1.contains(&line) {
+            entry.1.push(line);
+            entry.3 += 1; // uncovered count
+          }
+        }
+      }
+    }
+  }
+
+  let mut result = Vec::new();
+  for (url, (mut covered, mut uncovered, covered_count, uncovered_count)) in
+    file_coverages
+  {
+    covered.sort();
+    uncovered.sort();
+    let total = covered_count + uncovered_count;
+    let coverage_percent = if total > 0 {
+      (covered_count as f64 / total as f64) * 100.0
+    } else {
+      0.0
+    };
+
+    if let Ok(uri) = uri_parse_unencoded(&url) {
+      result.push(lsp_custom::FileCoverage {
+        uri,
+        covered_lines: covered,
+        uncovered_lines: uncovered,
+        coverage_percent,
+      });
+    }
+  }
+
+  Ok(result)
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
## Summary
- build line-start offsets once for coverage files
- map byte offsets to lines with binary search
- avoid repeated linear scans during coverage collection

## Validation
- cargo fmt --check
- cargo check -p deno

Closes #18147