### PR TITLE
docs: drop the removed typescript_go_client crate

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -99,8 +99,6 @@ Notable members:
 - `libs/resolver`, `libs/node_resolver`, `libs/npm`, `libs/npm_installer`,
   `libs/package_json`, `libs/lockfile`, `libs/config`, `libs/npmrc` — the
   resolution and package-management building blocks the CLI composes.
-- `libs/typescript_go_client` — client for the out-of-process TypeScript
-  type-checker.
 
 These crates are deliberately free of CLI concerns so they can be unit-tested in
 isolation and reused by other tools.

--- a/doc/codebase-map.md
+++ b/doc/codebase-map.md
@@ -62,8 +62,7 @@ packaging:
   `npm_installer`, `npmrc`, `package_json`, `lockfile`, `config`, `cli_parser`,
   `cache_dir`.
 - **Other building blocks:** `crypto`, `dotenv`, `eszip`, `http_h1`,
-  `inspector_server`, `maybe_sync`, `napi_sys`, `node_shim`,
-  `typescript_go_client`.
+  `inspector_server`, `maybe_sync`, `napi_sys`, `node_shim`.
 
 ## Inside `tests/`
 


### PR DESCRIPTION
Closes #36632.

`libs/typescript_go_client` was removed in `1e4b28cfec` ("chore: remove the dead forked typescript-go integration", #35935). Two developer docs still name it.

- `doc/architecture.md` carried a bullet describing it as the client for the out-of-process TypeScript type-checker. Removed rather than repointed, because that commit deleted the integration instead of moving it.
- `doc/codebase-map.md` listed it under **Other building blocks**. Dropped from the list and the line re-wrapped.

Verified against `main` at `ff672314`: `libs/` holds 26 crates and this is not among them, while every other crate named in the `architecture.md` list resolves.

**Disclosure: AI tools were used.** The first reference was found by [docproof](https://github.com/melbinjp/docproof), which resolves documented paths against the repository and its git history. The second is a bare backticked name the checker cannot see, found by reading. Both were checked against `main` by hand before this was sent.
