### PR TITLE
fix(ext/node): normalize resourceUsage maxRSS on macOS

### DIFF
--- a/ext/node/ops/process.rs
+++ b/ext/node/ops/process.rs
@@ -457,10 +457,10 @@ pub fn op_node_process_setuid(
 /// 8 swappedOut, 9 fsRead, 10 fsWrite, 11 ipcSent, 12 ipcReceived,
 /// 13 signalsCount, 14 voluntaryContextSwitches, 15 involuntaryContextSwitches.
 ///
-/// CPU times are in microseconds. This mirrors libuv's `uv_getrusage`, which
-/// Node.js uses: on Unix the values come from `getrusage(2)`, with max RSS
-/// normalized to kilobytes on Apple platforms. Fields unavailable on a
-/// platform are reported as `0`.
+/// CPU times are in microseconds. This follows libuv's `uv_getrusage` unit
+/// conventions for the platforms supported by Deno: on Unix the values come
+/// from `getrusage(2)`, with max RSS normalized to kilobytes on Apple
+/// platforms. Fields unavailable on a platform are reported as `0`.
 #[op2(fast)]
 pub fn op_node_process_resource_usage(#[buffer] out: &mut [f64]) {
   if out.len() < 16 {
@@ -517,21 +517,6 @@ fn max_rss_in_kb(ru_maxrss: libc::c_long) -> f64 {
 #[cfg(all(unix, not(target_vendor = "apple")))]
 fn max_rss_in_kb(ru_maxrss: libc::c_long) -> f64 {
   ru_maxrss as f64
-}
-
-#[cfg(all(test, unix))]
-mod resource_usage_tests {
-  use super::max_rss_in_kb;
-
-  #[test]
-  fn max_rss_is_normalized_to_kilobytes() {
-    let expected = if cfg!(target_vendor = "apple") {
-      1.0
-    } else {
-      1536.0
-    };
-    assert_eq!(max_rss_in_kb(1536), expected);
-  }
 }
 
 #[cfg(windows)]
@@ -596,6 +581,26 @@ fn get_resource_usage() -> [f64; 16] {
 #[cfg(not(any(unix, windows)))]
 fn get_resource_usage() -> [f64; 16] {
   [0.0; 16]
+}
+
+#[cfg(all(test, unix, target_vendor = "apple"))]
+mod tests {
+  use super::max_rss_in_kb;
+
+  #[test]
+  fn max_rss_converts_apple_bytes_to_kilobytes() {
+    assert_eq!(max_rss_in_kb(1536), 1.0);
+  }
+}
+
+#[cfg(all(test, unix, not(target_vendor = "apple")))]
+mod tests {
+  use super::max_rss_in_kb;
+
+  #[test]
+  fn max_rss_preserves_non_apple_unix_kilobytes() {
+    assert_eq!(max_rss_in_kb(1536), 1536.0);
+  }
 }
 
 /// Returns the cgroup-constrained memory limit, or 0 if unconstrained.

--- a/ext/node/ops/process.rs
+++ b/ext/node/ops/process.rs
@@ -458,8 +458,9 @@ pub fn op_node_process_setuid(
 /// 13 signalsCount, 14 voluntaryContextSwitches, 15 involuntaryContextSwitches.
 ///
 /// CPU times are in microseconds. This mirrors libuv's `uv_getrusage`, which
-/// Node.js uses: on Unix the values come straight from `getrusage(2)`, and on
-/// platforms that don't provide a field it is reported as `0`.
+/// Node.js uses: on Unix the values come from `getrusage(2)`, with max RSS
+/// normalized to kilobytes on Apple platforms. Fields unavailable on a
+/// platform are reported as `0`.
 #[op2(fast)]
 pub fn op_node_process_resource_usage(#[buffer] out: &mut [f64]) {
   if out.len() < 16 {
@@ -485,11 +486,12 @@ fn get_resource_usage() -> [f64; 16] {
   let micros = |tv: libc::timeval| -> f64 {
     (tv.tv_sec as f64) * 1_000_000.0 + (tv.tv_usec as f64)
   };
+  let max_rss = max_rss_in_kb(r.ru_maxrss);
 
   [
     micros(r.ru_utime),   // userCPUTime
     micros(r.ru_stime),   // systemCPUTime
-    r.ru_maxrss as f64,   // maxRSS
+    max_rss,              // maxRSS
     r.ru_ixrss as f64,    // sharedMemorySize
     r.ru_idrss as f64,    // unsharedDataSize
     r.ru_isrss as f64,    // unsharedStackSize
@@ -504,6 +506,32 @@ fn get_resource_usage() -> [f64; 16] {
     r.ru_nvcsw as f64,    // voluntaryContextSwitches
     r.ru_nivcsw as f64,   // involuntaryContextSwitches
   ]
+}
+
+#[cfg(all(unix, target_vendor = "apple"))]
+fn max_rss_in_kb(ru_maxrss: libc::c_long) -> f64 {
+  // macOS and iOS report ru_maxrss in bytes, unlike other Unix platforms.
+  (ru_maxrss / 1024) as f64
+}
+
+#[cfg(all(unix, not(target_vendor = "apple")))]
+fn max_rss_in_kb(ru_maxrss: libc::c_long) -> f64 {
+  ru_maxrss as f64
+}
+
+#[cfg(all(test, unix))]
+mod resource_usage_tests {
+  use super::max_rss_in_kb;
+
+  #[test]
+  fn max_rss_is_normalized_to_kilobytes() {
+    let expected = if cfg!(target_vendor = "apple") {
+      1.0
+    } else {
+      1536.0
+    };
+    assert_eq!(max_rss_in_kb(1536), expected);
+  }
 }
 
 #[cfg(windows)]

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3058,6 +3058,7 @@
     "parallel/test-readline.js": {},
     "parallel/test-ref-unref-return.js": {},
     "parallel/test-regression-object-prototype.js": {},
+    "parallel/test-resource-usage.js": {},
     "parallel/test-repl-async-iife.js": {},
     "parallel/test-repl-context.js": {},
     "parallel/test-repl-definecommand.js": {},

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1624,6 +1624,22 @@ Deno.test("process.resourceUsage()", () => {
   assert(later.systemCPUTime >= usage.systemCPUTime);
 });
 
+Deno.test("process.resourceUsage() maxRSS is in kilobytes", () => {
+  const rssBytes = Deno.memoryUsage().rss;
+  const { maxRSS } = process.resourceUsage();
+
+  // maxRSS is a peak, so it must be at least roughly the current RSS.
+  assert(
+    maxRSS * 1024 >= rssBytes / 2,
+    `maxRSS=${maxRSS} rss=${rssBytes}`,
+  );
+  // Keep this loose to account for peak-vs-current drift in the test process.
+  assert(
+    maxRSS * 1024 < rssBytes * 64,
+    `maxRSS=${maxRSS} rss=${rssBytes}`,
+  );
+});
+
 Deno.test("importedResourceUsage", async () => {
   const { resourceUsage } = await import("node:process");
   assert(resourceUsage === process.resourceUsage);


### PR DESCRIPTION


Fixes `process.resourceUsage().maxRSS` on macOS and iOS.

Apple platforms report `getrusage(2).ru_maxrss` in bytes, but Node.js/libuv expose this value in kilobytes. Deno was returning the raw Apple value, causing `maxRSS` to be approximately 1024 times larger than Node.js.

Fixes https://github.com/denoland/deno/issues/36783


I used CodeX to help investigate the platform-specific `ru_maxrss` behavior, review  and prepare this change.