### PR TITLE
fix(cli): accept all valid sys permission descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,6 +2200,7 @@ dependencies = [
  "deno_core",
  "deno_lib",
  "deno_npm_installer",
+ "deno_permissions",
  "deno_runtime",
  "deno_semver",
  "log",

--- a/libs/cli_parser/Cargo.toml
+++ b/libs/cli_parser/Cargo.toml
@@ -18,6 +18,7 @@ deno_config = { workspace = true, features = ["workspace"] }
 deno_core.workspace = true
 deno_lib.workspace = true
 deno_npm_installer.workspace = true
+deno_permissions.workspace = true
 deno_runtime.workspace = true
 deno_semver.workspace = true
 log.workspace = true

--- a/libs/cli_parser/src/convert.rs
+++ b/libs/cli_parser/src/convert.rs
@@ -14,6 +14,7 @@ use std::num::NonZeroU8;
 use std::num::NonZeroU32;
 use std::num::NonZeroUsize;
 
+use deno_permissions::SysDescriptor;
 use deno_semver::jsr::JsrDepPackageReq;
 use deno_semver::package::PackageKind;
 
@@ -1193,26 +1194,6 @@ fn watch_arg_parse_with_paths(
 // Subcommand conversion functions
 // ============================================================
 
-/// Known valid sys descriptors.
-const VALID_SYS_DESCRIPTORS: &[&str] = &[
-  "hostname",
-  "osRelease",
-  "osUptime",
-  "loadavg",
-  "networkInterfaces",
-  "systemMemoryInfo",
-  "uid",
-  "gid",
-  "cpus",
-  "homedir",
-  "getegid",
-  "username",
-  "statfs",
-  "getPriority",
-  "setPriority",
-  "userInfo",
-];
-
 fn validate_permission_args(
   _result: &ParseResult,
   flags: &Flags,
@@ -1242,7 +1223,7 @@ fn validate_permission_args(
   // Validate sys descriptor names
   if let Some(ref sys) = flags.permissions.allow_sys {
     for name in sys {
-      if !name.is_empty() && !VALID_SYS_DESCRIPTORS.contains(&name.as_str()) {
+      if !name.is_empty() && SysDescriptor::parse(name.to_string()).is_err() {
         return Err(CliError::new(
           CliErrorKind::InvalidValue,
           format!("unknown sys descriptor: '{name}'"),
@@ -1252,7 +1233,7 @@ fn validate_permission_args(
   }
   if let Some(ref sys) = flags.permissions.deny_sys {
     for name in sys {
-      if !name.is_empty() && !VALID_SYS_DESCRIPTORS.contains(&name.as_str()) {
+      if !name.is_empty() && SysDescriptor::parse(name.to_string()).is_err() {
         return Err(CliError::new(
           CliErrorKind::InvalidValue,
           format!("unknown sys descriptor: '{name}'"),

--- a/libs/cli_parser/src/tests_full.rs
+++ b/libs/cli_parser/src/tests_full.rs
@@ -2604,15 +2604,25 @@ fn allow_sys_allowlist_validator() {
     "script.ts"
   ]);
   assert!(r.is_ok());
+  let r = flags_from_vec(svec![
+    "deno",
+    "run",
+    "--allow-sys=inspector,setuid,umask,username",
+    "script.ts"
+  ]);
+  assert_eq!(
+    r.unwrap().permissions.allow_sys,
+    Some(svec!["inspector", "setuid", "umask", "username"])
+  );
   let r = flags_from_vec(svec!["deno", "run", "--allow-sys=foo", "script.ts"]);
-  assert!(r.is_err());
+  assert_eq!(r.unwrap_err().message, "unknown sys descriptor: 'foo'");
   let r = flags_from_vec(svec![
     "deno",
     "run",
     "--allow-sys=hostname,foo",
     "script.ts"
   ]);
-  assert!(r.is_err());
+  assert_eq!(r.unwrap_err().message, "unknown sys descriptor: 'foo'");
 }
 
 #[test]
@@ -2627,15 +2637,25 @@ fn deny_sys_denylist_validator() {
     "script.ts"
   ]);
   assert!(r.is_ok());
+  let r = flags_from_vec(svec![
+    "deno",
+    "run",
+    "--deny-sys=inspector,setuid,umask,username",
+    "script.ts"
+  ]);
+  assert_eq!(
+    r.unwrap().permissions.deny_sys,
+    Some(svec!["inspector", "setuid", "umask", "username"])
+  );
   let r = flags_from_vec(svec!["deno", "run", "--deny-sys=foo", "script.ts"]);
-  assert!(r.is_err());
+  assert_eq!(r.unwrap_err().message, "unknown sys descriptor: 'foo'");
   let r = flags_from_vec(svec![
     "deno",
     "run",
     "--deny-sys=hostname,foo",
     "script.ts"
   ]);
-  assert!(r.is_err());
+  assert_eq!(r.unwrap_err().message, "unknown sys descriptor: 'foo'");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

### Regression

Deno 2.9.6 has a regression (compared to 2.9.5) where it stops accepting valid granular sys permissions during CLI parsing. For example:

```console
$ deno run --allow-sys=inspector 'data:application/javascript,console.log("ok")'
error: unknown sys descriptor: 'inspector'
```

The `deno_cli_parser` cutover introduced a second sys-descriptor allowlist that had drifted from `deno_permissions::SysDescriptor::parse`. It omitted `inspector` and other valid descriptors such as `setuid` and `umask`.

### Fix

This PR removes the duplicate list and validates both `--allow-sys` and `--deny-sys` values with the runtime parser. Validation does not replace the original flag value, so aliases such as `username` retain their existing CLI representation.

Parser tests cover accepted descriptors, rejected descriptors, and alias preservation for both flags.

Related: #36519, which covers `node:inspector` sys-permission behavior and needs `--allow-sys=inspector`.

## Testing done

```sh
cargo test -p deno_cli_parser --features deno_core/v8
./x build
./target/debug/deno run --allow-sys=inspector 'data:application/javascript,console.log("ok")'
./x fmt
./x lint
```

## AI usage

I used OpenAI GPT-5.6 models via OpenCode for all of this.