### PR TITLE
fix(node): correct process.versions.unicode to match the regexp engine

### DIFF
--- a/ext/node/polyfills/_process/process.ts
+++ b/ext/node/polyfills/_process/process.ts
@@ -253,7 +253,7 @@ const versions = {
   cldr: "48.0",
   icu: "78.3",
   tz: "2026b",
-  unicode: "17.0",
+  unicode: "16.0",
   ngtcp2: "",
   nghttp3: "",
   sqlite: "3.53.1",

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -132,6 +132,24 @@ Deno.test({
 });
 
 Deno.test({
+  name: "process.versions.unicode matches RegExp engine capability",
+  fn() {
+    const versionMatch = process.versions.unicode.match(/^(\d+)/);
+    assert(versionMatch !== null);
+    const majorVersion = parseInt(versionMatch[1], 10);
+    
+    // U+323B0 is CJK Unified Ideographs Extension J, added in Unicode 17.0
+    const isUnicode17Supported = /\p{Letter}/u.test("\u{323B0}");
+    
+    if (majorVersion >= 17) {
+      assert(isUnicode17Supported, "process.versions.unicode claims >= 17.0, but RegExp engine failed to identify U+323B0 as a Letter");
+    } else {
+      assert(!isUnicode17Supported, "RegExp engine supports Unicode 17.0, but process.versions.unicode claims < 17.0");
+    }
+  }
+});
+
+Deno.test({
   name: "process.platform",
   fn() {
     const expectedOs = Deno.build.os == "windows" ? "win32" : Deno.build.os;


### PR DESCRIPTION
`process.versions.unicode` reports 17.0, but the regexp property tables come from the bundled V8, which is still classifying against Unicode 16.0. Code points that landed in Unicode 17.0, like CJK Extension J (U+323B0) or Beria Erfe (U+16EAC), fail `\p{L}` even though the runtime advertises a version it doesn't actually have.

The reporter put it plainly: either ship the 17.0 tables or correct the version. The tables are upstream V8 work (a V8 roll, a `rusty_v8` release, then a bump here), so the change that's correct today is to make the report match the engine and say 16.0.

That's the one-line change in `ext/node/polyfills/_process/process.ts`. The test guards against the drift coming back: it checks the reported major version is consistent with whether the engine can classify a Unicode 17.0 code point, so neither side can get ahead of the other without failing.

I couldn't compile Deno here (building V8 doesn't fit on this machine), so the test is written to run in CI rather than claimed as locally verified.

Closes #36628