### PR TITLE
fix(cli): restore optional-value semantics for deno bundle --sourcemap

### DIFF
--- a/libs/cli_parser/src/convert.rs
+++ b/libs/cli_parser/src/convert.rs
@@ -3200,11 +3200,17 @@ fn bundle_parse(result: &ParseResult, flags: &mut Flags) {
     "browser" => BundlePlatform::Browser,
     _ => BundlePlatform::Deno,
   };
-  let sourcemap = result.get_one("sourcemap").map(|s| match s {
-    "inline" => SourceMapType::Inline,
-    "external" => SourceMapType::External,
-    _ => SourceMapType::Linked,
-  });
+  // `--sourcemap` takes an optional value that must be attached with `=`, so a
+  // bare `--sourcemap` means "linked" and never swallows the next argument.
+  let sourcemap = if result.contains("sourcemap") {
+    Some(match result.get_one("sourcemap").unwrap_or("linked") {
+      "inline" => SourceMapType::Inline,
+      "external" => SourceMapType::External,
+      _ => SourceMapType::Linked,
+    })
+  } else {
+    None
+  };
   let external = result
     .get_many("external")
     .map(|v| v.to_vec())

--- a/libs/cli_parser/src/defs.rs
+++ b/libs/cli_parser/src/defs.rs
@@ -2809,7 +2809,9 @@ pub static BUNDLE_SUBCOMMAND: CommandDef = CommandDef {
     ArgDef::new("sourcemap")
       .long("sourcemap")
       .action(ArgAction::Set)
-      .num_args(NumArgs::Exact(1))
+      .num_args(NumArgs::Optional)
+      .require_equals()
+      .value_parser(ValueParser::Choices(&["linked", "inline", "external"]))
 .help("Generate source map. Accepted values are 'linked', 'inline', or 'external'"),
     ArgDef::new("external")
       .long("external")

--- a/libs/cli_parser/src/tests_full.rs
+++ b/libs/cli_parser/src/tests_full.rs
@@ -9766,3 +9766,51 @@ fn use_env_proxy_flags() {
   ]);
   assert!(r.is_err());
 }
+
+#[test]
+fn bundle_sourcemap_bare_does_not_consume_entrypoint() {
+  // `--sourcemap` takes an optional value that must be attached with `=`.
+  // Regression test for a bug where it was defined as taking exactly one
+  // value, so `--sourcemap main.ts` swallowed the entrypoint and left the
+  // bundle with no modules at all.
+  let flags =
+    flags_from_vec(svec!["deno", "bundle", "--sourcemap", "main.ts"]).unwrap();
+  let DenoSubcommand::Bundle(b) = flags.subcommand else {
+    unreachable!()
+  };
+  assert_eq!(b.entrypoints, svec!["main.ts"]);
+  assert_eq!(b.sourcemap, Some(SourceMapType::Linked));
+}
+
+#[test]
+fn bundle_sourcemap_values() {
+  let cases = [
+    ("--sourcemap=linked", SourceMapType::Linked),
+    ("--sourcemap=inline", SourceMapType::Inline),
+    ("--sourcemap=external", SourceMapType::External),
+  ];
+  for (flag, expected) in cases {
+    let flags = flags_from_vec(svec!["deno", "bundle", flag, "main.ts"])
+      .unwrap_or_else(|e| panic!("{flag} should parse: {e:?}"));
+    let DenoSubcommand::Bundle(b) = flags.subcommand else {
+      unreachable!()
+    };
+    assert_eq!(b.entrypoints, svec!["main.ts"], "{flag}");
+    assert_eq!(b.sourcemap, Some(expected), "{flag}");
+  }
+
+  // Absent means no source map at all.
+  let flags = flags_from_vec(svec!["deno", "bundle", "main.ts"]).unwrap();
+  let DenoSubcommand::Bundle(b) = flags.subcommand else {
+    unreachable!()
+  };
+  assert_eq!(b.sourcemap, None);
+}
+
+#[test]
+fn bundle_sourcemap_rejects_invalid_value() {
+  // Invalid values must error rather than being silently coerced to 'linked'.
+  let r =
+    flags_from_vec(svec!["deno", "bundle", "--sourcemap=bogus", "main.ts"]);
+  assert!(r.is_err(), "expected --sourcemap=bogus to be rejected");
+}


### PR DESCRIPTION
`deno bundle --sourcemap main.ts` silently bundles nothing on 2.9.6: it
reports "Bundled 0 modules", writes no output, and still exits 0. When
flag parsing moved off clap, `--sourcemap` was ported as an argument
taking exactly one value, losing clap's `num_args(0..=1)`,
`require_equals(true)` and `default_missing_value("linked")`. A bare
`--sourcemap` therefore consumed the following positional as its value
and swallowed the entrypoint. This was found downstream in jsr-io/jsr,
where it broke the merge queue by producing an empty `lb/dist/main.js`.

The same port also dropped the arg's `value_parser`, so invalid values
were silently coerced to 'linked' rather than rejected. This restores
both: the value must be attached with `=`, a bare `--sourcemap` means
'linked', and values are validated against 'linked', 'inline' and
'external'. Every sibling optional-value flag in the parser
(`--inline-imports`, `--coverage`, `--vendor` and the rest) was already
ported correctly, so `--sourcemap` was the only one that needed fixing.