### PR TITLE
fix(ext/node): close accepted connections that sent no request on server.close()

### DIFF
--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -196,7 +196,8 @@ const _kOnTimeout = HTTPParser.kOnTimeout | 0;
 class ConnectionsList {
   constructor() {
     this._all = new SafeSet();
-    this._active = new SafeMap(); // socket -> { headersCompleted, startTime, req }
+    // socket -> { requestStarted, headersCompleted, startTime, req }
+    this._active = new SafeMap();
   }
 
   add(socket) {
@@ -208,12 +209,22 @@ class ConnectionsList {
     this._active.delete(socket);
   }
 
-  pushActive(socket) {
+  // An entry is pushed twice for the same connection: once when it is
+  // accepted, so headersTimeout starts ticking against a client that connects
+  // and then says nothing, and again at every message begin. Only the latter
+  // means a request is actually on the wire, which is what distinguishes a
+  // connection that is busy from one that is merely open.
+  pushActive(socket, requestStarted = false) {
     this._active.set(socket, {
+      requestStarted,
       headersCompleted: false,
       startTime: performance.now(),
       req: null,
     });
+  }
+
+  hasRequestInProgress(socket) {
+    return this._active.get(socket)?.requestStarted === true;
   }
 
   popActive(socket) {
@@ -704,7 +715,7 @@ function onParserMessageBegin(server, socket) {
   const connections = server[kConnectionsKey];
   if (connections) {
     connections.popActive(socket);
-    connections.pushActive(socket);
+    connections.pushActive(socket, true);
   }
 }
 
@@ -1619,6 +1630,14 @@ Server.prototype.setTimeout = function setTimeout(msecs, callback) {
   return this;
 };
 
+// Node documents `close()` as closing every connection "which is not sending a
+// request or waiting for a response". Node's implementation does not actually
+// do that for a connection that was accepted and never sent a request - but
+// Node users cannot reach that state, because `close()` stops accepting and
+// such a connection is still sitting in the accept queue. Deno accepts eagerly,
+// so the connection is already tracked by the time `close()` runs and would
+// otherwise keep the server alive indefinitely. We follow the documented
+// contract rather than Node's implementation here; see closeIdleConnections.
 Server.prototype.close = function close(cb) {
   httpServerPreClose(this);
   return FunctionPrototypeCall(net.Server.prototype.close, this, cb);
@@ -1637,11 +1656,20 @@ Server.prototype.closeIdleConnections = function closeIdleConnections() {
   const connections = this[kConnectionsKey];
   if (connections) {
     for (const socket of new SafeSetIterator(connections._all)) {
-      // A socket is idle if it completed a request-response cycle and
-      // currently has no active HTTP response being written. Sockets
-      // that have never finished a response (e.g. still receiving
-      // headers) are not idle.
-      if (!socket._httpMessage && socket._httpMessageDetached) {
+      // Idle means no response is being written and no request is on the way
+      // in: either the connection finished a request-response cycle and is
+      // waiting for the next one, or it was accepted and never sent anything
+      // at all. Sockets still receiving a request are not idle.
+      //
+      // The second case is one Node's own implementation never has to handle,
+      // because Node stops accepting before the connection is handed to the
+      // server. Deno accepts eagerly, so without this such a connection pins
+      // `close()` open forever - see the comment on `Server.prototype.close`.
+      if (
+        !socket._httpMessage &&
+        (socket._httpMessageDetached ||
+          !connections.hasRequestInProgress(socket))
+      ) {
         socket.destroy();
       }
     }

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1890,6 +1890,7 @@
     "parallel/test-http-response-writehead-returns-this.js": {},
     "parallel/test-http-server-clear-timer.js": {},
     "parallel/test-http-server-close-all.js": {},
+    "parallel/test-http-server-close-idle-connections-pre-request.js": {},
     "parallel/test-http-server-close-idle-wait-response.js": {},
     "parallel/test-http-server-close-idle.js": {},
     "parallel/test-http-server-connection-list-when-close.js": {},

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1740,6 +1740,76 @@ Deno.test("[node/http] server closeIdleConnections shutdown", async () => {
   await promise;
 });
 
+// Fails within the timeout rather than hanging the whole test run, which is
+// what an unclosed idle connection would otherwise do.
+function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  const { promise: timeout, reject } = Promise.withResolvers<never>();
+  const id = setTimeout(() => reject(new Error(message)), 4000);
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(id));
+}
+
+Deno.test("[node/http] server.close() closes a connection that sent no request", async () => {
+  const server = http.createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  // Wait for the server to actually accept. Without this the connection can
+  // still be in the accept queue when close() runs, in which case closing the
+  // listener alone resets it and the test passes for the wrong reason.
+  const accepted = once(server, "connection");
+  const socket = net.connect(port, "127.0.0.1");
+  socket.on("error", () => {});
+  await once(socket, "connect");
+  await accepted;
+
+  const closed = Promise.all([once(server, "close"), once(socket, "close")]);
+  server.close();
+  await withTimeout(closed, "server.close() left the idle connection open");
+});
+
+Deno.test("[node/http] server.close() keeps a connection mid-request open", async () => {
+  // headersTimeout would otherwise abort the deliberately incomplete request
+  // below before the test gets to finish it.
+  const server = http.createServer(
+    { headersTimeout: 0, requestTimeout: 0 },
+    (_req, res) => res.end("done"),
+  );
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const accepted = once(server, "connection");
+  const socket = net.connect(port, "127.0.0.1");
+  socket.on("error", () => {});
+  // The socket stays paused without a data listener, and a paused socket never
+  // reaches "close" no matter what the server does.
+  let response = "";
+  socket.on("data", (chunk) => response += chunk);
+  await once(socket, "connect");
+  await accepted;
+
+  // A request is on the wire but its headers are incomplete, so this
+  // connection is not idle and close() must leave it alone. The parser
+  // consumes the socket handle directly, so there is no server-side "data"
+  // event to await - give the bytes a beat to be parsed instead.
+  socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n");
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const serverClosed = once(server, "close");
+  const socketClosed = once(socket, "close");
+  server.close();
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert(!socket.destroyed, "connection with a pending request was closed");
+
+  // Finishing the request lets the server drain and close normally.
+  socket.write("Connection: close\r\n\r\n");
+  await withTimeout(socketClosed, "pending request was never answered");
+  await withTimeout(serverClosed, "server did not close after draining");
+  assertStringIncludes(response, "200 OK");
+  assertStringIncludes(response, "done");
+});
+
 Deno.test("[node/http] client closing a streaming response doesn't terminate server", async () => {
   let interval: NodeJS.Timeout;
   const server = http.createServer((req, res) => {


### PR DESCRIPTION
A connection that was accepted but never sent a request was not treated as
idle, so `server.close()` left it open and its callback never ran. Such a
socket has no `_httpMessageDetached`, which is what `closeIdleConnections`
used as its idle test, so it fell through. The fix tracks whether a request
has actually begun on the wire, separately from the connections-list entry
pushed at accept time for `headersTimeout`, and treats a connection with no
request in progress as idle.

Node cannot reach this state, because `close()` stops accepting and such a
connection is still sitting in the accept queue when it gets reset. Deno
accepts eagerly, so the connection is already tracked and pins the server
open indefinitely. This follows the behavior Node documents for `close()`,
and it makes Node's own regression test for the case pass -
`test-http-server-close-idle-connections-pre-request.js`, which was disabled
and is enabled here.

Closes #36513