### PR TITLE
fix(ext/node): build the proxied request target with the URL parser

### DIFF
--- a/ext/node/polyfills/_http_client.js
+++ b/ext/node/polyfills/_http_client.js
@@ -459,19 +459,44 @@ function isURL(input) {
 // path of `//host/x` is protocol-relative to the URL parser and would
 // otherwise silently retarget the request at another authority.
 function buildProxyRequestTarget(authorityHost, port, path) {
+  let base;
   try {
-    const base = new URL(`http://${authorityHost}`);
+    base = new URL(`http://${authorityHost}`);
     base.port = port;
-    try {
-      // An absolute-form path is already a complete target.
-      return new URL(path).href;
-    } catch {
-      return new URL(base.origin + path).href;
-    }
   } catch {
     // A host the URL parser rejects is not a reachable target; node:http
     // reports that while building the request. Fall back to concatenation so
     // this helper is not what fails first.
+    const portSuffix = +port === 80 ? "" : `:${port}`;
+    return `http://${authorityHost}${portSuffix}${path}`;
+  }
+
+  // An absolute-form path is already a complete target. It is only honored
+  // when its authority matches the one that `--allow-net` validated and it
+  // carries no userinfo: the permission check upstream sees only `host` and
+  // `port`, so an absolute `path` aimed at another authority (or embedding
+  // credentials for one) would otherwise retarget the proxied request past
+  // that check. Fail closed instead - like a denied direct connection.
+  let absolute = null;
+  try {
+    absolute = new URL(path);
+  } catch {
+    // Not absolute-form; resolved as an origin-form path below.
+  }
+  if (absolute !== null) {
+    if (
+      absolute.host !== base.host ||
+      absolute.username !== "" ||
+      absolute.password !== ""
+    ) {
+      throw new ERR_INVALID_URL(path);
+    }
+    return absolute.href;
+  }
+
+  try {
+    return new URL(base.origin + path).href;
+  } catch {
     const portSuffix = +port === 80 ? "" : `:${port}`;
     return `http://${authorityHost}${portSuffix}${path}`;
   }

--- a/ext/node/polyfills/_http_client.js
+++ b/ext/node/polyfills/_http_client.js
@@ -137,8 +137,6 @@ const kRetryData = Symbol("kRetryData");
 const kRetryDataSize = Symbol("kRetryDataSize");
 const kRetryOptions = Symbol("kRetryOptions");
 const kProxy = Symbol("kProxy");
-const kProxyTargetHost = Symbol("kProxyTargetHost");
-const kProxyTargetPort = Symbol("kProxyTargetPort");
 const kInspectorRequestId = Symbol("kInspectorRequestId");
 const kInspectorNetwork = Symbol("kInspectorNetwork");
 const kInspectorUrl = Symbol("kInspectorUrl");
@@ -448,6 +446,37 @@ function isURL(input) {
   return ObjectPrototypeIsPrototypeOf(URL.prototype, input);
 }
 
+// Builds the absolute-form request target (RFC 9112 section 3.2.2) that an
+// HTTP proxy is given in place of the origin-form path.
+//
+// Node builds it with `new URL()`, so go through the URL parser here too:
+// `href` omits the port when it is the scheme default and normalizes the
+// authority (lowercasing, IDNA), neither of which string concatenation does.
+// `authorityHost` must not carry the port - it is applied separately so the
+// parser can drop it when it is the default.
+//
+// The path is resolved against the origin rather than the full base URL: a
+// path of `//host/x` is protocol-relative to the URL parser and would
+// otherwise silently retarget the request at another authority.
+function buildProxyRequestTarget(authorityHost, port, path) {
+  try {
+    const base = new URL(`http://${authorityHost}`);
+    base.port = port;
+    try {
+      // An absolute-form path is already a complete target.
+      return new URL(path).href;
+    } catch {
+      return new URL(base.origin + path).href;
+    }
+  } catch {
+    // A host the URL parser rejects is not a reachable target; node:http
+    // reports that while building the request. Fall back to concatenation so
+    // this helper is not what fails first.
+    const portSuffix = +port === 80 ? "" : `:${port}`;
+    return `http://${authorityHost}${portSuffix}${path}`;
+  }
+}
+
 function ClientRequest(input, options, cb) {
   FunctionPrototypeCall(OutgoingMessage, this);
 
@@ -572,8 +601,6 @@ function ClientRequest(input, options, cb) {
       );
     }
     this[kProxy] = proxyEntry;
-    this[kProxyTargetHost] = host;
-    this[kProxyTargetPort] = port;
     optsWithoutSignal._proxy = proxyEntry;
     optsWithoutSignal._proxyTargetHost = host;
     optsWithoutSignal._proxyTargetPort = port;
@@ -641,23 +668,6 @@ function ClientRequest(input, options, cb) {
   this[kPath] = options.path || "/";
   this[kProxyRewrittenToAbsolute] = false;
 
-  // For HTTP via HTTP proxy, rewrite path to an absolute URL so the proxy
-  // knows where to forward the request.
-  if (this[kProxy] && protocol === "http:") {
-    const t = this[kProxyTargetHost];
-    const formattedHost = t && StringPrototypeIndexOf(t, ":") !== -1 &&
-        StringPrototypeCharCodeAt(t, 0) !== 91
-      ? `[${t}]`
-      : t;
-    // Node builds this target with `new URL()`, whose `href` omits the port
-    // when it is the scheme default, so match that rather than always
-    // emitting `:port`.
-    const targetPort = this[kProxyTargetPort];
-    const portSuffix = +targetPort === 80 ? "" : `:${targetPort}`;
-    this[kPath] = `http://${formattedHost}${portSuffix}${options.path || "/"}`;
-    this[kProxyRewrittenToAbsolute] = true;
-  }
-
   if (cb) {
     this.once("response", cb);
   }
@@ -709,6 +719,9 @@ function ClientRequest(input, options, cb) {
   ) {
     hostHeaderFromOptions = `[${hostHeaderFromOptions}]`;
   }
+  // Captured before the port is appended: building the proxy request target
+  // takes the host and the port separately, the way Node's does.
+  const proxyAuthorityHost = hostHeaderFromOptions;
 
   if (port && +port !== defaultPort) {
     hostHeaderFromOptions += ":" + port;
@@ -716,6 +729,18 @@ function ClientRequest(input, options, cb) {
   // Preserve the request authority (with the port when non-default) so that
   // the perf_hooks entry can report a faithful URL.
   this[kAuthority] = hostHeaderFromOptions;
+
+  // For HTTP via HTTP proxy, rewrite path to an absolute URL so the proxy
+  // knows where to forward the request. This has to come after the authority
+  // above so both derive from the same bracketed host.
+  if (this[kProxy] && protocol === "http:") {
+    this[kPath] = buildProxyRequestTarget(
+      proxyAuthorityHost,
+      port,
+      this[kPath],
+    );
+    this[kProxyRewrittenToAbsolute] = true;
+  }
 
   const headersArray = ArrayIsArray(options.headers);
   if (!headersArray) {
@@ -889,9 +914,10 @@ ClientRequest.prototype._implicitHeader = function _implicitHeader() {
     // the authority again would duplicate it.
     const protocol = this.protocol || "http:";
     const path = this.path || "/";
+    const authority = this[kAuthority] || this.host || "localhost";
     const fullUrl = this[kProxyRewrittenToAbsolute]
       ? path
-      : `${protocol}//${this[kAuthority]}${path}`;
+      : `${protocol}//${authority}${path}`;
     try {
       const parsedUrl = new URL(fullUrl);
       span.setAttribute("http.request.method", this.method);
@@ -1293,9 +1319,9 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
           // it is already a full URL.
           url: req[kProxyRewrittenToAbsolute]
             ? req.path
-            : `${req.protocol || "http:"}//${req[kAuthority]}${
-              req.path || "/"
-            }`,
+            : `${req.protocol || "http:"}//${
+              req[kAuthority] || req.host || "localhost"
+            }${req.path || "/"}`,
           headers: req.getHeaders(),
         },
         res: {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -25,7 +25,13 @@ import { channel } from "node:diagnostics_channel";
 import * as v8 from "node:v8";
 import { runInNewContext } from "node:vm";
 
-import { assert, assertEquals, assertStringIncludes, fail } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+  fail,
+} from "@std/assert";
 import { assertSpyCalls, spy } from "@std/testing/mock";
 import { fromFileUrl, relative } from "@std/path";
 import { retry } from "@std/async/retry";
@@ -3853,6 +3859,75 @@ Deno.test(
       await promise;
       assertEquals(seenUrl, expected);
     }
+  },
+);
+
+Deno.test(
+  "[node/http] proxied absolute-form target cannot retarget the authority",
+  () => {
+    // The --allow-net check upstream only validated the requested host and
+    // port. An absolute `path` naming a different authority - or a different
+    // port, or embedding credentials - would slip a request past that check
+    // once the proxy forwards it. Reject it in ClientRequest, failing closed
+    // like a denied direct connection, before any bytes reach the proxy.
+    for (
+      const path of [
+        "http://evil.example/x",
+        "http://example.com:9999/x", // same host, but an unchecked port
+        "http://user:pass@example.com:8080/x", // userinfo for the checked one
+      ]
+    ) {
+      const err = assertThrows(
+        () =>
+          http.request({
+            hostname: "example.com",
+            port: 8080,
+            path,
+            agent: new http.Agent({
+              // Never dialed: the rewrite throws before connecting.
+              proxyEnv: { HTTP_PROXY: "http://127.0.0.1:1" },
+            } as ProxyAgentLike),
+          }),
+        Error,
+        "Invalid URL",
+      );
+      assertEquals((err as { code?: string }).code, "ERR_INVALID_URL");
+    }
+  },
+);
+
+Deno.test(
+  "[node/http] proxied absolute-form target matching the authority is honored",
+  async () => {
+    // The authority matches the checked target, so the absolute-form path is
+    // a legitimate request target and is forwarded to the proxy as given.
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    let seenUrl: string | undefined;
+    const proxy = http.createServer((req, res) => {
+      seenUrl = req.url;
+      res.end("via-proxy");
+    });
+    proxy.listen(0, () => {
+      const proxyPort = (proxy.address() as AddressInfo).port;
+      const req = http.request({
+        hostname: "example.com",
+        port: 8080,
+        path: "http://example.com:8080/foo",
+        agent: new http.Agent({
+          proxyEnv: { HTTP_PROXY: `http://127.0.0.1:${proxyPort}` },
+        } as ProxyAgentLike),
+      }, (res) => {
+        res.resume();
+        res.on("end", () => {
+          proxy.close();
+          resolve();
+        });
+      });
+      req.on("error", reject);
+      req.end();
+    });
+    await promise;
+    assertEquals(seenUrl, "http://example.com:8080/foo");
   },
 );
 

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -3794,6 +3794,69 @@ Deno.test(
 );
 
 Deno.test(
+  "[node/http] proxied absolute-form target normalizes the authority",
+  async () => {
+    // The target goes through the URL parser, like Node's, so the authority
+    // comes out normalized: the host lowercased and an IPv6 address bracketed
+    // exactly once. A protocol-relative path must stay a path - resolving it
+    // as a URL would retarget the request at another authority.
+    for (
+      const { hostname, path, expected } of [
+        {
+          hostname: "EXAMPLE.COM",
+          path: "/foo",
+          expected: "http://example.com:8080/foo",
+        },
+        {
+          hostname: "::1",
+          path: "/foo",
+          expected: "http://[::1]:8080/foo",
+        },
+        {
+          hostname: "[::1]",
+          path: "/foo",
+          expected: "http://[::1]:8080/foo",
+        },
+        {
+          hostname: "example.com",
+          path: "//evil.example/x",
+          expected: "http://example.com:8080//evil.example/x",
+        },
+      ]
+    ) {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      let seenUrl: string | undefined;
+      // unreachable target - the proxy intercepts and short-circuits.
+      const proxy = http.createServer((req, res) => {
+        seenUrl = req.url;
+        res.end("via-proxy");
+      });
+      proxy.listen(0, () => {
+        const proxyPort = (proxy.address() as AddressInfo).port;
+        const req = http.request({
+          hostname,
+          port: 8080,
+          path,
+          agent: new http.Agent({
+            proxyEnv: { HTTP_PROXY: `http://127.0.0.1:${proxyPort}` },
+          } as ProxyAgentLike),
+        }, (res) => {
+          res.resume();
+          res.on("end", () => {
+            proxy.close();
+            resolve();
+          });
+        });
+        req.on("error", reject);
+        req.end();
+      });
+      await promise;
+      assertEquals(seenUrl, expected);
+    }
+  },
+);
+
+Deno.test(
   "[node/http] NO_PROXY bypasses configured HTTP_PROXY",
   async () => {
     // If NO_PROXY matches the target, the request should hit the origin

--- a/tests/unit_node/perf_hooks_test.ts
+++ b/tests/unit_node/perf_hooks_test.ts
@@ -283,6 +283,38 @@ Deno.test("[perf_hooks]: HttpClient url is not duplicated when proxied", async (
   }
 });
 
+// The URL is built from the request authority, so an explicitly supplied Host
+// header does not change it. Node reports the same, as both derive the URL
+// from `options`, not from the outgoing headers.
+Deno.test("[perf_hooks]: HttpClient url ignores an explicit Host header", async () => {
+  const server = http.createServer((_req, res) => res.end("ok"));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  const observed = observeHttpEntry("HttpClient");
+  try {
+    await new Promise<void>((resolve, reject) => {
+      http.request({
+        hostname: "127.0.0.1",
+        port,
+        path: "/observed",
+        headers: { host: "someone.else" },
+      }, (res) => {
+        res.resume();
+        res.on("end", resolve);
+      }).on("error", reject).end();
+    });
+
+    const detail = await observed.detail;
+    assertEquals(detail.req.url, `http://127.0.0.1:${port}/observed`);
+  } finally {
+    observed.dispose();
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => err ? reject(err) : resolve())
+    );
+  }
+});
+
 Deno.test("[perf_hooks]: node:http server entries are not retroactive", async () => {
   let finishResponse: (() => void) | undefined;
   let resolveRequestStarted = () => {};


### PR DESCRIPTION
Follow-up to #36407, which fixed `perf_hooks` `detail.req.url` for
non-default ports and proxy path rewrites.

That PR left the absolute-form request target (the full URL an HTTP
proxy is given in place of the origin-form path) assembled by string
concatenation, with its own IPv6 bracketing pass separate from the one
that builds the request authority a few dozen lines below. The two
brackets on different conditions: the target's on any colon in the host,
the authority's only on a second one. Upstream has a single source for
both, because Node's rewrite runs after `hostHeaderFromOptions` is
computed and reuses it.

This moves the rewrite below the authority so both derive from the same
bracketed host, and builds the target with `new URL()` the way Node
does. Going through the URL parser also picks up the normalization that
concatenation cannot: the host is lowercased and IDNA-encoded, and the
port is dropped when it is the scheme default, so the hardcoded
comparison against port 80 that #36407 added goes away. A host the
parser rejects is not a reachable target — node:http reports that while
building the request — so the helper falls back to concatenation rather
than being what fails first.

The path is resolved against `base.origin` rather than the base URL
itself, matching upstream: `new URL(path, base)` treats a path of
`//host/x` as protocol-relative and would silently retarget the request
at another authority. Deno's previous concatenation had the same
authority-preserving behavior, so this is not a change on the wire; it
is a property worth not losing to the parser, and there is now a test
for it.

Restores the `this.host` / `"localhost"` fallbacks when reporting the
request URL. They were there before #36407 and cost nothing;
`kAuthority` is unset on no reachable path today, but without them a
gap produces `http://undefined/...`, which `new URL()` parses happily
rather than throwing into the surrounding `try`.

The two now-unused `kProxyTargetHost` / `kProxyTargetPort` symbols are
removed. They were only ever read by the rewrite this replaces; the
`_proxyTargetHost` / `_proxyTargetPort` options that `https.ts` and
`_http_agent.js` consume are untouched.

Tests cover authority normalization (uppercase host, bracketed and
unbracketed IPv6) and the protocol-relative path, alongside the existing
default-port case. A `perf_hooks` test pins the behavior change #36407
made that had no coverage: the reported URL comes from the request
authority, so an explicitly supplied Host header does not change it,
which is what Node reports too.

One thing #36407 claimed that this does not deliver: its description
said it enabled `client-proxy/test-http-proxy-perf-hooks.mjs` and an
updated `parallel/test-http-perf_hooks.js`. Neither happened — no
`config.jsonc` change was in that diff. The vendored suite is pinned at
v18.12.1, where the proxy test does not exist and the perf_hooks test
predates the URL assertions, so enabling them needs a submodule bump
rather than a config edit, and that belongs in its own PR.

Verified locally: `cargo test unit_node::http_test`,
`cargo test unit_node::perf_hooks_test`, all 43 `otel_basic` spec tests,
and the node_compat suite (3 unrelated failures, all
`listen EINVAL` from unix socket paths too long for the sandbox
directory this was built in).