### PR TITLE
refactor(ext/node): remove unused `n` arg from `IncomingMessage._read`

### DIFF
--- a/ext/node/polyfills/_http_incoming.js
+++ b/ext/node/polyfills/_http_incoming.js
@@ -202,7 +202,7 @@ IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 
 // The parser pushes body data directly via push(). We just need to
 // unpause the underlying socket so data flows.
-IncomingMessage.prototype._read = function _read(_n) {
+IncomingMessage.prototype._read = function _read() {
   if (!this._consuming) {
     this._readableState.readingMore = false;
     this._consuming = true;


### PR DESCRIPTION
Ports the upstream Node.js PR #64370, which removes an unused `n` argument from `IncomingMessage._read` (https://github.com/nodejs/node/pull/64370).

Previously, `IncomingMessage.prototype._read` accepted a `_n` parameter that was never used. The argument originated as a workaround for a long-fixed V8 bug (https://bugs.chromium.org/p/v8/issues/detail?id=10201), since the HTTP parser pushes body data directly via `push()` rather than relying on the `_read` size hint.

This structurally aligns Deno's `_http_incoming.js` with Node's by dropping the unused parameter so `IncomingMessage.prototype._read` is declared as `function _read()`.

The read path is unchanged: the socket is still unpaused in exactly the same way, so there is no behavioral difference and no benchmark regression (upstream reported `http/incoming_headers.js` at Δ +0.19% w=0, +0.20% w=6).

No new tests are required; the change only removes a dead parameter and existing `ext/node` HTTP incoming-message tests continue to cover behavior.

AI Disclosure:
This PR was prepared with the assistance of an AI coding tool. The underlying code port was authored by a human; the AI was used to audit and analyze the change, and also to compare it against the upstream Node.js PR.
