### PR TITLE
fix(npm): remove arrayref dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,12 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,7 +3003,6 @@ dependencies = [
 name = "deno_npm"
 version = "0.69.0"
 dependencies = [
- "arrayref",
  "async-trait",
  "bytemuck",
  "capacity_builder",

--- a/libs/npm/Cargo.toml
+++ b/libs/npm/Cargo.toml
@@ -18,7 +18,6 @@ simd = []
 tracing = []
 
 [dependencies]
-arrayref = "0.3.9"
 async-trait.workspace = true
 bytemuck = { workspace = true, features = ["aarch64_simd", "avx512_simd", "must_cast"] }
 capacity_builder.workspace = true

--- a/libs/npm/fast_registry_json.rs
+++ b/libs/npm/fast_registry_json.rs
@@ -62,8 +62,8 @@ impl<'a, const STEP_SIZE: usize> BufBlockReader<'a, STEP_SIZE> {
     self.idx < self.len_minus_step
   }
 
-  pub fn full_block(&self) -> &'a [u8] {
-    &self.buf[self.idx..]
+  pub fn full_block(&self) -> &'a [u8; STEP_SIZE] {
+    self.buf[self.idx..].first_chunk().unwrap()
   }
 
   pub fn get_remainder(&self, dest: &mut [u8]) -> usize {
@@ -769,8 +769,7 @@ impl<'a> Tokenizer<'a> {
   pub fn tokenize(mut self) -> Result<Vec<Token>, Error> {
     while self.block_reader.has_full_block() {
       let block = self.block_reader.full_block();
-      let block =
-        simd::Simd8x64::<u8>::load(arrayref::array_ref![block, 0, 64]);
+      let block = simd::Simd8x64::<u8>::load(block);
       let (strings, characters) = self.scanner.next(&block);
       self.block_reader.advance();
       self.process_json_block(strings, characters);
@@ -779,8 +778,7 @@ impl<'a> Tokenizer<'a> {
 
     let mut remainder_buf = [0; 64];
     let _pad = self.block_reader.get_remainder(&mut remainder_buf);
-    let block =
-      simd::Simd8x64::<u8>::load(arrayref::array_ref![&remainder_buf, 0, 64]);
+    let block = simd::Simd8x64::<u8>::load(&remainder_buf);
     let (strings, characters) = self.scanner.next(&block);
     self.block_reader.advance();
     self.process_json_block(strings, characters);
@@ -1357,7 +1355,7 @@ pub fn pluck_packument_index(input: &str) -> Result<PackumentIndex<'_>, Error> {
 
   while block_reader.has_full_block() {
     let block = block_reader.full_block();
-    let block = simd::Simd8x64::<u8>::load(arrayref::array_ref![block, 0, 64]);
+    let block = simd::Simd8x64::<u8>::load(block);
     let (strings, characters) = scanner.next(&block);
     block_reader.advance();
     let ops = characters.op() & !strings.in_string;
@@ -1373,8 +1371,7 @@ pub fn pluck_packument_index(input: &str) -> Result<PackumentIndex<'_>, Error> {
 
   let mut remainder_buf = [0; 64];
   let _pad = block_reader.get_remainder(&mut remainder_buf);
-  let block =
-    simd::Simd8x64::<u8>::load(arrayref::array_ref![&remainder_buf, 0, 64]);
+  let block = simd::Simd8x64::<u8>::load(&remainder_buf);
   let (strings, characters) = scanner.next(&block);
   block_reader.advance();
   let ops = characters.op() & !strings.in_string;

--- a/libs/npm/fast_registry_json/simd/width_128.rs
+++ b/libs/npm/fast_registry_json/simd/width_128.rs
@@ -15,8 +15,6 @@ use std::ops::BitOr;
 use std::ops::BitXor;
 use std::ops::Not;
 
-use arrayref::array_refs;
-use arrayref::mut_array_refs;
 use wide::u8x16;
 
 use crate::fast_registry_json::pick;
@@ -191,7 +189,7 @@ impl<T> Simd8x64<T> {
 impl Simd8x64<u8> {
   #[inline(always)]
   pub fn store(&self, buf: &mut [u8; 64]) {
-    let (a, b, c, d) = mut_array_refs![buf, 16, 16, 16, 16];
+    let [a, b, c, d] = bytemuck::must_cast_mut::<_, [[u8; 16]; 4]>(buf);
     self.chunks[0].store(a);
     self.chunks[1].store(b);
     self.chunks[2].store(c);
@@ -200,7 +198,7 @@ impl Simd8x64<u8> {
 
   #[inline(always)]
   pub fn load(buf: &[u8; 64]) -> Self {
-    let (a, b, c, d) = array_refs![buf, 16, 16, 16, 16];
+    let [a, b, c, d] = bytemuck::must_cast_ref::<_, [[u8; 16]; 4]>(buf);
     Self {
       chunks: [a.into(), b.into(), c.into(), d.into()],
     }


### PR DESCRIPTION
<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

## Why

`arrayref` crate was compromised in a supply chain attack.
The issue now appears to be resolved, but since the dependency handles operations that are fully supported by the standard library in modern Rust, and I recommend removing it to prevent a recurrence.

ref: https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/

## Disclosure

This PR is created using Codex (gpt-5.6-sol).