### PR TITLE
fix(desktop): complete deferred window close and fix NAPI symbol export on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,6 +3784,7 @@ dependencies = [
  "deno_v8",
  "denort",
  "laufey",
+ "libc",
  "libsui",
  "log",
  "raw-window-handle",

--- a/cli/rt_desktop/Cargo.toml
+++ b/cli/rt_desktop/Cargo.toml
@@ -36,6 +36,9 @@ denort = { path = "../rt", default-features = false }
 laufey = "0.7.0"
 libsui.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 log = { workspace = true, features = ["serde"] }
 raw-window-handle.workspace = true
 rustls.workspace = true

--- a/cli/rt_desktop/Cargo.toml
+++ b/cli/rt_desktop/Cargo.toml
@@ -36,15 +36,15 @@ denort = { path = "../rt", default-features = false }
 laufey = "0.7.0"
 libsui.workspace = true
 
-[target.'cfg(unix)'.dependencies]
-libc.workspace = true
-
 log = { workspace = true, features = ["serde"] }
 raw-window-handle.workspace = true
 rustls.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 v8.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -220,6 +220,11 @@ impl WefDesktopApi {
             window_id: ev.window_id,
           },
         );
+        // Since laufey 0.7.0 a registered close-requested handler *defers*
+        // the close: the window stays open until `Window::close()` is called.
+        // The JS "close" event is a plain notification (not cancelable), so
+        // complete the close here to keep the native close button working.
+        laufey::Window::from_id(ev.window_id).close();
       })
   }
 
@@ -1049,9 +1054,9 @@ fn promote_dylib_symbols_to_global() {
       flags: std::ffi::c_int,
     ) -> *mut std::ffi::c_void;
   }
-  const RTLD_LAZY: std::ffi::c_int = 0x1;
-  const RTLD_NOLOAD: std::ffi::c_int = 0x10;
-  const RTLD_GLOBAL: std::ffi::c_int = 0x8;
+  use libc::RTLD_GLOBAL;
+  use libc::RTLD_LAZY;
+  use libc::RTLD_NOLOAD;
 
   // SAFETY:
   // - `dladdr` reads the metadata of the function passed in; a known
@@ -1071,9 +1076,10 @@ fn promote_dylib_symbols_to_global() {
       let handle =
         dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD | RTLD_GLOBAL);
       if handle.is_null() {
-        log::debug!(
+        log::warn!(
           "[desktop] dlopen(self, RTLD_NOLOAD|RTLD_GLOBAL) returned NULL; \
-           NAPI symbols will not be globally visible"
+           NAPI symbols will not be globally visible and native Node-API \
+           addons will fail to load"
         );
       }
     }


### PR DESCRIPTION
Fixes #36715. Fixes #36712.

Two desktop regressions in 2.9.6, both surfaced by the laufey 0.7.0 bump / in-runtime HMR work:

**Window close button did nothing (#36715)**

laufey 0.7.0 changed `on_close_requested` from a plain notification into a deferred-close contract ([littledivy/laufey#65](https://github.com/littledivy/laufey/pull/65)): once a handler is registered, the backend holds the window open and the host must call `Window::close()` to complete the close. The desktop runtime registers that handler on every window (to forward the JS `close` event) but never completed the close, so the native close button (X / Alt+F4) did nothing — on every platform and both backends, not just Windows. Since the JS `close` event is a plain non-cancelable notification, the fix completes the close in the handler, restoring 2.9.5 behavior.

Verified on macOS (webview backend) with the issue's minimal repro: unfixed build ignores the close button click and keeps running; fixed build closes the window and the process exits cleanly.

**`deno desktop --hmr` crashed with Vite 8 / Rolldown on Linux (#36712)**

`promote_dylib_symbols_to_global()` — which re-`dlopen`s libdenort with `RTLD_NOLOAD | RTLD_GLOBAL` so native Node-API addons can resolve `napi_*` symbols from the dylib — hardcoded the **macOS** dlopen flag values. On Linux (glibc) `RTLD_GLOBAL` is `0x100` (the code passed `0x8`, which is `RTLD_DEEPBIND` there) and `RTLD_NOLOAD` is `0x4` (the code passed `0x10`), so the promotion silently never happened on Linux. macOS never noticed because classic napi addons there link with `-undefined dynamic_lookup` (flat lookup), but napi-rs v3 — which Rolldown uses — resolves symbols at runtime through `dlopen(NULL)`'s global scope, which on glibc only sees `RTLD_GLOBAL` images. Hence every `Node-API symbol X has not been loaded` followed by the `TsconfigCache` crash. The fix switches to `libc`'s per-target constants (macOS values are unchanged by this). Also upgraded the promotion-failure log from debug to warn, since a NULL there now reliably predicts broken native addons.

No spec tests added: desktop window tests need a real backend/window server, which CI doesn't have (consistent with prior desktop PRs).