### PR TITLE
fix(ext/node): pick shell:true arg quoting from the resolved shell

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -149,7 +149,16 @@ const {
 // Precompiled regular expressions (captured as SafeRegExp so the prototype
 // can't be tampered with at runtime).
 const cmdExeRe = new SafeRegExp("^(?:.*\\\\)?cmd(?:\\.exe)?$", "i");
+const powerShellRe = new SafeRegExp(
+  "^(?:.*\\\\)?(?:powershell|pwsh)(?:\\.exe)?$",
+  "i",
+);
 const winSpecialCharsRe = new SafeRegExp('[\\s"\\\\&|<>^!()]');
+// Characters that cannot be represented literally inside `cmd.exe /d /s /c
+// "..."`. cmd.exe parses the command string before the child's C runtime does
+// and has no escape for a double quote; \r and \n truncate the command.
+const cmdUnrepresentableRe = new SafeRegExp('["\\r\\n]');
+const psSpecialCharsRe = new SafeRegExp("[^a-zA-Z0-9_.:\\\\/-]");
 const winEscapeQuotesRe = new SafeRegExp('(\\\\*)"', "g");
 const winTrailingBackslashRe = new SafeRegExp("(\\\\+)$");
 const posixSpecialCharsRe = new SafeRegExp("[^a-zA-Z0-9_./-]");
@@ -1321,6 +1330,21 @@ function normalizeSpawnArguments(
   ]);
 
   if (options.shell) {
+    // Resolve the shell before escaping anything. Quoting rules belong to the
+    // shell that will actually parse the command, not to the host platform: a
+    // custom `powershell.exe` on Windows does not read cmd.exe quoting, and a
+    // custom `bash.exe` reads POSIX quoting.
+    let shellFile;
+    if (typeof options.shell === "string") {
+      shellFile = options.shell;
+    } else if (process.platform === "win32") {
+      shellFile = Deno.env.get("comspec") || "cmd.exe";
+    } else {
+      /** TODO: add Android condition */
+      shellFile = "/bin/sh";
+    }
+    const grammar = shellGrammarFor(shellFile);
+
     // When args are provided, escape them to prevent shell injection.
     // When no args are provided (just a string command), the user intends
     // for shell interpretation, so don't escape.
@@ -1335,11 +1359,20 @@ function normalizeSpawnArguments(
         );
         emittedShellDeprecation = true;
       }
+      let escapedFile = escapeShellArg(
+        stripShellArgQuotes(file, grammar),
+        grammar,
+      );
+      // PowerShell parses a quoted token in command position as a string
+      // expression, so a quoted program path needs the call operator to run.
+      if (grammar === "powershell" && escapedFile !== file) {
+        escapedFile = `& ${escapedFile}`;
+      }
       const escapedParts = [
-        escapeShellArg(stripShellArgQuotes(file)),
+        escapedFile,
         ...new SafeArrayIterator(ArrayPrototypeMap(
           args,
-          (arg) => escapeShellArg(stripShellArgQuotes(arg)),
+          (arg) => escapeShellArg(stripShellArgQuotes(arg, grammar), grammar),
         )),
       ];
       command = ArrayPrototypeJoin(escapedParts, " ");
@@ -1350,26 +1383,12 @@ function normalizeSpawnArguments(
     // Note: transformDenoShellCommand is NOT called here because buildCommand()
     // already handles it for both `-c` (POSIX) and `/d /s /c` (cmd.exe) cases.
     // Calling it here would cause double transformation.
-    if (process.platform === "win32") {
-      if (typeof options.shell === "string") {
-        file = options.shell;
-      } else {
-        file = Deno.env.get("comspec") || "cmd.exe";
-      }
-      // '/d /s /c' is used only for cmd.exe.
-      if (RegExpPrototypeExec(cmdExeRe, file) !== null) {
-        args = ["/d", "/s", "/c", `"${command}"`];
-        windowsVerbatimArguments = true;
-      } else {
-        args = ["-c", command];
-      }
+    file = shellFile;
+    // '/d /s /c' is used only for cmd.exe.
+    if (grammar === "cmd") {
+      args = ["/d", "/s", "/c", `"${command}"`];
+      windowsVerbatimArguments = true;
     } else {
-      /** TODO: add Android condition */
-      if (typeof options.shell === "string") {
-        file = options.shell;
-      } else {
-        file = "/bin/sh";
-      }
       args = ["-c", command];
     }
   }
@@ -1470,18 +1489,39 @@ function waitForStreamToClose(stream) {
 }
 
 /**
+ * Returns the quoting grammar understood by the shell that will parse the
+ * command, given the resolved shell executable.
+ *
+ * Only cmd.exe uses cmd quoting. Every other shell reachable here is invoked
+ * with `-c`: PowerShell has its own grammar, and anything else (`bash.exe`,
+ * `sh`, `zsh`, ...) parses POSIX quoting on Windows just as it does elsewhere.
+ */
+function shellGrammarFor(shellFile) {
+  if (lazyProcess().default.platform !== "win32") {
+    return "posix";
+  }
+  if (RegExpPrototypeExec(cmdExeRe, shellFile) !== null) {
+    return "cmd";
+  }
+  if (RegExpPrototypeExec(powerShellRe, shellFile) !== null) {
+    return "powershell";
+  }
+  return "posix";
+}
+
+/**
  * Removes one layer of quotes that callers added around a complete shell
  * argument. The argument is escaped again before being passed to the shell.
  */
-function stripShellArgQuotes(arg) {
+function stripShellArgQuotes(arg, grammar) {
   if (arg.length < 2) {
     return arg;
   }
   const doubleQuoted = StringPrototypeStartsWith(arg, '"') &&
     StringPrototypeEndsWith(arg, '"');
   // cmd.exe treats single quotes as ordinary characters, while POSIX shells
-  // recognize both single and double quotes.
-  const singleQuoted = lazyProcess().default.platform !== "win32" &&
+  // and PowerShell recognize both single and double quotes.
+  const singleQuoted = grammar !== "cmd" &&
     StringPrototypeStartsWith(arg, "'") &&
     StringPrototypeEndsWith(arg, "'");
   if (doubleQuoted || singleQuoted) {
@@ -1491,14 +1531,28 @@ function stripShellArgQuotes(arg) {
 }
 
 /**
- * Escapes a string for safe use as a shell argument.
- * On Unix, wraps in single quotes and escapes embedded single quotes.
- * On Windows, wraps in double quotes and escapes embedded double quotes and backslashes.
+ * Escapes a string for safe use as an argument to the given shell grammar, so
+ * that the shell passes it through to the child as one literal value.
+ *
+ * Throws `ERR_INVALID_ARG_VALUE` for values that the grammar cannot represent
+ * literally at all, rather than emitting an approximation that the shell would
+ * reinterpret as syntax.
  */
-function escapeShellArg(arg) {
-  const process = lazyProcess().default;
-  if (process.platform === "win32") {
-    // Windows: use double quotes, escape double quotes and backslashes
+function escapeShellArg(arg, grammar) {
+  if (grammar === "cmd") {
+    // cmd.exe parses the command string handed to `/d /s /c` before the child's
+    // C runtime sees it, and it has no escape character inside a quoted region:
+    // a `"` always toggles the quoting state, so backslash escaping cannot keep
+    // an embedded quote literal. \r and \n truncate the command. Reject these
+    // instead of producing a string cmd.exe would parse as extra commands.
+    if (RegExpPrototypeTest(cmdUnrepresentableRe, arg)) {
+      throw new ERR_INVALID_ARG_VALUE(
+        "args",
+        arg,
+        "must not contain a double quote, carriage return, or line feed when " +
+          "the shell is cmd.exe, which cannot represent them literally",
+      );
+    }
     // Empty string needs to be quoted
     if (arg === "") {
       return '""';
@@ -1510,11 +1564,25 @@ function escapeShellArg(arg) {
     if (!RegExpPrototypeTest(winSpecialCharsRe, arg)) {
       return arg;
     }
-    // Escape backslashes before quotes, then escape quotes
-    let escaped = StringPrototypeReplace(arg, winEscapeQuotesRe, '$1$1\\"');
-    // Escape trailing backslashes
-    escaped = StringPrototypeReplace(escaped, winTrailingBackslashRe, "$1$1");
+    // Double any trailing backslashes so the child's C runtime does not read
+    // them as escaping the closing quote.
+    const escaped = StringPrototypeReplace(
+      arg,
+      winTrailingBackslashRe,
+      "$1$1",
+    );
     return `"${escaped}"`;
+  } else if (grammar === "powershell") {
+    // PowerShell single-quoted strings are fully literal - no `$(...)`
+    // subexpressions, no `$var`, no backtick escapes - and an embedded single
+    // quote is written by doubling it.
+    if (arg === "") {
+      return "''";
+    }
+    if (!RegExpPrototypeTest(psSpecialCharsRe, arg)) {
+      return arg;
+    }
+    return "'" + StringPrototypeReplace(arg, singleQuoteRe, "''") + "'";
   } else {
     // Unix: use single quotes, escape embedded single quotes
     // Empty string needs to be quoted

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1820,6 +1820,78 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "shell cmd.exe rejects arguments it cannot represent literally",
+  ignore: Deno.build.os !== "windows",
+  fn() {
+    // cmd.exe has no escape for a double quote inside a quoted region, so an
+    // argument containing one cannot be passed through `/d /s /c` as a literal
+    // value. It must be rejected rather than silently broken into extra
+    // commands. \r and \n truncate the command string for the same reason.
+    for (const bad of ['safe"&echo pwned&rem "', "bad\rarg", "bad\narg"]) {
+      for (const spawnFn of [spawn, spawnSync]) {
+        assertThrows(
+          () =>
+            spawnFn(
+              Deno.execPath(),
+              ["eval", "console.log(Deno.args[0])", "--", bad],
+              { shell: true },
+            ),
+          TypeError,
+          "ERR_INVALID_ARG_VALUE",
+        );
+      }
+    }
+  },
+});
+
+Deno.test({
+  name: "shell cmd.exe still accepts arguments it can represent",
+  ignore: Deno.build.os !== "windows",
+  fn() {
+    const ret = spawnSync(
+      Deno.execPath(),
+      ["eval", "console.log(Deno.args[0])", "--", "a&b|c<d>e (f) !g^h"],
+      { shell: true, encoding: "utf-8" },
+    );
+    assertEquals(ret.status, 0);
+    assertEquals(ret.stdout.trim(), "a&b|c<d>e (f) !g^h");
+  },
+});
+
+Deno.test({
+  name: "custom powershell shell escapes with PowerShell quoting",
+  ignore: Deno.build.os !== "windows",
+  fn() {
+    // Quoting is chosen from the shell that parses the command, not from the
+    // host platform. cmd.exe's double quotes would let PowerShell evaluate
+    // `$(...)`; PowerShell single quotes keep it literal.
+    const payload = "safe$(Write-Output pwned)";
+    const ret = spawnSync("Write-Output", [payload], {
+      shell: "powershell.exe",
+      encoding: "utf-8",
+    });
+    assertEquals(ret.status, 0);
+    assertEquals(ret.stdout.trim(), payload);
+  },
+});
+
+Deno.test({
+  name: "custom powershell shell runs a quoted program path",
+  ignore: Deno.build.os !== "windows",
+  fn() {
+    // A quoted token in command position is a string expression in PowerShell,
+    // so a quoted program path needs the `&` call operator to actually run.
+    const ret = spawnSync(
+      Deno.execPath(),
+      ["eval", "console.log(Deno.args[0])", "--", "hello world"],
+      { shell: "powershell.exe", encoding: "utf-8" },
+    );
+    assertEquals(ret.status, 0);
+    assertEquals(ret.stdout.trim(), "hello world");
+  },
+});
+
 Deno.test(function spawnSyncReturnsPid() {
   const ret = spawnSync(Deno.execPath(), ["eval", "console.log('hi')"]);
   assertEquals(ret.status, 0);


### PR DESCRIPTION
`escapeShellArg` picked its quoting rules from `process.platform`, but
`normalizeSpawnArguments` only resolves which shell will actually run the
command afterwards. So the escaping never matched the parser it was aimed
at. On the default Windows path, arguments were handed to `cmd.exe` with
double quotes escaped as `\"`, a C runtime convention that cmd.exe does
not honor -- it toggles quoting state on every `"` regardless -- so an
argument containing a quote ended the quoted region early and the rest of
it was parsed as command syntax. With a custom `shell: "powershell.exe"`,
the command was built with cmd.exe quoting and then handed to PowerShell,
which expands `$()` inside double quotes.

This resolves the shell before building the command and escapes against
the grammar that shell actually parses. There is no way to represent an
embedded quote literally inside `cmd.exe /d /s /c "..."`, so that case now
throws `ERR_INVALID_ARG_VALUE` rather than emitting an approximation,
matching the approach taken for the native batch path in #36434. PowerShell
gets single-quoted arguments, which are fully literal, plus the `&` call
operator when the program path needs quoting -- previously a quoted path in
command position was parsed as a string expression and never ran. Every
other `-c` shell reachable here (`bash.exe`, `sh`, `zsh`) now gets POSIX
quoting on Windows too, where it was previously getting cmd.exe quoting.

Behavior on Unix is unchanged.