### PR TITLE
fix: validate --ignore-scripts package selectors

### DIFF
--- a/libs/cli_parser/src/convert.rs
+++ b/libs/cli_parser/src/convert.rs
@@ -1019,34 +1019,44 @@ fn allow_scripts_arg_parse(
   Ok(())
 }
 
-fn ignore_scripts_value(result: &ParseResult) -> PackagesAllowedScripts {
+fn ignore_scripts_value(
+  result: &ParseResult,
+) -> Result<PackagesAllowedScripts, CliError> {
   let Some(values) = result.get_many("ignore-scripts") else {
-    return PackagesAllowedScripts::None;
+    return Ok(PackagesAllowedScripts::None);
   };
   if values.is_empty() {
-    PackagesAllowedScripts::All
-  } else {
-    PackagesAllowedScripts::Some(
-      values
-        .iter()
-        .flat_map(|s| {
-          escape_and_split_commas(s.to_string()).unwrap_or_default()
-        })
-        .filter_map(|s| {
-          let value = if s.starts_with("npm:") || s.starts_with("jsr:") {
-            s.to_string()
-          } else {
-            format!("npm:{}", s)
-          };
-          let dep = JsrDepPackageReq::from_str_loose(&value).ok()?;
-          if dep.kind != PackageKind::Npm {
-            return None;
-          }
-          Some(dep.req)
-        })
-        .collect(),
-    )
+    return Ok(PackagesAllowedScripts::All);
   }
+
+  let mut packages = Vec::new();
+  for value in values {
+    for value in escape_and_split_commas(value.to_string())? {
+      let value = if value.starts_with("npm:") || value.starts_with("jsr:") {
+        value
+      } else {
+        format!("npm:{value}")
+      };
+      let dep = JsrDepPackageReq::from_str_loose(&value).map_err(|e| {
+        CliError::new(CliErrorKind::InvalidValue, e.to_string())
+      })?;
+      if dep.kind != PackageKind::Npm {
+        return Err(CliError::new(
+          CliErrorKind::InvalidValue,
+          format!("Only npm package constraints are supported: {value}"),
+        ));
+      }
+      if dep.req.version_req.tag().is_some() {
+        return Err(CliError::new(
+          CliErrorKind::InvalidValue,
+          format!("Tags are not supported in --ignore-scripts: {value}"),
+        ));
+      }
+      packages.push(dep.req);
+    }
+  }
+
+  Ok(PackagesAllowedScripts::Some(packages))
 }
 
 fn no_check_arg_parse(result: &ParseResult, flags: &mut Flags) {
@@ -3306,7 +3316,7 @@ fn x_parse(result: &ParseResult, flags: &mut Flags) -> Result<(), CliError> {
         XFlagsKind::Command(XCommandFlags {
           yes,
           command,
-          ignore_scripts: ignore_scripts_value(result),
+          ignore_scripts: ignore_scripts_value(result)?,
           package: result.get_one("package").map(|s| s.to_string()),
         })
       } else {

--- a/libs/cli_parser/src/tests_full.rs
+++ b/libs/cli_parser/src/tests_full.rs
@@ -7228,6 +7228,25 @@ fn x_ignore_scripts() {
       ..Flags::default()
     }
   );
+
+  for (flag, expected_error) in [
+    ("--ignore-scripts=npm:", "Invalid package requirement"),
+    (
+      "--ignore-scripts=jsr:@foo/bar",
+      "Only npm package constraints are supported",
+    ),
+    (
+      "--ignore-scripts=foo@latest",
+      "Tags are not supported in --ignore-scripts",
+    ),
+    ("--ignore-scripts=foo,", "Empty values are not allowed"),
+  ] {
+    let err = flags_from_vec(svec!["deno", "x", flag, "npm:foo"]).unwrap_err();
+    assert!(
+      err.to_string().contains(expected_error),
+      "expected to contain '{expected_error}' got '{err}'"
+    );
+  }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- restore strict validation for `deno x --ignore-scripts` after the CLI parser cutover in #35982
- reject malformed, non-npm, and dist-tag package selectors instead of silently dropping them or reaching lifecycle matching
- add regression coverage while preserving bare and valid scoped `--ignore-scripts` behavior

## Testing
- `cargo fmt --all -- --check`
- `cargo check -p deno_cli_parser -p deno_core --no-default-features --features quickjs --tests`
- `cargo clippy -p deno_cli_parser -p deno_core --no-default-features --features quickjs --tests -- -D warnings`

## AI usage
- OpenAI Codex was used to help analyze, implement, and test this change.
