### PR TITLE
fix(ext/http): preserve HTTP/1.1 keep-alive when handler fully consumed request body

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -4732,7 +4732,10 @@ async fn serve_http11_raw(
         if let Some(state) = state {
           let mut local_conn = state.conn;
           let mut local_scratch = state.scratch;
-          let keep_alive = keep_alive && !parsed.has_body;
+          let body_consumed = request_body_for_cancel
+            .as_ref()
+            .is_some_and(|b| !b.reader_owns_connection());
+          let keep_alive = keep_alive && (!parsed.has_body || body_consumed);
           match body {
             RawResponseBody::Flat(body) => {
               write_h1_flat_response(
@@ -4857,7 +4860,10 @@ async fn serve_http11_raw(
       }
       match body {
         RawResponseBody::Flat(body) => {
-          let keep_alive = keep_alive && !parsed.has_body;
+          let body_consumed = request_body_for_cancel
+            .as_ref()
+            .is_some_and(|b| !b.reader_owns_connection());
+          let keep_alive = keep_alive && (!parsed.has_body || body_consumed);
           write_h1_flat_response_shared(
             body_conn.clone(),
             parsed.version,

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -4877,7 +4877,11 @@ async fn serve_http11_raw(
         RawResponseBody::Stream(body) => {
           let response_context = RawH1ResponseContext {
             version: response_context.version,
-            keep_alive: response_context.keep_alive && !parsed.has_body,
+            keep_alive: response_context.keep_alive
+              && (!parsed.has_body
+                || request_body_for_cancel
+                  .as_ref()
+                  .is_some_and(|b| !b.reader_owns_connection())),
             head: response_context.head,
           };
           write_h1_stream_response_shared(


### PR DESCRIPTION
## Description

Fixes #36657

**Root cause:** `keep_alive = keep_alive && !parsed.has_body` used the `parsed.has_body` flag (a static fact set during HTTP header parsing) to decide whether to keep the connection alive. Once the handler read the body to EOF via `req.text()` / `req.json()`, `parsed.has_body` remained `true`, so keep-alive was always disabled for requests with bodies larger than the initial read buffer (~500 B).

**Fix:** Also check whether the request body reader has finished (`!reader_owns_connection()`). If the reader is done, the body was fully consumed and the connection can be reused.

**Affected paths:**
- Direct response path (line 4735)
- Shared flat response path (line 4860)
- Shared stream response path (line 4874)

## Testing

The issue includes a reproduction script that sends pipelined requests over one TCP connection and checks for `Connection: close` on the response. With this fix, keep-alive is preserved for both small and large request bodies.
