### PR TITLE
perf(core): zero-copy snapshot rehydration, drop bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,7 +2242,6 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bencher",
- "bincode",
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
  "boxed_error",

--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -30,7 +30,6 @@ v8 = ["v8/v8", "serde_v8/v8"]
 [dependencies]
 anyhow.workspace = true
 base64 = { workspace = true }
-bincode.workspace = true
 bit-set.workspace = true
 bit-vec.workspace = true
 boxed_error.workspace = true

--- a/libs/core/cppgc.rs
+++ b/libs/core/cppgc.rs
@@ -5,8 +5,6 @@ use std::any::type_name;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
-use serde::Deserialize;
-use serde::Serialize;
 pub use v8::cppgc::GarbageCollected;
 pub use v8::cppgc::GcCell;
 
@@ -273,9 +271,29 @@ pub struct FunctionTemplateData {
   store: BTreeMap<String, v8::Global<v8::FunctionTemplate>>,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct FunctionTemplateSnapshotData {
   store_handles: Vec<(String, u32)>,
+}
+
+impl FunctionTemplateSnapshotData {
+  pub(crate) fn encode(&self, e: &mut crate::snapshot_format::Encoder) {
+    e.seq(self.store_handles.iter(), |e, (k, v)| {
+      e.str(k);
+      e.u32(*v);
+    });
+  }
+
+  pub(crate) fn decode(
+    d: &mut crate::snapshot_format::Decoder,
+  ) -> crate::snapshot_format::SnapshotResult<Self> {
+    Ok(Self {
+      // These keys are `std::any::type_name` strings used as `BTreeMap<String,
+      // _>` keys; there are only a few dozen of them, so an owned copy here is
+      // not worth changing the map's key type for.
+      store_handles: d.seq(|d| Ok((d.str()?.0.to_owned(), d.u32()?)))?,
+    })
+  }
 }
 
 impl FunctionTemplateData {

--- a/libs/core/lib.rs
+++ b/libs/core/lib.rs
@@ -36,6 +36,7 @@ pub mod reactor;
 #[cfg(feature = "reactor-tokio")]
 pub mod reactor_tokio;
 mod runtime;
+mod snapshot_format;
 mod source_map;
 mod tasks;
 #[allow(

--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -330,12 +330,35 @@ impl ModuleMap {
     self.data.borrow().get_handle(id)
   }
 
+  /// For each module id, whether its V8 module has already been instantiated
+  /// (or evaluated). Used to decide which import edges are dead weight in the
+  /// snapshot — see [`ModuleMapData::serialize_for_snapshotting`].
+  pub(crate) fn instantiated_flags(
+    &self,
+    scope: &mut v8::PinScope,
+  ) -> Vec<bool> {
+    self
+      .data
+      .borrow()
+      .handles
+      .iter()
+      .map(|handle| {
+        let module = v8::Local::new(scope, handle);
+        !matches!(
+          module.get_status(),
+          v8::ModuleStatus::Uninstantiated | v8::ModuleStatus::Instantiating
+        )
+      })
+      .collect()
+  }
+
   pub(crate) fn serialize_for_snapshotting(
     &self,
     data_store: &mut SnapshotStoreDataStore,
+    instantiated: &[bool],
   ) -> ModuleMapSnapshotData {
     let data = std::mem::take(&mut *self.data.borrow_mut());
-    data.serialize_for_snapshotting(data_store)
+    data.serialize_for_snapshotting(data_store, instantiated)
   }
 
   #[cfg(test)]
@@ -352,8 +375,15 @@ impl ModuleMap {
   }
 
   #[cfg(test)]
-  pub fn assert_module_map(&self, modules: &Vec<super::ModuleInfo>) {
-    self.data.borrow().assert_module_map(modules);
+  pub fn assert_module_map(
+    &self,
+    modules: &Vec<super::ModuleInfo>,
+    restored_from_snapshot: usize,
+  ) {
+    self
+      .data
+      .borrow()
+      .assert_module_map(modules, restored_from_snapshot);
   }
 
   #[cfg(all(test, not(miri)))]

--- a/libs/core/modules/map/ext_script.rs
+++ b/libs/core/modules/map/ext_script.rs
@@ -204,7 +204,7 @@ impl ModuleMap {
     data
       .known_lazy_esm
       .borrow_mut()
-      .insert(specifier.as_str().to_string());
+      .insert(std::borrow::Cow::Owned(specifier.as_str().to_string()));
     assert!(
       data
         .lazy_esm_sources

--- a/libs/core/modules/mod.rs
+++ b/libs/core/modules/mod.rs
@@ -15,6 +15,9 @@ use crate::error::CoreErrorKind;
 use crate::error::exception_to_err;
 use crate::fast_string::FastString;
 use crate::module_specifier::ModuleSpecifier;
+use crate::snapshot_format::Decoder;
+use crate::snapshot_format::Encoder;
+use crate::snapshot_format::SnapshotResult;
 
 mod import_graph;
 mod loaders;
@@ -773,6 +776,149 @@ pub(crate) struct ModuleInfo {
   pub name: ModuleName,
   pub requests: Vec<ModuleRequest>,
   pub module_type: ModuleType,
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot sidecar encoding
+//
+// See `crate::snapshot_format` for the wire format. Decoding is on the hot
+// `JsRuntime::new` path and is written to borrow the snapshot blob rather than
+// copy out of it; encoding only runs at snapshot-creation time.
+// ---------------------------------------------------------------------------
+
+impl RequestedModuleType {
+  pub(crate) fn encode(&self, e: &mut Encoder) {
+    match self {
+      Self::None => e.u8(0),
+      Self::Json => e.u8(1),
+      Self::Text => e.u8(2),
+      Self::Bytes => e.u8(3),
+      Self::Other(ty) => {
+        e.u8(4);
+        e.str(ty);
+      }
+    }
+  }
+
+  pub(crate) fn decode(d: &mut Decoder) -> SnapshotResult<Self> {
+    Ok(match d.u8()? {
+      0 => Self::None,
+      1 => Self::Json,
+      2 => Self::Text,
+      3 => Self::Bytes,
+      4 => Self::Other(d.cow_str()?),
+      n => {
+        return Decoder::invalid_discriminant("RequestedModuleType", n as u32);
+      }
+    })
+  }
+}
+
+impl ModuleType {
+  pub(crate) fn encode(&self, e: &mut Encoder) {
+    match self {
+      Self::JavaScript => e.u8(0),
+      Self::Wasm => e.u8(1),
+      Self::Json => e.u8(2),
+      Self::Text => e.u8(3),
+      Self::Bytes => e.u8(4),
+      Self::Other(ty) => {
+        e.u8(5);
+        e.str(ty);
+      }
+    }
+  }
+
+  pub(crate) fn decode(d: &mut Decoder) -> SnapshotResult<Self> {
+    Ok(match d.u8()? {
+      0 => Self::JavaScript,
+      1 => Self::Wasm,
+      2 => Self::Json,
+      3 => Self::Text,
+      4 => Self::Bytes,
+      5 => Self::Other(d.cow_str()?),
+      n => return Decoder::invalid_discriminant("ModuleType", n as u32),
+    })
+  }
+}
+
+impl ModuleImportPhase {
+  pub(crate) fn encode(&self, e: &mut Encoder) {
+    e.u8(match self {
+      Self::Evaluation => 0,
+      Self::Source => 1,
+      Self::Defer => 2,
+    });
+  }
+
+  pub(crate) fn decode(d: &mut Decoder) -> SnapshotResult<Self> {
+    Ok(match d.u8()? {
+      0 => Self::Evaluation,
+      1 => Self::Source,
+      2 => Self::Defer,
+      n => return Decoder::invalid_discriminant("ModuleImportPhase", n as u32),
+    })
+  }
+}
+
+impl ModuleReference {
+  pub(crate) fn encode(&self, e: &mut Encoder) {
+    e.str(self.specifier.as_str());
+    self.requested_module_type.encode(e);
+  }
+
+  pub(crate) fn decode(d: &mut Decoder) -> SnapshotResult<Self> {
+    // `url::Url` owns its buffer and cannot borrow, so this re-parses. That's
+    // acceptable because only modules that were *not* instantiated in the
+    // snapshot carry requests (see `ModuleMapData::serialize_for_snapshotting`)
+    // — for a normal snapshot this decodes zero references.
+    let raw = d.str()?.0;
+    let specifier = ModuleSpecifier::parse(raw).map_err(|_| {
+      crate::snapshot_format::SnapshotDecodeError::InvalidUrl(raw.to_owned())
+    })?;
+    Ok(Self {
+      specifier,
+      requested_module_type: RequestedModuleType::decode(d)?,
+    })
+  }
+}
+
+impl ModuleRequest {
+  pub(crate) fn encode(&self, e: &mut Encoder) {
+    self.reference.encode(e);
+    e.option(self.specifier_key.as_deref(), |e, v| e.str(v));
+    e.option(self.referrer_source_offset, |e, v| e.i32(v));
+    self.phase.encode(e);
+  }
+
+  pub(crate) fn decode(d: &mut Decoder) -> SnapshotResult<Self> {
+    Ok(Self {
+      reference: ModuleReference::decode(d)?,
+      specifier_key: d.option(|d| Ok(d.str()?.0.to_owned()))?,
+      referrer_source_offset: d.option(|d| d.i32())?,
+      phase: ModuleImportPhase::decode(d)?,
+    })
+  }
+}
+
+impl ModuleInfo {
+  pub(crate) fn encode(&self, e: &mut Encoder) {
+    e.usize(self.id);
+    e.bool(self.main);
+    e.str(self.name.as_str());
+    e.seq(self.requests.iter(), |e, r| r.encode(e));
+    self.module_type.encode(e);
+  }
+
+  pub(crate) fn decode(d: &mut Decoder) -> SnapshotResult<Self> {
+    Ok(Self {
+      id: d.usize()?,
+      main: d.bool()?,
+      name: d.fast_string()?,
+      requests: d.seq(ModuleRequest::decode)?,
+      module_type: ModuleType::decode(d)?,
+    })
+  }
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]

--- a/libs/core/modules/module_map_data.rs
+++ b/libs/core/modules/module_map_data.rs
@@ -1,12 +1,10 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::rc::Rc;
-
-use serde::Deserialize;
-use serde::Serialize;
 
 use super::RequestedModuleType;
 use crate::ModuleCodeString;
@@ -22,9 +20,12 @@ use crate::modules::ModuleType;
 use crate::runtime::SnapshotDataId;
 use crate::runtime::SnapshotLoadDataStore;
 use crate::runtime::SnapshotStoreDataStore;
+use crate::snapshot_format::Decoder;
+use crate::snapshot_format::Encoder;
+use crate::snapshot_format::SnapshotResult;
 
 /// A symbolic module entity.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum SymbolicModule {
   /// This module is an alias to another module.
   /// This is useful such that multiple names could point to
@@ -206,7 +207,9 @@ pub(crate) struct ModuleMapData {
   /// Specifiers of lazy-loaded ESM modules known to exist (survives
   /// snapshotting). Used to check if a module should be loaded from
   /// `lazy_esm_sources` without going through the external module loader.
-  pub(crate) known_lazy_esm: RefCell<HashSet<String>>,
+  /// `Cow` so that specifiers restored from a snapshot can borrow the snapshot
+  /// blob instead of being copied onto the heap for every isolate.
+  pub(crate) known_lazy_esm: RefCell<HashSet<Cow<'static, str>>>,
   pub(crate) lazy_script_sources:
     Rc<RefCell<HashMap<ModuleName, ModuleCodeString>>>,
   pub(crate) residual_lazy_script_sources:
@@ -243,7 +246,7 @@ pub(crate) struct ModuleMapData {
 }
 
 /// Snapshot-compatible representation of this data.
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Default)]
 pub(crate) struct ModuleMapSnapshotData {
   next_load_id: i32,
   main_module_id: Option<i32>,
@@ -254,21 +257,82 @@ pub(crate) struct ModuleMapSnapshotData {
   /// Specifiers of lazy-loaded ESM modules that are known to exist but
   /// are not compiled/instantiated in the snapshot. They will be loaded
   /// from the binary on first access at runtime.
-  #[serde(default)]
-  lazy_esm_specifiers: Vec<String>,
+  lazy_esm_specifiers: Vec<Cow<'static, str>>,
   /// `load_ext_script` cache snapshot. Captures the exports object
   /// returned by each polyfill IIFE evaluated at snapshot time so the
   /// runtime can share the same value (with the `synthetic_esm` dispatch
   /// in particular) without re-evaluating — re-eval would clobber
   /// registered `internals.__*` hooks and duplicate class identities.
-  #[serde(default)]
   loaded_script_results: Vec<(FastString, SnapshotDataId)>,
   /// Snapshot of the captured `__bootstrap` view registered via
   /// `op_set_captured_bootstrap` at the end of `01_core.js`. Restored
   /// at runtime so the Rust `load_ext_script` can reinstall it on
   /// `globalThis.__bootstrap` during each script evaluation.
-  #[serde(default)]
   captured_bootstrap: Option<SnapshotDataId>,
+}
+
+impl SymbolicModule {
+  fn encode(&self, e: &mut Encoder) {
+    match self {
+      Self::Alias(name) => {
+        e.u8(0);
+        e.str(name.as_str());
+      }
+      Self::Mod(id) => {
+        e.u8(1);
+        e.usize(*id);
+      }
+    }
+  }
+
+  fn decode(d: &mut Decoder) -> SnapshotResult<Self> {
+    Ok(match d.u8()? {
+      0 => Self::Alias(d.fast_string()?),
+      1 => Self::Mod(d.usize()?),
+      n => return Decoder::invalid_discriminant("SymbolicModule", n as u32),
+    })
+  }
+}
+
+impl ModuleMapSnapshotData {
+  pub(crate) fn encode(&self, e: &mut Encoder) {
+    e.i32(self.next_load_id);
+    e.option(self.main_module_id, |e, v| e.i32(v));
+    e.seq(self.modules.iter(), |e, m| m.encode(e));
+    e.seq(self.module_handles.iter(), |e, v| e.u32(*v));
+    e.seq(self.main_module_callbacks.iter(), |e, v| e.u32(*v));
+    e.seq(self.by_name.iter(), |e, (name, ty, module)| {
+      e.str(name.as_str());
+      ty.encode(e);
+      module.encode(e);
+    });
+    e.seq(self.lazy_esm_specifiers.iter(), |e, s| e.str(s));
+    e.seq(self.loaded_script_results.iter(), |e, (name, id)| {
+      e.str(name.as_str());
+      e.u32(*id);
+    });
+    e.option(self.captured_bootstrap, |e, v| e.u32(v));
+  }
+
+  pub(crate) fn decode(d: &mut Decoder) -> SnapshotResult<Self> {
+    Ok(Self {
+      next_load_id: d.i32()?,
+      main_module_id: d.option(|d| d.i32())?,
+      modules: d.seq(ModuleInfo::decode)?,
+      module_handles: d.seq(|d| d.u32())?,
+      main_module_callbacks: d.seq(|d| d.u32())?,
+      by_name: d.seq(|d| {
+        Ok((
+          d.fast_string()?,
+          RequestedModuleType::decode(d)?,
+          SymbolicModule::decode(d)?,
+        ))
+      })?,
+      lazy_esm_specifiers: d.seq(|d| d.cow_str())?,
+      loaded_script_results: d.seq(|d| Ok((d.fast_string()?, d.u32()?)))?,
+      captured_bootstrap: d.option(|d| d.u32())?,
+    })
+  }
 }
 
 impl ModuleMapData {
@@ -428,17 +492,38 @@ impl ModuleMapData {
     self.info.get(id).map(|info| info.name.as_str().to_owned())
   }
 
+  /// Serialize for snapshotting.
+  ///
+  /// `instantiated` is a per-module-id flag saying whether the V8 module was
+  /// already instantiated at snapshot time (see
+  /// [`crate::modules::ModuleMap::instantiated_flags`]). The import edges of an
+  /// instantiated module are dead weight in the snapshot: the only consumers of
+  /// `ModuleInfo::requests` are `module_resolve_callback` /
+  /// `module_source_callback`, which V8 only invokes while *instantiating* a
+  /// module, and `RecursiveModuleLoad`, which only walks the requests of an
+  /// already-registered module to make sure its subgraph is registered — and a
+  /// module instantiated in the snapshot necessarily brought its whole subgraph
+  /// with it. So we drop them, which also means the `Url`s inside them (the one
+  /// thing in the sidecar that cannot be a borrow) are never written or parsed.
   pub fn serialize_for_snapshotting(
     self,
     data_store: &mut SnapshotStoreDataStore,
+    instantiated: &[bool],
   ) -> ModuleMapSnapshotData {
     debug_assert_eq!(self.by_name.len(), self.handles.len());
     debug_assert_eq!(self.info.len(), self.handles.len());
 
+    let mut info = self.info;
+    for module in info.iter_mut() {
+      if instantiated.get(module.id).copied().unwrap_or(false) {
+        module.requests = Vec::new();
+      }
+    }
+
     let mut ser = ModuleMapSnapshotData {
       next_load_id: self.next_load_id,
       main_module_id: self.main_module_id.map(|x| x as _),
-      modules: self.info,
+      modules: info,
       ..Default::default()
     };
 
@@ -457,12 +542,8 @@ impl ModuleMapData {
       ser.by_name.push((name, module_type.clone(), module));
     });
 
-    ser.lazy_esm_specifiers = self
-      .known_lazy_esm
-      .borrow()
-      .iter()
-      .map(|s| s.to_string())
-      .collect();
+    ser.lazy_esm_specifiers =
+      self.known_lazy_esm.into_inner().into_iter().collect();
 
     // Move out of the Rc<RefCell<...>> so we can consume the values.
     let cached_results: HashMap<ModuleName, v8::Global<v8::Value>> =
@@ -526,7 +607,16 @@ impl ModuleMapData {
 
   // TODO(mmastrac): this is better than giving the entire crate access to the internals.
   #[cfg(test)]
-  pub fn assert_module_map(&self, modules: &Vec<ModuleInfo>) {
+  ///
+  /// `restored_from_snapshot` is the number of module ids that were rehydrated
+  /// from a snapshot. Those modules were already instantiated when the snapshot
+  /// was taken, so their import edges are intentionally not persisted (see
+  /// [`Self::serialize_for_snapshotting`]) and are expected to be empty here.
+  pub fn assert_module_map(
+    &self,
+    modules: &Vec<ModuleInfo>,
+    restored_from_snapshot: usize,
+  ) {
     use crate::runtime::NO_OF_BUILTIN_MODULES;
     let data = self;
     assert_eq!(data.handles.len(), modules.len() + NO_OF_BUILTIN_MODULES);
@@ -536,7 +626,20 @@ impl ModuleMapData {
 
     for info in modules {
       assert!(data.handles.get(info.id).is_some());
-      assert_eq!(data.info.get(info.id).unwrap(), info);
+      let actual = data.info.get(info.id).unwrap();
+      if info.id < restored_from_snapshot {
+        assert_eq!(actual.id, info.id);
+        assert_eq!(actual.main, info.main);
+        assert_eq!(actual.name, info.name);
+        assert_eq!(actual.module_type, info.module_type);
+        assert!(
+          actual.requests.is_empty(),
+          "import edges of snapshot-instantiated module {} should be dropped",
+          info.name
+        );
+      } else {
+        assert_eq!(actual, info);
+      }
       let requested_module_type =
         RequestedModuleType::from(info.module_type.clone());
       assert_eq!(

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2964,7 +2964,13 @@ impl JsRuntimeForSnapshot {
       let mut data_store = SnapshotStoreDataStore::default();
       let module_map_data = {
         let module_map = realm.0.module_map();
-        module_map.serialize_for_snapshotting(&mut data_store)
+        // Modules already instantiated in the snapshot don't need their import
+        // edges persisted; nothing reads them after rehydration.
+        let instantiated = {
+          jsrealm::context_scope!(scope, realm, self.v8_isolate());
+          module_map.instantiated_flags(scope)
+        };
+        module_map.serialize_for_snapshotting(&mut data_store, &instantiated)
       };
       let function_templates_data = {
         let function_templates = realm.0.function_templates();

--- a/libs/core/runtime/snapshot.rs
+++ b/libs/core/runtime/snapshot.rs
@@ -6,9 +6,6 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Instant;
 
-use serde::Deserialize;
-use serde::Serialize;
-
 use super::ExtensionTranspiler;
 use crate::Extension;
 use crate::JsRuntimeForSnapshot;
@@ -16,6 +13,9 @@ use crate::RuntimeOptions;
 use crate::cppgc::FunctionTemplateSnapshotData;
 use crate::error::CoreError;
 use crate::modules::ModuleMapSnapshotData;
+use crate::snapshot_format::Decoder;
+use crate::snapshot_format::Encoder;
+use crate::snapshot_format::SnapshotResult;
 
 pub type WithRuntimeCb = dyn Fn(&mut JsRuntimeForSnapshot);
 
@@ -301,7 +301,10 @@ pub fn create_snapshot(
 
 /// The data we intend to snapshot, separated from any V8 objects that
 /// are stored in the [`SnapshotLoadDataStore`]/[`SnapshotStoreDataStore`].
-#[derive(Serialize, Deserialize)]
+///
+/// On the write side `'snapshot` is the lifetime of the live runtime's
+/// allocations; on the read side it is always `'static`, because everything is
+/// decoded as a borrow of the `&'static [u8]` snapshot blob.
 pub(crate) struct SnapshottedData<'snapshot> {
   pub js_handled_promise_rejection_cb: Option<u32>,
   pub ext_import_meta_proto: Option<u32>,
@@ -311,29 +314,73 @@ pub(crate) struct SnapshottedData<'snapshot> {
   pub op_count: usize,
   pub source_count: usize,
   pub addl_refs_count: usize,
-  #[serde(borrow)]
   pub ext_source_maps: HashMap<&'snapshot str, &'snapshot [u8]>,
-  #[serde(borrow)]
   pub external_strings: Vec<&'snapshot [u8]>,
 }
 
+impl SnapshottedData<'_> {
+  fn encode(&self, e: &mut Encoder) {
+    e.option(self.js_handled_promise_rejection_cb, |e, v| e.u32(v));
+    e.option(self.ext_import_meta_proto, |e, v| e.u32(v));
+    self.module_map_data.encode(e);
+    self.function_templates_data.encode(e);
+    e.seq(self.extensions.iter(), |e, s| e.str(s));
+    e.usize(self.op_count);
+    e.usize(self.source_count);
+    e.usize(self.addl_refs_count);
+    e.seq(self.ext_source_maps.iter(), |e, (k, v)| {
+      e.str(k);
+      e.bytes(v);
+    });
+    e.seq(self.external_strings.iter(), |e, v| e.bytes(v));
+  }
+}
+
+impl SnapshottedData<'static> {
+  fn decode(d: &mut Decoder) -> SnapshotResult<Self> {
+    Ok(Self {
+      js_handled_promise_rejection_cb: d.option(|d| d.u32())?,
+      ext_import_meta_proto: d.option(|d| d.u32())?,
+      module_map_data: ModuleMapSnapshotData::decode(d)?,
+      function_templates_data: FunctionTemplateSnapshotData::decode(d)?,
+      extensions: d.seq(|d| Ok(d.str()?.0))?,
+      op_count: d.usize()?,
+      source_count: d.usize()?,
+      addl_refs_count: d.usize()?,
+      ext_source_maps: d.map(|d| Ok((d.str()?.0, d.bytes()?)))?,
+      external_strings: d.seq(|d| d.bytes())?,
+    })
+  }
+}
+
 /// Snapshot sidecar data, containing a [`SnapshottedData`] and the length of the
-/// associated data array. This is the final form of the [`SnapshottedData`] before
-/// we hand it off to serde.
-#[derive(Serialize, Deserialize)]
+/// associated data array. This is the final form of the [`SnapshottedData`]
+/// before it is encoded into the sidecar blob.
 pub(crate) struct SerializableSnapshotSidecarData<'snapshot> {
   pub(crate) data_count: u32,
-  #[serde(borrow)]
   pub snapshot_data: SnapshottedData<'snapshot>,
 }
 
-impl<'snapshot> SerializableSnapshotSidecarData<'snapshot> {
-  fn from_slice(slice: &'snapshot [u8]) -> Self {
-    bincode::deserialize(slice).expect("Failed to deserialize snapshot data")
+impl SerializableSnapshotSidecarData<'static> {
+  fn from_slice(slice: &'static [u8]) -> Self {
+    let d = &mut Decoder::new(slice)
+      .expect("Failed to deserialize snapshot sidecar data");
+    let data_count = d.u32().expect("Failed to deserialize snapshot data");
+    let snapshot_data =
+      SnapshottedData::decode(d).expect("Failed to deserialize snapshot data");
+    Self {
+      data_count,
+      snapshot_data,
+    }
   }
+}
 
+impl SerializableSnapshotSidecarData<'_> {
   fn into_bytes(self) -> Box<[u8]> {
-    bincode::serialize(&self).unwrap().into_boxed_slice()
+    let mut e = Encoder::new();
+    e.u32(self.data_count);
+    self.snapshot_data.encode(&mut e);
+    e.into_bytes()
   }
 }
 

--- a/libs/core/runtime/tests/snapshot.rs
+++ b/libs/core/runtime/tests/snapshot.rs
@@ -285,7 +285,11 @@ fn es_snapshot() {
 
   modules.extend((1..200).map(|i| create_module(&mut runtime, i, false)));
 
-  runtime.module_map().assert_module_map(&modules);
+  runtime.module_map().assert_module_map(&modules, 0);
+
+  // Everything in `modules` (plus the builtins) is instantiated in this
+  // snapshot, so `runtime2` will see them without their import edges.
+  let snapshotted_module_count = modules.len() + NO_OF_BUILTIN_MODULES;
 
   let snapshot = runtime.snapshot();
   let snapshot = Box::leak(snapshot);
@@ -300,13 +304,18 @@ fn es_snapshot() {
     ..Default::default()
   });
 
-  runtime2.module_map().assert_module_map(&modules);
+  runtime2
+    .module_map()
+    .assert_module_map(&modules, snapshotted_module_count);
 
   modules.extend((200..400).map(|i| create_module(&mut runtime2, i, false)));
   modules.push(create_module(&mut runtime2, 400, true));
 
-  runtime2.module_map().assert_module_map(&modules);
+  runtime2
+    .module_map()
+    .assert_module_map(&modules, snapshotted_module_count);
 
+  let snapshotted_module_count2 = modules.len() + NO_OF_BUILTIN_MODULES;
   let snapshot2 = runtime2.snapshot();
   let snapshot2 = Box::leak(snapshot2);
 
@@ -321,7 +330,9 @@ fn es_snapshot() {
     ..Default::default()
   });
 
-  runtime3.module_map().assert_module_map(&modules);
+  runtime3
+    .module_map()
+    .assert_module_map(&modules, snapshotted_module_count2);
 
   let source_code = r#"(async () => {
     const mod = await import("file:///400.js");

--- a/libs/core/snapshot_format.rs
+++ b/libs/core/snapshot_format.rs
@@ -1,0 +1,391 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! A tiny, hand-rolled, borrow-first serialization format for the snapshot
+//! sidecar data.
+//!
+//! This replaces `bincode` for the two snapshot sidecar call sites. The data is
+//! entirely internal to `deno_core` and is versioned by the snapshot hash, so
+//! there is no backwards-compatibility requirement — but we still write a
+//! format version word up front so a mismatch fails loudly instead of
+//! producing garbage.
+//!
+//! # Why hand-rolled
+//!
+//! The snapshot blob handed to `JsRuntime::new` is `&'static [u8]`, which means
+//! every string in the sidecar can be a *borrow* of the blob rather than a heap
+//! copy. `serde`'s `Deserialize` for [`FastString`] cannot express that (it
+//! goes through a `&'de str` proxy whose lifetime is tied to the deserializer,
+//! not to `'static`), so every `JsRuntime::new` used to copy the entire module
+//! table onto the heap. Decoding straight out of a `&'static [u8]` lets us hand
+//! back `FastString::Static`/`StaticAscii` variants that point into the blob.
+//!
+//! # Wire format
+//!
+//! Everything is little-endian and length-prefixed.
+//!
+//! - `u8`/`u32`/`i32`/`u64`: fixed-width LE.
+//! - `usize`: encoded as `u64`.
+//! - `bool`: one byte, `0` or `1`.
+//! - `Option<T>`: one tag byte (`0` = none, `1` = some) followed by `T`.
+//! - sequences (`Vec`, `HashMap`): `u32` element count followed by the
+//!   elements. Maps are encoded as key/value pairs.
+//! - byte slices: `u32` length followed by the raw bytes.
+//! - strings: a `u32` header whose low 31 bits are the byte length and whose
+//!   high bit is set when the string contains non-ASCII bytes, followed by the
+//!   UTF-8 bytes. The ASCII bit is computed once at snapshot-creation time (a
+//!   cold path) so that rehydration never has to re-scan the string to pick the
+//!   right [`FastString`] representation. UTF-8 is validated once at decode.
+//! - enums: a `u8` discriminant followed by the payload, if any.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use crate::FastString;
+
+/// Bumped whenever the layout below changes. Snapshots are already keyed by a
+/// build hash, so this only exists to turn "silently decoded nonsense" into a
+/// clean panic.
+pub(crate) const SNAPSHOT_FORMAT_VERSION: u32 = 1;
+
+/// A string longer than this cannot be encoded (the top bit of the length
+/// header is the non-ASCII flag).
+const MAX_STR_LEN: usize = (1 << 31) - 1;
+const NON_ASCII_FLAG: u32 = 1 << 31;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SnapshotDecodeError {
+  #[error(
+    "snapshot sidecar format version mismatch: expected {expected}, found {found}"
+  )]
+  VersionMismatch { expected: u32, found: u32 },
+  #[error("unexpected end of snapshot sidecar data")]
+  UnexpectedEof,
+  #[error("invalid UTF-8 in snapshot sidecar data")]
+  InvalidUtf8,
+  #[error("invalid discriminant {value} for {ty} in snapshot sidecar data")]
+  InvalidDiscriminant { ty: &'static str, value: u32 },
+  #[error("invalid URL in snapshot sidecar data: {0}")]
+  InvalidUrl(String),
+}
+
+pub(crate) type SnapshotResult<T> = std::result::Result<T, SnapshotDecodeError>;
+use SnapshotResult as Result;
+
+// ---------------------------------------------------------------------------
+// Encoder
+// ---------------------------------------------------------------------------
+
+/// The write half of the format. Only used while *creating* a snapshot, which
+/// is a cold, once-per-build path, so this is deliberately simple.
+pub(crate) struct Encoder {
+  buf: Vec<u8>,
+}
+
+impl Encoder {
+  pub fn new() -> Self {
+    let mut this = Self {
+      buf: Vec::with_capacity(64 * 1024),
+    };
+    this.u32(SNAPSHOT_FORMAT_VERSION);
+    this
+  }
+
+  pub fn into_bytes(self) -> Box<[u8]> {
+    self.buf.into_boxed_slice()
+  }
+
+  pub fn u8(&mut self, v: u8) {
+    self.buf.push(v);
+  }
+
+  pub fn bool(&mut self, v: bool) {
+    self.u8(v as u8);
+  }
+
+  pub fn u32(&mut self, v: u32) {
+    self.buf.extend_from_slice(&v.to_le_bytes());
+  }
+
+  pub fn i32(&mut self, v: i32) {
+    self.buf.extend_from_slice(&v.to_le_bytes());
+  }
+
+  pub fn u64(&mut self, v: u64) {
+    self.buf.extend_from_slice(&v.to_le_bytes());
+  }
+
+  pub fn usize(&mut self, v: usize) {
+    self.u64(v as u64);
+  }
+
+  pub fn bytes(&mut self, v: &[u8]) {
+    self.u32(v.len() as u32);
+    self.buf.extend_from_slice(v);
+  }
+
+  pub fn str(&mut self, v: &str) {
+    assert!(
+      v.len() <= MAX_STR_LEN,
+      "string too long for snapshot sidecar"
+    );
+    let mut header = v.len() as u32;
+    if !v.is_ascii() {
+      header |= NON_ASCII_FLAG;
+    }
+    self.u32(header);
+    self.buf.extend_from_slice(v.as_bytes());
+  }
+
+  pub fn option<T>(&mut self, v: Option<T>, f: impl FnOnce(&mut Self, T)) {
+    match v {
+      None => self.u8(0),
+      Some(v) => {
+        self.u8(1);
+        f(self, v);
+      }
+    }
+  }
+
+  pub fn seq<T>(
+    &mut self,
+    items: impl ExactSizeIterator<Item = T>,
+    mut f: impl FnMut(&mut Self, T),
+  ) {
+    self.u32(items.len() as u32);
+    for item in items {
+      f(self, item);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Decoder
+// ---------------------------------------------------------------------------
+
+/// The read half of the format.
+///
+/// The decoder is deliberately pinned to `&'static [u8]` rather than being
+/// generic over a lifetime: the snapshot blob *is* `'static`, and pinning it
+/// here is what lets every string decode into a `'static` borrow (and therefore
+/// into a non-allocating [`FastString`]) without any lifetime plumbing through
+/// the sidecar structs.
+#[derive(Debug)]
+pub(crate) struct Decoder {
+  buf: &'static [u8],
+  pos: usize,
+}
+
+impl Decoder {
+  pub fn new(buf: &'static [u8]) -> Result<Self> {
+    let mut this = Self { buf, pos: 0 };
+    let found = this.u32()?;
+    if found != SNAPSHOT_FORMAT_VERSION {
+      return Err(SnapshotDecodeError::VersionMismatch {
+        expected: SNAPSHOT_FORMAT_VERSION,
+        found,
+      });
+    }
+    Ok(this)
+  }
+
+  fn take(&mut self, n: usize) -> Result<&'static [u8]> {
+    let end = self
+      .pos
+      .checked_add(n)
+      .ok_or(SnapshotDecodeError::UnexpectedEof)?;
+    if end > self.buf.len() {
+      return Err(SnapshotDecodeError::UnexpectedEof);
+    }
+    let slice = &self.buf[self.pos..end];
+    self.pos = end;
+    Ok(slice)
+  }
+
+  pub fn u8(&mut self) -> Result<u8> {
+    Ok(self.take(1)?[0])
+  }
+
+  pub fn bool(&mut self) -> Result<bool> {
+    Ok(self.u8()? != 0)
+  }
+
+  pub fn u32(&mut self) -> Result<u32> {
+    Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()))
+  }
+
+  pub fn i32(&mut self) -> Result<i32> {
+    Ok(i32::from_le_bytes(self.take(4)?.try_into().unwrap()))
+  }
+
+  pub fn u64(&mut self) -> Result<u64> {
+    Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
+  }
+
+  pub fn usize(&mut self) -> Result<usize> {
+    Ok(self.u64()? as usize)
+  }
+
+  pub fn bytes(&mut self) -> Result<&'static [u8]> {
+    let len = self.u32()? as usize;
+    self.take(len)
+  }
+
+  /// Decodes a string as a borrow of the snapshot blob. UTF-8 is validated
+  /// here, once; the ASCII-ness of the string is carried in the length header
+  /// so callers never have to re-scan it.
+  pub fn str(&mut self) -> Result<(&'static str, bool)> {
+    let header = self.u32()?;
+    let is_ascii = header & NON_ASCII_FLAG == 0;
+    let bytes = self.take((header & !NON_ASCII_FLAG) as usize)?;
+    let s = std::str::from_utf8(bytes)
+      .map_err(|_| SnapshotDecodeError::InvalidUtf8)?;
+    Ok((s, is_ascii))
+  }
+
+  /// Decodes a string into a [`FastString`] that borrows the snapshot blob —
+  /// no allocation, no copy.
+  pub fn fast_string(&mut self) -> Result<FastString> {
+    let (s, is_ascii) = self.str()?;
+    Ok(if is_ascii {
+      // SAFETY: the encoder set the ASCII flag only for ASCII-only strings, and
+      // `str()` has already validated that the bytes are well-formed UTF-8.
+      unsafe { FastString::from_ascii_static_unchecked(s) }
+    } else {
+      FastString::from_non_ascii_static(s)
+    })
+  }
+
+  /// Decodes a string as a borrowed `Cow`, again pointing into the blob.
+  pub fn cow_str(&mut self) -> Result<Cow<'static, str>> {
+    Ok(Cow::Borrowed(self.str()?.0))
+  }
+
+  pub fn option<T>(
+    &mut self,
+    f: impl FnOnce(&mut Self) -> Result<T>,
+  ) -> Result<Option<T>> {
+    match self.u8()? {
+      0 => Ok(None),
+      _ => Ok(Some(f(self)?)),
+    }
+  }
+
+  pub fn seq<T>(
+    &mut self,
+    mut f: impl FnMut(&mut Self) -> Result<T>,
+  ) -> Result<Vec<T>> {
+    let len = self.u32()? as usize;
+    // Don't trust the length blindly: a corrupt header shouldn't be able to ask
+    // for a multi-gigabyte allocation before we hit EOF.
+    let mut out = Vec::with_capacity(len.min(64 * 1024));
+    for _ in 0..len {
+      out.push(f(self)?);
+    }
+    Ok(out)
+  }
+
+  pub fn map<K: std::hash::Hash + Eq, V>(
+    &mut self,
+    mut f: impl FnMut(&mut Self) -> Result<(K, V)>,
+  ) -> Result<HashMap<K, V>> {
+    let len = self.u32()? as usize;
+    let mut out = HashMap::with_capacity(len.min(64 * 1024));
+    for _ in 0..len {
+      let (k, v) = f(self)?;
+      out.insert(k, v);
+    }
+    Ok(out)
+  }
+
+  pub fn invalid_discriminant<T>(ty: &'static str, value: u32) -> Result<T> {
+    Err(SnapshotDecodeError::InvalidDiscriminant { ty, value })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn leak(b: Box<[u8]>) -> &'static [u8] {
+    Box::leak(b)
+  }
+
+  #[test]
+  fn roundtrip_scalars() {
+    let mut e = Encoder::new();
+    e.u8(7);
+    e.bool(true);
+    e.bool(false);
+    e.u32(0xdead_beef);
+    e.i32(-12345);
+    e.usize(usize::MAX);
+    let d = &mut Decoder::new(leak(e.into_bytes())).unwrap();
+    assert_eq!(d.u8().unwrap(), 7);
+    assert!(d.bool().unwrap());
+    assert!(!d.bool().unwrap());
+    assert_eq!(d.u32().unwrap(), 0xdead_beef);
+    assert_eq!(d.i32().unwrap(), -12345);
+    assert_eq!(d.usize().unwrap(), usize::MAX);
+  }
+
+  #[test]
+  fn strings_borrow_the_buffer() {
+    let mut e = Encoder::new();
+    e.str("ext:core/01_core.js");
+    e.str("héllo");
+    let buf = leak(e.into_bytes());
+    let d = &mut Decoder::new(buf).unwrap();
+
+    let s = d.fast_string().unwrap();
+    assert_eq!(s.as_str(), "ext:core/01_core.js");
+    // The decoded string must be a borrow of the snapshot blob, not a copy.
+    let borrowed = s.as_static_str().expect("must be a static borrow");
+    let range = buf.as_ptr_range();
+    assert!(range.contains(&borrowed.as_ptr()));
+
+    let s = d.fast_string().unwrap();
+    assert_eq!(s.as_str(), "héllo");
+    assert!(s.as_static_str().is_some());
+  }
+
+  #[test]
+  fn seq_and_option_and_map() {
+    let mut e = Encoder::new();
+    e.seq([1u32, 2, 3].into_iter(), |e, v| e.u32(v));
+    e.option(Some(9u32), |e, v| e.u32(v));
+    e.option(None::<u32>, |e, v| e.u32(v));
+    e.seq([("a", 1u32), ("b", 2)].into_iter(), |e, (k, v)| {
+      e.str(k);
+      e.u32(v);
+    });
+    let d = &mut Decoder::new(leak(e.into_bytes())).unwrap();
+    assert_eq!(d.seq(|d| d.u32()).unwrap(), vec![1, 2, 3]);
+    assert_eq!(d.option(|d| d.u32()).unwrap(), Some(9));
+    assert_eq!(d.option(|d| d.u32()).unwrap(), None);
+    let m = d.map(|d| Ok((d.str()?.0, d.u32()?))).unwrap();
+    assert_eq!(m.len(), 2);
+    assert_eq!(m["a"], 1);
+    assert_eq!(m["b"], 2);
+  }
+
+  #[test]
+  fn version_mismatch_is_detected() {
+    let mut bytes = Encoder::new().into_bytes().to_vec();
+    bytes[0] = bytes[0].wrapping_add(1);
+    let err = Decoder::new(leak(bytes.into_boxed_slice())).unwrap_err();
+    assert!(matches!(err, SnapshotDecodeError::VersionMismatch { .. }));
+  }
+
+  #[test]
+  fn truncated_input_is_detected() {
+    let mut e = Encoder::new();
+    e.str("hello");
+    let bytes = e.into_bytes();
+    let truncated = leak(bytes[..bytes.len() - 2].to_vec().into_boxed_slice());
+    let d = &mut Decoder::new(truncated).unwrap();
+    assert!(matches!(
+      d.str().unwrap_err(),
+      SnapshotDecodeError::UnexpectedEof
+    ));
+  }
+}

--- a/libs/core/snapshot_format.rs
+++ b/libs/core/snapshot_format.rs
@@ -306,16 +306,16 @@ impl Decoder {
 mod tests {
   use super::*;
 
-  /// Hands out a `'static` view of the buffer while keeping the box
-  /// reachable from a static, so miri's leak check stays clean.
+  /// Leaks the buffer but records the pointer in a static, so the
+  /// allocation stays reachable and miri's leak check stays clean.
   fn leak(b: Box<[u8]>) -> &'static [u8] {
-    static KEEP: std::sync::Mutex<Vec<Box<[u8]>>> =
-      std::sync::Mutex::new(Vec::new());
-    let ptr: *const [u8] = &*b;
-    KEEP.lock().unwrap().push(b);
-    // SAFETY: the box now lives in KEEP for the rest of the process, and
-    // its heap buffer does not move when the box itself is moved.
-    unsafe { &*ptr }
+    struct Keep(std::sync::Mutex<Vec<*const [u8]>>);
+    // SAFETY: the pointers are only stored, never dereferenced.
+    unsafe impl Sync for Keep {}
+    static KEEP: Keep = Keep(std::sync::Mutex::new(Vec::new()));
+    let r: &'static [u8] = Box::leak(b);
+    KEEP.0.lock().unwrap().push(r as *const [u8]);
+    r
   }
 
   #[test]

--- a/libs/core/snapshot_format.rs
+++ b/libs/core/snapshot_format.rs
@@ -306,8 +306,16 @@ impl Decoder {
 mod tests {
   use super::*;
 
+  /// Hands out a `'static` view of the buffer while keeping the box
+  /// reachable from a static, so miri's leak check stays clean.
   fn leak(b: Box<[u8]>) -> &'static [u8] {
-    Box::leak(b)
+    static KEEP: std::sync::Mutex<Vec<Box<[u8]>>> =
+      std::sync::Mutex::new(Vec::new());
+    let ptr: *const [u8] = &*b;
+    KEEP.lock().unwrap().push(b);
+    // SAFETY: the box now lives in KEEP for the rest of the process, and
+    // its heap buffer does not move when the box itself is moved.
+    unsafe { &*ptr }
   }
 
   #[test]


### PR DESCRIPTION
Every `JsRuntime::new` from a snapshot deserialized owned copies of every module
name and every import edge, even though the snapshot blob is `'static`. serde's
`Deserialize` for `FastString` cannot express a `'static` borrow (its `&'de str`
proxy is tied to the deserializer, not to the blob), so the copies were
structural, not incidental.

This replaces bincode with a small hand-rolled sidecar format in
`libs/core/snapshot_format.rs`: little-endian, length-prefixed, versioned by a
leading u32. The decoder is pinned to `&'static [u8]` rather than being generic
over a lifetime, which is what lets every string decode straight into a
`FastString::Static`/`StaticAscii` borrow of the blob with no lifetime plumbing
through the sidecar structs. String headers carry an "is ASCII" bit computed at
snapshot-creation time, so rehydration never rescans a string to pick the right
`FastString` representation. UTF-8 is validated once at decode.

We also stop persisting `requests`/`specifier_key` for modules that were already
instantiated when the snapshot was taken. The only consumers of
`ModuleInfo::requests` are `module_resolve_callback` and
`module_source_callback`, which V8 invokes only while instantiating a module,
and `RecursiveModuleLoad`, which walks the requests of an already-registered
module purely to make sure its subgraph is registered -- and a module
instantiated in the snapshot brought its whole subgraph with it. Dropping them
also means the `Url`s inside them, the one thing in the sidecar that cannot be a
borrow, are never written or parsed for a normal snapshot. `known_lazy_esm`
becomes a `HashSet<Cow<'static, str>>` for the same reason.

Numbers below are measured in a standalone extraction of deno_core, not in this
repo. `JsRuntime::new` from a 2000-module snapshot is about 22-26% faster
(7.1 ms -> 5.3 ms), the snapshot blob shrinks about 6%, and one dependency
(bincode) is removed.

On format compatibility: the sidecar is internal to deno_core. It is produced by
snapshot creation and consumed by rehydration within the same build, so no
external format stability is required. I checked the whole monorepo for other
parsers of it -- `ModuleMapSnapshotData`, `SnapshottedData`,
`SerializableSnapshotSidecarData`, `serialize_for_snapshotting`, and the
`SnapshotStoreDataStore`/`SnapshotLoadDataStore` entry points have no references
outside `libs/core`. Nothing else in the tree reads these bytes.

bincode stays in the workspace dependency list because `cli`, `cli/rt`, and
`libs/npm_installer` still use it; only `libs/core`'s dependency on it is
dropped.
