### PR TITLE
fix(compile): extract a native addon's sibling files next to it

### DIFF
--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::ffi::OsString;
 use std::io::ErrorKind;
 use std::io::SeekFrom;
 use std::ops::Range;
@@ -41,6 +42,7 @@ use deno_runtime::deno_io::fs::FsStat;
 use deno_runtime::deno_io::fs::FsStatFs;
 use deno_runtime::deno_napi::DenoRtNativeAddonLoader;
 use deno_runtime::deno_napi::DenoRtNativeAddonLoaderRc;
+use deno_runtime::deno_napi::NativeAddonSibling;
 use deno_runtime::deno_permissions::CheckedPath;
 use deno_runtime::deno_permissions::CheckedPathBuf;
 #[cfg(windows)]
@@ -1863,6 +1865,42 @@ impl DenoRtNativeAddonLoader for FileBackedVfs {
     let file = self.file_entry(path).ok()?;
     self.read_file_offset_with_len(file.offset).ok()
   }
+
+  fn load_addon_siblings(&self, path: &Path) -> Vec<NativeAddonSibling> {
+    if !self.is_path_within(path) {
+      return Vec::new();
+    }
+    let Some(parent) = path.parent() else {
+      return Vec::new();
+    };
+    let Ok(dir) = self.dir_entry(parent) else {
+      return Vec::new();
+    };
+    let addon_name = path.file_name().and_then(|n| n.to_str());
+    dir
+      .entries
+      .iter()
+      .filter_map(|entry| {
+        // Only regular files can be siblings that the OS loader resolves
+        // from the addon's directory. Skip the addon itself.
+        let VfsEntry::File(file) = entry else {
+          return None;
+        };
+        let is_addon_itself = addon_name.is_some_and(|name| {
+          self.case_sensitivity.cmp_name(&file.name, name)
+            == std::cmp::Ordering::Equal
+        });
+        if is_addon_itself {
+          return None;
+        }
+        let bytes = self.read_file_offset_with_len(file.offset).ok()?;
+        Some(NativeAddonSibling {
+          name: OsString::from(file.name.clone()),
+          bytes,
+        })
+      })
+      .collect()
+  }
 }
 
 #[cfg(test)]
@@ -1980,6 +2018,71 @@ mod test {
     assert_eq!(
       virtual_fs.stat(&dest_path.join("e.txt")).unwrap().file_type,
       sys_traits::FileType::File
+    );
+  }
+
+  #[test]
+  fn load_addon_siblings_returns_files_in_same_dir() {
+    let temp_dir = TempDir::new();
+    let src_path = temp_dir.path().canonicalize().join("src");
+    src_path.create_dir_all();
+    src_path.join("addon_dir").create_dir_all();
+    src_path.join("addon_dir").join("nested").create_dir_all();
+    let src_path = src_path.to_path_buf();
+
+    let mut builder = VfsBuilder::new();
+    // anchor the vfs root at `src` (otherwise the builder collapses the root
+    // to the common minimum directory, i.e. `addon_dir`)
+    builder
+      .add_file_with_data_raw_for_testing(
+        &src_path.join("root.txt"),
+        "root".into(),
+        None,
+      )
+      .unwrap();
+    let addon_dir = src_path.join("addon_dir");
+    for (name, data) in [
+      ("my.node", "the addon"),
+      ("dep.dll", "a dependency"),
+      ("data.bin", "some data"),
+    ] {
+      builder
+        .add_file_with_data_raw_for_testing(
+          &addon_dir.join(name),
+          data.into(),
+          None,
+        )
+        .unwrap();
+    }
+    // a file in a nested dir should NOT be treated as a sibling
+    builder
+      .add_file_with_data_raw_for_testing(
+        &addon_dir.join("nested").join("deep.dll"),
+        "deep".into(),
+        None,
+      )
+      .unwrap();
+
+    let (dest_path, virtual_fs) = into_virtual_fs(builder, &temp_dir);
+
+    let addon_path = dest_path.join("addon_dir").join("my.node");
+    let mut siblings = virtual_fs.load_addon_siblings(&addon_path);
+    siblings.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // every regular file in the same directory except the addon itself
+    let names: Vec<_> = siblings
+      .iter()
+      .map(|s| s.name.to_string_lossy().into_owned())
+      .collect();
+    assert_eq!(names, vec!["data.bin", "dep.dll"]);
+    assert_eq!(siblings[0].bytes.as_ref(), b"some data");
+    assert_eq!(siblings[1].bytes.as_ref(), b"a dependency");
+
+    // a path outside the vfs has no siblings
+    assert!(
+      virtual_fs
+        .load_addon_siblings(Path::new("/not/in/vfs/x.node"))
+        .is_empty()
     );
   }
 

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -54,6 +54,7 @@ pub use deno_core::v8;
 use deno_permissions::PermissionCheckError;
 pub use denort_helper::DenoRtNativeAddonLoader;
 pub use denort_helper::DenoRtNativeAddonLoaderRc;
+pub use denort_helper::NativeAddonSibling;
 #[cfg(unix)]
 use libloading::os::unix::*;
 #[cfg(windows)]

--- a/ext/rt_helper/lib.rs
+++ b/ext/rt_helper/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
+use std::ffi::OsString;
 use std::fs;
 use std::fs::File;
 use std::hash::Hash;
@@ -40,12 +41,29 @@ pub enum LoadError {
 
 pub type DenoRtNativeAddonLoaderRc = Arc<dyn DenoRtNativeAddonLoader>;
 
+/// A file that lives in the same VFS directory as a native addon and must be
+/// extracted alongside it (e.g. a private `.dll`/`.so`/`.dylib` that the addon
+/// dynamically links against).
+pub struct NativeAddonSibling {
+  pub name: OsString,
+  pub bytes: Cow<'static, [u8]>,
+}
+
 /// Loads native addons in `deno compile`.
 ///
 /// The implementation should provide the bytes from the binary
 /// of the native file.
 pub trait DenoRtNativeAddonLoader: Send + Sync {
   fn load_if_in_vfs(&self, path: &Path) -> Option<Cow<'static, [u8]>>;
+
+  /// Returns the files that live in the same VFS directory as the native
+  /// addon at `path` (excluding the addon itself). These are extracted next
+  /// to the addon so that addons which depend on a private sibling dynamic
+  /// library (found by the OS loader in the module's own directory) keep
+  /// working after `deno compile`.
+  fn load_addon_siblings(&self, _path: &Path) -> Vec<NativeAddonSibling> {
+    Vec::new()
+  }
 
   fn load_and_resolve_path<'a>(
     &self,
@@ -60,36 +78,71 @@ pub trait DenoRtNativeAddonLoader: Send + Sync {
           .map(|s| s.to_string_lossy())
           .unwrap_or("denort".into());
         let cache_dir = native_addon_cache_dir().map_err(LoadError::Io)?;
-        let real_path =
-          resolve_temp_file_name(cache_dir, &exe_name, path, &bytes);
-        if let Err(err) = deno_path_util::fs::atomic_write_file(
-          &sys_traits::impls::RealSys,
-          &real_path,
-          &bytes,
-          0o644,
-        ) {
-          if err.kind() == std::io::ErrorKind::ReadOnlyFilesystem {
-            return Err(LoadError::ReadOnlyFilesystem {
-              real_path,
-              executable_path: path.to_path_buf(),
-            });
-          }
 
-          // another process might be using it... so only surface
-          // the error if the files aren't equivalent
-          if !file_matches_bytes(&real_path, &bytes) {
-            return Err(LoadError::FailedWriting {
-              executable_path: path.to_path_buf(),
-              real_path,
-              source: err,
-            });
+        let siblings = self.load_addon_siblings(path);
+        if siblings.is_empty() {
+          // Fast path: no sibling files, extract the addon on its own with a
+          // flat, content-addressed name.
+          let real_path =
+            resolve_temp_file_name(cache_dir, &exe_name, path, &bytes);
+          write_native_addon_file(&real_path, &bytes, path)?;
+          Ok(Cow::Owned(real_path))
+        } else {
+          // The addon ships sibling files (typically private dynamic
+          // libraries). Extract everything into a private per-addon
+          // subdirectory, preserving the original file names, so the OS
+          // dynamic loader resolves the siblings from the addon's own
+          // directory exactly as it does under `deno run`.
+          let addon_file_name = path.file_name().unwrap_or(path.as_os_str());
+          let addon_dir = resolve_temp_dir_name(
+            cache_dir, &exe_name, path, &bytes, &siblings,
+          );
+          for sibling in &siblings {
+            let sibling_path = addon_dir.join(&sibling.name);
+            write_native_addon_file(&sibling_path, &sibling.bytes, path)?;
           }
+          let real_path = addon_dir.join(addon_file_name);
+          write_native_addon_file(&real_path, &bytes, path)?;
+          Ok(Cow::Owned(real_path))
         }
-        Ok(Cow::Owned(real_path))
       }
       None => Ok(Cow::Borrowed(path)),
     }
   }
+}
+
+/// Atomically writes an extracted native addon (or one of its siblings) to
+/// `real_path`, tolerating a concurrent process that already wrote the same
+/// bytes.
+fn write_native_addon_file(
+  real_path: &Path,
+  bytes: &[u8],
+  executable_path: &Path,
+) -> Result<(), LoadError> {
+  if let Err(err) = deno_path_util::fs::atomic_write_file(
+    &sys_traits::impls::RealSys,
+    real_path,
+    bytes,
+    0o644,
+  ) {
+    if err.kind() == std::io::ErrorKind::ReadOnlyFilesystem {
+      return Err(LoadError::ReadOnlyFilesystem {
+        real_path: real_path.to_path_buf(),
+        executable_path: executable_path.to_path_buf(),
+      });
+    }
+
+    // another process might be using it... so only surface
+    // the error if the files aren't equivalent
+    if !file_matches_bytes(real_path, bytes) {
+      return Err(LoadError::FailedWriting {
+        executable_path: executable_path.to_path_buf(),
+        real_path: real_path.to_path_buf(),
+        source: err,
+      });
+    }
+  }
+  Ok(())
 }
 
 #[allow(clippy::disallowed_methods, reason = "requires real fs")]
@@ -175,6 +228,39 @@ fn resolve_temp_file_name(
     file_name.push_str(&ext.to_string_lossy());
   }
   cache_dir.join(&file_name)
+}
+
+/// Resolves a deterministic per-addon subdirectory name. The addon and its
+/// sibling files are extracted here with their original names, so the hash
+/// folds in the addon path plus the contents of the addon and every sibling
+/// (so a change to any of them yields a fresh directory).
+fn resolve_temp_dir_name(
+  cache_dir: &Path,
+  current_exe_name: &str,
+  path: &Path,
+  bytes: &[u8],
+  siblings: &[NativeAddonSibling],
+) -> PathBuf {
+  // should be deterministic
+  let path_hash = {
+    let mut hasher = twox_hash::XxHash64::default();
+    path.hash(&mut hasher);
+    hasher.finish()
+  };
+  let contents_hash = {
+    let mut hasher = twox_hash::XxHash64::default();
+    bytes.hash(&mut hasher);
+    // siblings are provided in a stable (name-sorted) order
+    for sibling in siblings {
+      sibling.name.hash(&mut hasher);
+      sibling.bytes.hash(&mut hasher);
+    }
+    hasher.finish()
+  };
+  cache_dir.join(format!(
+    "{}{}{}",
+    current_exe_name, path_hash, contents_hash
+  ))
 }
 
 fn native_addon_cache_dir() -> std::io::Result<&'static Path> {
@@ -329,6 +415,102 @@ mod test {
       temp_file,
       cache_dir.join("exe_name1805603793990095570513255480333703631005.node")
     );
+  }
+
+  #[test]
+  fn test_resolve_temp_dir_name_is_deterministic_and_content_sensitive() {
+    let cache_dir = PathBuf::from("/native-addons");
+    let file_path = PathBuf::from("/test/test.node");
+    let bytes: [u8; 3] = [1, 2, 3];
+    let siblings = vec![NativeAddonSibling {
+      name: OsString::from("dep.dll"),
+      bytes: Cow::Borrowed(&[4, 5, 6]),
+    }];
+    let dir1 =
+      resolve_temp_dir_name(&cache_dir, "exe", &file_path, &bytes, &siblings);
+    let dir2 =
+      resolve_temp_dir_name(&cache_dir, "exe", &file_path, &bytes, &siblings);
+    // deterministic
+    assert_eq!(dir1, dir2);
+    assert_eq!(dir1.parent(), Some(cache_dir.as_path()));
+
+    // a change to a sibling's bytes yields a different directory
+    let changed = vec![NativeAddonSibling {
+      name: OsString::from("dep.dll"),
+      bytes: Cow::Borrowed(&[9, 9, 9]),
+    }];
+    let dir3 =
+      resolve_temp_dir_name(&cache_dir, "exe", &file_path, &bytes, &changed);
+    assert_ne!(dir1, dir3);
+  }
+
+  struct TestLoader {
+    bytes: Vec<u8>,
+    siblings: Vec<(OsString, Vec<u8>)>,
+  }
+
+  impl DenoRtNativeAddonLoader for TestLoader {
+    fn load_if_in_vfs(&self, _path: &Path) -> Option<Cow<'static, [u8]>> {
+      Some(Cow::Owned(self.bytes.clone()))
+    }
+
+    fn load_addon_siblings(&self, _path: &Path) -> Vec<NativeAddonSibling> {
+      self
+        .siblings
+        .iter()
+        .map(|(name, bytes)| NativeAddonSibling {
+          name: name.clone(),
+          bytes: Cow::Owned(bytes.clone()),
+        })
+        .collect()
+    }
+  }
+
+  #[test]
+  fn test_load_and_resolve_path_extracts_siblings_next_to_addon() {
+    let loader = TestLoader {
+      bytes: b"the addon".to_vec(),
+      siblings: vec![
+        (OsString::from("dep_a.dll"), b"dependency a".to_vec()),
+        (OsString::from("dep_b.dll"), b"dependency b".to_vec()),
+      ],
+    };
+    // use a path unlikely to collide with anything else in the shared cache
+    let addon_path =
+      PathBuf::from("/test-rt-helper/siblings-fixture/my_addon.node");
+
+    let real_path = loader.load_and_resolve_path(&addon_path).unwrap();
+
+    // the addon keeps its original file name so its layout is preserved
+    assert_eq!(real_path.file_name().unwrap(), "my_addon.node");
+    assert_eq!(fs::read(real_path.as_ref()).unwrap(), b"the addon");
+
+    // siblings are extracted right next to it with their original names
+    let dir = real_path.parent().unwrap();
+    assert_eq!(fs::read(dir.join("dep_a.dll")).unwrap(), b"dependency a");
+    assert_eq!(fs::read(dir.join("dep_b.dll")).unwrap(), b"dependency b");
+
+    fs::remove_dir_all(dir).unwrap();
+  }
+
+  #[test]
+  fn test_load_and_resolve_path_without_siblings_is_flat() {
+    let loader = TestLoader {
+      bytes: b"lone addon".to_vec(),
+      siblings: Vec::new(),
+    };
+    let addon_path =
+      PathBuf::from("/test-rt-helper/flat-fixture/lone_addon.node");
+
+    let real_path = loader.load_and_resolve_path(&addon_path).unwrap();
+
+    // flat, content-addressed file name (not the original name, and no
+    // per-addon directory wrapping it)
+    assert_eq!(fs::read(real_path.as_ref()).unwrap(), b"lone addon");
+    assert_ne!(real_path.file_name().unwrap(), "lone_addon.node");
+    assert_eq!(real_path.parent(), Some(native_addon_cache_dir().unwrap()));
+
+    fs::remove_file(real_path.as_ref()).unwrap();
   }
 
   #[cfg(unix)]


### PR DESCRIPTION
## Summary

Fixes #36626.

`deno compile` bundles a native addon's `.node` (or FFI `.so`/`.dll`/`.dylib`) into the VFS, then at load time extracts **only that one file** into a temp cache dir under a flat, hashed name. Any dynamic library that shipped *next to* the addon in its npm package — e.g. `duckdb.dll` beside `duckdb.node` in `@duckdb/node-api` — was never extracted. The OS dynamic loader resolves an addon's private dependencies from the addon's **own directory**, so it couldn't find the sibling and the addon failed with the opaque `LoadLibraryExW failed` (`ERROR_MOD_NOT_FOUND`), even though the exact same code worked under `deno run`.

## Fix

When an addon is extracted, also extract the other files that live in its VFS directory, into a private per-addon subdirectory, preserving their **original file names**. The OS loader then resolves the addon's siblings from its own directory exactly as it does under `deno run` (Windows `LOAD_WITH_ALTERED_SEARCH_PATH`, Unix `$ORIGIN` rpath). Addons with no siblings keep the existing flat extraction fast-path unchanged.

This applies to both Node-API addons and `Deno.dlopen` FFI, since both resolve through the same `FileBackedVfs` loader.

### Details

- `ext/rt_helper/lib.rs` — add a `load_addon_siblings()` method to the `DenoRtNativeAddonLoader` trait (default returns none, so no other loader is affected). `load_and_resolve_path` branches: no siblings → existing flat file; has siblings → per-addon subdirectory keyed by a content hash of the addon plus every sibling (deterministic, cache-safe across processes, refreshed when any file changes). Extracted the atomic-write / read-only / concurrent-write handling into a shared `write_native_addon_file` helper.
- `cli/rt/file_system.rs` — implement `load_addon_siblings` on `FileBackedVfs`: enumerate regular files in the addon's VFS directory (excluding the addon itself, respecting case-sensitivity) and read their bytes.
- `ext/napi/lib.rs` — re-export `NativeAddonSibling`.

## Tests

Unit tests exercise the real code paths (not mocks):

- `denort_helper`: deterministic + content-sensitive subdirectory naming; full extraction placing siblings next to the addon with their original names/bytes; the no-siblings path stays flat.
- `denort` (`file_system`): VFS sibling enumeration returns only same-directory regular files (not nested, not the addon itself) and returns empty for out-of-VFS paths.

A full `deno compile` spec test would require a platform-specific compiled addon that dynamically links a sibling library (not portable to author in the suite), so the logic is covered at the unit level against the actual `FileBackedVfs` and `load_and_resolve_path` implementations.