### PR TITLE
chore(core): drop az, capacity_builder, and num-bigint's rand feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,12 +466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "az"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
-
-[[package]]
 name = "backhand"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,7 +2246,6 @@ name = "deno_core"
 version = "0.410.0"
 dependencies = [
  "anyhow",
- "az",
  "base64 0.22.1",
  "bencher",
  "bincode",
@@ -2260,7 +2253,6 @@ dependencies = [
  "bit-vec 0.8.0",
  "boxed_error",
  "bytes",
- "capacity_builder",
  "cooked-waker",
  "criterion",
  "deno_ast",
@@ -7168,7 +7160,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7160,6 +7160,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "rand 0.8.5",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ monch = "=0.6.0"
 msi = "0.10.0"
 netif = "0.1.6"
 notify = "8.2.0"
-num-bigint = { version = "0.4", features = ["rand"] }
+num-bigint = "0.4"
 num-bigint-dig = "0.8.2"
 num-integer = "0.1.45"
 num-traits = "0.2.19"

--- a/ext/node_crypto/Cargo.toml
+++ b/ext/node_crypto/Cargo.toml
@@ -41,7 +41,7 @@ hmac.workspace = true
 k256.workspace = true
 md-5 = { workspace = true, features = ["oid"] }
 md4.workspace = true
-num-bigint.workspace = true
+num-bigint = { workspace = true, features = ["rand"] }
 num-bigint-dig.workspace = true
 num-integer.workspace = true
 num-traits.workspace = true

--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -29,14 +29,12 @@ v8 = ["v8/v8", "serde_v8/v8"]
 
 [dependencies]
 anyhow.workspace = true
-az = "1.2.1"
 base64 = { workspace = true }
 bincode.workspace = true
 bit-set.workspace = true
 bit-vec.workspace = true
 boxed_error.workspace = true
 bytes.workspace = true
-capacity_builder = "0.5.0"
 cooked-waker.workspace = true
 deno_core_icudata = { workspace = true, optional = true }
 deno_error = { workspace = true, features = ["serde_json", "serde", "url", "tokio"] }

--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -1814,8 +1814,6 @@ fn maybe_to_path_str(string: &str) -> Option<String> {
 }
 
 pub mod callsite_fns {
-  use capacity_builder::StringBuilder;
-
   use super::*;
   use crate::FromV8;
   use crate::ToV8;
@@ -2065,14 +2063,7 @@ pub mod callsite_fns {
   }
 
   fn fmt_file_line_col(file: &str, line: i64, col: i64) -> String {
-    StringBuilder::build(|builder| {
-      builder.append(file);
-      builder.append(':');
-      builder.append(line);
-      builder.append(':');
-      builder.append(col);
-    })
-    .unwrap()
+    format!("{file}:{line}:{col}")
   }
 
   pub fn to_string<'s, 'i>(

--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -11,7 +11,6 @@ use std::rc::Rc;
 use std::task::Context;
 use std::task::Poll;
 
-use capacity_builder::StringBuilder;
 use deno_core::FastString;
 use deno_core::error::CoreError;
 use deno_error::JsErrorBox;
@@ -3673,6 +3672,62 @@ fn is_wasm_global_import(import_type: &wasm_dep_analyzer::ImportType) -> bool {
   matches!(import_type, wasm_dep_analyzer::ImportType::Global(_))
 }
 
+/// Values that [`StringBuilder::append`] knows how to write.
+trait AppendToString {
+  fn append_to(self, out: &mut String);
+}
+
+impl AppendToString for &str {
+  fn append_to(self, out: &mut String) {
+    out.push_str(self);
+  }
+}
+
+impl AppendToString for &String {
+  fn append_to(self, out: &mut String) {
+    out.push_str(self);
+  }
+}
+
+impl AppendToString for &Cow<'_, str> {
+  fn append_to(self, out: &mut String) {
+    out.push_str(self);
+  }
+}
+
+impl AppendToString for char {
+  fn append_to(self, out: &mut String) {
+    out.push(self);
+  }
+}
+
+impl AppendToString for usize {
+  fn append_to(self, out: &mut String) {
+    // Cold path (module rendering), so the temporary allocation is fine.
+    out.push_str(&self.to_string());
+  }
+}
+
+/// Append-only string builder over a preallocated [`String`].
+///
+/// Just enough of an API to render the synthetic Wasm wrapper module below
+/// without depending on a proc-macro string-building crate.
+struct StringBuilder(String);
+
+impl StringBuilder {
+  fn with_capacity(capacity: usize) -> Self {
+    Self(String::with_capacity(capacity))
+  }
+
+  fn append(&mut self, value: impl AppendToString) {
+    value.append_to(&mut self.0);
+  }
+
+  fn build(self) -> String {
+    self.0
+  }
+}
+
 fn render_js_wasm_module(specifier: &str, wasm_deps: WasmDeps) -> String {
   struct NamedImport {
     escaped_name: String,
@@ -3725,7 +3780,12 @@ fn render_js_wasm_module(specifier: &str, wasm_deps: WasmDeps) -> String {
     .collect::<Vec<_>>();
   let has_global_export = exports.iter().any(|(_, is_global)| *is_global);
 
-  StringBuilder::build(|builder| {
+  // Rough starting capacity; the builder grows as needed.
+  let mut builder = StringBuilder::with_capacity(
+    256 + 128 * (aggregated_imports.len() + exports.len()),
+  );
+  {
+    let builder = &mut builder;
     builder.append("import source wasmMod from \"");
     builder.append(specifier);
     builder.append("\";\n");
@@ -3749,7 +3809,9 @@ fn render_js_wasm_module(specifier: &str, wasm_deps: WasmDeps) -> String {
           builder.append("\";\n");
         }
         builder.append("import { ");
-        for (name_index, named_import) in import_info.named_imports.iter().enumerate() {
+        for (name_index, named_import) in
+          import_info.named_imports.iter().enumerate()
+        {
           if name_index > 0 {
             builder.append(", ");
           }
@@ -3791,7 +3853,9 @@ fn render_js_wasm_module(specifier: &str, wasm_deps: WasmDeps) -> String {
         builder.append(&import_info.key_escaped);
         builder.append("\": {\n");
 
-        for (name_index, named_import) in import_info.named_imports.iter().enumerate() {
+        for (name_index, named_import) in
+          import_info.named_imports.iter().enumerate()
+        {
           builder.append("    \"");
           builder.append(&named_import.escaped_name);
           builder.append("\": ");
@@ -3823,9 +3887,8 @@ fn render_js_wasm_module(specifier: &str, wasm_deps: WasmDeps) -> String {
 
       builder.append("const modInstance = new import.meta.WasmInstance(wasmMod, importsObject);\n");
     } else {
-      builder.append(
-        "const modInstance = new import.meta.WasmInstance(wasmMod);\n"
-      );
+      builder
+        .append("const modInstance = new import.meta.WasmInstance(wasmMod);\n");
     }
 
     if has_global_export {
@@ -3872,7 +3935,8 @@ fn render_js_wasm_module(specifier: &str, wasm_deps: WasmDeps) -> String {
         builder.append("\" };\n");
       }
     }
-  }).unwrap()
+  }
+  builder.build()
 }
 
 #[test]

--- a/libs/core/runtime/ops.rs
+++ b/libs/core/runtime/ops.rs
@@ -73,7 +73,9 @@ macro_rules! try_integer_some {
     if $n.$is() {
       // SAFETY: v8 handles can be transmuted
       let n: &v8::$type = unsafe { std::mem::transmute($n) };
-      return Some(az::wrapping_cast::<_, _>(n.value()));
+      // `n.value()` is already an integer here, so the `as` cast wraps on
+      // overflow rather than saturating. That is deliberate.
+      return Some(n.value() as _);
     }
   };
 }
@@ -83,7 +85,9 @@ macro_rules! try_number_int_some {
     if $n.$is() {
       // SAFETY: v8 handles can be transmuted
       let n: &v8::$type = unsafe { std::mem::transmute($n) };
-      return Some(az::wrapping_cast::<_, _>(n.value().trunc() as $trunc));
+      // The inner `as $trunc` saturates the float; the outer `as _` narrows
+      // the resulting integer with wrapping. Both are deliberate.
+      return Some(n.value().trunc() as $trunc as _);
     }
   };
 }


### PR DESCRIPTION
Three dependency cleanups in `libs/core`, all behavior-preserving:

- **`az`**: the two `wrapping_cast` calls in `runtime/ops.rs` were both integer-to-integer narrowing, which is exactly what a plain `as` cast does. Replaced with `as` plus a comment recording that the wrap is intentional. `libs/core` was the only user, so the crate leaves the tree entirely.
- **`capacity_builder`**: a proc-macro dependency used at two cold call sites. `error.rs` becomes a `format!`; `modules/map.rs` gets a small private `StringBuilder` over a preallocated `String` so the Wasm-wrapper renderer keeps its `builder.append(..)` shape unchanged. The crate stays in the workspace tree (deno_semver, config, etc. still use it) — this only removes `deno_core`'s dependence on it.
- **`num-bigint`'s `rand` feature**: dropped from the workspace-wide dependency. One crate really uses it (`ext/node_crypto`'s `gen_range` over a `BigInt` range), and it now declares `features = ["rand"]` explicitly instead of inheriting it silently through the workspace dep. Everyone else stops paying for it implicitly.

Net: `az` out of the lockfile entirely, one fewer proc-macro build for `deno_core`, the `rand` feature scoped to its one real user, zero behavior change.
