### PR TITLE
ci: time out the sysroot setup step after 10 minutes

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -132,6 +132,7 @@ jobs:
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Set up incremental LTO and sysroot build
         if: '(contains(github.event.pull_request.labels.*.name, ''ci-bench'') || github.ref == ''refs/heads/main'') && !startsWith(github.ref, ''refs/tags/'')'
+        timeout-minutes: 10
         run: |-
           # Setting up sysroot
           export DEBIAN_FRONTEND=noninteractive
@@ -4390,6 +4391,7 @@ jobs:
           echo '*** Installed packages'
           command -v dpkg && dpkg -l || echo 'No dpkg found or bad executable'
       - name: Set up incremental LTO and sysroot build
+        timeout-minutes: 10
         run: |-
           # Setting up sysroot
           export DEBIAN_FRONTEND=noninteractive
@@ -4903,6 +4905,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
       - name: Set up incremental LTO and sysroot build
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
+        timeout-minutes: 10
         run: |-
           # Setting up sysroot
           export DEBIAN_FRONTEND=noninteractive
@@ -5296,6 +5299,7 @@ jobs:
           echo '*** Installed packages'
           command -v dpkg && dpkg -l || echo 'No dpkg found or bad executable'
       - name: Set up incremental LTO and sysroot build
+        timeout-minutes: 10
         run: |-
           # Setting up sysroot
           export DEBIAN_FRONTEND=noninteractive
@@ -5588,6 +5592,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
       - name: Set up incremental LTO and sysroot build
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
+        timeout-minutes: 10
         run: |-
           # Setting up sysroot
           export DEBIAN_FRONTEND=noninteractive
@@ -6514,6 +6519,7 @@ jobs:
           command -v dpkg && dpkg -l || echo 'No dpkg found or bad executable'
       - name: Set up incremental LTO and sysroot build
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
+        timeout-minutes: 10
         run: |-
           # Setting up sysroot
           export DEBIAN_FRONTEND=noninteractive
@@ -7014,6 +7020,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
       - name: Set up incremental LTO and sysroot build
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
+        timeout-minutes: 10
         run: |-
           # Setting up sysroot
           export DEBIAN_FRONTEND=noninteractive
@@ -7408,6 +7415,7 @@ jobs:
           deno-version: v2.x
       - name: Set up incremental LTO and sysroot build
         if: '!startsWith(github.ref, ''refs/tags/'')'
+        timeout-minutes: 10
         run: |-
           # Setting up sysroot
           export DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -119,6 +119,10 @@ const installPkgsCommand =
   `sudo apt-get install -y --no-install-recommends clang-${llvmVersion} lld-${llvmVersion} clang-tools-${llvmVersion} clang-format-${llvmVersion} clang-tidy-${llvmVersion}`;
 const sysRootConfig = {
   name: "Set up incremental LTO and sysroot build",
+  // This normally takes under a minute, but `apt-get update` has been seen to
+  // hang indefinitely when a mirror is unreachable, burning the job's whole
+  // timeout before a single test runs. Fail fast instead.
+  timeoutMinutes: 10,
   run: `# Setting up sysroot
 export DEBIAN_FRONTEND=noninteractive
 # Avoid running man-db triggers, which sometimes takes several minutes


### PR DESCRIPTION
The "Set up incremental LTO and sysroot build" step normally finishes in
well under a minute, but the `apt-get update` inside it has no timeout of
its own, and when an Ubuntu mirror goes unreachable apt stalls without
ever failing or erroring out. In run 32062291523 that happened on four
`release linux-x86_64` runners at once: each sat in this step for 58
minutes and was then killed by the 60 minute job timeout, so the specs,
unit_node and node_compat shards never ran a single test and the only
signal was an opaque cancellation an hour later.

Ten minutes is generous for a step that installs a handful of packages
and unpacks a sysroot, so a step level timeout costs nothing when things
are healthy and points at the real cause when they are not. The change is
made in `ci.ts` on the shared step config, so it applies to every job that
sets up the sysroot, and `ci.generated.yml` is regenerated.