### PR TITLE
fix(transpile): don't report diagnostics from bundled assets in declaration emit

### DIFF
--- a/cli/type_checker.rs
+++ b/cli/type_checker.rs
@@ -225,8 +225,24 @@ impl TypeChecker {
       None,
     )?;
 
+    // Declaration emit type-checks with `TypeCheckMode::All`, which (unlike
+    // `deno check`'s default `Local` mode) doesn't scope semantic diagnostics
+    // to the user's own files. That widens the report to every file in the
+    // program, including deno's bundled `asset:///` declarations. Those aren't
+    // self-contained under a user-supplied `compilerOptions.lib`: with
+    // `"lib": ["dom", "deno.ns"]`, `lib.deno.ns.d.ts`'s own `import("node:net")`
+    // and `NodeJS.Timeout` references have nothing to resolve against, and
+    // adding `"node"` instead collides the bundled node types with the web
+    // ones. Either way the user gets errors in a file they can't edit.
+    // `deno check` never surfaces these, so neither should declaration emit.
+    let diagnostics = response.diagnostics.filter(|d| {
+      !d.file_name
+        .as_deref()
+        .is_some_and(|f| f.starts_with("asset:///"))
+    });
+
     Ok(EmitDeclarationsResult {
-      diagnostics: response.diagnostics,
+      diagnostics,
       emitted_files: response.emitted_files,
     })
   }

--- a/tests/specs/transpile_declaration_custom_lib/__test__.jsonc
+++ b/tests/specs/transpile_declaration_custom_lib/__test__.jsonc
@@ -1,0 +1,20 @@
+{
+  "tempDir": true,
+  "tests": {
+    // A user-supplied `compilerOptions.lib` leaves deno's own bundled
+    // `asset:///` declarations with unresolved references (e.g.
+    // `lib.deno.ns.d.ts` referencing `node:net` and `NodeJS.Timeout`).
+    // Those aren't user-editable and `deno check` doesn't report them, so
+    // declaration emit must not fail on them either.
+    "declaration_with_custom_lib": {
+      "args": "transpile main.ts -o out.js --declaration",
+      "output": "declaration_emit.out"
+    },
+    // ...but real errors in the user's own code must still be reported.
+    "declaration_reports_user_errors": {
+      "args": "transpile type_error.ts -o type_error_out.js --declaration",
+      "output": "type_error.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/transpile_declaration_custom_lib/declaration_emit.out
+++ b/tests/specs/transpile_declaration_custom_lib/declaration_emit.out
@@ -1,0 +1,3 @@
+[WILDCARD]deno transpile is experimental and subject to changes
+Emit [WILDCARD]out.js
+Emit [WILDCARD]main.d.ts

--- a/tests/specs/transpile_declaration_custom_lib/deno.json
+++ b/tests/specs/transpile_declaration_custom_lib/deno.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "deno.ns"]
+  }
+}

--- a/tests/specs/transpile_declaration_custom_lib/main.ts
+++ b/tests/specs/transpile_declaration_custom_lib/main.ts
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/tests/specs/transpile_declaration_custom_lib/type_error.out
+++ b/tests/specs/transpile_declaration_custom_lib/type_error.out
@@ -1,0 +1,7 @@
+[WILDCARD]deno transpile is experimental and subject to changes
+Emit [WILDCARD]type_error_out.js
+error: Type checking failed:
+TS2322 [ERROR]: Type 'string' is not assignable to type 'number'.
+export const x: number = "not a number";
+             ^
+    at file:///[WILDCARD]/type_error.ts:1:14

--- a/tests/specs/transpile_declaration_custom_lib/type_error.ts
+++ b/tests/specs/transpile_declaration_custom_lib/type_error.ts
@@ -1,0 +1,1 @@
+export const x: number = "not a number";


### PR DESCRIPTION
`deno transpile --declaration` failed with errors pointing inside deno's own
bundled declarations whenever the project set `compilerOptions.lib` explicitly.
With `"lib": ["dom", "dom.iterable", "deno.ns"]`, `lib.deno.ns.d.ts`'s own
`import("node:net")` and `NodeJS.Timeout` references had nothing to resolve
against and were reported as TS2591/TS2503; adding `"node"` instead collided the
bundled node types with the web ones. Either way the errors were in files the
user cannot edit, and `deno check` on the same input succeeded.

The cause is that declaration emit type-checks with `TypeCheckMode::All`, while
`deno check` defaults to `Local`. Only the local mode passes a `checkFiles` list
to the compiler, which scopes semantic diagnostics to the user's own files;
without it the diagnostics widen to every file in the program, deno's `asset:///`
declarations included. Those are never actionable, so declaration emit now drops
them. Genuine errors in the user's own code are unaffected, and there's a spec
test covering both directions.

Fixes #36709
