### PR TITLE
fix(desktop): keep the macOS bundle signature valid unless an update is applied

### DIFF
--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -3150,25 +3150,6 @@ async fn package_macos_app_bundle(
   // identifier we just wrote into the main plist.
   rewrite_cef_helper_bundle_ids(&contents_dir, &bundle_id)?;
 
-  // Codesign the assembled bundle. Helpers must be signed before the
-  // main bundle (Gatekeeper / CEF verify them in that order), and the
-  // main bundle's signature seals the helpers' signatures into its
-  // CodeDirectory.
-  //
-  // When the user provides an identity we use it (path to a real
-  // Developer ID for distribution). Otherwise — on a macOS host — we
-  // ad-hoc sign with `-`. Ad-hoc is required for the bundle to receive
-  // a stable code identity from the OS, which gates:
-  //   - UNUserNotificationCenter authorization (without signing,
-  //     `requestAuthorization` silently fails and the user sees
-  //     "denied" with no prompt — this is why Notification.permission
-  //     stays "denied" for unsigned dev builds);
-  //   - LaunchServices registration under a stable bundle id;
-  //   - TCC entries (microphone/camera/automation) attaching to a
-  //     persistent identity rather than re-prompting on every rebuild.
-  // We skip on non-macOS hosts (cross-build) since `codesign(1)` only
-  // exists on macOS.
-  //
   // Handle icon. Must land before codesigning: the bundle signature seals
   // `Contents/Resources`, so an icon copied in afterwards makes a fresh
   // build fail `codesign --verify --strict` on arrival (#36418).
@@ -3207,6 +3188,24 @@ async fn package_macos_app_bundle(
   // the signature and the app would be rejected on launch.
   register_deep_links(&app_bundle, desktop_flags)?;
 
+  // Codesign the assembled bundle. Helpers must be signed before the
+  // main bundle (Gatekeeper / CEF verify them in that order), and the
+  // main bundle's signature seals the helpers' signatures into its
+  // CodeDirectory.
+  //
+  // When the user provides an identity we use it (path to a real
+  // Developer ID for distribution). Otherwise — on a macOS host — we
+  // ad-hoc sign with `-`. Ad-hoc is required for the bundle to receive
+  // a stable code identity from the OS, which gates:
+  //   - UNUserNotificationCenter authorization (without signing,
+  //     `requestAuthorization` silently fails and the user sees
+  //     "denied" with no prompt — this is why Notification.permission
+  //     stays "denied" for unsigned dev builds);
+  //   - LaunchServices registration under a stable bundle id;
+  //   - TCC entries (microphone/camera/automation) attaching to a
+  //     persistent identity rather than re-prompting on every rebuild.
+  // We skip on non-macOS hosts (cross-build) since `codesign(1)` only
+  // exists on macOS.
   let codesign_identity = desktop_flags.codesign_identity.as_deref().or(
     if cfg!(target_os = "macos") {
       Some("-")

--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -3169,23 +3169,9 @@ async fn package_macos_app_bundle(
   // We skip on non-macOS hosts (cross-build) since `codesign(1)` only
   // exists on macOS.
   //
-  // Register any deep-link URL schemes before signing: codesign seals the
-  // bundle contents, so mutating `Info.plist` afterwards would invalidate
-  // the signature and the app would be rejected on launch.
-  register_deep_links(&app_bundle, desktop_flags)?;
-
-  let codesign_identity = desktop_flags.codesign_identity.as_deref().or(
-    if cfg!(target_os = "macos") {
-      Some("-")
-    } else {
-      None
-    },
-  );
-  if let Some(identity) = codesign_identity {
-    codesign_macos_bundle(&app_bundle, identity)?;
-  }
-
-  // Handle icon.
+  // Handle icon. Must land before codesigning: the bundle signature seals
+  // `Contents/Resources`, so an icon copied in afterwards makes a fresh
+  // build fail `codesign --verify --strict` on arrival (#36418).
   if let Some(ref icon) = desktop_flags.icon {
     let dest = resources_dir.join("AppIcon.icns");
     match icon {
@@ -3214,6 +3200,22 @@ async fn package_macos_app_bundle(
         convert_icon_set_to_icns(cli_options.initial_cwd(), entries, &dest)?;
       }
     }
+  }
+
+  // Register any deep-link URL schemes before signing: codesign seals the
+  // bundle contents, so mutating `Info.plist` afterwards would invalidate
+  // the signature and the app would be rejected on launch.
+  register_deep_links(&app_bundle, desktop_flags)?;
+
+  let codesign_identity = desktop_flags.codesign_identity.as_deref().or(
+    if cfg!(target_os = "macos") {
+      Some("-")
+    } else {
+      None
+    },
+  );
+  if let Some(identity) = codesign_identity {
+    codesign_macos_bundle(&app_bundle, identity)?;
   }
 
   // Remove the standalone dylib (it's now inside the .app).

--- a/runtime/ops/desktop.rs
+++ b/runtime/ops/desktop.rs
@@ -1100,8 +1100,16 @@ pub fn op_desktop_confirm_update(state: &mut OpState) {
       .extension()
       .unwrap_or_default()
       .to_string_lossy();
-    let sentinel = s.dylib_path.with_extension(format!("{}.update-ok", ext));
-    let _ = std::fs::write(&sentinel, b"ok");
+    // The sentinel only has meaning while a freshly-applied update's
+    // `.backup` exists (backup-without-sentinel on next boot → rollback).
+    // Writing it unconditionally put a stray file inside the app bundle's
+    // `Contents/MacOS/` on every first launch, which invalidates the
+    // bundle's code signature and even blocks re-signing (#36418).
+    let backup = s.dylib_path.with_extension(format!("{}.backup", ext));
+    if backup.exists() {
+      let sentinel = s.dylib_path.with_extension(format!("{}.update-ok", ext));
+      let _ = std::fs::write(&sentinel, b"ok");
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #36418.

Two ordering/placement bugs made a `deno desktop` macOS bundle fail `codesign --verify` without the user ever applying an update:

**Bug 1 — icon copied after signing.** The app icon was written into `Contents/Resources` *after* `codesign_macos_bundle` ran, so `AppIcon.icns` was never in the sealed resource list and any freshly built bundle with an icon configured failed verification immediately (`a sealed resource is missing or invalid`). The icon step now runs before deep-link registration and signing — signing is the last mutation of the bundle.

**Bug 2 — runtime wrote `.update-ok` inside `Contents/MacOS/` on every launch.** `op_desktop_confirm_update` unconditionally wrote the auto-update boot-success sentinel next to the dylib, invalidating the signature of every distributed copy on first launch and blocking later re-signing (`code object is not signed at all`). The sentinel only has meaning while a freshly-applied update's `.backup` exists (backup-without-sentinel on next boot → rollback), so it's now only written in that state. Apps that never applied an update never write into their own bundle, and the update/rollback state machine is unchanged (the cleanup boot removes `.backup` before the confirm runs, so no stray sentinel is left behind either).

## Scope

**This does not make the auto-update path signature-safe, and isn't trying to.** Applying an update still writes inside `Contents/MacOS/`: `op_desktop_stage_update` writes `<dylib>.update`, `apply_pending_update` hard-links `<dylib>.backup` (and may write `<dylib>.update.tmp` on the rename-fallback path), and the update replaces the sealed dylib itself. Swapping the dylib breaks the seal wherever the bookkeeping files live, so that needs a different answer — staging outside the bundle, re-signing after apply, or accepting that updated apps are ad-hoc-only. Tracked separately.

What this PR fixes is the case in the issue and the common one: an app that never takes an update no longer breaks its own signature, at build time or on launch.

## Verification

Issue repro (bundle with a PNG icon, webview backend, macOS arm64):
- `codesign --verify --deep --strict` passes on the freshly built bundle; `AppIcon.icns` appears in `CodeResources`.
- After launching and quitting the app, `Contents/MacOS/` still contains only the two executables and verification still passes.

The issue's related observation about Hardened Runtime/entitlements on the launcher script is a separate question (self-extract bundles) and isn't addressed here.
