### PR TITLE
fix(cli): preserve double dash before entrypoint

### DIFF
--- a/libs/cli_parser/src/parse.rs
+++ b/libs/cli_parser/src/parse.rs
@@ -187,9 +187,16 @@ fn parse_args(
         continue;
       }
 
-      result.trailing.push(arg.clone());
-      i += 1;
-      continue;
+      if cmd_def.trailing_var_arg {
+        result.trailing.push(arg.clone());
+        i += 1;
+        continue;
+      }
+
+      return Err(CliError::new(
+        CliErrorKind::UnexpectedPositional,
+        format!("unexpected argument '{arg}'"),
+      ));
     }
 
     // After `--`, everything is trailing

--- a/libs/cli_parser/src/parse.rs
+++ b/libs/cli_parser/src/parse.rs
@@ -119,6 +119,8 @@ fn parse_args(
   let mut i = 0;
   let mut positional_index = 0;
   let mut trailing_mode = false;
+  let mut positional_only = false;
+  let mut positional_started = false;
   let mut found_subcommand = skip_subcommand.is_none();
   let mut passthrough_from: Option<usize> = None;
   // Per-positional trailing: when set, ALL remaining args (including flags)
@@ -161,6 +163,35 @@ fn parse_args(
       continue;
     }
 
+    // After `--` before the first positional, consume positional values
+    // without interpreting leading hyphens as flags. Once the positional
+    // values are complete, the command's trailing arguments receive the rest.
+    if positional_only {
+      if let Some(pos_def) = positional_defs.get(positional_index) {
+        positional_started = true;
+        apply_value_with_delimiter(result, pos_def, arg)?;
+        i += 1;
+
+        match pos_def.num_args {
+          NumArgs::ZeroOrMore | NumArgs::OneOrMore => {}
+          _ => positional_index += 1,
+        }
+
+        if cmd_def.trailing_var_arg && positional_index >= positional_defs.len()
+        {
+          while i < args.len() {
+            result.trailing.push(args[i].clone());
+            i += 1;
+          }
+        }
+        continue;
+      }
+
+      result.trailing.push(arg.clone());
+      i += 1;
+      continue;
+    }
+
     // After `--`, everything is trailing
     if trailing_mode {
       result.trailing.push(arg.clone());
@@ -169,6 +200,12 @@ fn parse_args(
     }
 
     if arg == "--" {
+      if !positional_started && !positional_defs.is_empty() {
+        positional_only = true;
+        i += 1;
+        continue;
+      }
+
       // Check if the next positional has `trailing: true` - if so,
       // args after `--` go into that positional, not result.trailing.
       if let Some(next_pos) = positional_defs.get(positional_index)
@@ -213,6 +250,7 @@ fn parse_args(
     } else {
       // Positional argument
       if let Some(pos_def) = positional_defs.get(positional_index) {
+        positional_started = true;
         apply_value_with_delimiter(result, pos_def, arg)?;
 
         // If this positional has trailing: true, absorb everything

--- a/libs/cli_parser/src/tests.rs
+++ b/libs/cli_parser/src/tests.rs
@@ -1215,6 +1215,13 @@ fn eval_double_dash_before_code() {
 }
 
 #[test]
+fn upgrade_double_dash_rejects_extra_positional() {
+  let err = parse(&TEST_ROOT, &svec!["deno", "upgrade", "--", "v1", "v2"])
+    .unwrap_err();
+  assert!(matches!(err.kind, CliErrorKind::UnexpectedPositional));
+}
+
+#[test]
 fn unknown_flag_error() {
   let err = parse(
     &TEST_ROOT,

--- a/libs/cli_parser/src/tests.rs
+++ b/libs/cli_parser/src/tests.rs
@@ -883,6 +883,14 @@ fn run_double_dash_trailing() {
 }
 
 #[test]
+fn run_double_dash_before_script() {
+  let r =
+    parse(&TEST_ROOT, &svec!["deno", "run", "--", "-echo.ts", "arg1"]).unwrap();
+  assert_eq!(r.get_one("script_arg"), Some("-echo.ts"));
+  assert_eq!(r.trailing, vec!["arg1"]);
+}
+
+#[test]
 fn global_flags_before_subcommand() {
   let r = parse(
     &TEST_ROOT,
@@ -1193,6 +1201,17 @@ fn eval_print() {
   let r = parse(&TEST_ROOT, &svec!["deno", "eval", "-p", "1+1"]).unwrap();
   assert!(r.get_bool("print"));
   assert_eq!(r.get_one("code_arg"), Some("1+1"));
+}
+
+#[test]
+fn eval_double_dash_before_code() {
+  let r = parse(
+    &TEST_ROOT,
+    &svec!["deno", "eval", "--", "-1; console.log(0)", "arg1"],
+  )
+  .unwrap();
+  assert_eq!(r.get_one("code_arg"), Some("-1; console.log(0)"));
+  assert_eq!(r.trailing, vec!["arg1"]);
 }
 
 #[test]

--- a/libs/cli_parser/src/tests.rs
+++ b/libs/cli_parser/src/tests.rs
@@ -1262,6 +1262,18 @@ fn default_subcommand_with_flags() {
 }
 
 #[test]
+fn default_subcommand_double_dash_before_script() {
+  let r = parse(
+    &TEST_ROOT,
+    &svec!["deno", "--", "-echo.ts", "--", "--debug"],
+  )
+  .unwrap();
+  assert_eq!(r.subcommand.as_deref(), None);
+  assert_eq!(r.get_one("script_arg"), Some("-echo.ts"));
+  assert_eq!(r.trailing, vec!["--", "--debug"]);
+}
+
+#[test]
 fn default_subcommand_with_allow_read_values() {
   let r = parse(&TEST_ROOT, &svec!["deno", "--allow-read=/tmp", "script.ts"])
     .unwrap();

--- a/libs/cli_parser/src/tests.rs
+++ b/libs/cli_parser/src/tests.rs
@@ -1216,8 +1216,8 @@ fn eval_double_dash_before_code() {
 
 #[test]
 fn upgrade_double_dash_rejects_extra_positional() {
-  let err = parse(&TEST_ROOT, &svec!["deno", "upgrade", "--", "v1", "v2"])
-    .unwrap_err();
+  let err =
+    parse(&TEST_ROOT, &svec!["deno", "upgrade", "--", "v1", "v2"]).unwrap_err();
   assert!(matches!(err.kind, CliErrorKind::UnexpectedPositional));
 }
 


### PR DESCRIPTION
## What this fixes

Deno 2.9.6 regressed handling of `--` before the first positional entrypoint. Arguments after the separator could still be interpreted as CLI options instead of being accepted as the script path or eval source.

This change switches the parser into positional-only mode until it consumes that entrypoint, then resumes the command's existing trailing-argument behavior. Commands that do not accept trailing arguments still return `UnexpectedPositional` rather than silently accepting extra values.

## Regression coverage

- `deno run -- <script>`
- `deno eval -- <code>`
- root-script form: `deno -- <script>`
- preservation of a second `--` after the entrypoint
- rejection of extra positional values for commands without trailing arguments

## Validation

- `cargo test -p deno_cli_parser --lib --offline --features deno_core/v8`: 380 passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

Fixes #36792

## AI assistance disclosure

AI tools assisted with implementation and review. I verified the final changes and the validation results reported above.
