### PR TITLE
fix(ext/node): preserve numeric fd and inherit for spawnSync stdin

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1968,6 +1968,15 @@ function spawnSync(
   includeNpmProcessState = builtCommand[2];
   const input_ = normalizeInput(input);
 
+  // Route stdin through toDenoStdio so a numeric fd or "inherit" is preserved
+  // for the child, matching the async spawn path and Node.js. spawnSync has no
+  // live stdin writer, so a "piped" stdin with no `input` would leave the child
+  // blocked on read; map that case to "null" (empty stdin) to match Node.
+  let stdin_deno = toDenoStdio(stdin_);
+  if (stdin_deno === "piped" && input_ == null) {
+    stdin_deno = "null";
+  }
+
   const result = {};
   try {
     const output = nodeSpawnSyncChild({
@@ -1978,7 +1987,7 @@ function spawnSync(
       argv0: argv0 !== command ? argv0 : undefined,
       stdout: toDenoStdio(stdout_),
       stderr: toDenoStdio(stderr_),
-      stdin: stdin_ == "inherit" ? "inherit" : "null",
+      stdin: stdin_deno,
       uid,
       gid,
       clearEnv: false,

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1706,3 +1706,26 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "spawnSyncWithNumericFdStdin",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const fs = await import("node:fs");
+    const tmpFile = Deno.makeTempFileSync();
+    try {
+      Deno.writeTextFileSync(tmpFile, "hello-from-fd\n");
+      const fd = fs.openSync(tmpFile, "r");
+      const out = execFileSync(Deno.execPath(), [
+        "eval",
+        "import fs from 'node:fs'; process.stdout.write(fs.readFileSync(0,'utf8'));",
+      ], {
+        stdio: [fd, "pipe", "inherit"],
+      });
+      fs.closeSync(fd);
+      assertEquals(out.toString(), "hello-from-fd\n");
+    } finally {
+      Deno.removeSync(tmpFile);
+    }
+  },
+});


### PR DESCRIPTION
Assisted by Claude Opus 5, reviewed by me.

Fixes #36533