### PR TITLE
test: deflake lsp_node_modules_dir and pty_regex_literal_with_quote

### DIFF
--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -17408,7 +17408,19 @@ fn lsp_node_modules_dir() {
     "{ \"nodeModulesDir\": \"auto\" }\n",
   );
   refresh_config(&mut client);
-  let diagnostics = cache(&mut client);
+  // The npm package requirements are registered with the resolver lazily, when
+  // a document module is created. That can happen concurrently on the tsc
+  // thread, in which case the requirements are recorded before they've actually
+  // been resolved and the diagnostics for this request can still see the
+  // package as not installed. Caching again rebuilds the resolver, so retry a
+  // few times before giving up.
+  let mut diagnostics = cache(&mut client);
+  for _ in 0..5 {
+    if diagnostics.all().is_empty() {
+      break;
+    }
+    diagnostics = cache(&mut client);
+  }
   assert_eq!(diagnostics.all().len(), 0, "{:#?}", diagnostics);
 
   // the declaration should be found in the node_modules directory

--- a/tests/integration/repl_tests.rs
+++ b/tests/integration/repl_tests.rs
@@ -63,6 +63,12 @@ fn pty_regex_literal_with_quote() {
   // https://github.com/denoland/deno/issues/24963
   util::with_pty(&["repl"], |mut console| {
     console.write_line("let re = /[']/;");
+    // Wait for the statement to be evaluated before typing the next one.
+    // Rustyline is built without `buffer-redux`, so bytes it has already read
+    // into the buffer of the current `readline()` call are discarded when that
+    // call returns. Typing ahead can leave the next line stuck in that buffer
+    // and it will never reach the REPL.
+    console.expect("undefined");
     console.write_line("re.test(\"'\")");
     console.expect("true");
   });


### PR DESCRIPTION
Two unrelated flakes seen on recent CI runs of other PRs, fixed together
since both are one-test, test-side changes.

## `integration::lsp::lsp_node_modules_dir`

Flaked on Windows CI on two recent, unrelated PR runs (once on
`windows-aarch64`, once on `windows-x86_64`), failing 1-of-375 while
everything else passed. It's the same test reported in #35060, but the
earlier registry-server signature (`npm registry server error:
hyper::Error(...)`, fixed in #36138) is not present in these logs.

The failure is the last assertion of the test:

```
panicked at tests\integration\lsp_tests.rs:17412:3:
assertion failed: `(left == right)`
  message: "npm package \"chalk\" is not installed or doesn't exist."
  code: "not-installed-npm"
```

The two lines that show up earlier in the log are a red herring:

```
Could not add npm package requirements: Failed loading http://localhost:4260/chalk for package "chalk"
Could not add npm package requirements: Failed loading http://localhost:4260/@types%2fnode for package "@types/node"
```

They are printed on every run, not just failing ones. The LSP builds its
npm cache with `NpmCacheSetting::Only` (`cli/lsp/resolver.rs`), so before
the first `deno.cache` the packuments genuinely aren't in the fresh
`DENO_DIR` and the load is expected to fail; the inner cause is `npm
package not found in cache: "chalk", --cached-only is specified`, which
the outer `Failed loading <url>` error hides.

The actual race is in how npm package requirements get registered with
the LSP resolver. `deno.cache` ends in `post_cache()`, which rebuilds the
resolver from scratch (`refresh_resolver`) and clears the document module
cache (`refresh_documents_config`). The new resolver starts with no npm
requirements — the LSP writes no lockfile (`lockfile_skip_write: true`),
so there's nothing to seed them from — and they are re-registered lazily
from `DocumentModules::module()` → `LspResolver::did_create_module()` →
`add_npm_reqs()` the next time a module is built for the open document.

That module can be built from either the tsc thread (via the state
snapshot handed to `ts_server.project_changed`) or from the
`textDocument/diagnostic` request, and `add_npm_reqs` records the
requirements under a mutex *before* it resolves them:

```rust
npm_installer_reqs.extend(reqs.clone());
if npm_installer_reqs.len() == old_reqs_count {
  return;  // someone else already added these — but maybe not resolved yet
}
```

So if the tsc thread gets there first and is still blocked resolving,
the diagnostics request takes the early return, computes against a
resolver whose npm resolution is still empty, and
`is_pkg_req_folder_cached("chalk")` is false — hence `not-installed-npm`.
On a loaded Windows runner the resolution step is slow enough for the
request to lose that race occasionally.

Fixing this properly means production work on the LSP resolver (the
requirement set shouldn't be marked complete until resolution finishes),
which isn't something to sneak into a deflake. Instead the test now
retries the cache + collect-diagnostics sequence a handful of times
before asserting. Re-issuing `deno.cache` is what makes this
deterministic rather than just a sleep: it rebuilds the resolver, so the
requirements are registered again from a clean state. A genuine
regression still fails, since every attempt would report the package as
uninstalled.

## `integration::repl::pty_regex_literal_with_quote`

Failed once on the macOS x86_64 integration job of an unrelated PR
(1-of-357, after exhausting the `#[test(flaky)]` retries). The panic is
on the *second* `write_line`, not on the `expect`:

```
panicked at tests/integration/repl_tests.rs:66:13:
Timed out.
```

The captured PTY output ends with the first statement evaluated and a
fresh prompt drawn, and the second line is nowhere in the output — the
REPL never saw it:

```
"Deno 2.9.5\r\nexit using ctrl+d, ctrl+c, or close()\r\nlet re = /[']/;\r\n\u{1b}[?2004h...
 ...> let re = /[']/;\r\u{1b}[17C\u{1b}[?2026l\u{1b}[?2004l\r\nundefined\r\n\u{1b}[?2004h...> "
```

This test was the only REPL PTY test writing two lines back to back with
nothing in between, i.e. typing ahead across an evaluation boundary. That
isn't safe here: rustyline reads the tty through a `BufReader` that is
created per `readline()` call, and preserving that buffer across calls
requires its `buffer-redux` feature, which we don't enable (it isn't a
default feature and isn't in `Cargo.lock`). Bytes rustyline has already
pulled into the current call's buffer past the newline are therefore
dropped when `readline()` returns, so a line typed while the first one
was being read gets swallowed and the REPL waits at the next prompt
forever.

The window is wide open in this test because `write_line` only waits for
the echo of what it wrote, and for the first line that echo can come from
the kernel's canonical-mode echo before the REPL has even switched the
tty to raw mode — visible above as `let re = /[']/;\r\n` appearing before
the first `> ` prompt. So the second line is written while rustyline is
still reading the first.

The test now waits for `undefined` before typing the second line, like
every other REPL PTY test does. By the time that's printed, the
`readline()` call that could have swallowed the input has already
returned and dropped its buffer, so the next line lands in the tty queue
and is picked up by the next call. No sleep involved.

## Verification

Local runs on macOS: `lsp_node_modules_dir` passes 4/4;
`pty_regex_literal_with_quote` passes 25/25 (8 before the change, 17
after) with no flaky-retry warnings. Neither flake reproduces locally,
as expected for races that have only been seen on CI.
