### PR TITLE
fix(web): avoid inspecting getters on Event subclass prototypes

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -1205,7 +1205,7 @@ class ErrorEvent extends Event {
     return inspect(
       getCreateFilteredInspectProxy()({
         object: this,
-        evaluate: ObjectPrototypeIsPrototypeOf(ErrorEventPrototype, this),
+        evaluate: this[_attributes] !== undefined,
         keys: [
           ...new SafeArrayIterator(EVENT_PROPS),
           "message",
@@ -1271,7 +1271,7 @@ class CloseEvent extends Event {
     return inspect(
       getCreateFilteredInspectProxy()({
         object: this,
-        evaluate: ObjectPrototypeIsPrototypeOf(CloseEventPrototype, this),
+        evaluate: this[_attributes] !== undefined,
         keys: [
           ...new SafeArrayIterator(EVENT_PROPS),
           "wasClean",
@@ -1428,7 +1428,7 @@ class MessageEvent extends Event {
     return inspect(
       getCreateFilteredInspectProxy()({
         object: this,
-        evaluate: ObjectPrototypeIsPrototypeOf(MessageEventPrototype, this),
+        evaluate: this[_attributes] !== undefined,
         keys: [
           ...new SafeArrayIterator(EVENT_PROPS),
           "data",
@@ -1468,7 +1468,7 @@ class CustomEvent extends Event {
     return inspect(
       getCreateFilteredInspectProxy()({
         object: this,
-        evaluate: ObjectPrototypeIsPrototypeOf(CustomEventPrototype, this),
+        evaluate: this[_attributes] !== undefined,
         keys: [
           ...new SafeArrayIterator(EVENT_PROPS),
           "detail",
@@ -1504,7 +1504,7 @@ class ProgressEvent extends Event {
     return inspect(
       getCreateFilteredInspectProxy()({
         object: this,
-        evaluate: ObjectPrototypeIsPrototypeOf(ProgressEventPrototype, this),
+        evaluate: this[_attributes] !== undefined,
         keys: [
           ...new SafeArrayIterator(EVENT_PROPS),
           "lengthComputable",

--- a/tests/unit/event_test.ts
+++ b/tests/unit/event_test.ts
@@ -157,6 +157,35 @@ Deno.test(function inspectEvent() {
   );
 });
 
+// Regression for https://github.com/denoland/deno/issues/36510
+// Inspecting subclass prototypes must not throw "Cannot read private member".
+Deno.test(function inspectEventSubclassPrototypes() {
+  for (
+    const proto of [
+      ErrorEvent.prototype,
+      CloseEvent.prototype,
+      MessageEvent.prototype,
+      CustomEvent.prototype,
+      ProgressEvent.prototype,
+    ]
+  ) {
+    const out = Deno.inspect(proto);
+    assertStringIncludes(out, "Event {");
+  }
+
+  // ensure instances still inspect normally
+  assertStringIncludes(
+    Deno.inspect(new ErrorEvent("err", { message: "boom" })),
+    "ErrorEvent",
+  );
+  assertStringIncludes(
+    Deno.inspect(
+      new CustomEvent("evt", { detail: { hello: "world" } }),
+    ),
+    "detail:",
+  );
+});
+
 Deno.test(function removeEventListenerWithEmptyObjectOptions() {
   const target = new EventTarget();
   let callCount = 0;


### PR DESCRIPTION
Apply the same prototype-vs-instance guard introduced for the base `Event` class in #36509 to the five sibling classes that still use the vulnerable pattern.

The classes affected are `ErrorEvent`, `CloseEvent`, `MessageEvent`, `CustomEvent`, and `ProgressEvent`. Each previously used `ObjectPrototypeIsPrototypeOf(XPrototype, this)` as the `evaluate` predicate for `Deno.privateCustomInspect`. A bare `.prototype` object trivially satisfies that prototype-chain check, so calling `Deno.inspect(MyErrorEvent.prototype)` (or any other subclass prototype) walked getters that read uninitialized private fields and threw `TypeError: Cannot read private member #X from an object whose class did not declare it`.

The base `Event` class already uses the better check `this[_attributes] !== undefined` (the `[[attributes]]` slot is set in its constructor). Because every subclass inherits from `Event` and only an instance — never a prototype — has been through the constructor, that same predicate works unchanged for all five subclasses. No new state or constructor changes are needed.

This mirrors the approach taken for #36508 / PR #36509.

### Repro (from #36510)

```ts
class MyProgressEvent extends ProgressEvent {}
console.log(Object.getPrototypeOf(new MyProgressEvent("progress")));
// TypeError: Cannot read private member #<field> ...
```

### Verification

- Reproduction confirmed on `main` (1aa88c03) for all five subclass prototypes
- `./x fmt` and `./x lint` pass on the changed files (no formatting changes)
- `node --check` confirms the JS syntax of `ext/web/02_event.js` is valid
- The full Deno binary build was not attempted locally (disk space); CI will exercise the new regression test

### AI disclosure

This contribution was prepared with AI assistance and reviewed manually. The pattern matches the one used in #36509 for the same bug class.

Closes #36510