### PR TITLE
fix(ext/napi): surface OS error and path on addon load failure

### DIFF
--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -70,6 +70,17 @@ pub mod function;
 mod pe;
 mod value;
 
+/// Render the source (underlying OS error) of a `libloading::Error` as a
+/// `": <error>"` suffix, or an empty string when there is no source. libloading
+/// does not include the OS error in its own `Display`.
+fn fmt_lib_load_source(err: &libloading::Error) -> String {
+  use std::error::Error;
+  match err.source() {
+    Some(source) => format!(": {source}"),
+    None => String::new(),
+  }
+}
+
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum NApiError {
   #[class(type)]
@@ -79,8 +90,15 @@ pub enum NApiError {
   #[error(transparent)]
   DenoRtLoad(#[from] denort_helper::LoadError),
   #[class(type)]
-  #[error(transparent)]
-  LibLoading(#[from] libloading::Error),
+  // libloading's `Display` for a failed load is opaque (e.g. just
+  // `LoadLibraryExW failed` on Windows). Surface the underlying OS error via
+  // `source` and the resolved path so the failure is actionable. See
+  // denoland/deno#36622.
+  #[error("{source}{}\n  path: {}", fmt_lib_load_source(source), path.display())]
+  LibraryLoad {
+    source: libloading::Error,
+    path: PathBuf,
+  },
   #[class(type)]
   #[error("Unable to find register Node-API module at {}", .0.display())]
   ModuleNotFound(PathBuf),
@@ -1033,7 +1051,16 @@ fn op_napi_open<'scope>(
 
   // SAFETY: opening a DLL calls dlopen
   #[cfg(unix)]
-  let library = unsafe { Library::open(Some(real_path.as_ref()), flags) }?;
+  let library = match unsafe { Library::open(Some(real_path.as_ref()), flags) }
+  {
+    Ok(library) => library,
+    Err(err) => {
+      return Err(NApiError::LibraryLoad {
+        source: err,
+        path: real_path.to_path_buf(),
+      });
+    }
+  };
 
   // SAFETY: opening a DLL calls dlopen
   #[cfg(not(unix))]
@@ -1056,7 +1083,10 @@ fn op_napi_open<'scope>(
         {
           return Err(NApiError::UnsupportedNodeBinaryAddon(path.into_owned()));
         }
-        return Err(err.into());
+        return Err(NApiError::LibraryLoad {
+          source: err,
+          path: real_path.to_path_buf(),
+        });
       }
     };
 

--- a/tests/napi/init_test.js
+++ b/tests/napi/init_test.js
@@ -1,7 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { Buffer } from "node:buffer";
-import { assert, assertThrows, libSuffix } from "./common.js";
+import { assert, assertThrows, fromFileUrl, libSuffix } from "./common.js";
 import { Worker } from "node:worker_threads";
 const ops = Deno[Deno.internal].core.ops;
 const noop = () => {};
@@ -101,5 +101,40 @@ Deno.test("legacy V8 addon is rejected with a clear error", {
     },
     TypeError,
     "legacy Node.js native addon API",
+  );
+});
+
+// When the platform loader (dlopen / LoadLibraryExW) rejects a `.node`, the
+// error must surface the underlying OS error and the resolved path, instead of
+// an opaque message (e.g. a bare `LoadLibraryExW failed` on Windows that
+// discards both). See denoland/deno#36622.
+Deno.test("addon load failure surfaces the OS error and path", function () {
+  // `common.js` exists and is readable, but is a text file rather than a shared
+  // library, so the loader fails to open it.
+  const path = fromFileUrl(new URL("./common.js", import.meta.url));
+  const err = assertThrows(
+    () => {
+      ops.op_napi_open(
+        path,
+        {},
+        Buffer.from,
+        reportError,
+        emitInit,
+        emitBefore,
+        emitAfter,
+        emitDestroy,
+      );
+    },
+    TypeError,
+  );
+  // The resolved path is included so that, when the cause is path length, the
+  // error is self-diagnosing.
+  assert(
+    err.message.includes(path),
+    `expected the addon path in the error, got: ${err.message}`,
+  );
+  assert(
+    err.message.includes("path:"),
+    `expected a "path:" label in the error, got: ${err.message}`,
   );
 });


### PR DESCRIPTION
libloading's `Display` for a failed load is opaque (e.g. just `LoadLibraryExW failed` on Windows), discarding the underlying OS error and the path. This surfaces both:

```
LoadLibraryExW failed: The filename or extension is too long. (os error 206)
  path: C:\...\onnxruntime_binding.node
```

Covers every cause at once (path-too-long, missing sibling DLL, etc.) with no new detection logic.

Closes #36622