### PR TITLE
chore: upgrade deno_doc to 0.207.0 and deno_graph to 0.111.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.202.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd19673cd4b60b0ecfb9a2bdc594057417da1cd0c571f2516714d8dd44941c03"
+checksum = "3be16593d05e9f94267702f8c45adf0b5d335c584e5f0637238ba73f474282f8"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2537,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.110.1"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21645060a437bd3790c07ce715fc4e9727945527269d0cccee21e596f6bb953"
+checksum = "74d39f55639b6bffe4e886d2ea33724606729d3ec9c8e05a48952a56c1cef961"
 dependencies = [
  "async-trait",
  "boxed_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,9 +94,9 @@ repository = "https://github.com/denoland/deno"
 [workspace.dependencies]
 deno_ast = { version = "=0.53.3", features = ["transpiling"] }
 deno_core_icudata = "0.77.0"
-deno_doc = "=0.202.0"
+deno_doc = "=0.207.0"
 deno_error = "=0.7.1"
-deno_graph = { version = "=0.110.1", default-features = false }
+deno_graph = { version = "=0.111.0", default-features = false }
 deno_lint = "=0.84.1"
 deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -953,9 +953,10 @@ impl ModuleGraphBuilder {
           resolver: Some($resolver),
           locker: locker.as_mut().map(|l| l as _),
           unstable_bytes_imports: self.cli_options.unstable_raw_imports(),
-          unstable_text_imports: true,
           unstable_css_imports: self.cli_options.unstable_raw_imports(),
           unstable_config_imports: false,
+          prefer_cached_jsr_versions: self.cli_options.cache_setting()
+            == deno_cache_dir::file_fetcher::CacheSetting::Only,
         }
       };
     }

--- a/cli/jsr.rs
+++ b/cli/jsr.rs
@@ -78,8 +78,11 @@ impl JsrFetchResolver {
       let version_resolver = self
         .jsr_version_resolver
         .get_for_package(&req.name, &package_info);
-      let version =
-        version_resolver.resolve_version(req, Vec::new().into_iter());
+      let version = version_resolver.resolve_version(
+        req,
+        Vec::new().into_iter(),
+        &Default::default(),
+      );
       let version = if let Ok(version) = version {
         version.version.clone()
       } else {
@@ -92,7 +95,7 @@ impl JsrFetchResolver {
           .jsr_version_resolver
           .get_for_package(&req.name, &package_info);
         version_resolver
-          .resolve_version(req, Vec::new().into_iter())?
+          .resolve_version(req, Vec::new().into_iter(), &Default::default())?
           .version
           .clone()
       };

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -630,9 +630,9 @@ fn compute_document_doc_diagnostics(
       reporter: None,
       resolver: None,
       unstable_bytes_imports: false,
-      unstable_text_imports: false,
       unstable_css_imports: false,
       unstable_config_imports: false,
+      prefer_cached_jsr_versions: false,
     },
   ));
   if token.is_cancelled() {

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -191,9 +191,9 @@ async fn generate_doc_nodes_for_builtin_types(
         reporter: None,
         resolver: None,
         unstable_bytes_imports: false,
-        unstable_text_imports: true,
         unstable_css_imports: false,
         unstable_config_imports: false,
+        prefer_cached_jsr_versions: false,
       },
     )
     .await;
@@ -601,6 +601,7 @@ fn generate_docs_directory(
       )
     })),
     id_prefix: None,
+    symbol_listing_limit: None,
   };
 
   if let Some(built_in_types) = built_in_types {
@@ -627,6 +628,7 @@ fn generate_docs_directory(
         markdown_stripper: Arc::new(deno_doc::html::comrak::strip),
         head_inject: None,
         id_prefix: None,
+        symbol_listing_limit: None,
       },
       IndexMap::from([(
         ModuleSpecifier::parse("file:///lib.deno.d.ts").unwrap(),

--- a/tests/specs/add/only_unstable_versions/__test__.jsonc
+++ b/tests/specs/add/only_unstable_versions/__test__.jsonc
@@ -13,8 +13,7 @@
       "steps": [
         {
           "args": "add jsr:@denotest/unstable",
-          "output": "add_jsr.out",
-          "exitCode": 1
+          "output": "add_jsr.out"
         }
       ]
     }

--- a/tests/specs/add/only_unstable_versions/add_jsr.out
+++ b/tests/specs/add/only_unstable_versions/add_jsr.out
@@ -1,1 +1,2 @@
-error: jsr:@denotest/unstable has only pre-release versions available. Try specifying a version: `deno add jsr:@denotest/unstable@^1.0.0-beta.2`
+Add jsr:@denotest/unstable@1.0.0-beta.2
+Download http://127.0.0.1:4250/@denotest/unstable/1.0.0-beta.2/mod.ts

--- a/tests/specs/doc/html_lint_referenced_private_types_fixed/referenced_private_types_lint.out
+++ b/tests/specs/doc/html_lint_referenced_private_types_fixed/referenced_private_types_lint.out
@@ -1,8 +1,8 @@
 error[missing-jsdoc]: exported symbol is missing JSDoc documentation
- --> [WILDCARD]:5:1
+ --> [WILDCARD]:5:14
   | 
 5 | export class MyClass {
-  | ^
+  |              ^
 
 
 error[private-type-ref]: public type 'MyClass.prototype.prop' references private type 'MyInterface'

--- a/tests/specs/doc/lint_non_ascii/non_ascii.out
+++ b/tests/specs/doc/lint_non_ascii/non_ascii.out
@@ -1,8 +1,8 @@
 error[missing-jsdoc]: exported symbol is missing JSDoc documentation
- --> [WILDCARD]:2:1
+ --> [WILDCARD]:2:18
   | 
 2 | export interface 插件描述 {
-  | ^
+  |                  ^^
 
 
 error[missing-jsdoc]: exported symbol is missing JSDoc documentation
@@ -20,10 +20,10 @@ error[missing-jsdoc]: exported symbol is missing JSDoc documentation
 
 
 error[missing-jsdoc]: exported symbol is missing JSDoc documentation
-  --> [WILDCARD]:13:1
+  --> [WILDCARD]:13:18
    | 
 13 | export interface 公共接口 {
-   | ^
+   |                  ^^
 
 
 error[private-type-ref]: public type '公共接口["prop"]' references private type '私有类型'

--- a/tests/specs/doc/lint_referenced_private_types_error/referenced_private_types_lint.out
+++ b/tests/specs/doc/lint_referenced_private_types_error/referenced_private_types_lint.out
@@ -1,8 +1,8 @@
 error[missing-jsdoc]: exported symbol is missing JSDoc documentation
- --> [WILDCARD]:5:1
+ --> [WILDCARD]:5:14
   | 
 5 | export class MyClass {
-  | ^
+  |              ^
 
 
 error[private-type-ref]: public type 'MyClass.prototype.prop' references private type 'MyInterface'


### PR DESCRIPTION
Upgrades deno_doc 0.202.0 → 0.207.0 and deno_graph 0.110.1 → 0.111.0 (deno_doc 0.207.0 depends on deno_graph 0.111.0, so they move together).

API adjustments:
- `BuildOptions.unstable_text_imports` was removed upstream (text imports are always enabled now) — dropped at all three construction sites; `graph_util` already hardcoded it to `true`.
- New `BuildOptions.prefer_cached_jsr_versions`: wired to `cache_setting() == CacheSetting::Only` in `graph_util` so `--cached-only` resolution matches what a previous cache-building command materialized; `false` for the synthetic single-file graphs in `deno doc` and LSP diagnostics.
- `JsrVersionResolver::resolve_version` takes a new excluded-versions parameter — passing an empty set keeps the previous behavior.
- New `GenerateOptions.symbol_listing_limit` (`None` = render everything, the previous behavior) for `deno doc --html`.

deno_doc changes in this range affect `deno doc` output (module name formatting, variable alias resolution, spread element inference, various html fixes), so doc spec test expectations may need regeneration — will follow up on CI results.

Behavior change from deno_graph 0.111.0 (denoland/deno_graph#661): `deno add jsr:<pkg>` for a package that only has pre-release versions now resolves to the newest pre-release instead of erroring — matching the existing npm behavior. The `add::only_unstable_versions` spec is updated accordingly. Doc lint diagnostics now also underline the symbol name rather than column 1 (expectation updates included).
