### PR TITLE
test: don't assert a remote file's byte count in 017_import_redirect_info

### DIFF
--- a/tests/specs/run/_017_import_redirect_info/017_import_redirect_info.out
+++ b/tests/specs/run/_017_import_redirect_info/017_import_redirect_info.out
@@ -1,7 +1,7 @@
 local: [WILDCARD]017_import_redirect.ts
 type: TypeScript
 dependencies: 1 unique
-size: 660B
+size: [WILDLINE]
 
 file:///[WILDCARD]/017_import_redirect.ts ([WILDCARD])
 └── https://docs.deno.com/examples/scripts/hello_world.ts ([WILDCARD])


### PR DESCRIPTION
This test runs `deno info` on a file that imports
`https://docs.deno.com/examples/scripts/hello_world.ts`, and the total
size it prints is the local file plus that remote dependency. Asserting
that total as a literal `660B` ties the test to the current contents of a
docs page that nobody edits with this test in mind.

That page is now 545 bytes rather than 557, so the total is `648B` and
`test specs (1/2)` fails on all six platforms — `1 failed of 1551`, always
`specs::run::_017_import_redirect_info` — on every open PR, regardless of
what the diff touches.

The per-file sizes on the two lines below the total are already wildcarded
for exactly this reason, so this does the same for the total rather than
pinning a new number that will go stale the next time the page is edited.
Nothing else in the repo asserts a byte count for a remote file.