### PR TITLE
fix(compile): add --keep-names flag to deno compile --bundle

### DIFF
--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -865,6 +865,7 @@ pub async fn bundle_for_compile(
   entrypoint: String,
   external: Vec<String>,
   minify: bool,
+  keep_names: bool,
 ) -> Result<Vec<u8>, AnyError> {
   let bundle_flags = BundleFlags {
     entrypoints: vec![entrypoint],
@@ -874,7 +875,7 @@ pub async fn bundle_for_compile(
     external,
     format: BundleFormat::Esm,
     minify,
-    keep_names: false,
+    keep_names,
     code_splitting: false,
     inline_imports: true,
     packages: PackageHandling::Bundle,

--- a/cli/tools/compile.rs
+++ b/cli/tools/compile.rs
@@ -294,6 +294,7 @@ async fn run_bundle_for_compile(
     bundle_flags.clone(),
     compile_flags.source_file.clone(),
     compile_flags.minify,
+    compile_flags.keep_names,
   )
   .await?;
   let main_rewrite = rewrite_absolute_bundle_paths(&main_bytes, &initial_cwd)?;
@@ -319,6 +320,7 @@ async fn run_bundle_for_compile(
       bundle_flags.clone(),
       worker_abs.display().to_string(),
       compile_flags.minify,
+      compile_flags.keep_names,
     )
     .await?;
     let worker_rewrite =
@@ -373,13 +375,14 @@ async fn bundle_one_for_compile(
   flags: Arc<Flags>,
   entrypoint: String,
   minify: bool,
+  keep_names: bool,
 ) -> Result<Vec<u8>, AnyError> {
   // Always leave `.node` files external. esbuild has no loader for them
   // and would error if it tried to inline a native binary; with this
   // pattern the require() calls are emitted verbatim and resolved at
   // runtime against the embedded VFS by the native addon loader.
   let external = vec!["*.node".to_string()];
-  super::bundle::bundle_for_compile(flags, entrypoint, external, minify)
+  super::bundle::bundle_for_compile(flags, entrypoint, external, minify, keep_names)
     .boxed_local()
     .await
 }

--- a/libs/cli_parser/src/convert.rs
+++ b/libs/cli_parser/src/convert.rs
@@ -2138,6 +2138,7 @@ fn compile_parse(
     bundle: result.get_bool("bundle"),
     app_name: result.get_one("app-name").map(|s| s.to_string()),
     minify: result.get_bool("minify"),
+    keep_names: result.get_bool("keep-names"),
     exclude_unused_npm: result.get_bool("exclude-unused-npm"),
     engine: result
       .get_one("engine")

--- a/libs/cli_parser/src/defs.rs
+++ b/libs/cli_parser/src/defs.rs
@@ -1831,6 +1831,12 @@ pub static COMPILE_SUBCOMMAND: CommandDef = CommandDef {
       .set_true()
       .requires(&["bundle"])
 .help("Experimental. Minify the bundled output. Only meaningful with --bundle.\n  Reduces both the embedded bundle size and runtime memory use, at the cost of less readable stack traces."),
+    ArgDef::new("keep-names")
+      .long("keep-names")
+      .set_true()
+      .requires(&["bundle"])
+.help("Experimental. Keep function names in the bundled output. Only meaningful with --bundle.\n  Prevents esbuild from renaming top-level classes/functions, preserving Function.prototype.name at runtime."),
+
     ArgDef::new("app-name")
       .long("app-name")
       .action(ArgAction::Set)

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -214,6 +214,7 @@ pub struct CompileFlags {
   pub app_name: Option<String>,
   /// Minify the bundle. Only meaningful with `bundle: true`.
   pub minify: bool,
+  pub keep_names: bool,
   /// Prune the embedded managed npm snapshot to only those packages reachable
   /// from npm specifiers in the module graph. Opt-in because non-statically
   /// analyzable dynamic imports may not appear in the graph; pass


### PR DESCRIPTION
## Problem

`deno compile --bundle` uses esbuild to bundle the entrypoint, but unlike `deno bundle`, it has no `--keep-names` flag. This means esbuild can silently rename duplicate top-level class/function identifiers, changing `Function.prototype.name` at runtime. Any code that reads class names (serializers, DI containers, ORMs, schema generators) will observe different names under `deno compile --bundle` vs `deno run`.

`deno bundle` gained `--keep-names` in #32109. This PR brings the same flag to `deno compile --bundle`.

## Changes

- `libs/cli_parser/src/flags.rs`: Add `keep_names: bool` to `CompileFlags`
- `libs/cli_parser/src/defs.rs`: Add `--keep-names` CLI arg (requires `--bundle`)
- `libs/cli_parser/src/convert.rs`: Parse `--keep-names` into `CompileFlags`
- `cli/tools/compile.rs`: Pass `keep_names` through `bundle_one_for_compile`
- `cli/tools/bundle/mod.rs`: Accept and use `keep_names` in `bundle_for_compile` (was hardcoded `false`)

## Usage

```console
$ deno compile --bundle --keep-names -o app main.ts
```

Fixes #36540