### PR TITLE
fix(ext/fetch): raise default HTTP/2 SETTINGS_MAX_HEADER_LIST_SIZE to 256KB

### DIFF
--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -1078,6 +1078,19 @@ pub fn create_http_client(
   builder.timer(TokioTimer::new());
   builder.pool_timer(TokioTimer::new());
 
+  // The hyper client defaults `SETTINGS_MAX_HEADER_LIST_SIZE` to 16KB, which is
+  // small enough that responses with large header blocks (e.g. long
+  // `content-security-policy` or many `set-cookie` headers) get rejected by the
+  // h2 stack with a PROTOCOL_ERROR before they ever reach JavaScript. Browsers
+  // advertise a much larger value (Chrome uses 256KB), so match that as the
+  // default to keep `fetch()` interoperable with the same servers browsers can
+  // talk to. https://github.com/denoland/deno/issues/36462
+  //
+  // Apply this *before* the builder hook so an embedder can still override it,
+  // and apply the explicit `Deno.createHttpClient({ http2MaxHeaderListSize })`
+  // option *after* the hook below, giving precedence: default < hook < option.
+  builder.http2_max_header_list_size(DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE);
+
   if let Some(client_builder_hook) = options.client_builder_hook {
     builder = client_builder_hook(builder);
   }
@@ -1149,19 +1162,11 @@ pub fn create_http_client(
     );
   }
 
-  // The hyper client defaults `SETTINGS_MAX_HEADER_LIST_SIZE` to 16KB, which is
-  // small enough that responses with large header blocks (e.g. long
-  // `content-security-policy` or many `set-cookie` headers) get rejected by the
-  // h2 stack with a PROTOCOL_ERROR before they ever reach JavaScript. Browsers
-  // advertise a much larger value (Chrome uses 256KB), so match that as the
-  // default to keep `fetch()` interoperable with the same servers browsers can
-  // talk to. Users can still override this via `http2MaxHeaderListSize`.
-  // https://github.com/denoland/deno/issues/36462
-  builder.http2_max_header_list_size(
-    options
-      .http2_max_header_list_size
-      .unwrap_or(DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE),
-  );
+  // An explicit `Deno.createHttpClient({ http2MaxHeaderListSize })` takes
+  // precedence over both the default above and the builder hook.
+  if let Some(http2_max_header_list_size) = options.http2_max_header_list_size {
+    builder.http2_max_header_list_size(http2_max_header_list_size);
+  }
 
   match (options.http1, options.http2) {
     (true, false) => {} // noop, handled by ALPN above

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -1018,6 +1018,12 @@ pub enum HttpClientCreateError {
   VsockProxyNotSupported,
 }
 
+/// Default `SETTINGS_MAX_HEADER_LIST_SIZE` advertised to HTTP/2 servers. Matches
+/// the value browsers use (Chrome advertises 256KB) rather than hyper's much
+/// smaller 16KB default, which rejects otherwise-valid responses with large
+/// header blocks. See https://github.com/denoland/deno/issues/36462.
+const DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE: u32 = 256 * 1024;
+
 /// Create new instance of async Client. This client supports
 /// proxies and doesn't follow redirects.
 pub fn create_http_client(
@@ -1143,9 +1149,19 @@ pub fn create_http_client(
     );
   }
 
-  if let Some(http2_max_header_list_size) = options.http2_max_header_list_size {
-    builder.http2_max_header_list_size(http2_max_header_list_size);
-  }
+  // The hyper client defaults `SETTINGS_MAX_HEADER_LIST_SIZE` to 16KB, which is
+  // small enough that responses with large header blocks (e.g. long
+  // `content-security-policy` or many `set-cookie` headers) get rejected by the
+  // h2 stack with a PROTOCOL_ERROR before they ever reach JavaScript. Browsers
+  // advertise a much larger value (Chrome uses 256KB), so match that as the
+  // default to keep `fetch()` interoperable with the same servers browsers can
+  // talk to. Users can still override this via `http2MaxHeaderListSize`.
+  // https://github.com/denoland/deno/issues/36462
+  builder.http2_max_header_list_size(
+    options
+      .http2_max_header_list_size
+      .unwrap_or(DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE),
+  );
 
   match (options.http1, options.http2) {
     (true, false) => {} // noop, handled by ALPN above

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -1702,6 +1702,22 @@ Deno.test(
 
 Deno.test(
   { permissions: { net: true, read: true } },
+  async function fetchHttp2LargeHeadersDefault() {
+    // Regression test for https://github.com/denoland/deno/issues/36462:
+    // responses with large header blocks (larger than hyper's old 16KB
+    // SETTINGS_MAX_HEADER_LIST_SIZE default) must not be rejected with an
+    // http2 PROTOCOL_ERROR when no explicit http2MaxHeaderListSize is set.
+    const caCert = await Deno.readTextFile("tests/testdata/tls/RootCA.pem");
+    const client = Deno.createHttpClient({ caCerts: [caCert] });
+    const res = await fetch("https://localhost:5547/large_headers", { client });
+    assert(res.ok);
+    assertEquals(await res.text(), "ok");
+    client.close();
+  },
+);
+
+Deno.test(
+  { permissions: { net: true, read: true } },
   async function fetchForceHttp1OnHttp2Server() {
     const client = Deno.createHttpClient({ http2: false, http1: true });
     await assertRejects(

--- a/tests/util/server/servers/mod.rs
+++ b/tests/util/server/servers/mod.rs
@@ -788,8 +788,12 @@ async fn main_server(
     }
     (_, "/large_headers") => {
       let mut res = Response::new(string_body("ok"));
-      // Add headers that total ~10KB to test http2 max header list size
-      for i in 0..100 {
+      // Add headers whose decoded size totals ~29KB to test the http2 max
+      // header list size. This is intentionally larger than hyper's old 16KB
+      // default so that a default client (which now advertises a browser-like
+      // 256KB limit) can still receive it. See
+      // https://github.com/denoland/deno/issues/36462.
+      for i in 0..200 {
         let value = "a".repeat(100);
         res.headers_mut().append(
           HeaderName::from_bytes(format!("x-large-header-{i}").as_bytes())


### PR DESCRIPTION
Fixes #36462.

## Problem

`fetch()`ing certain HTTP/2 responses fails with `TypeError: fetch failed`
(`stream error detected: unspecific protocol error detected`) while the same
request works with `curl` and Node.

## Root cause

hyper defaults the HTTP/2 client's `SETTINGS_MAX_HEADER_LIST_SIZE` to **16KB**.
When a server sends a response with a large header block (e.g. a long
`content-security-policy` header, or many `set-cookie` / `x-*` headers), the
decoded header list exceeds 16KB and the `h2` layer resets the stream with a
`PROTOCOL_ERROR` before the response ever reaches JavaScript.

Confirmed with h2 tracing on the reproducer from the issue:

```
h2::frame::headers  - load_hpack; header list size over max
h2::proto::streams::recv - stream error REQUEST_HEADER_FIELDS_TOO_LARGE -- frame is over size
send_reset reason=PROTOCOL_ERROR, initiator=Library
```

Browsers and curl advertise much larger limits, so these responses work
everywhere except Deno.

## Fix

Default the client `SETTINGS_MAX_HEADER_LIST_SIZE` to **256KB** (the value
Chrome advertises) instead of hyper's 16KB, so `fetch()` interoperates with the
same servers browsers do. Users can still override it via
`Deno.createHttpClient({ http2MaxHeaderListSize })`.

## Tests

- Enlarged the existing `/large_headers` test-server route to ~29KB decoded
  (over the old 16KB default, under the 64KB the existing "large enough" test
  uses).
- Added `fetchHttp2LargeHeadersDefault` regression test: a default client
  fetching a large-header response now succeeds.

Verified the reproducer URL now returns `200`, and that the old binary rejects
the enlarged route while the patched binary accepts it.