### PR TITLE
fix(ext/net): skip unsupported DNS records in ANY queries

### DIFF
--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -1172,7 +1172,10 @@ fn format_dns_records<'a>(
       } else {
         record_type
       };
-      let r = format_rdata(effective_type)(rec.data()).transpose();
+      let r = match format_rdata(effective_type)(rec.data()) {
+        Err(NetError::UnsupportedRecordType) if is_any => None,
+        result => result.transpose(),
+      };
       r.map(|maybe_data| {
         maybe_data.map(|data| DnsRecordWithTtl {
           data,
@@ -1333,6 +1336,7 @@ mod tests {
   use deno_core::RuntimeOptions;
   use deno_core::futures::FutureExt;
   use hickory_proto::rr::Name;
+  use hickory_proto::rr::rdata::NULL;
   use hickory_proto::rr::rdata::SOA;
   use hickory_proto::rr::rdata::a::A;
   use hickory_proto::rr::rdata::aaaa::AAAA;
@@ -1426,6 +1430,51 @@ mod tests {
         ttl: 60,
       }]
     );
+  }
+
+  #[test]
+  fn dns_records_any_skips_unsupported_record_types() {
+    let name = Name::parse("www.iana.org.", None).unwrap();
+    let cname = Record::from_rdata(
+      name.clone(),
+      60,
+      RData::CNAME(CNAME(Name::parse("target.example.", None).unwrap())),
+    );
+    let rrsig = Record::from_rdata(
+      name,
+      60,
+      RData::Unknown {
+        code: RecordType::RRSIG,
+        rdata: NULL::with(vec![1]),
+      },
+    );
+    let records = [cname, rrsig];
+
+    assert_eq!(
+      format_dns_records(&records, RecordType::ANY).unwrap(),
+      vec![DnsRecordWithTtl {
+        data: DnsRecordData::Cname("target.example.".to_string()),
+        record_type: Some("CNAME".to_string()),
+        ttl: 60,
+      }]
+    );
+  }
+
+  #[test]
+  fn dns_records_explicit_unsupported_type_still_errors() {
+    let rrsig = Record::from_rdata(
+      Name::new(),
+      60,
+      RData::Unknown {
+        code: RecordType::RRSIG,
+        rdata: NULL::with(vec![1]),
+      },
+    );
+
+    assert!(matches!(
+      format_dns_records(&[rrsig], RecordType::RRSIG),
+      Err(NetError::UnsupportedRecordType)
+    ));
   }
 
   #[test]


### PR DESCRIPTION
Fixes #36609.

`node:dns.resolveAny()` sends a real ANY query through `deno_net`. Valid ANY responses can contain record types that Node does not expose, such as RRSIG, alongside records that it does expose. `format_dns_records()` previously propagated `UnsupportedRecordType` from any one response record, which discarded the entire ANY answer and surfaced as `queryAny UNKNOWN`.

I reproduced this on the same host and resolver: Node v24.18.0 returned a CNAME for `www.iana.org`, while Deno 2.9.5 canary returned `UNKNOWN`. A direct Hickory 0.25.2 query (the version used here) returned the CNAME plus an RRSIG record, isolating the failure to Deno's record formatting boundary.

This change ignores `UnsupportedRecordType` only while formatting an ANY response, preserving representable records. Explicit unsupported record types continue to return `UnsupportedRecordType`.

Validation:
- regression test fails on the unfixed code with `UnsupportedRecordType` and passes with the patch
- explicit unsupported-record control remains an error
- `cargo test -p deno_net --features deno_core/v8 --lib`: 51 passed
- `cargo clippy -p deno_net --features deno_core/v8 --lib --tests -- -D warnings`: passed
- dprint check for `ext/net/ops.rs`: passed
- `git diff --check`: passed

AI assistance disclosure: ChatGPT was used for investigation, implementation, and validation of this change.