### PR TITLE
feat(desktop): add BrowserWindow IME and composition events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4080,7 +4080,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.5",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -6193,7 +6193,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6377,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "laufey"
 version = "0.7.0"
-source = "git+https://github.com/petamoriken/laufey?branch=feat%2Fraw-ime#39e78f20442ace2a92c2541030e35e2c7b963e64"
+source = "git+https://github.com/petamoriken/laufey?branch=feat%2Fraw-ime#63476119b5ae7443a7f7dfebd26c17b7cfd47b60"
 dependencies = [
  "bindgen 0.72.1",
  "tokio",
@@ -8870,7 +8870,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9534,7 +9534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6193,7 +6193,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6377,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "laufey"
 version = "0.7.0"
-source = "git+https://github.com/petamoriken/laufey?branch=feat%2Fraw-ime#365608b7ebf71e3f3be8517642ac8d3c0f4eaefa"
+source = "git+https://github.com/petamoriken/laufey?branch=feat%2Fraw-ime#ea7487a8c120ab9843bd702542447d3766558a38"
 dependencies = [
  "bindgen 0.72.1",
  "tokio",
@@ -8870,7 +8870,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9534,7 +9534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6193,7 +6193,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6377,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "laufey"
 version = "0.7.0"
-source = "git+https://github.com/petamoriken/laufey?branch=feat%2Fraw-ime#63476119b5ae7443a7f7dfebd26c17b7cfd47b60"
+source = "git+https://github.com/petamoriken/laufey?branch=feat%2Fraw-ime#365608b7ebf71e3f3be8517642ac8d3c0f4eaefa"
 dependencies = [
  "bindgen 0.72.1",
  "tokio",
@@ -8870,7 +8870,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9534,7 +9534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6377,8 +6377,7 @@ dependencies = [
 [[package]]
 name = "laufey"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2a04490eb866f17dcbbb44c8277b45964eeb0f68bb17c444e69c2feff0db94"
+source = "git+https://github.com/petamoriken/laufey?branch=feat%2Fraw-ime#5bdc9060a2b509ff1fef92e9580c6ed7f8f6bc05"
 dependencies = [
  "bindgen 0.72.1",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6377,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "laufey"
 version = "0.7.0"
-source = "git+https://github.com/petamoriken/laufey?branch=feat%2Fraw-ime#5bdc9060a2b509ff1fef92e9580c6ed7f8f6bc05"
+source = "git+https://github.com/petamoriken/laufey?branch=feat%2Fraw-ime#39e78f20442ace2a92c2541030e35e2c7b963e64"
 dependencies = [
  "bindgen 0.72.1",
  "tokio",

--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -110,6 +110,17 @@ pub const DESKTOP_JS: &str = r#"
     }
   }
 
+  class CompositionEvent extends UIEvent {
+    #data = "";
+
+    get data() { return this.#data; }
+
+    constructor(type, init = {}) {
+      super(type, init);
+      this.#data = init.data ?? "";
+    }
+  }
+
   class MouseEvent extends UIEvent {
     #button = 0;
     #clientX = 0;
@@ -191,6 +202,9 @@ pub const DESKTOP_JS: &str = r#"
 
   internals.defineEventHandler(BrowserWindowPrototype, "keydown");
   internals.defineEventHandler(BrowserWindowPrototype, "keyup");
+  internals.defineEventHandler(BrowserWindowPrototype, "compositionstart");
+  internals.defineEventHandler(BrowserWindowPrototype, "compositionupdate");
+  internals.defineEventHandler(BrowserWindowPrototype, "compositionend");
   internals.defineEventHandler(BrowserWindowPrototype, "mousedown");
   internals.defineEventHandler(BrowserWindowPrototype, "mouseup");
   internals.defineEventHandler(BrowserWindowPrototype, "click");
@@ -307,6 +321,7 @@ pub const DESKTOP_JS: &str = r#"
     UIEvent: internals.core.propNonEnumerable(UIEvent),
     FocusEvent: internals.core.propNonEnumerable(FocusEvent),
     KeyboardEvent: internals.core.propNonEnumerable(KeyboardEvent),
+    CompositionEvent: internals.core.propNonEnumerable(CompositionEvent),
     MouseEvent: internals.core.propNonEnumerable(MouseEvent),
     WheelEvent: internals.core.propNonEnumerable(WheelEvent),
   });
@@ -804,6 +819,15 @@ pub const DESKTOP_JS: &str = r#"
               altKey: ev.alt,
               metaKey: ev.meta,
               repeat: ev.repeat,
+              isComposing: ev.isComposing,
+            }));
+            break;
+          }
+          case "compositionEvent": {
+            const target = windows.get(ev.windowId);
+            if (!target) break;
+            target.dispatchEvent(new CompositionEvent(ev.type, {
+              data: ev.data,
             }));
             break;
           }
@@ -1468,6 +1492,29 @@ mod tests {
     ));
     assert!(DESKTOP_JS.contains("case \"pageLoad\""));
     assert!(DESKTOP_JS.contains("dispatchEvent(new Event(\"load\"))"));
+  }
+
+  #[test]
+  fn desktop_js_installs_composition_events() {
+    assert!(
+      DESKTOP_JS.contains("class CompositionEvent extends UIEvent"),
+      "CompositionEvent must be a real UIEvent subclass"
+    );
+    assert!(DESKTOP_JS.contains(
+      "internals.defineEventHandler(BrowserWindowPrototype, \"compositionstart\")"
+    ));
+    assert!(DESKTOP_JS.contains(
+      "internals.defineEventHandler(BrowserWindowPrototype, \"compositionupdate\")"
+    ));
+    assert!(DESKTOP_JS.contains(
+      "internals.defineEventHandler(BrowserWindowPrototype, \"compositionend\")"
+    ));
+    assert!(DESKTOP_JS.contains("case \"compositionEvent\""));
+    assert!(DESKTOP_JS.contains("new CompositionEvent(ev.type"));
+    assert!(
+      DESKTOP_JS.contains("isComposing: ev.isComposing"),
+      "keydown/keyup must forward isComposing from the native event"
+    );
   }
 
   #[test]

--- a/cli/rt_desktop/Cargo.toml
+++ b/cli/rt_desktop/Cargo.toml
@@ -33,7 +33,7 @@ deno_runtime.workspace = true
 deno_snapshots.workspace = true
 deno_terminal.workspace = true
 denort = { path = "../rt", default-features = false }
-laufey = "0.7.0"
+laufey = { git = "https://github.com/petamoriken/laufey", branch = "feat/raw-ime" }
 libsui.workspace = true
 
 log = { workspace = true, features = ["serde"] }

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -72,6 +72,9 @@ impl WefDesktopApi {
     show_on_first_load: bool,
   ) -> laufey::Window {
     let kb_tx = self.event_tx.clone();
+    let ime_tx = self.event_tx.clone();
+    let composing = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let composing_for_kb = composing.clone();
     let mouse_click_tx = self.event_tx.clone();
     let mouse_move_tx = self.event_tx.clone();
     let wheel_tx = self.event_tx.clone();
@@ -101,6 +104,27 @@ impl WefDesktopApi {
             alt: ev.modifiers.alt,
             meta: ev.modifiers.meta,
             repeat: ev.repeat,
+            is_composing: composing_for_kb.load(Ordering::Acquire),
+          },
+        );
+      })
+      .on_ime_event(move |ev| {
+        let r#type = match ev.state {
+          laufey::ImeState::Start => {
+            composing.store(true, Ordering::Release);
+            "compositionstart"
+          }
+          laufey::ImeState::Update => "compositionupdate",
+          laufey::ImeState::End => {
+            composing.store(false, Ordering::Release);
+            "compositionend"
+          }
+        };
+        let _ = ime_tx.try_send(
+          deno_runtime::ops::desktop::DesktopEvent::CompositionEvent {
+            window_id: ev.window_id,
+            r#type: r#type.to_string(),
+            data: ev.data,
           },
         );
       })

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -44,7 +44,7 @@ use denort::run::RunOptions;
 /// makes the failure mode obvious instead of "the desktop app silently won't
 /// launch".
 const _: () = assert!(
-  laufey::LAUFEY_API_VERSION == 34,
+  laufey::LAUFEY_API_VERSION == 35,
   "LAUFEY_API_VERSION mismatch: update this assert and the prebuilt backend release pin in cli/tools/desktop.rs when laufey bumps its API version",
 );
 
@@ -338,6 +338,21 @@ impl denort::desktop::DesktopApi for WefDesktopApi {
 
   fn set_window_opacity(&self, window_id: u32, opacity: f64) {
     laufey::Window::from_id(window_id).set_opacity(opacity);
+  }
+
+  fn set_ime_allowed(&self, window_id: u32, allowed: bool) {
+    laufey::Window::from_id(window_id).set_ime_allowed(allowed);
+  }
+
+  fn set_ime_cursor_area(
+    &self,
+    window_id: u32,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+  ) {
+    laufey::Window::from_id(window_id).set_ime_cursor_area(x, y, width, height);
   }
 
   fn is_visible(&self, window_id: u32) -> bool {

--- a/cli/tsc/dts/lib.deno.desktop.d.ts
+++ b/cli/tsc/dts/lib.deno.desktop.d.ts
@@ -55,6 +55,15 @@ declare class KeyboardEvent extends UIEvent {
   getModifierState(key: string): boolean;
 }
 
+declare interface CompositionEventInit extends UIEventInit {
+  data?: string;
+}
+
+declare class CompositionEvent extends UIEvent {
+  constructor(type: string, init?: CompositionEventInit);
+  readonly data: string;
+}
+
 declare interface MouseEventInit extends UIEventInit {
   button?: number;
   clientX?: number;

--- a/cli/tsc/dts/lib.deno.desktop.d.ts
+++ b/cli/tsc/dts/lib.deno.desktop.d.ts
@@ -676,7 +676,8 @@ declare namespace Deno {
      */
     showContextMenu(x: number, y: number, menu: MenuItem[]): void;
 
-    /** Allow or deny IME on this window. Allowed by default.
+    /** Allow or deny IME on this window. Off by default (raw key delivery);
+     * pass `true` when a text field is focused so CJK composition can start.
      *
      * Raw/winit only. No-op on WebView and CEF, where the engine owns
      * composition. */

--- a/cli/tsc/dts/lib.deno.desktop.d.ts
+++ b/cli/tsc/dts/lib.deno.desktop.d.ts
@@ -676,6 +676,21 @@ declare namespace Deno {
      */
     showContextMenu(x: number, y: number, menu: MenuItem[]): void;
 
+    /** Allow or deny IME on this window. Allowed by default.
+     *
+     * Raw/winit only. No-op on WebView and CEF, where the engine owns
+     * composition. */
+    setImeAllowed(allowed: boolean): void;
+    /** Logical client rectangle (top-left origin, same space as
+     * {@linkcode showContextMenu}) the IME candidate window should sit next
+     * to. Raw/winit only. No-op on WebView and CEF. */
+    setImeCursorArea(
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+    ): void;
+
     getNativeWindow(): Deno.UnsafeWindowSurface;
 
     addEventListener<K extends keyof BrowserWindowEventMap>(

--- a/cli/tsc/dts/lib.deno.desktop.d.ts
+++ b/cli/tsc/dts/lib.deno.desktop.d.ts
@@ -567,6 +567,9 @@ declare namespace Deno {
   interface BrowserWindowEventMap {
     keydown: KeyboardEvent;
     keyup: KeyboardEvent;
+    compositionstart: CompositionEvent;
+    compositionupdate: CompositionEvent;
+    compositionend: CompositionEvent;
     mousedown: MouseEvent;
     mouseup: MouseEvent;
     click: MouseEvent;

--- a/runtime/ops/desktop.rs
+++ b/runtime/ops/desktop.rs
@@ -572,7 +572,7 @@ pub trait DesktopApi: Send + Sync + 'static {
     y: i32,
     menu: Vec<MenuItem>,
   );
-  /// Raw/winit: allow or deny IME (allowed by default). WebView / CEF: no-op.
+  /// Raw/winit: allow or deny IME (off by default). WebView / CEF: no-op.
   fn set_ime_allowed(&self, window_id: u32, allowed: bool);
   /// Raw/winit: logical top-left client rect for the IME candidate window.
   /// WebView / CEF: no-op.

--- a/runtime/ops/desktop.rs
+++ b/runtime/ops/desktop.rs
@@ -572,6 +572,18 @@ pub trait DesktopApi: Send + Sync + 'static {
     y: i32,
     menu: Vec<MenuItem>,
   );
+  /// Raw/winit: allow or deny IME (allowed by default). WebView / CEF: no-op.
+  fn set_ime_allowed(&self, window_id: u32, allowed: bool);
+  /// Raw/winit: logical top-left client rect for the IME candidate window.
+  /// WebView / CEF: no-op.
+  fn set_ime_cursor_area(
+    &self,
+    window_id: u32,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+  );
 
   /// Best-effort fetch of the OS-level window/display handles for the
   /// given window. Returning `Err` instead of panicking matters because
@@ -1017,6 +1029,18 @@ impl BrowserWindow {
     #[serde] menu: Vec<MenuItem>,
   ) {
     self.api.show_context_menu(self.window_id, x, y, menu);
+  }
+
+  #[fast]
+  fn set_ime_allowed(&self, allowed: bool) {
+    self.api.set_ime_allowed(self.window_id, allowed);
+  }
+
+  #[fast]
+  fn set_ime_cursor_area(&self, x: f64, y: f64, width: f64, height: f64) {
+    self
+      .api
+      .set_ime_cursor_area(self.window_id, x, y, width, height);
   }
 
   fn get_native_window(

--- a/runtime/ops/desktop.rs
+++ b/runtime/ops/desktop.rs
@@ -328,6 +328,13 @@ pub enum DesktopEvent {
     alt: bool,
     meta: bool,
     repeat: bool,
+    is_composing: bool,
+  },
+  #[serde(rename_all = "camelCase")]
+  CompositionEvent {
+    window_id: u32,
+    r#type: String,
+    data: String,
   },
   #[serde(rename_all = "camelCase")]
   BindCall {
@@ -2367,6 +2374,7 @@ mod tests {
       alt: false,
       meta: true,
       repeat: false,
+      is_composing: true,
     })
     .unwrap();
     // `type` (a Rust keyword, written `r#type`) must serialize as
@@ -2376,6 +2384,21 @@ mod tests {
     assert_eq!(v["windowId"], 1);
     assert_eq!(v["shift"], true);
     assert_eq!(v["meta"], true);
+    assert_eq!(v["isComposing"], true);
+  }
+
+  #[test]
+  fn composition_event_camelcases_and_keeps_type() {
+    let v = serde_json::to_value(DesktopEvent::CompositionEvent {
+      window_id: 1,
+      r#type: "compositionupdate".to_string(),
+      data: "あ".to_string(),
+    })
+    .unwrap();
+    assert_eq!(v["type"], "compositionupdate");
+    assert_eq!(v["kind"], "compositionEvent");
+    assert_eq!(v["windowId"], 1);
+    assert_eq!(v["data"], "あ");
   }
 
   #[test]
@@ -2515,8 +2538,17 @@ mod tests {
         alt: false,
         meta: false,
         repeat: false,
+        is_composing: false,
       }),
       "keyboardEvent"
+    );
+    assert_eq!(
+      kind_of(DesktopEvent::CompositionEvent {
+        window_id: 0,
+        r#type: "".into(),
+        data: "".into(),
+      }),
+      "compositionEvent"
     );
     assert_eq!(
       kind_of(DesktopEvent::BindCall {


### PR DESCRIPTION
<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing
-->

Closes #36752

## Summary

Raw `deno desktop` windows never start an IME session because winit leaves IME off by default. WebView / CEF already compose via the engine.

This wires the LAUFEY C ABI **v35** IME APIs through `DesktopApi` onto `BrowserWindow`:

- `setImeAllowed(allowed)` — IME stays **off by default** on raw (winit); pass `true` when a text field is focused so CJK composition can start. No-op on WebView / CEF.
- `setImeCursorArea(x, y, width, height)` — logical top-left client rect for the candidate window (same space as `showContextMenu`). No-op on WebView / CEF.
- `compositionstart` / `compositionupdate` / `compositionend` on `BrowserWindow`, with `CompositionEvent.data` carrying the preedit / commit string. Observed on raw, WebView, and CEF the same way as `keydown` / `keyup` (the engine still owns composition; the event is not consumed). CEF on Linux does not observe IME yet.
- `KeyboardEvent.isComposing` is `true` for `keydown` / `keyup` that fire between `compositionstart` and `compositionend`

Depends on https://github.com/littledivy/laufey/pull/78. Until that lands and a laufey release is cut, this branch pins:

```toml
laufey = { git = "https://github.com/petamoriken/laufey", branch = "feat/raw-ime" }
```

After the laufey release, that pin should be replaced with the published crate version and the prebuilt backend archives for API 35.

## AI Disclosure

This PR was drafted and filed by an AI assistant (Grok). I reviewed and edited it myself.