### PR TITLE
ci: drop the gcloud auth steps left over from the dl.deno.land move

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -912,7 +912,7 @@ jobs:
           name: release-macos-x86_64-test-server
           path: target/release/test_server
           retention-days: 3
-      - name: Upload release to dl.deno.land (unix)
+      - name: Upload release to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
@@ -2049,7 +2049,7 @@ jobs:
           name: release-macos-aarch64-test-server
           path: target/release/test_server
           retention-days: 3
-      - name: Upload release to dl.deno.land (unix)
+      - name: Upload release to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
@@ -3098,14 +3098,13 @@ jobs:
           name: release-windows-x86_64-test-server
           path: target/release/test_server.exe
           retention-days: 3
-      - name: Upload release to dl.deno.land (windows)
+      - name: Upload release to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
           AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
           AWS_ENDPOINT_URL_S3: '${{ vars.S3_ENDPOINT }}'
           AWS_DEFAULT_REGION: '${{ vars.S3_REGION }}'
-          CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         run: |-
           aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.zip"
           aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.sha256sum"
@@ -4006,14 +4005,13 @@ jobs:
           name: release-windows-aarch64-test-server
           path: target/release/test_server.exe
           retention-days: 3
-      - name: Upload release to dl.deno.land (windows)
+      - name: Upload release to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
           AWS_SECRET_ACCESS_KEY: '${{ secrets.S3_SECRET_ACCESS_KEY }}'
           AWS_ENDPOINT_URL_S3: '${{ vars.S3_ENDPOINT }}'
           AWS_DEFAULT_REGION: '${{ vars.S3_REGION }}'
-          CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         run: |-
           aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.zip"
           aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.sha256sum"
@@ -4666,7 +4664,7 @@ jobs:
           name: release-linux-x86_64-test-server
           path: target/release/test_server
           retention-days: 3
-      - name: Upload release to dl.deno.land (unix)
+      - name: Upload release to dl.deno.land
         if: 'github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
@@ -6804,7 +6802,7 @@ jobs:
           name: release-linux-aarch64-test-server
           path: target/release/test_server
           retention-days: 3
-      - name: Upload release to dl.deno.land (unix)
+      - name: Upload release to dl.deno.land
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && startsWith(github.ref, ''refs/tags/'')'
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -1229,9 +1229,8 @@ const buildJobs = buildItems.map((rawBuildItem) => {
         const shouldPublishCondition = isRelease.and(isDenoland)
           .and(isTag);
         const publishStep = step.if(shouldPublishCondition)(
-          step({
-            name: "Upload release to dl.deno.land (unix)",
-            if: isWindows.not(),
+          {
+            name: "Upload release to dl.deno.land",
             env: S3Envs,
             run: [
               'aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.zip"',
@@ -1239,20 +1238,7 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               'aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.symcache"',
               'aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.bsdiff"',
             ],
-          }, {
-            name: "Upload release to dl.deno.land (windows)",
-            if: isWindows,
-            env: {
-              ...S3Envs,
-              CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
-            },
-            run: [
-              'aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.zip"',
-              'aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.sha256sum"',
-              'aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.symcache"',
-              'aws s3 sync ./target/release/ s3://dl-deno-land/release/${GITHUB_REF#refs/*/}/ --exclude "*" --include "*.bsdiff"',
-            ],
-          }),
+          },
           {
             name: "Create release notes",
             run: [

--- a/.github/workflows/ecosystem_compat_test.generated.yml
+++ b/.github/workflows/ecosystem_compat_test.generated.yml
@@ -30,17 +30,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.11
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-        with:
-          project_id: denoland
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
-          export_environment_variables: true
-          create_credentials_file: true
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
-        with:
-          project_id: denoland
       - name: Run tests
         run: deno -A tools/ecosystem_compat_tests.ts
       - name: Upload the report to dl.deno.land
@@ -66,17 +55,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.11
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-        with:
-          project_id: denoland
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
-          export_environment_variables: true
-          create_credentials_file: true
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
-        with:
-          project_id: denoland
       - name: Post message to slack channel
         env:
           SLACK_TOKEN: '${{ secrets.NODE_COMPAT_SLACK_TOKEN }}'
@@ -86,5 +64,3 @@ jobs:
 # gagen:pin actions/checkout@v6 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
 # gagen:pin actions/setup-python@v6 = a309ff8b426b58ec0e2a45f0f869d46889d02405
 # gagen:pin denoland/setup-deno@v2 = 667a34cdef165d8d2b2e98dde39547c9daac7282
-# gagen:pin google-github-actions/auth@v3 = 7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-# gagen:pin google-github-actions/setup-gcloud@v3 = aa5489c8933f4cc7a4f7d45035b3b1440c9c10db

--- a/.github/workflows/ecosystem_compat_test.ts
+++ b/.github/workflows/ecosystem_compat_test.ts
@@ -36,21 +36,6 @@ const testJob = job("test", {
       with: { "python-version": 3.11 },
     }),
     step({
-      name: "Authenticate with Google Cloud",
-      uses: "google-github-actions/auth@v3",
-      with: {
-        project_id: "denoland",
-        credentials_json: "${{ secrets.GCP_SA_KEY }}",
-        export_environment_variables: true,
-        create_credentials_file: true,
-      },
-    }),
-    step({
-      name: "Setup gcloud",
-      uses: "google-github-actions/setup-gcloud@v3",
-      with: { project_id: "denoland" },
-    }),
-    step({
       name: "Run tests",
       run: "deno -A tools/ecosystem_compat_tests.ts",
     }),
@@ -95,21 +80,6 @@ const workflow = createWorkflow({
           name: "Install Python",
           uses: "actions/setup-python@v6",
           with: { "python-version": 3.11 },
-        }),
-        step({
-          name: "Authenticate with Google Cloud",
-          uses: "google-github-actions/auth@v3",
-          with: {
-            project_id: "denoland",
-            credentials_json: "${{ secrets.GCP_SA_KEY }}",
-            export_environment_variables: true,
-            create_credentials_file: true,
-          },
-        }),
-        step({
-          name: "Setup gcloud",
-          uses: "google-github-actions/setup-gcloud@v3",
-          with: { project_id: "denoland" },
         }),
         step({
           name: "Post message to slack channel",

--- a/.github/workflows/node_compat_test.generated.yml
+++ b/.github/workflows/node_compat_test.generated.yml
@@ -75,19 +75,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.11
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-        if: github.ref == 'refs/heads/main'
-        with:
-          project_id: denoland
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
-          export_environment_variables: true
-          create_credentials_file: true
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
-        if: github.ref == 'refs/heads/main'
-        with:
-          project_id: denoland
       - name: Run tests
         env:
           CARGO_ENCODED_RUSTFLAGS: ''
@@ -122,17 +109,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.11
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-        with:
-          project_id: denoland
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
-          export_environment_variables: true
-          create_credentials_file: true
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
-        with:
-          project_id: denoland
       - name: Add the day summary to the month summary
         run: deno -A --config tests/config/deno.json tests/node_compat/add_day_summary_to_month_summary.ts
       - name: Gzip the month summary
@@ -154,5 +130,3 @@ jobs:
 # gagen:pin actions/setup-python@v6 = a309ff8b426b58ec0e2a45f0f869d46889d02405
 # gagen:pin denoland/setup-deno@v2 = 667a34cdef165d8d2b2e98dde39547c9daac7282
 # gagen:pin dsherret/rust-toolchain-file@v1 = 3551321aa44dd44a0393eb3b6bdfbc5d25ecf621
-# gagen:pin google-github-actions/auth@v3 = 7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-# gagen:pin google-github-actions/setup-gcloud@v3 = aa5489c8933f4cc7a4f7d45035b3b1440c9c10db

--- a/.github/workflows/node_compat_test.ts
+++ b/.github/workflows/node_compat_test.ts
@@ -58,26 +58,7 @@ const installPython = step.dependsOn(setupDeno)({
   with: { "python-version": 3.11 },
 });
 
-const authGcloud = step.dependsOn(installPython)({
-  name: "Authenticate with Google Cloud",
-  if: isMainBranch,
-  uses: "google-github-actions/auth@v3",
-  with: {
-    project_id: "denoland",
-    credentials_json: "${{ secrets.GCP_SA_KEY }}",
-    export_environment_variables: true,
-    create_credentials_file: true,
-  },
-});
-
-const setupGcloud = step.dependsOn(authGcloud)({
-  name: "Setup gcloud",
-  if: isMainBranch,
-  uses: "google-github-actions/setup-gcloud@v3",
-  with: { project_id: "denoland" },
-});
-
-const runTests = step.dependsOn(setupGcloud)({
+const runTests = step.dependsOn(installPython)({
   name: "Run tests",
   env: {
     CARGO_ENCODED_RUSTFLAGS: "",
@@ -124,8 +105,6 @@ const testJob = job("test", {
     setupRust,
     setupDeno,
     installPython,
-    authGcloud,
-    setupGcloud,
     runTests,
     gzipReport,
     uploadReport,
@@ -157,24 +136,7 @@ const summaryInstallPython = step.dependsOn(summarySetupDeno)({
   with: { "python-version": 3.11 },
 });
 
-const summaryAuthGcloud = step.dependsOn(summaryInstallPython)({
-  name: "Authenticate with Google Cloud",
-  uses: "google-github-actions/auth@v3",
-  with: {
-    project_id: "denoland",
-    credentials_json: "${{ secrets.GCP_SA_KEY }}",
-    export_environment_variables: true,
-    create_credentials_file: true,
-  },
-});
-
-const summarySetupGcloud = step.dependsOn(summaryAuthGcloud)({
-  name: "Setup gcloud",
-  uses: "google-github-actions/setup-gcloud@v3",
-  with: { project_id: "denoland" },
-});
-
-const addDaySummary = step.dependsOn(summarySetupGcloud)({
+const addDaySummary = step.dependsOn(summaryInstallPython)({
   name: "Add the day summary to the month summary",
   run:
     "deno -A --config tests/config/deno.json tests/node_compat/add_day_summary_to_month_summary.ts",

--- a/.github/workflows/post_publish.generated.yml
+++ b/.github/workflows/post_publish.generated.yml
@@ -22,17 +22,6 @@ jobs:
       - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
         with:
           deno-version: v2.x
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-        with:
-          project_id: denoland
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
-          export_environment_variables: true
-          create_credentials_file: true
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
-        with:
-          project_id: denoland
       - name: Upload version file to dl.deno.land
         env:
           AWS_ACCESS_KEY_ID: '${{ vars.S3_ACCESS_KEY_ID }}'
@@ -67,5 +56,3 @@ jobs:
 
 # gagen:pin actions/checkout@v6 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
 # gagen:pin denoland/setup-deno@v2 = 667a34cdef165d8d2b2e98dde39547c9daac7282
-# gagen:pin google-github-actions/auth@v3 = 7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-# gagen:pin google-github-actions/setup-gcloud@v3 = aa5489c8933f4cc7a4f7d45035b3b1440c9c10db

--- a/.github/workflows/post_publish.ts
+++ b/.github/workflows/post_publish.ts
@@ -35,21 +35,6 @@ const workflow = createWorkflow({
         with: { "deno-version": "v2.x" },
       }),
       step({
-        name: "Authenticate with Google Cloud",
-        uses: "google-github-actions/auth@v3",
-        with: {
-          project_id: "denoland",
-          credentials_json: "${{ secrets.GCP_SA_KEY }}",
-          export_environment_variables: true,
-          create_credentials_file: true,
-        },
-      }),
-      step({
-        name: "Setup gcloud",
-        uses: "google-github-actions/setup-gcloud@v3",
-        with: { project_id: "denoland" },
-      }),
-      step({
         name: "Upload version file to dl.deno.land",
         env: {
           AWS_ACCESS_KEY_ID: "${{ vars.S3_ACCESS_KEY_ID }}",


### PR DESCRIPTION
* remove the "Authenticate with Google Cloud" and "Setup gcloud" steps
  from both jobs of ecosystem_compat_test.ts and node_compat_test.ts and
  from the "update dl.deno.land version" job of post_publish.ts; nothing
  in those jobs invokes gcloud or reads Google credentials anymore
* drop the gcloud-only CLOUDSDK_PYTHON env entry from the Windows
  release upload step in ci.ts, which leaves the Windows and unix upload
  steps identical, so collapse them into a single unconditional step
* regenerate the four *.generated.yml files, which also drops the
  gagen:pin entries for google-github-actions/auth and setup-gcloud

Every dl.deno.land upload has gone to R2 through the S3 API since #32335
and #32338, the last gcloud upload was removed in #33088, and the GCP
project the GCP_SA_KEY service account belonged to is being deleted.

