### PR TITLE
fix(npm): skip optional deps that fail to resolve instead of failing install

### DIFF
--- a/libs/npm/registry.rs
+++ b/libs/npm/registry.rs
@@ -666,6 +666,13 @@ pub struct NpmDependencyEntry {
   /// use this entry to resolve the dependency when it can't
   /// be resolved as a peer dependency.
   pub peer_dep_version_req: Option<VersionReq>,
+  /// Whether this dependency is listed in the package's
+  /// `optionalDependencies`. An optional dependency that fails to resolve
+  /// (missing version, or every matching version blocked by the minimum
+  /// dependency age) is skipped instead of aborting the whole install,
+  /// mirroring npm/yarn/pnpm. (os/cpu filtering happens separately, when the
+  /// snapshot is materialized for a specific system.)
+  pub optional: bool,
 }
 
 impl PartialOrd for NpmDependencyEntry {
@@ -995,6 +1002,7 @@ impl NpmPackageVersionInfo {
         name: PackageName::from_str(name),
         version_req,
         peer_dep_version_req: None,
+        optional: false,
       })
     }
 
@@ -1062,7 +1070,13 @@ impl NpmPackageVersionInfo {
     }
     for entry in normalized_dependencies.iter() {
       let entry = parse_dep_entry(nv, entry, NpmDependencyEntryKind::Dep)?;
-      if let Some(entry) = entry {
+      if let Some(mut entry) = entry {
+        // a dependency listed in `optionalDependencies` (regardless of whether
+        // it's also duplicated in `dependencies`) is optional: failing to
+        // resolve it must not abort the install.
+        entry.optional = self
+          .optional_dependencies
+          .contains_key(&entry.bare_specifier);
         // people may define a dependency as a peer dependency as well,
         // so in those cases, attempt to resolve as a peer dependency,
         // but then use this dependency version requirement otherwise

--- a/libs/npm/registry.rs
+++ b/libs/npm/registry.rs
@@ -1082,6 +1082,10 @@ impl NpmPackageVersionInfo {
         // but then use this dependency version requirement otherwise
         if let Some(peer_dep_entry) = result.get_mut(&entry.bare_specifier) {
           peer_dep_entry.peer_dep_version_req = Some(entry.version_req);
+          // the peer entry is the one that gets resolved, so carry the
+          // optional flag over to it rather than dropping it along with the
+          // rest of this entry
+          peer_dep_entry.optional = entry.optional;
         } else {
           result.insert(entry.bare_specifier.clone(), entry);
         }

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -96,7 +96,16 @@ fn is_skippable_optional_error(err: &NpmResolutionError) -> bool {
     NpmResolutionError::Registry(
       NpmRegistryPackageInfoLoadError::LoadError(_),
     ) => false,
-    NpmResolutionError::Resolution(_) => true,
+    NpmResolutionError::Resolution(
+      NpmPackageVersionResolutionError::DistTagNotFound { .. }
+      | NpmPackageVersionResolutionError::DistTagVersionNotFound { .. }
+      | NpmPackageVersionResolutionError::DistTagVersionTooNew { .. }
+      | NpmPackageVersionResolutionError::VersionNotFound(_)
+      | NpmPackageVersionResolutionError::VersionReqNotMatched { .. },
+    ) => true,
+    NpmResolutionError::Resolution(
+      NpmPackageVersionResolutionError::TrustPolicyDowngrade { .. },
+    ) => false,
     NpmResolutionError::DependencyEntry(_) => false,
   }
 }
@@ -3510,7 +3519,9 @@ mod test {
   use crate::resolution::NewestDependencyDate;
   use crate::resolution::NewestDependencyDateOptions;
   use crate::resolution::NpmPackageVersionNotFound;
+  use crate::resolution::NpmTrustPolicy;
   use crate::resolution::SerializedNpmResolutionSnapshot;
+  use crate::resolution::TrustPolicyOptions;
 
   #[test]
   fn resolved_id_tests() {
@@ -6172,6 +6183,66 @@ mod test {
         "@scope/linux-x64@1.0.0".to_string(),
         "package-a@1.0.0".to_string(),
       ]
+    );
+  }
+
+  #[tokio::test]
+  async fn resolve_optional_dep_trust_policy_downgrade_still_errors() {
+    let api = TestNpmRegistryApi::default();
+    api.ensure_package_version("package-a", "1.0.0");
+    api.add_optional_dep(("package-a", "1.0.0"), ("package-b", "1.1.0"));
+    api.with_package("package-b", |info| {
+      info.versions.insert(
+        version("1.0.0"),
+        serde_json::from_str(
+          r#"{ "version": "1.0.0", "_npmUser": { "approver": {} } }"#,
+        )
+        .unwrap(),
+      );
+      info.versions.insert(
+        version("1.1.0"),
+        serde_json::from_str(r#"{ "version": "1.1.0" }"#).unwrap(),
+      );
+      info.time.insert(
+        version("1.0.0"),
+        "2026-08-01T00:00:00.000Z".parse().unwrap(),
+      );
+      info.time.insert(
+        version("1.1.0"),
+        "2026-08-02T00:00:00.000Z".parse().unwrap(),
+      );
+    });
+
+    let snapshot = NpmResolutionSnapshot::new(Default::default());
+    let mut graph = Graph::from_snapshot(snapshot);
+    let npm_version_resolver = NpmVersionResolver {
+      trust_policy: TrustPolicyOptions {
+        policy: NpmTrustPolicy::NoDowngrade,
+        ..Default::default()
+      },
+      ..Default::default()
+    };
+    let mut resolver = GraphDependencyResolver::new(
+      &mut graph,
+      &api,
+      &npm_version_resolver,
+      None,
+      GraphDependencyResolverOptions { should_dedup: true },
+    );
+    let req = PackageReq::from_str("package-a@1.0.0").unwrap();
+    resolver
+      .add_package_req(&req, &api.package_info(&req.name).await.unwrap())
+      .unwrap();
+
+    let err = resolver.resolve_pending().await.unwrap_err();
+    assert!(
+      matches!(
+        err,
+        NpmResolutionError::Resolution(
+          NpmPackageVersionResolutionError::TrustPolicyDowngrade { .. }
+        )
+      ),
+      "expected TrustPolicyDowngrade, got {err:?}"
     );
   }
 

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -80,6 +80,27 @@ pub enum NpmResolutionError {
   DependencyEntry(#[from] Box<NpmDependencyEntryError>),
 }
 
+/// Whether an error resolving an *optional* dependency should be swallowed
+/// (skipping that dependency) rather than aborting the whole install.
+///
+/// Deterministic resolution failures — the package doesn't exist, no version
+/// satisfies the requirement, or every matching version is blocked by the
+/// minimum dependency age — mirror npm/yarn/pnpm, which never fail an install
+/// over an unmet optional dependency. Transient failures (e.g. a registry
+/// load error) are not swallowed so real problems still surface.
+fn is_skippable_optional_error(err: &NpmResolutionError) -> bool {
+  match err {
+    NpmResolutionError::Registry(
+      NpmRegistryPackageInfoLoadError::PackageNotExists { .. },
+    ) => true,
+    NpmResolutionError::Registry(
+      NpmRegistryPackageInfoLoadError::LoadError(_),
+    ) => false,
+    NpmResolutionError::Resolution(_) => true,
+    NpmResolutionError::DependencyEntry(_) => false,
+  }
+}
+
 /// A unique identifier to a node in the graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 struct NodeId(u32);
@@ -2724,9 +2745,11 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
   ) -> Result<bool, NpmResolutionError> {
     let package_info = match result {
       Ok(info) => info,
-      // npm doesn't fail on non-existent optional peer dependencies
+      // npm doesn't fail when an optional dependency (or optional peer
+      // dependency) doesn't exist in the registry — it's simply skipped.
       Err(NpmRegistryPackageInfoLoadError::PackageNotExists { .. })
-        if matches!(dep.kind, NpmDependencyEntryKind::OptionalPeer) =>
+        if dep.optional
+          || matches!(dep.kind, NpmDependencyEntryKind::OptionalPeer) =>
       {
         return Ok(false);
       }
@@ -2773,7 +2796,18 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
             child_id
           }
           None => {
-            self.analyze_dependency(dep, &version_resolver, parent_path)?
+            match self.analyze_dependency(dep, &version_resolver, parent_path) {
+              Ok(child_id) => child_id,
+              // An optional dependency that can't be resolved (no matching
+              // version, blocked by the minimum dependency age, etc.) is
+              // skipped rather than aborting the whole install, matching
+              // npm/yarn/pnpm. Only version-resolution failures are swallowed;
+              // transient errors (e.g. a registry load failure) still surface.
+              Err(err) if dep.optional && is_skippable_optional_error(&err) => {
+                return Ok(false);
+              }
+              Err(err) => return Err(err),
+            }
           }
         };
 
@@ -6049,6 +6083,110 @@ mod test {
     assert_eq!(
       packages,
       vec!["package-a@1.0.0".to_string(), "package-b@1.0.0".to_string()]
+    );
+  }
+
+  #[tokio::test]
+  async fn resolve_skips_unresolvable_optional_deps() {
+    // https://github.com/denoland/deno/issues/36597 and
+    // https://github.com/denoland/deno/issues/29307: an optional dependency
+    // that can't be resolved must be skipped rather than aborting the whole
+    // install, matching npm/yarn/pnpm.
+    let api = TestNpmRegistryApi::default();
+    api.ensure_package_version("package-a", "1.0.0");
+    api.ensure_package_version("package-b", "1.0.0");
+    api.ensure_package_version("package-c", "1.0.0");
+    // a resolvable optional dep — still installed
+    api.add_optional_dep(("package-a", "1.0.0"), ("package-b", "1"));
+    // an optional dep pointing at a version that doesn't exist
+    api.add_optional_dep(("package-a", "1.0.0"), ("package-c", "2"));
+    // an optional dep pointing at a package that doesn't exist at all
+    api.add_optional_dep(("package-a", "1.0.0"), ("package-d", "1"));
+
+    let snapshot =
+      run_resolver_and_get_snapshot(api, vec!["package-a@1.0.0"]).await;
+    let packages = package_names_with_info(
+      &snapshot,
+      &NpmSystemInfo {
+        os: "linux".into(),
+        cpu: "x64".into(),
+      },
+    );
+    assert_eq!(
+      packages,
+      vec!["package-a@1.0.0".to_string(), "package-b@1.0.0".to_string()]
+    );
+  }
+
+  #[tokio::test]
+  async fn resolve_skips_optional_dep_blocked_by_min_dependency_age() {
+    // https://github.com/denoland/deno/issues/36597: a foreign-platform
+    // optional dep whose only matching version is newer than the minimum
+    // dependency age is skipped instead of failing the install, while a
+    // sibling optional dep that is old enough still installs.
+    let api = TestNpmRegistryApi::default();
+    api.ensure_package_version("package-a", "1.0.0");
+    api.ensure_package_version("@scope/linux-x64", "1.0.0");
+    api.ensure_package_version("@scope/android-arm64", "1.0.0");
+    api.add_optional_dep(("package-a", "1.0.0"), ("@scope/linux-x64", "1.0.0"));
+    api.add_optional_dep(
+      ("package-a", "1.0.0"),
+      ("@scope/android-arm64", "1.0.0"),
+    );
+    api.with_package("@scope/linux-x64", |info| {
+      info.time.insert(
+        version("1.0.0"),
+        "2026-08-14T00:00:00.000Z".parse().unwrap(),
+      );
+    });
+    api.with_package("@scope/android-arm64", |info| {
+      // published after the cutoff -> blocked by the minimum dependency age
+      info.time.insert(
+        version("1.0.0"),
+        "2026-08-15T18:00:00.000Z".parse().unwrap(),
+      );
+    });
+
+    let snapshot = run_resolver_with_options_and_get_snapshot(
+      &api,
+      RunResolverOptions {
+        reqs: vec!["package-a@1.0.0"],
+        newest_dependency_date: NewestDependencyDateOptions::from_date(
+          "2026-08-15T00:00:00.000Z".parse().unwrap(),
+        ),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+    let packages = package_names_with_info(
+      &snapshot,
+      &NpmSystemInfo {
+        os: "linux".into(),
+        cpu: "x64".into(),
+      },
+    );
+    assert_eq!(
+      packages,
+      vec![
+        "@scope/linux-x64@1.0.0".to_string(),
+        "package-a@1.0.0".to_string(),
+      ]
+    );
+  }
+
+  #[tokio::test]
+  async fn resolve_required_dep_missing_version_still_errors() {
+    // Regression guard: skipping only applies to *optional* deps. A required
+    // dependency with an unresolvable version must still fail the install.
+    let api = TestNpmRegistryApi::default();
+    api.ensure_package_version("package-a", "1.0.0");
+    api.ensure_package_version("package-b", "1.0.0");
+    api.add_dependency(("package-a", "1.0.0"), ("package-b", "2"));
+    let err = run_resolver_and_get_error(api, vec!["package-a@1.0.0"]).await;
+    assert_eq!(
+      err.to_string(),
+      "Could not find npm package 'package-b' matching '2'."
     );
   }
 

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -88,6 +88,15 @@ pub enum NpmResolutionError {
 /// minimum dependency age — mirror npm/yarn/pnpm, which never fail an install
 /// over an unmet optional dependency. Transient failures (e.g. a registry
 /// load error) are not swallowed so real problems still surface.
+///
+/// Invariant: every variant classified as skippable here must be raised
+/// *before* the dependency's node is created in the graph (in practice, by
+/// `resolve_best_package_version_info`, which `analyze_dependency` calls
+/// before `create_node_from_version_info`). Skipping an error raised after
+/// node creation would leave an orphan node in the graph that no parent
+/// links to, and that node would then be materialized into the snapshot.
+/// If a new variant can be raised post-creation, it must be classified as
+/// non-skippable regardless of how deterministic it is.
 fn is_skippable_optional_error(err: &NpmResolutionError) -> bool {
   match err {
     NpmResolutionError::Registry(
@@ -1149,6 +1158,10 @@ pub struct GraphDependencyResolver<'a, TNpmRegistryApi: NpmRegistryApi> {
   /// don't pollute the root scope. Phase 2 uses these when a required
   /// peer isn't found in scope.
   peer_fallbacks: BTreeMap<StackString, NodeId>,
+  /// `name@version_req` of optional dependencies that have already been
+  /// warned about, so that an optional dep reached via several parent paths
+  /// only produces a single warning.
+  warned_skipped_optional: FxHashSet<String>,
 }
 
 impl<'a, TNpmRegistryApi: NpmRegistryApi>
@@ -1176,7 +1189,33 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       pure_pkgs: FxHashSet::default(),
       peers_cache: FxHashMap::default(),
       peer_fallbacks: BTreeMap::new(),
+      warned_skipped_optional: FxHashSet::default(),
     }
+  }
+
+  /// Warns that an optional dependency was skipped.
+  ///
+  /// Skipping keeps the install from failing, but the dropped package may be
+  /// the very one this system needs (e.g. the host platform's prebuild is the
+  /// one blocked by the minimum dependency age), in which case the failure
+  /// would otherwise resurface at runtime as an opaque "module not found".
+  /// The underlying error is included so a genuinely broken version
+  /// requirement in `optionalDependencies` stays diagnosable.
+  fn warn_skipped_optional_dep(
+    &mut self,
+    dep: &NpmDependencyEntry,
+    err: &dyn std::fmt::Display,
+  ) {
+    let key = format!("{}@{}", dep.name, dep.version_req.version_text());
+    if !self.warned_skipped_optional.insert(key) {
+      return;
+    }
+    log::warn!(
+      "Skipping optional dependency '{}@{}': {}",
+      dep.name,
+      dep.version_req.version_text(),
+      err
+    );
   }
 
   /// Follows the `node_id_mappings` chain to find the canonical (latest)
@@ -2756,10 +2795,15 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       Ok(info) => info,
       // npm doesn't fail when an optional dependency (or optional peer
       // dependency) doesn't exist in the registry — it's simply skipped.
-      Err(NpmRegistryPackageInfoLoadError::PackageNotExists { .. })
+      Err(err @ NpmRegistryPackageInfoLoadError::PackageNotExists { .. })
         if dep.optional
           || matches!(dep.kind, NpmDependencyEntryKind::OptionalPeer) =>
       {
+        // an unmet optional *peer* dep is routine and was always silent, so
+        // only warn for entries from `optionalDependencies`
+        if dep.optional {
+          self.warn_skipped_optional_dep(dep, &err);
+        }
         return Ok(false);
       }
       Err(e) => return Err(e.into()),
@@ -2813,6 +2857,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
               // npm/yarn/pnpm. Only version-resolution failures are swallowed;
               // transient errors (e.g. a registry load failure) still surface.
               Err(err) if dep.optional && is_skippable_optional_error(&err) => {
+                self.warn_skipped_optional_dep(dep, &err);
                 return Ok(false);
               }
               Err(err) => return Err(err),
@@ -6259,6 +6304,91 @@ mod test {
       err.to_string(),
       "Could not find npm package 'package-b' matching '2'."
     );
+  }
+
+  #[test]
+  fn skippable_optional_error_classification() {
+    // Exhaustive table for `is_skippable_optional_error`. Deterministic
+    // resolution failures are skipped for optional deps; anything that could
+    // mask a transient or genuinely dangerous condition is not.
+    let skippable: Vec<NpmResolutionError> = vec![
+      NpmRegistryPackageInfoLoadError::PackageNotExists {
+        package_name: "package-a".to_string(),
+      }
+      .into(),
+      NpmPackageVersionResolutionError::DistTagNotFound {
+        dist_tag: "latest".to_string(),
+        package_name: "package-a".into(),
+      }
+      .into(),
+      NpmPackageVersionResolutionError::DistTagVersionNotFound {
+        package_name: "package-a".into(),
+        dist_tag: "latest".to_string(),
+        version: "1.0.0".to_string(),
+      }
+      .into(),
+      NpmPackageVersionResolutionError::DistTagVersionTooNew {
+        package_name: "package-a".into(),
+        dist_tag: "latest".to_string(),
+        version: "1.0.0".to_string(),
+        publish_date: "2026-08-15T00:00:00.000Z".parse().unwrap(),
+        newest_dependency_date: NewestDependencyDate(
+          "2026-08-01T00:00:00.000Z".parse().unwrap(),
+        ),
+      }
+      .into(),
+      NpmPackageVersionResolutionError::VersionNotFound(
+        NpmPackageVersionNotFound(PackageNv {
+          name: "package-a".into(),
+          version: version("1.0.0"),
+        }),
+      )
+      .into(),
+      NpmPackageVersionResolutionError::VersionReqNotMatched {
+        package_name: "package-a".into(),
+        version_req: VersionReq::parse_from_npm("2").unwrap(),
+        newest_dependency_date: None,
+      }
+      .into(),
+    ];
+    for err in &skippable {
+      assert!(
+        is_skippable_optional_error(err),
+        "expected skippable: {err:?}"
+      );
+    }
+
+    let fatal: Vec<NpmResolutionError> = vec![
+      // transient — a registry hiccup must not silently drop a package
+      NpmRegistryPackageInfoLoadError::LoadError(Arc::new(
+        deno_error::JsErrorBox::generic("connection reset"),
+      ))
+      .into(),
+      // a possible supply chain incident is never worth swallowing
+      NpmPackageVersionResolutionError::TrustPolicyDowngrade {
+        package_name: "package-a".into(),
+        version: version("1.0.0"),
+        past_evidence: "provenance",
+        current_evidence: "nothing",
+      }
+      .into(),
+      // a malformed dependency entry is raised after the node is created,
+      // so skipping it would leave an orphan node in the graph
+      NpmResolutionError::DependencyEntry(Box::new(NpmDependencyEntryError {
+        parent_nv: PackageNv {
+          name: "package-a".into(),
+          version: version("1.0.0"),
+        },
+        key: "package-b".to_string(),
+        value: "not-a-version".to_string(),
+        source: NpmDependencyEntryErrorSource::LocalDependency {
+          specifier: "file:./b".to_string(),
+        },
+      })),
+    ];
+    for err in &fatal {
+      assert!(!is_skippable_optional_error(err), "expected fatal: {err:?}");
+    }
   }
 
   #[tokio::test]

--- a/tests/registry/npm/@denotest/napi-optional-platform-android-arm64/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/napi-optional-platform-android-arm64/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = "android-arm64";

--- a/tests/registry/npm/@denotest/napi-optional-platform-android-arm64/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/napi-optional-platform-android-arm64/1.0.0/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@denotest/napi-optional-platform-android-arm64",
+  "version": "1.0.0",
+  "main": "index.js",
+  "publishDate": "2035-01-01T00:00:00.000Z",
+  "os": [
+    "android"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/tests/registry/npm/@denotest/napi-optional-platform-linux-x64/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/napi-optional-platform-linux-x64/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = "linux-x64";

--- a/tests/registry/npm/@denotest/napi-optional-platform-linux-x64/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/napi-optional-platform-linux-x64/1.0.0/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@denotest/napi-optional-platform-linux-x64",
+  "version": "1.0.0",
+  "main": "index.js",
+  "publishDate": "2020-01-01T00:00:00.000Z",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/tests/registry/npm/@denotest/napi-optional-platform/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/napi-optional-platform/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = "napi-optional-platform";

--- a/tests/registry/npm/@denotest/napi-optional-platform/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/napi-optional-platform/1.0.0/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@denotest/napi-optional-platform",
+  "version": "1.0.0",
+  "main": "index.js",
+  "publishDate": "2020-01-01T00:00:00.000Z",
+  "optionalDependencies": {
+    "@denotest/napi-optional-platform-linux-x64": "1.0.0",
+    "@denotest/napi-optional-platform-android-arm64": "1.0.0"
+  }
+}

--- a/tests/specs/install/optional_dep_blocked_by_min_dependency_age/__test__.jsonc
+++ b/tests/specs/install/optional_dep_blocked_by_min_dependency_age/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  // Regression test for https://github.com/denoland/deno/issues/36597.
+  // `@denotest/napi-optional-platform` lists two platform prebuilds in its
+  // `optionalDependencies`. The `linux-x64` one is old enough, but the
+  // `android-arm64` one was published after the configured minimum dependency
+  // age. Install must skip the blocked (and foreign-platform) optional dep
+  // instead of aborting the whole install.
+  "steps": [{
+    "args": "install npm:@denotest/napi-optional-platform",
+    "output": "install.out"
+  }]
+}

--- a/tests/specs/install/optional_dep_blocked_by_min_dependency_age/__test__.jsonc
+++ b/tests/specs/install/optional_dep_blocked_by_min_dependency_age/__test__.jsonc
@@ -5,9 +5,15 @@
   // `optionalDependencies`. The `linux-x64` one is old enough, but the
   // `android-arm64` one was published after the configured minimum dependency
   // age. Install must skip the blocked (and foreign-platform) optional dep
-  // instead of aborting the whole install.
-  "steps": [{
-    "args": "install npm:@denotest/napi-optional-platform",
-    "output": "install.out"
-  }]
+  // instead of aborting the whole install, and must say that it did so.
+  "steps": [
+    {
+      "args": "install npm:@denotest/napi-optional-platform",
+      "output": "install.out"
+    },
+    {
+      "args": "run --allow-read check_lockfile.js",
+      "output": "check_lockfile.out"
+    }
+  ]
 }

--- a/tests/specs/install/optional_dep_blocked_by_min_dependency_age/check_lockfile.js
+++ b/tests/specs/install/optional_dep_blocked_by_min_dependency_age/check_lockfile.js
@@ -1,0 +1,10 @@
+// The blocked optional dep must be absent from the lockfile while the sibling
+// that resolved cleanly is still recorded. Asserting the two facts directly
+// rather than dumping the whole lockfile keeps this immune to unrelated
+// lockfile format churn.
+const lock = Deno.readTextFileSync("deno.lock");
+console.log("linux-x64:", lock.includes("napi-optional-platform-linux-x64"));
+console.log(
+  "android-arm64:",
+  lock.includes("napi-optional-platform-android-arm64"),
+);

--- a/tests/specs/install/optional_dep_blocked_by_min_dependency_age/check_lockfile.out
+++ b/tests/specs/install/optional_dep_blocked_by_min_dependency_age/check_lockfile.out
@@ -1,0 +1,2 @@
+linux-x64: true
+android-arm64: false

--- a/tests/specs/install/optional_dep_blocked_by_min_dependency_age/deno.json
+++ b/tests/specs/install/optional_dep_blocked_by_min_dependency_age/deno.json
@@ -1,0 +1,3 @@
+{
+  "minimumDependencyAge": "2030-01-01T00:00:00.000Z"
+}

--- a/tests/specs/install/optional_dep_blocked_by_min_dependency_age/install.out
+++ b/tests/specs/install/optional_dep_blocked_by_min_dependency_age/install.out
@@ -1,5 +1,9 @@
 Add npm:@denotest/napi-optional-platform@1.0.0
 [WILDCARD]
+Skipping optional dependency '@denotest/napi-optional-platform-android-arm64@1.0.0': Could not find npm package '@denotest/napi-optional-platform-android-arm64' matching '1.0.0'.
+
+A newer matching version was found, but it was not used because it was newer than the specified minimum dependency date of 2030-01-01 00:00:00 UTC.
+[WILDCARD]
 Dependencies:
 + npm:@denotest/napi-optional-platform 1.0.0
 [WILDCARD]

--- a/tests/specs/install/optional_dep_blocked_by_min_dependency_age/install.out
+++ b/tests/specs/install/optional_dep_blocked_by_min_dependency_age/install.out
@@ -1,0 +1,5 @@
+Add npm:@denotest/napi-optional-platform@1.0.0
+[WILDCARD]
+Dependencies:
++ npm:@denotest/napi-optional-platform 1.0.0
+[WILDCARD]


### PR DESCRIPTION
Fixes #36597. Also fixes #29307.

## Problem

`deno install` hard-fails when a package's `optionalDependencies` contains a native prebuild for another OS/CPU that can't be resolved on the host — for example a napi-rs style package that lists every platform in `optionalDependencies`, where one foreign-platform tarball was published more recently than the configured `minimumDependencyAge`:

```
error: Could not find npm package '@node-datachannel/android-arm64' matching '0.33.0'.

A newer matching version was found, but it was not used because it was newer than the specified minimum dependency date ...
```

Deno resolves *every* platform variant in `optionalDependencies` (to keep the lockfile portable across systems), so a resolution failure on any single variant aborted the whole install — even for a package the host will never load. `--min-dep-age=0` is not an acceptable workaround because it disables the supply-chain policy for every package.

npm/yarn/pnpm treat an unresolvable optional dependency as non-fatal and skip it.

## Fix

- Mark `NpmDependencyEntry` values that originate from `optionalDependencies` with a new `optional` flag.
- During graph resolution, when resolving an optional dependency fails with a **deterministic** resolution error (package doesn't exist, no version matches, or every matching version is blocked by the minimum dependency age), skip that dependency instead of aborting the install. This also extends the existing "package doesn't exist" skip that previously only applied to optional *peer* dependencies.
- Transient errors (a registry load failure) and trust-policy downgrades still surface — they are not swallowed.
- Warn when a dependency is skipped, including the underlying error. Skipping keeps the install alive, but the dropped package may be the one this system actually needs (e.g. the host platform's own prebuild is the one blocked by the min-dep-age cutoff), and without a warning that failure would resurface at runtime as an opaque "module not found". The warning also keeps a genuinely broken version requirement in `optionalDependencies` diagnosable, since a bogus range and an age-blocked version produce the same skip. Warnings are deduped per `name@version_req`, so an optional dep reached through several parent paths is reported once.

os/cpu filtering is unchanged and still happens when the snapshot is materialized for a specific system.

### Effect on the lockfile

A skipped dep is genuinely absent from the lockfile rather than being recorded and filtered later, which has two consequences worth calling out:

- A lockfile generated while a variant was age-blocked will not contain that variant, so a machine that *does* need it won't get it from that lockfile. This is not a regression — today that install fails outright — but it is why the warning matters.
- With a relative `minimumDependencyAge` (e.g. `"7 days"`) an optional dep can silently drop out of the lockfile today and reappear next week as the cutoff moves. For required deps the equivalent situation is at least loud.

## Tests

Unit tests in `libs/npm/resolution/graph.rs`:
- skip an optional dep with a missing version / non-existent package
- skip an optional dep blocked by the minimum dependency age while a resolvable sibling still installs
- exhaustive classification table for `is_skippable_optional_error`, pinning every error variant as skippable or fatal — including that a transient registry load error and a trust-policy downgrade are *not* swallowed
- regression guards: a **required** dep with an unresolvable version still errors, and a trust-policy downgrade on an optional dep still errors

Spec test `tests/specs/install/optional_dep_blocked_by_min_dependency_age` reproduces the issue end-to-end using three new `@denotest/napi-optional-platform*` registry packages, one of which is published past the configured min-dep-age cutoff. It asserts the skip warning and the resulting lockfile contents — the blocked variant absent, the resolvable sibling still recorded — rather than only that the install didn't error.
