### PR TITLE
perf(core): lazy UvLoop and fast paths for idle subsystems

### DIFF
--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -960,12 +960,11 @@ fn op_napi_open<'scope>(
   // through to other uv_* polyfill functions, which re-resolve it from
   // this thread-local in any case.
   {
-    let op_state = op_state.borrow();
-    if let Some(uv_loop) =
-      op_state.try_borrow::<Box<deno_core::uv_compat::UvLoop>>()
-    {
-      let loop_ptr =
-        &**uv_loop as *const deno_core::uv_compat::UvLoop as *mut _;
+    let mut op_state = op_state.borrow_mut();
+    // The loop is created lazily, and an addon that uses the uv timer
+    // polyfills is exactly the case that needs one, so ask for it rather
+    // than looking for one that may not exist yet.
+    if let Some(loop_ptr) = deno_core::ensure_uv_loop(&mut op_state) {
       crate::uv::register_default_uv_loop(loop_ptr);
     }
   }

--- a/ext/node/ops/handle_wrap.rs
+++ b/ext/node/ops/handle_wrap.rs
@@ -237,6 +237,12 @@ impl From<ProviderType> for i32 {
 pub use deno_core::uv_compat::AsyncId;
 
 fn next_async_id(state: &mut OpState) -> i64 {
+  // Async ids are handed out to things that never touch a uv handle, and
+  // the counter now arrives with the lazily created uv loop, so install it
+  // on first use instead of assuming a loop already exists.
+  if state.try_borrow::<AsyncId>().is_none() {
+    state.put(AsyncId::default());
+  }
   state.borrow_mut::<AsyncId>().next()
 }
 

--- a/ext/node/ops/pipe_wrap.rs
+++ b/ext/node/ops/pipe_wrap.rs
@@ -14,11 +14,11 @@ use std::rc::Rc;
 use deno_core::CppgcInherits;
 use deno_core::GarbageCollected;
 use deno_core::OpState;
+use deno_core::ensure_uv_loop;
 use deno_core::error::ResourceError;
 use deno_core::op2;
 use deno_core::uv_compat;
 use deno_core::uv_compat::UvConnect;
-use deno_core::uv_compat::UvLoop;
 use deno_core::uv_compat::UvStream;
 use deno_core::v8;
 use deno_net::check_unix_socket_path;
@@ -194,8 +194,9 @@ impl Drop for PipeWrap {
 
 impl PipeWrap {
   fn new(pipe_type: PipeType, op_state: &mut OpState) -> Self {
-    let loop_ =
-      &**op_state.borrow::<Box<UvLoop>>() as *const UvLoop as *mut UvLoop;
+    // The uv loop is created lazily, so this is one of the sites that
+    // brings it into existence.
+    let loop_ = ensure_uv_loop(op_state).expect("uv loop unavailable");
     let ipc = pipe_type == PipeType::Ipc;
     let pipe = OwnedPtr::from_box(Box::new(uv_compat::new_pipe(ipc)));
     // SAFETY: loop_ and pipe are valid pointers for uv_pipe_init.

--- a/ext/node/ops/tcp_wrap.rs
+++ b/ext/node/ops/tcp_wrap.rs
@@ -14,11 +14,11 @@ use deno_core::CppgcInherits;
 use deno_core::GarbageCollected;
 use deno_core::OpState;
 use deno_core::ResourceId;
+use deno_core::ensure_uv_loop;
 use deno_core::error::ResourceError;
 use deno_core::op2;
 use deno_core::uv_compat;
 use deno_core::uv_compat::UvConnect;
-use deno_core::uv_compat::UvLoop;
 use deno_core::uv_compat::UvStream;
 use deno_core::uv_compat::UvTcp;
 use deno_core::v8;
@@ -198,8 +198,9 @@ impl Drop for TCPWrap {
 
 impl TCPWrap {
   fn new(socket_type: SocketType, op_state: &mut OpState) -> Self {
-    let loop_ =
-      &**op_state.borrow::<Box<UvLoop>>() as *const UvLoop as *mut UvLoop;
+    // The uv loop is created lazily, so this is one of the sites that
+    // brings it into existence.
+    let loop_ = ensure_uv_loop(op_state).expect("uv loop unavailable");
 
     let tcp = OwnedPtr::from_box(Box::<UvTcp>::new_uninit());
 

--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -3335,9 +3335,10 @@ impl TLSWrap {
   ) -> i32 {
     let inner = unsafe { &mut *self.inner.as_mut_ptr() };
 
-    let loop_ = &**op_state.borrow::<Box<uv_compat::uv_loop_t>>()
-      as *const uv_compat::uv_loop_t
-      as *mut uv_compat::uv_loop_t;
+    // The uv loop is created lazily; make sure it exists before we stash a
+    // pointer to it.
+    let loop_ =
+      deno_core::ensure_uv_loop(op_state).expect("uv loop unavailable");
 
     inner.underlying = UnderlyingStream::Js { loop_ptr: loop_ };
     // SAFETY: scope is valid for the current isolate

--- a/ext/node/ops/tty_wrap.rs
+++ b/ext/node/ops/tty_wrap.rs
@@ -17,7 +17,6 @@ use deno_core::uv_compat::UV_ENOTSUP;
 use deno_core::uv_compat::UV_EPIPE;
 use deno_core::uv_compat::uv_guess_handle;
 use deno_core::uv_compat::uv_handle_type;
-use deno_core::uv_compat::uv_loop_t;
 use deno_core::uv_compat::uv_tty_get_winsize;
 use deno_core::uv_compat::uv_tty_init;
 use deno_core::uv_compat::uv_tty_mode_t;
@@ -101,11 +100,10 @@ impl TTY {
     fd: i32,
     op_state: &mut deno_core::OpState,
   ) -> (Self, i32) {
-    // todo: this should really not be a Box<uv_loop_t> because of uniqueness guarantees.
-    // instead it should be a custom wrapper around a raw pointer
-    // right now this is most likely ub
-    let loop_ = &**op_state.borrow::<Box<uv_loop_t>>() as *const uv_loop_t
-      as *mut uv_loop_t;
+    // The uv loop is created lazily, so this is one of the sites that
+    // brings it into existence.
+    let loop_ =
+      deno_core::ensure_uv_loop(op_state).expect("uv loop unavailable");
 
     let tty = OwnedPtr::from_box(Box::<uv_tty_t>::new_uninit());
 

--- a/libs/core/examples/loop_probe.rs
+++ b/libs/core/examples/loop_probe.rs
@@ -1,4 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
+#![allow(clippy::print_stdout, reason = "example code")]
 //! Measures per-iteration event loop cost.
 //!
 //! Two modes, both printing `key=value` lines on stdout:

--- a/libs/core/examples/loop_probe.rs
+++ b/libs/core/examples/loop_probe.rs
@@ -1,0 +1,157 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+//! Measures per-iteration event loop cost.
+//!
+//! Two modes, both printing `key=value` lines on stdout:
+//!
+//! - `ticks [N]`   -- poll the event loop `N` (default 200000) times with
+//!   nothing to do but a far-future timer. Each poll walks every event loop
+//!   phase, so this is the cost of an otherwise idle tick.
+//! - `new [N]`    -- create and drop `N` (default 50) empty runtimes.
+//! - `ops [B] [S]` -- await `B` (default 2000) batches of `S` (default 100)
+//!   `op_void_async_deferred` calls via `Promise.all`, i.e. the async op
+//!   completion path.
+
+use std::time::Instant;
+
+use deno_core::JsRuntime;
+use deno_core::PollEventLoopOptions;
+use deno_core::RuntimeOptions;
+
+/// This process's consumed CPU time (user + system) in nanoseconds. Wall
+/// time is useless for the timer-driven mode, which spends most of its life
+/// asleep waiting for the next 1 ms tick.
+#[cfg(unix)]
+fn cpu_time_ns() -> u64 {
+  // SAFETY: `getrusage` fills in the (zeroed) struct we hand it.
+  unsafe {
+    let mut usage: libc::rusage = std::mem::zeroed();
+    libc::getrusage(libc::RUSAGE_SELF, &mut usage);
+    let to_ns = |t: libc::timeval| {
+      t.tv_sec as u64 * 1_000_000_000 + t.tv_usec as u64 * 1_000
+    };
+    to_ns(usage.ru_utime) + to_ns(usage.ru_stime)
+  }
+}
+
+/// No `getrusage` off unix; the `*_cpu_*` numbers degrade to wall clock,
+/// which is fine for the modes that never sleep.
+#[cfg(not(unix))]
+fn cpu_time_ns() -> u64 {
+  use std::sync::OnceLock;
+  static START: OnceLock<Instant> = OnceLock::new();
+  START.get_or_init(Instant::now).elapsed().as_nanos() as u64
+}
+
+fn arg(n: usize, default: u64) -> u64 {
+  std::env::args()
+    .nth(n)
+    .map(|a| a.parse().expect("numeric argument expected"))
+    .unwrap_or(default)
+}
+
+async fn run(source: String, label: &str, iterations: u64) {
+  let mut runtime = JsRuntime::new(RuntimeOptions::default());
+  runtime.execute_script("<probe>", source).unwrap();
+  let start = Instant::now();
+  let cpu_start = cpu_time_ns();
+  runtime
+    .run_event_loop(PollEventLoopOptions::default())
+    .await
+    .unwrap();
+  let cpu = cpu_time_ns() - cpu_start;
+  let elapsed = start.elapsed();
+  println!("{label}_iterations={iterations}");
+  println!("{label}_total_ms={:.3}", elapsed.as_secs_f64() * 1000.0);
+  println!("{label}_cpu_ms={:.3}", cpu as f64 / 1e6);
+  println!(
+    "{label}_cpu_per_iteration_ns={:.1}",
+    cpu as f64 / iterations as f64
+  );
+  println!(
+    "{label}_per_iteration_ns={:.1}",
+    elapsed.as_nanos() as f64 / iterations as f64
+  );
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+  let mode = std::env::args()
+    .nth(1)
+    .unwrap_or_else(|| "ticks".to_string());
+  match mode.as_str() {
+    "ticks" => {
+      let n = arg(2, 200_000);
+      // Poll the event loop `n` times by hand. A far-future refed timer
+      // keeps it pending so every poll walks all six phases; polling
+      // directly (rather than letting a repeating timer drive the loop)
+      // keeps ~2 ms of sleeping per iteration out of the measurement.
+      let mut runtime = JsRuntime::new(RuntimeOptions::default());
+      runtime
+        .execute_script(
+          "<probe>",
+          "Deno.core.createSystemTimer(() => {}, 600000, true);",
+        )
+        .unwrap();
+      // `ticks N uv` forces the uv loop to exist, which measures the
+      // "uv actually in use" tick instead of the inert one.
+      if std::env::args().nth(3).as_deref() == Some("uv") {
+        runtime.uv_loop_ptr().expect("uv loop");
+      }
+      let waker = std::task::Waker::noop();
+      let mut cx = std::task::Context::from_waker(waker);
+      let start = Instant::now();
+      let cpu_start = cpu_time_ns();
+      for _ in 0..n {
+        let poll =
+          runtime.poll_event_loop(&mut cx, PollEventLoopOptions::default());
+        assert!(poll.is_pending(), "event loop should stay pending");
+      }
+      let cpu = cpu_time_ns() - cpu_start;
+      let elapsed = start.elapsed();
+      println!("ticks_iterations={n}");
+      println!("ticks_total_ms={:.3}", elapsed.as_secs_f64() * 1000.0);
+      println!("ticks_cpu_ms={:.3}", cpu as f64 / 1e6);
+      println!("ticks_cpu_per_iteration_ns={:.1}", cpu as f64 / n as f64);
+      println!(
+        "ticks_per_iteration_ns={:.1}",
+        elapsed.as_nanos() as f64 / n as f64
+      );
+    }
+    "new" => {
+      // Cost of creating (and dropping) an empty runtime.
+      let n = arg(2, 50);
+      let start = Instant::now();
+      let cpu_start = cpu_time_ns();
+      for _ in 0..n {
+        drop(JsRuntime::new(RuntimeOptions::default()));
+      }
+      let cpu = cpu_time_ns() - cpu_start;
+      let elapsed = start.elapsed();
+      println!("new_iterations={n}");
+      println!("new_total_ms={:.3}", elapsed.as_secs_f64() * 1000.0);
+      println!("new_cpu_per_runtime_us={:.1}", cpu as f64 / n as f64 / 1e3);
+      println!(
+        "new_per_runtime_us={:.1}",
+        elapsed.as_nanos() as f64 / n as f64 / 1e3
+      );
+    }
+    "ops" => {
+      let batches = arg(2, 2_000);
+      let size = arg(3, 100);
+      let src = format!(
+        r#"
+        const op = Deno.core.ops.op_void_async_deferred;
+        (async () => {{
+          for (let b = 0; b < {batches}; b++) {{
+            const promises = [];
+            for (let i = 0; i < {size}; i++) promises.push(op());
+            await Promise.all(promises);
+          }}
+        }})();
+        "#
+      );
+      run(src, "ops", batches * size).await;
+    }
+    other => panic!("unknown mode: {other}"),
+  }
+}

--- a/libs/core/lib.rs
+++ b/libs/core/lib.rs
@@ -192,6 +192,7 @@ pub use crate::runtime::RuntimeOptions;
 pub use crate::runtime::SharedArrayBufferStore;
 pub use crate::runtime::V8_WRAPPER_OBJECT_INDEX;
 pub use crate::runtime::V8_WRAPPER_TYPE_INDEX;
+pub use crate::runtime::ensure_uv_loop;
 pub use crate::runtime::host_defined_options::HOST_DEFINED_OPTIONS_KEY_INDEX;
 pub use crate::runtime::host_defined_options::HOST_DEFINED_OPTIONS_KIND_INDEX;
 pub use crate::runtime::host_defined_options::create_host_defined_options_with_kind;

--- a/libs/core/ops_builtin_v8.rs
+++ b/libs/core/ops_builtin_v8.rs
@@ -1612,6 +1612,13 @@ pub fn op_get_extras_binding_object<'s, 'i>(
 #[op2(fast)]
 pub fn op_immediate_check(scope: &mut v8::PinScope, make_ref: bool) {
   let context_state = JsRealm::state_from_scope(scope);
+  if make_ref && context_state.immediate_check_handle.borrow().is_none() {
+    // Refed immediates keep the event loop alive via the uv idle handle,
+    // so this is one of the triggers that forces the lazy uv loop into
+    // existence. Unrefing without a loop is a no-op.
+    let op_state = JsRuntime::op_state_from(scope);
+    crate::ensure_uv_loop(&mut op_state.borrow_mut());
+  }
   if let Some(handle) = context_state.immediate_check_handle.borrow().as_ref() {
     if make_ref {
       handle.make_ref();

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -1309,25 +1309,17 @@ impl JsRuntime {
       js_runtime.files_loaded_from_fs_during_snapshot = files_loaded;
     }
 
-    // Every runtime gets a uv loop for the libuv compat layer (timers,
-    // I/O, setImmediate, etc.). Stored in both OpState (for ext/node ops
-    // that need the raw pointer) and ContextState (for event loop phases).
+    // The libuv compat layer (timers, I/O, setImmediate, ...) is created
+    // lazily: runtimes that never touch a uv handle never pay for the loop.
+    // All we install here is the factory that knows how to build and wire
+    // one up on first use — see [`ensure_uv_loop`]. Snapshotting runtimes
+    // never get a loop at all (same as before).
     if !will_snapshot {
-      // SAFETY: zeroed memory is valid for uv_loop_t before uv_loop_init.
-      let mut uv_loop =
-        Box::new(unsafe { std::mem::zeroed::<uv_compat::UvLoop>() });
-      // SAFETY: uv_loop points to valid zeroed memory.
-      unsafe { uv_compat::uv_loop_init(&mut *uv_loop) };
-      let loop_ptr: *mut uv_compat::UvLoop = &mut *uv_loop;
-      // SAFETY: loop_ptr is valid and initialized.
-      unsafe { js_runtime.register_uv_loop(loop_ptr) };
-      js_runtime.inner.state.op_state.borrow_mut().put(uv_loop);
-      js_runtime
-        .inner
-        .state
-        .op_state
-        .borrow_mut()
-        .put(uv_compat::AsyncId::default());
+      let factory = UvLoopFactory {
+        context_state: js_runtime.inner.main_realm.0.context_state.clone(),
+        context: js_runtime.inner.main_realm.0.context().clone(),
+      };
+      js_runtime.inner.state.op_state.borrow_mut().put(factory);
     }
 
     // ...and we've made it; `JsRuntime` is ready to execute user code.
@@ -1940,9 +1932,22 @@ impl JsRuntime {
     self.inner.state.op_state.clone()
   }
 
-  /// Returns the raw `uv_loop_t` pointer registered with this runtime,
-  /// or `None` if no loop is registered.
+  /// Returns the raw `uv_loop_t` pointer for this runtime, creating and
+  /// registering the libuv compat loop on first call.
+  ///
+  /// Returns `None` only for snapshotting runtimes, which never get a loop.
   pub fn uv_loop_ptr(&self) -> Option<*mut uv_compat::uv_loop_t> {
+    if let Some(loop_ptr) =
+      self.inner.main_realm.0.context_state.uv_loop_ptr.get()
+    {
+      return Some(loop_ptr);
+    }
+    ensure_uv_loop(&mut self.inner.state.op_state.borrow_mut())
+  }
+
+  /// Returns the raw `uv_loop_t` pointer if a loop has already been created
+  /// for this runtime, without creating one.
+  pub fn existing_uv_loop_ptr(&self) -> Option<*mut uv_compat::uv_loop_t> {
     self.inner.main_realm.0.context_state.uv_loop_ptr.get()
   }
 
@@ -1968,28 +1973,14 @@ impl JsRuntime {
     loop_ptr: *mut uv_compat::uv_loop_t,
   ) {
     let realm = &self.inner.main_realm;
-    let context_state = &realm.0.context_state;
-    let inner_ptr = unsafe { uv_compat::uv_loop_get_inner_ptr(loop_ptr) };
-    let uv_inner = inner_ptr as *const uv_compat::UvLoopInner;
-    context_state.uv_loop_inner.set(Some(uv_inner));
-    context_state.uv_loop_ptr.set(Some(loop_ptr));
-
-    let global_ctx = realm.0.context().clone();
-    let raw = global_ctx.into_raw();
-    // SAFETY: `loop_ptr` is a valid, initialized `uv_loop_t` guaranteed
-    // by the caller. `raw` is a persistent-handle slot pointer from
-    // `Global::into_raw()` — V8 keeps it updated across GC cycles.
-    // The raw Global is reconstructed and dropped in `JsRealmInner::destroy`.
+    // SAFETY: forwarded from the caller's contract.
     unsafe {
-      (*loop_ptr).data = raw.as_ptr() as *mut std::ffi::c_void;
-    }
-
-    // Create the check handle for setImmediate.
-    // JS controls start/stop/ref/unref via op_immediate_check.
-    // SAFETY: loop_ptr is valid per caller contract.
-    let check_handle =
-      unsafe { uv_compat::ImmediateCheckHandle::new(loop_ptr) };
-    *context_state.immediate_check_handle.borrow_mut() = Some(check_handle);
+      register_uv_loop_with(
+        &realm.0.context_state,
+        realm.0.context().clone(),
+        loop_ptr,
+      )
+    };
   }
 
   /// Returns the runtime's op names, ordered by OpId.
@@ -2463,9 +2454,15 @@ impl JsRuntime {
     let mut dispatched_ops = false;
     let mut did_work = false;
     let mut uv_did_io = false;
+
+    // The libuv compat loop is created lazily (see `ensure_uv_loop`), so a
+    // runtime that never touches a uv handle has none — read the pointer
+    // once here and skip every uv phase below for the whole tick.
+    let uv_inner = context_state.uv_loop_inner.get();
+
     // ===== Phase 1: Timers =====
     // 1a. Fire expired libuv C timers
-    if let Some(uv_inner_ptr) = context_state.uv_loop_inner.get() {
+    if let Some(uv_inner_ptr) = uv_inner {
       // Update cached loop time at the start of each tick, matching libuv.
       unsafe { (*uv_inner_ptr).update_time() };
       unsafe { (*uv_inner_ptr).run_timers() };
@@ -2515,8 +2512,14 @@ impl JsRuntime {
     // ===== Phase 3: Idle / Prepare =====
     // In libuv: idle runs after pending callbacks, prepare runs right
     // before I/O polling. Both must precede I/O.
-    let has_uv = context_state.uv_loop_inner.get().is_some();
-    if let Some(uv_inner_ptr) = context_state.uv_loop_inner.get() {
+    // Ops and JS that ran in phase 2 may have created the loop (lazily), so
+    // refresh the pointer once before the remaining phases.
+    let uv_inner = match uv_inner {
+      Some(ptr) => Some(ptr),
+      None => context_state.uv_loop_inner.get(),
+    };
+    let has_uv = uv_inner.is_some();
+    if let Some(uv_inner_ptr) = uv_inner {
       unsafe {
         (*uv_inner_ptr).run_idle();
         (*uv_inner_ptr).run_prepare();
@@ -2534,7 +2537,7 @@ impl JsRuntime {
     // event loop processing hundreds of handles back-to-back, which
     // crushes tail latency (p99 30–200 ms vs ~1 ms with a single
     // call).
-    if let Some(uv_inner_ptr) = context_state.uv_loop_inner.get() {
+    if let Some(uv_inner_ptr) = uv_inner {
       unsafe {
         (*uv_inner_ptr).set_waker(cx.waker());
       }
@@ -2556,7 +2559,7 @@ impl JsRuntime {
     // In libuv: check runs right after I/O polling.
     // Immediates fire here, matching Node.js's setImmediate semantics
     // (libuv check phase, after I/O).
-    if let Some(uv_inner_ptr) = context_state.uv_loop_inner.get() {
+    if let Some(uv_inner_ptr) = uv_inner {
       unsafe { (*uv_inner_ptr).run_check() };
     }
     // Drain immediates in the check phase, matching Node.js semantics:
@@ -2597,7 +2600,7 @@ impl JsRuntime {
       let mut phases = context_state.event_loop_phases.borrow_mut();
       phases.run_close_callbacks();
     }
-    if let Some(uv_inner_ptr) = context_state.uv_loop_inner.get() {
+    if let Some(uv_inner_ptr) = uv_inner {
       unsafe { (*uv_inner_ptr).run_close() };
     }
     // Run V8 close callbacks (JS handle.close() callbacks).
@@ -3026,6 +3029,91 @@ impl JsRuntimeForSnapshot {
 
     snapshot::serialize(v8_data, sidecar_data)
   }
+}
+
+/// Everything needed to build and wire up a libuv compat loop after the
+/// runtime is already running. Stored in `OpState` for non-snapshotting
+/// runtimes so that the first piece of code needing a `uv_loop_t` can
+/// create one — see [`ensure_uv_loop`].
+///
+/// This is deliberately tiny: the expensive parts (the loop itself, its
+/// handle tables and the setImmediate check/idle handles) are only
+/// allocated if something actually asks for the loop.
+pub(crate) struct UvLoopFactory {
+  context_state: Rc<ContextState>,
+  context: v8::Global<v8::Context>,
+}
+
+/// Wire an already-initialized `uv_loop_t` into a context.
+///
+/// # Safety
+/// `loop_ptr` must be a valid, initialized `uv_loop_t` that outlives
+/// `context_state`.
+unsafe fn register_uv_loop_with(
+  context_state: &ContextState,
+  context: v8::Global<v8::Context>,
+  loop_ptr: *mut uv_compat::uv_loop_t,
+) {
+  // SAFETY: `loop_ptr` is a valid, initialized loop per caller contract.
+  let inner_ptr = unsafe { uv_compat::uv_loop_get_inner_ptr(loop_ptr) };
+  let uv_inner = inner_ptr as *const uv_compat::UvLoopInner;
+  context_state.uv_loop_inner.set(Some(uv_inner));
+  context_state.uv_loop_ptr.set(Some(loop_ptr));
+
+  let raw = context.into_raw();
+  // SAFETY: `loop_ptr` is a valid, initialized `uv_loop_t` guaranteed
+  // by the caller. `raw` is a persistent-handle slot pointer from
+  // `Global::into_raw()` — V8 keeps it updated across GC cycles.
+  // The raw Global is reconstructed and dropped in `JsRealmInner::destroy`.
+  unsafe {
+    (*loop_ptr).data = raw.as_ptr() as *mut std::ffi::c_void;
+  }
+
+  // Create the check handle for setImmediate.
+  // JS controls start/stop/ref/unref via op_immediate_check.
+  // SAFETY: loop_ptr is valid per caller contract.
+  let check_handle = unsafe { uv_compat::ImmediateCheckHandle::new(loop_ptr) };
+  *context_state.immediate_check_handle.borrow_mut() = Some(check_handle);
+}
+
+/// Returns the runtime's libuv compat loop, creating and registering it on
+/// first use. This is the lazy-creation seam: anything that needs a
+/// `uv_loop_t` (a uv handle, `setImmediate` refs, napi, ...) goes through
+/// here, and runtimes that never do pay nothing.
+///
+/// Returns `None` if this `OpState` does not belong to a runtime that can
+/// host a uv loop (i.e. a snapshotting runtime).
+///
+/// The loop is owned by `OpState` as a `Box<UvLoop>`, so after the first
+/// call `op_state.borrow::<Box<UvLoop>>()` works as it always has.
+pub fn ensure_uv_loop(
+  op_state: &mut OpState,
+) -> Option<*mut uv_compat::uv_loop_t> {
+  if let Some(uv_loop) = op_state.try_borrow::<Box<uv_compat::UvLoop>>() {
+    return Some(&**uv_loop as *const uv_compat::UvLoop as *mut _);
+  }
+  let factory = op_state.try_borrow::<UvLoopFactory>()?;
+  let context_state = factory.context_state.clone();
+  let context = factory.context.clone();
+
+  // SAFETY: zeroed memory is valid for uv_loop_t before uv_loop_init.
+  let mut uv_loop =
+    Box::new(unsafe { std::mem::zeroed::<uv_compat::UvLoop>() });
+  // SAFETY: uv_loop points to valid zeroed memory.
+  unsafe { uv_compat::uv_loop_init(&mut *uv_loop) };
+  let loop_ptr: *mut uv_compat::UvLoop = &mut *uv_loop;
+  // SAFETY: the loop was just initialized and is owned by `OpState`, which
+  // outlives the context state (see `InnerIsolateState::cleanup`).
+  unsafe { register_uv_loop_with(&context_state, context, loop_ptr) };
+  // Moving the `Box` does not move the loop itself, so `loop_ptr` stays
+  // valid.
+  op_state.put(uv_loop);
+  // `put` overwrites, and ext/node hands out async ids before anything
+  // needs a uv loop, so don't reset a counter that is already running.
+  if op_state.try_borrow::<uv_compat::AsyncId>().is_none() {
+    op_state.put(uv_compat::AsyncId::default());
+  }
+  Some(loop_ptr)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -3567,10 +3655,17 @@ impl JsRuntime {
         }
       }
 
-      context_state.unrefed_ops.borrow_mut().remove(&promise_id);
-      context_state
-        .activity_traces
-        .complete(RuntimeActivityType::AsyncOp, promise_id as _);
+      // Both of these are no-ops in the common case: most runtimes never
+      // unref an op and leak tracing is off unless a test enables it. The
+      // guards avoid a `RefCell` borrow + hash/tree lookup per completion.
+      if !context_state.unrefed_ops.borrow().is_empty() {
+        context_state.unrefed_ops.borrow_mut().remove(&promise_id);
+      }
+      if context_state.activity_traces.is_enabled() {
+        context_state
+          .activity_traces
+          .complete(RuntimeActivityType::AsyncOp, promise_id as _);
+      }
       args.push(v8::Integer::new(scope, promise_id).into());
       args.push(v8::Boolean::new(scope, res.is_ok()).into());
       args.push(res.unwrap_or_else(std::convert::identity));

--- a/libs/core/runtime/mod.rs
+++ b/libs/core/runtime/mod.rs
@@ -40,6 +40,7 @@ pub(crate) use jsruntime::NO_OF_BUILTIN_MODULES;
 pub use jsruntime::PollEventLoopOptions;
 pub use jsruntime::RuntimeOptions;
 pub use jsruntime::SharedArrayBufferStore;
+pub use jsruntime::ensure_uv_loop;
 pub use snapshot::CreateSnapshotOptions;
 pub use snapshot::CreateSnapshotOutput;
 pub(crate) use snapshot::SnapshotDataId;

--- a/libs/core/runtime/tests/misc.rs
+++ b/libs/core/runtime/tests/misc.rs
@@ -2192,3 +2192,58 @@ fn foreground_tasks_delivered_without_tokio_handle() {
     runtime.resolve_value(promise).await.unwrap();
   });
 }
+
+#[tokio::test]
+async fn uv_loop_is_created_lazily() {
+  let mut runtime = JsRuntime::new(Default::default());
+  assert!(
+    runtime.existing_uv_loop_ptr().is_none(),
+    "a fresh runtime must not allocate a uv loop"
+  );
+  runtime
+    .execute_script("lazy_uv.js", "globalThis.x = 1 + 1;")
+    .unwrap();
+  runtime.run_event_loop(Default::default()).await.unwrap();
+  assert!(
+    runtime.existing_uv_loop_ptr().is_none(),
+    "plain JS must not bring the uv loop into existence"
+  );
+
+  // Asking for the loop creates it, registers it with the event loop and
+  // parks the owning `Box` in `OpState` where ext code looks for it.
+  let loop_ptr = runtime.uv_loop_ptr().expect("loop should be created");
+  assert_eq!(runtime.existing_uv_loop_ptr(), Some(loop_ptr));
+  assert_eq!(
+    runtime.uv_loop_ptr(),
+    Some(loop_ptr),
+    "the loop is created exactly once"
+  );
+  {
+    let op_state = runtime.op_state();
+    let op_state = op_state.borrow();
+    let uv_loop = op_state.borrow::<Box<crate::uv_compat::UvLoop>>();
+    assert_eq!(
+      &**uv_loop as *const crate::uv_compat::UvLoop as *mut _,
+      loop_ptr
+    );
+  }
+  runtime.run_event_loop(Default::default()).await.unwrap();
+}
+
+#[tokio::test]
+async fn refed_immediate_creates_uv_loop() {
+  // Refed immediates keep the event loop alive through the uv idle handle,
+  // so refing one has to force the lazy loop into existence.
+  let mut runtime = JsRuntime::new(Default::default());
+  runtime
+    .execute_script("immediate_uv.js", "Deno.core.immediateRefCount(true);")
+    .unwrap();
+  assert!(
+    runtime.existing_uv_loop_ptr().is_some(),
+    "a refed immediate must create the uv loop"
+  );
+  runtime
+    .execute_script("immediate_uv.js", "Deno.core.immediateRefCount(false);")
+    .unwrap();
+  runtime.run_event_loop(Default::default()).await.unwrap();
+}


### PR DESCRIPTION
Ported from denoland/deno_core_revamp#21 (design rationale in
denoland/deno_core_revamp#8). No conditional compilation: `uv_compat` still
builds unconditionally, what changes is when its cost is paid.

`JsRuntime::new` used to allocate a `uv_loop_t`, its `UvLoopInner` (eight
handle tables plus the cross-thread `LoopShared` arc) and the two
`setImmediate` check/idle handles for every non-snapshot runtime, including
`deno eval 1+1`. It now installs a small `UvLoopFactory` in `OpState` — an
`Rc<ContextState>` plus a `Global<Context>` clone — and the loop is built on
first use by the new `deno_core::ensure_uv_loop(&mut OpState)`. The loop still
ends up owned by `OpState` as a `Box<UvLoop>`, so
`op_state.borrow::<Box<UvLoop>>()` keeps working once a loop exists.

Two triggers reach the seam inside `libs/core`: `JsRuntime::uv_loop_ptr()`,
which now creates on demand, and `op_immediate_check(true)`, because refed
immediates keep the event loop alive through the uv idle handle and so must
force the loop into existence. `JsRuntime::existing_uv_loop_ptr()` is the new
non-creating accessor. Snapshotting runtimes still never get a loop: no
factory is installed and `ensure_uv_loop` returns `None`.

`poll_event_loop_inner` now reads the `UvLoopInner` pointer once at the top of
the tick instead of six times, and skips timers/idle/prepare/io/check/close
outright when there is no loop. The one subtlety is that phase 2 runs ops and
JS which may create the loop mid-tick, so the pointer is refreshed once after
phase 2; if a loop appears later than that, `EventLoopPendingState` still sees
it with its own fresh read and the loop is re-polled. No phase was reordered,
and `has_uv_alive_handles` already degraded to `false` with no loop.

Two pieces of per-completion bookkeeping in the op-completion loop also get
fast paths: the unrefed-ops removal is skipped when nothing has ever been
unrefed, and `activity_traces.complete()` is called only when leak tracing is
enabled (`set_enabled(false)` clears the trace maps, so gating on the flag
cannot strand entries).

## Companion changes outside `libs/core`

Every caller that assumed an eagerly created loop now goes through the seam,
since the `OpState` entry may not be there yet:

- `ext/node/ops/tcp_wrap.rs` and `ext/node/ops/pipe_wrap.rs`:
  `op_state.borrow::<Box<UvLoop>>()` becomes `ensure_uv_loop(op_state)`.
- `ext/napi/lib.rs`: the `op_napi_open` registration that used
  `try_borrow::<Box<UvLoop>>()` becomes `ensure_uv_loop`, so an addon using
  the libuv timer polyfills brings the loop into existence rather than
  silently finding none.
- `ext/node/ops/handle_wrap.rs`: `next_async_id` installs the `AsyncId`
  counter on first use instead of assuming a loop already put one there.
  Async ids are handed out via `op_node_new_async_id` to things that never
  touch a uv handle, so that op would otherwise panic on a runtime with no
  loop. Correspondingly `ensure_uv_loop` only inserts `AsyncId` when one is
  not already present, so it can never reset a counter that is already
  handing out ids.

## Deviations from the source PR

- The revamp PR adds `libc` as a dev-dependency for the new
  `examples/loop_probe.rs`; `libs/core` already depends on `libc`
  unconditionally, so no manifest change was needed here and `Cargo.lock` is
  untouched.
- `loop_probe`'s `getrusage`-based CPU clock is now `#[cfg(unix)]`, with a
  wall-clock fallback elsewhere, so the example still compiles on the Windows
  CI targets.

## Numbers

All measurements below come from denoland/deno_core_revamp#21 and were taken
in that repository (macOS arm64, release, interleaved A/B against its `main`,
medians), not on this branch. They are quoted because the code is the same;
they have not been reproduced against `libs/core`.

| Measurement | before | after |
|---|---|---|
| idle tick, no uv loop (500k polls x 5) | 362.8 ns | 203.1 ns (-44%) |
| idle tick, uv loop forced | 368.4 ns | 367.2 ns (unchanged) |
| async op completion (300k ops x 6) | 302 ns/op | 304 ns/op (no difference) |
| empty `JsRuntime::new` + drop | ~3.5 ms | ~3.5 ms (no difference) |
| `hello_world` startup (hyperfine, 300 runs) | 8.8 ms +/- 0.5 | 8.8 ms +/- 0.7 |
| per-runtime RSS | 4.81-4.99 MB | 4.84-5.03 MB (noise) |

The idle-tick win is the result; the control that forces the loop back into
existence restores the old number exactly, which says the win comes from
skipping phases rather than from anything getting cheaper. Startup, runtime
creation and RSS show no measurable difference — a uv loop is a handful of
small allocations against ~3.5 ms of isolate and extension-JS init. The
op-completion fast paths likewise measured flat when interleaved; they are
kept because they are strictly less work, not because the benchmark rewarded
them.

## Verification

`cargo test -p deno_core` passes: 477 passed, 2 ignored, plus doctests. The
`uv_compat` suite exercises real uv handles through `JsRuntime::uv_loop_ptr()`,
so it now runs entirely on the lazy path. Two new tests cover the seam:
`uv_loop_is_created_lazily` (a fresh runtime and plain JS never create a loop;
asking for it creates exactly one and parks it in `OpState`) and
`refed_immediate_creates_uv_loop`. `ext/node` and `ext/napi` were checked to
compile against the new API; the remaining node-compat coverage is left to CI.
