### PR TITLE
ci: stop node_compat shard 0 starving its runner

### DIFF
--- a/.github/workflows/node_compat_test.generated.yml
+++ b/.github/workflows/node_compat_test.generated.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: '${{ matrix.runner }}'
+    timeout-minutes: 30
     strategy:
       matrix:
         include:

--- a/.github/workflows/node_compat_test.generated.yml
+++ b/.github/workflows/node_compat_test.generated.yml
@@ -57,6 +57,7 @@ jobs:
             shard_index: '2'
             shard_total: '3'
             shard_label: (3/3)
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/node_compat_test.ts
+++ b/.github/workflows/node_compat_test.ts
@@ -112,6 +112,10 @@ const testJob = job("test", {
   // 6 hour default keep the job around.
   timeoutMinutes: 30,
   strategy: {
+    // The shards are independent: one of them going down says nothing about
+    // the other eight, and cancelling them throws away reports that would
+    // otherwise have been uploaded for the day's summary.
+    failFast: false,
     matrix,
   },
   steps: [

--- a/.github/workflows/node_compat_test.ts
+++ b/.github/workflows/node_compat_test.ts
@@ -107,6 +107,10 @@ const uploadReport = step.dependsOn(gzipReport)({
 
 const testJob = job("test", {
   runsOn: matrix.runner,
+  // Shards normally finish well inside 15 minutes. A shard that blows past
+  // this is a wedged runner, not slow tests, so cap it rather than let the
+  // 6 hour default keep the job around.
+  timeoutMinutes: 30,
   strategy: {
     matrix,
   },

--- a/tests/node_compat/mod.rs
+++ b/tests/node_compat/mod.rs
@@ -157,9 +157,18 @@ fn main() {
     return;
   }
 
-  // Partition into sequential and parallel tests
-  let (sequential_category, parallel_category) =
-    category.partition(|test| test.data.test_path.starts_with("sequential/"));
+  // Partition into sequential and parallel tests.
+  //
+  // `pummel/` is upstream Node's stress suite: several of its tests allocate
+  // multi-gigabyte buffers or spin the CPU deliberately. Running a handful of
+  // them concurrently starves a CI runner badly enough that the machine stops
+  // responding, so they get the same one-at-a-time treatment as `sequential/`.
+  const SEQUENTIAL_TEST_DIRS: &[&str] = &["sequential/", "pummel/"];
+  let (sequential_category, parallel_category) = category.partition(|test| {
+    SEQUENTIAL_TEST_DIRS
+      .iter()
+      .any(|dir| test.data.test_path.starts_with(dir))
+  });
 
   let parallelism = Parallelism::default();
   let flaky_test_tracker = Arc::new(FlakyTestTracker::default());

--- a/tests/util/lib/test_runner.rs
+++ b/tests/util/lib/test_runner.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::hash::Hasher;
 use std::io::IsTerminal;
 use std::io::Write;
 use std::sync::Arc;
@@ -41,7 +42,7 @@ impl ShardConfig {
 }
 
 /// Filter a collected test category to only include tests assigned to this shard.
-/// Uses round-robin distribution by sorted test name.
+/// Distributes by a hash of the test name.
 pub fn filter_to_shard<T>(
   category: CollectedTestCategory<T>,
   shard: &ShardConfig,
@@ -80,15 +81,27 @@ fn assign_shard_tests(
   all_names: Vec<String>,
   shard: &ShardConfig,
 ) -> HashSet<String> {
-  // round-robin: distribute by sorted name index
-  let mut sorted: Vec<_> = all_names;
-  sorted.sort();
-  sorted
+  all_names
     .into_iter()
-    .enumerate()
-    .filter(|(i, _)| i % shard.total == shard.index)
-    .map(|(_, name)| name)
+    .filter(|name| shard_index_of(name, shard.total) == shard.index)
     .collect()
+}
+
+/// Which shard a test belongs to, derived only from its own name.
+///
+/// Deliberately *not* round-robin over the sorted test list: with positional
+/// assignment, adding or removing a single test shifts every test after it
+/// into a different shard. That made suite updates (e.g. bumping the vendored
+/// node_compat suite) silently re-deal expensive tests onto one runner, which
+/// then ran out of memory. Hashing the name keeps every other test where it
+/// was, so a suite bump only moves the tests it actually adds or removes.
+///
+/// Shards end up approximately, rather than exactly, even in size. That is the
+/// intended trade: stability matters more here than a perfect split.
+fn shard_index_of(name: &str, shard_total: usize) -> usize {
+  let mut hasher = twox_hash::XxHash64::default();
+  hasher.write(name.as_bytes());
+  (hasher.finish() % shard_total as u64) as usize
 }
 
 /// Tracks the number of times each test has been flaky
@@ -877,5 +890,61 @@ impl<TData> file_test_runner::reporter::Reporter<TData> for PtyReporter {
     let mut stderr = std::io::stderr().lock();
     _ = stderr.write_all(&final_text);
     _ = stderr.flush();
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn adding_a_test_does_not_move_the_others() {
+    let names: Vec<String> = (0..200)
+      .map(|i| format!("suite::category::test-{i:03}.js"))
+      .collect();
+    let assign = |names: &[String]| -> Vec<(String, usize)> {
+      (0..3)
+        .flat_map(|index| {
+          let shard = ShardConfig { index, total: 3 };
+          assign_shard_tests(names.to_vec(), &shard)
+            .into_iter()
+            .map(move |name| (name, index))
+        })
+        .collect()
+    };
+
+    let before = assign(&names);
+
+    // Insert a test that sorts near the front, which under positional
+    // round-robin would have re-dealt every test after it.
+    let mut after_names = names.clone();
+    after_names.push("suite::category::test-000-new.js".to_string());
+    let after: HashMap<String, usize> =
+      assign(&after_names).into_iter().collect();
+
+    for (name, shard) in before {
+      assert_eq!(after.get(&name), Some(&shard), "{name} changed shard");
+    }
+  }
+
+  #[test]
+  fn shards_are_roughly_even() {
+    let names: Vec<String> = (0..3000)
+      .map(|i| format!("suite::category::test-{i}.js"))
+      .collect();
+    for total in [2, 3, 5] {
+      let mut counts = vec![0usize; total];
+      for name in &names {
+        counts[shard_index_of(name, total)] += 1;
+      }
+      let expected = names.len() / total;
+      for count in counts {
+        // within 10% of an even split
+        assert!(
+          count.abs_diff(expected) < expected / 10,
+          "shard sizes {count} vs expected {expected}"
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
The nightly node_compat_test workflow has failed every run since the
Node.js 26.5.1 suite bump, and always on the same job: linux shard 0.
Every failure annotation is either "The hosted runner lost communication
with the server ... starves it for CPU/Memory" or exit code 143 after
"The runner has received a shutdown signal". No test is failing -- the
runner VM is being killed.

Shards are assigned round-robin over the sorted test list, so a test's
shard is a function of its position. The bump added 192 files, shifting
every test after the first new name into a different shard, which
re-dealt a cluster of `pummel/` tests onto linux shard 0: three that
each allocate 2 GiB, plus fs-readfile-tostring-fail and a couple of CPU
spinners. `pummel/` is upstream Node's stress suite and only
`sequential/` was being serialized, so several of these ran at once on
one 4-core/16 GB runner. This serializes `pummel/` too, and derives a
test's shard from a hash of its own name so future suite bumps only move
the tests they actually add or remove. Shards stay within about 1% of
even on the current suite. The test job also gets a 30 minute cap, since
a shard running long here means a wedged runner rather than slow tests.

Separately, the matrix no longer fail-fasts. The nine shards are
independent, and cancelling eight healthy ones because a ninth went down
is how a single starved runner turned into zero uploaded reports and an
empty day summary.