### PR TITLE
fix(desktop): create minimal .app bundle for raw backend on macOS

### DIFF
--- a/cli/tools/desktop.rs
+++ b/cli/tools/desktop.rs
@@ -2334,10 +2334,34 @@ fn locate_backend_binary(
 fn locate_app_bundle(dir: &Path, backend: &str) -> Option<PathBuf> {
   let name = match backend {
     "cef" => "laufey.app",
+    "raw" => "laufey_winit.app",
     _ => "laufey_webview.app",
   };
   let p = dir.join(name);
-  p.exists().then_some(p)
+  if p.exists() {
+    return Some(p);
+  }
+  // The raw backend doesn't ship a .app bundle on macOS — it's a single
+  // binary. Create a minimal .app wrapper so the macOS packaging code
+  // can proceed.
+  if backend == "raw" {
+    let binary = dir.join("laufey_winit");
+    if binary.exists() {
+      // Create Contents/MacOS and copy the binary in.
+      std::fs::create_dir_all(&p.join("Contents/MacOS")).ok()?;
+      std::fs::copy(&binary, p.join("Contents/MacOS/laufey_winit")).ok()?;
+      // Write a minimal Info.plist with the correct CFBundleExecutable.
+      std::fs::write(
+        &p.join("Contents/Info.plist"),
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>CFBundleExecutable</key><string>laufey_winit</string></dict></plist>
+"#,
+      ).ok()?;
+      return p.exists().then_some(p);
+    }
+  }
+  None
 }
 
 /// Target triple to use when selecting a laufey backend archive. Honors
@@ -6521,6 +6545,37 @@ def456  other.zip
     // accidentally match).
     let tmp = tempfile::tempdir().unwrap();
     assert!(locate_dev_app_bundle(tmp.path(), "raw").is_none());
+  }
+
+  #[test]
+  fn locate_app_bundle_creates_winit_bundle() {
+    // The raw backend doesn't ship a .app bundle — locate_app_bundle
+    // must create a minimal one when the binary exists alongside.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("raw/aarch64-apple-darwin");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("laufey_winit"), b"binary").unwrap();
+
+    let found = locate_app_bundle(&dir, "raw");
+    assert!(found.is_some(), "expected a synthetic .app bundle");
+    let bundle = found.unwrap();
+
+    // The bundle should be a properly structured .app directory.
+    assert!(bundle.join("Contents/MacOS/laufey_winit").exists(),
+      "expected laufey_winit binary inside .app");
+    assert!(bundle.join("Contents/Info.plist").exists(),
+      "expected Info.plist inside .app");
+  }
+
+  #[test]
+  fn locate_app_bundle_finds_webview() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("webview");
+    std::fs::create_dir_all(&dir).unwrap();
+    let app = dir.join("laufey_webview.app");
+    std::fs::create_dir_all(&app).unwrap();
+    let found = locate_app_bundle(&dir, "webview");
+    assert_eq!(found.as_deref(), Some(app.as_path()));
   }
 
   #[test]


### PR DESCRIPTION
## Description

The `raw` backend (laufey_winit) ships as a plain binary, not a `.app` bundle. When packaging on macOS, `find_app_bundle` calls `locate_app_bundle` which previously only looked for `laufey_webview.app`, failing with:

```
error: could not find 'raw' .app bundle inside ... (backend may not ship as an app for target 'aarch64-apple-darwin')
```

## Fix

Modified `locate_app_bundle` in `cli/tools/desktop.rs` to create a minimal `.app` wrapper around the raw backend binary when no `.app` bundle exists:

1. Added `"raw" => "laufey_winit.app"` to the name match
2. When the `.app` doesn't exist but the `laufey_winit` binary does, creates:
   - `laufey_winit.app/Contents/MacOS/laufey_winit` (copied binary)
   - `laufey_winit.app/Contents/Info.plist` (minimal plist with `CFBundleExecutable = laufey_winit`)

This allows the existing `package_macos_app_bundle` code to proceed uniformly for all backends — it copies the synthetic `.app` as the app shell, writes its own `Info.plist`, copies the compiled dylib, and codesigns.

## Tests added

- `locate_app_bundle_creates_winit_bundle` — verifies that a minimal `.app` is created when the `raw` binary exists
- `locate_app_bundle_finds_webview` — verifies that existing `.app` bundles are still found (regression guard)

Closes #36594