### PR TITLE
fix(npm): flatten single-resolution peers when building package ids

### DIFF
--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -9499,6 +9499,87 @@ mod test {
     }
   }
 
+  /// An `NpmPackageId` encodes each of its peers as that peer's full id,
+  /// so serializing one unfolds the peer graph into a tree: a peer
+  /// reachable by many paths is written out once per path. Ids therefore
+  /// grow exponentially in the depth of the peer graph.
+  ///
+  /// `compute_all_npm_pkg_ids` flattens a peer to a bare `name@version`
+  /// only when the two sit in the same NV-level SCC *and* that SCC is a
+  /// real cycle, which bounds the mutually-recursive case covered by
+  /// `peer_dep_id_length_bounded`. It does not bound this one: the chain
+  /// below only has forward edges, so every package is its own singleton
+  /// non-cyclic SCC and no peer is ever flattened.
+  ///
+  /// A 14-deep chain is enough to produce a ~135KB id; an 18-deep one
+  /// gives ~2.4MB and takes several seconds. This is what
+  /// `npm:@deepseek-ai/dsh` (see #36599) hits once peer resolution itself
+  /// terminates — the `@deepseek-ai/*` packages form a deep peer DAG.
+  ///
+  /// Note the ids are *not* duplicated in memory: `peer_dependencies` is
+  /// an `EcoVec`, so the cache in `compute_all_npm_pkg_ids` keeps a
+  /// properly shared DAG and cloning a peer id is a refcount bump. Only
+  /// serialization and the derived `Hash` materialize the tree, which
+  /// rules out fixing this by interning or deduplicating in memory — the
+  /// id's serialized *value* is what is exponential.
+  ///
+  /// Ignored because a fix means changing how peers are encoded into an
+  /// id, and that encoding is written to the lockfile (see the warning on
+  /// `NpmPackageId::as_serialized_with_level`), so it is a format decision
+  /// rather than a local bug fix. Run with `--ignored` to reproduce.
+  #[ignore = "known bug: peer DAGs give exponentially large ids (#36599)"]
+  #[tokio::test]
+  async fn peer_dep_id_length_bounded_for_peer_dag() {
+    let api = TestNpmRegistryApi::default();
+
+    // A chain where each package peer-depends on the next two, so every
+    // package is reachable by many paths but the peer graph stays acyclic.
+    let depth = 14;
+    let names: Vec<String> = (0..depth).map(|i| format!("h-{i}")).collect();
+    for (i, name) in names.iter().enumerate() {
+      api.ensure_package_version(name, "1.0.0");
+      for step in 1..=2 {
+        if let Some(next) = names.get(i + step) {
+          api.add_peer_dependency(
+            (name.as_str(), "1.0.0"),
+            (next.as_str(), "*"),
+          );
+        }
+      }
+    }
+
+    api.ensure_package_version("app", "1.0.0");
+    api.add_dependency(("app", "1.0.0"), ("h-0", "1"));
+
+    let (packages, _) = run_resolver_and_get_output(api, vec!["app@1"]).await;
+
+    // Check the graph really was resolved with its peers before asserting
+    // on id length — peers going missing entirely would also produce short
+    // ids, and this test doesn't run in CI to catch that separately.
+    assert_eq!(packages.len(), depth + 1);
+    let h0 = packages
+      .iter()
+      .find(|p| p.pkg_id.starts_with("h-0@1.0.0"))
+      .expect("should have resolved h-0");
+    assert!(
+      h0.pkg_id.starts_with("h-0@1.0.0_h-1@1.0.0__h-2@1.0.0"),
+      "h-0 should have h-1 and h-2 as peers, got: {}",
+      &h0.pkg_id[..60.min(h0.pkg_id.len())]
+    );
+
+    let longest = packages
+      .iter()
+      .max_by_key(|p| p.pkg_id.len())
+      .expect("should have resolved packages");
+    assert!(
+      longest.pkg_id.len() < 2000,
+      "package id is {} chars for a {} package graph: {}...",
+      longest.pkg_id.len(),
+      packages.len(),
+      &longest.pkg_id[..100.min(longest.pkg_id.len())]
+    );
+  }
+
   /// Test that NpmPackageId serialization length stays bounded.
   /// With the Expo-like pattern of many plugins with circular peer deps,
   /// no single package ID should exceed a reasonable length.

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -637,6 +637,20 @@ impl Graph {
     let mut cache: FxHashMap<NodeId, NpmPackageId> =
       FxHashMap::with_capacity_and_hasher(self.nodes.len(), Default::default());
 
+    // How many distinct nodes exist per name@version. A peer whose
+    // name@version resolved exactly one way in this graph can be written
+    // flat: the bare name@version already identifies it unambiguously, and
+    // its own peers are recorded on its own entry. Expanding it instead
+    // unfolds the peer graph into a tree, duplicating a peer once per path
+    // that reaches it, which makes ids exponential in the depth of the
+    // peer graph.
+    let mut nodes_per_nv: FxHashMap<Rc<PackageNv>, usize> =
+      FxHashMap::with_capacity_and_hasher(self.nodes.len(), Default::default());
+    for (resolved_id, _) in self.resolved_node_ids.node_to_resolved_id.values()
+    {
+      *nodes_per_nv.entry(resolved_id.nv.clone()).or_default() += 1;
+    }
+
     for scc in &node_sccs {
       for &node_id in scc {
         let resolved_id = match self.resolved_node_ids.get(node_id) {
@@ -672,8 +686,12 @@ impl Graph {
             && child_nv_scc == my_nv_scc
             && cyclic_nvs.contains(child_nv.as_ref());
 
-          if is_in_same_nv_cycle {
-            // Cyclic peer deps: use flat name@version (no nested peers).
+          let resolved_one_way =
+            nodes_per_nv.get(child_nv.as_ref()).copied().unwrap_or(0) <= 1;
+
+          if is_in_same_nv_cycle || resolved_one_way {
+            // Cyclic peer deps, or a peer with only one resolution: use
+            // flat name@version (no nested peers).
             npm_pkg_id.peer_dependencies.push(NpmPackageId {
               nv: (**child_nv).clone(),
               peer_dependencies: Default::default(),
@@ -4548,7 +4566,7 @@ mod test {
       packages,
       vec![
         TestNpmResolutionPackage {
-          pkg_id: "package-0@1.0.0_package-peer-a@2.0.0__package-peer-b@3.0.0_package-peer-b@3.0.0"
+          pkg_id: "package-0@1.0.0_package-peer-a@2.0.0_package-peer-b@3.0.0"
             .to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([(
@@ -4575,8 +4593,7 @@ mod test {
       package_reqs,
       vec![(
         "package-0@1.0".to_string(),
-        "package-0@1.0.0_package-peer-a@2.0.0__package-peer-b@3.0.0_package-peer-b@3.0.0"
-          .to_string()
+        "package-0@1.0.0_package-peer-a@2.0.0_package-peer-b@3.0.0".to_string()
       )]
     );
   }
@@ -4603,8 +4620,7 @@ mod test {
       packages,
       vec![
         TestNpmResolutionPackage {
-          pkg_id: "package-0@1.0.0_package-peer-a@2.0.0__package-peer-b@3.0.0"
-            .to_string(),
+          pkg_id: "package-0@1.0.0_package-peer-a@2.0.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
             (
@@ -4637,8 +4653,7 @@ mod test {
       vec![
         (
           "package-0@1.0".to_string(),
-          "package-0@1.0.0_package-peer-a@2.0.0__package-peer-b@3.0.0"
-            .to_string()
+          "package-0@1.0.0_package-peer-a@2.0.0".to_string()
         ),
         (
           "package-peer-a@2".to_string(),
@@ -4702,11 +4717,11 @@ mod test {
           dependencies: BTreeMap::from([
             (
               "package-b".to_string(),
-              "package-b@2.0.0_package-peer-a@4.0.0__package-peer-b@5.4.1_package-peer-c@6.2.0_package-peer-b@5.4.1".to_string(),
+              "package-b@2.0.0_package-peer-a@4.0.0_package-peer-c@6.2.0_package-peer-b@5.4.1".to_string(),
             ),
             (
               "package-c".to_string(),
-              "package-c@3.0.0_package-peer-a@4.0.0__package-peer-b@5.4.1_package-peer-b@5.4.1".to_string(),
+              "package-c@3.0.0_package-peer-a@4.0.0_package-peer-b@5.4.1".to_string(),
             ),
             (
               "package-d".to_string(),
@@ -4720,7 +4735,7 @@ mod test {
 
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-b@2.0.0_package-peer-a@4.0.0__package-peer-b@5.4.1_package-peer-c@6.2.0_package-peer-b@5.4.1".to_string(),
+          pkg_id: "package-b@2.0.0_package-peer-a@4.0.0_package-peer-c@6.2.0_package-peer-b@5.4.1".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
             (
@@ -4734,7 +4749,7 @@ mod test {
           ])
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-c@3.0.0_package-peer-a@4.0.0__package-peer-b@5.4.1_package-peer-b@5.4.1".to_string(),
+          pkg_id: "package-c@3.0.0_package-peer-a@4.0.0_package-peer-b@5.4.1".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([(
             "package-peer-a".to_string(),
@@ -4927,13 +4942,12 @@ mod test {
       packages,
       vec![
         TestNpmResolutionPackage {
-          pkg_id: "package-a@1.0.0_package-b@1.0.0__package-peer@1.0.0"
-            .to_string(),
+          pkg_id: "package-a@1.0.0_package-b@1.0.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
             (
               "package-c".to_string(),
-              "package-c@1.0.0_package-b@1.0.0__package-peer@1.0.0_package-peer@1.0.0".to_string(),
+              "package-c@1.0.0_package-b@1.0.0_package-peer@1.0.0".to_string(),
             ),
             ("package-peer".to_string(), "package-peer@1.0.0".to_string(),)
           ]),
@@ -4947,7 +4961,7 @@ mod test {
           )]),
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-c@1.0.0_package-b@1.0.0__package-peer@1.0.0_package-peer@1.0.0"
+          pkg_id: "package-c@1.0.0_package-b@1.0.0_package-peer@1.0.0"
             .to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([(
@@ -4967,7 +4981,7 @@ mod test {
       vec![
         (
           "package-a@1.0".to_string(),
-          "package-a@1.0.0_package-b@1.0.0__package-peer@1.0.0".to_string()
+          "package-a@1.0.0_package-b@1.0.0".to_string()
         ),
         (
           "package-b@1.0".to_string(),
@@ -5458,13 +5472,16 @@ mod test {
         TestNpmResolutionPackage {
           pkg_id: "package-0@1.0.0".to_string(),
           copy_index: 0,
-          dependencies: BTreeMap::from([(
-            "package-a".to_string(),
-            "package-a@1.0.0_package-0@1.0.0".to_string(),
-          ), (
-            "package-1".to_string(),
-            "package-1@1.0.0_package-0@1.0.0".to_string(),
-          )]),
+          dependencies: BTreeMap::from([
+            (
+              "package-a".to_string(),
+              "package-a@1.0.0_package-0@1.0.0".to_string(),
+            ),
+            (
+              "package-1".to_string(),
+              "package-1@1.0.0_package-0@1.0.0".to_string(),
+            )
+          ]),
         },
         TestNpmResolutionPackage {
           pkg_id: "package-1@1.0.0_package-0@1.0.0".to_string(),
@@ -5479,53 +5496,44 @@ mod test {
           copy_index: 0,
           dependencies: BTreeMap::from([(
             "package-b".to_string(),
-            "package-b@1.0.0_package-0@1.0.0_package-a@1.0.0__package-0@1.0.0".to_string(),
+            "package-b@1.0.0_package-0@1.0.0_package-a@1.0.0".to_string(),
           )]),
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-b@1.0.0_package-0@1.0.0_package-a@1.0.0__package-0@1.0.0".to_string(),
+          pkg_id: "package-b@1.0.0_package-0@1.0.0_package-a@1.0.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
-            (
-              "package-0".to_string(),
-              "package-0@1.0.0".to_string(),
-            ),
+            ("package-0".to_string(), "package-0@1.0.0".to_string(),),
             (
               "package-a".to_string(),
               "package-a@1.0.0_package-0@1.0.0".to_string(),
             ),
             (
               "package-c".to_string(),
-              "package-c@1.0.0_package-0@1.0.0_package-a@1.0.0__package-0@1.0.0".to_string(),
+              "package-c@1.0.0_package-0@1.0.0_package-a@1.0.0".to_string(),
             )
           ]),
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-c@1.0.0_package-0@1.0.0_package-a@1.0.0__package-0@1.0.0".to_string(),
+          pkg_id: "package-c@1.0.0_package-0@1.0.0_package-a@1.0.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
-            (
-              "package-0".to_string(),
-              "package-0@1.0.0".to_string(),
-            ),
+            ("package-0".to_string(), "package-0@1.0.0".to_string(),),
             (
               "package-a".to_string(),
               "package-a@1.0.0_package-0@1.0.0".to_string(),
             ),
             (
               "package-d".to_string(),
-              "package-d@1.0.0_package-0@1.0.0_package-a@1.0.0__package-0@1.0.0".to_string(),
+              "package-d@1.0.0_package-0@1.0.0_package-a@1.0.0".to_string(),
             )
           ]),
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-d@1.0.0_package-0@1.0.0_package-a@1.0.0__package-0@1.0.0".to_string(),
+          pkg_id: "package-d@1.0.0_package-0@1.0.0_package-a@1.0.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
-            (
-              "package-0".to_string(),
-              "package-0@1.0.0".to_string(),
-            ),
+            ("package-0".to_string(), "package-0@1.0.0".to_string(),),
             (
               "package-a".to_string(),
               "package-a@1.0.0_package-0@1.0.0".to_string(),
@@ -5723,11 +5731,11 @@ mod test {
           copy_index: 0,
           dependencies: BTreeMap::from([(
             "package-c".to_string(),
-            "package-c@1.0.0_package-b@1.0.0__package-a@1.0.0_package-a@1.0.0".to_string(),
+            "package-c@1.0.0_package-b@1.0.0_package-a@1.0.0".to_string(),
           )]),
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-c@1.0.0_package-b@1.0.0__package-a@1.0.0_package-a@1.0.0".to_string(),
+          pkg_id: "package-c@1.0.0_package-b@1.0.0_package-a@1.0.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
             (
@@ -5736,41 +5744,40 @@ mod test {
             ),
             (
               "package-d".to_string(),
-              "package-d@1.0.0_package-b@1.0.0__package-a@1.0.0".to_string(),
+              "package-d@1.0.0_package-b@1.0.0".to_string(),
             ),
             (
               "package-e".to_string(),
-              "package-e@1.0.0_package-a@1.0.0_package-b@1.0.0__package-a@1.0.0".to_string()
+              "package-e@1.0.0_package-a@1.0.0_package-b@1.0.0".to_string()
             )
           ]),
-
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-d@1.0.0_package-b@1.0.0__package-a@1.0.0".to_string(),
+          pkg_id: "package-d@1.0.0_package-b@1.0.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([(
             "package-c".to_string(),
-            "package-c@1.0.0_package-b@1.0.0__package-a@1.0.0_package-a@1.0.0".to_string(),
+            "package-c@1.0.0_package-b@1.0.0_package-a@1.0.0".to_string(),
           )]),
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-e@1.0.0_package-a@1.0.0_package-b@1.0.0__package-a@1.0.0".to_string(),
+          pkg_id: "package-e@1.0.0_package-a@1.0.0_package-b@1.0.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([(
             "package-f".to_string(),
-            "package-f@1.0.0_package-a@1.0.0_package-b@1.0.0__package-a@1.0.0".to_string(),
+            "package-f@1.0.0_package-a@1.0.0_package-b@1.0.0".to_string(),
           )]),
         },
         TestNpmResolutionPackage {
-          pkg_id: "package-f@1.0.0_package-a@1.0.0_package-b@1.0.0__package-a@1.0.0".to_string(),
+          pkg_id: "package-f@1.0.0_package-a@1.0.0_package-b@1.0.0".to_string(),
           copy_index: 0,
-          dependencies: BTreeMap::from([(
-            "package-a".to_string(),
-            "package-a@1.0.0".to_string(),
-          ), (
-            "package-d".to_string(),
-            "package-d@1.0.0_package-b@1.0.0__package-a@1.0.0".to_string(),
-          )]),
+          dependencies: BTreeMap::from([
+            ("package-a".to_string(), "package-a@1.0.0".to_string(),),
+            (
+              "package-d".to_string(),
+              "package-d@1.0.0_package-b@1.0.0".to_string(),
+            )
+          ]),
         },
       ]
     );
@@ -5823,14 +5830,11 @@ mod test {
           copy_index: 0,
           dependencies: BTreeMap::from([(
             "package-d".to_string(),
-            "package-d@1.0.0_package-c@1.0.0__package-a@1.0.0_package-a@1.0.0"
-              .to_string(),
+            "package-d@1.0.0_package-c@1.0.0_package-a@1.0.0".to_string(),
           )]),
         },
         TestNpmResolutionPackage {
-          pkg_id:
-            "package-d@1.0.0_package-c@1.0.0__package-a@1.0.0_package-a@1.0.0"
-              .to_string(),
+          pkg_id: "package-d@1.0.0_package-c@1.0.0_package-a@1.0.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
             (
@@ -7149,26 +7153,26 @@ mod test {
           copy_index: 0,
           dependencies: BTreeMap::from([
               ("@aws-sdk/client-sso-oidc".to_string(), "@aws-sdk/client-sso-oidc@3.679.0_@aws-sdk+client-sts@3.679.0".to_string()),
-              ("@aws-sdk/credential-provider-node".to_string(), "@aws-sdk/credential-provider-node@3.679.0_@aws-sdk+client-sso-oidc@3.679.0__@aws-sdk+client-sts@3.679.0_@aws-sdk+client-sts@3.679.0".to_string()),
+              ("@aws-sdk/credential-provider-node".to_string(), "@aws-sdk/credential-provider-node@3.679.0_@aws-sdk+client-sso-oidc@3.679.0_@aws-sdk+client-sts@3.679.0".to_string()),
           ]),
       },
       TestNpmResolutionPackage {
-          pkg_id: "@aws-sdk/credential-provider-ini@3.679.0_@aws-sdk+client-sts@3.679.0_@aws-sdk+client-sso-oidc@3.679.0__@aws-sdk+client-sts@3.679.0".to_string(),
+          pkg_id: "@aws-sdk/credential-provider-ini@3.679.0_@aws-sdk+client-sts@3.679.0_@aws-sdk+client-sso-oidc@3.679.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
               ("@aws-sdk/client-sts".to_string(), "@aws-sdk/client-sts@3.679.0".to_string()),
-              ("@aws-sdk/credential-provider-sso".to_string(), "@aws-sdk/credential-provider-sso@3.679.0_@aws-sdk+client-sso-oidc@3.679.0__@aws-sdk+client-sts@3.679.0_@aws-sdk+client-sts@3.679.0".to_string()),
+              ("@aws-sdk/credential-provider-sso".to_string(), "@aws-sdk/credential-provider-sso@3.679.0_@aws-sdk+client-sso-oidc@3.679.0_@aws-sdk+client-sts@3.679.0".to_string()),
           ]),
       },
       TestNpmResolutionPackage {
-          pkg_id: "@aws-sdk/credential-provider-node@3.679.0_@aws-sdk+client-sso-oidc@3.679.0__@aws-sdk+client-sts@3.679.0_@aws-sdk+client-sts@3.679.0".to_string(),
+          pkg_id: "@aws-sdk/credential-provider-node@3.679.0_@aws-sdk+client-sso-oidc@3.679.0_@aws-sdk+client-sts@3.679.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
-              ("@aws-sdk/credential-provider-ini".to_string(), "@aws-sdk/credential-provider-ini@3.679.0_@aws-sdk+client-sts@3.679.0_@aws-sdk+client-sso-oidc@3.679.0__@aws-sdk+client-sts@3.679.0".to_string()),
+              ("@aws-sdk/credential-provider-ini".to_string(), "@aws-sdk/credential-provider-ini@3.679.0_@aws-sdk+client-sts@3.679.0_@aws-sdk+client-sso-oidc@3.679.0".to_string()),
           ]),
       },
       TestNpmResolutionPackage {
-          pkg_id: "@aws-sdk/credential-provider-sso@3.679.0_@aws-sdk+client-sso-oidc@3.679.0__@aws-sdk+client-sts@3.679.0_@aws-sdk+client-sts@3.679.0".to_string(),
+          pkg_id: "@aws-sdk/credential-provider-sso@3.679.0_@aws-sdk+client-sso-oidc@3.679.0_@aws-sdk+client-sts@3.679.0".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
               ("@aws-sdk/client-sso-oidc".to_string(), "@aws-sdk/client-sso-oidc@3.679.0_@aws-sdk+client-sts@3.679.0".to_string()),
@@ -7352,56 +7356,59 @@ mod test {
       )
       .await;
       assert_eq!(
-      packages,
-      vec![
-        TestNpmResolutionPackage {
-          pkg_id: "package-a@1.0.0_package-peer@1.0.1".to_string(),
-          copy_index: 0,
-          dependencies: BTreeMap::from([(
-            "package-b".to_string(),
-            "package-b@1.0.0_package-peer@1.0.1".to_string(),
-          ), (
-            "package-c".to_string(),
-            "package-c@1.0.0_package-b@1.0.0__package-peer@1.0.1".to_string(),
-          ), (
-            "package-peer".to_string(),
-            "package-peer@1.0.1".to_string()
-          )])
-        },
-        TestNpmResolutionPackage {
-          pkg_id: "package-b@1.0.0_package-peer@1.0.1".to_string(),
-          copy_index: 0,
-          dependencies: BTreeMap::from([(
-            "package-peer".to_string(),
-            "package-peer@1.0.1".to_string(),
-          )])
-        },
-        TestNpmResolutionPackage {
-          pkg_id: "package-c@1.0.0_package-b@1.0.0__package-peer@1.0.1".to_string(),
-          copy_index: 0,
-          dependencies: BTreeMap::from([(
-            "package-d".to_string(),
-            "package-d@1.0.0_package-b@1.0.0__package-peer@1.0.1_package-peer@1.0.1".to_string(),
-          ), (
-            "package-peer".to_string(),
-            "package-peer@1.0.1".to_string(),
-          )]),
-        },
-        TestNpmResolutionPackage {
-          pkg_id: "package-d@1.0.0_package-b@1.0.0__package-peer@1.0.1_package-peer@1.0.1".to_string(),
-          copy_index: 0,
-          dependencies: BTreeMap::from([(
-            "package-b".to_string(),
-            "package-b@1.0.0_package-peer@1.0.1".to_string(),
-          )])
-        },
-        TestNpmResolutionPackage {
-          pkg_id: "package-peer@1.0.1".to_string(),
-          copy_index: 0,
-          dependencies: Default::default(),
-        },
-      ]
-    );
+        packages,
+        vec![
+          TestNpmResolutionPackage {
+            pkg_id: "package-a@1.0.0_package-peer@1.0.1".to_string(),
+            copy_index: 0,
+            dependencies: BTreeMap::from([
+              (
+                "package-b".to_string(),
+                "package-b@1.0.0_package-peer@1.0.1".to_string(),
+              ),
+              (
+                "package-c".to_string(),
+                "package-c@1.0.0_package-b@1.0.0".to_string(),
+              ),
+              ("package-peer".to_string(), "package-peer@1.0.1".to_string())
+            ])
+          },
+          TestNpmResolutionPackage {
+            pkg_id: "package-b@1.0.0_package-peer@1.0.1".to_string(),
+            copy_index: 0,
+            dependencies: BTreeMap::from([(
+              "package-peer".to_string(),
+              "package-peer@1.0.1".to_string(),
+            )])
+          },
+          TestNpmResolutionPackage {
+            pkg_id: "package-c@1.0.0_package-b@1.0.0".to_string(),
+            copy_index: 0,
+            dependencies: BTreeMap::from([
+              (
+                "package-d".to_string(),
+                "package-d@1.0.0_package-b@1.0.0_package-peer@1.0.1"
+                  .to_string(),
+              ),
+              ("package-peer".to_string(), "package-peer@1.0.1".to_string(),)
+            ]),
+          },
+          TestNpmResolutionPackage {
+            pkg_id: "package-d@1.0.0_package-b@1.0.0_package-peer@1.0.1"
+              .to_string(),
+            copy_index: 0,
+            dependencies: BTreeMap::from([(
+              "package-b".to_string(),
+              "package-b@1.0.0_package-peer@1.0.1".to_string(),
+            )])
+          },
+          TestNpmResolutionPackage {
+            pkg_id: "package-peer@1.0.1".to_string(),
+            copy_index: 0,
+            dependencies: Default::default(),
+          },
+        ]
+      );
       assert_eq!(
         package_reqs,
         vec![
@@ -7570,8 +7577,7 @@ mod test {
       packages,
       vec![
         TestNpmResolutionPackage {
-          pkg_id: "@deno/vite-plugin@1.0.4_vite@6.2.4__lightningcss@1.29.2"
-            .to_string(),
+          pkg_id: "@deno/vite-plugin@1.0.4_vite@6.2.4".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([(
             "vite".to_string(),
@@ -7579,8 +7585,7 @@ mod test {
           )])
         },
         TestNpmResolutionPackage {
-          pkg_id: "@tailwindcss/vite@4.0.17_vite@6.2.4__lightningcss@1.29.2"
-            .to_string(),
+          pkg_id: "@tailwindcss/vite@4.0.17_vite@6.2.4".to_string(),
           copy_index: 0,
           dependencies: BTreeMap::from([
             (
@@ -7613,12 +7618,11 @@ mod test {
       vec![
         (
           "@deno/vite-plugin@~1.0.4".to_string(),
-          "@deno/vite-plugin@1.0.4_vite@6.2.4__lightningcss@1.29.2".to_string()
+          "@deno/vite-plugin@1.0.4_vite@6.2.4".to_string()
         ),
         (
           "@tailwindcss/vite@~4.0.17".to_string(),
-          "@tailwindcss/vite@4.0.17_vite@6.2.4__lightningcss@1.29.2"
-            .to_string()
+          "@tailwindcss/vite@4.0.17_vite@6.2.4".to_string()
         ),
       ]
     );
@@ -9499,35 +9503,20 @@ mod test {
     }
   }
 
-  /// An `NpmPackageId` encodes each of its peers as that peer's full id,
-  /// so serializing one unfolds the peer graph into a tree: a peer
-  /// reachable by many paths is written out once per path. Ids therefore
-  /// grow exponentially in the depth of the peer graph.
+  /// An `NpmPackageId` used to encode every peer as that peer's full id,
+  /// which unfolds the peer graph into a tree: a peer reachable by many
+  /// paths gets written out once per path, so ids grew exponentially in
+  /// the depth of the peer graph.
   ///
-  /// `compute_all_npm_pkg_ids` flattens a peer to a bare `name@version`
-  /// only when the two sit in the same NV-level SCC *and* that SCC is a
-  /// real cycle, which bounds the mutually-recursive case covered by
-  /// `peer_dep_id_length_bounded`. It does not bound this one: the chain
-  /// below only has forward edges, so every package is its own singleton
-  /// non-cyclic SCC and no peer is ever flattened.
+  /// Flattening same-cycle peers bounds the mutually-recursive case in
+  /// `peer_dep_id_length_bounded`, but not this one — the chain below has
+  /// only forward edges, so every package is its own singleton non-cyclic
+  /// SCC. Before peers with a single resolution were also flattened, a
+  /// 14-deep chain produced a ~135KB id and an 18-deep one ~2.4MB.
   ///
-  /// A 14-deep chain is enough to produce a ~135KB id; an 18-deep one
-  /// gives ~2.4MB and takes several seconds. This is what
-  /// `npm:@deepseek-ai/dsh` (see #36599) hits once peer resolution itself
-  /// terminates — the `@deepseek-ai/*` packages form a deep peer DAG.
-  ///
-  /// Note the ids are *not* duplicated in memory: `peer_dependencies` is
-  /// an `EcoVec`, so the cache in `compute_all_npm_pkg_ids` keeps a
-  /// properly shared DAG and cloning a peer id is a refcount bump. Only
-  /// serialization and the derived `Hash` materialize the tree, which
-  /// rules out fixing this by interning or deduplicating in memory — the
-  /// id's serialized *value* is what is exponential.
-  ///
-  /// Ignored because a fix means changing how peers are encoded into an
-  /// id, and that encoding is written to the lockfile (see the warning on
-  /// `NpmPackageId::as_serialized_with_level`), so it is a format decision
-  /// rather than a local bug fix. Run with `--ignored` to reproduce.
-  #[ignore = "known bug: peer DAGs give exponentially large ids (#36599)"]
+  /// This is what `npm:@deepseek-ai/dsh` (#36599) hits once peer
+  /// resolution itself terminates, since the `@deepseek-ai/*` packages
+  /// form a deep peer DAG.
   #[tokio::test]
   async fn peer_dep_id_length_bounded_for_peer_dag() {
     let api = TestNpmRegistryApi::default();
@@ -9561,8 +9550,10 @@ mod test {
       .iter()
       .find(|p| p.pkg_id.starts_with("h-0@1.0.0"))
       .expect("should have resolved h-0");
+    // Peers are recorded, but each as a flat name@version rather than as
+    // its own fully expanded id.
     assert!(
-      h0.pkg_id.starts_with("h-0@1.0.0_h-1@1.0.0__h-2@1.0.0"),
+      h0.pkg_id.starts_with("h-0@1.0.0_h-1@1.0.0_h-2@1.0.0"),
       "h-0 should have h-1 and h-2 as peers, got: {}",
       &h0.pkg_id[..60.min(h0.pkg_id.len())]
     );

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -2352,7 +2352,16 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
 
       // Check each resolved peer: is the same peer available in current scope?
       for (name, cached_id) in &entry.resolved_peers {
-        match parent_pkgs.get(name) {
+        // Look the peer up the same way `find_peer_node_id` did when the
+        // entry was built: scope first, then the auto-installed peer
+        // fallbacks. Checking only `parent_pkgs` here meant any entry
+        // whose peer came from a fallback could never match — the name is
+        // absent from every scope — so those packages were re-resolved on
+        // every path and resolution never terminated.
+        match parent_pkgs
+          .get(name)
+          .or_else(|| self.peer_fallbacks.get(name))
+        {
           Some(current_id) if current_id == cached_id => continue,
           Some(current_id) => {
             // Different NodeId. Check if same package version.
@@ -2394,7 +2403,9 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
 
       // Check that previously missing peers are still missing
       for name in entry.missing_peers.keys() {
-        if parent_pkgs.contains_key(name) {
+        if parent_pkgs.contains_key(name)
+          || self.peer_fallbacks.contains_key(name)
+        {
           all_match = false;
           break;
         }
@@ -9495,6 +9506,102 @@ mod test {
           .any(|p| p.pkg_id.starts_with(&format!("{}@", name))),
         "should have {}",
         name
+      );
+    }
+  }
+
+  /// Regression test for a hang resolving `npm:@deepseek-ai/dsh`.
+  ///
+  /// That package pulls in ~60 sibling packages that all peer-depend on a
+  /// shared "core" package (plus helpers that themselves peer-depend on
+  /// core), and nothing depends on those shared packages as a regular dep,
+  /// so they get auto-installed into `peer_fallbacks` instead of living in
+  /// any scope.
+  ///
+  /// `find_peer_node_id` resolves peers from the scope *or* the fallbacks,
+  /// but `find_peers_cache_hit` only looked at the scope. So every cache
+  /// entry for a package whose peer came from a fallback recorded a name
+  /// that is absent from every scope, and could never match. Each of those
+  /// packages was then re-resolved once per path through the DAG — and
+  /// because the paths grow exponentially, resolution never finished.
+  ///
+  /// Unlike `peer_deps_mutual_many_packages_no_hang`, the peers here are
+  /// NOT in the root scope, which is what routes them through the
+  /// fallbacks.
+  #[tokio::test]
+  async fn peer_deps_layered_dag_no_hang() {
+    let api = TestNpmRegistryApi::default();
+
+    // Shared packages that nearly everything peer-depends on.
+    api.ensure_package_version("core", "1.0.0");
+    api.ensure_package_version("invariants", "1.0.0");
+    api.ensure_package_version("brand", "1.0.0");
+
+    // core has optional peers back on plugins that are themselves in the
+    // graph, forming peer cycles through the shared cluster.
+    api.ensure_package_version("plugin-a", "1.0.0");
+    api.ensure_package_version("plugin-b", "1.0.0");
+    api.add_optional_peer_dependency(("core", "1.0.0"), ("plugin-a", "*"));
+    api.add_optional_peer_dependency(("core", "1.0.0"), ("plugin-b", "*"));
+    api.add_peer_dependency(("plugin-a", "1.0.0"), ("core", "*"));
+    api.add_peer_dependency(("plugin-b", "1.0.0"), ("core", "*"));
+
+    api.add_peer_dependency(("invariants", "1.0.0"), ("core", "*"));
+    api.add_peer_dependency(("brand", "1.0.0"), ("core", "*"));
+    api.add_peer_dependency(("brand", "1.0.0"), ("invariants", "*"));
+
+    // A layered DAG of packages. Each depends on the next few, so the
+    // number of distinct root->leaf paths grows exponentially in `n`
+    // while the node count stays linear.
+    let n = 24;
+    let pkg_names: Vec<String> = (0..n).map(|i| format!("pkg-{i}")).collect();
+    for (i, name) in pkg_names.iter().enumerate() {
+      api.ensure_package_version(name, "1.0.0");
+      // Every package peer-depends on the shared cluster, so none of them
+      // can be marked "pure" and short-circuited.
+      api.add_peer_dependency((name, "1.0.0"), ("core", "*"));
+      api.add_peer_dependency((name, "1.0.0"), ("brand", "*"));
+      for step in 1..=3 {
+        if let Some(next) = pkg_names.get(i + step) {
+          api.add_dependency((name, "1.0.0"), (next.as_str(), "1"));
+        }
+      }
+    }
+
+    // Root only depends on the first few packages, so the rest are reached
+    // transitively through the DAG. Nothing depends on the shared cluster
+    // as a regular dep, so those packages are auto-installed as peer
+    // fallbacks rather than living in any scope.
+    api.ensure_package_version("app", "1.0.0");
+    for name in pkg_names.iter().take(3) {
+      api.add_dependency(("app", "1.0.0"), (name.as_str(), "1"));
+    }
+
+    // Phase 2 is synchronous, so `tokio::time::timeout` can't interrupt it
+    // — assert on elapsed time instead. With the cache working this takes
+    // milliseconds; when it regresses it takes minutes.
+    let start = std::time::Instant::now();
+    let (packages, _) = run_resolver_and_get_output(api, vec!["app@1"]).await;
+    let elapsed = start.elapsed();
+    assert!(
+      elapsed < std::time::Duration::from_secs(30),
+      "resolution took {elapsed:?} — Phase 2 peer resolution is re-walking \
+       the graph once per path instead of once per distinct peer context"
+    );
+
+    // plugin-a/plugin-b are only optional peers of core, so they are not
+    // auto-installed — they exist to put an optional-peer cycle through
+    // the shared cluster.
+    for name in pkg_names.iter().map(|s| s.as_str()).chain([
+      "core",
+      "brand",
+      "invariants",
+    ]) {
+      assert!(
+        packages
+          .iter()
+          .any(|p| p.pkg_id.starts_with(&format!("{name}@"))),
+        "should have {name}"
       );
     }
   }


### PR DESCRIPTION
An NpmPackageId encoded every one of its peers as that peer's full id,
which unfolds the peer graph into a tree: a peer reachable by many paths
was written out once per path, so ids grew exponentially in the depth of
the peer graph. Flattening same-cycle peers bounded the mutually
recursive case, but not an acyclic peer DAG, where every package is its
own singleton non-cyclic SCC and so nothing was ever flattened. In the
added test a 14-deep chain produced a ~135KB id and an 18-deep one
~2.4MB, and hashing or serializing one of those walks the whole tree.

This also flattens a peer whose name@version resolved exactly one way in
the graph. The bare name@version identifies it unambiguously in that
case, and its own peers stay recorded on its own entry, so nothing is
lost. The same 14-deep chain now produces a 143 character id.

Existing lockfiles are unaffected, since the ids recorded there are
reused rather than recomputed — verified by resolving with a released
deno and then re-running against the same lockfile. A fresh resolution
of a graph with nested peers does write shorter ids, so the expectations
in the affected tests are updated to match.

This is the second of two bugs behind #36599; it is stacked on #36607,
which fixes the peer resolution hang that has to be cleared before this
one is even reachable. With both, `deno install npm:@deepseek-ai/dsh`
completes in about 19 seconds from a cold cache, having previously hung
indefinitely.

Fixes #36599
