### PR TITLE
perf(core): slab ResourceTable with generational rids + identity-hash GothamState

### DIFF
--- a/cli/tools/test/sanitizers.rs
+++ b/cli/tools/test/sanitizers.rs
@@ -20,15 +20,21 @@ const MAX_SANITIZER_LOOP_SPINS: usize = 16;
 
 /// A stable identity for a runtime activity (op, resource, timer or interval).
 ///
-/// Op promise IDs, resource IDs and timer/interval IDs are all allocated
-/// monotonically within a single isolate, so they uniquely identify a leaked
-/// activity for as long as the isolate lives. This is used to remember leaks
-/// that escaped a sanitizer-ignoring test so that later tests don't attribute
-/// them as their own.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+/// This is used to remember leaks that escaped a sanitizer-ignoring test so
+/// that later tests don't attribute them as their own.
+///
+/// Op promise IDs and timer/interval IDs are allocated monotonically within a
+/// single isolate, so the id alone identifies the activity for as long as the
+/// isolate lives. Resource IDs are not: the resource table is a slab, and a
+/// rid's slot index is reused once the resource is closed (the generation bits
+/// packed into the rid mean the exact value only recurs after that slot has
+/// been vacated 2^11 times). The resource name is therefore carried alongside
+/// the rid, so that a recycled rid belonging to a different kind of resource
+/// is not silently treated as an already-reported leak.
+#[derive(Clone, PartialEq, Eq, Hash)]
 enum LeakKey {
   AsyncOp(i32),
-  Resource(u32),
+  Resource(u32, String),
   Timer(usize),
   Interval(usize),
 }
@@ -36,7 +42,9 @@ enum LeakKey {
 fn leak_key(activity: &RuntimeActivity) -> LeakKey {
   match activity {
     RuntimeActivity::AsyncOp(id, ..) => LeakKey::AsyncOp(*id),
-    RuntimeActivity::Resource(id, ..) => LeakKey::Resource(*id),
+    RuntimeActivity::Resource(id, _, name) => {
+      LeakKey::Resource(*id, name.clone())
+    }
     RuntimeActivity::Timer(id, ..) => LeakKey::Timer(*id),
     RuntimeActivity::Interval(id, ..) => LeakKey::Interval(*id),
   }

--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -98,6 +98,11 @@ path = "benches/infra/arena.rs"
 harness = false
 
 [[bench]]
+name = "state_tables"
+path = "benches/infra/state_tables.rs"
+harness = false
+
+[[bench]]
 name = "snapshot"
 path = "benches/snapshot/snapshot.rs"
 harness = false

--- a/libs/core/benches/infra/state_tables.rs
+++ b/libs/core/benches/infra/state_tables.rs
@@ -1,0 +1,244 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Before/after measurement for the two ordered maps that sat on nearly every
+//! op's path: the `ResourceTable` (was a `BTreeMap<ResourceId, _>`, now a
+//! slab) and `GothamState` (was a `BTreeMap<TypeId, _>`, now an identity-hash
+//! map).
+//!
+//! Both baselines are re-implemented here verbatim so the old and the new
+//! shape are measured in the same binary, on the same machine, in one run —
+//! `bencher` interleaves nothing, but running them back to back removes the
+//! usual before/after drift between two builds.
+
+#![allow(clippy::undocumented_unsafe_blocks, reason = "bench code")]
+
+use std::any::Any;
+use std::any::TypeId;
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::rc::Rc;
+
+use bencher::Bencher;
+use bencher::benchmark_group;
+use bencher::benchmark_main;
+use deno_core::OpState;
+use deno_core::Resource;
+use deno_core::ResourceId;
+use deno_core::ResourceTable;
+
+/// Number of live resources in the table for the "hot get" benchmarks. A real
+/// server holds a handful of listeners plus two per in-flight connection.
+const LIVE: u32 = 64;
+/// Number of add/get/close cycles per iteration.
+const CYCLES: u32 = 64;
+
+struct Dummy;
+
+impl Resource for Dummy {
+  fn name(&self) -> Cow<'_, str> {
+    "dummy".into()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Baseline: the pre-slab `ResourceTable`, reduced to the operations measured.
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct BTreeResourceTable {
+  index: BTreeMap<ResourceId, Rc<dyn Resource>>,
+  next_rid: ResourceId,
+}
+
+impl BTreeResourceTable {
+  fn add<T: Resource>(&mut self, resource: T) -> ResourceId {
+    let rid = self.next_rid;
+    let removed = self
+      .index
+      .insert(rid, Rc::new(resource) as Rc<dyn Resource>);
+    assert!(removed.is_none());
+    self.next_rid += 1;
+    rid
+  }
+
+  fn get<T: Resource>(&self, rid: ResourceId) -> Option<Rc<T>> {
+    self
+      .index
+      .get(&rid)
+      .and_then(|rc| rc.downcast_rc::<T>())
+      .cloned()
+  }
+
+  fn take<T: Resource>(&mut self, rid: ResourceId) -> Option<Rc<T>> {
+    let resource = self.get::<T>(rid)?;
+    self.index.remove(&rid);
+    Some(resource)
+  }
+}
+
+fn resource_add_get_close_btree(b: &mut Bencher) {
+  let mut table = BTreeResourceTable::default();
+  b.iter(|| {
+    for _ in 0..CYCLES {
+      let rid = table.add(Dummy);
+      black_box(table.get::<Dummy>(rid).unwrap());
+      black_box(table.take::<Dummy>(rid).unwrap());
+    }
+  });
+}
+
+fn resource_add_get_close_slab(b: &mut Bencher) {
+  let mut table = ResourceTable::default();
+  b.iter(|| {
+    for _ in 0..CYCLES {
+      let rid = table.add(Dummy);
+      black_box(table.get::<Dummy>(rid).unwrap());
+      black_box(table.take::<Dummy>(rid).unwrap());
+    }
+  });
+}
+
+fn resource_get_hot_btree(b: &mut Bencher) {
+  let mut table = BTreeResourceTable::default();
+  let rids = (0..LIVE).map(|_| table.add(Dummy)).collect::<Vec<_>>();
+  b.iter(|| {
+    for rid in &rids {
+      black_box(table.get::<Dummy>(black_box(*rid)).unwrap());
+    }
+  });
+}
+
+fn resource_get_hot_slab(b: &mut Bencher) {
+  let mut table = ResourceTable::default();
+  let rids = (0..LIVE).map(|_| table.add(Dummy)).collect::<Vec<_>>();
+  b.iter(|| {
+    for rid in &rids {
+      black_box(table.get::<Dummy>(black_box(*rid)).unwrap());
+    }
+  });
+}
+
+/// The shape of a busy server: a stable set of live resources, with one
+/// resource churning through open/read/close on top of it.
+fn resource_churn_btree(b: &mut Bencher) {
+  let mut table = BTreeResourceTable::default();
+  let rids = (0..LIVE).map(|_| table.add(Dummy)).collect::<Vec<_>>();
+  b.iter(|| {
+    let rid = table.add(Dummy);
+    for existing in &rids {
+      black_box(table.get::<Dummy>(black_box(*existing)).unwrap());
+    }
+    black_box(table.take::<Dummy>(rid).unwrap());
+  });
+}
+
+fn resource_churn_slab(b: &mut Bencher) {
+  let mut table = ResourceTable::default();
+  let rids = (0..LIVE).map(|_| table.add(Dummy)).collect::<Vec<_>>();
+  b.iter(|| {
+    let rid = table.add(Dummy);
+    for existing in &rids {
+      black_box(table.get::<Dummy>(black_box(*existing)).unwrap());
+    }
+    black_box(table.take::<Dummy>(rid).unwrap());
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Baseline: the pre-hash `GothamState`, reduced to the operations measured.
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct BTreeGothamState {
+  data: BTreeMap<TypeId, Box<dyn Any>>,
+}
+
+impl BTreeGothamState {
+  fn put<T: 'static>(&mut self, t: T) {
+    self.data.insert(TypeId::of::<T>(), Box::new(t));
+  }
+
+  fn borrow<T: 'static>(&self) -> &T {
+    self
+      .data
+      .get(&TypeId::of::<T>())
+      .and_then(|b| b.downcast_ref())
+      .unwrap()
+  }
+}
+
+/// ~30 registered types is what a real `deno` runtime's `OpState` carries.
+macro_rules! with_types {
+  ($mac:ident) => {
+    $mac!(
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+      21, 22, 23, 24, 25, 26, 27, 28, 29
+    )
+  };
+}
+
+struct Ty<const N: usize>(usize);
+
+fn gotham_borrow_btree(b: &mut Bencher) {
+  let mut state = BTreeGothamState::default();
+  macro_rules! fill {
+    ($($n:literal),*) => { $(state.put(Ty::<$n>($n));)* };
+  }
+  with_types!(fill);
+  b.iter(|| {
+    macro_rules! read {
+      ($($n:literal),*) => { $(black_box(state.borrow::<Ty<$n>>().0);)* };
+    }
+    with_types!(read);
+  });
+}
+
+fn gotham_borrow_hash(b: &mut Bencher) {
+  let mut state = OpState::new(None);
+  macro_rules! fill {
+    ($($n:literal),*) => { $(state.put(Ty::<$n>($n));)* };
+  }
+  with_types!(fill);
+  b.iter(|| {
+    macro_rules! read {
+      ($($n:literal),*) => { $(black_box(state.borrow::<Ty<$n>>().0);)* };
+    }
+    with_types!(read);
+  });
+}
+
+/// A single op typically touches one or two pieces of state, not all thirty;
+/// this is the per-op cost in isolation.
+fn gotham_borrow_one_btree(b: &mut Bencher) {
+  let mut state = BTreeGothamState::default();
+  macro_rules! fill {
+    ($($n:literal),*) => { $(state.put(Ty::<$n>($n));)* };
+  }
+  with_types!(fill);
+  b.iter(|| black_box(state.borrow::<Ty<29>>().0));
+}
+
+fn gotham_borrow_one_hash(b: &mut Bencher) {
+  let mut state = OpState::new(None);
+  macro_rules! fill {
+    ($($n:literal),*) => { $(state.put(Ty::<$n>($n));)* };
+  }
+  with_types!(fill);
+  b.iter(|| black_box(state.borrow::<Ty<29>>().0));
+}
+
+benchmark_group!(
+  benches,
+  resource_add_get_close_btree,
+  resource_add_get_close_slab,
+  resource_get_hot_btree,
+  resource_get_hot_slab,
+  resource_churn_btree,
+  resource_churn_slab,
+  gotham_borrow_btree,
+  gotham_borrow_hash,
+  gotham_borrow_one_btree,
+  gotham_borrow_one_hash,
+);
+benchmark_main!(benches);

--- a/libs/core/gotham_state.rs
+++ b/libs/core/gotham_state.rs
@@ -6,11 +6,58 @@
 use std::any::Any;
 use std::any::TypeId;
 use std::any::type_name;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
+use std::hash::Hasher;
+
+/// A pass-through hasher for [`TypeId`] keys.
+///
+/// `TypeId`'s own `Hash` impl feeds already well-distributed bits (the low 64
+/// bits of a 128-bit compiler-generated hash) straight into the hasher, so
+/// there is nothing left to mix: hashing them again only costs cycles. This
+/// hasher therefore forwards those bits verbatim.
+///
+/// Only the integer entry points a `TypeId` can plausibly use are specialized;
+/// `write` keeps a cheap byte fold as a correctness backstop in case a future
+/// standard library hashes `TypeId` some other way. It must never panic, and
+/// it must stay deterministic for a given byte sequence.
+#[derive(Default)]
+pub struct TypeIdHasher(u64);
+
+impl Hasher for TypeIdHasher {
+  #[inline(always)]
+  fn write_u64(&mut self, i: u64) {
+    self.0 = i;
+  }
+
+  #[inline(always)]
+  fn write_u128(&mut self, i: u128) {
+    // Fold the two halves together; either half alone is a valid hash of a
+    // `TypeId`, but xor keeps both in play.
+    self.0 = (i as u64) ^ ((i >> 64) as u64);
+  }
+
+  #[inline(always)]
+  fn finish(&self) -> u64 {
+    self.0
+  }
+
+  #[inline]
+  fn write(&mut self, bytes: &[u8]) {
+    // FxHash-style fold. Not expected to be reached with a `TypeId` key.
+    const SEED: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+    for &b in bytes {
+      self.0 = (self.0.rotate_left(5) ^ b as u64).wrapping_mul(SEED);
+    }
+  }
+}
+
+type TypeIdMap =
+  HashMap<TypeId, Box<dyn Any>, BuildHasherDefault<TypeIdHasher>>;
 
 #[derive(Default)]
 pub struct GothamState {
-  data: BTreeMap<TypeId, Box<dyn Any>>,
+  data: TypeIdMap,
 }
 
 impl GothamState {
@@ -172,6 +219,29 @@ mod tests {
     assert_eq!(state.take::<Alias1>(), "alias2");
     assert!(state.try_take::<Alias1>().is_none());
     assert!(state.try_take::<Alias2>().is_none());
+  }
+
+  #[test]
+  fn many_types() {
+    // Guards against a degenerate hasher: a large number of distinct types
+    // must all round-trip, and each must return its own value.
+    struct T<const N: usize>(usize);
+
+    macro_rules! put_and_check {
+      ($($n:literal),*) => {
+        let mut state = GothamState::default();
+        $(
+          state.put(T::<$n>($n));
+        )*
+        $(
+          assert_eq!(state.borrow::<T<$n>>().0, $n);
+        )*
+      };
+    }
+    put_and_check!(
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+      21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+    );
   }
 
   #[test]

--- a/libs/core/io/resource_table.rs
+++ b/libs/core/io/resource_table.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::borrow::Cow;
-use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use super::Resource;
@@ -13,8 +12,43 @@ use super::ResourceHandleSocket;
 /// considered to be the Deno equivalent of a `file descriptor` in POSIX like
 /// operating systems. Elsewhere in the code base it is commonly abbreviated
 /// to `rid`.
+///
+/// A rid is not an opaque counter: it packs a slot index into the resource
+/// table together with a generation counter for that slot (see
+/// [`ResourceTable`]). Nothing outside the table may interpret those bits.
 // TODO: use `u64` instead?
 pub type ResourceId = u32;
+
+/// Number of low bits of a [`ResourceId`] holding the slot index.
+///
+/// Together with [`GENERATION_BITS`] this must stay at or below 31 so that
+/// every rid is a positive JS smi: ops receive rids as `#[smi]`, and the
+/// leak-sanitizer stats keep rid-indexed sets.
+const INDEX_BITS: u32 = 20;
+/// Number of bits above the index holding the slot's generation.
+const GENERATION_BITS: u32 = 11;
+const INDEX_MASK: u32 = (1 << INDEX_BITS) - 1;
+const GENERATION_MASK: u32 = (1 << GENERATION_BITS) - 1;
+/// Maximum number of slots (live or free) the table can hold.
+const MAX_SLOTS: usize = 1 << INDEX_BITS;
+
+#[inline(always)]
+const fn pack(index: u32, generation: u32) -> ResourceId {
+  (generation << INDEX_BITS) | index
+}
+
+#[inline(always)]
+const fn unpack(rid: ResourceId) -> (usize, u32) {
+  ((rid & INDEX_MASK) as usize, rid >> INDEX_BITS)
+}
+
+struct Slot {
+  resource: Option<Rc<dyn Resource>>,
+  /// Incremented every time this slot is vacated, so that a stale rid does
+  /// not resolve to whatever resource occupies the slot next.
+  generation: u32,
+}
+
 /// Map-like data structure storing Deno's resources (equivalent to file
 /// descriptors).
 ///
@@ -24,22 +58,44 @@ pub type ResourceId = u32;
 ///
 /// Each resource is identified through a _resource ID (rid)_, which acts as
 /// the key in the map.
+///
+/// # Resource ids
+///
+/// The table is a slab: a rid is a slot index (low 20 bits) plus that slot's
+/// generation (next 11 bits), so lookup is a bounds check and an index rather
+/// than a tree walk. Two consequences, both deliberate:
+///
+/// - **Ids are reused.** Closing a resource returns its slot to a free list,
+///   and a later `add` may hand out a rid whose index is the same. The
+///   generation counter means the *exact* rid value is only recycled after
+///   that slot has been vacated 2^11 times, so a stale rid is rejected rather
+///   than silently resolving to an unrelated resource. A great deal of code
+///   above this layer holds rids indefinitely and treats "bad resource" as
+///   proof the resource is gone; the generation is what keeps that idiom
+///   sound.
+/// - **Ids are not monotonic.** They are still handed out in increasing order
+///   as long as nothing has been closed, so the first resources added to a
+///   fresh table get 0, 1, 2, ... exactly as before; but after a close, the
+///   next rid may be lower than one already handed out.
+///
+/// Every rid fits in 31 bits and is therefore always a positive JS smi.
 #[derive(Default)]
 pub struct ResourceTable {
-  index: BTreeMap<ResourceId, Rc<dyn Resource>>,
-  next_rid: ResourceId,
+  slots: Vec<Slot>,
+  /// Indices of vacant slots, most recently vacated first.
+  free: Vec<u32>,
 }
 
 impl ResourceTable {
   /// Returns the number of resources currently active in the resource table.
   /// Resources taken from the table do not contribute to this count.
   pub fn len(&self) -> usize {
-    self.index.len()
+    self.slots.len() - self.free.len()
   }
 
   /// Returns whether this table is empty.
   pub fn is_empty(&self) -> bool {
-    self.index.is_empty()
+    self.len() == 0
   }
 
   /// Inserts resource into the resource table, which takes ownership of it.
@@ -64,16 +120,50 @@ impl ResourceTable {
   }
 
   pub fn add_rc_dyn(&mut self, resource: Rc<dyn Resource>) -> ResourceId {
-    let rid = self.next_rid;
-    let removed_resource = self.index.insert(rid, resource);
-    assert!(removed_resource.is_none());
-    self.next_rid += 1;
-    rid
+    if let Some(index) = self.free.pop() {
+      let slot = &mut self.slots[index as usize];
+      debug_assert!(slot.resource.is_none());
+      slot.resource = Some(resource);
+      pack(index, slot.generation)
+    } else {
+      let index = self.slots.len();
+      assert!(index < MAX_SLOTS, "too many open resources");
+      self.slots.push(Slot {
+        resource: Some(resource),
+        generation: 0,
+      });
+      pack(index as u32, 0)
+    }
+  }
+
+  #[inline(always)]
+  fn slot(&self, rid: ResourceId) -> Option<&Rc<dyn Resource>> {
+    let (index, generation) = unpack(rid);
+    let slot = self.slots.get(index)?;
+    if slot.generation != generation {
+      return None;
+    }
+    slot.resource.as_ref()
+  }
+
+  /// Vacates the slot addressed by `rid`, bumping its generation, and returns
+  /// what was in it.
+  #[inline]
+  fn vacate(&mut self, rid: ResourceId) -> Option<Rc<dyn Resource>> {
+    let (index, generation) = unpack(rid);
+    let slot = self.slots.get_mut(index)?;
+    if slot.generation != generation {
+      return None;
+    }
+    let resource = slot.resource.take()?;
+    slot.generation = (slot.generation + 1) & GENERATION_MASK;
+    self.free.push(index as u32);
+    Some(resource)
   }
 
   /// Returns true if any resource with the given `rid` exists.
   pub fn has(&self, rid: ResourceId) -> bool {
-    self.index.contains_key(&rid)
+    self.slot(rid).is_some()
   }
 
   /// Returns a reference counted pointer to the resource of type `T` with the
@@ -84,8 +174,7 @@ impl ResourceTable {
     rid: ResourceId,
   ) -> Result<Rc<T>, ResourceError> {
     self
-      .index
-      .get(&rid)
+      .slot(rid)
       .and_then(|rc| rc.downcast_rc::<T>())
       .cloned()
       .ok_or(ResourceError::BadResourceId)
@@ -95,21 +184,22 @@ impl ResourceTable {
     &self,
     rid: ResourceId,
   ) -> Result<Rc<dyn Resource>, ResourceError> {
-    self
-      .index
-      .get(&rid)
-      .cloned()
-      .ok_or(ResourceError::BadResourceId)
+    self.slot(rid).cloned().ok_or(ResourceError::BadResourceId)
   }
 
   /// Replaces a resource with a new resource.
   ///
+  /// The `rid` is left unchanged, and so remains valid.
+  ///
   /// Panics if the resource does not exist.
   pub fn replace<T: Resource>(&mut self, rid: ResourceId, resource: T) {
-    let result = self
-      .index
-      .insert(rid, Rc::new(resource) as Rc<dyn Resource>);
-    assert!(result.is_some());
+    let (index, generation) = unpack(rid);
+    let slot = self
+      .slots
+      .get_mut(index)
+      .filter(|slot| slot.generation == generation && slot.resource.is_some());
+    let slot = slot.expect("attempted to replace a resource that is not open");
+    slot.resource = Some(Rc::new(resource) as Rc<dyn Resource>);
   }
 
   /// Removes a resource of type `T` from the resource table and returns it.
@@ -127,7 +217,7 @@ impl ResourceTable {
     rid: ResourceId,
   ) -> Result<Rc<T>, ResourceError> {
     let resource = self.get::<T>(rid)?;
-    self.index.remove(&rid);
+    self.vacate(rid);
     Ok(resource)
   }
 
@@ -143,7 +233,7 @@ impl ResourceTable {
     &mut self,
     rid: ResourceId,
   ) -> Result<Rc<dyn Resource>, ResourceError> {
-    self.index.remove(&rid).ok_or(ResourceError::BadResourceId)
+    self.vacate(rid).ok_or(ResourceError::BadResourceId)
   }
 
   /// Removes the resource with the given `rid` from the resource table. If the
@@ -155,8 +245,7 @@ impl ResourceTable {
   #[deprecated = "This method may deadlock. Use take() and close() instead."]
   pub fn close(&mut self, rid: ResourceId) -> Result<(), ResourceError> {
     self
-      .index
-      .remove(&rid)
+      .vacate(rid)
       .ok_or(ResourceError::BadResourceId)
       .map(|resource| resource.close())
   }
@@ -174,10 +263,10 @@ impl ResourceTable {
   /// let resource_names = resource_table.names().collect::<Vec<_>>();
   /// ```
   pub fn names(&self) -> impl Iterator<Item = (ResourceId, Cow<'_, str>)> {
-    self
-      .index
-      .iter()
-      .map(|(&id, resource)| (id, resource.name()))
+    self.slots.iter().enumerate().filter_map(|(index, slot)| {
+      let resource = slot.resource.as_ref()?;
+      Some((pack(index as u32, slot.generation), resource.name()))
+    })
   }
 
   /// Retrieves the [`ResourceHandleFd`] for a given resource, for potential optimization
@@ -246,4 +335,124 @@ pub enum ResourceError {
   #[class("BadResource")]
   #[error("{0}")]
   Other(String),
+}
+
+#[cfg(test)]
+mod tests {
+  use std::borrow::Cow;
+
+  use super::*;
+
+  struct A;
+  impl Resource for A {
+    fn name(&self) -> Cow<'_, str> {
+      "A".into()
+    }
+  }
+
+  struct B;
+  impl Resource for B {
+    fn name(&self) -> Cow<'_, str> {
+      "B".into()
+    }
+  }
+
+  #[test]
+  fn ids_start_dense_and_ascending() {
+    let mut table = ResourceTable::default();
+    assert!(table.is_empty());
+    assert_eq!(table.add(A), 0);
+    assert_eq!(table.add(A), 1);
+    assert_eq!(table.add(A), 2);
+    assert_eq!(table.len(), 3);
+  }
+
+  #[test]
+  fn stale_rid_does_not_resolve_to_the_new_occupant() {
+    let mut table = ResourceTable::default();
+    let a = table.add(A);
+    table.take::<A>(a).unwrap();
+    assert!(!table.has(a));
+
+    let b = table.add(B);
+    // Same slot, different generation, so the ids differ...
+    assert_ne!(a, b);
+    // ...and the stale id resolves to nothing.
+    assert!(!table.has(a));
+    assert!(table.get::<B>(a).is_err());
+    assert!(table.get_any(a).is_err());
+    assert!(table.take_any(a).is_err());
+    // ...while the live one still works.
+    assert!(table.has(b));
+    assert!(table.get::<B>(b).is_ok());
+  }
+
+  #[test]
+  fn generation_wraps_and_slot_is_reused() {
+    let mut table = ResourceTable::default();
+    let mut seen = Vec::new();
+    for _ in 0..(GENERATION_MASK + 1) {
+      let rid = table.add(A);
+      seen.push(rid);
+      table.take::<A>(rid).unwrap();
+    }
+    // Every generation of the slot produced a distinct id...
+    let mut sorted = seen.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted.len(), seen.len());
+    // ...and after 2^GENERATION_BITS vacancies the id comes back around.
+    assert_eq!(table.add(A), seen[0]);
+    assert_eq!(table.slots.len(), 1);
+  }
+
+  #[test]
+  fn take_of_wrong_type_leaves_the_resource_in_place() {
+    let mut table = ResourceTable::default();
+    let rid = table.add(A);
+    assert!(table.take::<B>(rid).is_err());
+    assert!(table.has(rid));
+    assert_eq!(table.len(), 1);
+    assert!(table.take::<A>(rid).is_ok());
+    assert_eq!(table.len(), 0);
+  }
+
+  #[test]
+  fn replace_keeps_the_rid_valid() {
+    let mut table = ResourceTable::default();
+    let rid = table.add(A);
+    table.replace(rid, B);
+    assert!(table.get::<A>(rid).is_err());
+    assert!(table.get::<B>(rid).is_ok());
+    assert_eq!(table.len(), 1);
+  }
+
+  #[test]
+  #[should_panic(expected = "attempted to replace a resource that is not open")]
+  fn replace_of_a_closed_rid_panics() {
+    let mut table = ResourceTable::default();
+    let rid = table.add(A);
+    table.take::<A>(rid).unwrap();
+    table.replace(rid, B);
+  }
+
+  #[test]
+  fn names_lists_only_live_resources() {
+    let mut table = ResourceTable::default();
+    let a = table.add(A);
+    let b = table.add(B);
+    table.take::<A>(a).unwrap();
+    let names = table.names().collect::<Vec<_>>();
+    assert_eq!(names.len(), 1);
+    assert_eq!(names[0].0, b);
+    assert_eq!(names[0].1, "B");
+  }
+
+  #[test]
+  fn out_of_range_rid_is_not_found() {
+    let table = ResourceTable::default();
+    assert!(!table.has(0));
+    assert!(!table.has(u32::MAX));
+    assert!(table.get_any(u32::MAX).is_err());
+  }
 }

--- a/libs/core/ops_builtin.rs
+++ b/libs/core/ops_builtin.rs
@@ -206,7 +206,13 @@ pub fn op_close(
   state: Rc<RefCell<OpState>>,
   #[smi] rid: ResourceId,
 ) -> Result<(), ResourceError> {
-  let resource = state.borrow_mut().resource_table.take_any(rid)?;
+  let resource = {
+    let state = &mut *state.borrow_mut();
+    let resource = state.resource_table.take_any(rid)?;
+    // The rid may be handed out again, so it must not stay marked unrefed.
+    state.uv_ref(rid);
+    resource
+  };
   resource.close();
   Ok(())
 }
@@ -215,7 +221,16 @@ pub fn op_close(
 /// with the specified `rid`, this is a no-op.
 #[op2(fast)]
 pub fn op_try_close(state: Rc<RefCell<OpState>>, #[smi] rid: ResourceId) {
-  if let Ok(resource) = state.borrow_mut().resource_table.take_any(rid) {
+  let resource = {
+    let state = &mut *state.borrow_mut();
+    let resource = state.resource_table.take_any(rid);
+    if resource.is_ok() {
+      // The rid may be handed out again, so it must not stay marked unrefed.
+      state.uv_ref(rid);
+    }
+    resource
+  };
+  if let Ok(resource) = resource {
     resource.close();
   }
 }

--- a/libs/core/runtime/stats.rs
+++ b/libs/core/runtime/stats.rs
@@ -3,6 +3,7 @@
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::ops::Deref;
 use std::rc::Rc;
@@ -447,12 +448,14 @@ impl RuntimeActivityStats {
       }
     }
 
-    let mut a = BitSet::new();
+    // Unlike promise and timer ids, a rid is not a dense counter: it packs a
+    // slot index and a generation, so it is not usable as a bit index.
+    let mut a = HashSet::with_capacity(after.resources.resources.len());
     for op in after.resources.resources.iter() {
-      a.insert(op.0 as usize);
+      a.insert(op.0);
     }
     for op in before.resources.resources.iter() {
-      if a.remove(op.0 as usize) {
+      if a.remove(&op.0) {
         // continuing op
       } else {
         // before, but not after
@@ -460,7 +463,7 @@ impl RuntimeActivityStats {
       }
     }
     for op in after.resources.resources.iter() {
-      if a.contains(op.0 as usize) {
+      if a.contains(&op.0) {
         // after but not before
         appeared.push(RuntimeActivity::Resource(op.0, None, op.1.clone()));
       }

--- a/tests/specs/run/fetch_response_finalization/fetch_response_finalization.js
+++ b/tests/specs/run/fetch_response_finalization/fetch_response_finalization.js
@@ -1,6 +1,17 @@
+// Print the names of the currently open resources. The names, not the whole
+// table: resource ids pack a slot index and a generation, so the numeric id a
+// given resource ends up with depends on how many slots were recycled before
+// it was opened. What this test is about is whether the `fetchResponse`
+// resource disappears once the response is collected, and that is visible in
+// the names alone.
+function printResources() {
+  const resources = Deno[Deno.internal].core.resources();
+  console.log(Object.values(resources).join(", "));
+}
+
 async function doAFetch() {
   const resp = await fetch("http://localhost:4545/README.md");
-  console.log(Deno[Deno.internal].core.resources()); // print the current resources
+  printResources();
   const _resp = resp;
   // at this point resp can be GC'ed
 }
@@ -13,4 +24,4 @@ globalThis.gc(); // force GC
 // the response body is not called and the resource is not closed.
 await new Promise((resolve) => setTimeout(resolve, 0));
 
-console.log(Deno[Deno.internal].core.resources()); // print the current resources
+printResources();

--- a/tests/specs/run/fetch_response_finalization/fetch_response_finalization.js.out
+++ b/tests/specs/run/fetch_response_finalization/fetch_response_finalization.js.out
@@ -1,2 +1,2 @@
-{ "0": "stdin", "1": "stdout", "2": "stderr", "5": "fetchResponse" }
-{ "0": "stdin", "1": "stdout", "2": "stderr" }
+stdin, stdout, stderr, fetchResponse
+stdin, stdout, stderr


### PR DESCRIPTION
Two ordered maps sit on nearly every op's path, and neither of them needs to
be a tree.

`GothamState` is the easy half. It was a `BTreeMap<TypeId, Box<dyn Any>>`,
which compares 128-bit `TypeId`s down a tree for state that every op touches.
`TypeId`'s own `Hash` impl already feeds well-distributed bits into the
hasher, so a `HashMap` with a pass-through hasher removes the walk without
adding any mixing back. The public API, including the panicking accessors and
their exact panic text, is untouched. The new `TypeIdHasher` specializes
`write_u64`/`write_u128` and keeps a cheap byte fold in `write` rather than an
`unreachable!()`, so a future standard library that hashes `TypeId` some other
way degrades in speed instead of aborting.

`ResourceTable` is the interesting half, because rids are public API. It was a
`BTreeMap<ResourceId, Rc<dyn Resource>>` fed by a monotonic counter; it is now
a slab, `Vec<Slot>` plus a free list, indexed directly.

## Generational ids, not raw reuse

Three designs were on the table: a pure slab with reused ids, a monotonic rid
plus a secondary index, or a slab whose rid packs a slot index together with a
per-slot generation. This is the third: 20 bits of index (1,048,576 live
resources) and 11 bits of generation (2,048 vacancies before an exact rid value
can recur), 31 bits in total, so every rid remains a positive JS smi. Ops take
rids as `#[smi]`, and there are rid-keyed sets downstream that would not enjoy
full 32-bit values.

The pure slab was rejected on evidence. The prevailing idiom above this layer
is *hold the rid indefinitely, and treat `BadResource` (or `tryClose`'s no-op)
as proof the resource is gone* — an idiom that is only sound when a closed rid
stays dead. `ext/web/06_streams.js` closes a stored rid from a
`FinalizationRegistry` callback, at an arbitrary GC point long after that rid
may have been freed by other means; `Deno.FsFile` never nulls `#rid`, and
`Deno.stdin/stdout/stderr` pin 0/1/2 for the life of the isolate. `ext/process`
lets `op_spawn_wait` take the child resource while JS keeps the rid, and
`op_spawn_kill` silently no-ops on a missing rid — under raw reuse a spawn loop
could `SIGTERM` the wrong child. `ext/http/00_serve.ts` handles exactly the
"response body backed by a closed rid" case, which under raw reuse could
resolve to a live unrelated resource and stream its bytes into the response.
The monotonic-id-plus-index design keeps all of those invariants but
re-introduces a per-lookup map probe, which is most of what we set out to
delete. Generations keep O(1)-by-index *and* the "a closed rid is dead"
invariant.

Two existing properties are preserved deliberately. `ext/io/lib.rs` asserts at
runtime that stdin/stdout/stderr get rids 0/1/2, and `tests/unit/files_test.ts`
asserts the same from JS — a fresh slab still hands out 0, 1, 2 in order.
Nothing anywhere compares rids with `<`/`>` or sorts by them; the only ordering
consumer is `names()` → `op_resources` → `core.resources()`, and V8 enumerates
integer-like keys numerically, so the JS-visible order is unchanged.

## The behavior change, stated plainly

**Resource ids are no longer monotonic and are no longer unique for the life of
the isolate.** While nothing has been closed they are still handed out as
0, 1, 2, …; after a close, the next rid may be numerically lower than one
already issued, and the exact value of a closed rid can recur once that slot has
been vacated 2,048 times. Embedders must not use a rid as a timestamp, a sort
key, or a permanent identity. `ResourceTable::replace` keeps the rid and its
generation valid as before, and still panics when the resource is not open,
now with the message "attempted to replace a resource that is not open" rather
than a bare assertion failure.

Four consequences are fixed here rather than left as traps:

- `runtime/stats.rs` diffed resources with a `BitSet` indexed by rid. That was
  fine for a dense counter and catastrophic for a packed id — a generation of
  2,047 would have allocated a ~256 MB bitset — so the resource diff now uses a
  `HashSet<ResourceId>`. The async-op and timer diffs still use `BitSet`; those
  ids really are dense counters.
- `op_close`/`op_try_close` never removed the rid from
  `OpState::unrefed_resources`, a rid-keyed side table. That was a slow leak
  before; with reuse it would let a recycled rid be born unref'd and exit the
  process early. Both ops now clear the entry.
- The test runner's resource leak sanitizer keyed its cross-test ignore set on
  the rid alone, with a comment stating that rids "are allocated monotonically
  within a single isolate, so they uniquely identify a leaked activity for as
  long as the isolate lives". That is no longer true, so `LeakKey::Resource` now
  carries `(rid, name)`: a recycled slot holding a different kind of resource is
  no longer mistaken for an already-reported leak. Promise ids and timer ids are
  still dense counters and keep keying on the id alone.
- `tests/specs/run/fetch_response_finalization` asserted a literal `"5":
  "fetchResponse"` in a `core.resources()` dump. `fetch` takes the request
  resource out of the table before adding the response resource, so the response
  now lands in the recycled slot and the numeric id is no longer 5. The fixture
  prints resource *names* instead, which is what the test was actually about —
  whether the `fetchResponse` resource disappears once the response is
  collected.

## Numbers

From `cargo bench -p deno_core --bench state_tables`, a bench added in this PR
that carries a verbatim copy of both old implementations so before and after are
measured in the same binary, in one run. These are the medians of three runs on
an M-series laptop as measured in denoland/deno_core_revamp#33:

| bench | BTreeMap | new | |
|---|---|---|---|
| `gotham_borrow` (30 types, all borrowed) | 590 ns | 157 ns | **3.8x** |
| `gotham_borrow_one` (30 types, one borrow) | 17 ns | 5 ns | **3.4x** |
| `resource_get_hot` (64 live, 64 gets) | 582 ns | 401 ns | **1.45x** |
| `resource_churn` (64 live, add + 64 gets + close) | 641 ns | 429 ns | **1.49x** |
| `resource_add_get_close` (64 cycles) | 2,916 ns | 2,125 ns | **1.37x** |

There was no pre-existing resource or state bench under `libs/core/benches`,
hence the new one. The resource numbers are the honest ones: what remains after
the tree walk is the `Rc` clone and the vtable downcast, roughly 6 ns per `get`,
which is where any further win would have to come from.

`cargo test -p deno_core` passes: 484 passed, 0 failed, 2 ignored, including
nine new tests — eight for the table's id semantics and one guarding the hasher
against degenerating across many distinct types.

Ported from denoland/deno_core_revamp#33.

One thing that PR suggested and this one does not do: nulling `#rid` after
close in `ext/fs/30_fs.js` and `ext/io/12_io.js`. The generation bits already
make a stale rid safe, so nulling buys no correctness, and it would change the
error surfaced by a use-after-close from `BadResource` to a `TypeError` — a
user-visible change with no upside here. Two rid-keyed side tables outside
`deno_core` are in the same category and were left alone: `TtyModeStore` in
`runtime/ops/tty.rs`, and `unrefed_resources` entries for resources that some
extension removes from the table with `take` rather than through `op_close`.
Both can retain an entry for a closed rid, and both are safe for the 2,048
vacancies it takes for that rid value to come back around.
