### PR TITLE
fix(cli): don't panic when the test worker cannot create its pipes

### DIFF
--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -317,6 +317,8 @@ impl TestRun {
       let worker_factory = worker_factory.clone();
       let cli_options = cli_options.clone();
       let permission_desc_parser = permission_desc_parser.clone();
+      // Carried into the task rather than unwrapped here: the pipes can be
+      // refused by the OS, and that has to surface as a normal error.
       let worker_sender = test_event_sender_factory.worker();
       let fail_fast_tracker = fail_fast_tracker.clone();
       let lsp_filter = self.filters.get(&specifier);
@@ -335,6 +337,7 @@ impl TestRun {
       let token = self.token.clone();
 
       spawn_blocking(move || {
+        let worker_sender = worker_sender?;
         // Various test files should not share the same permissions in terms of
         // `PermissionsContainer` - otherwise granting/revoking permissions in one
         // file would have impact on other files, which is undesirable.

--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -117,7 +117,7 @@ pub async fn kernel(
 
   let repl_thread = std::thread::spawn(move || {
     let fut = async move {
-      let (worker, test_event_receiver) = create_single_test_event_channel();
+      let (worker, test_event_receiver) = create_single_test_event_channel()?;
       let TestEventWorkerSender {
         sender: test_event_sender,
         stdout,
@@ -194,7 +194,7 @@ pub async fn kernel(
   )
   .unwrap();
 
-  let (worker2, _) = create_single_test_event_channel();
+  let (worker2, _) = create_single_test_event_channel()?;
   let TestEventWorkerSender {
     sender: _test_sender2,
     stdout: stdout2,

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -165,7 +165,7 @@ pub async fn run(
   let file_fetcher = factory.file_fetcher()?;
   let compiler_options_resolver = factory.compiler_options_resolver()?;
   let worker_factory = factory.create_cli_main_worker_factory().await?;
-  let (worker, test_event_receiver) = create_single_test_event_channel();
+  let (worker, test_event_receiver) = create_single_test_event_channel()?;
   let test_event_sender = worker.sender;
   let mut worker = worker_factory
     .create_custom_worker(

--- a/cli/tools/test/channel.rs
+++ b/cli/tools/test/channel.rs
@@ -11,6 +11,8 @@ use std::task::Poll;
 use std::task::ready;
 use std::time::Duration;
 
+use deno_core::anyhow::Context;
+use deno_core::error::AnyError;
 use deno_core::parking_lot;
 use deno_core::parking_lot::lock_api::RawMutex;
 use deno_core::parking_lot::lock_api::RawMutexTimed;
@@ -86,9 +88,9 @@ pub fn create_test_event_channel() -> (TestEventSenderFactory, TestEventReceiver
 /// Create a [`TestEventWorkerSender`] and [`TestEventReceiver`] pair.The [`TestEventReceiver`]
 /// will be kept alive until the [`TestEventSender`] is dropped.
 pub fn create_single_test_event_channel()
--> (TestEventWorkerSender, TestEventReceiver) {
+-> Result<(TestEventWorkerSender, TestEventReceiver), AnyError> {
   let (factory, receiver) = create_test_event_channel();
-  (factory.worker(), receiver)
+  Ok((factory.worker()?, receiver))
 }
 
 /// Polls for the next [`TestEvent`] from any worker. Events from multiple worker
@@ -247,14 +249,23 @@ pub struct TestEventSenderFactory {
 
 impl TestEventSenderFactory {
   /// Create a [`TestEventWorkerSender`], along with a stdout/stderr stream.
-  pub fn worker(&self) -> TestEventWorkerSender {
+  ///
+  /// Fails if the OS refuses the pipes the worker writes its output through,
+  /// which a restricted Windows environment can do.
+  pub fn worker(&self) -> Result<TestEventWorkerSender, AnyError> {
     let id = self.worker_id.fetch_add(1, Ordering::AcqRel);
-    let (stdout_reader, stdout_writer) = pipe().unwrap();
-    let (stderr_reader, stderr_writer) = pipe().unwrap();
+    let (stdout_reader, stdout_writer) =
+      pipe().context("Failed to create a pipe for test worker stdout")?;
+    let (stderr_reader, stderr_writer) =
+      pipe().context("Failed to create a pipe for test worker stderr")?;
     let (sync_sender, mut sync_receiver) =
       tokio::sync::mpsc::unbounded_channel::<(SendMutex, SendMutex)>();
-    let stdout = stdout_writer.try_clone().unwrap();
-    let stderr = stderr_writer.try_clone().unwrap();
+    let stdout = stdout_writer
+      .try_clone()
+      .context("Failed to clone the test worker stdout pipe")?;
+    let stderr = stderr_writer
+      .try_clone()
+      .context("Failed to clone the test worker stderr pipe")?;
     let sender = self.sender.clone();
 
     // Each worker spawns its own output monitoring and serialization task. This task will
@@ -333,11 +344,11 @@ impl TestEventSenderFactory {
       stderr_writer,
     };
 
-    TestEventWorkerSender {
+    Ok(TestEventWorkerSender {
       sender,
       stdout,
       stderr,
-    }
+    })
   }
 
   /// A [`TestEventWeakSender`] has a unique ID, but will not keep the [`TestEventReceiver`] alive.
@@ -450,7 +461,8 @@ mod tests {
   #[tokio::test]
   async fn spawn_worker() {
     test_util::timeout!(60);
-    let (mut worker, mut receiver) = create_single_test_event_channel();
+    let (mut worker, mut receiver) =
+      create_single_test_event_channel().unwrap();
 
     let recv_handle = spawn(async move {
       let mut queue = vec![];
@@ -503,7 +515,8 @@ mod tests {
   #[tokio::test]
   async fn test_flush_lots() {
     test_util::timeout!(240);
-    let (mut worker, mut receiver) = create_single_test_event_channel();
+    let (mut worker, mut receiver) =
+      create_single_test_event_channel().unwrap();
     let recv_handle = spawn(async move {
       let mut queue = vec![];
       while let Some((_, message)) = receiver.recv().await {
@@ -528,7 +541,8 @@ mod tests {
   #[tokio::test]
   async fn test_flush_large() {
     test_util::timeout!(240);
-    let (mut worker, mut receiver) = create_single_test_event_channel();
+    let (mut worker, mut receiver) =
+      create_single_test_event_channel().unwrap();
     let recv_handle = spawn(async move {
       let mut queue = vec![];
       while let Some((_, message)) = receiver.recv().await {
@@ -563,7 +577,7 @@ mod tests {
   #[tokio::test]
   async fn test_flush_with_close() {
     test_util::timeout!(240);
-    let (worker, mut receiver) = create_single_test_event_channel();
+    let (worker, mut receiver) = create_single_test_event_channel().unwrap();
     let TestEventWorkerSender {
       mut sender,
       stderr,
@@ -608,7 +622,8 @@ mod tests {
   async fn test_interleave() {
     test_util::timeout!(60);
     const MESSAGE_COUNT: usize = 10_000;
-    let (mut worker, mut receiver) = create_single_test_event_channel();
+    let (mut worker, mut receiver) =
+      create_single_test_event_channel().unwrap();
     let recv_handle = spawn(async move {
       let mut i = 0;
       while let Some((_, message)) = receiver.recv().await {
@@ -652,7 +667,8 @@ mod tests {
   async fn test_sender_shutdown_before_receive() {
     test_util::timeout!(60);
     for _ in 0..10 {
-      let (mut worker, mut receiver) = create_single_test_event_channel();
+      let (mut worker, mut receiver) =
+        create_single_test_event_channel().unwrap();
       worker.stderr.write_all(b"hello").unwrap();
       worker
         .sender
@@ -681,7 +697,8 @@ mod tests {
       .build()
       .unwrap();
     runtime.block_on(async {
-      let (mut worker, mut receiver) = create_single_test_event_channel();
+      let (mut worker, mut receiver) =
+        create_single_test_event_channel().unwrap();
       tokio::task::spawn(async move {
         loop {
           if receiver.recv().await.is_none() {

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -1756,12 +1756,15 @@ async fn test_specifiers(
     let specifier_dir = cli_options.workspace().resolve_member_dir(&specifier);
     let preload_modules = preload_modules.clone();
     let require_modules = require_modules.clone();
+    // Carried into the task rather than unwrapped here: the pipes can be
+    // refused by the OS, and that has to surface as a normal error.
     let worker_sender = test_event_sender_factory.worker();
     let fail_fast_tracker = fail_fast_tracker.clone();
     let specifier_options = options.specifier.clone();
     let cli_options = cli_options.clone();
     let permission_desc_parser = permission_desc_parser.clone();
     spawn_blocking(move || {
+      let worker_sender = worker_sender?;
       // Various test files should not share the same permissions in terms of
       // `PermissionsContainer` - otherwise granting/revoking permissions in one
       // file would have impact on other files, which is undesirable.


### PR DESCRIPTION
Closes #36365.

## Problem

`deno test` aborts with a panic when the OS refuses the pipes a test worker writes its output through:

```
*** Unexpected client pipe failure '\\.\pipe\deno_pipe_*': 5

thread 'main' panicked at cli\tools\test\channel.rs:252:49:
called `Result::unwrap()` on an `Err` value:
Os { code: 6, kind: Uncategorized, message: "The handle is invalid." }
```

`TestEventSenderFactory::worker()` returned `TestEventWorkerSender` unconditionally, so the two `pipe()` calls and the two `try_clone()` calls inside it had nowhere to put a failure and unwrapped instead. The reporter hit this repeatedly inside a managed/restricted Windows process environment, and not outside it — so this is the environment saying no, not an internal invariant being violated, and it should read as an error and a non-zero exit rather than a crash.

## Change

`worker()` now returns `Result<TestEventWorkerSender, AnyError>` and each fallible step carries what it was doing:

```rust
let (stdout_reader, stdout_writer) =
  pipe().context("Failed to create a pipe for test worker stdout")?;
```

`create_single_test_event_channel()` follows, since it is a thin wrapper around `worker()`. Its three non-test callers — two in `cli/tools/jupyter/mod.rs`, one in `cli/tools/repl/mod.rs` — are all in functions that already return `Result`, so they take a `?` and nothing else changes.

## Why the two test-runner call sites look the way they do

`cli/tools/test/mod.rs` and `cli/lsp/testing/execution.rs` both build their join handles in a lazy `.map()` closure and hand the resulting iterator to `stream::iter(...).buffer_unordered(concurrent_jobs)`. Collecting that into a `Result<Vec<_>, _>` to get a `?` would have called `spawn_blocking` for every specifier up front, which drops all the test files onto the blocking pool at once and defeats `concurrent_jobs` — the limit that [`execution.rs`](https://github.com/denoland/deno/blob/main/cli/lsp/testing/execution.rs#L296) describes as guarding against "some sort of invisible resource limit" on Windows.

So the `Result` is carried into the task instead and unwrapped there:

```rust
spawn_blocking(move || {
  let worker_sender = worker_sender?;
```

The blocking closure already returns `Result<(), AnyError>` and its result already flows out through `join_result??`, so a pipe failure now surfaces the same way any other test-setup failure does. Ordering, laziness and the concurrency limit are all unchanged.

## What I verified, and what I could not

- `cargo check -p deno` — clean.
- `cargo fmt -- --check` — clean. I ran it on an unmodified checkout of `main` first to be sure I was not reading someone else's drift as mine; `main` is clean too, and the only reflow in this change is in the seven test call sites that grew past the line limit.

I could not run `cargo test`. Building the test binary on this machine ends in `rustc-LLVM ERROR: out of memory` — it has 32 GB but not enough of it free, and dropping to `-j 1` starved the OS rather than fixing it. So the seven existing `tools::test::channel` tests have been updated for the new signature (they take a `.unwrap()`) but I have not seen them go green locally, and I am relying on CI for that. Please don't take my word for it there.

On the checklist item asking for tests covering the change: I don't have one, and I want to be straight about why rather than quietly skip it. The behaviour that changed is what happens when `pipe()` fails, and I could not find a way to make it fail deterministically from inside the test process on every platform. It would need a seam to inject the failure through, which is a production-code change made only for the test — worth doing if you'd like it, but not something I wanted to slip in unasked. What is covered is that the success path still works through the new signature.

## AI assistance disclosure

I used AI for this contribution, and substantively: the code, this description and the investigation behind them were produced by Claude Opus 5 running in Claude Code, directed by me (@MLuc24). I read the diff and I will read and answer review comments myself before anything is posted in reply.
