### PR TITLE
perf(core): grow the op driver's future arena on demand

### DIFF
--- a/libs/core/arena/unique_arena.rs
+++ b/libs/core/arena/unique_arena.rs
@@ -191,6 +191,16 @@ impl<T> ArenaUnique<T> {
     }
   }
 
+  /// The number of slots in this arena that [`reserve_space`](Self::reserve_space)
+  /// can still hand out without falling back to the system allocator.
+  ///
+  /// Note that this only tracks the arena's own block: allocations made by
+  /// [`allocate`](Self::allocate) once the arena is full come from the system
+  /// allocator and are not counted here.
+  pub fn remaining(&self) -> usize {
+    unsafe { (*self.ptr.as_ptr()).raw_arena.remaining() }
+  }
+
   #[cold]
   #[inline(never)]
   unsafe fn drop_data(data: NonNull<ArenaUniqueData<T>>) {

--- a/libs/core/runtime/op_driver/future_arena.rs
+++ b/libs/core/runtime/op_driver/future_arena.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+use std::cell::Cell;
+use std::cell::RefCell;
 use std::cell::UnsafeCell;
 use std::future::Future;
 use std::marker::PhantomData;
@@ -14,11 +16,18 @@ use pin_project::pin_project;
 use super::erased_future::TypeErased;
 use crate::arena::ArenaBox;
 use crate::arena::ArenaUnique;
+use crate::arena::ArenaUniqueReservation;
 
 const MAX_ARENA_FUTURE_SIZE: usize = 1024;
 
-/// The number of futures we'll allow to live in the Arena.
-const FUTURE_ARENA_COUNT: usize = 256;
+/// The number of futures the arena has room for before it needs to grow. This
+/// is allocated up-front by every runtime, so it is kept small: workloads that
+/// need more get it on demand.
+const FUTURE_ARENA_INITIAL_COUNT: usize = 16;
+
+/// The number of futures we'll allow to live in the Arena. Once the arena has
+/// grown this far, further futures are allocated on the heap.
+const FUTURE_ARENA_MAX_COUNT: usize = 256;
 
 /// The [`FutureArena`] requires context for each submitted future. This mapper provides the context, as well
 /// as finalizes the output of the future to the correct output type for this arena.
@@ -159,21 +168,122 @@ impl<T, C, M: FutureContextMapper<T, C, F::Output>, F: Future> Future
   }
 }
 
+type Chunk<T, C> = ArenaUnique<DynFutureInfoErased<T, C>>;
+type Reservation<T, C> = ArenaUniqueReservation<DynFutureInfoErased<T, C>>;
+
 /// An arena of erased futures with associated mapping functions. Futures too large for the arena,
 /// or futures allocated when the arena are full, are automatically moved to the heap instead.
 ///
 /// Each future is associated with an output type and a context. The context is used to create the
 /// output type.
-#[repr(transparent)]
+///
+/// The arena starts out with room for [`FUTURE_ARENA_INITIAL_COUNT`] futures
+/// and grows on demand -- by doubling -- up to [`FUTURE_ARENA_MAX_COUNT`].
+/// Growth appends a new chunk rather than reallocating: futures in the arena
+/// are pinned in place while they are in flight, so an existing slot must never
+/// move.
 pub struct FutureArena<T, C> {
-  arena: ArenaUnique<DynFutureInfoErased<T, C>>,
+  /// The chunk we're currently handing slots out of. This is a separate field
+  /// rather than an index into `retired` so that the common case -- allocating
+  /// from a chunk that has room -- is the same single pointer load it was when
+  /// the arena was one fixed block.
+  ///
+  /// Only ever mutated by [`FutureArena::reserve_slow`], which holds no other
+  /// reference to it while doing so.
+  current: UnsafeCell<Chunk<T, C>>,
+  /// Chunks that were full at the point we last needed a slot from them. They
+  /// may since have had futures complete, so we look here for a free slot
+  /// before growing.
+  retired: RefCell<Vec<Chunk<T, C>>>,
+  /// The total number of slots across `current` and `retired`.
+  capacity: Cell<usize>,
 }
 
 impl<T, C> Default for FutureArena<T, C> {
   fn default() -> Self {
     FutureArena {
-      arena: ArenaUnique::with_capacity(FUTURE_ARENA_COUNT),
+      current: UnsafeCell::new(ArenaUnique::with_capacity(
+        FUTURE_ARENA_INITIAL_COUNT,
+      )),
+      retired: RefCell::new(Vec::new()),
+      capacity: Cell::new(FUTURE_ARENA_INITIAL_COUNT),
     }
+  }
+}
+
+impl<T, C> FutureArena<T, C> {
+  /// Reserve a slot in the current chunk, growing the arena (or recycling a
+  /// retired chunk that has since freed a slot) if it is full. Returns [`None`]
+  /// if the arena is at its maximum size and every chunk is full.
+  ///
+  /// On success the reservation always belongs to `current`, so the caller
+  /// completes it against `current` in both the fast and the slow case.
+  ///
+  /// # Safety
+  ///
+  /// The returned reservation must be completed or forgotten against
+  /// `self.current`, and must not outlive another call to this method.
+  #[inline(always)]
+  unsafe fn reserve(&self) -> Option<Reservation<T, C>> {
+    // SAFETY: no other reference to `current` is alive at this point, and
+    // `reserve_space` does not touch the `UnsafeCell` itself.
+    if let Some(reservation) = unsafe { (*self.current.get()).reserve_space() }
+    {
+      return Some(reservation);
+    }
+    self.reserve_slow()
+  }
+
+  #[cold]
+  #[inline(never)]
+  fn reserve_slow(&self) -> Option<Reservation<T, C>> {
+    let mut retired = self.retired.borrow_mut();
+
+    // Did a future in one of the retired chunks complete? Take the emptiest one
+    // so we come back here as rarely as possible.
+    let emptiest = retired
+      .iter()
+      .enumerate()
+      .map(|(i, chunk)| (chunk.remaining(), i))
+      .filter(|&(remaining, _)| remaining > 0)
+      .max();
+    if let Some((_, i)) = emptiest {
+      let chunk = retired.swap_remove(i);
+      // SAFETY: the chunk has room, so this returns a reservation belonging to
+      // `chunk`, which we immediately install as `current`. Moving the
+      // `ArenaUnique` handle does not move the slots it owns.
+      let reservation = unsafe { chunk.reserve_space() };
+      debug_assert!(reservation.is_some());
+      // SAFETY: `retired` is borrowed, but nothing borrows `current` here.
+      let full = unsafe { std::mem::replace(&mut *self.current.get(), chunk) };
+      retired.push(full);
+      return reservation;
+    }
+
+    // Everything is full: double the arena if we're still under the cap.
+    let capacity = self.capacity.get();
+    let growth = std::cmp::min(capacity, FUTURE_ARENA_MAX_COUNT - capacity);
+    if growth == 0 {
+      return None;
+    }
+
+    let chunk = ArenaUnique::with_capacity(growth);
+    // SAFETY: a fresh chunk always has room, and moving the `ArenaUnique`
+    // handle does not move the slots it owns.
+    let reservation = unsafe { chunk.reserve_space() };
+    debug_assert!(reservation.is_some());
+    // SAFETY: `retired` is borrowed, but nothing borrows `current` here.
+    let full = unsafe { std::mem::replace(&mut *self.current.get(), chunk) };
+    retired.push(full);
+    self.capacity.set(capacity + growth);
+    reservation
+  }
+
+  /// The number of futures this arena has room for without growing. Grows over
+  /// the life of the arena, up to [`FUTURE_ARENA_MAX_COUNT`].
+  #[cfg(test)]
+  fn capacity(&self) -> usize {
+    self.capacity.get()
   }
 }
 
@@ -199,8 +309,10 @@ impl<T, C: Clone> FutureArena<T, C> {
     if std::mem::size_of::<DynFutureInfo<T, C, M, F>>() <= MAX_ARENA_FUTURE_SIZE
     {
       unsafe {
-        if let Some(reservation) = self.arena.reserve_space() {
-          let alloc = self.arena.complete_reservation(
+        if let Some(reservation) = self.reserve() {
+          // SAFETY: `reserve` always hands back a reservation belonging to the
+          // current chunk.
+          let alloc = (*self.current.get()).complete_reservation(
             reservation,
             DynFutureInfoErased {
               ptr: MaybeUninit::uninit(),
@@ -302,6 +414,105 @@ mod tests {
       v.push(arena.allocate(INFO, ready(Box::new(1_i32))));
     }
     drop(v);
+  }
+
+  fn is_arena<T, C, M: FutureContextMapper<T, C, F::Output>, F: Future>(
+    alloc: &TypedFutureAllocation<T, C, M, F>,
+  ) -> bool {
+    matches!(alloc.inner, FutureAllocation::Arena(..))
+  }
+
+  /// The arena starts small and doubles, and futures already in flight keep
+  /// their address as it grows.
+  #[test]
+  fn test_growth_keeps_futures_pinned() {
+    let arena = FutureArena::<Stringish, usize>::default();
+    assert_eq!(arena.capacity(), FUTURE_ARENA_INITIAL_COUNT);
+
+    let mut v = vec![];
+    let mut addresses = vec![];
+    let mut capacities = vec![];
+    for _ in 0..FUTURE_ARENA_MAX_COUNT {
+      let f = arena.allocate(INFO, ready(1_i32));
+      assert!(is_arena(&f));
+      addresses.push(f.ptr.as_ptr() as usize);
+      v.push(f);
+      // Every allocated future must still live where it was put.
+      for (f, address) in v.iter().zip(addresses.iter()) {
+        assert_eq!(f.ptr.as_ptr() as usize, *address);
+      }
+      if capacities.last() != Some(&arena.capacity()) {
+        capacities.push(arena.capacity());
+      }
+    }
+    assert_eq!(capacities, vec![16, 32, 64, 128, 256]);
+    assert_eq!(arena.capacity(), FUTURE_ARENA_MAX_COUNT);
+
+    // The arena is full now, so this one goes to the heap.
+    let boxed = arena.allocate(INFO, ready(1_i32));
+    assert!(!is_arena(&boxed));
+    assert_eq!(arena.capacity(), FUTURE_ARENA_MAX_COUNT);
+
+    // ... and everything still polls to completion.
+    for mut f in v {
+      let Poll::Ready(v) =
+        f.poll_unpin(&mut Context::from_waker(Waker::noop()))
+      else {
+        panic!();
+      };
+      assert_eq!(v, 1);
+    }
+  }
+
+  /// Completed futures return their slot to the arena, and we don't grow while
+  /// there are slots to reuse.
+  #[test]
+  fn test_slots_are_reused() {
+    let arena = FutureArena::<Stringish, usize>::default();
+    for _ in 0..100 {
+      let v = (0..FUTURE_ARENA_INITIAL_COUNT)
+        .map(|_| arena.allocate(INFO, ready(1_i32)))
+        .collect::<Vec<_>>();
+      assert!(v.iter().all(is_arena));
+      drop(v);
+      assert_eq!(arena.capacity(), FUTURE_ARENA_INITIAL_COUNT);
+    }
+  }
+
+  /// A slot freed in a chunk we've already moved past is picked up again rather
+  /// than growing the arena.
+  #[test]
+  fn test_retired_chunk_slots_are_reused() {
+    let arena = FutureArena::<Stringish, usize>::default();
+    // Fill the first chunk, then the second: capacity 16 + 16.
+    let mut v = (0..FUTURE_ARENA_INITIAL_COUNT * 2)
+      .map(|_| arena.allocate(INFO, ready(1_i32)))
+      .collect::<Vec<_>>();
+    assert_eq!(arena.capacity(), FUTURE_ARENA_INITIAL_COUNT * 2);
+
+    // Free a slot in the first (retired) chunk. The current chunk is still
+    // full, so the next allocation has to find this one.
+    let address = v.remove(0).ptr.as_ptr() as usize;
+    let reused = arena.allocate(INFO, ready(1_i32));
+    assert!(is_arena(&reused));
+    assert_eq!(reused.ptr.as_ptr() as usize, address);
+    assert_eq!(arena.capacity(), FUTURE_ARENA_INITIAL_COUNT * 2);
+  }
+
+  /// Futures too large for a slot skip the arena entirely.
+  #[test]
+  fn test_oversized_future_is_boxed() {
+    let arena = FutureArena::<Stringish, usize>::default();
+    let big = arena.allocate(INFO, async {
+      let large = [0_u8; MAX_ARENA_FUTURE_SIZE];
+      ready(1_i32).await;
+      large[0] as i32
+    });
+    assert!(!is_arena(&big));
+    // An oversized future doesn't consume arena capacity.
+    assert_eq!(arena.capacity(), FUTURE_ARENA_INITIAL_COUNT);
+    let small = arena.allocate(INFO, ready(1_i32));
+    assert!(is_arena(&small));
   }
 
   #[test]


### PR DESCRIPTION
The op driver's `FutureArena` allocated all 256 future slots when the runtime
was created. Every `JsRuntime` paid roughly 323 KB of heap up front, whether or
not it ever ran an async op, and most of that arena went unused.

This starts the arena at 16 slots and doubles on demand up to the same 256-slot
cap. Past the cap, futures keep falling back to the heap exactly as before.

Futures in the arena are pinned while they are in flight, so growth cannot
reallocate. Instead it appends a new chunk and existing slots never move. The
chunking sits on top of `ArenaUnique` rather than inside `RawArena`: an
`ArenaBox` already routes its slot back to the chunk that handed it out, so
recycling needs no new unsafe code, and `RawArena` -- which also backs
`ArenaShared` and `ArenaSharedAtomic` -- is left untouched. The chunk we
allocate from is kept in its own field, so the common case of a chunk with room
is the same single pointer load it was before. Only when that chunk is full do
we scan the retired chunks for a slot freed by a completed future, and only then
do we grow.

Numbers below were measured in the standalone deno_core repository, not in this
monorepo. With a counting global allocator, live heap per `JsRuntime` for the
arena drops by 257 KB, from 323,127 to 65,887 bytes, about 80 percent. Op
throughput was flat in interleaved A/B runs at batch sizes 8, 64 and 250.
