### PR TITLE
fix(pack): preserve computed symbol methods in declarations

### DIFF
--- a/cli/tools/pack/mod.rs
+++ b/cli/tools/pack/mod.rs
@@ -15,6 +15,7 @@ use deno_core::anyhow::bail;
 use deno_core::error::AnyError;
 use deno_graph::Module;
 use deno_graph::ModuleGraph;
+use deno_resolver::deno_json::CompilerOptionsKey;
 use deno_terminal::colors;
 
 use crate::args::CliOptions;
@@ -835,61 +836,78 @@ async fn emit_declarations_for_pack(
   paths: &[CollectedPath],
   ts_type_lib: crate::args::TsTypeLib,
 ) -> Result<BTreeMap<String, String>, AnyError> {
-  let mut source_by_dts_path = BTreeMap::new();
-  let root_names = paths
-    .iter()
-    .filter_map(|path| {
-      let Some(Module::Js(js_module)) = graph.get(&path.specifier) else {
-        return None;
-      };
-      js_module
-        .fast_check_module()
-        .and_then(|module| module.dts.as_ref())?;
-      let media_type = js_module.media_type;
-      if !matches!(
-        media_type,
-        MediaType::TypeScript
-          | MediaType::Tsx
-          | MediaType::Mts
-          | MediaType::Cts
-      ) {
-        return None;
-      }
-      let mut source_path = path.specifier.to_file_path().ok()?;
-      let file_name = source_path.file_name()?.to_str()?;
-      source_path.set_file_name(ts_to_dts_extension(file_name));
-      source_by_dts_path.insert(source_path, path.specifier.clone());
-      Some((path.specifier.clone(), media_type))
-    })
-    .collect::<Vec<_>>();
-  if root_names.is_empty() {
+  let compiler_options_resolver = cli_factory.compiler_options_resolver()?;
+  let mut roots_by_scope: BTreeMap<CompilerOptionsKey, Vec<_>> =
+    BTreeMap::new();
+  for path in paths {
+    let Some(Module::Js(js_module)) = graph.get(&path.specifier) else {
+      continue;
+    };
+    if js_module
+      .fast_check_module()
+      .and_then(|module| module.dts.as_ref())
+      .is_none()
+    {
+      continue;
+    }
+    let media_type = js_module.media_type;
+    if !matches!(
+      media_type,
+      MediaType::TypeScript | MediaType::Tsx | MediaType::Mts | MediaType::Cts
+    ) {
+      continue;
+    }
+    let Ok(mut dts_path) = path.specifier.to_file_path() else {
+      continue;
+    };
+    let Some(file_name) = dts_path.file_name().and_then(|f| f.to_str()) else {
+      continue;
+    };
+    dts_path.set_file_name(ts_to_dts_extension(file_name));
+    let (scope, _) =
+      compiler_options_resolver.entry_for_specifier(&path.specifier);
+    roots_by_scope.entry(scope).or_default().push((
+      path.specifier.clone(),
+      media_type,
+      dts_path,
+    ));
+  }
+  if roots_by_scope.is_empty() {
     return Ok(BTreeMap::new());
   }
 
   let type_checker = cli_factory.type_checker().await?;
-  let result = type_checker.emit_declarations(
-    Arc::new(graph.clone()),
-    root_names,
-    ts_type_lib,
-  )?;
-  if result.diagnostics.has_diagnostic() {
-    log::warn!(
-      "TypeScript diagnostics while generating package declarations:\n{}",
-      result.diagnostics
-    );
-  }
-
+  let graph = Arc::new(graph.clone());
   let mut dts_by_source = BTreeMap::new();
-  for (file_name, content) in result.emitted_files {
-    let path = ModuleSpecifier::parse(&file_name)
-      .ok()
-      .and_then(|specifier| specifier.to_file_path().ok())
-      .unwrap_or_else(|| PathBuf::from(&file_name));
-    if let Some(source_specifier) = source_by_dts_path.get(&path) {
-      dts_by_source.insert(
-        source_specifier.to_string(),
-        strip_amd_module_directives(content),
+  for roots in roots_by_scope.into_values() {
+    let source_by_dts_path = roots
+      .iter()
+      .map(|(specifier, _, dts_path)| (dts_path.clone(), specifier.clone()))
+      .collect::<BTreeMap<_, _>>();
+    let root_names = roots
+      .iter()
+      .map(|(specifier, media_type, _)| (specifier.clone(), *media_type))
+      .collect();
+    let result =
+      type_checker.emit_declarations(graph.clone(), root_names, ts_type_lib)?;
+    if result.diagnostics.has_diagnostic() {
+      log::warn!(
+        "TypeScript diagnostics while generating package declarations:\n{}",
+        result.diagnostics
       );
+    }
+
+    for (file_name, content) in result.emitted_files {
+      let path = ModuleSpecifier::parse(&file_name)
+        .ok()
+        .and_then(|specifier| specifier.to_file_path().ok())
+        .unwrap_or_else(|| PathBuf::from(&file_name));
+      if let Some(source_specifier) = source_by_dts_path.get(&path) {
+        dts_by_source.insert(
+          source_specifier.to_string(),
+          strip_amd_module_directives(content),
+        );
+      }
     }
   }
   Ok(dts_by_source)

--- a/cli/tools/pack/mod.rs
+++ b/cli/tools/pack/mod.rs
@@ -34,6 +34,7 @@ mod unfurl;
 
 use extensions::compute_output_path;
 use extensions::media_type_extension;
+use extensions::ts_to_dts_extension;
 use npm_tarball::create_npm_tarball;
 use npm_tarball::default_tarball_filename;
 use package_json::generate_package_json;
@@ -165,7 +166,10 @@ pub async fn pack(
       parsed_source_cache.as_ref(),
       &pack_flags,
       &package.config_file,
+      &cli_factory,
+      cli_options.ts_type_lib_window(),
     )
+    .await
     .with_context(|| {
       format!("Failed to process modules for package '{}'", package.name)
     })?;
@@ -671,17 +675,25 @@ fn create_transpile_options(
   })
 }
 
-fn process_modules(
+async fn process_modules(
   graph: &ModuleGraph,
   paths: &[CollectedPath],
   parsed_source_cache: &deno_resolver::cache::ParsedSourceCache,
   pack_flags: &PackFlags,
   config_file: &deno_config::deno_json::ConfigFile,
+  cli_factory: &CliFactory,
+  ts_type_lib: crate::args::TsTypeLib,
 ) -> Result<Vec<ProcessedFile>, AnyError> {
   let mut processed = Vec::new();
 
   // Get transpile options from deno.json compiler options
   let transpile_options = create_transpile_options(config_file)?;
+
+  let dts_by_source = if pack_flags.allow_slow_types {
+    BTreeMap::new()
+  } else {
+    emit_declarations_for_pack(cli_factory, graph, paths, ts_type_lib).await?
+  };
 
   for path in paths {
     let module = graph.get(&path.specifier);
@@ -696,6 +708,7 @@ fn process_modules(
       parsed_source_cache,
       pack_flags,
       &transpile_options,
+      &dts_by_source,
     )?;
     processed.push(file);
   }
@@ -710,6 +723,7 @@ fn process_single_module(
   parsed_source_cache: &deno_resolver::cache::ParsedSourceCache,
   pack_flags: &PackFlags,
   transpile_options: &deno_ast::TranspileOptions,
+  dts_by_source: &BTreeMap<String, String>,
 ) -> Result<ProcessedFile, AnyError> {
   let media_type = js_module.media_type;
   let raw_source = js_module.source.text.as_ref();
@@ -792,7 +806,10 @@ fn process_single_module(
 
   // Extract .d.ts if available and not skipped, then unfurl its specifiers
   let dts_content = if !pack_flags.allow_slow_types {
-    let dts = extract_dts(js_module, media_type);
+    let dts = dts_by_source
+      .get(path.specifier.as_str())
+      .cloned()
+      .or_else(|| extract_dts(js_module, media_type));
     dts.map(|dts_text| unfurl_dts_content(dts_text, &path.specifier, graph))
   } else {
     None
@@ -808,6 +825,81 @@ fn process_single_module(
     dts_content,
     dependencies,
   })
+}
+
+/// Emit declarations with TypeScript so the package's public declarations use
+/// the same complete emitter as `deno transpile --declaration`.
+async fn emit_declarations_for_pack(
+  cli_factory: &CliFactory,
+  graph: &ModuleGraph,
+  paths: &[CollectedPath],
+  ts_type_lib: crate::args::TsTypeLib,
+) -> Result<BTreeMap<String, String>, AnyError> {
+  let mut source_by_dts_path = BTreeMap::new();
+  let root_names = paths
+    .iter()
+    .filter_map(|path| {
+      let Some(Module::Js(js_module)) = graph.get(&path.specifier) else {
+        return None;
+      };
+      js_module
+        .fast_check_module()
+        .and_then(|module| module.dts.as_ref())?;
+      let media_type = js_module.media_type;
+      if !matches!(
+        media_type,
+        MediaType::TypeScript
+          | MediaType::Tsx
+          | MediaType::Mts
+          | MediaType::Cts
+      ) {
+        return None;
+      }
+      let mut source_path = path.specifier.to_file_path().ok()?;
+      let file_name = source_path.file_name()?.to_str()?;
+      source_path.set_file_name(ts_to_dts_extension(file_name));
+      source_by_dts_path.insert(source_path, path.specifier.clone());
+      Some((path.specifier.clone(), media_type))
+    })
+    .collect::<Vec<_>>();
+  if root_names.is_empty() {
+    return Ok(BTreeMap::new());
+  }
+
+  let type_checker = cli_factory.type_checker().await?;
+  let result = type_checker.emit_declarations(
+    Arc::new(graph.clone()),
+    root_names,
+    ts_type_lib,
+  )?;
+  if result.diagnostics.has_diagnostic() {
+    log::warn!(
+      "TypeScript diagnostics while generating package declarations:\n{}",
+      result.diagnostics
+    );
+  }
+
+  let mut dts_by_source = BTreeMap::new();
+  for (file_name, content) in result.emitted_files {
+    let path = ModuleSpecifier::parse(&file_name)
+      .ok()
+      .and_then(|specifier| specifier.to_file_path().ok())
+      .unwrap_or_else(|| PathBuf::from(&file_name));
+    if let Some(source_specifier) = source_by_dts_path.get(&path) {
+      dts_by_source.insert(
+        source_specifier.to_string(),
+        strip_amd_module_directives(content),
+      );
+    }
+  }
+  Ok(dts_by_source)
+}
+
+fn strip_amd_module_directives(content: String) -> String {
+  content
+    .split_inclusive('\n')
+    .filter(|line| !line.trim_start().starts_with("/// <amd-module"))
+    .collect()
 }
 
 /// Parse and unfurl specifiers in generated .d.ts content.

--- a/cli/type_checker.rs
+++ b/cli/type_checker.rs
@@ -170,7 +170,34 @@ impl TypeChecker {
     root_names: Vec<(ModuleSpecifier, MediaType)>,
     lib: TsTypeLib,
   ) -> Result<EmitDeclarationsResult, CheckError> {
+    if root_names.is_empty() {
+      return Ok(EmitDeclarationsResult {
+        diagnostics: Diagnostics::default(),
+        emitted_files: BTreeMap::new(),
+      });
+    }
+
     let first_specifier = &root_names[0].0;
+    // A single TSC program has one compiler-options object. Callers that need
+    // to emit roots from multiple Deno scopes must split them first.
+    let (first_scope, _) = self
+      .compiler_options_resolver
+      .entry_for_specifier(first_specifier);
+    for (specifier, _) in root_names.iter().skip(1) {
+      let (scope, _) = self
+        .compiler_options_resolver
+        .entry_for_specifier(specifier);
+      if scope != first_scope {
+        return Err(
+          CheckErrorKind::Other(JsErrorBox::generic(format!(
+            "Cannot emit declarations for roots with different compiler option scopes: '{}' uses scope '{}' but '{}' uses scope '{}'.",
+            first_specifier, first_scope, specifier, scope,
+          )))
+          .into(),
+        );
+      }
+    }
+
     let compiler_options_data = self
       .compiler_options_resolver
       .for_specifier(first_specifier);

--- a/tests/specs/pack/computed_symbol_dts/__test__.jsonc
+++ b/tests/specs/pack/computed_symbol_dts/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tempDir": true,
+  "tests": {
+    "preserves_computed_symbol_members": {
+      "steps": [{
+        "args": "pack --allow-dirty",
+        "output": "[WILDCARD]"
+      }, {
+        "args": ["run", "--allow-read", "verify.ts"],
+        "output": "computed symbol declarations preserved: true\n"
+      }]
+    }
+  }
+}

--- a/tests/specs/pack/computed_symbol_dts/deno.json
+++ b/tests/specs/pack/computed_symbol_dts/deno.json
@@ -2,6 +2,11 @@
   "name": "@test/computed-symbol-dts",
   "version": "1.0.0",
   "exports": "./mod.ts",
+  "workspace": ["./member"],
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": false
+  },
   "publish": {
     "exclude": ["verify.ts"]
   }

--- a/tests/specs/pack/computed_symbol_dts/deno.json
+++ b/tests/specs/pack/computed_symbol_dts/deno.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/computed-symbol-dts",
+  "version": "1.0.0",
+  "exports": "./mod.ts",
+  "publish": {
+    "exclude": ["verify.ts"]
+  }
+}

--- a/tests/specs/pack/computed_symbol_dts/member/deno.json
+++ b/tests/specs/pack/computed_symbol_dts/member/deno.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/computed-symbol-member",
+  "version": "1.0.0",
+  "exports": "./mod.ts",
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true
+  }
+}

--- a/tests/specs/pack/computed_symbol_dts/member/mod.ts
+++ b/tests/specs/pack/computed_symbol_dts/member/mod.ts
@@ -1,0 +1,2 @@
+const memberIndex: number = 0 as number;
+export const looseValue = ["member"][memberIndex];

--- a/tests/specs/pack/computed_symbol_dts/mod.ts
+++ b/tests/specs/pack/computed_symbol_dts/mod.ts
@@ -1,6 +1,10 @@
 import type { Options } from "./types.ts";
+export { looseValue } from "./member/mod.ts";
 
 export const customSymbol: unique symbol = Symbol("custom");
+export const strictValue = null;
+const rootIndex: number = 0 as number;
+export const rootValue = ["root"][rootIndex];
 
 export class Base {
   inherited(): string {

--- a/tests/specs/pack/computed_symbol_dts/mod.ts
+++ b/tests/specs/pack/computed_symbol_dts/mod.ts
@@ -1,0 +1,31 @@
+import type { Options } from "./types.ts";
+
+export const customSymbol: unique symbol = Symbol("custom");
+
+export class Base {
+  inherited(): string {
+    return "base";
+  }
+}
+
+export class Resource extends Base {
+  regular(): number {
+    return 1;
+  }
+
+  [customSymbol](): boolean {
+    return true;
+  }
+
+  [Symbol.dispose](): void {}
+
+  async [Symbol.asyncDispose](): Promise<void> {}
+
+  configure(_options: Options): void {}
+
+  overloaded(value: string): string;
+  overloaded(value: number): number;
+  overloaded(value: string | number): string | number {
+    return value;
+  }
+}

--- a/tests/specs/pack/computed_symbol_dts/types.ts
+++ b/tests/specs/pack/computed_symbol_dts/types.ts
@@ -1,0 +1,3 @@
+export interface Options {
+  value: string;
+}

--- a/tests/specs/pack/computed_symbol_dts/verify.ts
+++ b/tests/specs/pack/computed_symbol_dts/verify.ts
@@ -24,8 +24,61 @@ for (const chunk of chunks) {
   offset += chunk.length;
 }
 
-const text = new TextDecoder().decode(tar);
+const decoder = new TextDecoder();
+
+function readTarString(
+  header: Uint8Array,
+  start: number,
+  length: number,
+): string {
+  const field = header.subarray(start, start + length);
+  const end = field.indexOf(0);
+  return decoder.decode(end === -1 ? field : field.subarray(0, end));
+}
+
+function parseTarEntries(tar: Uint8Array): Map<string, Uint8Array> {
+  const entries = new Map<string, Uint8Array>();
+  for (let offset = 0; offset + 512 <= tar.length;) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const path = prefix === "" ? name : `${prefix}/${name}`;
+    const size = Number.parseInt(readTarString(header, 124, 12).trim(), 8);
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw new Error(`invalid tar entry size for ${path}`);
+    }
+
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+    if (dataEnd > tar.length) {
+      throw new Error(`truncated tar entry: ${path}`);
+    }
+    // Only regular files are relevant to the declaration assertions. Keep
+    // their bytes separate so a filename or string in another entry cannot
+    // satisfy a check accidentally.
+    if (header[156] === 0 || header[156] === 0x30) {
+      entries.set(path, tar.slice(dataStart, dataEnd));
+    }
+    offset = dataStart + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+const entries = parseTarEntries(tar);
+function readText(path: string): string {
+  const content = entries.get(path);
+  if (content == null) throw new Error(`missing tar entry: ${path}`);
+  return decoder.decode(content);
+}
+
+const declaration = readText("package/mod.d.ts");
+const memberDeclaration = readText("package/member/mod.d.ts");
+const typesDeclaration = readText("package/types.d.ts");
+const packageJson = JSON.parse(readText("package/package.json"));
 const checks = [
+  ["root compiler scope", "export declare const rootValue: string;"],
   ["regular method", "regular(): number;"],
   ["inherited method", "inherited(): string;"],
   ["class inheritance", "export declare class Resource extends Base {"],
@@ -35,15 +88,26 @@ const checks = [
   ["overload", "overloaded(value: string): string;"],
   ["second overload", "overloaded(value: number): number;"],
   ["type import", 'from "./types.js"'],
-  ["imported declaration", "package/types.d.ts"],
-  ["types metadata", '"types": "./mod.d.ts"'],
 ];
 for (const [name, value] of checks) {
-  if (!text.includes(value)) {
+  if (!declaration.includes(value)) {
     throw new Error(`missing ${name}: ${value}`);
   }
 }
-if (text.includes("/// <amd-module")) {
+if (!typesDeclaration.includes("value: string;")) {
+  throw new Error("missing imported declaration content");
+}
+if (
+  !memberDeclaration.includes(
+    "export declare const looseValue: string | undefined;",
+  )
+) {
+  throw new Error("nested declaration did not use its own compiler scope");
+}
+if (packageJson.types !== "./mod.d.ts") {
+  throw new Error("package metadata does not point to mod.d.ts");
+}
+if (declaration.includes("/// <amd-module")) {
   throw new Error("generated declarations expose an internal module path");
 }
 console.log("computed symbol declarations preserved: true");

--- a/tests/specs/pack/computed_symbol_dts/verify.ts
+++ b/tests/specs/pack/computed_symbol_dts/verify.ts
@@ -28,10 +28,12 @@ const text = new TextDecoder().decode(tar);
 const checks = [
   ["regular method", "regular(): number;"],
   ["inherited method", "inherited(): string;"],
+  ["class inheritance", "export declare class Resource extends Base {"],
   ["computed symbol", "[customSymbol](): boolean;"],
   ["sync dispose", "[Symbol.dispose](): void;"],
   ["async dispose", "[Symbol.asyncDispose](): Promise<void>;"],
   ["overload", "overloaded(value: string): string;"],
+  ["second overload", "overloaded(value: number): number;"],
   ["type import", 'from "./types.js"'],
   ["imported declaration", "package/types.d.ts"],
   ["types metadata", '"types": "./mod.d.ts"'],

--- a/tests/specs/pack/computed_symbol_dts/verify.ts
+++ b/tests/specs/pack/computed_symbol_dts/verify.ts
@@ -1,0 +1,47 @@
+const tarPath = [...Deno.readDirSync(".")]
+  .map((entry) => entry.name)
+  .find((name) => name.endsWith(".tgz"));
+if (tarPath == null) {
+  throw new Error("pack did not create a tarball");
+}
+
+const compressed = await Deno.readFile(tarPath);
+const stream = new Blob([compressed])
+  .stream()
+  .pipeThrough(new DecompressionStream("gzip"));
+const reader = stream.getReader();
+const chunks: Uint8Array[] = [];
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  chunks.push(value);
+}
+const size = chunks.reduce((total, chunk) => total + chunk.length, 0);
+const tar = new Uint8Array(size);
+let offset = 0;
+for (const chunk of chunks) {
+  tar.set(chunk, offset);
+  offset += chunk.length;
+}
+
+const text = new TextDecoder().decode(tar);
+const checks = [
+  ["regular method", "regular(): number;"],
+  ["inherited method", "inherited(): string;"],
+  ["computed symbol", "[customSymbol](): boolean;"],
+  ["sync dispose", "[Symbol.dispose](): void;"],
+  ["async dispose", "[Symbol.asyncDispose](): Promise<void>;"],
+  ["overload", "overloaded(value: string): string;"],
+  ["type import", 'from "./types.js"'],
+  ["imported declaration", "package/types.d.ts"],
+  ["types metadata", '"types": "./mod.d.ts"'],
+];
+for (const [name, value] of checks) {
+  if (!text.includes(value)) {
+    throw new Error(`missing ${name}: ${value}`);
+  }
+}
+if (text.includes("/// <amd-module")) {
+  throw new Error("generated declarations expose an internal module path");
+}
+console.log("computed symbol declarations preserved: true");


### PR DESCRIPTION
Fixes #36567

### Summary

`deno pack` now uses the existing TypeScript declaration emitter for modules
that pass the package fast-check declaration gate. This preserves computed
symbol members such as `[Symbol.dispose]` and `[Symbol.asyncDispose]`, while
keeping package path rewriting, metadata generation, fallbacks, and
`--allow-slow-types` behavior intact.

Declaration roots are emitted separately for each compiler-options scope, so
workspace members retain their own compiler configuration and cannot overwrite
one another's `.d.ts` output. If the TypeScript emitter does not produce a
declaration for a source, the existing source-declaration fallback remains in
place.

### Test plan

- Added `tests/specs/pack/computed_symbol_dts`, which parses actual gzip tar
  entries and covers regular methods, inheritance, overloads, an ordinary
  computed symbol, both dispose symbols, imported declarations, package
  `types` metadata, path rewriting, and a workspace member with a different
  compiler-options scope.
- `cargo +1.95.0 test -p specs_tests --test specs specs::pack::computed_symbol_dts -- --no-capture`
- `cargo +1.95.0 test -p specs_tests --test specs specs::pack -- --no-capture` (30 passed)
- `cargo +1.95.0 check -p deno --bin deno --offline -j 1`
- `cargo +1.95.0 build -p deno --bin deno --offline -j 1`
- `cargo +1.95.0 clippy -p deno --bin deno --offline -j 1 -- -D warnings`
- `cargo +1.90.0 fmt --all -- --check`
- `deno fmt --check tests/specs/pack/computed_symbol_dts`
- `deno lint tests/specs/pack/computed_symbol_dts`

### AI disclosure
AI was used only as supplementary support for targeted inspection, coding assistance, and validation cross-checks; it did not replace my engineering judgment, execution, or final approval.