### PR TITLE
fix(serve): warn when DENO_SERVE_ADDRESS overrides an explicit port

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -1187,6 +1187,22 @@ function serve(arg1, arg2) {
     switch (overrideKind) {
       case 1: {
         // TCP
+        // Surface the clobber instead of silently ignoring an explicit,
+        // different port: under `deno desktop` (and anything else that sets
+        // DENO_SERVE_ADDRESS) the first server must listen on the
+        // runtime-assigned address, and users passing `{ port }` otherwise
+        // print/expect a URL that nothing is listening on (#36092).
+        if (
+          typeof options.port === "number" && options.port !== 0 &&
+          options.port !== overridePort
+        ) {
+          // deno-lint-ignore no-console
+          console.warn(
+            `%cwarning: %cDeno.serve option \`port: ${options.port}\` is overridden to ${overridePort} by the runtime-assigned serve address (DENO_SERVE_ADDRESS)`,
+            "color: yellow",
+            "color: inherit",
+          );
+        }
         envOptions = {
           ...envOptions,
           hostname: overrideHost,


### PR DESCRIPTION
Fixes #36092.

Under `deno desktop` (and anything else that sets `DENO_SERVE_ADDRESS`) the first `Deno.serve` call must listen on the runtime-assigned address so the webview knows where to navigate — but an explicit `{ port }` option was silently replaced, so apps printed and expected a URL that nothing was listening on:

```
Usage dashboard running at http://localhost:8787
Listening on http://127.0.0.1:32935/
```

Now, when the override replaces an explicitly-configured different port, a warning makes the mismatch visible:

```
Dashboard at http://localhost:8787
warning: Deno.serve option `port: 8787` is overridden to 57621 by the runtime-assigned serve address (DENO_SERVE_ADDRESS)
Listening on http://127.0.0.1:57621/
```

No warning when no port was given, when `port: 0` was requested, or when the ports happen to match. Verified with a desktop run of the issue's snippet.

