### PR TITLE
test: longer timeout for pummel/test-blob-slice-with-large-size.js

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -5468,7 +5468,10 @@
       "windows": false,
       "reason": "not passing"
     },
-    "pummel/test-blob-slice-with-large-size.js": {},
+    "pummel/test-blob-slice-with-large-size.js": {
+      "timeoutMs": 60000,
+      "reason": "allocates a 2 GiB buffer and copies it into the blob store, peaking above 4 GiB RSS; faulting that much memory in on a loaded CI runner regularly exceeds the default 10s timeout"
+    },
     "pummel/test-buffer-large-size-buffer-alloc.js": {},
     "pummel/test-buffer-large-size-buffer-write.js": {},
     "pummel/test-buffer-large-size-slowbuffer.js": {},

--- a/tests/node_compat/mod.rs
+++ b/tests/node_compat/mod.rs
@@ -97,6 +97,11 @@ struct TestConfig {
   /// requires and that we explicitly do not want every test to inherit.
   #[serde(rename = "extraDenoArgs", default)]
   extra_deno_args: Vec<String>,
+  /// Overrides the per-test timeout (in milliseconds). Use sparingly - only
+  /// for tests that are legitimately slow (e.g. `pummel/` tests that allocate
+  /// and copy multi-gigabyte buffers), never to paper over a hang.
+  #[serde(rename = "timeoutMs")]
+  timeout_ms: Option<u64>,
 }
 
 /// The full config.json structure
@@ -671,11 +676,14 @@ impl TestSetup {
       }
     }
 
-    let timeout = Duration::from_millis(if cfg!(target_os = "macos") {
-      20_000
-    } else {
-      10_000
-    });
+    let timeout =
+      Duration::from_millis(test_config.and_then(|c| c.timeout_ms).unwrap_or(
+        if cfg!(target_os = "macos") {
+          20_000
+        } else {
+          10_000
+        },
+      ));
 
     TestSetup {
       test_suite_path,

--- a/tests/node_compat/schema.json
+++ b/tests/node_compat/schema.json
@@ -90,6 +90,11 @@
           "description": "Per-test environment variables, layered on top of the runner's defaults. Use sparingly — only for tests where one Node fixture needs a config the rest of the suite must not have.",
           "additionalProperties": { "type": "string" }
         },
+        "timeoutMs": {
+          "type": "integer",
+          "description": "Overrides the per-test timeout in milliseconds (default 10s, 20s on macOS). Use sparingly — only for tests that are legitimately slow, such as pummel tests that allocate multi-gigabyte buffers.",
+          "minimum": 1
+        },
         "extraDenoArgs": {
           "type": "array",
           "description": "Extra deno run/test CLI flags for this test only. Use sparingly — typically for security knobs like --unsafely-ignore-certificate-errors that one specific test requires.",


### PR DESCRIPTION
`pummel/test-blob-slice-with-large-size.js` times out often on CI. It is
not a hang: the test allocates a 2 GiB buffer and then hands it to
`new Blob([buf])`, which copies it into the blob store, so the process
holds both the JS buffer and the Rust copy at once and peaks above 4 GiB
RSS — roughly double the next heaviest test in the suite. Faulting that
much memory in on a loaded runner regularly takes longer than the
runner's default 10s per-test timeout. The copy itself is required by
Blob's snapshot semantics, so it cannot be avoided.

This adds a per-test `timeoutMs` override to the node_compat config and
applies it only to that test. Running `pummel/` one test at a time
already landed in #36620, so the remaining problem was wall-clock, not
contention; retries do not help either, since CI already treats every
node_compat test as flaky.