### PR TITLE
fix(cli): Do not output literal "\n" in bash completion script

### DIFF
--- a/libs/cli_parser/src/completions.rs
+++ b/libs/cli_parser/src/completions.rs
@@ -46,15 +46,14 @@ fn generate_bash(cmd: &CommandDef) -> Vec<u8> {
   // Add subcommand detection
   for sub in cmd.subcommands {
     out.push_str(&format!(
-            "            \"{name},{}\")\\n                cmd=\"{name}__{}\"\n                ;;\n",
+            "            \"{name},{}\")\n                cmd=\"{name}__{}\"\n                ;;\n",
             sub.name,
             sub.name.replace('-', "__"),
         ));
   }
 
-  out.push_str(
-    "            *)\\n                ;;\n        esac\n    done\n\n",
-  );
+  out
+    .push_str("            *)\n                ;;\n        esac\n    done\n\n");
 
   // Root command completions
   let root_flags: Vec<String> = cmd


### PR DESCRIPTION
This fixes the bash completion script generated by `deno completions`, which includes literal "\n" in a few places since the cutover to cli_parser in 4e8b2f46ab638ae6fa20cf53a9a4cd3b5f4550bf.

Fixes #36554.

No AI used.

<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
