### PR TITLE
feat(permissions): match unix net grants as directory prefixes

### DIFF
--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1963,7 +1963,10 @@ impl QueryDescriptor for NetDescriptor {
       ) => a == b,
       (Host::Ip(a), Host::Ip(b)) => a == b,
       (Host::Vsock(a), Host::Vsock(b)) => a == b,
-      (Host::UnixSocket(a), Host::UnixSocket(b)) => a == b,
+      // Directory grants cover sockets under that path, same as --allow-read.
+      // Path::starts_with is component-bounded, so /tmp/app does not
+      // match /tmp/app-evil.sock.
+      (Host::UnixSocket(a), Host::UnixSocket(b)) => b.starts_with(a),
       (Host::IpSubnet(a), Host::Ip(b)) => a.contains(b),
       _ => false,
     }
@@ -4842,11 +4845,13 @@ impl PermissionsContainer {
   ///
   /// `path` must already be resolved to an absolute path (typically by the
   /// caller's earlier `check_open` pass). Matched lexically against
-  /// `--allow-net=unix:<absolute-path>` rules. Both sides are lexically
-  /// normalized (`.`/`..` components removed; rules at parse time, the query
-  /// path by `check_open`), but symlinks are deliberately not resolved,
-  /// mirroring `check_open`'s symlink-location semantics: a rule scopes the
-  /// socket *location*, not the inode it points at.
+  /// `--allow-net=unix:<absolute-path>` rules. A directory grant also matches
+  /// sockets under that directory (`Path::starts_with`, component bounded).
+  /// Both sides are lexically normalized (`.`/`..` components removed; rules
+  /// at parse time, the query path by `check_open`), but symlinks are
+  /// deliberately not resolved, mirroring `check_open`'s symlink-location
+  /// semantics: a rule scopes the socket *location*, not the inode it points
+  /// at.
   ///
   /// Abstract socket paths (Linux, leading NUL) are not absolute, so they
   /// cannot be expressed as a scoped `unix:` rule and are only reachable via
@@ -8408,6 +8413,36 @@ mod tests {
         "'{input}'"
       );
     }
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn test_unix_socket_directory_grant_matches_children() {
+    let grant =
+      NetDescriptor(Host::UnixSocket(PathBuf::from("/tmp/app")), None);
+    let child =
+      NetDescriptor(Host::UnixSocket(PathBuf::from("/tmp/app/abc.sock")), None);
+    let nested = NetDescriptor(
+      Host::UnixSocket(PathBuf::from("/tmp/app/nested/x.sock")),
+      None,
+    );
+    let exact =
+      NetDescriptor(Host::UnixSocket(PathBuf::from("/tmp/app")), None);
+    let sibling = NetDescriptor(
+      Host::UnixSocket(PathBuf::from("/tmp/app-evil.sock")),
+      None,
+    );
+    let other =
+      NetDescriptor(Host::UnixSocket(PathBuf::from("/tmp/other.sock")), None);
+    assert!(child.matches_allow(&grant));
+    assert!(nested.matches_allow(&grant));
+    assert!(exact.matches_allow(&grant));
+    assert!(!sibling.matches_allow(&grant));
+    assert!(!other.matches_allow(&grant));
+    // A child grant does not cover the parent path.
+    assert!(!grant.matches_allow(&child));
+    assert!(child.matches_deny(&grant));
+    assert!(!sibling.matches_deny(&grant));
   }
 
   #[test]

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -2534,8 +2534,7 @@ Deno.test(
   },
 );
 
-// The scoped form must match the exact path: an `--allow-net=unix:<path>` rule
-// for a different socket does not grant the Unix proxy access to this one.
+// A unix: grant for a different socket does not cover this Unix proxy.
 Deno.test(
   {
     ignore: Deno.build.os === "windows",

--- a/tests/unit/net_test.ts
+++ b/tests/unit/net_test.ts
@@ -1677,8 +1677,7 @@ Deno.test(
   },
 );
 
-// Scoped form must match the exact path — a different unix path does not
-// grant access to this one.
+// A unix: grant for a different path does not cover this socket.
 Deno.test(
   {
     ignore: Deno.build.os === "windows",


### PR DESCRIPTION
Closes #36762

`--allow-net=unix:<path>` only matches that exact socket. That is what you want for `/var/run/docker.sock`. It is not enough when `deno compile` has to bake the grant in and the socket name is chosen at runtime.

unix: grants now match like `--allow-read`. `--allow-net=unix:/tmp/app` covers `/tmp/app` and `/tmp/app/abc.sock`, and does not cover `/tmp/app-evil.sock`. TCP is unchanged.

Written with AI assistance (Grok).