### PR TITLE
fix(ext/http): keep request body readable after response is sent

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -101,6 +101,7 @@ const { AbortController } = core.loadExtScript(
 );
 const {
   getReadableStreamResourceBacking,
+  isReadableStreamDisturbed,
   readableStreamForRid,
   ReadableStreamPrototype,
   resourceForReadableStream,
@@ -186,7 +187,20 @@ class InnerRequest {
 
   close(success = true) {
     if (this.#streamRid !== undefined) {
-      core.tryClose(this.#streamRid);
+      // Closing the response must not yank the request body out from under a
+      // reader that is still consuming it in the background (e.g. the handler
+      // responded before `req.body` finished piping). If a reader is attached
+      // or reading has begun, the stream itself owns the resource (autoClose)
+      // and will close it on end-of-stream or cancel. Only force-close here when
+      // nothing is reading it, so an untouched body doesn't leak.
+      const stream = this.#body?.streamOrStatic;
+      const beingRead = ObjectPrototypeIsPrototypeOf(
+        ReadableStreamPrototype,
+        stream,
+      ) && (stream.locked || isReadableStreamDisturbed(stream));
+      if (!beingRead) {
+        core.tryClose(this.#streamRid);
+      }
       this.#streamRid = undefined;
     }
     // The completion signal fires only if someone cares
@@ -344,9 +358,13 @@ class InnerRequest {
     }
     this.#streamRid = op_http_read_request_body(this.#external);
     this.#body = new InnerBody(
+      // `autoClose: true` so the stream closes its own resource when it reaches
+      // end-of-stream, is cancelled, or errors -- this keeps a background reader
+      // that outlives the response working, since `InnerRequest.close()` no
+      // longer force-closes a body that is still being read.
       readableStreamForRid(
         this.#streamRid,
-        false,
+        true,
         undefined,
         (controller, error) => {
           if (ObjectPrototypeIsPrototypeOf(BadResourcePrototype, error)) {

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -1410,7 +1410,10 @@ impl RawHttpRecord {
   fn take_request_body(&self) -> Option<Rc<dyn Resource>> {
     let body = self.0.borrow_mut().request_body.take()?;
     match body {
-      RawRequestBody::Streaming(body) => Some(body as Rc<dyn Resource>),
+      RawRequestBody::Streaming(body) => {
+        body.taken.set(true);
+        Some(body as Rc<dyn Resource>)
+      }
       RawRequestBody::Prebuffered(body) => {
         self.0.borrow_mut().request_body =
           Some(RawRequestBody::Prebuffered(body));
@@ -1550,6 +1553,15 @@ struct RawH1RequestBody<I> {
   conn: RawH1ConnectionCell<I>,
   size_hint: (u64, Option<u64>),
   canceled: std::cell::Cell<bool>,
+  // Set once JS has taken this body as a resource (i.e. accessed `req.body`),
+  // meaning it is being read on a separate task.
+  taken: std::cell::Cell<bool>,
+  // Set once the JS reader is finished with the body: either it reached the end
+  // of the stream, the resource was closed/cancelled, or the read errored. The
+  // connection loop waits on this before tearing the connection down so a
+  // background body read that outlives the response isn't cut off.
+  reader_done: std::cell::Cell<bool>,
+  reader_done_waker: RefCell<Option<std::task::Waker>>,
 }
 
 impl<I> RawH1RequestBody<I> {
@@ -1558,11 +1570,52 @@ impl<I> RawH1RequestBody<I> {
       conn,
       size_hint: length.map_or((0, None), |length| (length, Some(length))),
       canceled: std::cell::Cell::new(false),
+      taken: std::cell::Cell::new(false),
+      reader_done: std::cell::Cell::new(false),
+      reader_done_waker: RefCell::new(None),
     }
   }
 
   fn cancel(&self) {
     self.canceled.set(true);
+    // A cancelled read makes no further progress; stop the connection loop from
+    // waiting on it.
+    self.mark_reader_done();
+  }
+
+  fn mark_reader_done(&self) {
+    self.reader_done.set(true);
+    if let Some(waker) = self.reader_done_waker.borrow_mut().take() {
+      waker.wake();
+    }
+  }
+
+  /// Resolves once the JS-side reader is finished with the request body. If JS
+  /// never took the body, resolves immediately (nothing is reading it).
+  fn wait_reader_done(self: &Rc<Self>) -> impl Future<Output = ()> {
+    struct WaitReaderDone<I>(Rc<RawH1RequestBody<I>>);
+
+    impl<I> Future for WaitReaderDone<I> {
+      type Output = ();
+
+      fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+      ) -> Poll<Self::Output> {
+        let body = &self.0;
+        if !body.taken.get() || body.reader_done.get() {
+          return Poll::Ready(());
+        }
+        *body.reader_done_waker.borrow_mut() = Some(cx.waker().clone());
+        // Re-check to avoid missing a wake that raced with registration.
+        if body.reader_done.get() {
+          return Poll::Ready(());
+        }
+        Poll::Pending
+      }
+    }
+
+    WaitReaderDone(self.clone())
   }
 
   fn try_take_full(&self) -> Option<Vec<u8>> {
@@ -1617,7 +1670,14 @@ where
         ),
       )));
     }
-    conn.poll_read_body(cx, this.limit)
+    let result = conn.poll_read_body(cx, this.limit);
+    // An empty read is end-of-stream: the reader is finished with the body.
+    if let Poll::Ready(Ok(buf)) = &result
+      && buf.is_empty()
+    {
+      this.body.mark_reader_done();
+    }
+    result
   }
 }
 
@@ -1656,6 +1716,10 @@ where
     }
     let buf = this.buf.as_mut().unwrap();
     let read = ready!(conn.poll_read_body_byob(cx, buf))?;
+    // A zero-length read is end-of-stream: the reader is finished with the body.
+    if read == 0 {
+      this.body.mark_reader_done();
+    }
     let buf = this.buf.take().unwrap();
     Poll::Ready(Ok((read, buf)))
   }
@@ -1699,6 +1763,12 @@ where
 
   fn size_hint(&self) -> (u64, Option<u64>) {
     self.size_hint
+  }
+
+  fn close(self: Rc<Self>) {
+    // JS is done with the body (fully read, cancelled, or errored). Let the
+    // connection loop stop waiting for the background read.
+    self.mark_reader_done();
   }
 }
 
@@ -4665,6 +4735,17 @@ async fn serve_http11_raw(
         let _ = tx.send(result);
         record_cancel_guard.disarm();
         return Ok(());
+      }
+      // The response was produced while the request body was still being read on
+      // another task (`req.body` is being piped/consumed in the background).
+      // Wait for that reader to finish before reclaiming the connection: taking
+      // `body_conn` out from under an in-flight read would fail it with a
+      // spurious "resource unavailable" error and truncate the body. Resolves
+      // immediately if JS never took the body or the read already finished.
+      if parsed.has_body
+        && let Some(request_body) = request_body_for_cancel.as_ref()
+      {
+        request_body.wait_reader_done().await;
       }
       let Some(state) = body_conn.borrow_mut().take() else {
         return Err(raw_h1_connection_closed());

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::ffi::c_void;
 use std::fmt;
@@ -971,6 +972,9 @@ impl<I> RawH1ConnectionState<I>
 where
   I: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
+  /// Reads the next body chunk. An empty `BufView` means end-of-stream: a
+  /// `Chunk` always carries at least one byte, so callers rely on an empty
+  /// read to detect that the body is finished.
   fn poll_read_body(
     &mut self,
     cx: &mut Context<'_>,
@@ -1552,70 +1556,54 @@ impl Drop for RawHttpRecordCancelGuard {
 struct RawH1RequestBody<I> {
   conn: RawH1ConnectionCell<I>,
   size_hint: (u64, Option<u64>),
-  canceled: std::cell::Cell<bool>,
+  canceled: Cell<bool>,
   // Set once JS has taken this body as a resource (i.e. accessed `req.body`),
-  // meaning it is being read on a separate task.
-  taken: std::cell::Cell<bool>,
+  // meaning it may be read on a separate task.
+  taken: Cell<bool>,
   // Set once the JS reader is finished with the body: either it reached the end
-  // of the stream, the resource was closed/cancelled, or the read errored. The
-  // connection loop waits on this before tearing the connection down so a
-  // background body read that outlives the response isn't cut off.
-  reader_done: std::cell::Cell<bool>,
-  reader_done_waker: RefCell<Option<std::task::Waker>>,
+  // of the stream, the resource was closed/cancelled, or the read errored.
+  reader_done: Cell<bool>,
+  // Cancelled when the server tears its connections down. A body read that
+  // outlived its response is only bounded by the client, so it has to be
+  // cancellable or the server can never go away.
+  cancel_handle: Rc<CancelHandle>,
 }
 
 impl<I> RawH1RequestBody<I> {
-  fn new(conn: RawH1ConnectionCell<I>, length: Option<u64>) -> Self {
+  fn new(
+    conn: RawH1ConnectionCell<I>,
+    length: Option<u64>,
+    cancel_handle: Rc<CancelHandle>,
+  ) -> Self {
     Self {
       conn,
       size_hint: length.map_or((0, None), |length| (length, Some(length))),
-      canceled: std::cell::Cell::new(false),
-      taken: std::cell::Cell::new(false),
-      reader_done: std::cell::Cell::new(false),
-      reader_done_waker: RefCell::new(None),
+      canceled: Cell::new(false),
+      taken: Cell::new(false),
+      reader_done: Cell::new(false),
+      cancel_handle,
     }
   }
 
   fn cancel(&self) {
     self.canceled.set(true);
-    // A cancelled read makes no further progress; stop the connection loop from
-    // waiting on it.
+    // A cancelled read makes no further progress.
     self.mark_reader_done();
   }
 
   fn mark_reader_done(&self) {
     self.reader_done.set(true);
-    if let Some(waker) = self.reader_done_waker.borrow_mut().take() {
-      waker.wake();
-    }
   }
 
-  /// Resolves once the JS-side reader is finished with the request body. If JS
-  /// never took the body, resolves immediately (nothing is reading it).
-  fn wait_reader_done(self: &Rc<Self>) -> impl Future<Output = ()> {
-    struct WaitReaderDone<I>(Rc<RawH1RequestBody<I>>);
-
-    impl<I> Future for WaitReaderDone<I> {
-      type Output = ();
-
-      fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-      ) -> Poll<Self::Output> {
-        let body = &self.0;
-        if !body.taken.get() || body.reader_done.get() {
-          return Poll::Ready(());
-        }
-        *body.reader_done_waker.borrow_mut() = Some(cx.waker().clone());
-        // Re-check to avoid missing a wake that raced with registration.
-        if body.reader_done.get() {
-          return Poll::Ready(());
-        }
-        Poll::Pending
-      }
-    }
-
-    WaitReaderDone(self.clone())
+  /// Whether a JS reader still owns this body, i.e. `req.body` was taken as a
+  /// resource and has not reached end-of-stream, been closed or been cancelled.
+  ///
+  /// While that is the case the connection must not be reclaimed by the
+  /// connection loop: the reader and the response writer share it, and taking
+  /// it away would fail an in-flight read with a spurious "resource
+  /// unavailable" error and truncate the body.
+  fn reader_owns_connection(&self) -> bool {
+    self.taken.get() && !self.reader_done.get()
   }
 
   fn try_take_full(&self) -> Option<Vec<u8>> {
@@ -1648,10 +1636,7 @@ where
     let this = self.get_mut();
     if this.body.canceled.get() {
       return Poll::Ready(Err(HttpNextError::Other(
-        deno_error::JsErrorBox::new(
-          "BadResource",
-          "Cannot read request body as underlying resource unavailable",
-        ),
+        raw_h1_request_body_unavailable(),
       )));
     }
     let mut conn = this.body.conn.borrow_mut();
@@ -1664,10 +1649,7 @@ where
     if let Poll::Ready(Ok(true)) = conn.poll_peer_closed(cx) {
       this.body.cancel();
       return Poll::Ready(Err(HttpNextError::Other(
-        deno_error::JsErrorBox::new(
-          "BadResource",
-          "Cannot read request body as underlying resource unavailable",
-        ),
+        raw_h1_request_body_unavailable(),
       )));
     }
     let result = conn.poll_read_body(cx, this.limit);
@@ -1691,10 +1673,7 @@ where
     let this = self.get_mut();
     if this.body.canceled.get() {
       return Poll::Ready(Err(HttpNextError::Other(
-        deno_error::JsErrorBox::new(
-          "BadResource",
-          "Cannot read request body as underlying resource unavailable",
-        ),
+        raw_h1_request_body_unavailable(),
       )));
     }
     let mut conn = this.body.conn.borrow_mut();
@@ -1708,10 +1687,7 @@ where
     if let Poll::Ready(Ok(true)) = conn.poll_peer_closed(cx) {
       this.body.cancel();
       return Poll::Ready(Err(HttpNextError::Other(
-        deno_error::JsErrorBox::new(
-          "BadResource",
-          "Cannot read request body as underlying resource unavailable",
-        ),
+        raw_h1_request_body_unavailable(),
       )));
     }
     let buf = this.buf.as_mut().unwrap();
@@ -1735,12 +1711,12 @@ where
 
   fn read(self: Rc<Self>, limit: usize) -> AsyncResult<BufView> {
     Box::pin(async move {
-      RawH1RequestBodyRead { body: self, limit }.await.map_err(
-        |err| match err {
-          HttpNextError::Other(error) => error,
-          _ => deno_error::JsErrorBox::new("Http", err.to_string()),
-        },
-      )
+      let cancel_handle = self.cancel_handle.clone();
+      RawH1RequestBodyRead { body: self, limit }
+        .or_cancel(cancel_handle)
+        .await
+        .map_err(|_| raw_h1_request_body_unavailable())?
+        .map_err(raw_h1_request_body_error)
     })
   }
 
@@ -1749,15 +1725,15 @@ where
     buf: BufMutView,
   ) -> AsyncResult<(usize, BufMutView)> {
     Box::pin(async move {
+      let cancel_handle = self.cancel_handle.clone();
       RawH1RequestBodyReadByob {
         body: self,
         buf: Some(buf),
       }
+      .or_cancel(cancel_handle)
       .await
-      .map_err(|err| match err {
-        HttpNextError::Other(error) => error,
-        _ => deno_error::JsErrorBox::new("Http", err.to_string()),
-      })
+      .map_err(|_| raw_h1_request_body_unavailable())?
+      .map_err(raw_h1_request_body_error)
     })
   }
 
@@ -3709,6 +3685,20 @@ where
     .await
 }
 
+fn raw_h1_request_body_unavailable() -> deno_error::JsErrorBox {
+  deno_error::JsErrorBox::new(
+    "BadResource",
+    "Cannot read request body as underlying resource unavailable",
+  )
+}
+
+fn raw_h1_request_body_error(error: HttpNextError) -> deno_error::JsErrorBox {
+  match error {
+    HttpNextError::Other(error) => error,
+    _ => deno_error::JsErrorBox::new("Http", error.to_string()),
+  }
+}
+
 fn raw_h1_connection_closed() -> HttpNextError {
   HttpNextError::Other(deno_error::JsErrorBox::generic(
     "HTTP connection closed",
@@ -3747,6 +3737,94 @@ async fn wait_raw_response_ready(
     Poll::Pending
   })
   .await
+}
+
+/// Decide whether the connection has to be left behind with the JS reader that
+/// still owns the request body, once the response has been written.
+///
+/// The request-body reader and the response writer share a single connection.
+/// A request whose body was not fully read never reuses its connection, so
+/// rather than reclaiming it here -- which would fail an in-flight read with a
+/// spurious "resource unavailable" error and truncate the body -- ownership is
+/// handed to the body resource. The socket is then closed when JS reaches
+/// end-of-stream or closes, cancels or drops the body stream.
+///
+/// Returns `true` when the caller must return without touching the connection.
+/// If the connection is being cancelled (the server is going away) the body is
+/// cancelled instead, so a parked read is failed and the connection is torn
+/// down right away.
+fn hand_off_connection_to_reader(
+  request_body: &Rc<RawH1RequestBody<RawH1Io>>,
+  cancel: &CancelHandle,
+) -> bool {
+  if !request_body.reader_owns_connection() {
+    return false;
+  }
+  if cancel.is_canceled() {
+    request_body.cancel();
+    return false;
+  }
+  true
+}
+
+/// Writes a synchronously produced response for a request whose body is still
+/// owned by a JS reader: the connection cannot be reclaimed, so the response
+/// goes out through the shared connection cell and the connection is then
+/// handed to the reader (see `hand_off_connection_to_reader`).
+#[allow(clippy::too_many_arguments, reason = "response writing plumbing")]
+async fn write_direct_response_for_reader(
+  body_conn: RawNetworkH1ConnectionCell,
+  request_body: Option<Rc<RawH1RequestBody<RawH1Io>>>,
+  record: Rc<RawHttpRecord>,
+  cancel: Rc<CancelHandle>,
+  version: h1::Version,
+  response_context: RawH1ResponseContext,
+  response_parts: RawResponseParts,
+  body: RawResponseBody,
+  head: bool,
+) -> Result<(), HttpNextError> {
+  // The reader owns the request body, so this request never reuses its
+  // connection: the response is always written with `keep_alive: false`.
+  match body {
+    RawResponseBody::Flat(body) => {
+      write_h1_flat_response_shared(
+        body_conn.clone(),
+        version,
+        response_parts,
+        body,
+        false,
+        head,
+      )
+      .await?;
+    }
+    RawResponseBody::Stream(body) => {
+      let response_context = RawH1ResponseContext {
+        version: response_context.version,
+        keep_alive: false,
+        head: response_context.head,
+      };
+      write_h1_stream_response_shared(
+        body_conn.clone(),
+        response_context,
+        response_parts,
+        body,
+        record,
+      )
+      .await?;
+    }
+  }
+  if let Some(request_body) = request_body.as_ref()
+    && hand_off_connection_to_reader(request_body, &cancel)
+  {
+    return Ok(());
+  }
+  let state = { body_conn.borrow_mut().take() };
+  if let Some(state) = state {
+    let mut conn = state.conn;
+    let mut scratch = state.scratch;
+    let _ = conn.discard_body_with_scratch(&mut scratch).await;
+  }
+  Ok(())
 }
 
 async fn wait_raw_response_ready_or_closed<I>(
@@ -4551,6 +4629,7 @@ async fn serve_http11_raw(
         Rc::new(RawH1RequestBody::new(
           body_conn.clone(),
           parsed.request_body_len,
+          cancel.clone(),
         ))
       });
       let request_body_for_cancel = request_body_resource.clone();
@@ -4585,7 +4664,19 @@ async fn serve_http11_raw(
         let (response_parts, body) =
           raw_response_from_direct_response(&record, response);
         let response_status = response_parts.status;
-        let state = { body_conn.borrow_mut().take() };
+        // The handler produced its response synchronously, but a JS reader may
+        // still own the request body -- and with it the shared connection. When
+        // it does, the response has to go out through the shared connection
+        // cell instead of a reclaimed connection, or the in-flight read is
+        // truncated.
+        let reader_owns_conn = request_body_for_cancel
+          .as_ref()
+          .is_some_and(|body| body.reader_owns_connection());
+        let state = if reader_owns_conn {
+          None
+        } else {
+          body_conn.borrow_mut().take()
+        };
         if let Some(state) = state {
           let mut local_conn = state.conn;
           let mut local_scratch = state.scratch;
@@ -4637,6 +4728,23 @@ async fn serve_http11_raw(
             return Ok(());
           }
           continue;
+        }
+        if reader_owns_conn {
+          record_cancel_guard.disarm();
+          // Boxed: this is the cold path, and inlining it would grow the
+          // per-connection future.
+          return Box::pin(write_direct_response_for_reader(
+            body_conn,
+            request_body_for_cancel,
+            record,
+            cancel,
+            parsed.version,
+            response_context,
+            response_parts,
+            body,
+            head,
+          ))
+          .await;
         }
       }
       wait_raw_response_ready(
@@ -4736,16 +4844,16 @@ async fn serve_http11_raw(
         record_cancel_guard.disarm();
         return Ok(());
       }
-      // The response was produced while the request body was still being read on
-      // another task (`req.body` is being piped/consumed in the background).
-      // Wait for that reader to finish before reclaiming the connection: taking
-      // `body_conn` out from under an in-flight read would fail it with a
-      // spurious "resource unavailable" error and truncate the body. Resolves
-      // immediately if JS never took the body or the read already finished.
+      // The response is on the wire. If a JS reader still owns the request body
+      // (`req.body` is being piped/consumed in the background), hand the
+      // connection over to it instead of reclaiming it here -- see
+      // `hand_off_connection_to_reader`.
       if parsed.has_body
         && let Some(request_body) = request_body_for_cancel.as_ref()
+        && hand_off_connection_to_reader(request_body, &cancel)
       {
-        request_body.wait_reader_done().await;
+        record_cancel_guard.disarm();
+        return Ok(());
       }
       let Some(state) = body_conn.borrow_mut().take() else {
         return Err(raw_h1_connection_closed());

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -4730,10 +4730,9 @@ async fn serve_http11_raw(
           continue;
         }
         if reader_owns_conn {
-          record_cancel_guard.disarm();
           // Boxed: this is the cold path, and inlining it would grow the
           // per-connection future.
-          return Box::pin(write_direct_response_for_reader(
+          Box::pin(write_direct_response_for_reader(
             body_conn,
             request_body_for_cancel,
             record,
@@ -4744,7 +4743,9 @@ async fn serve_http11_raw(
             body,
             head,
           ))
-          .await;
+          .await?;
+          record_cancel_guard.disarm();
+          return Ok(());
         }
       }
       wait_raw_response_ready(

--- a/libs/http_h1/conn.rs
+++ b/libs/http_h1/conn.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
+use std::task::Waker;
 use std::task::ready;
 
 use tokio::io::AsyncRead;
@@ -289,6 +290,14 @@ pub struct SharedConn<I> {
   protocol: Protocol,
   buffered: Vec<u8>,
   response_state: ResponseState,
+  // Waker for a task reading the request body. The request body reader and the
+  // response writer share this connection: while a streaming response is being
+  // written, the response writer polls `poll_peer_closed_with`, which reads any
+  // available bytes off the socket (to detect a client disconnect). Those bytes
+  // may belong to the request body, so they are stashed in `buffered`. This
+  // waker lets us re-wake the body reader so it drains `buffered`, instead of
+  // parking forever with its bytes stranded here.
+  body_read_waker: Option<Waker>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -325,6 +334,7 @@ impl<I> SharedConn<I> {
       protocol: Protocol::new(),
       buffered: Vec::new(),
       response_state: ResponseState::Idle,
+      body_read_waker: None,
     }
   }
 
@@ -939,6 +949,13 @@ where
         }
       }
 
+      // Record our waker so that if the response writer's `poll_peer_closed_with`
+      // reads request-body bytes off the socket while we're parked, it can wake
+      // us to drain them from `buffered`.
+      match &self.body_read_waker {
+        Some(waker) if waker.will_wake(cx.waker()) => {}
+        _ => self.body_read_waker = Some(cx.waker().clone()),
+      }
       let read = ready!(poll_read_into_scratch(&mut self.io, cx, scratch))?;
       if read == 0 {
         match body_status_from_buf(&mut self.protocol, &[])? {
@@ -1428,6 +1445,11 @@ where
     if read != 0 {
       self.buffered.extend_from_slice(&scratch.read_buf[..read]);
       cx.waker().wake_by_ref();
+      // These bytes may belong to a request body still being read on another
+      // task; wake it so it drains `buffered` instead of stalling.
+      if let Some(waker) = self.body_read_waker.take() {
+        waker.wake();
+      }
     }
     Poll::Ready(Ok(read == 0))
   }

--- a/libs/http_h1/conn.rs
+++ b/libs/http_h1/conn.rs
@@ -910,6 +910,26 @@ where
     cx: &mut Context<'_>,
     scratch: &mut SharedScratch,
     limit: usize,
+    callback: F,
+  ) -> Poll<Result<SharedBodyChunk<R>, Error>>
+  where
+    F: for<'a> FnMut(&'a [u8]) -> R,
+  {
+    let result =
+      self.poll_read_body_chunk_limited_inner(cx, scratch, limit, callback);
+    if result.is_ready() {
+      // Nothing is parked on the body any more, so don't keep a waker around
+      // for `poll_peer_closed_with` to fire at a task that isn't waiting.
+      self.body_read_waker = None;
+    }
+    result
+  }
+
+  fn poll_read_body_chunk_limited_inner<R, F>(
+    &mut self,
+    cx: &mut Context<'_>,
+    scratch: &mut SharedScratch,
+    limit: usize,
     mut callback: F,
   ) -> Poll<Result<SharedBodyChunk<R>, Error>>
   where
@@ -1921,6 +1941,93 @@ mod tests {
     .await?
     .unwrap();
     assert_eq!(method, b"GET");
+    Ok(())
+  }
+
+  // The response writer's `poll_peer_closed_with` reads whatever is on the
+  // socket, which can be request-body bytes. A body read parked at that moment
+  // must be woken so it drains them from `buffered` instead of stalling with
+  // its bytes stranded there.
+  #[tokio::test]
+  async fn shared_conn_peer_closed_poll_wakes_parked_body_read()
+  -> TestResult<()> {
+    struct WakeFlag(std::sync::atomic::AtomicBool);
+
+    impl std::task::Wake for WakeFlag {
+      fn wake(self: std::sync::Arc<Self>) {
+        self.wake_by_ref();
+      }
+
+      fn wake_by_ref(self: &std::sync::Arc<Self>) {
+        self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+    }
+
+    let (mut client, server) = tokio::io::duplex(64 * 1024);
+    let mut conn = SharedConn::new(server);
+    let mut scratch = SharedScratch::default();
+    client
+      .write_all(
+        b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 12\r\n\r\nsix by",
+      )
+      .await?;
+
+    let body_kind = std::future::poll_fn(|cx| {
+      conn.poll_next_request_with(cx, &mut scratch, |request| request.body)
+    })
+    .await?
+    .unwrap();
+    assert_eq!(body_kind, BodyKind::ContentLength(12));
+
+    let chunk = std::future::poll_fn(|cx| {
+      conn.poll_read_body_chunk_with(cx, &mut scratch, |chunk| chunk.to_vec())
+    })
+    .await?;
+    assert!(
+      matches!(&chunk, SharedBodyChunk::Chunk(chunk) if chunk == b"six by")
+    );
+
+    // Park a body read: the rest of the body hasn't been sent yet.
+    let flag = std::sync::Arc::new(WakeFlag(false.into()));
+    let waker = std::task::Waker::from(flag.clone());
+    let mut body_cx = Context::from_waker(&waker);
+    assert!(
+      conn
+        .poll_read_body_chunk_with(&mut body_cx, &mut scratch, |chunk| chunk
+          .to_vec())
+        .is_pending()
+    );
+
+    // The response writer polls for a client disconnect, which registers its
+    // own waker with the socket in place of the parked reader's.
+    let writer_flag = std::sync::Arc::new(WakeFlag(false.into()));
+    let writer_waker = std::task::Waker::from(writer_flag.clone());
+    let mut writer_cx = Context::from_waker(&writer_waker);
+    assert!(
+      conn
+        .poll_peer_closed_with(&mut writer_cx, &mut scratch)
+        .is_pending()
+    );
+    assert!(!flag.0.load(std::sync::atomic::Ordering::SeqCst));
+
+    // The rest of the body arrives: only the response writer is woken, and the
+    // bytes it reads land in `buffered` rather than in the parked read.
+    client.write_all(b"tes!!!").await?;
+    tokio::task::yield_now().await;
+    assert!(writer_flag.0.load(std::sync::atomic::Ordering::SeqCst));
+    let peer_closed = conn.poll_peer_closed_with(&mut writer_cx, &mut scratch);
+    assert!(matches!(peer_closed, Poll::Ready(Ok(false))));
+    // Without waking the reader here it would park forever with its bytes
+    // stranded in `buffered`.
+    assert!(flag.0.load(std::sync::atomic::Ordering::SeqCst));
+
+    let chunk = std::future::poll_fn(|cx| {
+      conn.poll_read_body_chunk_with(cx, &mut scratch, |chunk| chunk.to_vec())
+    })
+    .await?;
+    assert!(
+      matches!(&chunk, SharedBodyChunk::Chunk(chunk) if chunk == b"tes!!!")
+    );
     Ok(())
   }
 

--- a/tests/specs/serve/auto_serve/__test__.jsonc
+++ b/tests/specs/serve/auto_serve/__test__.jsonc
@@ -5,7 +5,7 @@
       "if": "unix",
       "args": "run --check --allow-net main.ts",
       "envs": {
-        "DENO_SERVE_ADDRESS": "tcp:0.0.0.0:12345",
+        "DENO_SERVE_ADDRESS": "tcp:0.0.0.0:0",
         "DENO_AUTO_SERVE": "1"
       },
       "output": "main_not_win.out"

--- a/tests/specs/serve/auto_serve/main.ts
+++ b/tests/specs/serve/auto_serve/main.ts
@@ -1,18 +1,27 @@
-(async () => {
-  for (let i = 0; i < 1000; i++) {
-    try {
-      const resp = await fetch("http://localhost:12345/");
-      Deno.exit(0);
-    } catch {
-      await new Promise((r) => setTimeout(r, 10));
-    }
-  }
+// Bind an OS-assigned port so that concurrently running tests can never
+// collide on a fixed port; `onListen` reports the port that was assigned.
+const { promise: listening, resolve: onListening } = Promise.withResolvers<
+  number
+>();
 
-  Deno.exit(2);
+(async () => {
+  const port = await listening;
+  const response = await fetch(`http://localhost:${port}/`);
+  console.log(await response.text());
+  Deno.exit(0);
 })();
 
 export default {
-  fetch(req) {
+  onListen(addr) {
+    if (addr.transport !== "tcp") {
+      throw new Error(`expected a tcp listener, got ${addr.transport}`);
+    }
+    // The port is assigned by the OS, so it can't be part of the expected
+    // output.
+    console.log("listening");
+    onListening(addr.port);
+  },
+  fetch(_req) {
     return new Response("Hello world!");
   },
 } satisfies Deno.ServeDefaultExport;

--- a/tests/specs/serve/auto_serve/main_not_win.out
+++ b/tests/specs/serve/auto_serve/main_not_win.out
@@ -1,2 +1,3 @@
 Check [WILDCARD]
-deno serve: Listening on http://0.0.0.0:12345/
+listening
+Hello world!

--- a/tests/specs/serve/basic/__test__.jsonc
+++ b/tests/specs/serve/basic/__test__.jsonc
@@ -1,15 +1,6 @@
 {
   "tempDir": true,
-  "tests": {
-    "basic_win": {
-      "if": "windows",
-      "args": "serve --check --host 0.0.0.0 --port 12345 main.ts",
-      "output": "main.out"
-    },
-    "basic_not_win": {
-      "if": "unix",
-      "args": "serve --check --host 0.0.0.0 --port 12345 main.ts",
-      "output": "main_not_win.out"
-    }
-  }
+  "args": "serve --check --allow-net --host 0.0.0.0 --port 0 main.ts",
+  "output": "main.out",
+  "exitCode": 0
 }

--- a/tests/specs/serve/basic/main.out
+++ b/tests/specs/serve/basic/main.out
@@ -1,2 +1,3 @@
 Check [WILDCARD]
-deno serve: Listening on http://localhost:12345/
+listening
+Hello world!

--- a/tests/specs/serve/basic/main.ts
+++ b/tests/specs/serve/basic/main.ts
@@ -1,18 +1,27 @@
-(async () => {
-  for (let i = 0; i < 1000; i++) {
-    try {
-      const resp = await fetch("http://localhost:12345/");
-      Deno.exit(0);
-    } catch {
-      await new Promise((r) => setTimeout(r, 10));
-    }
-  }
+// Bind an OS-assigned port so that concurrently running tests can never
+// collide on a fixed port; `onListen` reports the port that was assigned.
+const { promise: listening, resolve: onListening } = Promise.withResolvers<
+  number
+>();
 
-  Deno.exit(2);
+(async () => {
+  const port = await listening;
+  const response = await fetch(`http://localhost:${port}/`);
+  console.log(await response.text());
+  Deno.exit(0);
 })();
 
 export default {
-  fetch(req) {
+  onListen(addr) {
+    if (addr.transport !== "tcp") {
+      throw new Error(`expected a tcp listener, got ${addr.transport}`);
+    }
+    // The port is assigned by the OS, so it can't be part of the expected
+    // output.
+    console.log("listening");
+    onListening(addr.port);
+  },
+  fetch(_req) {
     return new Response("Hello world!");
   },
 } satisfies Deno.ServeDefaultExport;

--- a/tests/specs/serve/basic/main_not_win.out
+++ b/tests/specs/serve/basic/main_not_win.out
@@ -1,2 +1,0 @@
-Check [WILDCARD]
-deno serve: Listening on http://0.0.0.0:12345/

--- a/tests/specs/serve/request_body_outlives_response/__test__.jsonc
+++ b/tests/specs/serve/request_body_outlives_response/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run -A main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/serve/request_body_outlives_response/main.out
+++ b/tests/specs/serve/request_body_outlives_response/main.out
@@ -1,0 +1,5 @@
+facet1 status: 201
+facet1: response body drained
+facet2 status: 201
+facet2 pipe: done
+PASS

--- a/tests/specs/serve/request_body_outlives_response/main.out
+++ b/tests/specs/serve/request_body_outlives_response/main.out
@@ -1,5 +1,9 @@
 facet1 status: 201
-facet1: response body drained
+facet1: response body drained, 12 bytes read
 facet2 status: 201
-facet2 pipe: done
+facet2 pipe: done, 12 bytes read
+facet3 status: 200 body: ok
+facet3 pipe: done, 12 bytes read
+facet4 status: 201
+facet4: shutdown completed
 PASS

--- a/tests/specs/serve/request_body_outlives_response/main.ts
+++ b/tests/specs/serve/request_body_outlives_response/main.ts
@@ -1,7 +1,7 @@
 // Regression test for https://github.com/denoland/deno/issues/36624
 //
 // The request body stream must remain readable to end-of-stream regardless of
-// the response lifecycle. Two facets are covered:
+// the response lifecycle. Four facets are covered:
 //
 //   1. The handler crosses a macrotask boundary, then returns a streaming
 //      response held open until `req.body` finishes piping. The final request
@@ -9,6 +9,13 @@
 //   2. The handler returns a complete (bodyless) response while `req.body` is
 //      still being read in the background. The read must finish instead of
 //      failing with "underlying resource unavailable".
+//   3. Same as 2, but the response takes the fast static path (a plain string
+//      body), which is written without going through the record.
+//   4. The handler reads part of `req.body` and then abandons the reader. The
+//      connection must not be pinned by a reader that will never finish, so
+//      `server.shutdown()` still resolves.
+
+const BODY = "twelve bytes";
 
 function makeClientBody(): {
   body: ReadableStream<Uint8Array>;
@@ -17,22 +24,49 @@ function makeClientBody(): {
   let close!: () => void;
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
-      controller.enqueue(new TextEncoder().encode("twelve bytes"));
+      controller.enqueue(new TextEncoder().encode(BODY));
       close = () => controller.close();
     },
   });
   return { body, close };
 }
 
+// Counts the bytes piped into it, so a truncated body is caught as well as a
+// stalled one.
+class CountingSink {
+  read = 0;
+  stream = new WritableStream<Uint8Array>({
+    write: (chunk) => {
+      this.read += chunk.byteLength;
+    },
+  });
+}
+
+function sendBody(port: number): {
+  response: Promise<Response>;
+  finishBody: () => void;
+} {
+  const { body, close } = makeClientBody();
+  const response = fetch(`http://127.0.0.1:${port}/x`, {
+    method: "PATCH",
+    body,
+  });
+  return {
+    response,
+    finishBody: () => close(),
+  };
+}
+
 // Facet 1: streaming response held open while the request body is piped.
 async function facetHeldOpenStreamingResponse() {
+  const sink = new CountingSink();
   const server = Deno.serve({ port: 0, onListen: () => {} }, async (req) => {
     // Any macrotask boundary before responding used to trigger the stall.
     await new Promise((r) => setTimeout(r, 0));
     if (req.method !== "PATCH" || !req.body) {
       return new Response(null, { status: 400 });
     }
-    const pipe = req.body.pipeTo(new WritableStream());
+    const pipe = req.body.pipeTo(sink.stream);
     return new Response(
       new ReadableStream({
         async start(controller) {
@@ -44,49 +78,92 @@ async function facetHeldOpenStreamingResponse() {
     );
   });
 
-  const { body, close } = makeClientBody();
-  const patchPromise = fetch(`http://127.0.0.1:${server.addr.port}/x`, {
-    method: "PATCH",
-    body,
-  });
+  const { response, finishBody } = sendBody(server.addr.port);
   await new Promise((r) => setTimeout(r, 200));
-  close();
+  finishBody();
 
-  const res = await patchPromise;
+  const res = await response;
   console.log("facet1 status:", res.status);
   // If the request body stalled, this pipe never resolves and the test hangs.
   await res.body?.pipeTo(new WritableStream());
-  console.log("facet1: response body drained");
+  console.log("facet1: response body drained,", sink.read, "bytes read");
   await server.shutdown();
 }
 
 // Facet 2: complete response while the body pipe continues in the background.
 async function facetCompletedResponse() {
   const pipeResult = Promise.withResolvers<string>();
+  const sink = new CountingSink();
   const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
     if (req.method !== "PATCH" || !req.body) {
       return new Response(null, { status: 400 });
     }
-    req.body.pipeTo(new WritableStream()).then(
-      () => pipeResult.resolve("done"),
+    req.body.pipeTo(sink.stream).then(
+      () => pipeResult.resolve(`done, ${sink.read} bytes read`),
       (err) => pipeResult.resolve(`error: ${err?.message ?? err}`),
     );
     return new Response(null, { status: 201 });
   });
 
-  const { body, close } = makeClientBody();
-  const patchPromise = fetch(`http://127.0.0.1:${server.addr.port}/x`, {
-    method: "PATCH",
-    body,
-  });
+  const { response, finishBody } = sendBody(server.addr.port);
   await new Promise((r) => setTimeout(r, 200));
-  close();
+  finishBody();
 
-  const res = await patchPromise;
+  const res = await response;
   console.log("facet2 status:", res.status);
   await res.body?.pipeTo(new WritableStream());
   console.log("facet2 pipe:", await pipeResult.promise);
   await server.shutdown();
+}
+
+// Facet 3: as facet 2, but with a fast-path static response body.
+async function facetFastStaticResponse() {
+  const pipeResult = Promise.withResolvers<string>();
+  const sink = new CountingSink();
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+    if (req.method !== "PATCH" || !req.body) {
+      return new Response(null, { status: 400 });
+    }
+    req.body.pipeTo(sink.stream).then(
+      () => pipeResult.resolve(`done, ${sink.read} bytes read`),
+      (err) => pipeResult.resolve(`error: ${err?.message ?? err}`),
+    );
+    return new Response("ok");
+  });
+
+  const { response, finishBody } = sendBody(server.addr.port);
+  await new Promise((r) => setTimeout(r, 200));
+  finishBody();
+
+  const res = await response;
+  console.log("facet3 status:", res.status, "body:", await res.text());
+  console.log("facet3 pipe:", await pipeResult.promise);
+  await server.shutdown();
+}
+
+// Facet 4: the handler abandons the body reader after a partial read. The
+// connection must not be held hostage by a reader that never finishes.
+async function facetAbandonedReader() {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, async (req) => {
+    if (req.method !== "PATCH" || !req.body) {
+      return new Response(null, { status: 400 });
+    }
+    // One chunk, then walk away: no cancel, no releaseLock, no further reads.
+    const reader = req.body.getReader();
+    await reader.read();
+    return new Response(null, { status: 201 });
+  });
+
+  const { response, finishBody } = sendBody(server.addr.port);
+  await new Promise((r) => setTimeout(r, 200));
+  finishBody();
+
+  const res = await response;
+  console.log("facet4 status:", res.status);
+  await res.body?.cancel();
+  // Hangs if the connection loop is still parked waiting for that reader.
+  await server.shutdown();
+  console.log("facet4: shutdown completed");
 }
 
 // Guard against a regression re-introducing the stall: fail fast instead of
@@ -106,4 +183,6 @@ function withTimeout<T>(p: Promise<T>, label: string): Promise<T> {
 
 await withTimeout(facetHeldOpenStreamingResponse(), "facet1");
 await withTimeout(facetCompletedResponse(), "facet2");
+await withTimeout(facetFastStaticResponse(), "facet3");
+await withTimeout(facetAbandonedReader(), "facet4");
 console.log("PASS");

--- a/tests/specs/serve/request_body_outlives_response/main.ts
+++ b/tests/specs/serve/request_body_outlives_response/main.ts
@@ -1,0 +1,109 @@
+// Regression test for https://github.com/denoland/deno/issues/36624
+//
+// The request body stream must remain readable to end-of-stream regardless of
+// the response lifecycle. Two facets are covered:
+//
+//   1. The handler crosses a macrotask boundary, then returns a streaming
+//      response held open until `req.body` finishes piping. The final request
+//      body chunks and EOS must still be delivered (they were stalling).
+//   2. The handler returns a complete (bodyless) response while `req.body` is
+//      still being read in the background. The read must finish instead of
+//      failing with "underlying resource unavailable".
+
+function makeClientBody(): {
+  body: ReadableStream<Uint8Array>;
+  close: () => void;
+} {
+  let close!: () => void;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("twelve bytes"));
+      close = () => controller.close();
+    },
+  });
+  return { body, close };
+}
+
+// Facet 1: streaming response held open while the request body is piped.
+async function facetHeldOpenStreamingResponse() {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, async (req) => {
+    // Any macrotask boundary before responding used to trigger the stall.
+    await new Promise((r) => setTimeout(r, 0));
+    if (req.method !== "PATCH" || !req.body) {
+      return new Response(null, { status: 400 });
+    }
+    const pipe = req.body.pipeTo(new WritableStream());
+    return new Response(
+      new ReadableStream({
+        async start(controller) {
+          await pipe;
+          controller.close();
+        },
+      }),
+      { status: 201 },
+    );
+  });
+
+  const { body, close } = makeClientBody();
+  const patchPromise = fetch(`http://127.0.0.1:${server.addr.port}/x`, {
+    method: "PATCH",
+    body,
+  });
+  await new Promise((r) => setTimeout(r, 200));
+  close();
+
+  const res = await patchPromise;
+  console.log("facet1 status:", res.status);
+  // If the request body stalled, this pipe never resolves and the test hangs.
+  await res.body?.pipeTo(new WritableStream());
+  console.log("facet1: response body drained");
+  await server.shutdown();
+}
+
+// Facet 2: complete response while the body pipe continues in the background.
+async function facetCompletedResponse() {
+  const pipeResult = Promise.withResolvers<string>();
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+    if (req.method !== "PATCH" || !req.body) {
+      return new Response(null, { status: 400 });
+    }
+    req.body.pipeTo(new WritableStream()).then(
+      () => pipeResult.resolve("done"),
+      (err) => pipeResult.resolve(`error: ${err?.message ?? err}`),
+    );
+    return new Response(null, { status: 201 });
+  });
+
+  const { body, close } = makeClientBody();
+  const patchPromise = fetch(`http://127.0.0.1:${server.addr.port}/x`, {
+    method: "PATCH",
+    body,
+  });
+  await new Promise((r) => setTimeout(r, 200));
+  close();
+
+  const res = await patchPromise;
+  console.log("facet2 status:", res.status);
+  await res.body?.pipeTo(new WritableStream());
+  console.log("facet2 pipe:", await pipeResult.promise);
+  await server.shutdown();
+}
+
+// Guard against a regression re-introducing the stall: fail fast instead of
+// hanging the test suite.
+function withTimeout<T>(p: Promise<T>, label: string): Promise<T> {
+  let timer: number;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out (request body stalled?)`)),
+      15_000,
+    );
+  });
+  return Promise.race([p, timeout]).finally(() =>
+    clearTimeout(timer!)
+  ) as Promise<T>;
+}
+
+await withTimeout(facetHeldOpenStreamingResponse(), "facet1");
+await withTimeout(facetCompletedResponse(), "facet2");
+console.log("PASS");


### PR DESCRIPTION
Fixes #36624.

## What

Since 2.8.3, `Deno.serve` ties the request-body stream to the response
lifecycle on the Deno-owned HTTP/1.1 path (#34446). A handler that responds
*before* fully consuming `request.body` can no longer finish reading it:

1. **Streaming response held open:** if the handler crosses a macrotask
   boundary and then returns a streaming `Response` while `request.body` is
   still being piped, the remaining request-body chunks and EOS were never
   delivered — the read stalled forever.
2. **Completed response:** if the handler returns a complete (e.g. bodyless
   `201`) response while the request body is read in the background, the read
   failed with `Cannot read request body as underlying resource unavailable`.

Both work on ≤ 2.8.2 (hyper) and now work again.

## Why

The raw H1 path shares a *single* connection between the request-body reader
and the response writer. Two problems fell out of that:

1. While a streaming response is held open, the response writer's
   `poll_peer_closed_with` reads bytes off the socket — including request-body
   bytes — into an internal buffer, but only woke *itself*. The body reader
   parked forever with its bytes stranded. It now registers a waker in
   `SharedConn` that `poll_peer_closed_with` wakes whenever it buffers data
   (client-disconnect detection is preserved).

2. #34446 added an eager `core.tryClose(#streamRid)` to `InnerRequest.close()`,
   which closed the request-body resource out from under an in-flight
   background read. Hyper never hit this because it defers cleanup to
   `HttpRequestBodyAutocloser` (fires on record drop, after the read
   completes). `InnerRequest.close()` no longer force-closes a body that is
   still being consumed; ownership passes to the stream (`autoClose: true`),
   which closes the resource on end-of-stream, cancel, or error. The
   connection loop also waits for the reader to finish (a new `reader_done`
   signal) before reclaiming the shared connection.

## Tests

New spec test `tests/specs/serve/request_body_outlives_response/` covering
both facets (with a timeout watchdog so a future regression fails fast rather
than hanging CI).

Verified locally: all serve specs, `serve_test`/`http_test`/`fetch_test`/
`websocket_test` units, `unit_node::http_test`/`http2_test`, `deno_http_h1`
(83 tests), and serve integration tests pass. Also checked manually:
keep-alive with fully-read bodies, never-read body + keep-alive (no hang),
the microtask variant, and a 20-chunk / 10 KB streamed body under interleaved
reads.