### PR TITLE
fix(tests): update check_node_builtin_modules output for @types/node 26.4.0

### DIFF
--- a/tests/specs/check/check_node_builtin_modules/mod.js.out
+++ b/tests/specs/check/check_node_builtin_modules/mod.js.out
@@ -1,7 +1,7 @@
 Check mod.js
 TS2769 [ERROR]: No overload matches this call.
   The last overload gave the following error.
-    Argument of type '123' is not assignable to parameter of type 'BufferEncoding | (ObjectEncodingOptions & { flag?: string | undefined; }) | null | undefined'.
+    Type '123' has no properties in common with type 'ReadFileSyncOptions'.
 const _data = fs.readFileSync("./node_builtin.js", 123);
                                                    ~~~
     at file:///[WILDCARD]/mod.js:3:52

--- a/tests/specs/check/check_node_builtin_modules/mod.ts.out
+++ b/tests/specs/check/check_node_builtin_modules/mod.ts.out
@@ -1,7 +1,7 @@
 Check mod.ts
 TS2769 [ERROR]: No overload matches this call.
   The last overload gave the following error.
-    Argument of type '123' is not assignable to parameter of type 'BufferEncoding | (ObjectEncodingOptions & { flag?: string | undefined; }) | null | undefined'.
+    Type '123' has no properties in common with type 'ReadFileSyncOptions'.
 const _data = fs.readFileSync("./node_builtin.js", 123);
                                                    ~~~
     at file:///[WILDCARD]/mod.ts:2:52


### PR DESCRIPTION
`deno check` resolves the built-in Node typings as `@types/node@*`, so the
spec suite type-checks against whatever npm publishes as latest at the time
the job runs. `@types/node@26.4.0` landed on 2026-08-27 and reworked the
`fs.readFileSync` overloads, which changed the last-overload error that
TS2769 reports. The two `check_node_builtin_modules` expectations still
carried the old wording, so every `test specs (2/2)` shard started failing
on all platforms for any run after the publish, including main.

This updates both `.out` files to the diagnostic the new typings produce.
Nothing in the runtime changed. Worth noting that because the typings
version floats, this class of break can recur on any `@types/node` release;
pinning it, or relaxing that line to a `[WILDLINE]`, would avoid that at
the cost of a weaker assertion.