### PR TITLE
fix(ext/node): keep writev buffer boundaries in TLS record framing

### DIFF
--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -1275,6 +1275,22 @@ fn rustls_error_to_node_error(
   }
 }
 
+/// End offset of the write chunk containing `offset`, i.e. the first
+/// boundary greater than `offset` (or `total` when the boundaries are
+/// unknown/exhausted). `idx` is a cursor into the ascending `boundaries`
+/// so repeated calls walking `offset` forward stay linear.
+fn chunk_end(
+  boundaries: &[usize],
+  idx: &mut usize,
+  offset: usize,
+  total: usize,
+) -> usize {
+  while boundaries.get(*idx).is_some_and(|&b| b <= offset) {
+    *idx += 1;
+  }
+  boundaries.get(*idx).copied().unwrap_or(total)
+}
+
 impl TLSWrapInner {
   fn new(kind: Kind, task_spawner: Option<V8TaskSpawner>) -> Self {
     Self {
@@ -1497,17 +1513,21 @@ impl TLSWrapInner {
     let feed_end = total.min(start + MAX_CLEAR_IN);
     let mut offset = start;
     let mut write_error = false;
+    // Cursor into the ascending boundary list, advanced by chunk_end.
+    let mut boundary_idx = self
+      .pending_cleartext_boundaries
+      .partition_point(|&b| b <= offset);
     'feed: while offset < feed_end {
       // Never hand rustls bytes from two write chunks in one write() call:
       // rustls fragments records per write() call, and record boundaries
       // must match the caller's chunk boundaries (see field comment).
-      let seg_end = self
-        .pending_cleartext_boundaries
-        .iter()
-        .copied()
-        .find(|&b| b > offset)
-        .unwrap_or(total)
-        .min(feed_end);
+      let seg_end = chunk_end(
+        &self.pending_cleartext_boundaries,
+        &mut boundary_idx,
+        offset,
+        total,
+      )
+      .min(feed_end);
       while offset < seg_end {
         match conn
           .writer()
@@ -2137,19 +2157,22 @@ impl TLSWrap {
     scope: &mut v8::PinScope,
     op_state: &mut OpState,
   ) -> i32 {
-    self.write_data_segments(req_wrap_obj, &[data], scope, op_state)
+    self.write_data_segments(req_wrap_obj, data, &[data.len()], scope, op_state)
   }
 
-  /// Like `write_data`, but each segment keeps its own TLS record
-  /// boundary (Node encrypts each writev buffer with its own SSL_write).
+  /// Like `write_data`, but `boundaries` (ascending end offsets into `data`,
+  /// last one == `data.len()`) splits it into the caller's write chunks, each
+  /// of which keeps its own TLS record boundary (Node encrypts each writev
+  /// buffer with its own SSL_write).
   fn write_data_segments(
     &self,
     req_wrap_obj: v8::Local<v8::Object>,
-    segments: &[&[u8]],
+    data: &[u8],
+    boundaries: &[usize],
     scope: &mut v8::PinScope,
     op_state: &mut OpState,
   ) -> i32 {
-    let byte_length = segments.iter().map(|s| s.len()).sum::<usize>();
+    let byte_length = data.len();
     let inner = unsafe { self.inner.as_mut() };
 
     if inner.tls_conn.is_none() {
@@ -2159,12 +2182,11 @@ impl TLSWrap {
         inner.current_write_obj = Some(v8::Global::new(scope, req_wrap_obj));
         inner.current_write_bytes = byte_length;
         inner.write_callback_scheduled = true;
-        for seg in segments {
-          inner.pending_cleartext.extend_from_slice(seg);
-          inner
-            .pending_cleartext_boundaries
-            .push(inner.pending_cleartext.len());
-        }
+        let base = inner.pending_cleartext.len();
+        inner.pending_cleartext.extend_from_slice(data);
+        inner
+          .pending_cleartext_boundaries
+          .extend(boundaries.iter().map(|b| base + b));
 
         let state_global = &op_state.borrow::<StreamBaseState>().array;
         let state_array = v8::Local::new(scope, state_global);
@@ -2202,14 +2224,12 @@ impl TLSWrap {
     // clear_in() feeds up to 48KB to rustls per call, preventing
     // the TCP send buffer from being overwhelmed.
     inner.pending_cleartext.clear();
+    inner.pending_cleartext.extend_from_slice(data);
     inner.pending_cleartext_boundaries.clear();
+    inner
+      .pending_cleartext_boundaries
+      .extend_from_slice(boundaries);
     inner.pending_cleartext_offset = 0;
-    for seg in segments {
-      inner.pending_cleartext.extend_from_slice(seg);
-      inner
-        .pending_cleartext_boundaries
-        .push(inner.pending_cleartext.len());
-    }
     inner.in_dowrite = true;
     inner.clear_in();
     let enc_action = inner.enc_out_collect();
@@ -2648,7 +2668,8 @@ impl TLSWrap {
     scope: &mut v8::PinScope,
     op_state: &mut OpState,
   ) -> i32 {
-    let mut segments: Vec<Vec<u8>> = Vec::new();
+    let mut data = Vec::new();
+    let mut boundaries = Vec::new();
     if all_buffers {
       let len = chunks.length();
       for i in 0..len {
@@ -2671,7 +2692,8 @@ impl TLSWrap {
           // SAFETY: ptr + offset is within the ArrayBuffer backing store
           let slice =
             unsafe { std::slice::from_raw_parts(ptr.add(byte_off), byte_len) };
-          segments.push(slice.to_vec());
+          data.extend_from_slice(slice);
+          boundaries.push(data.len());
         }
       }
     } else {
@@ -2695,7 +2717,8 @@ impl TLSWrap {
           // SAFETY: ptr + offset is within the ArrayBuffer backing store
           let slice =
             unsafe { std::slice::from_raw_parts(ptr.add(byte_off), byte_len) };
-          segments.push(slice.to_vec());
+          data.extend_from_slice(slice);
+          boundaries.push(data.len());
         } else if let Ok(s) = TryInto::<v8::Local<v8::String>>::try_into(chunk)
         {
           let encoding_idx = i * 2 + 1;
@@ -2710,14 +2733,13 @@ impl TLSWrap {
           );
           // SAFETY: written bytes are initialized by write_utf8_uninit_v2
           unsafe { buf.set_len(written) };
-          segments.push(buf);
+          data.extend_from_slice(&buf);
+          boundaries.push(data.len());
         }
       }
     }
 
-    let seg_slices: Vec<&[u8]> =
-      segments.iter().map(|s| s.as_slice()).collect();
-    self.write_data_segments(req_wrap_obj, &seg_slices, scope, op_state)
+    self.write_data_segments(req_wrap_obj, &data, &boundaries, scope, op_state)
   }
 
   /// DoWrite — encrypt cleartext and write to underlying stream.
@@ -5208,5 +5230,35 @@ mod tests {
       "payload was not fully consumed"
     );
     assert_eq!(inner.pending_cleartext_offset, 0);
+  }
+
+  /// chunk_end must stop at every write-chunk boundary so no rustls
+  /// write() call (and therefore no TLS record) spans two chunks.
+  #[test]
+  fn chunk_end_walks_write_chunk_boundaries() {
+    // Chunks of 4096 / 4096 / 54, as tedious writes TDS packets.
+    let boundaries = [4096, 8192, 8246];
+    let total = 8246;
+    let mut idx = 0;
+    let mut offset = 0;
+    let mut ends = Vec::new();
+    while offset < total {
+      let end = chunk_end(&boundaries, &mut idx, offset, total);
+      ends.push(end);
+      offset = end;
+    }
+    assert_eq!(ends, boundaries);
+
+    // Resuming mid-chunk (clear_in stopped at MAX_CLEAR_IN) must not
+    // merge the remainder of the chunk with the next one.
+    let mut idx = boundaries.partition_point(|&b| b <= 6000);
+    assert_eq!(chunk_end(&boundaries, &mut idx, 6000, total), 8192);
+
+    // Empty chunks are skipped, and an empty boundary list (pending
+    // cleartext installed without boundaries) feeds everything at once.
+    let mut idx = 0;
+    assert_eq!(chunk_end(&[4096, 4096, 8192], &mut idx, 4096, 8192), 8192);
+    let mut idx = 0;
+    assert_eq!(chunk_end(&[], &mut idx, 0, total), total);
   }
 }

--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -2671,7 +2671,7 @@ impl TLSWrap {
     let len = chunks.length();
     let mut data = Vec::new();
     let boundary_count = if all_buffers { len } else { len / 2 };
-    let mut boundaries = Vec::with_capacity(boundary_count as _);
+    let mut boundaries = Vec::with_capacity(boundary_count as usize);
     if all_buffers {
       for i in 0..len {
         let Some(chunk) = chunks.get_index(scope, i) else {

--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -2668,10 +2668,11 @@ impl TLSWrap {
     scope: &mut v8::PinScope,
     op_state: &mut OpState,
   ) -> i32 {
+    let len = chunks.length();
     let mut data = Vec::new();
-    let mut boundaries = Vec::new();
+    let boundary_count = if all_buffers { len } else { len / 2 };
+    let mut boundaries = Vec::with_capacity(boundary_count as _);
     if all_buffers {
-      let len = chunks.length();
       for i in 0..len {
         let Some(chunk) = chunks.get_index(scope, i) else {
           continue;
@@ -2697,7 +2698,6 @@ impl TLSWrap {
         }
       }
     } else {
-      let len = chunks.length();
       let count = len / 2;
       for i in 0..count {
         let Some(chunk) = chunks.get_index(scope, i * 2) else {

--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -1093,6 +1093,13 @@ struct TLSWrapInner {
   // and copy the remaining tail on every chunk (O(n²) for large writes).
   pending_cleartext: Vec<u8>,
   pending_cleartext_offset: usize,
+  // End offsets of the caller's write chunks inside `pending_cleartext`.
+  // clear_in never passes bytes from two chunks to a single rustls
+  // `writer().write()` call, so each chunk gets its own TLS record(s),
+  // matching Node's per-buffer SSL_write. Protocols that tunnel framed
+  // data over TLS rely on this: SQL Server (TDS) drops the connection
+  // when a record crosses a TDS packet boundary.
+  pending_cleartext_boundaries: Vec<usize>,
 
   // Buffered encrypted output that failed to write (e.g. EBADF because the
   // underlying stream wasn't connected yet).  Retried on the next enc_out().
@@ -1287,6 +1294,7 @@ impl TLSWrapInner {
       enc_writes_in_flight: 0,
       pending_cleartext: Vec::new(),
       pending_cleartext_offset: 0,
+      pending_cleartext_boundaries: Vec::new(),
       pending_enc_out: Vec::new(),
       underlying: UnderlyingStream::None,
       js_handle: None,
@@ -1484,22 +1492,39 @@ impl TLSWrapInner {
     // Consumed bytes are tracked via pending_cleartext_offset instead of
     // re-allocating the unwritten tail on every chunk.
     const MAX_CLEAR_IN: usize = 48 * 1024;
-    let feed_end = data.len().min(MAX_CLEAR_IN);
-    let mut offset = 0;
+    let total = self.pending_cleartext.len();
+    let start = self.pending_cleartext_offset;
+    let feed_end = total.min(start + MAX_CLEAR_IN);
+    let mut offset = start;
     let mut write_error = false;
-    while offset < feed_end {
-      match conn.writer().write(&data[offset..feed_end]) {
-        Ok(0) => break,
-        Ok(n) => offset += n,
-        Err(e) => {
-          // Store the error so it can be surfaced to JS.
-          self.error = Some(format!("SSL write error: {e}"));
-          write_error = true;
-          break;
+    'feed: while offset < feed_end {
+      // Never hand rustls bytes from two write chunks in one write() call:
+      // rustls fragments records per write() call, and record boundaries
+      // must match the caller's chunk boundaries (see field comment).
+      let seg_end = self
+        .pending_cleartext_boundaries
+        .iter()
+        .copied()
+        .find(|&b| b > offset)
+        .unwrap_or(total)
+        .min(feed_end);
+      while offset < seg_end {
+        match conn
+          .writer()
+          .write(&self.pending_cleartext[offset..seg_end])
+        {
+          Ok(0) => break 'feed,
+          Ok(n) => offset += n,
+          Err(e) => {
+            // Store the error so it can be surfaced to JS.
+            self.error = Some(format!("SSL write error: {e}"));
+            write_error = true;
+            break 'feed;
+          }
         }
       }
     }
-    self.pending_cleartext_offset += offset;
+    self.pending_cleartext_offset = offset;
     if write_error
       || self.pending_cleartext_offset >= self.pending_cleartext.len()
     {
@@ -1507,6 +1532,7 @@ impl TLSWrapInner {
       // behavior of not restoring the tail) — release the buffer.
       self.pending_cleartext = Vec::new();
       self.pending_cleartext_offset = 0;
+      self.pending_cleartext_boundaries = Vec::new();
     }
   }
 
@@ -2111,7 +2137,19 @@ impl TLSWrap {
     scope: &mut v8::PinScope,
     op_state: &mut OpState,
   ) -> i32 {
-    let byte_length = data.len();
+    self.write_data_segments(req_wrap_obj, &[data], scope, op_state)
+  }
+
+  /// Like `write_data`, but each segment keeps its own TLS record
+  /// boundary (Node encrypts each writev buffer with its own SSL_write).
+  fn write_data_segments(
+    &self,
+    req_wrap_obj: v8::Local<v8::Object>,
+    segments: &[&[u8]],
+    scope: &mut v8::PinScope,
+    op_state: &mut OpState,
+  ) -> i32 {
+    let byte_length = segments.iter().map(|s| s.len()).sum::<usize>();
     let inner = unsafe { self.inner.as_mut() };
 
     if inner.tls_conn.is_none() {
@@ -2121,7 +2159,12 @@ impl TLSWrap {
         inner.current_write_obj = Some(v8::Global::new(scope, req_wrap_obj));
         inner.current_write_bytes = byte_length;
         inner.write_callback_scheduled = true;
-        inner.pending_cleartext.extend_from_slice(data);
+        for seg in segments {
+          inner.pending_cleartext.extend_from_slice(seg);
+          inner
+            .pending_cleartext_boundaries
+            .push(inner.pending_cleartext.len());
+        }
 
         let state_global = &op_state.borrow::<StreamBaseState>().array;
         let state_array = v8::Local::new(scope, state_global);
@@ -2159,8 +2202,14 @@ impl TLSWrap {
     // clear_in() feeds up to 48KB to rustls per call, preventing
     // the TCP send buffer from being overwhelmed.
     inner.pending_cleartext.clear();
-    inner.pending_cleartext.extend_from_slice(data);
+    inner.pending_cleartext_boundaries.clear();
     inner.pending_cleartext_offset = 0;
+    for seg in segments {
+      inner.pending_cleartext.extend_from_slice(seg);
+      inner
+        .pending_cleartext_boundaries
+        .push(inner.pending_cleartext.len());
+    }
     inner.in_dowrite = true;
     inner.clear_in();
     let enc_action = inner.enc_out_collect();
@@ -2586,7 +2635,8 @@ impl TLSWrap {
     0
   }
 
-  /// Writev — collect multiple buffers into one and write through TLS.
+  /// Writev - write multiple buffers through TLS, one record boundary per
+  /// buffer (Node's TLSWrap::DoWrite calls SSL_write per buffer).
   /// Without this override, the base LibUvStreamWrap::writev would bypass
   /// TLS and write directly to the underlying TCP stream.
   #[nofast]
@@ -2598,7 +2648,7 @@ impl TLSWrap {
     scope: &mut v8::PinScope,
     op_state: &mut OpState,
   ) -> i32 {
-    let mut data = Vec::new();
+    let mut segments: Vec<Vec<u8>> = Vec::new();
     if all_buffers {
       let len = chunks.length();
       for i in 0..len {
@@ -2621,7 +2671,7 @@ impl TLSWrap {
           // SAFETY: ptr + offset is within the ArrayBuffer backing store
           let slice =
             unsafe { std::slice::from_raw_parts(ptr.add(byte_off), byte_len) };
-          data.extend_from_slice(slice);
+          segments.push(slice.to_vec());
         }
       }
     } else {
@@ -2645,7 +2695,7 @@ impl TLSWrap {
           // SAFETY: ptr + offset is within the ArrayBuffer backing store
           let slice =
             unsafe { std::slice::from_raw_parts(ptr.add(byte_off), byte_len) };
-          data.extend_from_slice(slice);
+          segments.push(slice.to_vec());
         } else if let Ok(s) = TryInto::<v8::Local<v8::String>>::try_into(chunk)
         {
           let encoding_idx = i * 2 + 1;
@@ -2660,12 +2710,14 @@ impl TLSWrap {
           );
           // SAFETY: written bytes are initialized by write_utf8_uninit_v2
           unsafe { buf.set_len(written) };
-          data.extend_from_slice(&buf);
+          segments.push(buf);
         }
       }
     }
 
-    self.write_data(req_wrap_obj, &data, scope, op_state)
+    let seg_slices: Vec<&[u8]> =
+      segments.iter().map(|s| s.as_slice()).collect();
+    self.write_data_segments(req_wrap_obj, &seg_slices, scope, op_state)
   }
 
   /// DoWrite — encrypt cleartext and write to underlying stream.

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -1755,3 +1755,87 @@ Deno.test("tls autoSelectFamily fallback preserves a validated session", async (
     await closeServer(server);
   }
 });
+
+// Regression test: each buffer of a corked/writev batch must be encrypted
+// into its own TLS record(s), matching Node's TLSWrap::DoWrite which calls
+// SSL_write once per buffer. tedious/mssql relies on this: SQL Server's
+// TDS-over-TLS drops the connection when a TLS record crosses a TDS packet
+// boundary, so a >2-packet INSERT (where the stream machinery batches
+// packets 2..n into one writev) failed with "socket hang up".
+Deno.test(
+  "tls js-backed duplex client keeps writev chunk boundaries in TLS records",
+  async () => {
+    const chunkSizes = [4096, 4096, 54];
+    const total = chunkSizes.reduce((a, b) => a + b, 0);
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+    const server = tls.createServer({ key, cert }, (sock) => {
+      let received = 0;
+      sock.on("data", (d: Uint8Array) => {
+        received += d.length;
+        if (received >= total) sock.write("done");
+      });
+      sock.on("error", () => {});
+    });
+
+    // Parse client->server TLS records from the wire.
+    const recordLens: number[] = [];
+    let wire = Buffer.alloc(0);
+    const parseRecords = (chunk: Uint8Array) => {
+      wire = Buffer.concat([wire, chunk]);
+      while (wire.length >= 5) {
+        const type = wire[0];
+        const len = wire.readUInt16BE(3);
+        if (wire.length < 5 + len) break;
+        if (type === 23) recordLens.push(len); // application_data
+        wire = wire.subarray(5 + len);
+      }
+    };
+
+    let clientTls: tls.TLSSocket | undefined;
+    let raw: net.Socket | undefined;
+    server.listen(0, () => {
+      const { port } = server.address() as net.AddressInfo;
+      raw = net.connect(port, "localhost", () => {
+        const { socket1, socket2 } = backToBackDuplexPair();
+        raw!.pipe(socket2);
+        socket2.pipe(raw!);
+        socket2.on("data", parseRecords); // taps client->server bytes
+        clientTls = tls.connect({
+          socket: socket1 as net.Socket,
+          servername: "localhost",
+          rejectUnauthorized: false,
+          // tedious forces TLS 1.2; also keeps alerts distinguishable from
+          // application_data records in the parser above.
+          maxVersion: "TLSv1.2",
+        });
+        clientTls.on("error", reject);
+        clientTls.on("secureConnect", () => {
+          // Cork so the chunks flow through a single _writev batch, like a
+          // Writable draining queued packets after an in-flight write.
+          clientTls!.cork();
+          for (const size of chunkSizes) {
+            clientTls!.write(Buffer.alloc(size, 0x78));
+          }
+          clientTls!.uncork();
+        });
+        clientTls.on("data", () => resolve());
+      });
+      raw.on("error", reject);
+    });
+
+    await deadline(promise, 10_000);
+    // One record per chunk: normalize by the constant per-record cipher
+    // overhead (nonce/tag) derived from the first record.
+    assertEquals(recordLens.length, chunkSizes.length);
+    const overhead = recordLens[0] - chunkSizes[0];
+    assert(overhead >= 0 && overhead <= 64, `overhead=${overhead}`);
+    assertEquals(
+      recordLens.map((l) => l - overhead),
+      chunkSizes,
+    );
+    clientTls?.destroy();
+    raw?.destroy();
+    server.close();
+  },
+);

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -1762,80 +1762,110 @@ Deno.test("tls autoSelectFamily fallback preserves a validated session", async (
 // TDS-over-TLS drops the connection when a TLS record crosses a TDS packet
 // boundary, so a >2-packet INSERT (where the stream machinery batches
 // packets 2..n into one writev) failed with "socket hang up".
-Deno.test(
-  "tls js-backed duplex client keeps writev chunk boundaries in TLS records",
-  async () => {
-    const chunkSizes = [4096, 4096, 54];
-    const total = chunkSizes.reduce((a, b) => a + b, 0);
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
+// tedious itself pins TLS 1.2 (TDS 7.x caps there), but the framing is
+// version-independent, so both versions are covered.
+for (const version of ["TLSv1.2", "TLSv1.3"] as const) {
+  Deno.test(
+    `tls js-backed duplex client keeps writev chunk boundaries in TLS records (${version})`,
+    async () => {
+      const chunkSizes = [4096, 4096, 54];
+      const total = chunkSizes.reduce((a, b) => a + b, 0);
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
 
-    const server = tls.createServer({ key, cert }, (sock) => {
-      let received = 0;
-      sock.on("data", (d: Uint8Array) => {
-        received += d.length;
-        if (received >= total) sock.write("done");
-      });
-      sock.on("error", () => {});
-    });
-
-    // Parse client->server TLS records from the wire.
-    const recordLens: number[] = [];
-    let wire = Buffer.alloc(0);
-    const parseRecords = (chunk: Uint8Array) => {
-      wire = Buffer.concat([wire, chunk]);
-      while (wire.length >= 5) {
-        const type = wire[0];
-        const len = wire.readUInt16BE(3);
-        if (wire.length < 5 + len) break;
-        if (type === 23) recordLens.push(len); // application_data
-        wire = wire.subarray(5 + len);
-      }
-    };
-
-    let clientTls: tls.TLSSocket | undefined;
-    let raw: net.Socket | undefined;
-    server.listen(0, () => {
-      const { port } = server.address() as net.AddressInfo;
-      raw = net.connect(port, "localhost", () => {
-        const { socket1, socket2 } = backToBackDuplexPair();
-        raw!.pipe(socket2);
-        socket2.pipe(raw!);
-        socket2.on("data", parseRecords); // taps client->server bytes
-        clientTls = tls.connect({
-          socket: socket1 as net.Socket,
-          servername: "localhost",
-          rejectUnauthorized: false,
-          // tedious forces TLS 1.2; also keeps alerts distinguishable from
-          // application_data records in the parser above.
-          maxVersion: "TLSv1.2",
-        });
-        clientTls.on("error", reject);
-        clientTls.on("secureConnect", () => {
-          // Cork so the chunks flow through a single _writev batch, like a
-          // Writable draining queued packets after an in-flight write.
-          clientTls!.cork();
-          for (const size of chunkSizes) {
-            clientTls!.write(Buffer.alloc(size, 0x78));
+      const server = tls.createServer({ key, cert }, (sock) => {
+        let received = 0;
+        let acked = false;
+        sock.on("data", (d: Uint8Array) => {
+          if (!acked) {
+            // First write is the handshake-drained marker, see below; the
+            // client sends nothing else until this reply arrives.
+            acked = true;
+            sock.write("k");
+            return;
           }
-          clientTls!.uncork();
+          received += d.length;
+          if (received >= total) sock.write("done");
         });
-        clientTls.on("data", () => resolve());
+        sock.on("error", () => {});
       });
-      raw.on("error", reject);
-    });
 
-    await deadline(promise, 10_000);
-    // One record per chunk: normalize by the constant per-record cipher
-    // overhead (nonce/tag) derived from the first record.
-    assertEquals(recordLens.length, chunkSizes.length);
-    const overhead = recordLens[0] - chunkSizes[0];
-    assert(overhead >= 0 && overhead <= 64, `overhead=${overhead}`);
-    assertEquals(
-      recordLens.map((l) => l - overhead),
-      chunkSizes,
-    );
-    clientTls?.destroy();
-    raw?.destroy();
-    server.close();
-  },
-);
+      // Parse client->server TLS records off the wire. Capture starts only
+      // once the handshake bytes are through: under TLS 1.3 the client's
+      // Finished is also an outer application_data record.
+      let capture = false;
+      const recordLens: number[] = [];
+      let wire = Buffer.alloc(0);
+      const parseRecords = (chunk: Uint8Array) => {
+        wire = Buffer.concat([wire, chunk]);
+        while (wire.length >= 5) {
+          const type = wire[0];
+          const len = wire.readUInt16BE(3);
+          if (wire.length < 5 + len) break;
+          if (type === 23 && capture) recordLens.push(len); // application_data
+          wire = wire.subarray(5 + len);
+        }
+      };
+
+      let clientTls: tls.TLSSocket | undefined;
+      let raw: net.Socket | undefined;
+      server.listen(0, () => {
+        const { port } = server.address() as net.AddressInfo;
+        raw = net.connect(port, "localhost", () => {
+          const { socket1, socket2 } = backToBackDuplexPair();
+          raw!.pipe(socket2);
+          socket2.pipe(raw!);
+          socket2.on("data", parseRecords); // taps client->server bytes
+          clientTls = tls.connect({
+            socket: socket1 as net.Socket,
+            servername: "localhost",
+            rejectUnauthorized: false,
+            minVersion: version,
+            maxVersion: version,
+          });
+          clientTls.on("error", reject);
+          clientTls.on("secureConnect", () => {
+            // One byte and wait for the echo: the reply proves every
+            // handshake record has already passed the tap above, so what
+            // is captured next is only the corked batch.
+            clientTls!.write("p");
+          });
+          let started = false;
+          clientTls.on("data", () => {
+            if (started) {
+              resolve();
+              return;
+            }
+            started = true;
+            capture = true;
+            // Cork so the chunks flow through a single _writev batch, like
+            // a Writable draining queued packets after an in-flight write.
+            clientTls!.cork();
+            for (const size of chunkSizes) {
+              clientTls!.write(Buffer.alloc(size, 0x78));
+            }
+            clientTls!.uncork();
+          });
+        });
+        raw.on("error", reject);
+      });
+
+      try {
+        await deadline(promise, 10_000);
+        // One record per chunk: normalize by the constant per-record cipher
+        // overhead (nonce/tag, plus the inner content type on TLS 1.3)
+        // derived from the first record.
+        assertEquals(recordLens.length, chunkSizes.length);
+        const overhead = recordLens[0] - chunkSizes[0];
+        assert(overhead >= 0 && overhead <= 64, `overhead=${overhead}`);
+        assertEquals(
+          recordLens.map((l) => l - overhead),
+          chunkSizes,
+        );
+      } finally {
+        clientTls?.destroy();
+        raw?.destroy();
+        server.close();
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Problem

`npm:tedious` (and therefore `npm:mssql` and `@prisma/adapter-mssql`) connections to SQL Server / Azure SQL fail with `socket hang up` / `Connection lost - socket hang up` whenever a query's TDS message spans 3 or more TDS packets (roughly > 8 KB with the default 4096-byte packet size). Small queries work; the same code works on Node. This is distinct from the implicit session-resumption issue fixed by #36592 and from the JSStreamSocket deadlock fixed for #33907 — with both of those fixes in place (Deno 2.9.6), large writes still kill the connection.

Mechanism, verified against a real SQL Server 2022 with a record-level wire capture:

- tedious writes one TDS packet (4096 bytes) per stream write. Packet 1 flushes alone; while it is in flight, packets 2..n queue in the `Writable` and are submitted together through `_writev`.
- Deno's `TLSWrap.writev` flattened all chunks into one slice before feeding rustls, and rustls fragments records per `writer().write()` call — so the resulting application-data record spanned two TDS packets. For a 3-packet message the capture shows Deno sending records of 4096 + 4150 plaintext bytes where Node sends 4096 + 4096 + 54.
- Node encrypts each writev buffer with its own `SSL_write` (`TLSWrap::DoWrite` loops over the buffers), so records always align with TDS packet boundaries. SQL Server appears to require this alignment: in our captures it closes the connection (TCP FIN, no TLS alert) as soon as a record crosses a packet boundary. Capping the record size alone (rustls `max_fragment_size = 4096`) did **not** help — alignment is what matters, not size. tedious's `setMaxSendFragment(packetSize)` call points at the same server behavior.

The total plaintext Deno sent was byte-identical to Node's — only the record framing differed.

## Fix

Track the end offset of each write chunk in `pending_cleartext_boundaries`, have `writev` record those offsets alongside the concatenated buffer instead of discarding them, and make `clear_in` never pass bytes from two chunks to a single rustls `write()` call. Since rustls fragments per `write()` call, each chunk now gets its own TLS record(s), matching Node's per-buffer `SSL_write`. Single-buffer writes and the `MAX_CLEAR_IN` rate-limiting behave exactly as before; a chunk that straddles a `MAX_CLEAR_IN` cut is still only split *within* itself, never merged with the next one.

Tradeoff: a `writev` batch of many small chunks now produces a record per chunk (~22 bytes overhead each) rather than one coalesced record. That is Node's behavior, and it is the property protocols like TDS depend on.

## Testing

- New regression test in `tests/unit_node/tls_test.ts`, run for both TLS 1.2 and 1.3, builds the same topology tedious uses (TLS client over a back-to-back Duplex pair), corks three writes (4096/4096/54) so they flow through one `_writev` batch, and asserts one application-data record per chunk by parsing the record headers off the encrypted side. Both versions fail without the fix (the three chunks arrive as one merged record) and pass with it.
- New Rust unit test for the boundary walk, including resuming mid-chunk after a `MAX_CLEAR_IN` cut.
- End-to-end repro against SQL Server 2022 in Docker (tedious 19.2.1, `encrypt: true`): before the change every INSERT whose TDS message needs > 2 packets fails with `socket hang up` (threshold bisected exactly to the 2-to-3 packet boundary); with the change, inserts up to 1 MB pass and the client's TLS record sizes match Node's byte-for-byte.
- `cargo test unit_node::tls_test` and the existing `tls_wrap` Rust unit tests pass.

Likely also relevant to older reports of `mssql`/Prisma failures that persisted after #33914, e.g. the "more than N rows" symptom in #32271.

I used Claude Code to help investigate and write this change.

