### PR TITLE
fix(desktop): align raw BrowserWindow with CEF / WebView and add devicePixelRatio, innerWidth / innerHeight, outerWidth / outerHeight, screenX / screenY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4080,7 +4080,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.5",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -6193,7 +6193,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6377,8 +6377,7 @@ dependencies = [
 [[package]]
 name = "laufey"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2a04490eb866f17dcbbb44c8277b45964eeb0f68bb17c444e69c2feff0db94"
+source = "git+https://github.com/petamoriken/laufey?branch=fix%2Fwinit-mouse-enter-dblclick#d31f54219a9861160098db9584f7879d2b7e1cc7"
 dependencies = [
  "bindgen 0.72.1",
  "tokio",
@@ -8871,7 +8870,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9535,7 +9534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -112,18 +112,22 @@ pub const DESKTOP_JS: &str = r#"
 
   class MouseEvent extends UIEvent {
     #button = 0;
+    #buttons = 0;
     #clientX = 0;
     #clientY = 0;
+    #screenX = 0;
+    #screenY = 0;
     #ctrlKey = false;
     #shiftKey = false;
     #altKey = false;
     #metaKey = false;
 
     get button() { return this.#button; }
+    get buttons() { return this.#buttons; }
     get clientX() { return this.#clientX; }
     get clientY() { return this.#clientY; }
-    get screenX() { return this.#clientX; }
-    get screenY() { return this.#clientY; }
+    get screenX() { return this.#screenX; }
+    get screenY() { return this.#screenY; }
     get ctrlKey() { return this.#ctrlKey; }
     get shiftKey() { return this.#shiftKey; }
     get altKey() { return this.#altKey; }
@@ -132,8 +136,11 @@ pub const DESKTOP_JS: &str = r#"
     constructor(type, init = {}) {
       super(type, init);
       this.#button = init.button ?? 0;
+      this.#buttons = init.buttons ?? 0;
       this.#clientX = init.clientX ?? 0;
       this.#clientY = init.clientY ?? 0;
+      this.#screenX = init.screenX ?? this.#clientX;
+      this.#screenY = init.screenY ?? this.#clientY;
       this.#ctrlKey = init.ctrlKey ?? false;
       this.#shiftKey = init.shiftKey ?? false;
       this.#altKey = init.altKey ?? false;
@@ -207,6 +214,52 @@ pub const DESKTOP_JS: &str = r#"
   internals.defineEventHandler(BrowserWindowPrototype, "close");
   internals.defineEventHandler(BrowserWindowPrototype, "menuclick");
   internals.defineEventHandler(BrowserWindowPrototype, "contextmenuclick");
+
+  // Per-window pressed-button mask (DOM `MouseEvent.buttons`).
+  const windowButtons = new Map();
+
+  function buttonBit(button) {
+    switch (button) {
+      case 0: return 1;
+      case 1: return 4;
+      case 2: return 2;
+      case 3: return 8;
+      case 4: return 16;
+      default: return 0;
+    }
+  }
+
+  function screenXY(target, clientX, clientY) {
+    try {
+      const pos = typeof target.getInnerPosition === "function"
+        ? target.getInnerPosition()
+        : target.getPosition();
+      if (Array.isArray(pos) && pos.length >= 2) {
+        return [pos[0] + clientX, pos[1] + clientY];
+      }
+    } catch (_) {
+      // Native getter missing or closed.
+    }
+    return [clientX, clientY];
+  }
+
+  function mouseInit(target, ev, extra) {
+    extra = extra || {};
+    const [screenX, screenY] = screenXY(target, ev.clientX, ev.clientY);
+    return {
+      button: ev.button ?? 0,
+      buttons: extra.buttons ?? 0,
+      clientX: ev.clientX,
+      clientY: ev.clientY,
+      screenX,
+      screenY,
+      ctrlKey: ev.control,
+      shiftKey: ev.shift,
+      altKey: ev.alt,
+      metaKey: ev.meta,
+      detail: extra.detail ?? 0,
+    };
+  }
 
   // Per-window bind callback registry: windowId -> Map<name, fn>
   const windowBindCallbacks = new Map();
@@ -838,19 +891,22 @@ pub const DESKTOP_JS: &str = r#"
           case "mouseClick": {
             const target = windows.get(ev.windowId);
             if (!target) break;
-            const init = {
-              button: ev.button,
-              clientX: ev.clientX,
-              clientY: ev.clientY,
-              ctrlKey: ev.control,
-              shiftKey: ev.shift,
-              altKey: ev.alt,
-              metaKey: ev.meta,
-              detail: ev.clickCount,
-            };
+            const bit = buttonBit(ev.button);
+            let buttons = windowButtons.get(ev.windowId) ?? 0;
             if (ev.state === "pressed") {
-              target.dispatchEvent(new MouseEvent("mousedown", init));
+              buttons |= bit;
+              windowButtons.set(ev.windowId, buttons);
+              target.dispatchEvent(new MouseEvent(
+                "mousedown",
+                mouseInit(target, ev, { buttons, detail: ev.clickCount }),
+              ));
             } else {
+              buttons &= ~bit;
+              windowButtons.set(ev.windowId, buttons);
+              const init = mouseInit(target, ev, {
+                buttons,
+                detail: ev.clickCount,
+              });
               target.dispatchEvent(new MouseEvent("mouseup", init));
               if (ev.button === 0) {
                 target.dispatchEvent(new MouseEvent("click", init));
@@ -864,45 +920,36 @@ pub const DESKTOP_JS: &str = r#"
           case "mouseMove": {
             const target = windows.get(ev.windowId);
             if (!target) break;
-            target.dispatchEvent(new MouseEvent("mousemove", {
-              clientX: ev.clientX,
-              clientY: ev.clientY,
-              ctrlKey: ev.control,
-              shiftKey: ev.shift,
-              altKey: ev.alt,
-              metaKey: ev.meta,
-            }));
+            target.dispatchEvent(new MouseEvent(
+              "mousemove",
+              mouseInit(target, ev, {
+                buttons: windowButtons.get(ev.windowId) ?? 0,
+              }),
+            ));
             break;
           }
           case "wheel": {
             const target = windows.get(ev.windowId);
             if (!target) break;
             target.dispatchEvent(new WheelEvent("wheel", {
+              ...mouseInit(target, ev, {
+                buttons: windowButtons.get(ev.windowId) ?? 0,
+              }),
               deltaX: ev.deltaX,
               deltaY: ev.deltaY,
               deltaMode: ev.deltaMode,
-              clientX: ev.clientX,
-              clientY: ev.clientY,
-              ctrlKey: ev.control,
-              shiftKey: ev.shift,
-              altKey: ev.alt,
-              metaKey: ev.meta,
             }));
             break;
           }
           case "cursorEnterLeave": {
             const target = windows.get(ev.windowId);
             if (!target) break;
-            const init = {
-              clientX: ev.clientX,
-              clientY: ev.clientY,
-              ctrlKey: ev.control,
-              shiftKey: ev.shift,
-              altKey: ev.alt,
-              metaKey: ev.meta,
-            };
             target.dispatchEvent(new MouseEvent(
-              ev.entered ? "mouseenter" : "mouseleave", init));
+              ev.entered ? "mouseenter" : "mouseleave",
+              mouseInit(target, ev, {
+                buttons: windowButtons.get(ev.windowId) ?? 0,
+              }),
+            ));
             break;
           }
           case "focusChanged": {

--- a/cli/rt/desktop.rs
+++ b/cli/rt/desktop.rs
@@ -178,6 +178,422 @@ pub const DESKTOP_JS: &str = r#"
     }
   }
 
+  // width / height / aspect-ratio / orientation / resolution /
+  // device-pixel-ratio. Colon form, boolean features, MQ4 ranges.
+  function mqSplitTop(s, sep) {
+    const out = [];
+    let buf = "";
+    let depth = 0;
+    for (let i = 0; i < s.length; i++) {
+      const ch = s[i];
+      if (ch === "(") depth++;
+      else if (ch === ")") depth = Math.max(0, depth - 1);
+      if (ch === sep && depth === 0) {
+        out.push(buf);
+        buf = "";
+      } else {
+        buf += ch;
+      }
+    }
+    out.push(buf);
+    return out;
+  }
+
+  function mqSplitAndOr(s) {
+    const parts = [];
+    let buf = "";
+    let depth = 0;
+    let pendingOp = "";
+    const lower = s.toLowerCase();
+    const flush = (nextOp) => {
+      if (buf.trim()) {
+        parts.push({ op: pendingOp, text: buf });
+        pendingOp = nextOp;
+        buf = "";
+      }
+    };
+    for (let i = 0; i < s.length; i++) {
+      const ch = s[i];
+      if (ch === "(") depth++;
+      else if (ch === ")") depth = Math.max(0, depth - 1);
+      if (depth === 0) {
+        if (lower.startsWith(" and ", i) || (i === 0 && lower.startsWith("and ", i))) {
+          flush("and");
+          i += (lower.startsWith(" and ", i) ? 5 : 4) - 1;
+          continue;
+        }
+        if (lower.startsWith(" or ", i) || (i === 0 && lower.startsWith("or ", i))) {
+          flush("or");
+          i += (lower.startsWith(" or ", i) ? 4 : 3) - 1;
+          continue;
+        }
+      }
+      buf += ch;
+    }
+    flush("");
+    return parts;
+  }
+
+  function mqUnwrap(s) {
+    s = s.trim();
+    while (s.startsWith("(") && s.endsWith(")")) {
+      let depth = 0;
+      let wraps = true;
+      for (let i = 0; i < s.length; i++) {
+        if (s[i] === "(") depth++;
+        else if (s[i] === ")") {
+          depth--;
+          if (depth === 0 && i !== s.length - 1) {
+            wraps = false;
+            break;
+          }
+        }
+      }
+      if (!wraps) break;
+      s = s.slice(1, -1).trim();
+    }
+    return s;
+  }
+
+  function mqParseNumber(s) {
+    const m = String(s).trim().match(/^([+-]?(?:\d+\.?\d*|\.\d+))(.*)$/);
+    if (!m) return null;
+    const n = parseFloat(m[1]);
+    if (!Number.isFinite(n)) return null;
+    return { n, unit: m[2].trim().toLowerCase() };
+  }
+
+  function mqParsePx(s) {
+    const v = mqParseNumber(s);
+    if (!v) return null;
+    if (v.unit === "" || v.unit === "px") return v.n;
+    return null;
+  }
+
+  function mqParseDppx(s) {
+    const v = mqParseNumber(s);
+    if (!v) return null;
+    if (v.unit === "" || v.unit === "dppx" || v.unit === "x") return v.n;
+    if (v.unit === "dpi") return v.n / 96;
+    if (v.unit === "dpcm") return v.n / (96 / 2.54);
+    return null;
+  }
+
+  function mqParseRatio(s) {
+    const t = String(s).trim();
+    const frac = t.match(/^([+-]?(?:\d+\.?\d*|\.\d+))\s*\/\s*([+-]?(?:\d+\.?\d*|\.\d+))$/);
+    if (frac) {
+      const a = parseFloat(frac[1]);
+      const b = parseFloat(frac[2]);
+      if (!Number.isFinite(a) || !Number.isFinite(b) || b === 0) return null;
+      return a / b;
+    }
+    const n = parseFloat(t);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  function mqCanonical(name) {
+    name = name.toLowerCase();
+    if (name === "-webkit-device-pixel-ratio") return "device-pixel-ratio";
+    return name;
+  }
+
+  function mqIsRangeName(name) {
+    name = mqCanonical(name);
+    return name === "width" || name === "height" || name === "aspect-ratio" ||
+      name === "resolution" || name === "device-pixel-ratio";
+  }
+
+  function mqActual(ctx, name) {
+    name = mqCanonical(name);
+    if (name === "width") return ctx.width;
+    if (name === "height") return ctx.height;
+    if (name === "aspect-ratio") {
+      return ctx.height > 0 ? ctx.width / ctx.height : 0;
+    }
+    if (name === "resolution" || name === "device-pixel-ratio") return ctx.dpr;
+    if (name === "orientation") {
+      return ctx.width >= ctx.height ? "landscape" : "portrait";
+    }
+    return null;
+  }
+
+  function mqParseValue(name, raw) {
+    name = mqCanonical(name);
+    if (name === "width" || name === "height") return mqParsePx(raw);
+    if (name === "aspect-ratio") return mqParseRatio(raw);
+    if (name === "resolution") return mqParseDppx(raw);
+    if (name === "device-pixel-ratio") {
+      const v = mqParseNumber(raw);
+      return v && (v.unit === "") ? v.n : null;
+    }
+    return null;
+  }
+
+  function mqCmp(actual, op, expected) {
+    if (actual == null || expected == null || Number.isNaN(expected)) return false;
+    switch (op) {
+      case "<": return actual < expected;
+      case "<=": return actual <= expected;
+      case ">": return actual > expected;
+      case ">=": return actual >= expected;
+      case "=": return Math.abs(actual - expected) < 1e-6;
+      default: return false;
+    }
+  }
+
+  function mqFlip(op) {
+    if (op === "<") return ">";
+    if (op === "<=") return ">=";
+    if (op === ">") return "<";
+    if (op === ">=") return "<=";
+    return op;
+  }
+
+  function mqSameDir(op1, op2) {
+    const lt = op1 === "<" || op1 === "<=";
+    const lt2 = op2 === "<" || op2 === "<=";
+    const gt = op1 === ">" || op1 === ">=";
+    const gt2 = op2 === ">" || op2 === ">=";
+    return (lt && lt2) || (gt && gt2);
+  }
+
+  function mqEvalColon(ctx, name, value) {
+    let min = false;
+    let max = false;
+    name = name.toLowerCase();
+    if (name.startsWith("min-")) {
+      min = true;
+      name = name.slice(4);
+    } else if (name.startsWith("max-")) {
+      max = true;
+      name = name.slice(4);
+    } else if (name === "-webkit-min-device-pixel-ratio") {
+      min = true;
+      name = "device-pixel-ratio";
+    } else if (name === "-webkit-max-device-pixel-ratio") {
+      max = true;
+      name = "device-pixel-ratio";
+    }
+    name = mqCanonical(name);
+    if (name === "orientation") {
+      if (min || max) return false;
+      return mqActual(ctx, name) === String(value).trim().toLowerCase();
+    }
+    if (!mqIsRangeName(name)) return false;
+    const expected = mqParseValue(name, value);
+    const actual = mqActual(ctx, name);
+    if (min) return mqCmp(actual, ">=", expected);
+    if (max) return mqCmp(actual, "<=", expected);
+    return mqCmp(actual, "=", expected);
+  }
+
+  function mqEvalBoolean(ctx, name) {
+    name = mqCanonical(name);
+    if (name === "orientation") return true;
+    if (!mqIsRangeName(name)) return false;
+    const actual = mqActual(ctx, name);
+    return typeof actual === "number" && actual > 0;
+  }
+
+  function mqEvalPlainFeature(ctx, inner) {
+    inner = inner.trim();
+    const range3 = /^(.+?)\s*(<=|>=|<|>|=)\s*([-\w]+)\s*(<=|>=|<|>|=)\s*(.+)$/
+      .exec(inner);
+    if (range3 && mqIsRangeName(range3[3])) {
+      const op1 = range3[2];
+      const op2 = range3[4];
+      if (op1 === "=" || op2 === "=" || !mqSameDir(op1, op2)) return false;
+      const name = range3[3];
+      const actual = mqActual(ctx, name);
+      return mqCmp(actual, mqFlip(op1), mqParseValue(name, range3[1])) &&
+        mqCmp(actual, op2, mqParseValue(name, range3[5]));
+    }
+    const leftName = /^([-\w]+)\s*(<=|>=|<|>|=)\s*(.+)$/.exec(inner);
+    if (leftName && mqIsRangeName(leftName[1])) {
+      const name = leftName[1];
+      return mqCmp(
+        mqActual(ctx, name),
+        leftName[2],
+        mqParseValue(name, leftName[3]),
+      );
+    }
+    const rightName = /^(.+?)\s*(<=|>=|<|>|=)\s*([-\w]+)$/.exec(inner);
+    if (rightName && mqIsRangeName(rightName[3])) {
+      const name = rightName[3];
+      return mqCmp(
+        mqActual(ctx, name),
+        mqFlip(rightName[2]),
+        mqParseValue(name, rightName[1]),
+      );
+    }
+    const colon = /^([-\w]+)\s*:\s*(.+)$/.exec(inner);
+    if (colon) return mqEvalColon(ctx, colon[1], colon[2]);
+    const bool = /^([-\w]+)$/.exec(inner);
+    if (bool) return mqEvalBoolean(ctx, bool[1]);
+    return false;
+  }
+
+  function mqEvalCondition(ctx, raw) {
+    const parts = mqSplitAndOr(raw.trim());
+    if (parts.length === 0) return false;
+    let sawAnd = false;
+    let sawOr = false;
+    for (let i = 1; i < parts.length; i++) {
+      if (parts[i].op === "and") sawAnd = true;
+      if (parts[i].op === "or") sawOr = true;
+    }
+    if (sawAnd && sawOr) return false;
+    const evalPart = (text) => {
+      let t = text.trim();
+      const not = /^not\s+/i.exec(t);
+      let negated = false;
+      if (not) {
+        negated = true;
+        t = t.slice(not[0].length);
+      }
+      const inner = mqUnwrap(t);
+      let ok;
+      if (inner !== t.trim() || /^\(.*\)$/.test(t.trim())) {
+        const unwrapped = mqUnwrap(t);
+        if (
+          /\band\b|\bor\b|^not\s+/i.test(unwrapped) &&
+          !/^[-\w]+\s*(<=|>=|<|>|=|:)/.test(unwrapped)
+        ) {
+          ok = mqEvalCondition(ctx, unwrapped);
+        } else {
+          ok = mqEvalPlainFeature(ctx, unwrapped);
+        }
+      } else {
+        ok = mqEvalPlainFeature(ctx, inner);
+      }
+      return negated ? !ok : ok;
+    };
+    if (sawOr) return parts.some((p) => evalPart(p.text));
+    return parts.every((p) => evalPart(p.text));
+  }
+
+  function evalMediaQuery(ctx, query) {
+    let q = query.trim();
+    if (!q) return false;
+    let negated = false;
+    const prefix = /^(only|not)\s+/i.exec(q);
+    if (prefix) {
+      if (prefix[1].toLowerCase() === "not") negated = true;
+      q = q.slice(prefix[0].length);
+    }
+    let result;
+    if (q.startsWith("(") || /^not\s*\(/i.test(q)) {
+      result = mqEvalCondition(ctx, q);
+    } else {
+      const m = /^([a-zA-Z][\w-]*)(?:\s+and\s+([\s\S]+))?$/i.exec(q);
+      if (!m) return false;
+      const type = m[1].toLowerCase();
+      const typeOk = type === "all" || type === "screen";
+      result = typeOk && (m[2] ? mqEvalCondition(ctx, m[2]) : true);
+    }
+    return negated ? !result : result;
+  }
+
+  function evalMediaQueryList(ctx, media) {
+    const s = String(media);
+    if (s.trim() === "") return true;
+    return mqSplitTop(s, ",").some((q) => evalMediaQuery(ctx, q));
+  }
+
+  function mediaContext(win) {
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+    try {
+      width = win.innerWidth;
+      height = win.innerHeight;
+      dpr = win.devicePixelRatio;
+    } catch (_) {
+      // Native getters throw on a closed window.
+    }
+    if (!(dpr > 0)) dpr = 1;
+    return { width, height, dpr };
+  }
+
+  const mediaLists = new WeakMap();
+
+  class MediaQueryListEvent extends Event {
+    #media = "";
+    #matches = false;
+    get media() { return this.#media; }
+    get matches() { return this.#matches; }
+    constructor(type, init = {}) {
+      super(type, init);
+      this.#media = init.media ?? "";
+      this.#matches = !!init.matches;
+    }
+  }
+
+  class MediaQueryList extends EventTarget {
+    #win;
+    #query;
+    #matches;
+    #listening = false;
+
+    constructor(win, query) {
+      super();
+      if (win == null || typeof win !== "object") {
+        throw new TypeError("Illegal constructor");
+      }
+      this.#win = win;
+      this.#query = String(query);
+      this.#matches = evalMediaQueryList(mediaContext(win), this.#query);
+    }
+
+    get matches() {
+      return evalMediaQueryList(mediaContext(this.#win), this.#query);
+    }
+    get media() { return this.#query; }
+
+    #track() {
+      if (this.#listening) return;
+      this.#listening = true;
+      let set = mediaLists.get(this.#win);
+      if (!set) {
+        set = new Set();
+        mediaLists.set(this.#win, set);
+      }
+      set.add(this);
+    }
+
+    addEventListener(type, cb, opts) {
+      super.addEventListener(type, cb, opts);
+      if (type === "change" && cb != null) this.#track();
+    }
+
+    addListener(cb) {
+      if (cb == null) return;
+      this.addEventListener("change", cb);
+    }
+    removeListener(cb) {
+      if (cb == null) return;
+      this.removeEventListener("change", cb);
+    }
+
+    static reeval(win) {
+      const set = mediaLists.get(win);
+      if (!set) return;
+      for (const list of set) list.#reeval();
+    }
+
+    #reeval() {
+      const next = evalMediaQueryList(mediaContext(this.#win), this.#query);
+      if (next === this.#matches) return;
+      this.#matches = next;
+      this.dispatchEvent(new MediaQueryListEvent("change", {
+        media: this.#query,
+        matches: next,
+      }));
+    }
+  }
+  internals.defineEventHandler(MediaQueryList.prototype, "change");
+
   op_desktop_init(
     internals.webidlBrand,
     internals.setEventTargetData,
@@ -214,6 +630,10 @@ pub const DESKTOP_JS: &str = r#"
   internals.defineEventHandler(BrowserWindowPrototype, "close");
   internals.defineEventHandler(BrowserWindowPrototype, "menuclick");
   internals.defineEventHandler(BrowserWindowPrototype, "contextmenuclick");
+
+  BrowserWindowPrototype.matchMedia = function(query) {
+    return new MediaQueryList(this, query);
+  };
 
   // Per-window pressed-button mask (DOM `MouseEvent.buttons`).
   const windowButtons = new Map();
@@ -362,6 +782,8 @@ pub const DESKTOP_JS: &str = r#"
     KeyboardEvent: internals.core.propNonEnumerable(KeyboardEvent),
     MouseEvent: internals.core.propNonEnumerable(MouseEvent),
     WheelEvent: internals.core.propNonEnumerable(WheelEvent),
+    MediaQueryList: internals.core.propNonEnumerable(MediaQueryList),
+    MediaQueryListEvent: internals.core.propNonEnumerable(MediaQueryListEvent),
   });
 
   const DockPrototype = Dock.prototype;
@@ -961,6 +1383,7 @@ pub const DESKTOP_JS: &str = r#"
           case "windowResize": {
             const target = windows.get(ev.windowId);
             if (!target) break;
+            MediaQueryList.reeval(target);
             target.dispatchEvent(new CustomEvent("resize", {
               detail: { width: ev.width, height: ev.height },
             }));
@@ -969,6 +1392,7 @@ pub const DESKTOP_JS: &str = r#"
           case "windowMove": {
             const target = windows.get(ev.windowId);
             if (!target) break;
+            MediaQueryList.reeval(target);
             target.dispatchEvent(new CustomEvent("move", {
               detail: { x: ev.x, y: ev.y },
             }));
@@ -1515,6 +1939,16 @@ mod tests {
     ));
     assert!(DESKTOP_JS.contains("case \"pageLoad\""));
     assert!(DESKTOP_JS.contains("dispatchEvent(new Event(\"load\"))"));
+  }
+
+  #[test]
+  fn desktop_js_installs_match_media() {
+    assert!(DESKTOP_JS.contains("BrowserWindowPrototype.matchMedia"));
+    assert!(DESKTOP_JS.contains("class MediaQueryList "));
+    assert!(DESKTOP_JS.contains("evalMediaQueryList"));
+    assert!(DESKTOP_JS.contains("MediaQueryList.reeval(target)"));
+    assert!(DESKTOP_JS.contains("case \"windowResize\""));
+    assert!(DESKTOP_JS.contains("case \"windowMove\""));
   }
 
   #[test]

--- a/cli/rt_desktop/Cargo.toml
+++ b/cli/rt_desktop/Cargo.toml
@@ -33,7 +33,9 @@ deno_runtime.workspace = true
 deno_snapshots.workspace = true
 deno_terminal.workspace = true
 denort = { path = "../rt", default-features = false }
-laufey = "0.7.0"
+# Until littledivy/laufey#fix/winit-mouse-enter-dblclick lands and a
+# release is cut. Replace with the published crate version afterwards.
+laufey = { git = "https://github.com/petamoriken/laufey", branch = "fix/winit-mouse-enter-dblclick" }
 libsui.workspace = true
 
 log = { workspace = true, features = ["serde"] }

--- a/cli/rt_desktop/lib.rs
+++ b/cli/rt_desktop/lib.rs
@@ -44,7 +44,7 @@ use denort::run::RunOptions;
 /// makes the failure mode obvious instead of "the desktop app silently won't
 /// launch".
 const _: () = assert!(
-  laufey::LAUFEY_API_VERSION == 34,
+  laufey::LAUFEY_API_VERSION == 35,
   "LAUFEY_API_VERSION mismatch: update this assert and the prebuilt backend release pin in cli/tools/desktop.rs when laufey bumps its API version",
 );
 
@@ -304,12 +304,24 @@ impl denort::desktop::DesktopApi for WefDesktopApi {
     laufey::Window::from_id(window_id).get_size()
   }
 
+  fn get_window_outer_size(&self, window_id: u32) -> (i32, i32) {
+    laufey::Window::from_id(window_id).get_outer_size()
+  }
+
+  fn get_window_scale_factor(&self, window_id: u32) -> f64 {
+    laufey::Window::from_id(window_id).get_scale_factor()
+  }
+
   fn set_window_size(&self, window_id: u32, width: i32, height: i32) {
     laufey::Window::from_id(window_id).set_size(width, height);
   }
 
   fn get_window_position(&self, window_id: u32) -> (i32, i32) {
     laufey::Window::from_id(window_id).get_position()
+  }
+
+  fn get_window_inner_position(&self, window_id: u32) -> (i32, i32) {
+    laufey::Window::from_id(window_id).get_inner_position()
   }
 
   fn set_window_position(&self, window_id: u32, x: i32, y: i32) {

--- a/cli/tsc/dts/lib.deno.desktop.d.ts
+++ b/cli/tsc/dts/lib.deno.desktop.d.ts
@@ -645,8 +645,19 @@ declare namespace Deno {
 
     /** Physical pixels per CSS pixel for this window, like
      * [`window.devicePixelRatio`](https://developer.mozilla.org/docs/Web/API/Window/devicePixelRatio).
-     * Updates when the window moves to a display with a different scale. */
+     * Updates when the window moves to a display with a different scale.
+     * Observe that with {@linkcode BrowserWindow.matchMedia}, not
+     * {@linkcode BrowserWindowEventMap.resize}. */
     readonly devicePixelRatio: number;
+
+    /** [`window.matchMedia`](https://developer.mozilla.org/docs/Web/API/Window/matchMedia)
+     * for this window. `change` fires when a move or resize crosses the
+     * query, including a move onto a display with a different
+     * {@linkcode BrowserWindow.devicePixelRatio}. Understands `width`,
+     * `height`, `aspect-ratio`, `orientation`, `resolution`, and
+     * `-webkit-device-pixel-ratio` / `device-pixel-ratio`, including
+     * Media Queries Level 4 range syntax. */
+    matchMedia(query: string): MediaQueryList;
 
     getPosition(): [number, number];
     setPosition(x: number, y: number): void;

--- a/cli/tsc/dts/lib.deno.desktop.d.ts
+++ b/cli/tsc/dts/lib.deno.desktop.d.ts
@@ -57,8 +57,11 @@ declare class KeyboardEvent extends UIEvent {
 
 declare interface MouseEventInit extends UIEventInit {
   button?: number;
+  buttons?: number;
   clientX?: number;
   clientY?: number;
+  screenX?: number;
+  screenY?: number;
   ctrlKey?: boolean;
   shiftKey?: boolean;
   altKey?: boolean;
@@ -68,6 +71,7 @@ declare interface MouseEventInit extends UIEventInit {
 declare class MouseEvent extends UIEvent {
   constructor(type: string, init?: MouseEventInit);
   readonly button: number;
+  readonly buttons: number;
   readonly clientX: number;
   readonly clientY: number;
   readonly screenX: number;
@@ -622,9 +626,52 @@ declare namespace Deno {
 
     getSize(): [number, number];
     setSize(width: number, height: number): void;
+    /** Viewport width in CSS pixels, like
+     * [`window.innerWidth`](https://developer.mozilla.org/docs/Web/API/Window/innerWidth).
+     * Same as the first element of {@linkcode BrowserWindow.getSize}. */
+    readonly innerWidth: number;
+    /** Viewport height in CSS pixels, like
+     * [`window.innerHeight`](https://developer.mozilla.org/docs/Web/API/Window/innerHeight).
+     * Same as the second element of {@linkcode BrowserWindow.getSize}. */
+    readonly innerHeight: number;
+    /** Chrome-inclusive width in CSS pixels, like
+     * [`window.outerWidth`](https://developer.mozilla.org/docs/Web/API/Window/outerWidth).
+     * A frameless window matches {@linkcode BrowserWindow.innerWidth}. */
+    readonly outerWidth: number;
+    /** Chrome-inclusive height in CSS pixels, like
+     * [`window.outerHeight`](https://developer.mozilla.org/docs/Web/API/Window/outerHeight).
+     * A frameless window matches {@linkcode BrowserWindow.innerHeight}. */
+    readonly outerHeight: number;
+
+    /** Physical pixels per CSS pixel for this window, like
+     * [`window.devicePixelRatio`](https://developer.mozilla.org/docs/Web/API/Window/devicePixelRatio).
+     * Updates when the window moves to a display with a different scale. */
+    readonly devicePixelRatio: number;
 
     getPosition(): [number, number];
     setPosition(x: number, y: number): void;
+    /** Frame origin in screen CSS pixels, like
+     * [`window.screenX`](https://developer.mozilla.org/docs/Web/API/Window/screenX).
+     * Same as the first element of {@linkcode BrowserWindow.getPosition}.
+     * Not {@linkcode MouseEvent.screenX} — that is
+     * {@linkcode BrowserWindow.getInnerPosition}`()[0] + clientX`. */
+    readonly screenX: number;
+    /** Frame origin in screen CSS pixels, like
+     * [`window.screenY`](https://developer.mozilla.org/docs/Web/API/Window/screenY).
+     * Same as the second element of {@linkcode BrowserWindow.getPosition}.
+     * Not {@linkcode MouseEvent.screenY} — that is
+     * {@linkcode BrowserWindow.getInnerPosition}`()[1] + clientY`. */
+    readonly screenY: number;
+    /** Alias of {@linkcode BrowserWindow.screenX}, like
+     * [`window.screenLeft`](https://developer.mozilla.org/docs/Web/API/Window/screenLeft). */
+    readonly screenLeft: number;
+    /** Alias of {@linkcode BrowserWindow.screenY}, like
+     * [`window.screenTop`](https://developer.mozilla.org/docs/Web/API/Window/screenTop). */
+    readonly screenTop: number;
+    /** Top-left of the content view in screen CSS pixels. Differs from
+     * {@linkcode BrowserWindow.getPosition} by the title-bar height, so
+     * `getInnerPosition()[1] + clientY` is `MouseEvent.screenY`. */
+    getInnerPosition(): [number, number];
 
     isResizable(): boolean;
     setResizable(resizable: boolean): void;

--- a/runtime/ops/desktop.rs
+++ b/runtime/ops/desktop.rs
@@ -538,9 +538,16 @@ pub trait DesktopApi: Send + Sync + 'static {
 
   fn get_window_size(&self, window_id: u32) -> (i32, i32);
   fn set_window_size(&self, window_id: u32, width: i32, height: i32);
+  /// Chrome-inclusive size (`window.outerWidth` / `outerHeight`).
+  fn get_window_outer_size(&self, window_id: u32) -> (i32, i32);
+
+  /// Physical pixels per DIP for this window (`window.devicePixelRatio`).
+  fn get_window_scale_factor(&self, window_id: u32) -> f64;
 
   fn get_window_position(&self, window_id: u32) -> (i32, i32);
   fn set_window_position(&self, window_id: u32, x: i32, y: i32);
+  /// Content-view origin in the same space as `get_window_position`.
+  fn get_window_inner_position(&self, window_id: u32) -> (i32, i32);
 
   fn is_resizable(&self, window_id: u32) -> bool;
   fn set_resizable(&self, window_id: u32, resizable: bool);
@@ -876,12 +883,70 @@ impl BrowserWindow {
   }
 
   #[fast]
+  #[getter]
+  fn inner_width(&self) -> i32 {
+    self.api.get_window_size(self.window_id).0
+  }
+
+  #[fast]
+  #[getter]
+  fn inner_height(&self) -> i32 {
+    self.api.get_window_size(self.window_id).1
+  }
+
+  #[fast]
+  #[getter]
+  fn outer_width(&self) -> i32 {
+    self.api.get_window_outer_size(self.window_id).0
+  }
+
+  #[fast]
+  #[getter]
+  fn outer_height(&self) -> i32 {
+    self.api.get_window_outer_size(self.window_id).1
+  }
+
+  #[fast]
+  #[getter]
+  fn device_pixel_ratio(&self) -> f64 {
+    self.api.get_window_scale_factor(self.window_id)
+  }
+
+  #[fast]
   fn set_size(&self, #[smi] width: i32, #[smi] height: i32) {
     self.api.set_window_size(self.window_id, width, height);
   }
 
   fn get_position(&self) -> (i32, i32) {
     self.api.get_window_position(self.window_id)
+  }
+
+  #[fast]
+  #[getter]
+  fn screen_x(&self) -> i32 {
+    self.api.get_window_position(self.window_id).0
+  }
+
+  #[fast]
+  #[getter]
+  fn screen_y(&self) -> i32 {
+    self.api.get_window_position(self.window_id).1
+  }
+
+  #[fast]
+  #[getter]
+  fn screen_left(&self) -> i32 {
+    self.api.get_window_position(self.window_id).0
+  }
+
+  #[fast]
+  #[getter]
+  fn screen_top(&self) -> i32 {
+    self.api.get_window_position(self.window_id).1
+  }
+
+  fn get_inner_position(&self) -> (i32, i32) {
+    self.api.get_window_inner_position(self.window_id)
   }
 
   #[fast]


### PR DESCRIPTION
## Summary

Two parts: bring raw `BrowserWindow` in line with CEF / WebView, and add Web-shaped viewport getters that every backend was missing.

### Align raw with CEF / WebView

- Mouse events fill `buttons` and `screenX`/`screenY`
- `dblclick` fires on a real double-click
- Wheel `deltaY` uses the DOM sign (positive = down)
- `screenX`/`screenY` use the content-view origin (`getInnerPosition`), so the title bar is included
- Windows re-reads the pointer before a press (the matching laufey change)
- `getSize`, `resize`, `getPosition`, and `clientX`/`clientY` are logical pixels, same as CEF / WebView and the constructor
- Opening no longer fires `resize` twice; Windows intermediate sizes wait until the event loop is idle
- `getPosition()` is the real frame origin after the window exists
- Constructor-time `getInnerPosition()` offsets by the chrome on Windows and macOS
- Shift / Control / Alt / Meta emit `keydown` / `keyup`; Super maps to `Meta`
- macOS WebView also emits those modifiers (`FlagsChanged`) and keeps `click.detail` at 1

### New getters

New on every backend (raw, CEF, and WebView), not raw-only fixes.

- `devicePixelRatio` — [`window.devicePixelRatio`](https://developer.mozilla.org/docs/Web/API/Window/devicePixelRatio). Honest in the constructor (seeded from the primary display, not `1`); updates when the window changes monitor. Observe a scale change with `matchMedia`, not `resize`
- `matchMedia` — [`window.matchMedia`](https://developer.mozilla.org/docs/Web/API/Window/matchMedia). `change` fires on move or resize when the query result crosses, including a move onto another display. Understands `width`, `height`, `aspect-ratio`, `orientation`, `resolution`, and `-webkit-device-pixel-ratio` / `device-pixel-ratio`, including Media Queries Level 4 range syntax
- `innerWidth` / `innerHeight` — same logical viewport as `getSize()`, like [`window.innerWidth`](https://developer.mozilla.org/docs/Web/API/Window/innerWidth) / [`innerHeight`](https://developer.mozilla.org/docs/Web/API/Window/innerHeight)
- `outerWidth` / `outerHeight` — chrome-inclusive size, like [`window.outerWidth`](https://developer.mozilla.org/docs/Web/API/Window/outerWidth) / [`outerHeight`](https://developer.mozilla.org/docs/Web/API/Window/outerHeight). Frameless matches `innerWidth` / `innerHeight`
- `screenX` / `screenY` (`screenLeft` / `screenTop` aliases) — frame origin, same as `getPosition()`, like [`window.screenX`](https://developer.mozilla.org/docs/Web/API/Window/screenX). Not `MouseEvent.screenX` / `screenY` (`getInnerPosition() + client`)

Depends on https://github.com/littledivy/laufey/pull/80 (ABI 35). Until that lands and a laufey release is cut, this branch pins:

```toml
laufey = { git = "https://github.com/petamoriken/laufey", branch = "fix/winit-mouse-enter-dblclick" }
```

After the laufey change is on crates.io, that pin should be replaced with the published crate version.

## AI Disclosure

This PR was drafted and filed by an AI assistant (Grok). I reviewed and edited it myself.