### PR TITLE
fix(ext/napi): track pending finalizers by identity

### DIFF
--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -45,6 +45,9 @@ struct Reference {
   finalize_cb: Option<napi_finalize>,
   finalize_data: *mut c_void,
   finalize_hint: *mut c_void,
+  /// Identity of this reference's entry in the env's shutdown finalizer list,
+  /// as long as the finalizer hasn't run yet.
+  finalizer_id: Option<NapiFinalizerId>,
 }
 
 impl Reference {
@@ -57,6 +60,18 @@ impl Reference {
     finalize_data: *mut c_void,
     finalize_hint: *mut c_void,
   ) -> Box<Self> {
+    // Register the finalizer so that it still runs at environment shutdown for
+    // references that were never collected, the same way Node.js finalizes its
+    // remaining `reflist` entries in `napi_env::DeleteMe()`.
+    let finalizer_id = finalize_cb.map(|cb| {
+      unsafe { &*env }.add_ref_finalizer(
+        env as napi_env,
+        cb,
+        finalize_data,
+        finalize_hint,
+      )
+    });
+
     let isolate = unsafe { (*env).isolate() };
 
     let mut reference = Box::new(Reference {
@@ -67,6 +82,7 @@ impl Reference {
       finalize_cb,
       finalize_data,
       finalize_hint,
+      finalizer_id,
     });
 
     if initial_ref_count == 0 {
@@ -95,7 +111,12 @@ impl Reference {
     self.ref_count
   }
 
+  /// Drops this reference's finalizer, deregistering it from the env's
+  /// shutdown finalizer list so that it cannot be called (again) there.
   fn reset(&mut self) {
+    if let Some(id) = self.finalizer_id.take() {
+      unsafe { &*self.env }.remove_ref_finalizer(id);
+    }
     self.finalize_cb = None;
     self.finalize_data = std::ptr::null_mut();
     self.finalize_hint = std::ptr::null_mut();
@@ -149,11 +170,10 @@ impl Reference {
     // finalizer; doing that from V8's second-pass callback is what produced
     // the intermittent `napi_unwrap` failure reported in #33924 / #34008
     // ("Failed to unwrap exclusive reference of `...` type from napi value").
+    // `reset()` above already deregistered the shutdown finalizer entry, so it
+    // is not called again at env shutdown (matches Node's `Unlink` ordering in
+    // `Reference::Finalize`).
     if let Some(finalize_cb) = finalize_cb {
-      // Deregister before dispatching so the finalizer is not called again
-      // at env shutdown (matches Node's `Unlink` ordering in
-      // `Reference::Finalize`).
-      unsafe { &*env_ptr }.remove_ref_finalizer(finalize_data);
       unsafe {
         finalize_cb(env_ptr as _, finalize_data, finalize_hint);
       }
@@ -181,6 +201,17 @@ impl Reference {
       r.reset();
     } else {
       unsafe { drop(Reference::from_raw(r)) }
+    }
+  }
+}
+
+impl Drop for Reference {
+  fn drop(&mut self) {
+    // A reference that goes away without its finalizer having run (e.g. via
+    // `napi_delete_reference`) must not leave a dangling entry behind: Node
+    // unlinks the reference from the env's list in `~RefTracker`.
+    if let Some(id) = self.finalizer_id.take() {
+      unsafe { &*self.env }.remove_ref_finalizer(id);
     }
   }
 }
@@ -3009,15 +3040,6 @@ fn napi_wrap(
     finalize_hint,
   );
 
-  if let Some(cb) = finalize_cb {
-    env.add_ref_finalizer(
-      env_ptr as napi_env,
-      cb,
-      native_object,
-      finalize_hint,
-    );
-  }
-
   let reference = Reference::into_raw(reference) as *mut c_void;
 
   if !result.is_null() {
@@ -3069,7 +3091,6 @@ fn unwrap(
   }
 
   if !keep {
-    env.remove_ref_finalizer(reference.finalize_data);
     assert!(obj.delete_private(scope, napi_wrap).unwrap_or(false));
     unsafe { Reference::remove(reference) };
   }
@@ -3120,19 +3141,13 @@ fn napi_create_external<'s>(
   v8::callback_scope!(unsafe scope, env.context());
   let external = v8::External::new(scope, wrapper as _);
 
-  if let Some(finalize_cb) = finalize_cb {
-    env.add_ref_finalizer(
-      env_ptr as napi_env,
-      finalize_cb,
-      data,
-      finalize_hint,
-    );
+  if finalize_cb.is_some() {
     Reference::into_raw(Reference::new(
       env_ptr,
       external.into(),
       0,
       ReferenceOwnership::Runtime,
-      Some(finalize_cb),
+      finalize_cb,
       data,
       finalize_hint,
     ));
@@ -4208,15 +4223,6 @@ fn napi_add_finalizer(
     ReferenceOwnership::Userland
   };
 
-  if let Some(cb) = finalize_cb {
-    env.add_ref_finalizer(
-      env_ptr as napi_env,
-      cb,
-      finalize_data,
-      finalize_hint,
-    );
-  }
-
   let reference = Reference::new(
     env,
     value.into(),
@@ -4227,9 +4233,14 @@ fn napi_add_finalizer(
     finalize_hint,
   );
 
+  // Both ownership modes keep the reference alive: a runtime-owned one frees
+  // itself in its weak callback, a userland-owned one is freed by the addon
+  // through `napi_delete_reference`.
+  let reference = Reference::into_raw(reference);
+
   if !result.is_null() {
     unsafe {
-      *result = Reference::into_raw(reference) as _;
+      *result = reference as _;
     }
   }
 

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -343,18 +343,65 @@ impl<T> PendingNapiAsyncWork for T where T: FnOnce() + Send + 'static {}
 /// This matches Node.js's behavior of tracking references with finalize
 /// callbacks and calling them during `napi_env::DeleteMe()`.
 pub struct PendingNapiFinalizer {
+  /// Unique identity of this registration. Finalizers must be deregistered by
+  /// id, never by `data`: several live registrations can share the same `data`
+  /// pointer (addons routinely pass a null or repeated `native_object`), and
+  /// removing an arbitrary entry with a matching `data` leaves the entry whose
+  /// callback already ran behind, which then runs a second time at shutdown.
+  pub id: NapiFinalizerId,
   pub env: napi_env,
   pub cb: napi_finalize,
   pub data: *mut c_void,
   pub hint: *mut c_void,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NapiFinalizerId(u64);
+
+/// Tracked finalizer callbacks that should be called at shutdown.
+/// Matches Node.js `finalizing_reflist` / `reflist` behavior.
+#[derive(Default)]
+pub struct RefTracker {
+  next_id: u64,
+  pending: Vec<PendingNapiFinalizer>,
+}
+
+impl RefTracker {
+  /// Removes and returns all pending finalizers, leaving the tracker empty.
+  pub fn take_pending(&mut self) -> Vec<PendingNapiFinalizer> {
+    std::mem::take(&mut self.pending)
+  }
+
+  fn add(
+    &mut self,
+    env: napi_env,
+    cb: napi_finalize,
+    data: *mut c_void,
+    hint: *mut c_void,
+  ) -> NapiFinalizerId {
+    let id = NapiFinalizerId(self.next_id);
+    self.next_id += 1;
+    self.pending.push(PendingNapiFinalizer {
+      id,
+      env,
+      cb,
+      data,
+      hint,
+    });
+    id
+  }
+
+  fn remove(&mut self, id: NapiFinalizerId) {
+    if let Some(pos) = self.pending.iter().rposition(|f| f.id == id) {
+      self.pending.remove(pos);
+    }
+  }
+}
+
 pub struct NapiState {
   // Thread safe functions.
   pub env_cleanup_hooks: Rc<RefCell<Vec<(napi_cleanup_hook, *mut c_void)>>>,
-  /// Tracked finalizer callbacks that should be called at shutdown.
-  /// Matches Node.js `finalizing_reflist` / `reflist` behavior.
-  pub ref_tracker: Rc<RefCell<Vec<PendingNapiFinalizer>>>,
+  pub ref_tracker: Rc<RefCell<RefTracker>>,
   pub env_shared_ptrs: Vec<*mut EnvShared>,
   /// Raw Env pointers for teardown of external string finalizers.
   pub env_ptrs: Vec<*mut Env>,
@@ -490,7 +537,7 @@ pub struct Env {
   pub shared: *mut EnvShared,
   pub async_work_sender: V8CrossThreadTaskSpawner,
   cleanup_hooks: Rc<RefCell<Vec<(napi_cleanup_hook, *mut c_void)>>>,
-  ref_tracker: Rc<RefCell<Vec<PendingNapiFinalizer>>>,
+  ref_tracker: Rc<RefCell<RefTracker>>,
   external_ops_tracker: ExternalOpsTracker,
   pub last_error: napi_extended_error_info,
   pub last_exception: Option<v8::Global<v8::Value>>,
@@ -521,7 +568,7 @@ impl Env {
     async_hooks_destroy: v8::Global<v8::Function>,
     sender: V8CrossThreadTaskSpawner,
     cleanup_hooks: Rc<RefCell<Vec<(napi_cleanup_hook, *mut c_void)>>>,
-    ref_tracker: Rc<RefCell<Vec<PendingNapiFinalizer>>>,
+    ref_tracker: Rc<RefCell<RefTracker>>,
     external_ops_tracker: ExternalOpsTracker,
   ) -> Self {
     Self {
@@ -630,20 +677,12 @@ impl Env {
     cb: napi_finalize,
     data: *mut c_void,
     hint: *mut c_void,
-  ) {
-    self.ref_tracker.borrow_mut().push(PendingNapiFinalizer {
-      env,
-      cb,
-      data,
-      hint,
-    });
+  ) -> NapiFinalizerId {
+    self.ref_tracker.borrow_mut().add(env, cb, data, hint)
   }
 
-  pub fn remove_ref_finalizer(&self, data: *mut c_void) {
-    let mut tracker = self.ref_tracker.borrow_mut();
-    if let Some(pos) = tracker.iter().rposition(|f| f.data == data) {
-      tracker.remove(pos);
-    }
+  pub fn remove_ref_finalizer(&self, id: NapiFinalizerId) {
+    self.ref_tracker.borrow_mut().remove(id);
   }
 }
 
@@ -657,7 +696,7 @@ deno_core::extension!(deno_napi,
   state = |state, options| {
     state.put(NapiState {
       env_cleanup_hooks: Rc::new(RefCell::new(vec![])),
-      ref_tracker: Rc::new(RefCell::new(vec![])),
+      ref_tracker: Rc::new(RefCell::new(RefTracker::default())),
       env_shared_ptrs: vec![],
       env_ptrs: vec![],
       napi_wrap: None,

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -1125,10 +1125,7 @@ impl MainWorker {
       let op_state = self.js_runtime.op_state();
       let op_state = op_state.borrow();
       match op_state.try_borrow::<deno_napi::NapiState>() {
-        Some(s) => {
-          let mut tracker = s.ref_tracker.borrow_mut();
-          std::mem::take(&mut *tracker)
-        }
+        Some(s) => s.ref_tracker.borrow_mut().take_pending(),
         None => return,
       }
     };

--- a/tests/integration/napi_tests.rs
+++ b/tests/integration/napi_tests.rs
@@ -141,6 +141,45 @@ fn napi_wrap_leak_pointers_finalizer_on_shutdown() {
   );
 }
 
+/// Test that finalizers of externals sharing a `data` pointer are tracked
+/// individually, so that collecting one of them neither loses another one's
+/// finalizer nor makes its own finalizer run a second time at shutdown.
+/// Regression test for #36538, which crashed `@duckdb/node-api` under GC
+/// pressure.
+#[test_util::test]
+fn napi_shared_data_finalizers_run_once() {
+  napi_build();
+
+  let output = deno_cmd()
+    .current_dir(napi_tests_path())
+    .arg("run")
+    .arg("--allow-read")
+    .arg("--allow-env")
+    .arg("--allow-ffi")
+    .arg("--v8-flags=--expose-gc")
+    .arg("--config")
+    .arg(deno_config_path())
+    .arg("--no-lock")
+    .arg("finalizer_shared_data.js")
+    .envs(env_vars_for_npm_tests())
+    .output()
+    .unwrap();
+  let stdout = std::str::from_utf8(&output.stdout).unwrap();
+  let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+  if !output.status.success() {
+    eprintln!("exit code {:?}", output.status.code());
+    println!("stdout {}", stdout);
+    println!("stderr {}", stderr);
+  }
+  assert!(output.status.success());
+  assert!(
+    stdout.contains("shared data externals finalized once"),
+    "Expected the script to run to completion, got stdout: {}",
+    stdout
+  );
+}
+
 /// Test that NAPI wrap finalizers are also called at shutdown when the
 /// wrapping happens inside a `Deno.test`. Regression test for #35692, where
 /// the `deno test` worker was torn down without draining the NAPI finalizer

--- a/tests/napi/finalizer_shared_data.js
+++ b/tests/napi/finalizer_shared_data.js
@@ -1,0 +1,44 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Regression test for #36538. All the externals created here share the same
+// (null) `data` pointer while each carries its own finalize hint, which is the
+// shape addons such as `@duckdb/node-api` produce. The runtime used to identify
+// pending finalizers by their `data` pointer, so collecting one external
+// deregistered an unrelated external's finalizer; the collected one's finalizer
+// was then called a second time during shutdown, with an already freed hint,
+// crashing the process with SIGSEGV/SIGBUS.
+
+import { assert, assertEquals, loadTestLibrary } from "./common.js";
+
+const lib = loadTestLibrary();
+
+const kept = [];
+for (let i = 0; i < 200; i++) {
+  const external = lib.test_shared_data_external(i);
+  // Keep a quarter of them reachable, so that they are only finalized at
+  // shutdown while the rest are finalized by the garbage collector.
+  if (i % 4 === 0) {
+    kept.push(external);
+  }
+}
+
+for (let i = 0; i < 3; i++) {
+  globalThis.gc();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+assert(
+  lib.test_shared_data_finalized_count() > 0,
+  "expected the garbage collector to finalize some externals",
+);
+assertEquals(
+  lib.test_shared_data_double_count(),
+  0,
+  "no finalizer may run more than once",
+);
+
+// Keep the remaining externals alive until shutdown; finalizing them must not
+// re-run the finalizers of the ones already collected above.
+globalThis.keptExternals = kept;
+// deno-lint-ignore no-console
+console.log("shared data externals finalized once");

--- a/tests/napi/src/finalizer.rs
+++ b/tests/napi/src/finalizer.rs
@@ -237,6 +237,84 @@ extern "C" fn test_deferred_finalizer_check(
   result
 }
 
+/// Ids of the externals created by `test_shared_data_external` that have not
+/// been finalized yet.
+static SHARED_DATA_LIVE: std::sync::Mutex<
+  Option<std::collections::HashSet<usize>>,
+> = std::sync::Mutex::new(None);
+static SHARED_DATA_FINALIZED: std::sync::atomic::AtomicUsize =
+  std::sync::atomic::AtomicUsize::new(0);
+static SHARED_DATA_DOUBLE: std::sync::atomic::AtomicUsize =
+  std::sync::atomic::AtomicUsize::new(0);
+
+/// All externals created by `test_shared_data_external` share this `data`
+/// pointer while each has its own `hint`, the shape addons like
+/// `@duckdb/node-api` produce through `Napi::External`. The finalizer must be
+/// called exactly once per external.
+unsafe extern "C" fn shared_data_finalize_cb(
+  _env: napi_env,
+  data: *mut ::std::os::raw::c_void,
+  hint: *mut ::std::os::raw::c_void,
+) {
+  assert!(data.is_null());
+  let id = hint as usize;
+  let mut live = SHARED_DATA_LIVE.lock().unwrap();
+  let live = live.get_or_insert_with(Default::default);
+  if !live.remove(&id) {
+    SHARED_DATA_DOUBLE.fetch_add(1, Ordering::SeqCst);
+    panic!("finalizer for external {id} called more than once");
+  }
+  SHARED_DATA_FINALIZED.fetch_add(1, Ordering::SeqCst);
+}
+
+extern "C" fn test_shared_data_external(
+  env: napi_env,
+  info: napi_callback_info,
+) -> napi_value {
+  let (args, argc, _) = napi_get_callback_info!(env, info, 1);
+  assert_eq!(argc, 1);
+
+  let mut id: u32 = 0;
+  assert_napi_ok!(napi_get_value_uint32(env, args[0], &mut id));
+  // Ids start at 1 so that no id collides with a null `hint`.
+  let id = id as usize + 1;
+
+  {
+    let mut live = SHARED_DATA_LIVE.lock().unwrap();
+    assert!(live.get_or_insert_with(Default::default).insert(id));
+  }
+
+  let mut result = ptr::null_mut();
+  assert_napi_ok!(napi_create_external(
+    env,
+    ptr::null_mut(),
+    Some(shared_data_finalize_cb),
+    id as *mut ::std::os::raw::c_void,
+    &mut result
+  ));
+  result
+}
+
+extern "C" fn test_shared_data_finalized_count(
+  env: napi_env,
+  _: napi_callback_info,
+) -> napi_value {
+  let mut result = ptr::null_mut();
+  let count = SHARED_DATA_FINALIZED.load(Ordering::SeqCst);
+  assert_napi_ok!(napi_create_uint32(env, count as u32, &mut result));
+  result
+}
+
+extern "C" fn test_shared_data_double_count(
+  env: napi_env,
+  _: napi_callback_info,
+) -> napi_value {
+  let mut result = ptr::null_mut();
+  let count = SHARED_DATA_DOUBLE.load(Ordering::SeqCst);
+  assert_napi_ok!(napi_create_uint32(env, count as u32, &mut result));
+  result
+}
+
 pub fn init(env: napi_env, exports: napi_value) {
   let properties = &[
     napi_new_property!(env, "test_bind_finalizer", test_bind_finalizer),
@@ -258,6 +336,21 @@ pub fn init(env: napi_env, exports: napi_value) {
       env,
       "test_deferred_finalizer_check",
       test_deferred_finalizer_check
+    ),
+    napi_new_property!(
+      env,
+      "test_shared_data_external",
+      test_shared_data_external
+    ),
+    napi_new_property!(
+      env,
+      "test_shared_data_finalized_count",
+      test_shared_data_finalized_count
+    ),
+    napi_new_property!(
+      env,
+      "test_shared_data_double_count",
+      test_shared_data_double_count
     ),
   ];
 


### PR DESCRIPTION
Pending Node-API finalizers were deregistered by their `data` pointer,
which only works if every live registration has a distinct one. Addons
routinely break that assumption by passing a null or repeated
`native_object` — `@duckdb/node-api` does it through `Napi::External` —
and then collecting one value removed an arbitrary entry with a matching
`data` instead of its own. The entry belonging to the value that was just
finalized stayed behind and ran a second time at shutdown, with a hint
the addon had already freed, killing the process with SIGSEGV/SIGBUS.
That is why it only showed up under garbage-collection pressure: GC has
to collect some of the duplicates mid-run for the mixup to happen.

Every registration now has a unique id and is deregistered by that id. A
reference registers its finalizer when it is created and drops the
registration when it is reset or goes away, so a finalizer can no longer
outlive its reference either. As a consequence `napi_add_finalizer` has
to keep its runtime-owned reference alive, which also fixes those
finalizers running only at shutdown instead of on collection.

Fixes #36538