### PR TITLE
chore: bump v8 crate to 152.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11218,9 +11218,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "150.4.0"
+version = "152.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a978ff11f15b24e5c05a7123cf2b68f41e763546699781a924ef4e2cf43a49"
+checksum = "a10fe1a92da5c32c7c7f838ce36c0ccfcfd5edf0865b58bdde820aa64cea9888"
 dependencies = [
  "bindgen 0.72.1",
  "bitflags 2.9.3",

--- a/ext/node/ops/handle_wrap.rs
+++ b/ext/node/ops/handle_wrap.rs
@@ -375,7 +375,7 @@ impl HandleWrap {
 
       if let Some(cb) = cb {
         let recv = v8::undefined(scope);
-        cb.open(scope).call(scope, recv.into(), &[]);
+        v8::Local::new(scope, &cb).call(scope, recv.into(), &[]);
       }
     };
 

--- a/ext/node/ops/vm.rs
+++ b/ext/node/ops/vm.rs
@@ -353,7 +353,12 @@ impl ContextifyScript {
 }
 
 pub struct ContextifyContext {
-  microtask_queue: *mut v8::MicrotaskQueue,
+  /// Owns the queue for contexts created with `microtaskMode: "afterEvaluate"`,
+  /// and is `None` otherwise (the context then uses the isolate's default
+  /// queue). Dropping the handle releases a root into the isolate's heap; the
+  /// associated context keeps the queue itself alive for as long as it needs
+  /// it, so there is nothing else to tear down by hand.
+  microtask_queue: Option<v8::OwnedMicrotaskQueue>,
   context: v8::TracedReference<v8::Context>,
   sandbox: v8::TracedReference<v8::Object>,
   allow_code_gen_wasm: bool,
@@ -368,17 +373,6 @@ unsafe impl deno_core::GarbageCollected for ContextifyContext {
 
   fn get_name(&self) -> &'static std::ffi::CStr {
     c"ContextifyContext"
-  }
-}
-
-impl Drop for ContextifyContext {
-  fn drop(&mut self) {
-    if !self.microtask_queue.is_null() {
-      // SAFETY: If this isn't null, it is a valid MicrotaskQueue.
-      unsafe {
-        std::ptr::drop_in_place(self.microtask_queue);
-      }
-    }
   }
 }
 
@@ -470,17 +464,14 @@ impl ContextifyContext {
 
     let tmp = init_global_template(scope, ContextInitMode::UseSnapshot);
 
-    let microtask_queue = if own_microtask_queue {
-      new_leaked_microtask_queue(scope, v8::MicrotasksPolicy::Explicit)
-    } else {
-      std::ptr::null_mut()
-    };
+    let microtask_queue = own_microtask_queue
+      .then(|| v8::MicrotaskQueue::new(scope, v8::MicrotasksPolicy::Explicit));
 
     let context = create_v8_context(
       scope,
       tmp,
       ContextInitMode::UseSnapshot,
-      microtask_queue,
+      microtask_queue_ptr(&microtask_queue),
     );
 
     let context_state = main_context.get_aligned_pointer_from_embedder_data(
@@ -566,20 +557,18 @@ impl ContextifyContext {
   ) -> v8::Local<'s, v8::Object> {
     let main_context = scope.get_current_context();
 
-    let microtask_queue = if own_microtask_queue {
-      new_leaked_microtask_queue(scope, v8::MicrotasksPolicy::Explicit)
-    } else {
-      std::ptr::null_mut()
-    };
+    let microtask_queue = own_microtask_queue
+      .then(|| v8::MicrotaskQueue::new(scope, v8::MicrotasksPolicy::Explicit));
 
     // Create a vanilla V8 context without global template (no interceptors)
     let context = {
+      let queue_ptr = microtask_queue_ptr(&microtask_queue);
       let esc_scope = std::pin::pin!(v8::EscapableHandleScope::new(scope));
       let esc_scope = &mut esc_scope.init();
       let ctx = v8::Context::new(
         esc_scope,
         v8::ContextOptions {
-          microtask_queue: Some(microtask_queue),
+          microtask_queue: Some(queue_ptr),
           ..Default::default()
         },
       );
@@ -714,12 +703,14 @@ impl ContextifyContext {
   }
 
   fn microtask_queue(&self) -> Option<&v8::MicrotaskQueue> {
-    if self.microtask_queue.is_null() {
-      None
-    } else {
-      // SAFETY: If this isn't null, it is a valid MicrotaskQueue.
-      Some(unsafe { &*self.microtask_queue })
-    }
+    self.microtask_queue.as_deref()
+  }
+
+  /// A non-owning alias of the queue, for the callers that still need to hand
+  /// it to V8 as a raw pointer. Null when this context uses the isolate's
+  /// default queue.
+  fn microtask_queue_ptr(&self) -> *mut v8::MicrotaskQueue {
+    microtask_queue_ptr(&self.microtask_queue)
   }
 
   fn get<'a, 'c>(
@@ -748,21 +739,19 @@ pub enum ContextInitMode {
   UseSnapshot,
 }
 
-/// Creates a microtask queue and hands ownership of it to the caller as a raw
-/// pointer, for passing to `v8::ContextOptions::microtask_queue`.
+/// A non-owning alias of `handle`'s queue, for passing to
+/// `v8::ContextOptions::microtask_queue`, which still takes a raw pointer.
+/// Null when there is no handle, which tells V8 to use the isolate's default
+/// queue.
 ///
-/// The queue has to outlive the context that uses it, and V8 gives us no hook
-/// for when that context goes away, so the handle is leaked. This preserves the
-/// behaviour of `UniqueRef::into_raw`, which earlier versions of the `v8` crate
-/// returned from `MicrotaskQueue::new`.
-fn new_leaked_microtask_queue(
-  scope: &mut v8::Isolate,
-  policy: v8::MicrotasksPolicy,
+/// The queue is only borrowed here: whoever holds the [`v8::OwnedMicrotaskQueue`]
+/// keeps it alive, and must outlive every context created with the pointer.
+fn microtask_queue_ptr(
+  handle: &Option<v8::OwnedMicrotaskQueue>,
 ) -> *mut v8::MicrotaskQueue {
-  let handle = v8::MicrotaskQueue::new(scope, policy);
-  let ptr = &*handle as *const v8::MicrotaskQueue as *mut v8::MicrotaskQueue;
-  std::mem::forget(handle);
-  ptr
+  handle.as_ref().map_or(std::ptr::null_mut(), |queue| {
+    &**queue as *const v8::MicrotaskQueue as *mut v8::MicrotaskQueue
+  })
 }
 
 pub fn create_v8_context<'a>(
@@ -1652,13 +1641,11 @@ pub fn op_vm_script_create_cached_data<'s>(
 pub struct ContextifyModule {
   module: v8::TracedReference<v8::Module>,
   context: v8::TracedReference<v8::Context>,
-  // SAFETY invariant: `microtask_queue` aliases the `MicrotaskQueue` owned
-  // by the `ContextifyContext` of `context`. The queue is a separate C++
-  // allocation, but `ContextifyContext` keeps it alive for as long as the
-  // context is reachable, and the `TracedReference<v8::Context>` above
-  // keeps the context reachable for this module's lifetime. Dereferencing
-  // is therefore safe as long as no code path drops the `ContextifyContext`
-  // while a `ContextifyModule` is still live.
+  // SAFETY invariant: `microtask_queue` aliases the queue whose handle is held
+  // by the `ContextifyContext` of `context`. The `TracedReference<v8::Context>`
+  // above keeps that context reachable for this module's lifetime, and a
+  // context keeps its queue alive independently of the handle, so the alias
+  // stays valid even if the owning `ContextifyContext` is collected first.
   microtask_queue: *mut v8::MicrotaskQueue,
   identifier: String,
   /// Map of import specifier -> resolved ContextifyModule wrapper object.
@@ -1862,7 +1849,7 @@ fn resolve_module_context<'s>(
   if let Some(context_object) = context_object {
     let contextify =
       ContextifyContext::from_sandbox_obj(scope, context_object)?;
-    Some((contextify.context(scope), contextify.microtask_queue))
+    Some((contextify.context(scope), contextify.microtask_queue_ptr()))
   } else {
     Some((scope.get_current_context(), std::ptr::null_mut()))
   }

--- a/ext/node/ops/vm.rs
+++ b/ext/node/ops/vm.rs
@@ -1015,7 +1015,7 @@ fn property_setter<'s>(
   key: v8::Local<'s, v8::Name>,
   value: v8::Local<'s, v8::Value>,
   args: v8::PropertyCallbackArguments<'s>,
-  _rv: v8::ReturnValue<v8::Boolean>,
+  _rv: v8::PropertyInterceptorReturnValue<'_>,
 ) -> v8::Intercepted {
   let Some(ctx) = ContextifyContext::get(scope, args.holder()) else {
     return v8::Intercepted::kNo;
@@ -1131,7 +1131,7 @@ fn property_definer<'s>(
   key: v8::Local<'s, v8::Name>,
   desc: &v8::PropertyDescriptor,
   args: v8::PropertyCallbackArguments<'s>,
-  _: v8::ReturnValue<v8::Boolean>,
+  _: v8::PropertyInterceptorReturnValue<'_>,
 ) -> v8::Intercepted {
   let Some(ctx) = ContextifyContext::get(scope, args.holder()) else {
     return v8::Intercepted::kNo;
@@ -1340,7 +1340,7 @@ fn indexed_property_setter<'s>(
   index: u32,
   value: v8::Local<'s, v8::Value>,
   args: v8::PropertyCallbackArguments<'s>,
-  rv: v8::ReturnValue<v8::Boolean>,
+  rv: v8::PropertyInterceptorReturnValue<'_>,
 ) -> v8::Intercepted {
   let key = uint32_to_name(scope, index);
   property_setter(scope, key, value, args, rv)
@@ -1361,7 +1361,7 @@ fn indexed_property_definer<'s>(
   index: u32,
   descriptor: &v8::PropertyDescriptor,
   args: v8::PropertyCallbackArguments<'s>,
-  rv: v8::ReturnValue<v8::Boolean>,
+  rv: v8::PropertyInterceptorReturnValue<'_>,
 ) -> v8::Intercepted {
   let key = uint32_to_name(scope, index);
   property_definer(scope, key, descriptor, args, rv)

--- a/ext/node/ops/vm.rs
+++ b/ext/node/ops/vm.rs
@@ -471,7 +471,7 @@ impl ContextifyContext {
     let tmp = init_global_template(scope, ContextInitMode::UseSnapshot);
 
     let microtask_queue = if own_microtask_queue {
-      v8::MicrotaskQueue::new(scope, v8::MicrotasksPolicy::Explicit).into_raw()
+      new_leaked_microtask_queue(scope, v8::MicrotasksPolicy::Explicit)
     } else {
       std::ptr::null_mut()
     };
@@ -567,7 +567,7 @@ impl ContextifyContext {
     let main_context = scope.get_current_context();
 
     let microtask_queue = if own_microtask_queue {
-      v8::MicrotaskQueue::new(scope, v8::MicrotasksPolicy::Explicit).into_raw()
+      new_leaked_microtask_queue(scope, v8::MicrotasksPolicy::Explicit)
     } else {
       std::ptr::null_mut()
     };
@@ -746,6 +746,23 @@ pub const VM_CONTEXT_INDEX: usize = 0;
 pub enum ContextInitMode {
   ForSnapshot,
   UseSnapshot,
+}
+
+/// Creates a microtask queue and hands ownership of it to the caller as a raw
+/// pointer, for passing to `v8::ContextOptions::microtask_queue`.
+///
+/// The queue has to outlive the context that uses it, and V8 gives us no hook
+/// for when that context goes away, so the handle is leaked. This preserves the
+/// behaviour of `UniqueRef::into_raw`, which earlier versions of the `v8` crate
+/// returned from `MicrotaskQueue::new`.
+fn new_leaked_microtask_queue(
+  scope: &mut v8::Isolate,
+  policy: v8::MicrotasksPolicy,
+) -> *mut v8::MicrotaskQueue {
+  let handle = v8::MicrotaskQueue::new(scope, policy);
+  let ptr = &*handle as *const v8::MicrotaskQueue as *mut v8::MicrotaskQueue;
+  std::mem::forget(handle);
+  ptr
 }
 
 pub fn create_v8_context<'a>(
@@ -998,7 +1015,7 @@ fn property_setter<'s>(
   key: v8::Local<'s, v8::Name>,
   value: v8::Local<'s, v8::Value>,
   args: v8::PropertyCallbackArguments<'s>,
-  _rv: v8::ReturnValue<()>,
+  _rv: v8::ReturnValue<v8::Boolean>,
 ) -> v8::Intercepted {
   let Some(ctx) = ContextifyContext::get(scope, args.holder()) else {
     return v8::Intercepted::kNo;
@@ -1114,7 +1131,7 @@ fn property_definer<'s>(
   key: v8::Local<'s, v8::Name>,
   desc: &v8::PropertyDescriptor,
   args: v8::PropertyCallbackArguments<'s>,
-  _: v8::ReturnValue<()>,
+  _: v8::ReturnValue<v8::Boolean>,
 ) -> v8::Intercepted {
   let Some(ctx) = ContextifyContext::get(scope, args.holder()) else {
     return v8::Intercepted::kNo;
@@ -1323,7 +1340,7 @@ fn indexed_property_setter<'s>(
   index: u32,
   value: v8::Local<'s, v8::Value>,
   args: v8::PropertyCallbackArguments<'s>,
-  rv: v8::ReturnValue<()>,
+  rv: v8::ReturnValue<v8::Boolean>,
 ) -> v8::Intercepted {
   let key = uint32_to_name(scope, index);
   property_setter(scope, key, value, args, rv)
@@ -1344,7 +1361,7 @@ fn indexed_property_definer<'s>(
   index: u32,
   descriptor: &v8::PropertyDescriptor,
   args: v8::PropertyCallbackArguments<'s>,
-  rv: v8::ReturnValue<()>,
+  rv: v8::ReturnValue<v8::Boolean>,
 ) -> v8::Intercepted {
   let key = uint32_to_name(scope, index);
   property_definer(scope, key, descriptor, args, rv)

--- a/ext/webgpu/buffer.rs
+++ b/ext/webgpu/buffer.rs
@@ -79,7 +79,7 @@ impl Drop for GPUBuffer {
 impl GPUBuffer {
   fn detach_mapped_js_buffers(&self, scope: &mut v8::PinScope<'_, '_>) {
     for mapped in self.mapped_js_buffers.replace(vec![]) {
-      let ab = mapped.buffer.open(scope);
+      let ab = v8::Local::new(scope, &mapped.buffer);
       ab.detach(None);
     }
   }
@@ -90,7 +90,7 @@ impl GPUBuffer {
   ) -> Result<(), BufferError> {
     let mut first_error = None;
     for mapped in self.mapped_js_buffers.replace(vec![]) {
-      let ab = mapped.buffer.open(scope);
+      let ab = v8::Local::new(scope, &mapped.buffer);
       // A zero `byte_length` means the range is already detached, which can
       // only happen if the caller detached it themselves (e.g. by transferring
       // it to a worker). There is nothing left to read from, so the range is

--- a/ext/webgpu/error.rs
+++ b/ext/webgpu/error.rs
@@ -154,7 +154,7 @@ impl DeviceErrorHandler {
           .unwrap();
 
         let recv = v8::Local::new(scope, device);
-        func.open(scope).call(scope, recv, &[event.into()]);
+        v8::Local::new(scope, &func).call(scope, recv, &[event.into()]);
       });
     }
   }

--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -403,7 +403,7 @@ pub fn to_v8_error<'s, 'i>(
     .borrow()
     .clone()
     .expect("Custom error builder must be set");
-  let cb = cb.open(tc_scope);
+  let cb = v8::Local::new(tc_scope, &cb);
   let this = v8::undefined(tc_scope).into();
   let class = v8::String::new(tc_scope, &error.get_class()).unwrap();
   let message = v8::String::new(tc_scope, &error.get_message()).unwrap();
@@ -1040,7 +1040,7 @@ impl JsError {
     let js_format_exception_cb =
       exception_state.js_format_exception_cb.borrow().clone();
     if let Some(format_exception_cb) = js_format_exception_cb {
-      let format_exception_cb = format_exception_cb.open(scope);
+      let format_exception_cb = v8::Local::new(scope, &format_exception_cb);
       let this = v8::undefined(scope).into();
       let formatted = format_exception_cb.call(scope, this, &[exception]);
       if let Some(formatted) = formatted

--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -1818,7 +1818,7 @@ impl ModuleMap {
         }
 
         // No pending TLA, safe to resolve immediately
-        let resolver = resolver_handle.open(scope);
+        let resolver = v8::Local::new(scope, &resolver_handle);
         let module_namespace = module.get_module_namespace();
         resolver.resolve(scope, module_namespace).unwrap();
 
@@ -1835,7 +1835,7 @@ impl ModuleMap {
     {
       match self.lazy_load_esm_module(scope, module_specifier.as_str()) {
         Ok(module_ns) => {
-          let resolver = resolver_handle.open(scope);
+          let resolver = v8::Local::new(scope, &resolver_handle);
           let module_ns_local = v8::Local::new(scope, module_ns);
           resolver.resolve(scope, module_ns_local).unwrap();
           return false;
@@ -1843,7 +1843,7 @@ impl ModuleMap {
         Err(e) => {
           let exception = e.to_v8_error(scope);
           let exception_local = v8::Local::new(scope, exception);
-          let resolver = resolver_handle.open(scope);
+          let resolver = v8::Local::new(scope, &resolver_handle);
           resolver.reject(scope, exception_local).unwrap();
           return false;
         }
@@ -1866,7 +1866,7 @@ impl ModuleMap {
         .lazy_load_synthetic_esm_module(scope, module_specifier.as_str())
       {
         Ok(module_ns) => {
-          let resolver = resolver_handle.open(scope);
+          let resolver = v8::Local::new(scope, &resolver_handle);
           let module_ns_local = v8::Local::new(scope, module_ns);
           resolver.resolve(scope, module_ns_local).unwrap();
           return false;
@@ -1874,7 +1874,7 @@ impl ModuleMap {
         Err(e) => {
           let exception = e.to_v8_error(scope);
           let exception_local = v8::Local::new(scope, exception);
-          let resolver = resolver_handle.open(scope);
+          let resolver = v8::Local::new(scope, &resolver_handle);
           resolver.reject(scope, exception_local).unwrap();
           return false;
         }
@@ -2219,7 +2219,7 @@ impl ModuleMap {
     let module_handle = self.get_handle(id).expect("ModuleInfo not found");
 
     let status = {
-      let module = module_handle.open(scope);
+      let module = v8::Local::new(scope, &module_handle);
       module.get_status()
     };
 
@@ -2315,7 +2315,7 @@ impl ModuleMap {
     let mut resolved_any = false;
     let mut still_pending = vec![];
     for eval in pending {
-      let promise = eval.promise.open(scope);
+      let promise = v8::Local::new(scope, &eval.promise);
       match promise.state() {
         v8::PromiseState::Pending => {
           still_pending.push(eval);
@@ -2350,7 +2350,7 @@ impl ModuleMap {
       let module_namespace = module.get_module_namespace();
 
       for resolver_handle in waiters {
-        let resolver = resolver_handle.open(scope);
+        let resolver = v8::Local::new(scope, &resolver_handle);
         resolver.resolve(scope, module_namespace).unwrap();
       }
       if !JsRealm::state_from_scope(scope).has_tick_scheduled() {
@@ -2370,7 +2370,7 @@ impl ModuleMap {
     if let Some(waiters) = waiters {
       let exception = v8::Local::new(scope, exception);
       for resolver_handle in waiters {
-        let resolver = resolver_handle.open(scope);
+        let resolver = v8::Local::new(scope, &resolver_handle);
         resolver.reject(scope, exception).unwrap();
       }
       if !JsRealm::state_from_scope(scope).has_tick_scheduled() {
@@ -2391,7 +2391,7 @@ impl ModuleMap {
       .remove(&id)
       .expect("Invalid dynamic import id")
       .resolver;
-    let resolver = resolver_handle.open(scope);
+    let resolver = v8::Local::new(scope, &resolver_handle);
 
     let exception = v8::Local::new(scope, exception);
     resolver.reject(scope, exception).unwrap();
@@ -2412,7 +2412,7 @@ impl ModuleMap {
       .remove(&id)
       .expect("Invalid dynamic import id")
       .resolver;
-    let resolver = resolver_handle.open(scope);
+    let resolver = v8::Local::new(scope, &resolver_handle);
 
     let module = self
       .data
@@ -2636,7 +2636,7 @@ impl ModuleMap {
                     .remove(&dyn_import_id)
                     .expect("Invalid dynamic import id")
                     .resolver;
-                  let resolver = resolver_handle.open(tc_scope);
+                  let resolver = v8::Local::new(tc_scope, &resolver_handle);
                   resolver.resolve(tc_scope, module_namespace).unwrap();
                   tc_scope.perform_microtask_checkpoint();
                 }
@@ -2684,7 +2684,7 @@ impl ModuleMap {
                 let source = data.sources.get(&key).expect("Source had to have been inserted successfully, or recursion would error.");
                 v8::Local::new(scope, source).into()
               };
-              let resolver = state.resolver.open(scope);
+              let resolver = v8::Local::new(scope, &state.resolver);
               resolver.resolve(scope, source).unwrap();
             }
           }
@@ -2733,7 +2733,7 @@ impl ModuleMap {
       .get_handle(module_id)
       .expect("ModuleInfo not found");
 
-    let module = module_handle.open(scope);
+    let module = v8::Local::new(scope, &module_handle);
 
     if module.get_status() == v8::ModuleStatus::Errored {
       let exception = module.get_exception();

--- a/libs/core/ops_builtin_v8.rs
+++ b/libs/core/ops_builtin_v8.rs
@@ -1407,9 +1407,11 @@ pub fn wasm_streaming_callback<'a>(
 
   let undefined = v8::undefined(scope);
   let rid = serde_v8::to_v8(scope, streaming_rid).unwrap();
-  cb_handle
-    .open(scope)
-    .call(scope, undefined.into(), &[arg, rid]);
+  v8::Local::new(scope, &cb_handle).call(
+    scope,
+    undefined.into(),
+    &[arg, rid],
+  );
 }
 
 // This op is re-entrant as it makes a v8 call. It also cannot be fast because

--- a/libs/core/ops_builtin_v8.rs
+++ b/libs/core/ops_builtin_v8.rs
@@ -1407,11 +1407,7 @@ pub fn wasm_streaming_callback<'a>(
 
   let undefined = v8::undefined(scope);
   let rid = serde_v8::to_v8(scope, streaming_rid).unwrap();
-  v8::Local::new(scope, &cb_handle).call(
-    scope,
-    undefined.into(),
-    &[arg, rid],
-  );
+  v8::Local::new(scope, &cb_handle).call(scope, undefined.into(), &[arg, rid]);
 }
 
 // This op is re-entrant as it makes a v8 call. It also cannot be fast because

--- a/libs/core/runtime/jsrealm.rs
+++ b/libs/core/runtime/jsrealm.rs
@@ -356,7 +356,7 @@ impl JsRealmInner {
     std::mem::take(&mut *state.js_wasm_streaming_cb.borrow_mut());
 
     {
-      let ctx = self.context().open(scope);
+      let ctx = v8::Local::new(scope, self.context());
       // SAFETY: Clear all embedder data
       unsafe {
         let ctx_state =

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2091,7 +2091,7 @@ impl JsRuntime {
   ) -> impl Future<Output = Result<v8::Global<v8::Value>, Box<JsError>>> + use<>
   {
     v8::tc_scope!(let scope, scope);
-    let cb = function.open(scope);
+    let cb = v8::Local::new(scope, function);
     let this = v8::undefined(scope).into();
     let promise = if args.is_empty() {
       cb.call(scope, this, &[])
@@ -3402,7 +3402,7 @@ impl JsRuntime {
     let run_immediate_callbacks_cb =
       context_state.run_immediate_callbacks_cb.borrow();
     let run_immediate_callbacks_cb =
-      run_immediate_callbacks_cb.as_ref().unwrap().open(tc_scope);
+      v8::Local::new(tc_scope, run_immediate_callbacks_cb.as_ref().unwrap());
 
     run_immediate_callbacks_cb.call(tc_scope, undefined, &[]);
 
@@ -3472,7 +3472,7 @@ impl JsRuntime {
     v8::tc_scope!(let tc_scope, scope);
 
     let process_timers_cb = context_state.js_process_timers_cb.borrow();
-    let process_timers_fn = process_timers_cb.as_ref().unwrap().open(tc_scope);
+    let process_timers_fn = v8::Local::new(tc_scope, process_timers_cb.as_ref().unwrap());
     let now_val = v8::Number::new(tc_scope, now);
     let undefined: v8::Local<v8::Value> = v8::undefined(tc_scope).into();
 
@@ -3583,7 +3583,7 @@ impl JsRuntime {
     v8::tc_scope!(let tc_scope, scope);
 
     let tick_cb = context_state.js_event_loop_tick_cb.borrow();
-    let tick_fn = tick_cb.as_ref().unwrap().open(tc_scope);
+    let tick_fn = v8::Local::new(tc_scope, tick_cb.as_ref().unwrap());
     tick_fn.call(tc_scope, undefined, args.as_slice());
 
     if let Some(exception) = tc_scope.exception() {
@@ -3615,7 +3615,7 @@ impl JsRuntime {
         .borrow()
         .as_ref()
       {
-        let function = handler.open(scope);
+        let function = v8::Local::new(scope, handler);
         let args = [
           v8::Local::new(scope, promise).into(),
           v8::Local::new(scope, result),
@@ -3661,7 +3661,7 @@ impl JsRuntime {
 
     let handle_rejections_cb = context_state.js_handle_rejections_cb.borrow();
     let handle_rejections_fn =
-      handle_rejections_cb.as_ref().unwrap().open(tc_scope);
+      v8::Local::new(tc_scope, handle_rejections_cb.as_ref().unwrap());
     let undefined: v8::Local<v8::Value> = v8::undefined(tc_scope).into();
     handle_rejections_fn.call(tc_scope, undefined, args.as_slice());
 
@@ -3708,7 +3708,7 @@ impl JsRuntime {
     v8::tc_scope!(let tc_scope, scope);
 
     let drain_cb = context_state.js_drain_next_tick_and_macrotasks_cb.borrow();
-    let drain_fn = drain_cb.as_ref().unwrap().open(tc_scope);
+    let drain_fn = v8::Local::new(tc_scope, drain_cb.as_ref().unwrap());
     drain_fn.call(tc_scope, undefined, &[]);
 
     if let Some(exception) = tc_scope.exception() {

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -3472,7 +3472,8 @@ impl JsRuntime {
     v8::tc_scope!(let tc_scope, scope);
 
     let process_timers_cb = context_state.js_process_timers_cb.borrow();
-    let process_timers_fn = v8::Local::new(tc_scope, process_timers_cb.as_ref().unwrap());
+    let process_timers_fn =
+      v8::Local::new(tc_scope, process_timers_cb.as_ref().unwrap());
     let now_val = v8::Number::new(tc_scope, now);
     let undefined: v8::Local<v8::Value> = v8::undefined(tc_scope).into();
 

--- a/libs/core/runtime/setup.rs
+++ b/libs/core/runtime/setup.rs
@@ -164,7 +164,6 @@ fn v8_init(
   }
 
   let base_flags = concat!(
-    " --no-validate-asm",
     " --turbo_fast_api_calls",
     " --harmony-temporal",
     " --js-float16array",

--- a/libs/core/runtime/tests/misc.rs
+++ b/libs/core/runtime/tests/misc.rs
@@ -47,13 +47,13 @@ fn test_execute_script_return_value() {
   let value_global = runtime.execute_script("a.js", "a = 1 + 2").unwrap();
   {
     deno_core::scope!(scope, runtime);
-    let value = value_global.open(scope);
+    let value = v8::Local::new(scope, &value_global);
     assert_eq!(value.integer_value(scope).unwrap(), 3);
   }
   let value_global = runtime.execute_script("b.js", "b = 'foobar'").unwrap();
   {
     deno_core::scope!(scope, runtime);
-    let value = value_global.open(scope);
+    let value = v8::Local::new(scope, &value_global);
     assert!(value.is_string());
     assert_eq!(
       value.to_string(scope).unwrap().to_rust_string_lossy(scope),
@@ -280,13 +280,13 @@ async fn test_resolve_value_generic(
     }
     Ok(Some(v)) => {
       let value = result_global.unwrap();
-      let value = value.open(scope);
+      let value = v8::Local::new(scope, &value);
       assert_eq!(value.integer_value(scope).unwrap(), v as i64);
     }
     Err(e) => {
       let Err(err) = result_global else {
         let value = result_global.unwrap();
-        let value = value.open(scope);
+        let value = v8::Local::new(scope, &value);
         panic!(
           "Expected an error, got {}",
           value.to_rust_string_lossy(scope)
@@ -418,7 +418,7 @@ async fn wasm_streaming_op_invocation_in_import() {
   #[allow(deprecated, reason = "test code")]
   let value = runtime.resolve_value(promise).await.unwrap();
   deno_core::scope!(scope, runtime);
-  let val = value.open(scope);
+  let val = v8::Local::new(scope, &value);
   assert!(val.is_object());
 }
 
@@ -564,7 +564,7 @@ fn test_heap_limits() {
     .unwrap();
   let _guard = tokio.enter();
   let create_params =
-    v8::Isolate::create_params().heap_limits(0, 5 * 1024 * 1024);
+    v8::Isolate::create_params().heap_limits(0, 20 * 1024 * 1024);
   let mut runtime = JsRuntime::new(RuntimeOptions {
     create_params: Some(create_params),
     ..Default::default()
@@ -613,7 +613,7 @@ fn test_heap_limit_cb_multiple() {
     .unwrap();
   let _guard = tokio.enter();
   let create_params =
-    v8::Isolate::create_params().heap_limits(0, 5 * 1024 * 1024);
+    v8::Isolate::create_params().heap_limits(0, 20 * 1024 * 1024);
   let mut runtime = JsRuntime::new(RuntimeOptions {
     create_params: Some(create_params),
     ..Default::default()
@@ -1339,7 +1339,7 @@ async fn generic_in_extension_middleware() {
 
   // Check the result
   deno_core::scope!(scope, &mut runtime);
-  let value = value_global.open(scope);
+  let value = v8::Local::new(scope, &value_global);
 
   let result = value.to_rust_string_lossy(scope);
   assert_eq!(result, "Hello World and Hello World");
@@ -1559,7 +1559,7 @@ async fn global_template_middleware() {
     _key: v8::Local<'s, v8::Name>,
     _value: v8::Local<'s, v8::Value>,
     _args: v8::PropertyCallbackArguments<'s>,
-    _rv: v8::ReturnValue<()>,
+    _rv: v8::ReturnValue<v8::Boolean>,
   ) -> v8::Intercepted {
     CALLS.lock().push("setter".to_string());
     v8::Intercepted::kNo
@@ -1570,7 +1570,7 @@ async fn global_template_middleware() {
     _key: v8::Local<'s, v8::Name>,
     _descriptor: &v8::PropertyDescriptor,
     _args: v8::PropertyCallbackArguments<'s>,
-    _rv: v8::ReturnValue<()>,
+    _rv: v8::ReturnValue<v8::Boolean>,
   ) -> v8::Intercepted {
     CALLS.lock().push("definer".to_string());
     v8::Intercepted::kNo

--- a/libs/core/runtime/tests/misc.rs
+++ b/libs/core/runtime/tests/misc.rs
@@ -1559,7 +1559,7 @@ async fn global_template_middleware() {
     _key: v8::Local<'s, v8::Name>,
     _value: v8::Local<'s, v8::Value>,
     _args: v8::PropertyCallbackArguments<'s>,
-    _rv: v8::ReturnValue<v8::Boolean>,
+    _rv: v8::PropertyInterceptorReturnValue<'_>,
   ) -> v8::Intercepted {
     CALLS.lock().push("setter".to_string());
     v8::Intercepted::kNo
@@ -1570,7 +1570,7 @@ async fn global_template_middleware() {
     _key: v8::Local<'s, v8::Name>,
     _descriptor: &v8::PropertyDescriptor,
     _args: v8::PropertyCallbackArguments<'s>,
-    _rv: v8::ReturnValue<v8::Boolean>,
+    _rv: v8::PropertyInterceptorReturnValue<'_>,
   ) -> v8::Intercepted {
     CALLS.lock().push("definer".to_string());
     v8::Intercepted::kNo

--- a/libs/core/runtime/tests/ops.rs
+++ b/libs/core/runtime/tests/ops.rs
@@ -193,7 +193,7 @@ fn test_op_high_arity() {
     .execute_script("test.js", "Deno.core.ops.op_add_4(1, 2, 3, 4)")
     .unwrap();
   deno_core::scope!(scope, runtime);
-  assert_eq!(r.open(scope).integer_value(scope), Some(10));
+  assert_eq!(v8::Local::new(scope, &r).integer_value(scope), Some(10));
 }
 
 #[test]

--- a/libs/deno_v8/Cargo.toml
+++ b/libs/deno_v8/Cargo.toml
@@ -37,5 +37,5 @@ v8_enable_v8_checks = [
 ]
 
 [dependencies]
-rusty_v8 = { package = "v8", version = "150.4.0", optional = true, default-features = false }
+rusty_v8 = { package = "v8", version = "152.2.0", optional = true, default-features = false }
 v8x_backend = { package = "v8x", version = "=149.4.0-rc.4", optional = true, default-features = false }

--- a/libs/deno_v8/lib.rs
+++ b/libs/deno_v8/lib.rs
@@ -26,3 +26,17 @@ pub type PropertyInterceptorReturnValue<'cb> =
 #[cfg(all(feature = "quickjs", not(feature = "v8")))]
 pub type PropertyInterceptorReturnValue<'cb> =
   v8x_backend::ReturnValue<'cb, ()>;
+
+/// What `MicrotaskQueue::new` hands back: an owning RAII handle that releases
+/// the queue on drop and derefs to [`MicrotaskQueue`].
+///
+/// V8 152 returns a `MicrotaskQueueHandle`, which owns a root into the
+/// isolate's heap rather than the queue itself. The QuickJS backend vendors an
+/// older rusty_v8 that returns `UniqueRef<MicrotaskQueue>`, which owns the
+/// queue allocation directly. Both drop correctly on their own, so holders can
+/// name this alias and let ordinary ownership do the cleanup.
+#[cfg(all(feature = "v8", not(feature = "quickjs")))]
+pub type OwnedMicrotaskQueue = rusty_v8::MicrotaskQueueHandle;
+#[cfg(all(feature = "quickjs", not(feature = "v8")))]
+pub type OwnedMicrotaskQueue =
+  v8x_backend::UniqueRef<v8x_backend::MicrotaskQueue>;

--- a/libs/deno_v8/lib.rs
+++ b/libs/deno_v8/lib.rs
@@ -10,3 +10,19 @@ compile_error!("either feature `v8` or `quickjs` must be enabled");
 pub use rusty_v8::*;
 #[cfg(all(feature = "quickjs", not(feature = "v8")))]
 pub use v8x_backend::*;
+
+/// The `ReturnValue` handed to the named and indexed property *setter* and
+/// *definer* interceptors.
+///
+/// V8 152 changed these two interceptors from `ReturnValue<()>` to
+/// `ReturnValue<Boolean>`, bringing them in line with the deleter interceptor,
+/// which already carried a `Boolean`. The QuickJS backend vendors an older
+/// rusty_v8 and still expects `ReturnValue<()>`, so interceptor callbacks name
+/// this alias rather than writing the payload type out and only compiling
+/// against one backend.
+#[cfg(all(feature = "v8", not(feature = "quickjs")))]
+pub type PropertyInterceptorReturnValue<'cb> =
+  rusty_v8::ReturnValue<'cb, rusty_v8::Boolean>;
+#[cfg(all(feature = "quickjs", not(feature = "v8")))]
+pub type PropertyInterceptorReturnValue<'cb> =
+  v8x_backend::ReturnValue<'cb, ()>;


### PR DESCRIPTION
Updates the `v8` crate from 150.4.0 to 152.2.0, which brings V8 15.2.124.1.

Four things in the new version needed adapting to.

`Global::open` is now `unsafe`, because the reference it hands back is tied to
the lifetime of the `Global` rather than to a handle scope. Every call site in
this repo was of the same shape — open a `Global` and immediately call a method
on it — so rather than wrapping them in `unsafe` blocks they now go through
`v8::Local::new(scope, handle)`, which is safe and is what upstream recommends.
That covers 25 sites in `libs/core` plus a handful in `ext/webgpu` and
`ext/node`.

`MicrotaskQueue::new` now returns an owning `MicrotaskQueueHandle` that frees
the queue on drop, where it previously returned a `UniqueRef` whose `into_raw`
leaked it. `ext/node/ops/vm.rs` relies on that leak: the queue is handed to a
context as a raw pointer and has to outlive it, and V8 offers no hook for when
the context goes away. The leak is now spelled out in a small helper with a
comment explaining why it is deliberate, instead of being implied by
`into_raw`.

The named and indexed setter and definer interceptors now take
`ReturnValue<Boolean>` instead of `ReturnValue<()>`, matching the deleter
interceptor, which already used `Boolean`. All the affected callbacks either
ignore the return value or forward it unchanged, so this is a type change only.

Finally, V8 removed asm.js validation and with it the `--no-validate-asm` flag.
This one is worth calling out: the flag sat first in `base_flags`, and V8 stops
parsing at the first unrecognized flag, so leaving it in caused every flag after
it — `--turbo_fast_api_calls`, `--harmony-temporal`, `--js-float16array`,
`--js-explicit-resource-management`, `--js-source-phase-imports`,
`--js-defer-import-eval` and `--enable-queue-microtask` — to be silently
dropped. The `no_validate_asm` integration test stays as-is and still passes,
since removing the validator means there is no output to suppress either way.

The two heap-limit tests in `libs/core` capped the isolate at 5MB, which V8
152 can no longer bootstrap within; since the callbacks under test are
registered after `JsRuntime::new` returns, there was nothing to raise the limit
and the test aborted the process on OOM. Both caps are raised to 20MB, which
leaves what the tests actually assert untouched.

`cargo test -p deno_core` passes (451 tests) and the full runtime unit suite
passes (104 test files), as do the `node:vm` tests that exercise the microtask
queue change.

One wrinkle worth flagging for review: the `quickjs` backend behind the
`deno_v8` facade vendors an older rusty_v8 which still expects
`ReturnValue<()>` for the setter and definer interceptors, and there is no
`v8x` release tracking v8 152 to bump to. So rather than writing the payload
type directly in `ext/node/ops/vm.rs`, the interceptors now name a
`PropertyInterceptorReturnValue` alias defined in the facade, which resolves to
`Boolean` on the v8 backend and `()` on QuickJS. Papering over backend
differences is what the facade is for, and this keeps both backends building
from one set of callbacks. `cargo check -p deno -p denort --no-default-features
--features quickjs` passes alongside the default build.
