### PR TITLE
ci: read CLOUDFLARE_ZONE_ID from secrets in post_publish

### DIFF
--- a/.github/workflows/post_publish.generated.yml
+++ b/.github/workflows/post_publish.generated.yml
@@ -5,6 +5,12 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to publish, e.g. v2.9.6'
+        type: string
+        required: true
 jobs:
   update-dl-version:
     name: update dl.deno.land version
@@ -33,8 +39,16 @@ jobs:
           AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
           AWS_ENDPOINT_URL_S3: '${{ vars.S3_ENDPOINT }}'
           AWS_DEFAULT_REGION: '${{vars.S3_REGION }}'
+          INPUT_VERSION: '${{ inputs.version }}'
         run: |-
-          VERSION=${GITHUB_REF#refs/*/}
+          # On a manual run GITHUB_REF is whatever branch the job was
+          # dispatched from, so the version has to come from the input.
+          VERSION="${INPUT_VERSION:-${GITHUB_REF#refs/*/}}"
+          # Never let a branch name reach the version files.
+          case "$VERSION" in
+            v[0-9]*) ;;
+            *) echo "Not a release tag: $VERSION" >&2; exit 1 ;;
+          esac
           deno run --allow-net --allow-write tools/release/update_versions_json.ts "$VERSION"
           aws s3 cp versions.json s3://dl-deno-land/versions.json --content-type application/json
           LATEST_FILE=$(deno run --allow-net --allow-write tools/release/upload_version_file.ts "$VERSION" || exit 0)

--- a/.github/workflows/post_publish.generated.yml
+++ b/.github/workflows/post_publish.generated.yml
@@ -43,7 +43,7 @@ jobs:
           echo "LATEST_FILE=$LATEST_FILE" >> "$GITHUB_ENV"
       - name: Purge CDN cache
         env:
-          CLOUDFLARE_ZONE_ID: '${{ vars.CLOUDFLARE_ZONE_ID }}'
+          CLOUDFLARE_ZONE_ID: '${{ secrets.CLOUDFLARE_ZONE_ID }}'
           CLOUDFLARE_API_TOKEN: '${{ secrets.CLOUDFLARE_API_TOKEN }}'
         run: |-
           # These live at a stable URL but change every release, so the edge

--- a/.github/workflows/post_publish.ts
+++ b/.github/workflows/post_publish.ts
@@ -59,7 +59,7 @@ const workflow = createWorkflow({
       step({
         name: "Purge CDN cache",
         env: {
-          CLOUDFLARE_ZONE_ID: "${{ vars.CLOUDFLARE_ZONE_ID }}",
+          CLOUDFLARE_ZONE_ID: "${{ secrets.CLOUDFLARE_ZONE_ID }}",
           CLOUDFLARE_API_TOKEN: "${{ secrets.CLOUDFLARE_API_TOKEN }}",
         },
         run: [

--- a/.github/workflows/post_publish.ts
+++ b/.github/workflows/post_publish.ts
@@ -8,6 +8,17 @@ const workflow = createWorkflow({
     release: {
       types: ["published"],
     },
+    // For re-running the job when a release publish failed part way
+    // through, e.g. the upload landed but the CDN purge did not.
+    workflow_dispatch: {
+      inputs: {
+        version: {
+          description: "Release tag to publish, e.g. v2.9.6",
+          type: "string",
+          required: true,
+        },
+      },
+    },
   },
   jobs: [{
     id: "update-dl-version",
@@ -45,9 +56,17 @@ const workflow = createWorkflow({
           AWS_SECRET_ACCESS_KEY: "${{ secrets.S3_SECRET_ACCESS_KEY }}",
           AWS_ENDPOINT_URL_S3: "${{ vars.S3_ENDPOINT }}",
           AWS_DEFAULT_REGION: "${{vars.S3_REGION }}",
+          INPUT_VERSION: "${{ inputs.version }}",
         },
         run: [
-          "VERSION=${GITHUB_REF#refs/*/}",
+          "# On a manual run GITHUB_REF is whatever branch the job was",
+          "# dispatched from, so the version has to come from the input.",
+          'VERSION="${INPUT_VERSION:-${GITHUB_REF#refs/*/}}"',
+          "# Never let a branch name reach the version files.",
+          'case "$VERSION" in',
+          "  v[0-9]*) ;;",
+          '  *) echo "Not a release tag: $VERSION" >&2; exit 1 ;;',
+          "esac",
           'deno run --allow-net --allow-write tools/release/update_versions_json.ts "$VERSION"',
           "aws s3 cp versions.json s3://dl-deno-land/versions.json --content-type application/json",
           'LATEST_FILE=$(deno run --allow-net --allow-write tools/release/upload_version_file.ts "$VERSION" || exit 0)',


### PR DESCRIPTION
The "Purge CDN cache" step added in #36458 has never actually run. It
reads the zone id from `${{ vars.CLOUDFLARE_ZONE_ID }}`, but the zone id
is stored as a repository secret rather than a variable, so the
expansion produced an empty string and `purge_cdn_cache.ts` threw
"CLOUDFLARE_ZONE_ID and CLOUDFLARE_API_TOKEN must both be set." before
issuing the purge. This happened on the v2.9.6 release, which is why the
edge kept serving a stale `release-latest.txt` and `deno upgrade` kept
reporting an older version as the newest one.

The upload step itself succeeded, so the objects in S3 were correct the
whole time; only the edge invalidation was missing.

This switches the reference to `secrets.CLOUDFLARE_ZONE_ID` and
regenerates `post_publish.generated.yml`. The cache for the current
release still has to be purged by hand once, since re-running the failed
job would use the workflow file from the release commit.