### PR TITLE
chore(flake): fix the nix-update-rusty-v8 script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,7 @@
             function update() {
               sys=$1
               target=$2
-              url="https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_$target.a.gz"
+              url="https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_simdutf_release_$target.a.gz"
               hash=$(nix store prefetch-file --json "$url" | ${pkgs.lib.getExe pkgs.jq} -r '.hash')
               sed -i "s|\"$sys\" = \"sha256-[^\"]*\";|\"$sys\" = \"$hash\";|" flake.nix
             }


### PR DESCRIPTION
Fixes the script used to update the hashes of rusty-v8 release artifacts. The script targeted the wrong type of artifact which was the non-simdutf artifact, leading to hash mismatch errors. I changed it to instead target the simdutf artifact and it worked without any mismatches.