### PR TITLE
chore: update esbuild to 0.28.2

### DIFF
--- a/cli/tools/bundle/esbuild.rs
+++ b/cli/tools/bundle/esbuild.rs
@@ -18,7 +18,7 @@ use crate::npm::CliNpmCacheHttpClient;
 use crate::npm::CliNpmRegistryInfoProvider;
 use crate::sys::CliSys;
 
-pub const ESBUILD_VERSION: &str = "0.25.5";
+pub const ESBUILD_VERSION: &str = "0.28.2";
 // Bump when helper acquisition semantics change so an existing executable is
 // reacquired under the new rules.
 const ESBUILD_CACHE_VERSION: u8 = 1;

--- a/tests/specs/bundle/dir_import_package_json/bundle.out
+++ b/tests/specs/bundle/dir_import_package_json/bundle.out
@@ -5,7 +5,11 @@ var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
 var __commonJS = (cb, mod) => function __require() {
-  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  try {
+    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  } catch (e) {
+    throw mod = 0, e;
+  }
 };
 var __copyProps = (to, from, except, desc) => {
   if (from && typeof from === "object" || typeof from === "function") {

--- a/tests/util/server/npm.rs
+++ b/tests/util/server/npm.rs
@@ -18,7 +18,7 @@ use crate::PathRef;
 use crate::root_path;
 use crate::tests_path;
 
-pub static ESBUILD_VERSION: &str = "0.25.5";
+pub static ESBUILD_VERSION: &str = "0.28.2";
 
 pub static PUBLIC_TEST_NPM_REGISTRY: Lazy<TestNpmRegistry> = Lazy::new(|| {
   TestNpmRegistry::new(

--- a/tests/util/server/servers/npm_registry.rs
+++ b/tests/util/server/servers/npm_registry.rs
@@ -533,7 +533,7 @@ async fn download_npm_registry_file(
   Ok(())
 }
 
-const PREBUILT_URL: &str = "https://raw.githubusercontent.com/denoland/deno_third_party/d074edee0f4199f8226e1f87b88ccb7956d94454/prebuilt/";
+const PREBUILT_URL: &str = "https://raw.githubusercontent.com/denoland/deno_third_party/11713a75449eb48d9c82af7496d9d3caf1d238bc/prebuilt/";
 
 async fn ensure_esbuild_prebuilt() -> Result<(), anyhow::Error> {
   let bin_name = match (std::env::consts::ARCH, std::env::consts::OS) {


### PR DESCRIPTION
Bumps the pinned esbuild version from 0.25.5 to 0.28.2 (latest).

- `ESBUILD_VERSION` in `cli/tools/bundle/esbuild.rs` and in the test registry (`tests/util/server/npm.rs`)
- `PREBUILT_URL` now points at the deno_third_party commit carrying the 0.28.2 prebuilts
- Updated the `dir_import_package_json` expectation: esbuild's `__commonJS` helper now wraps the module body in a `try`/`catch` so a module that throws is re-evaluated on the next `require` instead of being cached as broken

**Blocked on two things:**

1. https://github.com/denoland/deno_third_party/pull/132 — the 0.28.2 prebuilt binaries. `PREBUILT_URL` currently points at that PR's head commit (raw.githubusercontent already serves it, so CI works); it should be repointed at the master sha once that merges.
2. https://github.com/denoland/esbuild_client/pull/20 + a 0.7.3 release — esbuild 0.27.6 changed the build response's `metafile` field from a string to raw UTF-8 bytes, so with the current esbuild_client 0.7.2 every bundle fails with `failed to handle packet expected string`. This PR needs the `esbuild_client` dependency bumped to the release containing that fix.

Verified locally with an `esbuild_client` path override: all 66 `specs::bundle` tests, `unit::bundle_test`, and the bundle watcher integration tests pass.