### PR TITLE
test: preserve package registry origin in CA store spec

### DIFF
--- a/tests/specs/audit/ca_store/.npmrc
+++ b/tests/specs/audit/ca_store/.npmrc
@@ -1,0 +1,1 @@
+@denotest:registry=http://localhost:4260/

--- a/tests/specs/audit/ca_store/__test__.jsonc
+++ b/tests/specs/audit/ca_store/__test__.jsonc
@@ -7,6 +7,14 @@
     },
     {
       "args": "audit",
+      "output": "[WILDCARD]invalid peer certificate: UnknownIssuer[WILDCARD]",
+      "envs": {
+        "NPM_CONFIG_REGISTRY": "https://localhost:5545/"
+      },
+      "exitCode": 1
+    },
+    {
+      "args": "audit",
       "output": "audit.out",
       "envs": {
         "DENO_CERT": "$PWD/RootCA.pem",


### PR DESCRIPTION
The `audit::ca_store` spec installs `@denotest/say-hello` from the HTTP test registry, then changes the default registry to the HTTPS audit endpoint. Since #36430, loading that lockfile fails origin validation before the test reaches the TLS request. This breaks the spec across platforms on `main` and PRs such as #36696.

Pin the `@denotest` scope to the HTTP package registry in the fixture's `.npmrc`. The package's expected origin then stays consistent, while audit still uses the default HTTPS endpoint and the configured CA from #36728. Add a negative step asserting that the HTTPS request fails with `UnknownIssuer` without `DENO_CERT`, followed by the existing successful audit with the custom CA.

AI assistance: Codex investigated the failure and prepared this fix.

Validation: ran `audit::ca_store` through the spec harness using the macOS ARM64 Deno and test-server artifacts from CI run 34222212239. Confirmed the lockfile-origin failure without `.npmrc`, then confirmed the updated spec passes, including both TLS assertions. The fixture formatting and `git diff --check` also pass.
