### PR TITLE
test(core): serialize snapshot-creating tests behind a process-wide lock

### DIFF
--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -2039,6 +2039,7 @@ fn main_and_side_module() {
 
 #[test]
 fn dynamic_imports_snapshot() {
+  let _snapshot_lock = crate::runtime::tests::snapshot_test_lock();
   //TODO: Once the issue with the ModuleNamespaceEntryGetter is fixed, we can maintain a reference to the module
   // and use it when loading the snapshot
   let snapshot = {
@@ -2079,6 +2080,7 @@ fn dynamic_imports_snapshot() {
 
 #[test]
 fn import_meta_snapshot() {
+  let _snapshot_lock = crate::runtime::tests::snapshot_test_lock();
   let snapshot = {
     const MAIN_WITH_CODE_SRC: &str = r#"
       if (import.meta.url != 'file:///main_with_code.js') throw Error();

--- a/libs/core/runtime/mod.rs
+++ b/libs/core/runtime/mod.rs
@@ -15,7 +15,7 @@ pub mod stats;
 pub mod v8_static_strings;
 
 #[cfg(all(test, not(miri)))]
-mod tests;
+pub(crate) mod tests;
 
 pub const V8_WRAPPER_TYPE_INDEX: i32 = 0;
 pub const V8_WRAPPER_OBJECT_INDEX: i32 = 1;

--- a/libs/core/runtime/tests/jsrealm.rs
+++ b/libs/core/runtime/tests/jsrealm.rs
@@ -133,6 +133,7 @@ async fn js_realm_ref_unref_ops() {
 
 #[test]
 fn es_snapshot() {
+  let _snapshot_lock = super::snapshot_test_lock();
   let startup_data = {
     deno_core::extension!(
       module_snapshot,

--- a/libs/core/runtime/tests/mod.rs
+++ b/libs/core/runtime/tests/mod.rs
@@ -102,3 +102,14 @@ fn setup(mode: Mode) -> (JsRuntime, Arc<AtomicUsize>) {
   assert_eq!(dispatch_count.load(Ordering::Relaxed), 0);
   (runtime, dispatch_count)
 }
+
+/// Snapshot-creating isolates crash (SIGSEGV inside V8) when two
+/// `JsRuntimeForSnapshot`s are constructed concurrently in one process — see
+/// denoland/deno_core_revamp#17. Every test that builds a
+/// `JsRuntimeForSnapshot` must hold this lock for its whole body; without it
+/// the tests pass in the diluted full suite most of the time and reliably
+/// crash under a narrow test filter, which made this look like a flake.
+pub(crate) fn snapshot_test_lock() -> parking_lot::MutexGuard<'static, ()> {
+  static LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+  LOCK.lock()
+}

--- a/libs/core/runtime/tests/snapshot.rs
+++ b/libs/core/runtime/tests/snapshot.rs
@@ -15,6 +15,7 @@ use crate::*;
 
 #[test]
 fn will_snapshot() {
+  let _snapshot_lock = super::snapshot_test_lock();
   let snapshot = {
     let mut runtime = JsRuntimeForSnapshot::new(Default::default());
     runtime.execute_script("a.js", "a = 1 + 2").unwrap();
@@ -33,6 +34,7 @@ fn will_snapshot() {
 
 #[test]
 fn will_snapshot2() {
+  let _snapshot_lock = super::snapshot_test_lock();
   let startup_data = {
     let mut runtime = JsRuntimeForSnapshot::new(Default::default());
     runtime.execute_script("a.js", "let a = 1 + 2").unwrap();
@@ -70,6 +72,7 @@ fn will_snapshot2() {
 
 #[test]
 fn test_snapshot_callbacks() {
+  let _snapshot_lock = super::snapshot_test_lock();
   let snapshot = {
     let mut runtime = JsRuntimeForSnapshot::new(Default::default());
     runtime
@@ -106,6 +109,7 @@ fn test_snapshot_callbacks() {
 
 #[test]
 fn test_from_snapshot() {
+  let _snapshot_lock = super::snapshot_test_lock();
   let snapshot = {
     let mut runtime = JsRuntimeForSnapshot::new(Default::default());
     runtime.execute_script("a.js", "a = 1 + 2").unwrap();
@@ -125,6 +129,7 @@ fn test_from_snapshot() {
 /// Smoke test for create_snapshot.
 #[test]
 fn test_snapshot_creator() {
+  let _snapshot_lock = super::snapshot_test_lock();
   let output = create_snapshot(
     CreateSnapshotOptions {
       cargo_manifest_dir: "",
@@ -153,6 +158,7 @@ fn test_snapshot_creator() {
 
 #[test]
 fn test_snapshot_creator_warmup() {
+  let _snapshot_lock = super::snapshot_test_lock();
   let counter = Rc::new(RefCell::new(0));
 
   let c = counter.clone();
@@ -190,6 +196,7 @@ fn test_snapshot_creator_warmup() {
 
 #[test]
 fn es_snapshot() {
+  let _snapshot_lock = super::snapshot_test_lock();
   fn create_module(
     runtime: &mut JsRuntime,
     i: usize,
@@ -333,6 +340,7 @@ fn es_snapshot() {
 
 #[test]
 pub(crate) fn es_snapshot_without_runtime_module_loader() {
+  let _snapshot_lock = super::snapshot_test_lock();
   let startup_data = {
     deno_core::extension!(
       module_snapshot,
@@ -405,6 +413,7 @@ pub(crate) fn es_snapshot_without_runtime_module_loader() {
 
 #[test]
 pub fn snapshot_with_additional_extensions() {
+  let _snapshot_lock = super::snapshot_test_lock();
   #[op2]
   #[string]
   fn op_before() -> String {
@@ -465,6 +474,7 @@ pub fn snapshot_with_additional_extensions() {
 
 #[test]
 fn lazy_loaded_esm_not_snapshotted_but_metadata_survives() {
+  let _snapshot_lock = super::snapshot_test_lock();
   let snapshot = {
     deno_core::extension!(
       test_ext,


### PR DESCRIPTION
Two `JsRuntimeForSnapshot` isolates constructed concurrently in one process SIGSEGV inside V8 (heap verification: `IsFreeSpaceOrFiller`).

Deterministic repro on current `main`:

```
cargo test -p deno_core --lib es_snapshot -- --test-threads=2
# signal: 11, SIGSEGV: invalid memory reference  (5/5 runs)
```

The full suite usually dodges it because ~450 tests dilute the schedule — which also explains the rare snapshot-test flake in CI. Filtered runs (`--lib es_snapshot`) crash reliably.

This PR serializes all 14 snapshot-creating tests behind a process-wide mutex so no two snapshot creators ever run concurrently. Test-only change; no library code is touched.

With the lock, both the filtered repro and the full `deno_core` lib suite pass.

Whether concurrent `SnapshotCreator`s are supposed to work at all is a separate upstream (rusty_v8/V8) question; this makes the test suite stop rolling those dice.
