### PR TITLE
fix(ext/node): allow repeated child process signals

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -217,6 +217,7 @@ function stdioStringToArray(
 const kClosesNeeded = Symbol("_closesNeeded");
 const kClosesReceived = Symbol("_closesReceived");
 const kCanDisconnect = Symbol("_canDisconnect");
+const kSigkillIssued = Symbol("_sigkillIssued");
 const kChildStdioUsedAsInput = Symbol("childStdioUsedAsInput");
 const childStdioStreamsByFd = new SafeMap();
 let emittedShellDeprecation = false;
@@ -306,10 +307,12 @@ class ChildProcess extends EventEmitter {
   disconnect;
 
   #process;
+  #windowsSignalFallback: string | null = null;
   #spawned = PromiseWithResolvers();
   [kClosesNeeded] = 1;
   [kClosesReceived] = 0;
   [kCanDisconnect] = false;
+  [kSigkillIssued] = false;
 
   constructor() {
     super();
@@ -663,7 +666,7 @@ class ChildProcess extends EventEmitter {
 
       (async () => {
         const status = await this.#process.status;
-        this.signalCode = this.signalCode || status.signal || null;
+        this.signalCode = status.signal || this.#windowsSignalFallback;
         if (this.signalCode) {
           this.exitCode = null;
         } else {
@@ -811,9 +814,9 @@ class ChildProcess extends EventEmitter {
   kill(signal) {
     const process = lazyProcess().default;
     // Signal 0 is a special case: it checks if the process exists
-    // without sending a signal (POSIX kill(pid, 0)). This must run
-    // before the `killed` check because kill(0) is an existence probe
-    // that should work even after a prior successful kill().
+    // without sending a signal (POSIX kill(pid, 0)). It must be handled
+    // separately because it is an existence probe that should work even
+    // after a prior successful kill().
     if (signal === 0 || signal === "0") {
       try {
         process.kill(this.pid, 0);
@@ -823,12 +826,11 @@ class ChildProcess extends EventEmitter {
       }
     }
 
-    if (this.killed) {
-      return false;
-    }
-
+    // `killed` records whether a signal has ever been sent successfully; it
+    // must not prevent later signals from reaching a still-running process.
+    // In particular, SIGSTOP followed by SIGCONT is a supported way to
+    // suspend and resume a child.
     let signalName = signal == null ? "SIGTERM" : toDenoSignal(signal);
-    this.#closePipes();
     try {
       this.#process.kill(signalName);
     } catch (err) {
@@ -873,20 +875,22 @@ class ChildProcess extends EventEmitter {
       }
     }
 
-    /* Cancel any pending IPC I/O */
-    if (this[kCanDisconnect]) {
-      this.disconnect?.();
+    this.#recordWindowsSignalFallback(signalName);
+    if (signalName === "SIGKILL") {
+      this[kSigkillIssued] = true;
     }
-
     this.killed = true;
-    this.signalCode = signalName;
     return true;
   }
 
-  [SymbolDispose]() {
-    if (!this.killed) {
-      this.kill();
+  #recordWindowsSignalFallback(signalName: string) {
+    if (isWindows) {
+      this.#windowsSignalFallback = signalName;
     }
+  }
+
+  [SymbolDispose]() {
+    this.kill();
   }
 
   ref() {
@@ -2670,6 +2674,7 @@ function setupChannel(
   }
 
   function dispatch(message, handleInfo, callback) {
+    const sigkillIssuedAtDispatch = target[kSigkillIssued] === true;
     if (handleInfo) {
       // Start queueing subsequent sends until the ACK arrives.
       handleQueue = [];
@@ -2717,7 +2722,13 @@ function setupChannel(
             }
           }
         }
-        if (
+        if (!sigkillIssuedAtDispatch && target[kSigkillIssued]) {
+          // SIGKILL cannot be handled or ignored. Match Node by treating an
+          // IPC write accepted before the local SIGKILL as completed.
+          if (typeof callback === "function") {
+            nextTick(callback, null);
+          }
+        } else if (
           ObjectPrototypeIsPrototypeOf(Deno.errors.Interrupted.prototype, err)
         ) {
           // Channel closed on us mid-write.
@@ -2743,7 +2754,7 @@ function setupChannel(
   async function readLoop() {
     try {
       while (true) {
-        if (!target.connected || target.killed) {
+        if (!target.connected) {
           return;
         }
         // TODO(nathanwhit): maybe allow returning multiple messages in a single read? needs benchmarking.

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -666,7 +666,16 @@ class ChildProcess extends EventEmitter {
 
       (async () => {
         const status = await this.#process.status;
-        this.signalCode = status.signal || this.#windowsSignalFallback;
+        // Windows has no POSIX termination status, so a successfully delivered
+        // signal is recorded locally instead. Only trust that record when the
+        // child actually exited unsuccessfully: `kill()` can race a child that
+        // was already exiting on its own, and `TerminateProcess` still reports
+        // success in that window. Reporting a signal for an exit code of 0
+        // would hide the real status.
+        const windowsSignal = status.success
+          ? null
+          : this.#windowsSignalFallback;
+        this.signalCode = status.signal || windowsSignal;
         if (this.signalCode) {
           this.exitCode = null;
         } else {
@@ -677,6 +686,15 @@ class ChildProcess extends EventEmitter {
           this.emit("exit", this.exitCode, this.signalCode);
           await this.#_waitForChildStreamsToClose();
           this.#closePipes();
+          // The child is gone, so the IPC channel can never carry another
+          // message. Tear it down here rather than in `kill()`: a signal does
+          // not necessarily terminate the child, but an exit always ends the
+          // channel. Without this the read loop never observes the EOF (its
+          // pending read is unref'd, so the event loop can drain first) and
+          // 'close' would never be emitted for a killed forked child.
+          if (this[kCanDisconnect]) {
+            this.disconnect?.();
+          }
           maybeClose(this);
           nextTick(flushStdio, this);
         });
@@ -808,9 +826,6 @@ class ChildProcess extends EventEmitter {
     }
   }
 
-  /**
-   * @param signal NOTE: this parameter is not yet implemented.
-   */
   kill(signal) {
     const process = lazyProcess().default;
     // Signal 0 is a special case: it checks if the process exists
@@ -875,18 +890,15 @@ class ChildProcess extends EventEmitter {
       }
     }
 
-    this.#recordWindowsSignalFallback(signalName);
+    if (isWindows) {
+      // See the `#windowsSignalFallback` use in the status handler above.
+      this.#windowsSignalFallback = signalName;
+    }
     if (signalName === "SIGKILL") {
       this[kSigkillIssued] = true;
     }
     this.killed = true;
     return true;
-  }
-
-  #recordWindowsSignalFallback(signalName: string) {
-    if (isWindows) {
-      this.#windowsSignalFallback = signalName;
-    }
   }
 
   [SymbolDispose]() {
@@ -2507,6 +2519,21 @@ function createIpcHandle(message, rawFd) {
   return undefined;
 }
 
+// The IPC channel was torn down underneath us: either the resource is gone or
+// the peer reset the connection.
+function isChannelClosedError(err) {
+  return ObjectPrototypeIsPrototypeOf(Deno.errors.BadResource.prototype, err) ||
+    ObjectPrototypeIsPrototypeOf(Deno.errors.ConnectionReset.prototype, err);
+}
+
+function isInterruptedError(err) {
+  return ObjectPrototypeIsPrototypeOf(Deno.errors.Interrupted.prototype, err);
+}
+
+function isBrokenPipeError(err) {
+  return ObjectPrototypeIsPrototypeOf(Deno.errors.BrokenPipe.prototype, err);
+}
+
 function setupChannel(
   target,
   ipc,
@@ -2722,15 +2749,22 @@ function setupChannel(
             }
           }
         }
-        if (!sigkillIssuedAtDispatch && target[kSigkillIssued]) {
-          // SIGKILL cannot be handled or ignored. Match Node by treating an
-          // IPC write accepted before the local SIGKILL as completed.
+        if (
+          !sigkillIssuedAtDispatch && target[kSigkillIssued] &&
+          (isBrokenPipeError(err) || isChannelClosedError(err))
+        ) {
+          // This write was accepted before a local SIGKILL and only failed
+          // because that SIGKILL tore the channel down underneath it. SIGKILL
+          // cannot be handled or ignored, so unlike a terminating signal the
+          // child had no chance to drain the pipe; Node reports the send as
+          // completed here, so match that. Sends issued after the SIGKILL
+          // (`sigkillIssuedAtDispatch`) and sends racing external termination
+          // still report the error. Errors unrelated to channel teardown are
+          // never suppressed, even inside this window.
           if (typeof callback === "function") {
             nextTick(callback, null);
           }
-        } else if (
-          ObjectPrototypeIsPrototypeOf(Deno.errors.Interrupted.prototype, err)
-        ) {
+        } else if (isInterruptedError(err)) {
           // Channel closed on us mid-write.
         } else {
           // Match Node: errors raised from a failed IPC send carry
@@ -2812,11 +2846,7 @@ function setupChannel(
       // RST, surfacing here as ECONNRESET. Node treats an IPC channel teardown
       // as a disconnect, never as a process `error`, so we follow suit and tear
       // down cleanly instead of emitting an uncaught error.
-      if (
-        ObjectPrototypeIsPrototypeOf(Deno.errors.Interrupted.prototype, err) ||
-        ObjectPrototypeIsPrototypeOf(Deno.errors.BadResource.prototype, err) ||
-        ObjectPrototypeIsPrototypeOf(Deno.errors.ConnectionReset.prototype, err)
-      ) {
+      if (isInterruptedError(err) || isChannelClosedError(err)) {
         // Channel torn down from under us; release any handles awaiting an
         // ACK that will now never arrive so they don't keep us alive.
         cleanupPendingHandles();

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -871,7 +871,9 @@ Deno.test({
     await pStdout.promise;
     await pStderr.promise;
     assert(cp.killed);
-    assertEquals(cp.signalCode, "SIGIOT");
+    // SIGIOT is an alias for SIGABRT on POSIX systems, so Node reports the
+    // canonical signal name from the OS exit status.
+    assertEquals(cp.signalCode, "SIGABRT");
   },
 });
 
@@ -1396,13 +1398,132 @@ Deno.test(async function killMultipleTimesNoError() {
   child.on("close", () => {
     timeout.resolve();
   });
-  child.kill();
+  assertEquals(child.kill(), true);
   child.kill();
 
-  // explicitly calling disconnect after kill should throw
-  assertThrows(() => child.disconnect());
+  // Sending a signal does not implicitly disconnect the IPC channel.
+  assertEquals(child.connected, true);
+  child.disconnect();
 
   await timeout.promise;
+});
+
+Deno.test({
+  name: "[node/child_process] SIGSTOP and SIGCONT preserve child state",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const child = CP.spawn(
+      Deno.execPath(),
+      [
+        "eval",
+        `
+          await Deno.stdout.write(new TextEncoder().encode("ready\\n"));
+          for await (const chunk of Deno.stdin.readable) {
+            await Deno.stdout.write(chunk);
+          }
+        `,
+      ],
+      { stdio: ["pipe", "pipe", "inherit"] },
+    );
+    const output: string[] = [];
+    const ready = withTimeout<void>();
+    const closed = withTimeout<void>();
+    child.stdout.on("data", (chunk) => {
+      output.push(chunk.toString());
+      if (output.join("").includes("ready\n")) {
+        ready.resolve();
+      }
+    });
+    child.on("close", () => closed.resolve());
+
+    try {
+      await ready.promise;
+      assertEquals(child.kill("SIGSTOP"), true);
+      assertEquals(child.killed, true);
+      assertEquals(child.signalCode, null);
+      assertEquals(child.exitCode, null);
+      assertEquals(child.stdout.destroyed, false);
+
+      assertEquals(child.kill("SIGCONT"), true);
+      assertEquals(child.signalCode, null);
+      assertEquals(child.exitCode, null);
+      assertEquals(child.stdout.destroyed, false);
+
+      const resumed = withTimeout<void>();
+      child.stdout.on("data", (_chunk) => {
+        if (output.join("").includes("resumed\n")) {
+          resumed.resolve();
+        }
+      });
+      child.stdin.write("resumed\n");
+      await resumed.promise;
+      assertEquals(child.signalCode, null);
+      assertEquals(child.exitCode, null);
+
+      assertEquals(child.kill("SIGSTOP"), true);
+      // `killed` is already true, but disposal must still send SIGTERM.
+      child[Symbol.dispose]();
+      child.kill("SIGCONT");
+      await closed.promise;
+      assertEquals(child.signalCode, "SIGTERM");
+      assertEquals(child.exitCode, null);
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+      child.stdout.destroy();
+      child.stdin.destroy();
+    }
+  },
+});
+
+Deno.test({
+  name: "[node/child_process] SIGSTOP and SIGCONT preserve IPC channel",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const file = await Deno.makeTempFile();
+    await Deno.writeTextFile(
+      file,
+      `
+        process.on("message", (message) => process.send(message));
+        setInterval(() => {}, 10000);
+      `,
+    );
+    const child = CP.fork(file, [], {
+      stdio: ["ignore", "ignore", "inherit", "ipc"],
+    });
+    const response = withTimeout<string>();
+    const closed = withTimeout<void>();
+    child.on("message", (message) => {
+      if (typeof message === "string") {
+        response.resolve(message);
+      } else {
+        response.reject(new TypeError("expected a string IPC response"));
+      }
+    });
+    child.on("close", () => closed.resolve());
+
+    try {
+      assertEquals(child.kill("SIGSTOP"), true);
+      assertEquals(child.connected, true);
+      assertEquals(child.send("resumed"), true);
+      assertEquals(child.kill("SIGCONT"), true);
+      assertEquals(await response.promise, "resumed");
+      assertEquals(child.signalCode, null);
+      assertEquals(child.exitCode, null);
+      assertEquals(child.kill("SIGTERM"), true);
+      await closed.promise;
+      assertEquals(child.signalCode, "SIGTERM");
+      assertEquals(child.exitCode, null);
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+      if (child.connected) {
+        child.disconnect();
+      }
+    }
+  },
 });
 
 // Make sure that you receive messages sent before a "message" event listener is set up

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1450,8 +1450,13 @@ Deno.test({
       assertEquals(child.stdout.destroyed, false);
 
       const resumed = withTimeout<void>();
-      child.stdout.on("data", (_chunk) => {
-        if (output.join("").includes("resumed\n")) {
+      // Accumulate locally instead of reading `output`: that array is filled
+      // by the listener registered above, so relying on it here would make
+      // this assertion depend on listener invocation order.
+      let echoed = "";
+      child.stdout.on("data", (chunk) => {
+        echoed += chunk.toString();
+        if (echoed.includes("resumed\n")) {
           resumed.resolve();
         }
       });
@@ -1523,6 +1528,29 @@ Deno.test({
         child.disconnect();
       }
     }
+  },
+});
+
+Deno.test({
+  name: "[node/child_process] windows reports the delivered signal",
+  ignore: Deno.build.os !== "windows",
+  async fn() {
+    // Windows has no POSIX termination status, so `signalCode` comes from the
+    // signal `kill()` recorded locally. The POSIX stop/resume tests above are
+    // skipped here, making this the only coverage of that fallback.
+    const child = CP.spawn(
+      Deno.execPath(),
+      ["eval", "setInterval(() => {}, 10000)"],
+      { stdio: ["ignore", "ignore", "inherit"] },
+    );
+    const closed = withTimeout<void>();
+    child.on("close", () => closed.resolve());
+
+    assertEquals(child.kill("SIGTERM"), true);
+    assertEquals(child.killed, true);
+    await closed.promise;
+    assertEquals(child.signalCode, "SIGTERM");
+    assertEquals(child.exitCode, null);
   },
 });
 


### PR DESCRIPTION
## Summary

Deno's `node:child_process` compatibility layer treated `ChildProcess.killed` as a one-shot gate. After one successful non-terminating signal such as `SIGSTOP`, later calls such as `SIGCONT` returned `false` without reaching the process.

This PR restores Node-compatible signal delivery semantics:

- attempt each requested signal while the child process handle is still available;
- keep `killed` as a record that at least one signal was sent successfully, not proof that the child exited;
- keep stdio and IPC alive until actual process or channel termination;
- keep the IPC read loop alive after non-terminating signals;
- derive `signalCode` from final process status on POSIX, with an explicit Windows fallback;
- make `Symbol.dispose` still attempt termination after an earlier non-terminating signal.

Closes #36643.

## Reproduction

Before this change:

```text
child.kill("SIGSTOP") → true
child.kill("SIGCONT") → false
```

The second signal was blocked only because `child.killed` was already `true`. Node and Deno's native `ChildProcess.kill()` both support the corresponding stop/resume sequence.

## Implementation

The previous compatibility implementation also closed stdin, disconnected IPC, stopped the IPC read loop, and assigned `signalCode` immediately after any successful signal. Those actions assume every signal terminates the child, which is not true for `SIGSTOP` and `SIGCONT`.

Final process status is now authoritative. Windows does not expose POSIX termination status through the same backend, so a Windows-only fallback records the last successfully delivered compatible signal.

`Symbol.dispose` now delegates unconditionally to `kill()`. This matters after `SIGSTOP`: `killed` is already `true`, but the process is only stopped and still needs the default terminating signal.

Per review feedback, the general IPC write/termination race machinery—signal-generation maps, deferred write failures, shared terminal observers, and associated concurrency tests—has been removed. Fork CI then exposed the existing Node compatibility contract for a write accepted immediately before local `SIGKILL`. Because `SIGKILL` cannot be handled or ignored, a one-way per-process marker preserves only that deterministic callback boundary. Sends issued after local `SIGKILL` and sends racing external termination still report `EPIPE`.

## Testing

- [x] `cargo build --bin deno`
- [x] `cargo test -p unit_node_tests --test unit_node -- child_process_test`
- [x] `cargo test -p node_compat_tests --test node_compat -- test-child-process-send-returns-boolean`
- [x] repeated focused child-process harness stability run
- [x] existing Node send-before-`SIGKILL` test, 50/50 passes
- [x] ordering probe: send-before-local-`SIGKILL` callback success 50/50; send-after-local-`SIGKILL` and external-`SIGKILL` `EPIPE` 50/50
- [x] `SIGSTOP` → `SIGCONT` with resumed stdio
- [x] `SIGSTOP` → `SIGCONT` with resumed IPC
- [x] disposal after a non-terminating signal, with final `signalCode === "SIGTERM"`
- [x] `./tools/format.js --check`
- [x] `./tools/lint.js --js`
- [x] `git diff --check`
- [x] current-main safe fork mirror matrix: [xz-dev/deno#2](https://github.com/xz-dev/deno/pull/2), [run 33465648363](https://github.com/xz-dev/deno/actions/runs/33465648363) — attempt 2 completed with 132 success, 2 skipped, and 0 failures after one evidence-backed job-level retry of a GitHub network/DNS failure that occurred before tests

The PR branch is one signed commit directly on upstream `main` `e5575e2c0ac3c6ea5281d685bab4c33be8c8b38d`. The safe fork PR's merge tree is byte-identical to candidate tree `a7a57bad30b94e8ff5f547cbae8f84d9f3443b38`.

`SIGSTOP`/`SIGCONT` tests are skipped on Windows because Windows does not implement the POSIX stop/resume signal model. The normal Windows matrix still covers compilation and the fallback path.

## AI assistance disclosure

ChatGPT assisted with investigation, source tracing, implementation, tests, verification, commit preparation, and this PR description. It ran as **gpt-5.6-sol** inside the **Pi** coding-agent harness; it was not Codex. The human contributor directed the work and requested the submission.
