### PR TITLE
fix(ext/node_sqlite): invalidate sessions on database close

### DIFF
--- a/ext/node_sqlite/database.rs
+++ b/ext/node_sqlite/database.rs
@@ -33,6 +33,7 @@ use rusqlite::limits::Limit;
 use super::Session;
 use super::SqliteError;
 use super::StatementSync;
+use super::session::InnerSessionPtr;
 use super::session::SessionOptions;
 use super::sql_tag_store::SQLTagStore;
 use super::statement::InnerStatementPtr;
@@ -572,6 +573,7 @@ impl<'a> ApplyChangesetOptions<'a> {
 pub struct DatabaseSync {
   pub conn: Rc<RefCell<Option<rusqlite::Connection>>>,
   statements: Rc<RefCell<Vec<InnerStatementPtr>>>,
+  sessions: Rc<RefCell<Vec<InnerSessionPtr>>>,
   options: DatabaseSyncOptions,
   location: String,
   ignore_next_sqlite_error: Rc<Cell<bool>>,
@@ -873,6 +875,7 @@ impl DatabaseSync {
     Ok(DatabaseSync {
       conn: Rc::new(RefCell::new(db)),
       statements: Rc::new(RefCell::new(Vec::new())),
+      sessions: Rc::new(RefCell::new(Vec::new())),
       location,
       options,
       ignore_next_sqlite_error: Rc::new(Cell::new(false)),
@@ -945,6 +948,18 @@ impl DatabaseSync {
           stmt.set(None);
         }
       };
+    }
+
+    // Delete all sessions while their database connection is still valid.
+    for session in self.sessions.borrow_mut().drain(..) {
+      if let Some(ptr) = session.take() {
+        // SAFETY: `ptr` is a valid session handle associated with the open
+        // connection. Taking it first prevents stale Session objects from
+        // deleting or using it after the connection is reopened.
+        unsafe {
+          libsqlite3_sys::sqlite3session_delete(ptr);
+        }
+      }
     }
 
     {
@@ -1605,10 +1620,13 @@ impl DatabaseSync {
       return Err(SqliteError::SessionCreateFailed);
     }
 
+    let session = Rc::new(Cell::new(Some(raw_session)));
+    self.sessions.borrow_mut().push(Rc::clone(&session));
+
     Ok(Session {
-      inner: raw_session,
-      freed: Cell::new(false),
+      inner: session,
       db: self.conn.clone(),
+      sessions: Rc::clone(&self.sessions),
     })
   }
 

--- a/ext/node_sqlite/session.rs
+++ b/ext/node_sqlite/session.rs
@@ -87,12 +87,14 @@ impl FromV8<'_> for SessionOptions {
 }
 
 pub struct Session {
-  pub(crate) inner: *mut ffi::sqlite3_session,
-  pub(crate) freed: Cell<bool>,
+  pub(crate) inner: InnerSessionPtr,
 
   // Hold a weak reference to the database.
   pub(crate) db: Rc<RefCell<Option<rusqlite::Connection>>>,
+  pub(crate) sessions: Rc<RefCell<Vec<InnerSessionPtr>>>,
 }
+
+pub(crate) type InnerSessionPtr = Rc<Cell<Option<*mut ffi::sqlite3_session>>>;
 
 // SAFETY: we're sure this can be GCed
 unsafe impl GarbageCollected for Session {
@@ -111,18 +113,21 @@ impl Drop for Session {
 
 impl Session {
   fn delete(&self) -> Result<(), SqliteError> {
-    if self.freed.get() {
-      return Err(SqliteError::SessionClosed);
+    let ptr = self.inner.take().ok_or(SqliteError::SessionClosed)?;
+    let mut sessions = self.sessions.borrow_mut();
+    if let Some(pos) = sessions
+      .iter()
+      .position(|session| Rc::ptr_eq(session, &self.inner))
+    {
+      sessions.remove(pos);
     }
-
-    self.freed.set(true);
     if self.db.borrow().is_none() {
       return Ok(());
     }
-    // Safety: `self.inner` is a valid session. double free is
-    // prevented by `freed` flag.
+    // Safety: `ptr` is a valid session. Double free is prevented by taking
+    // the pointer from `inner` before deleting it.
     unsafe {
-      ffi::sqlite3session_delete(self.inner);
+      ffi::sqlite3session_delete(ptr);
     }
 
     Ok(())
@@ -157,11 +162,9 @@ impl Session {
     if self.db.borrow().is_none() {
       return Err(SqliteError::AlreadyClosed);
     }
-    if self.freed.get() {
-      return Err(SqliteError::SessionClosed);
-    }
+    let ptr = self.inner.get().ok_or(SqliteError::SessionClosed)?;
 
-    session_buffer_op(self.inner, ffi::sqlite3session_changeset)
+    session_buffer_op(ptr, ffi::sqlite3session_changeset)
   }
 
   // Similar to the method above, but generates a more compact patchset.
@@ -172,11 +175,9 @@ impl Session {
     if self.db.borrow().is_none() {
       return Err(SqliteError::AlreadyClosed);
     }
-    if self.freed.get() {
-      return Err(SqliteError::SessionClosed);
-    }
+    let ptr = self.inner.get().ok_or(SqliteError::SessionClosed)?;
 
-    session_buffer_op(self.inner, ffi::sqlite3session_patchset)
+    session_buffer_op(ptr, ffi::sqlite3session_patchset)
   }
 }
 

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -737,6 +737,21 @@ Deno.test("[node/sqlite] calling StatementSync and Session methods after connect
   assertThrows(() => sess.patchset(), Error, errMessageClosed);
 });
 
+Deno.test("[node/sqlite] Session stays closed after connection reopens", () => {
+  using db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE data(value INTEGER)");
+  const session = db.createSession();
+  db.exec("INSERT INTO data VALUES (1)");
+
+  db.close();
+  db.open();
+
+  const errMessage = "session is not open";
+  assertThrows(() => session.changeset(), Error, errMessage);
+  assertThrows(() => session.patchset(), Error, errMessage);
+  assertThrows(() => session.close(), Error, errMessage);
+});
+
 // Regression test for https://github.com/denoland/deno/issues/30144
 Deno.test("[node/sqlite] StatementSync iterate should not reuse previous state", () => {
   using db = new DatabaseSync(":memory:");


### PR DESCRIPTION
## Summary

- track sessions created by `DatabaseSync`
- close and invalidate active sessions before closing the database connection
- keep sessions from an earlier connection closed after the database is reopened

## Motivation

Session objects checked whether the database's shared connection state was populated. Reopening the database populated that state again, so sessions created for the previous connection could be treated as open.

Tying each session handle to the database's active-session list keeps its lifecycle associated with the connection that created it.

## Testing

- `cargo check -p deno --lib`
- `cargo test unit_node::sqlite_test`
- `./tools/format.js ext/node_sqlite/database.rs ext/node_sqlite/session.rs tests/unit_node/sqlite_test.ts`
- `./tools/lint.js`
