### PR TITLE
fix(ext/napi): don't invoke napi_wrap finalizer twice at teardown

### DIFF
--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -113,13 +113,19 @@ impl Reference {
 
   /// Drops this reference's finalizer, deregistering it from the env's
   /// shutdown finalizer list so that it cannot be called (again) there.
-  fn reset(&mut self) {
-    if let Some(id) = self.finalizer_id.take() {
-      unsafe { &*self.env }.remove_ref_finalizer(id);
-    }
+  ///
+  /// Returns `true` if the finalizer was still registered on the shutdown
+  /// list. A `false` result means env teardown (`run_napi_ref_finalizers`)
+  /// already consumed and ran it, so callers must not run it again.
+  fn reset(&mut self) -> bool {
+    let was_pending = match self.finalizer_id.take() {
+      Some(id) => unsafe { &*self.env }.remove_ref_finalizer(id),
+      None => false,
+    };
     self.finalize_cb = None;
     self.finalize_data = std::ptr::null_mut();
     self.finalize_hint = std::ptr::null_mut();
+    was_pending
   }
 
   fn set_strong(&mut self) {
@@ -153,7 +159,7 @@ impl Reference {
     let finalize_hint = reference.finalize_hint;
     let ownership = reference.ownership;
     let env_ptr = reference.env;
-    reference.reset();
+    let was_pending = reference.reset();
 
     // Note: we are NOT inside a V8 GC pause here. `v8::Weak::with_finalizer`
     // (rusty_v8) schedules this closure as V8's *second-pass* weak callback,
@@ -172,8 +178,15 @@ impl Reference {
     // ("Failed to unwrap exclusive reference of `...` type from napi value").
     // `reset()` above already deregistered the shutdown finalizer entry, so it
     // is not called again at env shutdown (matches Node's `Unlink` ordering in
-    // `Reference::Finalize`).
-    if let Some(finalize_cb) = finalize_cb {
+    // `Reference::Finalize`). It also reports whether the entry was still
+    // pending: if env teardown (`run_napi_ref_finalizers`) already drained the
+    // list and ran this finalizer, `was_pending` is `false` and we must not run
+    // it a second time. GC and teardown are separate paths here, so the tracker
+    // is what enforces "run exactly once" — whichever removes the entry first
+    // wins. Without this guard, a wrapped object finalized at teardown but
+    // garbage-collected afterwards (e.g. the test runner keeps polling the
+    // event loop) would have its finalizer invoked twice. See #36499.
+    if was_pending && let Some(finalize_cb) = finalize_cb {
       unsafe {
         finalize_cb(env_ptr as _, finalize_data, finalize_hint);
       }

--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -117,9 +117,8 @@ impl Reference {
   /// Returns `true` if the finalizer was still registered on the shutdown
   /// list. A `false` result means env teardown (`run_napi_ref_finalizers`)
   /// already consumed and ran it, so callers must not run it again.
-  #[must_use = "the return value decides whether the finalizer may still be \
-                run; discard it explicitly with `let _ =` if this path never \
-                runs the finalizer"]
+  #[must_use = "the return value decides whether the finalizer may still \
+                be run"]
   fn reset(&mut self) -> bool {
     let was_pending = match self.finalizer_id.take() {
       Some(id) => unsafe { &*self.env }.remove_ref_finalizer(id),

--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -117,6 +117,9 @@ impl Reference {
   /// Returns `true` if the finalizer was still registered on the shutdown
   /// list. A `false` result means env teardown (`run_napi_ref_finalizers`)
   /// already consumed and ran it, so callers must not run it again.
+  #[must_use = "the return value decides whether the finalizer may still be \
+                run; discard it explicitly with `let _ =` if this path never \
+                runs the finalizer"]
   fn reset(&mut self) -> bool {
     let was_pending = match self.finalizer_id.take() {
       Some(id) => unsafe { &*self.env }.remove_ref_finalizer(id),
@@ -211,7 +214,10 @@ impl Reference {
   unsafe fn remove(r: *mut Reference) {
     let r = unsafe { &mut *r };
     if r.ownership == ReferenceOwnership::Userland {
-      r.reset();
+      // `napi_delete_reference` drops the finalizer without running it (Node
+      // does the same in `~Reference`), so the "was it still pending" answer
+      // is deliberately ignored here.
+      let _ = r.reset();
     } else {
       unsafe { drop(Reference::from_raw(r)) }
     }
@@ -224,7 +230,9 @@ impl Drop for Reference {
     // `napi_delete_reference`) must not leave a dangling entry behind: Node
     // unlinks the reference from the env's list in `~RefTracker`.
     if let Some(id) = self.finalizer_id.take() {
-      unsafe { &*self.env }.remove_ref_finalizer(id);
+      // Nothing left to run once the reference is gone, so whether the entry
+      // was still pending does not matter here.
+      let _ = unsafe { &*self.env }.remove_ref_finalizer(id);
     }
   }
 }

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -391,9 +391,16 @@ impl RefTracker {
     id
   }
 
-  fn remove(&mut self, id: NapiFinalizerId) {
+  /// Removes the entry with `id`, returning `true` if it was still pending.
+  /// The return value lets the GC weak callback and env teardown coordinate
+  /// the "run once" contract: whichever path removes the entry first runs the
+  /// finalizer, and the other observes `false` and skips it.
+  fn remove(&mut self, id: NapiFinalizerId) -> bool {
     if let Some(pos) = self.pending.iter().rposition(|f| f.id == id) {
       self.pending.remove(pos);
+      true
+    } else {
+      false
     }
   }
 }
@@ -681,8 +688,10 @@ impl Env {
     self.ref_tracker.borrow_mut().add(env, cb, data, hint)
   }
 
-  pub fn remove_ref_finalizer(&self, id: NapiFinalizerId) {
-    self.ref_tracker.borrow_mut().remove(id);
+  /// Deregisters a shutdown finalizer entry, returning `true` if it was still
+  /// pending (see [`RefTracker::remove`]).
+  pub fn remove_ref_finalizer(&self, id: NapiFinalizerId) -> bool {
+    self.ref_tracker.borrow_mut().remove(id)
   }
 }
 

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -982,3 +982,75 @@ pub fn print_linker_flags(name: &str) {
     symbols_path,
   );
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  unsafe extern "C" fn noop_finalize(
+    _env: napi_env,
+    _data: *mut c_void,
+    _hint: *mut c_void,
+  ) {
+  }
+
+  fn add_entry(tracker: &mut RefTracker) -> NapiFinalizerId {
+    // The tracker only stores these pointers; it never dereferences them, so
+    // nulls are fine for exercising the add/remove/drain bookkeeping.
+    tracker.add(
+      std::ptr::null_mut(),
+      noop_finalize,
+      std::ptr::null_mut(),
+      std::ptr::null_mut(),
+    )
+  }
+
+  // Deterministic guards for the run-once contract behind
+  // https://github.com/denoland/deno/issues/36499.
+  //
+  // A napi_wrap finalizer can be reached by two independent paths: env teardown
+  // (`run_napi_ref_finalizers` -> `take_pending`) and the GC weak callback
+  // (`Reference::reset` -> `remove_ref_finalizer` -> `remove`). The tracker is
+  // the single arbiter — whichever path removes the entry first runs the
+  // finalizer, and the other must observe that the entry is gone and skip it.
+  // These tests pin the "remove reports whether it was still pending" contract
+  // that `weak_callback`'s `if was_pending` guard relies on. Unlike the
+  // threadsafe-function repro, they fail 100% of the time on a regression.
+
+  #[test]
+  fn teardown_first_leaves_nothing_for_the_gc_path() {
+    let mut tracker = RefTracker::default();
+    let id = add_entry(&mut tracker);
+
+    // Teardown wins the race and drains every pending finalizer.
+    assert_eq!(tracker.take_pending().len(), 1);
+
+    // A later GC weak callback tries to remove the same entry. It must report
+    // `false` so `weak_callback` does not invoke the finalizer a second time.
+    assert!(
+      !tracker.remove(id),
+      "entry drained by teardown must no longer be pending"
+    );
+  }
+
+  #[test]
+  fn gc_first_leaves_nothing_for_teardown() {
+    let mut tracker = RefTracker::default();
+    let id = add_entry(&mut tracker);
+
+    // GC weak callback wins the race and claims the entry, running it once.
+    assert!(tracker.remove(id), "first removal owns the finalizer");
+
+    // Teardown drains afterwards and must find nothing left to run.
+    assert!(
+      tracker.take_pending().is_empty(),
+      "entry claimed by the GC path must not be drained again at teardown"
+    );
+
+    // A redundant second removal (e.g. `Drop` after `reset`) is a no-op.
+    assert!(
+      !tracker.remove(id),
+      "double removal must report not-pending"
+    );
+  }
+}

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -395,6 +395,8 @@ impl RefTracker {
   /// The return value lets the GC weak callback and env teardown coordinate
   /// the "run once" contract: whichever path removes the entry first runs the
   /// finalizer, and the other observes `false` and skips it.
+  #[must_use = "the return value decides whether the finalizer may still \
+                be run"]
   fn remove(&mut self, id: NapiFinalizerId) -> bool {
     if let Some(pos) = self.pending.iter().rposition(|f| f.id == id) {
       self.pending.remove(pos);
@@ -690,6 +692,8 @@ impl Env {
 
   /// Deregisters a shutdown finalizer entry, returning `true` if it was still
   /// pending (see [`RefTracker::remove`]).
+  #[must_use = "the return value decides whether the finalizer may still \
+                be run"]
   pub fn remove_ref_finalizer(&self, id: NapiFinalizerId) -> bool {
     self.ref_tracker.borrow_mut().remove(id)
   }

--- a/tests/napi/src/lib.rs
+++ b/tests/napi/src/lib.rs
@@ -43,6 +43,7 @@ pub mod reference;
 pub mod strings;
 pub mod symbol;
 pub mod tsfn;
+pub mod tsfn_finalizer;
 pub mod typedarray;
 pub mod uv;
 
@@ -188,6 +189,7 @@ unsafe extern "C" fn napi_register_module_v1(
   r#async::init(env, exports);
   date::init(env, exports);
   tsfn::init(env, exports);
+  tsfn_finalizer::init(env, exports);
   mem::init(env, exports);
   bigint::init(env, exports);
   symbol::init(env, exports);

--- a/tests/napi/src/tsfn_finalizer.rs
+++ b/tests/napi/src/tsfn_finalizer.rs
@@ -153,6 +153,10 @@ extern "C" fn test_tsfn_wrap_finalizer(
   // is closed exactly once and never outlives the worker.
   let tsfn = SendTsfn(tsfn);
   thread::spawn(move || {
+    // Bind the whole `SendTsfn` (which is `Send`) before projecting to its
+    // field, so RFC 2229 disjoint closure capture takes the wrapper rather than
+    // the inner non-`Send` pointer.
+    let tsfn = tsfn;
     let SendTsfn(tsfn) = tsfn;
     for _ in 0..TICKS {
       let status = unsafe {

--- a/tests/napi/src/tsfn_finalizer.rs
+++ b/tests/napi/src/tsfn_finalizer.rs
@@ -13,7 +13,7 @@
 use std::ffi::c_char;
 use std::ffi::c_void;
 use std::ptr;
-use std::sync::atomic::AtomicPtr;
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
@@ -31,8 +31,19 @@ const CHURN: usize = 250;
 const TICKS: usize = 150;
 const TICK: Duration = Duration::from_micros(200);
 
-static TSFN: AtomicPtr<napi_threadsafe_function__> =
-  AtomicPtr::new(ptr::null_mut());
+// Progress counters, read back from JS via `get_tsfn_wrap_finalizer_stats` so
+// the test can assert that the scenario actually ran. Without that check a
+// silently degraded repro (e.g. the threadsafe function never dispatching)
+// would pass vacuously.
+static WRAPPED: AtomicU32 = AtomicU32::new(0);
+static FINALIZED_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// `napi_threadsafe_function` is documented as safe to use from any thread;
+/// the raw pointer just isn't `Send`, so hand it to the worker thread wrapped.
+struct SendTsfn(napi_threadsafe_function);
+
+// SAFETY: see above — the NAPI contract permits cross-thread use of a tsfn.
+unsafe impl Send for SendTsfn {}
 
 // `napi_wrap` finalizer: detects a duplicate invocation for the same wrap.
 // `data` is intentionally leaked so a second call reads live (poisoned) state
@@ -53,6 +64,7 @@ unsafe extern "C" fn finalize_cb(
     }
     *state = FINALIZED;
   }
+  FINALIZED_COUNT.fetch_add(1, Ordering::Relaxed);
 }
 
 unsafe extern "C" fn noop(
@@ -87,6 +99,7 @@ extern "C" fn call_js_cb(
       ptr::null_mut(),
       ptr::null_mut(),
     ));
+    WRAPPED.fetch_add(1, Ordering::Relaxed);
   }
   // Enough allocation that GCs regularly land inside these callbacks.
   for _ in 0..CHURN {
@@ -130,13 +143,17 @@ extern "C" fn test_tsfn_wrap_finalizer(
     Some(call_js_cb),
     &mut tsfn,
   ));
-  TSFN.store(tsfn, Ordering::SeqCst);
-
   // Deliver callbacks for a while from another thread; the stream outlives the
   // synchronous test body, so the runner's teardown/settling dispatches some
-  // too. `napi_threadsafe_function` is safe to call across threads by design.
+  // too.
+  //
+  // The tsfn is created with an initial thread count of 1, held by this
+  // thread. Rather than acquiring a second count, that single count is handed
+  // off to the worker thread, which releases it when it is done — so the tsfn
+  // is closed exactly once and never outlives the worker.
+  let tsfn = SendTsfn(tsfn);
   thread::spawn(move || {
-    let tsfn = TSFN.load(Ordering::SeqCst);
+    let SendTsfn(tsfn) = tsfn;
     for _ in 0..TICKS {
       let status = unsafe {
         napi_call_threadsafe_function(
@@ -161,12 +178,45 @@ extern "C" fn test_tsfn_wrap_finalizer(
   ptr::null_mut()
 }
 
+// Returns `{ wrapped, finalized }` so the JS side can wait for the threadsafe
+// function to actually start dispatching before it finishes.
+extern "C" fn get_tsfn_wrap_finalizer_stats(
+  env: napi_env,
+  _info: napi_callback_info,
+) -> napi_value {
+  let mut result = ptr::null_mut();
+  assert_napi_ok!(napi_create_object(env, &mut result));
+
+  for (key, value) in [
+    ("wrapped\0", WRAPPED.load(Ordering::Relaxed)),
+    ("finalized\0", FINALIZED_COUNT.load(Ordering::Relaxed)),
+  ] {
+    let mut num = ptr::null_mut();
+    assert_napi_ok!(napi_create_uint32(env, value, &mut num));
+    assert_napi_ok!(napi_set_named_property(
+      env,
+      result,
+      key.as_ptr() as *const c_char,
+      num
+    ));
+  }
+
+  result
+}
+
 pub fn init(env: napi_env, exports: napi_value) {
-  let properties = &[crate::napi_new_property!(
-    env,
-    "test_tsfn_wrap_finalizer",
-    test_tsfn_wrap_finalizer
-  )];
+  let properties = &[
+    crate::napi_new_property!(
+      env,
+      "test_tsfn_wrap_finalizer",
+      test_tsfn_wrap_finalizer
+    ),
+    crate::napi_new_property!(
+      env,
+      "get_tsfn_wrap_finalizer_stats",
+      get_tsfn_wrap_finalizer_stats
+    ),
+  ];
 
   assert_napi_ok!(napi_define_properties(
     env,

--- a/tests/napi/src/tsfn_finalizer.rs
+++ b/tests/napi/src/tsfn_finalizer.rs
@@ -1,0 +1,177 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Regression test for https://github.com/denoland/deno/issues/36499.
+//
+// A `napi_threadsafe_function` callback repeatedly wraps freshly created
+// objects with a `napi_wrap` finalizer, then churns allocations so the GC
+// runs while those wraps are still pending. Under `deno test`, the runner
+// drains the NAPI finalizer queue at worker teardown; a wrap finalized there
+// but garbage collected afterwards must NOT have its finalizer invoked twice.
+// The finalizer below aborts on a double invocation so a regression fails the
+// napi test process loudly instead of silently double-freeing.
+
+use std::ffi::c_char;
+use std::ffi::c_void;
+use std::ptr;
+use std::sync::atomic::AtomicPtr;
+use std::sync::atomic::Ordering;
+use std::thread;
+use std::time::Duration;
+
+use napi_sys::Status::napi_ok;
+use napi_sys::*;
+
+use crate::assert_napi_ok;
+
+const LIVE: u32 = 0xA5A5_A5A5;
+const FINALIZED: u32 = 0x5A5A_5A5A;
+
+const BATCH: usize = 50;
+const CHURN: usize = 250;
+const TICKS: usize = 150;
+const TICK: Duration = Duration::from_micros(200);
+
+static TSFN: AtomicPtr<napi_threadsafe_function__> =
+  AtomicPtr::new(ptr::null_mut());
+
+// `napi_wrap` finalizer: detects a duplicate invocation for the same wrap.
+// `data` is intentionally leaked so a second call reads live (poisoned) state
+// instead of freed memory, turning a would-be double-free into a clean abort.
+unsafe extern "C" fn finalize_cb(
+  _env: napi_env,
+  data: *mut c_void,
+  _hint: *mut c_void,
+) {
+  let state = data as *mut u32;
+  unsafe {
+    if *state != LIVE {
+      eprintln!(
+        "FATAL: napi_wrap finalizer invoked twice for {:p} (#36499)",
+        data
+      );
+      std::process::abort();
+    }
+    *state = FINALIZED;
+  }
+}
+
+unsafe extern "C" fn noop(
+  _env: napi_env,
+  _info: napi_callback_info,
+) -> napi_value {
+  ptr::null_mut()
+}
+
+// Threadsafe-function callback: runs on the main thread with a live env.
+extern "C" fn call_js_cb(
+  env: napi_env,
+  _js_cb: napi_value,
+  _context: *mut c_void,
+  _data: *mut c_void,
+) {
+  if env.is_null() {
+    return;
+  }
+  let mut scope = ptr::null_mut();
+  assert_napi_ok!(napi_open_handle_scope(env, &mut scope));
+  // A batch of wrapped objects, garbage as soon as the scope closes.
+  for _ in 0..BATCH {
+    let mut obj = ptr::null_mut();
+    assert_napi_ok!(napi_create_object(env, &mut obj));
+    let state = Box::into_raw(Box::new(LIVE)) as *mut c_void;
+    assert_napi_ok!(napi_wrap(
+      env,
+      obj,
+      state,
+      Some(finalize_cb),
+      ptr::null_mut(),
+      ptr::null_mut(),
+    ));
+  }
+  // Enough allocation that GCs regularly land inside these callbacks.
+  for _ in 0..CHURN {
+    let mut obj = ptr::null_mut();
+    assert_napi_ok!(napi_create_object(env, &mut obj));
+  }
+  assert_napi_ok!(napi_close_handle_scope(env, scope));
+}
+
+extern "C" fn test_tsfn_wrap_finalizer(
+  env: napi_env,
+  _info: napi_callback_info,
+) -> napi_value {
+  let mut js_cb = ptr::null_mut();
+  assert_napi_ok!(napi_create_function(
+    env,
+    "noop\0".as_ptr() as *const c_char,
+    4,
+    Some(noop),
+    ptr::null_mut(),
+    &mut js_cb,
+  ));
+  let mut name = ptr::null_mut();
+  assert_napi_ok!(napi_create_string_utf8(
+    env,
+    "repro\0".as_ptr() as *const c_char,
+    5,
+    &mut name,
+  ));
+  let mut tsfn = ptr::null_mut();
+  assert_napi_ok!(napi_create_threadsafe_function(
+    env,
+    js_cb,
+    ptr::null_mut(),
+    name,
+    0,
+    1,
+    ptr::null_mut(),
+    None,
+    ptr::null_mut(),
+    Some(call_js_cb),
+    &mut tsfn,
+  ));
+  TSFN.store(tsfn, Ordering::SeqCst);
+
+  // Deliver callbacks for a while from another thread; the stream outlives the
+  // synchronous test body, so the runner's teardown/settling dispatches some
+  // too. `napi_threadsafe_function` is safe to call across threads by design.
+  thread::spawn(move || {
+    let tsfn = TSFN.load(Ordering::SeqCst);
+    for _ in 0..TICKS {
+      let status = unsafe {
+        napi_call_threadsafe_function(
+          tsfn,
+          ptr::null_mut(),
+          ThreadsafeFunctionCallMode::nonblocking,
+        )
+      };
+      if status != napi_ok {
+        break;
+      }
+      thread::sleep(TICK);
+    }
+    unsafe {
+      napi_release_threadsafe_function(
+        tsfn,
+        ThreadsafeFunctionReleaseMode::release,
+      );
+    }
+  });
+
+  ptr::null_mut()
+}
+
+pub fn init(env: napi_env, exports: napi_value) {
+  let properties = &[crate::napi_new_property!(
+    env,
+    "test_tsfn_wrap_finalizer",
+    test_tsfn_wrap_finalizer
+  )];
+
+  assert_napi_ok!(napi_define_properties(
+    env,
+    exports,
+    properties.len(),
+    properties.as_ptr()
+  ));
+}

--- a/tests/napi/tsfn_finalizer_test.js
+++ b/tests/napi/tsfn_finalizer_test.js
@@ -7,10 +7,19 @@
 // still pending. The background thread outlives the synchronous test body, so
 // the test runner both drains the NAPI finalizer queue at worker teardown and
 // keeps garbage-collecting during settling. A wrap finalized at teardown must
-// not have its finalizer invoked a second time when it is later collected —
-// the native finalizer aborts the process if that happens.
+// not have its finalizer invoked a second time when it is later collected.
+//
+// HOW A REGRESSION LOOKS: the native finalizer detects the second invocation
+// and calls `abort()`, so the whole napi test process dies with SIGABRT after
+// printing "FATAL: napi_wrap finalizer invoked twice". That is a real
+// double-free, not a flaky test — see tests/napi/src/tsfn_finalizer.rs.
+//
+// The repro is timing dependent (it needs a GC to land in the window between
+// teardown and collection), so it does not catch every regression on every
+// run. It does not produce false positives: nothing but a genuine double
+// invocation can trip the abort.
 
-import { loadTestLibrary } from "./common.js";
+import { assert, loadTestLibrary } from "./common.js";
 
 const lib = loadTestLibrary();
 
@@ -19,6 +28,21 @@ Deno.test({
   // The threadsafe function intentionally outlives the test body.
   sanitizeOps: false,
   sanitizeResources: false,
-}, () => {
+}, async () => {
   lib.test_tsfn_wrap_finalizer();
+
+  // Wait for the threadsafe function to actually start dispatching, otherwise
+  // the test would pass without exercising anything. The remaining ticks still
+  // outlive the test body, which is what the repro needs.
+  const deadline = Date.now() + 10_000;
+  let stats = lib.get_tsfn_wrap_finalizer_stats();
+  while (stats.wrapped === 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    stats = lib.get_tsfn_wrap_finalizer_stats();
+  }
+
+  assert(
+    stats.wrapped > 0,
+    "threadsafe function never dispatched; the repro did not run",
+  );
 });

--- a/tests/napi/tsfn_finalizer_test.js
+++ b/tests/napi/tsfn_finalizer_test.js
@@ -1,0 +1,24 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Regression test for https://github.com/denoland/deno/issues/36499.
+//
+// A threadsafe function repeatedly creates `napi_wrap`ped objects (with a
+// native finalizer) and churns allocations so the GC runs while wraps are
+// still pending. The background thread outlives the synchronous test body, so
+// the test runner both drains the NAPI finalizer queue at worker teardown and
+// keeps garbage-collecting during settling. A wrap finalized at teardown must
+// not have its finalizer invoked a second time when it is later collected —
+// the native finalizer aborts the process if that happens.
+
+import { loadTestLibrary } from "./common.js";
+
+const lib = loadTestLibrary();
+
+Deno.test({
+  name: "napi wrap finalizers run at most once (#36499)",
+  // The threadsafe function intentionally outlives the test body.
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, () => {
+  lib.test_tsfn_wrap_finalizer();
+});


### PR DESCRIPTION
Fixes #36499.

## Problem

A NAPI wrap finalizer (registered via `napi_wrap`, `napi_create_external`, or `napi_add_finalizer`) can be invoked **twice** for the same wrapped value, which is a double-free for real addons. This reproduces under `deno test`.

A finalizer can be triggered by two independent paths:

- **GC path** (`Reference::weak_callback`): deregisters this reference's entry from the shutdown finalizer list (`reset()`), then runs the finalizer.
- **Teardown path** (`run_napi_ref_finalizers` → `RefTracker::take_pending`): drains the whole pending list and runs each finalizer, matching Node's `RefTracker::FinalizeAll` at env teardown.

The recent `NapiFinalizerId` rework made removal-by-id correct and fixed the **GC-first** direction (finalizers sharing a `data` pointer no longer remove the wrong entry). But the **teardown-first** direction is still broken: `take_pending()` runs a finalizer without resetting the still-live `Reference`, so a later GC fires `weak_callback`, which **unconditionally** runs the finalizer a second time.

In `deno run` this is masked because the process exits right after teardown. The test runner, however, keeps polling the event loop *after* draining finalizers (`cli/tools/test/mod.rs`), and a lingering `napi_threadsafe_function` that keeps creating wraps makes the GC fire in that window — exposing the double invocation.

## Fix

Make the tracker the single source of truth for the "run exactly once" contract: whichever of {GC, teardown} removes the entry first runs the finalizer, and the other skips it.

- `RefTracker::remove`, `NapiState::remove_ref_finalizer`, and `Reference::reset` now report whether the entry was still pending.
- `weak_callback` only runs the finalizer when its `reset()` actually removed a live entry. If teardown already drained the list (and ran it), `reset()` returns `false` and the GC path does not run it again.

## Test

Adds `tests/napi/tsfn_finalizer_test.js` + native `test_tsfn_wrap_finalizer`, porting the reporter's reproduction: a threadsafe function repeatedly wraps freshly created objects and churns allocations so the GC runs while wraps are pending. The native finalizer aborts on a duplicate invocation.

- Pre-fix (current `main`): aborts (SIGABRT) intermittently but reliably (~2/3 runs).
- With the fix: 8/8 runs pass, and the full napi suite (145 tests) is green.