### PR TITLE
fix(ext/crypto): declare Argon2 deriveBits parameters

### DIFF
--- a/cli/tsc/dts/lib.deno_crypto.d.ts
+++ b/cli/tsc/dts/lib.deno_crypto.d.ts
@@ -193,6 +193,16 @@ interface Pbkdf2Params extends Algorithm {
 }
 
 /** @category Crypto */
+interface Argon2Params extends Algorithm {
+  memory: number;
+  passes: number;
+  parallelism: number;
+  nonce: BufferSource;
+  secretValue?: BufferSource;
+  associatedData?: BufferSource;
+}
+
+/** @category Crypto */
 interface AesDerivedKeyParams extends Algorithm {
   length: number;
 }
@@ -560,6 +570,7 @@ interface SubtleCrypto {
       | AlgorithmIdentifier
       | HkdfParams
       | Pbkdf2Params
+      | Argon2Params
       | EcdhKeyDeriveParams,
     baseKey: CryptoKey,
     length: number,

--- a/tests/unit/webcrypto_test.ts
+++ b/tests/unit/webcrypto_test.ts
@@ -3525,7 +3525,7 @@ Deno.test(async function argon2DeriveBitsRfcVectors() {
           nonce,
           secretValue,
           associatedData,
-        } as AnyAlg,
+        },
         key,
         256,
       ),


### PR DESCRIPTION
Fixes #36667.

Adds the Argon2 parameter dictionary already accepted by the runtime to the `SubtleCrypto.deriveBits()` declaration. The existing RFC-vector test now exercises the declaration without an `AnyAlg` cast.

Validation:
- TypeScript 6.0.3 regression check: baseline rejects `memory`; patched declaration has no diagnostics
- `deno test --no-check --filter argon2DeriveBitsRfcVectors tests/unit/webcrypto_test.ts`
- dprint check on both changed files
- `deno lint tests/unit/webcrypto_test.ts`

AI tools assisted with implementation and test setup. I reviewed the final diff and independently verified the type and runtime behavior.
