### PR TITLE
Fix Response.redirect header mutability

### DIFF
--- a/ext/fetch/23_response.js
+++ b/ext/fetch/23_response.js
@@ -683,7 +683,7 @@ class Response {
     inner.type = "default";
     ArrayPrototypePush(inner.headerList, ["Location", parsedURL.href]);
     const response = webidl.createBranded(Response);
-    initializeResponseBase(response, inner, "immutable");
+    initializeResponseBase(response, inner, "response");
     maybeSetServeNativeFromInner(response);
     return response;
   }

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -1095,6 +1095,12 @@ Deno.test(function responseRedirect() {
   assertEquals(redir.type, "default");
 });
 
+Deno.test(function responseRedirectHeadersAreMutable() {
+  const redir = Response.redirect("http://example.com/newLocation");
+  redir.headers.set("X-Test", "value");
+  assertEquals(redir.headers.get("X-Test"), "value");
+});
+
 Deno.test(function responseRedirectTakeURLObjectAsParameter() {
   const redir = Response.redirect(new URL("https://example.com/"));
   assertEquals(


### PR DESCRIPTION
## Summary

- Make headers returned by `Response.redirect()` mutable.
- Add a regression test covering mutation of a redirect response header.

Fixes #36692

This contribution was prepared with assistance from AI tools.

## Testing

- `deno lint ext/fetch/23_response.js tests/unit/fetch_test.ts`
- `deno run -A --no-config npm:dprint@0.47.2 check --config=.dprint.json ext/fetch/23_response.js tests/unit/fetch_test.ts`
- `git diff --check`
- Not run: `./x test-unit responseRedirectHeadersAreMutable` (Rust/Cargo is not installed in the local environment).
- The repository-wide formatter/lint wrapper could not complete in the sparse checkout because it requires omitted Rust workspace files and `rustfmt`; the changed JS/TS files pass targeted formatting and lint checks.
