### PR TITLE
feat(compile): embed V8 code cache at build time

### DIFF
--- a/cli/lib/standalone/binary.rs
+++ b/cli/lib/standalone/binary.rs
@@ -18,6 +18,11 @@ use crate::args::UnstableConfig;
 
 pub const MAGIC_BYTES: &[u8; 8] = b"d3n0l4nd";
 
+/// Internal hand-off used only by the temporary standalone executable that
+/// `deno compile --include-code-cache` launches during compilation.
+pub const CODE_CACHE_GENERATION_ENV_VAR: &str =
+  "DENO_INTERNAL_CODE_CACHE_GENERATION_PATH";
+
 pub trait DenoRtDeserializable<'a>: Sized {
   fn deserialize(input: &'a [u8]) -> std::io::Result<(&'a [u8], Self)>;
 }
@@ -78,6 +83,8 @@ pub struct Metadata {
   pub argv: Vec<String>,
   pub seed: Option<u64>,
   pub code_cache_key: Option<u64>,
+  #[serde(default)]
+  pub code_cache_generation: bool,
   pub permissions: PermissionsOptions,
   pub location: Option<Url>,
   pub v8_flags: Vec<String>,

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -997,6 +997,24 @@ impl LibMainWorker {
     Ok(())
   }
 
+  /// Compile and instantiate the standalone startup graph (preload/require
+  /// modules plus the statically reachable main graph) without evaluating user
+  /// code. `deno compile --include-code-cache` uses this in a temporary
+  /// executable to ask V8 for cache data without running the application.
+  pub async fn generate_code_cache(&mut self) -> Result<(), CoreError> {
+    for preload_module_url in self.preload_modules.iter() {
+      self.worker.preload_side_module(preload_module_url).await?;
+    }
+    for require_module_url in self.require_modules.iter() {
+      self.worker.preload_side_module(require_module_url).await?;
+    }
+    self.worker.preload_main_module(&self.main_module).await?;
+    // Module compilation queues code-cache callbacks on the module map. Drive
+    // the event loop once so every callback reaches the cache collector.
+    self.worker.run_event_loop(false).await?;
+    Ok(())
+  }
+
   /// The "load phase": run any preload/require modules, then load and
   /// first-evaluate the main module and fire the `load` event. This is
   /// everything that happens before the steady-state event loop begins.

--- a/cli/rt/binary.rs
+++ b/cli/rt/binary.rs
@@ -46,6 +46,7 @@ use crate::file_system::VfsRoot;
 
 pub struct StandaloneData {
   pub metadata: Metadata,
+  pub embedded_code_cache: Option<&'static [u8]>,
   pub modules: Arc<StandaloneModules>,
   pub npm_snapshot: Option<ValidSerializedNpmResolutionSnapshot>,
   pub root_path: PathBuf,
@@ -96,6 +97,7 @@ pub fn extract_standalone_with_finder(
 
   let DeserializedDataSection {
     npm_snapshot,
+    embedded_code_cache,
     modules_store: remote_modules,
     vfs_root_entries,
     vfs_files_data,
@@ -146,6 +148,7 @@ pub fn extract_standalone_with_finder(
   };
   Ok(StandaloneData {
     metadata,
+    embedded_code_cache,
     modules: Arc::new(StandaloneModules {
       modules: remote_modules,
       vfs: vfs.clone(),
@@ -463,6 +466,7 @@ fn read_from_file_fallback() -> Result<&'static [u8], AnyError> {
 
 pub struct DeserializedDataSection {
   pub npm_snapshot: Option<ValidSerializedNpmResolutionSnapshot>,
+  pub embedded_code_cache: Option<&'static [u8]>,
   pub modules_store: RemoteModulesStore,
   pub vfs_root_entries: VirtualDirectoryEntries,
   pub vfs_files_data: &'static [u8],
@@ -510,19 +514,23 @@ fn deserialize_binary_data_section(
   } else {
     Some(deserialize_npm_snapshot(data).context("deserializing npm snapshot")?)
   };
-  // 3. Specifiers
+  // 3. Embedded V8 code cache
+  let (input, data) =
+    read_bytes_with_u64_len(input).context("reading embedded code cache")?;
+  let embedded_code_cache = (!data.is_empty()).then_some(data);
+  // 4. Specifiers
   let (input, specifiers_store) =
     SpecifierStore::deserialize(root_dir_url, input)
       .context("deserializing specifiers")?;
-  // 4. Redirects
+  // 5. Redirects
   let (input, redirects_store) =
     SpecifierDataStore::<SpecifierId>::deserialize(input)
       .context("deserializing redirects")?;
-  // 5. Remote modules
+  // 6. Remote modules
   let (input, remote_modules_store) =
     SpecifierDataStore::<RemoteModuleEntry<'static>>::deserialize(input)
       .context("deserializing remote modules")?;
-  // 6. VFS
+  // 7. VFS
   let (input, data) = read_bytes_with_u64_len(input).context("vfs")?;
   let vfs_root_entries: VirtualDirectoryEntries =
     serde_json::from_slice(data).context("deserializing vfs data")?;
@@ -543,6 +551,7 @@ fn deserialize_binary_data_section(
 
   Ok(DeserializedDataSection {
     npm_snapshot,
+    embedded_code_cache,
     modules_store,
     vfs_root_entries,
     vfs_files_data,

--- a/cli/rt/code_cache.rs
+++ b/cli/rt/code_cache.rs
@@ -32,10 +32,28 @@ pub struct DenoCompileCodeCacheEntry {
 
 pub struct DenoCompileCodeCache {
   strategy: CodeCacheStrategy,
+  specifier_base: Option<String>,
 }
 
 impl DenoCompileCodeCache {
-  pub fn new(file_path: PathBuf, cache_key: u64) -> Self {
+  pub fn new(
+    file_path: PathBuf,
+    cache_key: u64,
+    embedded_data: Option<&[u8]>,
+    specifier_base: Option<&Url>,
+  ) -> Self {
+    if let Some(embedded_data) = embedded_data {
+      match deserialize_bytes(embedded_data, cache_key) {
+        Ok(data) => {
+          log::debug!("Loaded {} embedded code cache entries", data.len());
+          return Self::subsequent_run(data, specifier_base);
+        }
+        Err(err) => {
+          log::debug!("Failed to deserialize embedded code cache: {:#}", err);
+        }
+      }
+    }
+
     // attempt to deserialize the cache data
     match deserialize(&file_path, cache_key) {
       Ok(data) => {
@@ -44,14 +62,7 @@ impl DenoCompileCodeCache {
           data.len(),
           file_path.display()
         );
-        Self {
-          strategy: CodeCacheStrategy::SubsequentRun(
-            SubsequentRunCodeCacheStrategy {
-              is_finished: AtomicFlag::lowered(),
-              data: Mutex::new(data),
-            },
-          ),
-        }
+        Self::subsequent_run(data, specifier_base)
       }
       Err(err) => {
         log::debug!(
@@ -59,19 +70,52 @@ impl DenoCompileCodeCache {
           file_path.display(),
           err
         );
-        Self {
-          strategy: CodeCacheStrategy::FirstRun(FirstRunCodeCacheStrategy {
-            cache_key,
-            file_path,
-            is_finished: AtomicFlag::lowered(),
-            data: Mutex::new(FirstRunCodeCacheData {
-              cache: HashMap::new(),
-              add_count: 0,
-            }),
-          }),
-        }
+        Self::first_run(file_path, cache_key, specifier_base)
       }
     }
+  }
+
+  fn first_run(
+    file_path: PathBuf,
+    cache_key: u64,
+    specifier_base: Option<&Url>,
+  ) -> Self {
+    Self {
+      strategy: CodeCacheStrategy::FirstRun(FirstRunCodeCacheStrategy {
+        cache_key,
+        file_path,
+        is_finished: AtomicFlag::lowered(),
+        data: Mutex::new(FirstRunCodeCacheData {
+          cache: HashMap::new(),
+          add_count: 0,
+        }),
+      }),
+      specifier_base: specifier_base.map(|url| url.as_str().to_string()),
+    }
+  }
+
+  fn subsequent_run(
+    data: HashMap<CodeCacheKey, DenoCompileCodeCacheEntry>,
+    specifier_base: Option<&Url>,
+  ) -> Self {
+    Self {
+      strategy: CodeCacheStrategy::SubsequentRun(
+        SubsequentRunCodeCacheStrategy {
+          is_finished: AtomicFlag::lowered(),
+          data: Mutex::new(data),
+        },
+      ),
+      specifier_base: specifier_base.map(|url| url.as_str().to_string()),
+    }
+  }
+
+  fn specifier_key(&self, specifier: &Url) -> String {
+    self
+      .specifier_base
+      .as_deref()
+      .and_then(|base| specifier.as_str().strip_prefix(base))
+      .map(|relative| format!("deno-compile-internal:///{}", relative))
+      .unwrap_or_else(|| specifier.to_string())
   }
 
   pub fn for_deno_core(self: Arc<Self>) -> Arc<dyn CodeCache> {
@@ -111,7 +155,11 @@ impl CodeCache for DenoCompileCodeCache {
         if strategy.is_finished.is_raised() {
           return None;
         }
-        strategy.take_from_cache(specifier, code_cache_type, source_hash)
+        strategy.take_from_cache(
+          &self.specifier_key(specifier),
+          code_cache_type,
+          source_hash,
+        )
       }
     }
   }
@@ -129,10 +177,11 @@ impl CodeCache for DenoCompileCodeCache {
           return;
         }
 
+        let specifier = self.specifier_key(&specifier);
         let data_to_serialize = {
           let mut data = strategy.data.lock();
           data.cache.insert(
-            (specifier.to_string(), code_cache_type),
+            (specifier, code_cache_type),
             DenoCompileCodeCacheEntry {
               source_hash,
               data: bytes.to_vec(),
@@ -211,7 +260,7 @@ struct SubsequentRunCodeCacheStrategy {
 impl SubsequentRunCodeCacheStrategy {
   fn take_from_cache(
     &self,
-    specifier: &Url,
+    specifier: &str,
     code_cache_type: CodeCacheType,
     source_hash: u64,
   ) -> Option<Vec<u8>> {
@@ -259,22 +308,31 @@ fn serialize_with_writer<T: Write>(
   cache_key: u64,
   cache: &HashMap<CodeCacheKey, DenoCompileCodeCacheEntry>,
 ) -> Result<(), AnyError> {
+  // The external cache did not need stable ordering, but embedded cache bytes
+  // become part of the compiled executable. Sort them so identical inputs do
+  // not produce different executables because of HashMap randomization.
+  let mut entries = cache.iter().collect::<Vec<_>>();
+  entries.sort_unstable_by(
+    |((specifier_a, type_a), _), ((specifier_b, type_b), _)| {
+      specifier_a.cmp(specifier_b).then_with(|| {
+        code_cache_type_byte(type_a).cmp(&code_cache_type_byte(type_b))
+      })
+    },
+  );
+
   // header
   writer.write_all(&cache_key.to_le_bytes())?;
   writer.write_all(&(cache.len() as u32).to_le_bytes())?;
   // lengths of each entry
-  for ((specifier, _), entry) in cache {
+  for ((specifier, _), entry) in &entries {
     let len: u64 =
       entry.data.len() as u64 + specifier.len() as u64 + 1 + 4 + 8 + 8;
     writer.write_all(&len.to_le_bytes())?;
   }
   // entries
-  for ((specifier, code_cache_type), entry) in cache {
+  for ((specifier, code_cache_type), entry) in entries {
     writer.write_all(&entry.data)?;
-    writer.write_all(&[match code_cache_type {
-      CodeCacheType::EsModule => 0,
-      CodeCacheType::Script => 1,
-    }])?;
+    writer.write_all(&[code_cache_type_byte(code_cache_type)])?;
     writer.write_all(specifier.as_bytes())?;
     writer.write_all(&(specifier.len() as u32).to_le_bytes())?;
     writer.write_all(&entry.source_hash.to_le_bytes())?;
@@ -289,6 +347,13 @@ fn serialize_with_writer<T: Write>(
   Ok(())
 }
 
+fn code_cache_type_byte(code_cache_type: &CodeCacheType) -> u8 {
+  match code_cache_type {
+    CodeCacheType::EsModule => 0,
+    CodeCacheType::Script => 1,
+  }
+}
+
 fn deserialize(
   file_path: &Path,
   expected_cache_key: u64,
@@ -296,6 +361,13 @@ fn deserialize(
   let cache_file = std::fs::File::open(file_path)?;
   let mut reader = BufReader::new(cache_file);
   deserialize_with_reader(&mut reader, expected_cache_key)
+}
+
+fn deserialize_bytes(
+  bytes: &[u8],
+  expected_cache_key: u64,
+) -> Result<HashMap<CodeCacheKey, DenoCompileCodeCacheEntry>, AnyError> {
+  deserialize_with_reader(&mut BufReader::new(bytes), expected_cache_key)
 }
 
 fn deserialize_with_reader<T: Read>(
@@ -445,6 +517,117 @@ mod test {
   }
 
   #[test]
+  fn embedded_code_cache() {
+    let cache_key = 1234;
+    let url = Url::parse("https://deno.land/embedded.js").unwrap();
+    let cache = HashMap::from([(
+      (url.to_string(), CodeCacheType::EsModule),
+      DenoCompileCodeCacheEntry {
+        source_hash: 42,
+        data: vec![1, 2, 3],
+      },
+    )]);
+    let mut buffer = Vec::new();
+    serialize_with_writer(&mut BufWriter::new(&mut buffer), cache_key, &cache)
+      .unwrap();
+
+    let temp_dir = TempDir::new();
+    let file_path = temp_dir.path().join("unused-cache.bin").to_path_buf();
+    let code_cache = DenoCompileCodeCache::new(
+      file_path.clone(),
+      cache_key,
+      Some(&buffer),
+      None,
+    );
+
+    assert_eq!(
+      code_cache.get_sync(&url, CodeCacheType::EsModule, 42),
+      Some(vec![1, 2, 3])
+    );
+    assert!(!file_path.exists());
+  }
+
+  #[test]
+  fn embedded_code_cache_is_independent_of_executable_name() {
+    let cache_key = 1234;
+    let generation_base =
+      Url::parse("file:///tmp/deno-compile-code-cache-generator/").unwrap();
+    let final_base =
+      Url::parse("file:///tmp/deno-compile-production-binary/").unwrap();
+    let generation_url = generation_base.join("main.js").unwrap();
+    let final_url = final_base.join("main.js").unwrap();
+    let temp_dir = TempDir::new();
+    let generated_path =
+      temp_dir.path().join("generated-cache.bin").to_path_buf();
+
+    let generator = DenoCompileCodeCache::new(
+      generated_path.clone(),
+      cache_key,
+      None,
+      Some(&generation_base),
+    );
+    assert_eq!(
+      generator.get_sync(&generation_url, CodeCacheType::EsModule, 42),
+      None
+    );
+    generator.set_sync(generation_url, CodeCacheType::EsModule, 42, &[1, 2, 3]);
+
+    let bytes = std::fs::read(generated_path).unwrap();
+    let embedded = DenoCompileCodeCache::new(
+      temp_dir.path().join("unused-cache.bin").to_path_buf(),
+      cache_key,
+      Some(&bytes),
+      Some(&final_base),
+    );
+    assert_eq!(
+      embedded.get_sync(&final_url, CodeCacheType::EsModule, 42),
+      Some(vec![1, 2, 3])
+    );
+  }
+
+  #[test]
+  fn serialization_is_deterministic() {
+    let entry = |index: u8| {
+      (
+        (format!("file:///{}.js", index), CodeCacheType::EsModule),
+        DenoCompileCodeCacheEntry {
+          source_hash: index as u64,
+          data: vec![index],
+        },
+      )
+    };
+    let forward = (0..8).map(entry).collect::<HashMap<_, _>>();
+    let reverse = (0..8).rev().map(entry).collect::<HashMap<_, _>>();
+    let mut forward_bytes = Vec::new();
+    let mut reverse_bytes = Vec::new();
+
+    serialize_with_writer(
+      &mut BufWriter::new(&mut forward_bytes),
+      1234,
+      &forward,
+    )
+    .unwrap();
+    serialize_with_writer(
+      &mut BufWriter::new(&mut reverse_bytes),
+      1234,
+      &reverse,
+    )
+    .unwrap();
+
+    assert_eq!(forward_bytes, reverse_bytes);
+    let positions = (0..8)
+      .map(|index| {
+        let specifier = format!("file:///{}.js", index);
+        forward_bytes
+          .windows(specifier.len())
+          .position(|window| window == specifier.as_bytes())
+          .unwrap()
+      })
+      .collect::<Vec<_>>();
+    assert!(positions.windows(2).all(|pair| pair[0] < pair[1]));
+  }
+
+  #[test]
   fn serialize_deserialize_corrupt() {
     let buffer = "corrupttestingtestingtesting".as_bytes().to_vec();
     let err = deserialize_with_reader(&mut BufReader::new(&buffer[..]), 1234)
@@ -460,7 +643,8 @@ mod test {
     let url2 = Url::parse("https://deno.land/example2.js").unwrap();
     // first run
     {
-      let code_cache = DenoCompileCodeCache::new(file_path.clone(), 1234);
+      let code_cache =
+        DenoCompileCodeCache::new(file_path.clone(), 1234, None, None);
       assert!(
         code_cache
           .get_sync(&url1, CodeCacheType::EsModule, 0)
@@ -481,7 +665,8 @@ mod test {
     }
     // second run
     {
-      let code_cache = DenoCompileCodeCache::new(file_path.clone(), 1234);
+      let code_cache =
+        DenoCompileCodeCache::new(file_path.clone(), 1234, None, None);
       assert!(code_cache.enabled());
       let result1 = code_cache
         .get_sync(&url1, CodeCacheType::EsModule, 0)
@@ -497,7 +682,8 @@ mod test {
 
     // new cache key first run
     {
-      let code_cache = DenoCompileCodeCache::new(file_path.clone(), 54321);
+      let code_cache =
+        DenoCompileCodeCache::new(file_path.clone(), 54321, None, None);
       assert!(
         code_cache
           .get_sync(&url1, CodeCacheType::EsModule, 0)
@@ -513,7 +699,8 @@ mod test {
     }
     // new cache key second run
     {
-      let code_cache = DenoCompileCodeCache::new(file_path.clone(), 54321);
+      let code_cache =
+        DenoCompileCodeCache::new(file_path.clone(), 54321, None, None);
       let result1 = code_cache
         .get_sync(&url1, CodeCacheType::EsModule, 0)
         .unwrap();

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -19,6 +19,7 @@ use deno_core::ModuleType;
 use deno_core::RequestedModuleType;
 use deno_core::ResolutionKind;
 use deno_core::SourceCodeCacheInfo;
+use deno_core::anyhow::anyhow;
 use deno_core::error::AnyError;
 use deno_core::error::ModuleLoaderError;
 use deno_core::futures::FutureExt;
@@ -36,6 +37,7 @@ use deno_lib::loader::module_type_from_media_and_requested_type;
 use deno_lib::npm::NpmRegistryReadPermissionChecker;
 use deno_lib::npm::NpmRegistryReadPermissionCheckerMode;
 use deno_lib::npm::create_npm_process_state_provider;
+use deno_lib::standalone::binary::CODE_CACHE_GENERATION_ENV_VAR;
 use deno_lib::standalone::binary::NodeModules;
 use deno_lib::util::hash::FastInsecureHasher;
 use deno_lib::util::text_encoding::from_utf8_lossy_cow;
@@ -1364,11 +1366,13 @@ pub async fn run_with_options(
   let override_main_module = options.override_main_module;
   let StandaloneData {
     metadata,
+    embedded_code_cache,
     modules,
     npm_snapshot,
     root_path,
     vfs,
   } = data;
+  let code_cache_generation = metadata.code_cache_generation;
 
   let root_cert_store_provider = Arc::new(StandaloneRootCertStoreProvider {
     sys: sys.clone(),
@@ -1638,13 +1642,29 @@ pub async fn run_with_options(
     )
   };
   let code_cache = match metadata.code_cache_key {
-    Some(code_cache_key) => Some(Arc::new(DenoCompileCodeCache::new(
-      root_path.with_file_name(format!(
-        "{}.cache",
-        root_path.file_name().unwrap().to_string_lossy()
-      )),
-      code_cache_key,
-    ))),
+    Some(code_cache_key) => {
+      let file_path = if code_cache_generation {
+        let path =
+          std::env::var_os(CODE_CACHE_GENERATION_ENV_VAR).ok_or_else(|| {
+            anyhow!("Missing internal code cache generation path")
+          })?;
+        // SAFETY: single-threaded during startup, before the runtime is created.
+        unsafe { std::env::remove_var(CODE_CACHE_GENERATION_ENV_VAR) };
+        PathBuf::from(path)
+      } else {
+        root_path.with_file_name(format!(
+          "{}.cache",
+          root_path.file_name().unwrap().to_string_lossy()
+        ))
+      };
+      Some(Arc::new(DenoCompileCodeCache::new(
+        file_path,
+        code_cache_key,
+        embedded_code_cache,
+        (code_cache_generation || embedded_code_cache.is_some())
+          .then_some(root_dir_url.as_ref()),
+      )))
+    }
     None => {
       log::debug!("Code cache disabled.");
       None
@@ -1856,6 +1876,11 @@ pub async fn run_with_options(
   if let Some(init_fn) = op_state_init {
     let op_state = worker.js_runtime().op_state();
     init_fn(&mut op_state.borrow_mut());
+  }
+
+  if code_cache_generation {
+    worker.generate_code_cache().await?;
+    return Ok(0);
   }
 
   // Initialize desktop APIs (Deno.desktop.*).

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -362,6 +362,8 @@ pub struct WriteBinOptions<'a> {
   pub include_paths: &'a [ModuleSpecifier],
   pub exclude_paths: Vec<PathBuf>,
   pub compile_flags: &'a CompileFlags,
+  pub code_cache_generation: bool,
+  pub embedded_code_cache: Option<&'a [u8]>,
 }
 
 pub struct DenoCompileBinaryWriter<'a> {
@@ -644,6 +646,8 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       include_paths,
       exclude_paths,
       compile_flags,
+      code_cache_generation,
+      embedded_code_cache,
     } = options;
     let ca_data = match self.cli_options.ca_data() {
       Some(CaData::File(ca_file)) => Some(
@@ -1105,7 +1109,9 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       aggregated_env_vars
     };
 
-    output_vfs(&vfs, display_output_filename);
+    if !code_cache_generation {
+      output_vfs(&vfs, display_output_filename);
+    }
 
     let preload_modules = self
       .cli_options
@@ -1125,6 +1131,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       argv: compile_flags.args.clone(),
       seed: self.cli_options.seed(),
       code_cache_key,
+      code_cache_generation,
       location: self.cli_options.location_flag().clone(),
       permissions: self.cli_options.permissions_options()?,
       v8_flags: construct_v8_flags(
@@ -1242,6 +1249,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
     let (data_section_bytes, section_sizes) = serialize_binary_data_section(
       &metadata,
       npm_snapshot.map(|s| s.into_serialized()),
+      embedded_code_cache,
       &specifier_store.for_serialization(&root_dir_url),
       &redirects_store,
       &remote_modules_store,
@@ -1249,21 +1257,32 @@ impl<'a> DenoCompileBinaryWriter<'a> {
     )
     .context("Serializing binary data section.")?;
 
-    log::info!(
-      "\n{} {}",
-      crate::colors::bold("Files:"),
-      crate::util::display::human_size(section_sizes.vfs as f64)
-    );
-    log::info!(
-      "{} {}",
-      crate::colors::bold("Metadata:"),
-      crate::util::display::human_size(section_sizes.metadata as f64)
-    );
-    log::info!(
-      "{} {}\n",
-      crate::colors::bold("Remote modules:"),
-      crate::util::display::human_size(section_sizes.remote_modules as f64)
-    );
+    if !code_cache_generation {
+      log::info!(
+        "\n{} {}",
+        crate::colors::bold("Files:"),
+        crate::util::display::human_size(section_sizes.vfs as f64)
+      );
+      log::info!(
+        "{} {}",
+        crate::colors::bold("Metadata:"),
+        crate::util::display::human_size(
+          section_sizes.metadata.saturating_sub(section_sizes.code_cache) as f64
+        )
+      );
+      if section_sizes.code_cache != 0 {
+        log::info!(
+          "{} {}",
+          crate::colors::bold("Code cache:"),
+          crate::util::display::human_size(section_sizes.code_cache as f64)
+        );
+      }
+      log::info!(
+        "{} {}\n",
+        crate::colors::bold("Remote modules:"),
+        crate::util::display::human_size(section_sizes.remote_modules as f64)
+      );
+    }
 
     write_binary_bytes(writer, original_bin, data_section_bytes, compile_flags)
       .context("Writing binary bytes")
@@ -1648,6 +1667,7 @@ fn write_binary_bytes(
 
 struct BinaryDataSectionSizes {
   metadata: usize,
+  code_cache: usize,
   remote_modules: usize,
   vfs: usize,
 }
@@ -1656,6 +1676,7 @@ struct BinaryDataSectionSizes {
 /// * d3n0l4nd
 /// * <metadata_len><metadata>
 /// * <npm_snapshot_len><npm_snapshot>
+/// * <code_cache_len><code_cache>
 /// * <specifiers>
 /// * <redirects>
 /// * <remote_modules>
@@ -1666,6 +1687,7 @@ struct BinaryDataSectionSizes {
 fn serialize_binary_data_section(
   metadata: &Metadata,
   npm_snapshot: Option<SerializedNpmResolutionSnapshot>,
+  code_cache: Option<&[u8]>,
   specifiers: &SpecifierStoreForSerialization,
   redirects: &SpecifierDataStore<SpecifierId>,
   remote_modules: &SpecifierDataStore<RemoteModuleEntry<'_>>,
@@ -1674,6 +1696,7 @@ fn serialize_binary_data_section(
   let metadata = serde_json::to_string(metadata)?;
   let npm_snapshot =
     npm_snapshot.map(serialize_npm_snapshot).unwrap_or_default();
+  let code_cache = code_cache.unwrap_or_default();
   let serialized_vfs = serde_json::to_string(&vfs.entries)?;
 
   let remote_modules_len = Cell::new(0);
@@ -1692,15 +1715,20 @@ fn serialize_binary_data_section(
       builder.append_le(npm_snapshot.len() as u64);
       builder.append(&npm_snapshot);
     }
+    // 3. Embedded V8 code cache
+    {
+      builder.append_le(code_cache.len() as u64);
+      builder.append(code_cache);
+    }
     metadata_len.set(builder.len());
-    // 3. Specifiers
+    // 4. Specifiers
     builder.append(specifiers);
-    // 4. Redirects
+    // 5. Redirects
     redirects.serialize(builder);
-    // 5. Remote modules
+    // 6. Remote modules
     remote_modules.serialize(builder);
     remote_modules_len.set(builder.len() - metadata_len.get());
-    // 6. VFS
+    // 7. VFS
     {
       builder.append_le(serialized_vfs.len() as u64);
       builder.append(&serialized_vfs);
@@ -1721,6 +1749,7 @@ fn serialize_binary_data_section(
     bytes,
     BinaryDataSectionSizes {
       metadata: metadata_len.get(),
+      code_cache: code_cache.len(),
       remote_modules: remote_modules_len.get(),
       vfs: vfs_len.get(),
     },

--- a/cli/tools/compile.rs
+++ b/cli/tools/compile.rs
@@ -17,6 +17,7 @@ use deno_core::error::AnyError;
 use deno_core::futures::FutureExt;
 use deno_graph::GraphKind;
 use deno_graph::ModuleGraph;
+use deno_lib::standalone::binary::CODE_CACHE_GENERATION_ENV_VAR;
 use deno_npm_installer::graph::NpmCachingStrategy;
 use deno_path_util::resolve_url_or_path;
 use deno_path_util::url_from_file_path;
@@ -30,7 +31,9 @@ use crate::args::CompileFlags;
 use crate::args::ConfigFlag;
 use crate::args::DenoSubcommand;
 use crate::args::Flags;
+use crate::args::JavaScriptEngine;
 use crate::args::TypeCheckMode;
+use crate::args::resolve_compile_target;
 use crate::factory::CliFactory;
 use crate::graph_util::ModuleGraphCreator;
 use crate::standalone::binary::WriteBinOptions;
@@ -639,6 +642,22 @@ pub async fn compile_binary(
   is_desktop: bool,
   watcher_communicator: Option<Arc<WatcherCommunicator>>,
 ) -> Result<PathBuf, AnyError> {
+  if compile_flags.include_code_cache {
+    if is_desktop {
+      bail!("--include-code-cache is not supported for desktop compilation");
+    }
+    let target = resolve_compile_target(&compile_flags);
+    if target != env!("TARGET") {
+      bail!(
+        "--include-code-cache requires the compile target to match the host target ({})",
+        env!("TARGET")
+      );
+    }
+    if compile_flags.engine != JavaScriptEngine::V8 {
+      bail!("--include-code-cache is only supported with the V8 engine");
+    }
+  }
+
   let factory = if let Some(watcher_communicator) = watcher_communicator.clone()
   {
     CliFactory::from_flags_for_watcher(flags, watcher_communicator)
@@ -735,6 +754,106 @@ pub async fn compile_binary(
   ));
   let temp_path = output_path.with_file_name(temp_filename);
 
+  let display_output_filename = output_path
+    .file_name()
+    .unwrap()
+    .to_string_lossy()
+    .into_owned();
+  let exclude_paths = effective_exclude
+    .iter()
+    .map(|p| cli_options.initial_cwd().join(p))
+    .chain(std::iter::once(
+      cli_options.initial_cwd().join(&output_path),
+    ))
+    .chain(std::iter::once(cli_options.initial_cwd().join(&temp_path)))
+    .collect::<Vec<_>>();
+
+  let embedded_code_cache = if compile_flags.include_code_cache {
+    log::info!("Generating V8 code cache for the compiled executable");
+    let generation_dir = tempfile::Builder::new()
+      .prefix(".deno-compile-code-cache-")
+      .tempdir_in(output_path.parent().unwrap_or_else(|| Path::new(".")))
+      .context("Creating temporary code cache generation directory")?;
+    let generation_binary = generation_dir.path().join(if cfg!(windows) {
+      "code-cache-generator.exe"
+    } else {
+      "code-cache-generator"
+    });
+    let generation_cache = generation_dir.path().join("code-cache.bin");
+    let generation_file = std::fs::File::create(&generation_binary)
+      .with_context(|| {
+        format!(
+          "Opening code cache generator '{}'",
+          generation_binary.display()
+        )
+      })?;
+    let mut generation_compile_flags = compile_flags.clone();
+    // The generator never evaluates user code and does not need packaging-only
+    // transformations that could prevent the temporary binary from running.
+    generation_compile_flags.no_terminal = false;
+    generation_compile_flags.icon = None;
+    generation_compile_flags.self_extracting = false;
+
+    binary_writer
+      .write_bin(WriteBinOptions {
+        writer: generation_file,
+        display_output_filename: &display_output_filename,
+        graph: &graph,
+        entrypoint,
+        include_paths: &roots.include_paths,
+        exclude_paths: exclude_paths
+          .iter()
+          .cloned()
+          .chain(std::iter::once(generation_dir.path().to_path_buf()))
+          .collect(),
+        compile_flags: &generation_compile_flags,
+        code_cache_generation: true,
+        embedded_code_cache: None,
+      })
+      .await
+      .context("Writing temporary code cache generator")?;
+
+    #[cfg(unix)]
+    {
+      use std::os::unix::fs::PermissionsExt;
+      std::fs::set_permissions(
+        &generation_binary,
+        std::fs::Permissions::from_mode(0o755),
+      )?;
+    }
+
+    let output = tokio::process::Command::new(&generation_binary)
+      .env(CODE_CACHE_GENERATION_ENV_VAR, &generation_cache)
+      .kill_on_drop(true)
+      .output()
+      .await
+      .with_context(|| {
+        format!(
+          "Running code cache generator '{}'",
+          generation_binary.display()
+        )
+      })?;
+    if !output.status.success() {
+      bail!(
+        "Failed generating embedded code cache (status {}):\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+      );
+    }
+    let code_cache = std::fs::read(&generation_cache).with_context(|| {
+      format!(
+        "The code cache generator did not write '{}'",
+        generation_cache.display()
+      )
+    })?;
+    if code_cache.is_empty() {
+      bail!("The generated V8 code cache was empty");
+    }
+    Some(code_cache)
+  } else {
+    None
+  };
+
   let file = std::fs::File::create(&temp_path).with_context(|| {
     format!("Opening temporary file '{}'", temp_path.display())
   })?;
@@ -742,22 +861,14 @@ pub async fn compile_binary(
   let write_result = binary_writer
     .write_bin(WriteBinOptions {
       writer: file,
-      display_output_filename: &output_path
-        .file_name()
-        .unwrap()
-        .to_string_lossy(),
+      display_output_filename: &display_output_filename,
       graph: &graph,
       entrypoint,
       include_paths: &roots.include_paths,
-      exclude_paths: effective_exclude
-        .iter()
-        .map(|p| cli_options.initial_cwd().join(p))
-        .chain(std::iter::once(
-          cli_options.initial_cwd().join(&output_path),
-        ))
-        .chain(std::iter::once(cli_options.initial_cwd().join(&temp_path)))
-        .collect(),
+      exclude_paths,
       compile_flags: &compile_flags,
+      code_cache_generation: false,
+      embedded_code_cache: embedded_code_cache.as_deref(),
     })
     .await
     .with_context(|| {
@@ -1388,6 +1499,7 @@ mod test {
         args: Vec::new(),
         target: None,
         no_terminal: false,
+        include_code_cache: false,
         icon: Some("favicon.ico".to_string()),
         include: Default::default(),
         exclude: Default::default(),
@@ -1419,6 +1531,7 @@ mod test {
         args: Vec::new(),
         target: Some("x86_64-unknown-linux-gnu".to_string()),
         no_terminal: false,
+        include_code_cache: false,
         icon: None,
         include: Default::default(),
         exclude: Default::default(),
@@ -1460,6 +1573,7 @@ mod test {
         exclude: Default::default(),
         icon: None,
         no_terminal: false,
+        include_code_cache: false,
         eszip: true,
         self_extracting: false,
         bundle: false,

--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -512,6 +512,7 @@ async fn compile_desktop(
     args: desktop_flags.args.clone(),
     target: desktop_flags.target.clone(),
     no_terminal: false,
+    include_code_cache: false,
     icon: match &desktop_flags.icon {
       Some(crate::args::IconConfig::Single(s)) => Some(s.clone()),
       _ => None,

--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -388,6 +388,7 @@ async fn install_global_compiled(
     args: install_flags_global.args,
     target: None,
     no_terminal: false,
+    include_code_cache: false,
     icon: None,
     include: vec![],
     exclude: vec![],

--- a/libs/cli_parser/src/convert.rs
+++ b/libs/cli_parser/src/convert.rs
@@ -2105,6 +2105,7 @@ fn compile_parse(
   let target = result.get_one("target").map(|s| s.to_string());
   let icon = result.get_one("icon").map(|s| s.to_string());
   let no_terminal = result.get_bool("no-terminal");
+  let include_code_cache = result.get_bool("include-code-cache");
   let eszip = result.get_bool("eszip-internal-do-not-use");
   let self_extracting = result.get_bool("self-extracting");
 
@@ -2130,6 +2131,7 @@ fn compile_parse(
     args,
     target,
     no_terminal,
+    include_code_cache,
     icon,
     include,
     exclude,

--- a/libs/cli_parser/src/defs.rs
+++ b/libs/cli_parser/src/defs.rs
@@ -1813,7 +1813,15 @@ pub static COMPILE_SUBCOMMAND: CommandDef = CommandDef {
     ArgDef::new("no-code-cache")
       .long("no-code-cache")
       .set_true()
+      .conflicts_with(&["include-code-cache"])
 .help("Disable V8 code cache feature"),
+    ArgDef::new("include-code-cache")
+      .long("include-code-cache")
+      .set_true()
+      .conflicts_with(&["no-code-cache"])
+.help("Generate and embed V8 code cache in the executable.
+  Improves first-start performance at the cost of a larger binary.
+  Only supported for native, non-desktop compilation."),
     ArgDef::new("ext")
       .long("ext")
       .action(ArgAction::Set)

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -200,6 +200,9 @@ pub struct CompileFlags {
   pub args: Vec<String>,
   pub target: Option<String>,
   pub no_terminal: bool,
+  /// Generate V8 code cache while compiling and embed it in the executable.
+  /// This only works when the compile target matches the host target.
+  pub include_code_cache: bool,
   pub icon: Option<String>,
   pub include: Vec<String>,
   pub exclude: Vec<String>,

--- a/libs/cli_parser/src/tests_full.rs
+++ b/libs/cli_parser/src/tests_full.rs
@@ -5039,6 +5039,7 @@ fn compile() {
         args: vec![],
         target: None,
         no_terminal: false,
+        include_code_cache: false,
         icon: None,
         include: Default::default(),
         exclude: Default::default(),
@@ -5054,6 +5055,28 @@ fn compile() {
       code_cache_enabled: true,
       ..Flags::default()
     }
+  );
+}
+
+#[test]
+fn compile_include_code_cache() {
+  let flags =
+    flags_from_vec(svec!["deno", "compile", "--include-code-cache", "main.ts"])
+      .unwrap();
+  let DenoSubcommand::Compile(compile) = flags.subcommand else {
+    panic!("expected compile subcommand");
+  };
+  assert!(compile.include_code_cache);
+
+  assert!(
+    flags_from_vec(svec![
+      "deno",
+      "compile",
+      "--include-code-cache",
+      "--no-code-cache",
+      "main.ts"
+    ])
+    .is_err()
   );
 }
 
@@ -5171,6 +5194,7 @@ fn compile_watch_with_no_clear_screen() {
         args: vec![],
         target: None,
         no_terminal: false,
+        include_code_cache: false,
         icon: None,
         include: Default::default(),
         exclude: Default::default(),
@@ -5208,6 +5232,7 @@ fn compile_with_flags() {
         args: svec!["foo", "bar", "-p", "8080"],
         target: None,
         no_terminal: true,
+        include_code_cache: false,
         icon: Some(String::from("favicon.ico")),
         include: vec!["include.txt".to_string()],
         exclude: vec!["exclude.txt".to_string()],
@@ -8179,6 +8204,7 @@ fn preload_flag_test() {
         args: vec![],
         target: None,
         no_terminal: false,
+        include_code_cache: false,
         icon: None,
         include: Default::default(),
         exclude: Default::default(),

--- a/tests/specs/compile/include_code_cache/__test__.jsonc
+++ b/tests/specs/compile/include_code_cache/__test__.jsonc
@@ -1,0 +1,23 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "if": "unix",
+      "args": "compile --output embedded_cache --allow-write=. --include-code-cache --log-level=debug main.ts",
+      "output": "[WILDCARD]"
+    },
+    {
+      "if": "windows",
+      "args": "compile --output embedded_cache.exe --allow-write=. --include-code-cache --log-level=debug main.ts",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "run -A verify_generation.ts",
+      "output": "code cache generation did not evaluate user code\n"
+    },
+    {
+      "args": "run -A verify.ts",
+      "output": "embedded code cache verified\n"
+    }
+  ]
+}

--- a/tests/specs/compile/include_code_cache/deno.json
+++ b/tests/specs/compile/include_code_cache/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@std/url/join": "jsr:@std/url@0.220/join"
+  }
+}

--- a/tests/specs/compile/include_code_cache/main.ts
+++ b/tests/specs/compile/include_code_cache/main.ts
@@ -1,0 +1,4 @@
+import { join } from "@std/url/join";
+
+Deno.writeTextFileSync("main-evaluated.txt", "evaluated");
+console.log(join);

--- a/tests/specs/compile/include_code_cache/package.json
+++ b/tests/specs/compile/include_code_cache/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/tests/specs/compile/include_code_cache/verify.ts
+++ b/tests/specs/compile/include_code_cache/verify.ts
@@ -1,0 +1,51 @@
+import { basename, join } from "node:path";
+import { tmpdir } from "node:os";
+
+const executable = join(
+  Deno.cwd(),
+  Deno.build.os === "windows" ? "embedded_cache.exe" : "embedded_cache",
+);
+const externalCache = join(
+  tmpdir(),
+  `deno-compile-${basename(executable)}.cache`,
+);
+try {
+  await Deno.remove(externalCache);
+} catch (error) {
+  if (!(error instanceof Deno.errors.NotFound)) {
+    throw error;
+  }
+}
+
+const output = new Deno.Command(executable).outputSync();
+const stdout = new TextDecoder().decode(output.stdout);
+const stderr = new TextDecoder().decode(output.stderr);
+
+if (!output.success) {
+  throw new Error(`compiled executable failed: ${stderr}`);
+}
+if (!/Loaded \d+ embedded code cache entries/.test(stderr)) {
+  throw new Error(`embedded code cache was not loaded:\n${stderr}`);
+}
+if (stderr.includes("Serialized ")) {
+  throw new Error(
+    `first run unexpectedly serialized an external cache:\n${stderr}`,
+  );
+}
+if (!stdout.includes("[Function: join]")) {
+  throw new Error(`compiled executable produced unexpected output:\n${stdout}`);
+}
+if (Deno.readTextFileSync("main-evaluated.txt") !== "evaluated") {
+  throw new Error("compiled executable did not evaluate the main module");
+}
+
+try {
+  Deno.statSync(externalCache);
+  throw new Error(`unexpected external code cache at ${externalCache}`);
+} catch (error) {
+  if (!(error instanceof Deno.errors.NotFound)) {
+    throw error;
+  }
+}
+
+console.log("embedded code cache verified");

--- a/tests/specs/compile/include_code_cache/verify_generation.ts
+++ b/tests/specs/compile/include_code_cache/verify_generation.ts
@@ -1,0 +1,10 @@
+try {
+  Deno.statSync("main-evaluated.txt");
+  throw new Error("code cache generation evaluated user code");
+} catch (error) {
+  if (!(error instanceof Deno.errors.NotFound)) {
+    throw error;
+  }
+}
+
+console.log("code cache generation did not evaluate user code");


### PR DESCRIPTION
Closes #26979.

## Summary

- add an opt-in `deno compile --include-code-cache` flag for native V8 builds
- generate cache data with a temporary standalone executable built from the same module graph and runtime
- embed the generated cache in the final standalone data section and load it on the first launch
- keep existing external subsequent-run code-cache behavior unchanged when the flag is omitted

## Motivation

Compiled executables currently create their V8 code cache only after the first run. That does not help one-shot or ephemeral deployments such as freshly started containers and serverless instances, where the first process may be the only process. The issue now also contains a production AWS Lambda report in which a compiled application occasionally exceeds a 10-second initialization window while the equivalent Deno CLI startup remains below one second.

## Design

The compile path performs an additional native-only pass when the flag is set:

1. It writes a temporary standalone executable using the already-built module graph.
2. That executable loads and instantiates preload/require modules and the statically reachable main graph without evaluating application modules.
3. V8's generated cache entries are serialized to an internal temporary file.
4. The compiler embeds those bytes in the final standalone data section.
5. The final runtime deserializes the embedded entries before it considers the existing external cache path.

Local standalone specifiers include an executable-specific temporary root. Cache keys therefore normalize that root to an internal stable prefix, allowing the temporary generator and final executable (including a renamed executable) to share the same entries. Serialized entries are sorted so HashMap iteration order does not make the embedded section nondeterministic.

The option is rejected for cross-compilation, QuickJS, and desktop builds because the generator must execute the exact native V8 runtime that will consume the cache. Temporary generator files are RAII-managed, excluded from the compiled VFS, and the internal hand-off environment variable is removed before worker creation.

This is complementary to #36143: that PR changes where the external cache produced after a first run is persisted, while this change creates and embeds cache data during compilation so it is available on the first run.

## Validation

- `deno run -A x lint`
- `cargo fmt --all -- --check`
- `deno fmt --check tests/specs/compile/include_code_cache`
- `deno lint tests/specs/compile/include_code_cache`
- `cargo test -p deno_cli_parser --features deno_core/v8 --lib compile_include_code_cache`
- `cargo test -p denort --lib code_cache::test`
- native spec: `include_code_cache`
- existing native specs: `specs::compile::code_cache` and `code_cache_wasm_npm`
- native debug builds: `deno`, `denort`, and `test_server`
- CLI rejection checks for conflicting cache flags, cross-target compilation, and QuickJS
- native end-to-end checks for a renamed executable, `--self-extracting`, and `--bundle`; each loaded its embedded entries on the first run without creating an external cache

## AI disclosure

AI assistance (OpenAI Codex) was used to research the issue, implement and review the change, and run the validation described above.
