### PR TITLE
perf(core): bitflag event loop state; idle tick down to one microtask checkpoint

### DIFF
--- a/libs/core/event_loop.rs
+++ b/libs/core/event_loop.rs
@@ -37,10 +37,14 @@ pub struct EventLoopPhases {
 
 impl EventLoopPhases {
   /// Drain and run all close callbacks.
-  pub fn run_close_callbacks(&mut self) {
+  /// Returns `true` if at least one callback ran.
+  pub fn run_close_callbacks(&mut self) -> bool {
+    let mut ran = false;
     while let Some(cb) = self.close_callbacks.pop_front() {
+      ran = true;
       (cb.callback)();
     }
+    ran
   }
 
   /// Drain all V8 close callbacks (called with a scope from jsruntime).

--- a/libs/core/examples/loop_probe.rs
+++ b/libs/core/examples/loop_probe.rs
@@ -7,6 +7,10 @@
 //!   nothing to do but a far-future timer. Each poll walks every event loop
 //!   phase, so this is the cost of an otherwise idle tick.
 //! - `new [N]`    -- create and drop `N` (default 50) empty runtimes.
+//!
+//! Built with `debug_assertions`, `ticks` additionally reports
+//! `ticks_checkpoints_per_iteration` -- the number of V8 microtask
+//! checkpoints the event loop performs per tick.
 //! - `ops [B] [S]` -- await `B` (default 2000) batches of `S` (default 100)
 //!   `op_void_async_deferred` calls via `Promise.all`, i.e. the async op
 //!   completion path.
@@ -99,6 +103,11 @@ async fn main() {
       }
       let waker = std::task::Waker::noop();
       let mut cx = std::task::Context::from_waker(waker);
+      // Microtask checkpoints are only counted in debug builds (the counter
+      // would otherwise sit in the release hot path); the count itself does
+      // not depend on optimization level.
+      #[cfg(debug_assertions)]
+      let checkpoints_before = JsRuntime::microtask_checkpoint_count();
       let start = Instant::now();
       let cpu_start = cpu_time_ns();
       for _ in 0..n {
@@ -115,6 +124,12 @@ async fn main() {
       println!(
         "ticks_per_iteration_ns={:.1}",
         elapsed.as_nanos() as f64 / n as f64
+      );
+      #[cfg(debug_assertions)]
+      println!(
+        "ticks_checkpoints_per_iteration={:.3}",
+        (JsRuntime::microtask_checkpoint_count() - checkpoints_before) as f64
+          / n as f64
       );
     }
     "new" => {

--- a/libs/core/modules/map/dynamic.rs
+++ b/libs/core/modules/map/dynamic.rs
@@ -200,6 +200,18 @@ impl ModuleMap {
     self.pending_dyn_mod_evaluations.is_pending()
   }
 
+  /// True when [`ModuleMap::poll_progress`] could do anything at all.
+  ///
+  /// Every queue it drains is gated on a `Cell<bool>`, so this is a handful of
+  /// `Cell` reads and lets the event loop prove that a tick's module phase was
+  /// a no-op (and therefore cannot have queued a microtask).
+  pub(crate) fn has_pending_work(&self) -> bool {
+    self.preparing_dynamic_imports.is_pending()
+      || self.pending_dynamic_imports.is_pending()
+      || self.code_cache_ready_futs.is_pending()
+      || self.pending_dyn_mod_evaluations.is_pending()
+  }
+
   fn dynamic_import_module_evaluate(
     &self,
     scope: &mut v8::PinScope,

--- a/libs/core/ops.rs
+++ b/libs/core/ops.rs
@@ -21,6 +21,7 @@ use crate::io::ResourceTable;
 use crate::ops_metrics::OpMetricsFn;
 use crate::runtime::JsRuntimeState;
 use crate::runtime::OpDriverImpl;
+use crate::runtime::SchedFlags;
 use crate::runtime::UnrefedOps;
 
 pub type PromiseId = i32;
@@ -396,6 +397,9 @@ pub struct OpState {
   pub op_stack_trace_callback: Option<OpStackTraceCallback>,
   /// Reference to the unrefered ops state in `ContextState`.
   pub(crate) unrefed_ops: UnrefedOps,
+  /// Shared event-loop scheduling word (see [`SchedFlags`]). Created here
+  /// because `OpState` is built before `ContextState`, which clones it.
+  pub(crate) sched: SchedFlags,
   /// Resources that are not referenced by the event loop. All async
   /// resource ops on these resources will not keep the event loop alive.
   ///
@@ -414,6 +418,7 @@ impl OpState {
       },
       op_stack_trace_callback,
       unrefed_ops: Default::default(),
+      sched: Default::default(),
       unrefed_resources: Default::default(),
     }
   }

--- a/libs/core/ops_builtin.rs
+++ b/libs/core/ops_builtin.rs
@@ -34,6 +34,7 @@ use crate::op2;
 use crate::ops_builtin_types;
 use crate::ops_builtin_v8;
 use crate::runtime::JsRealm;
+use crate::runtime::SchedFlags;
 use crate::runtime::v8_static_strings;
 
 macro_rules! builtin_ops {
@@ -340,6 +341,7 @@ fn get_resource(
 
   if op_state.unrefed_resources.contains(&rid) {
     op_state.unrefed_ops.borrow_mut().insert(promise_id);
+    op_state.sched.set(SchedFlags::UNREFED_OPS);
   }
 
   Ok(resource)

--- a/libs/core/ops_builtin_v8.rs
+++ b/libs/core/ops_builtin_v8.rs
@@ -23,6 +23,7 @@ use crate::ops_builtin::WasmStreamingResource;
 use crate::resolve_url;
 use crate::runtime::JsRealm;
 use crate::runtime::JsRuntimeState;
+use crate::runtime::SchedFlags;
 use crate::runtime::v8_static_strings;
 use crate::source_map::SourceMapApplication;
 use crate::stats::RuntimeActivityType;
@@ -54,13 +55,18 @@ pub fn op_set_handled_promise_rejection_handler(
 #[op2(fast)]
 pub fn op_ref_op(scope: &mut v8::PinScope, promise_id: i32) {
   let context_state = JsRealm::state_from_scope(scope);
-  context_state.unrefed_ops.borrow_mut().remove(&promise_id);
+  let mut unrefed = context_state.unrefed_ops.borrow_mut();
+  unrefed.remove(&promise_id);
+  context_state
+    .sched
+    .clear_if(SchedFlags::UNREFED_OPS, unrefed.is_empty());
 }
 
 #[op2(fast)]
 pub fn op_unref_op(scope: &mut v8::PinScope, promise_id: i32) {
   let context_state = JsRealm::state_from_scope(scope);
   context_state.unrefed_ops.borrow_mut().insert(promise_id);
+  context_state.sched.set(SchedFlags::UNREFED_OPS);
 }
 
 #[op2(fast)]
@@ -158,16 +164,19 @@ pub fn op_timer_track(
     .active_timers
     .borrow_mut()
     .insert(id as usize, (is_repeat, is_system));
+  context_state.sched.set(SchedFlags::ACTIVE_TIMERS);
 }
 
 /// Unregister a JS-managed timer from the Rust stats system.
 #[op2(fast)]
 pub fn op_timer_untrack(scope: &mut v8::PinScope, #[smi] id: i32) {
   let context_state = JsRealm::state_from_scope(scope);
+  let mut active_timers = context_state.active_timers.borrow_mut();
+  active_timers.remove(&(id as usize));
   context_state
-    .active_timers
-    .borrow_mut()
-    .remove(&(id as usize));
+    .sched
+    .clear_if(SchedFlags::ACTIVE_TIMERS, active_timers.is_empty());
+  drop(active_timers);
   context_state
     .activity_traces
     .complete(RuntimeActivityType::Timer, id as usize);
@@ -243,11 +252,15 @@ pub fn op_run_microtasks(isolate: &mut v8::Isolate) {
 pub fn op_drain_pending_rejections<'s>(
   scope: &mut v8::PinScope<'s, '_>,
 ) -> v8::Local<'s, v8::Value> {
-  let exception_state = JsRealm::exception_state_from_scope(scope);
+  let context_state = JsRealm::state_from_scope(scope);
+  let exception_state = &context_state.exception_state;
   let mut pending = exception_state.pending_promise_rejections.borrow_mut();
   if pending.is_empty() {
+    context_state.sched.clear(SchedFlags::PROMISE_REJECTIONS);
     return v8::undefined(scope).into();
   }
+  // The loop below pops every entry, so the queue is empty on return.
+  context_state.sched.clear(SchedFlags::PROMISE_REJECTIONS);
   let len = pending.len();
   let arr = v8::Array::new(scope, (len * 3) as i32);
   let mut idx = 0u32;

--- a/libs/core/runtime/event_loop_flags.rs
+++ b/libs/core/runtime/event_loop_flags.rs
@@ -1,0 +1,188 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Bitflags for event-loop scheduling and liveness.
+//!
+//! Two distinct words live here:
+//!
+//! * [`SchedFlags`] — *scheduling* bits, set at the point work is **enqueued**
+//!   and cleared when the corresponding queue is observed empty. Its purpose is
+//!   to let the event loop skip a queue entirely without borrowing the
+//!   `RefCell` that holds it.
+//! * [`EventLoopPendingState`] — *liveness* bits, recomputed once per tick to
+//!   answer "does anything keep this event loop alive?".
+//!
+//! # Why the scheduling word is only *advisory*
+//!
+//! Every bit in [`SchedFlags`] is conservative in one direction only: a set bit
+//! whose queue is actually empty costs one wasted (cheap) check, whereas a
+//! clear bit whose queue is non-empty **hangs the event loop**. Bits are
+//! therefore set unconditionally at every enqueue site, and cleared only after
+//! the authoritative container has been observed empty — never blindly at the
+//! top of a tick, which would race with work enqueued mid-tick (the same
+//! wrinkle the lazy `UvLoop` creation hit: the loop can come into existence
+//! *during* phase 2, so the pointer is re-read before phase 3).
+//!
+//! The lazy-clear pattern is:
+//!
+//! ```ignore
+//! if !sched.has(SchedFlags::FOO) {
+//!   // Definitely empty: no borrow, no work.
+//! } else {
+//!   drain_foo();
+//!   // Only now, with the container observed empty, is it safe to clear.
+//!   sched.clear_if(SchedFlags::FOO, foo.borrow().is_empty());
+//! }
+//! ```
+//!
+//! Because the clear is gated on an authoritative emptiness check taken *after*
+//! the drain, a mid-drain enqueue either (a) happens before the check, which
+//! then sees a non-empty container and leaves the bit set, or (b) happens after
+//! the clear, in which case the enqueue site sets the bit again. There is no
+//! window in which work is queued with the bit clear.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+/// A shared handle to the event loop's scheduling word.
+///
+/// Cheap to clone (`Rc`), `!Send`/`!Sync` — every holder lives on the event
+/// loop thread. Handed to `OpState`, `ContextState` and `ExceptionState` so
+/// that all three can mark work as scheduled without a back-pointer to the
+/// runtime.
+#[derive(Clone, Default)]
+pub(crate) struct SchedFlags(Rc<Cell<u16>>);
+
+impl SchedFlags {
+  /// `ContextState::unrefed_ops` may be non-empty.
+  ///
+  /// Set by `op_unref_op` / `op_void_async_deferred`-style unref paths.
+  pub const UNREFED_OPS: u16 = 1 << 0;
+  /// `ContextState::active_timers` may be non-empty.
+  ///
+  /// Set when JS arms a timer (`op_timer_queue*`).
+  pub const ACTIVE_TIMERS: u16 = 1 << 1;
+  /// `ExceptionState::pending_promise_rejections` may be non-empty.
+  ///
+  /// Set from the V8 promise reject callback and from
+  /// `op_dispatch_promise_rejection`.
+  pub const PROMISE_REJECTIONS: u16 = 1 << 2;
+  /// `ExceptionState::pending_handled_promise_rejections` may be non-empty.
+  ///
+  /// Set from the V8 promise reject callback (`kHandlerAddedAfterReject`).
+  pub const HANDLED_REJECTIONS: u16 = 1 << 3;
+
+  /// Mark work as scheduled. Must be called at *every* enqueue site for the
+  /// corresponding queue.
+  #[inline(always)]
+  pub fn set(&self, bits: u16) {
+    self.0.set(self.0.get() | bits);
+  }
+
+  /// Clear `bits` unconditionally. Only valid immediately after observing the
+  /// backing container empty.
+  #[inline(always)]
+  pub fn clear(&self, bits: u16) {
+    self.0.set(self.0.get() & !bits);
+  }
+
+  /// Clear `bits` when `empty` is an authoritative "the queue is empty right
+  /// now" observation.
+  #[inline(always)]
+  pub fn clear_if(&self, bits: u16, empty: bool) {
+    if empty {
+      self.clear(bits);
+    }
+  }
+
+  /// `false` guarantees the corresponding queues are empty.
+  #[inline(always)]
+  pub fn has(&self, bits: u16) -> bool {
+    self.0.get() & bits != 0
+  }
+}
+
+/// What is keeping the event loop alive, as a bitfield.
+///
+/// Recomputed once per tick by [`EventLoopPendingState::new`]. Replaces the
+/// twelve-`bool` struct this used to be: `is_pending()` is now a single mask
+/// test instead of nine short-circuiting field loads, and the several
+/// multi-field `||` chains in `poll_event_loop_inner` collapse to one `&`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub(crate) struct EventLoopPendingState(u16);
+
+impl EventLoopPendingState {
+  /// Any async op in flight (refed or not).
+  pub const PENDING_OPS: u16 = 1 << 0;
+  /// An async op in flight that has *not* been unref'd, a queued V8 task, or
+  /// a refed user timer — i.e. an op that keeps the loop alive.
+  pub const PENDING_REFED_OPS: u16 = 1 << 1;
+  /// A dynamic import is loading.
+  pub const DYN_IMPORTS: u16 = 1 << 2;
+  /// A dynamically imported module is mid-evaluation.
+  pub const DYN_MODULE_EVAL: u16 = 1 << 3;
+  /// A statically imported module is mid-evaluation (top-level await).
+  pub const MODULE_EVAL: u16 = 1 << 4;
+  /// V8 has background work (compilation, GC) outstanding.
+  pub const BACKGROUND_TASKS: u16 = 1 << 5;
+  /// `process.nextTick` work is queued.
+  pub const TICK_SCHEDULED: u16 = 1 << 6;
+  /// Unhandled/handled promise rejections are queued.
+  pub const PROMISE_EVENTS: u16 = 1 << 7;
+  /// An embedder has taken an external op ref.
+  pub const EXTERNAL_OPS: u16 = 1 << 8;
+  /// `setImmediate` callbacks are outstanding.
+  pub const OUTSTANDING_IMMEDIATES: u16 = 1 << 9;
+  /// JS-managed timers exist (refed or not; tracked for the leak sanitizer).
+  pub const TIMERS: u16 = 1 << 10;
+  /// The libuv compat loop has alive handles.
+  pub const UV_ALIVE_HANDLES: u16 = 1 << 11;
+
+  /// The subset that keeps the event loop alive.
+  ///
+  /// Deliberately excludes `PENDING_OPS` (unref'd ops do not hold the loop
+  /// open), `OUTSTANDING_IMMEDIATES` and `TIMERS` — matching the old
+  /// `is_pending()` exactly.
+  const KEEPS_ALIVE: u16 = Self::PENDING_REFED_OPS
+    | Self::DYN_IMPORTS
+    | Self::DYN_MODULE_EVAL
+    | Self::MODULE_EVAL
+    | Self::BACKGROUND_TASKS
+    | Self::TICK_SCHEDULED
+    | Self::PROMISE_EVENTS
+    | Self::EXTERNAL_OPS
+    | Self::UV_ALIVE_HANDLES;
+
+  /// True when *any* of `bits` is set.
+  #[inline(always)]
+  pub fn has(&self, bits: u16) -> bool {
+    self.0 & bits != 0
+  }
+
+  #[inline(always)]
+  pub fn is_pending(&self) -> bool {
+    self.0 & Self::KEEPS_ALIVE != 0
+  }
+}
+
+/// Accumulates the pending-state bits as each source is checked.
+pub(crate) struct EventLoopPendingBuilder(u16);
+
+impl EventLoopPendingBuilder {
+  #[inline(always)]
+  pub fn new() -> Self {
+    Self(0)
+  }
+
+  #[inline(always)]
+  pub fn set_if(&mut self, bits: u16, cond: bool) -> bool {
+    if cond {
+      self.0 |= bits;
+    }
+    cond
+  }
+
+  #[inline(always)]
+  pub fn build(self) -> EventLoopPendingState {
+    EventLoopPendingState(self.0)
+  }
+}

--- a/libs/core/runtime/exception_state.rs
+++ b/libs/core/runtime/exception_state.rs
@@ -6,9 +6,12 @@ use std::collections::VecDeque;
 
 use crate::error::JsError;
 use crate::error::exception_to_err_result;
+use crate::runtime::SchedFlags;
 
-#[derive(Default)]
 pub(crate) struct ExceptionState {
+  /// Shared event-loop scheduling word; bits are set when a rejection is
+  /// pushed onto either queue below. See [`SchedFlags`].
+  sched: SchedFlags,
   // TODO(nayeemrmn): This is polled in `exception_to_err_result()` which is
   // flimsy. Try to poll it similarly to `pending_promise_rejections`.
   dispatched_exception: Cell<Option<v8::Global<v8::Value>>>,
@@ -36,6 +39,20 @@ pub(crate) struct ExceptionState {
 }
 
 impl ExceptionState {
+  pub(crate) fn new(sched: SchedFlags) -> Self {
+    Self {
+      sched,
+      dispatched_exception: Default::default(),
+      dispatched_exception_is_promise: Default::default(),
+      pending_promise_rejections: Default::default(),
+      pending_handled_promise_rejections: Default::default(),
+      js_build_custom_error_cb: Default::default(),
+      js_error_constructors: Default::default(),
+      js_handled_promise_rejection_cb: Default::default(),
+      js_format_exception_cb: Default::default(),
+    }
+  }
+
   /// Clear all the associated v8 objects to prepare for this isolate to be torn down, either for
   /// a snapshot or for process termination purposes.
   ///
@@ -48,6 +65,7 @@ impl ExceptionState {
     self.js_handled_promise_rejection_cb.borrow_mut().take();
     self.js_format_exception_cb.borrow_mut().take();
     self.pending_promise_rejections.borrow_mut().clear();
+    self.sched.clear(SchedFlags::PROMISE_REJECTIONS);
     self.dispatched_exception.set(None);
   }
 
@@ -149,6 +167,9 @@ impl ExceptionState {
           error_global,
           async_context_global,
         ));
+        // Enqueue point: the event loop skips the rejection phase entirely
+        // when this bit is clear.
+        self.sched.set(SchedFlags::PROMISE_REJECTIONS);
       }
       PromiseHandlerAddedAfterReject => {
         // The code has until the event loop yields to attach a handler and avoid an unhandled rejection
@@ -158,6 +179,9 @@ impl ExceptionState {
         let mut rejections = self.pending_promise_rejections.borrow_mut();
         let previous_len = rejections.len();
         rejections.retain(|(key, _, _)| key != &promise_global);
+        self
+          .sched
+          .clear_if(SchedFlags::PROMISE_REJECTIONS, rejections.is_empty());
         if rejections.len() == previous_len {
           // Don't hold the lock while we go back into v8
           drop(rejections);
@@ -170,6 +194,8 @@ impl ExceptionState {
               .pending_handled_promise_rejections
               .borrow_mut()
               .push_back((promise_global, error_global));
+            // Enqueue point for the "rejectionhandled" phase.
+            self.sched.set(SchedFlags::HANDLED_REJECTIONS);
           }
         }
       }

--- a/libs/core/runtime/jsrealm.rs
+++ b/libs/core/runtime/jsrealm.rs
@@ -8,6 +8,7 @@ use std::hash::Hasher;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use super::event_loop_flags::SchedFlags;
 use super::exception_state::ExceptionState;
 #[cfg(test)]
 use super::op_driver::OpDriver;
@@ -97,6 +98,9 @@ pub struct ContextState {
   // record from the ESM integration proposal (same trick as Node.js).
   pub(crate) wasm_instances_map: RefCell<Option<v8::Global<v8::Object>>>,
   pub(crate) unrefed_ops: UnrefedOps,
+  /// Event-loop scheduling word shared with `OpState` and `ExceptionState`.
+  /// See [`SchedFlags`] for the set/clear discipline.
+  pub(crate) sched: SchedFlags,
   pub(crate) activity_traces: RuntimeActivityTraces,
   pub(crate) pending_ops: Rc<OpDriverImpl>,
   // We don't explicitly re-read this prop but need the slice to live alongside
@@ -179,6 +183,35 @@ pub struct ContextState {
 }
 
 impl ContextState {
+  /// True when either promise-rejection queue is non-empty.
+  ///
+  /// Gated on the scheduling bits so the common (empty) case costs one `Cell`
+  /// read rather than two `RefCell` borrows. Clears each bit that is found to
+  /// be stale, which is safe here: the observation and the clear happen back
+  /// to back with no yield to JS in between.
+  pub(crate) fn has_pending_rejections(&self) -> bool {
+    let mut pending = false;
+    if self.sched.has(SchedFlags::PROMISE_REJECTIONS) {
+      let empty = self
+        .exception_state
+        .pending_promise_rejections
+        .borrow()
+        .is_empty();
+      self.sched.clear_if(SchedFlags::PROMISE_REJECTIONS, empty);
+      pending |= !empty;
+    }
+    if self.sched.has(SchedFlags::HANDLED_REJECTIONS) {
+      let empty = self
+        .exception_state
+        .pending_handled_promise_rejections
+        .borrow()
+        .is_empty();
+      self.sched.clear_if(SchedFlags::HANDLED_REJECTIONS, empty);
+      pending |= !empty;
+    }
+    pending
+  }
+
   pub(crate) fn has_tick_scheduled(&self) -> bool {
     self.tick_info[0] != 0
   }
@@ -191,6 +224,10 @@ impl ContextState {
     self.tick_info[1] != 0
   }
 
+  #[allow(
+    clippy::too_many_arguments,
+    reason = "plumbing shared state built before the context exists"
+  )]
   pub(crate) fn new(
     op_driver: Rc<OpDriverImpl>,
     isolate_ptr: v8::UnsafeRawIsolatePtr,
@@ -199,10 +236,11 @@ impl ContextState {
     methods_ctx_offset: usize,
     external_ops_tracker: ExternalOpsTracker,
     unrefed_ops: UnrefedOps,
+    sched: SchedFlags,
   ) -> Self {
     Self {
       isolate: Some(isolate_ptr),
-      exception_state: Default::default(),
+      exception_state: Rc::new(ExceptionState::new(sched.clone())),
       tick_info: Box::new([0u8; 2]),
       immediate_info: Box::new([0u32; 3]),
       js_event_loop_tick_cb: Default::default(),
@@ -225,6 +263,7 @@ impl ContextState {
       timer_info: Box::new([0i32; 1]),
       active_timers: Default::default(),
       unrefed_ops,
+      sched,
       external_ops_tracker,
       ext_import_meta_proto: Default::default(),
       webidl_sequence_keys: Default::default(),

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -123,8 +123,11 @@ use crate::modules::script_origin;
 use crate::ops_metrics::OpMetricsFactoryFn;
 use crate::ops_metrics::dispatch_metrics_async;
 use crate::runtime::ContextState;
+use crate::runtime::EventLoopPendingBuilder;
+use crate::runtime::EventLoopPendingState;
 use crate::runtime::JsRealm;
 use crate::runtime::OpDriverImpl;
+use crate::runtime::SchedFlags;
 use crate::runtime::jsrealm;
 use crate::runtime::jsrealm::IMM_IDX_COUNT;
 use crate::runtime::jsrealm::IMM_IDX_HAS_OUTSTANDING;
@@ -133,6 +136,23 @@ use crate::source_map::SourceMapData;
 use crate::source_map::SourceMapper;
 use crate::stats::RuntimeActivityType;
 use crate::uv_compat;
+
+#[cfg(debug_assertions)]
+static MICROTASK_CHECKPOINTS: std::sync::atomic::AtomicU64 =
+  std::sync::atomic::AtomicU64::new(0);
+
+/// `scope.perform_microtask_checkpoint()`, counted in debug builds.
+///
+/// Every checkpoint made by the event loop tick goes through this macro so
+/// that `JsRuntime::microtask_checkpoint_count()` can report the per-tick
+/// count. Compiles to the bare call in release.
+macro_rules! checkpoint {
+  ($scope:expr) => {{
+    #[cfg(debug_assertions)]
+    MICROTASK_CHECKPOINTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    $scope.perform_microtask_checkpoint();
+  }};
+}
 
 pub type WaitForInspectorDisconnectCallback = Box<dyn Fn()>;
 
@@ -816,6 +836,7 @@ impl JsRuntime {
     let _phase = startup_phase_begin();
     let mut op_state = OpState::new(options.maybe_op_stack_trace_callback);
     let unrefed_ops = op_state.unrefed_ops.clone();
+    let sched = op_state.sched.clone();
 
     let lazy_extensions =
       extension_set::setup_op_state(&mut op_state, &mut extensions);
@@ -1014,6 +1035,7 @@ impl JsRuntime {
       methods_ctx_offset,
       op_state.borrow().external_ops_tracker.clone(),
       unrefed_ops,
+      sched,
     ));
 
     // TODO(bartlomieju): factor out
@@ -2395,6 +2417,15 @@ impl JsRuntime {
     result
   }
 
+  /// Number of `perform_microtask_checkpoint` calls made from the event loop
+  /// tick, for measuring checkpoint elimination. Debug builds only: counting
+  /// is build-independent, so a debug run answers "how many checkpoints does
+  /// an idle tick make?" without putting an atomic in the release hot path.
+  #[cfg(debug_assertions)]
+  pub fn microtask_checkpoint_count() -> u64 {
+    MICROTASK_CHECKPOINTS.load(std::sync::atomic::Ordering::Relaxed)
+  }
+
   /// Phase-based event loop tick, loosely following libuv's architecture:
   ///
   /// 1. Timers          -- fire expired libuv C timers + JS user timers
@@ -2405,7 +2436,18 @@ impl JsRuntime {
   /// 5. Check            -- libuv check callbacks + immediates
   /// 6. Close            -- close callbacks (Rust + libuv)
   ///
-  /// Microtask checkpoints run between phases.
+  /// Microtask checkpoints run between phases — but only where the preceding
+  /// phase can actually have queued a microtask. `microtasks_dirty` tracks
+  /// that: it starts `true` (whatever ran between polls is unknown to us), is
+  /// cleared by every checkpoint, and is re-set by every phase that entered
+  /// JS. A checkpoint whose `microtasks_dirty` is `false` is provably a no-op
+  /// — V8's queue was drained by the previous checkpoint and nothing has run
+  /// since — so it is skipped. An idle tick therefore performs exactly one
+  /// checkpoint (the pre-phase one) instead of four (six with a uv loop).
+  ///
+  /// Phases report "did I run anything?" rather than being inferred from
+  /// queue state, so the flag can never be cleared while a phase is midway
+  /// through calling into JS.
   fn poll_event_loop_inner(
     &self,
     cx: &mut Context,
@@ -2415,6 +2457,10 @@ impl JsRuntime {
     let has_inspector = self.inner.state.has_inspector.get();
     self.inner.state.waker.register(cx.waker());
 
+    // Whether anything may have queued a microtask since the last checkpoint.
+    // Starts `true`: an embedder can run arbitrary JS between two polls.
+    let mut microtasks_dirty = true;
+
     // Pre-phase: Inspector + drain foreground tasks + microtask checkpoint
     if has_inspector {
       self.inspector().poll_sessions_from_event_loop(cx);
@@ -2422,16 +2468,19 @@ impl JsRuntime {
     {
       // Drain and run foreground tasks queued by the custom V8 platform.
       // Uses the local Arc shared with the registry — no global map lookup.
-      let tasks =
-        std::mem::take(&mut *self.inner.state.foreground_tasks.lock().unwrap());
-      for task in tasks {
-        task.run();
+      // `take()` short-circuits on an atomic load, so the (overwhelmingly
+      // common) empty case never touches the mutex.
+      if let Some(tasks) = self.inner.state.foreground_tasks.take() {
+        for task in tasks {
+          task.run();
+        }
       }
 
       v8::tc_scope!(let tc_scope, scope);
       let context_state = JsRealm::state_from_scope(tc_scope);
       if !context_state.has_tick_scheduled() {
-        tc_scope.perform_microtask_checkpoint();
+        checkpoint!(tc_scope);
+        microtasks_dirty = false;
       }
       if let Some(exception) = tc_scope.exception() {
         return Poll::Ready(Err(
@@ -2465,11 +2514,15 @@ impl JsRuntime {
     if let Some(uv_inner_ptr) = uv_inner {
       // Update cached loop time at the start of each tick, matching libuv.
       unsafe { (*uv_inner_ptr).update_time() };
-      unsafe { (*uv_inner_ptr).run_timers() };
+      microtasks_dirty |= unsafe { (*uv_inner_ptr).run_timers() };
     }
 
     // ===== Phase 2: Pending work =====
-    // Module progress polling (before ops, matching original ordering)
+    // Module progress polling (before ops, matching original ordering).
+    // `poll_progress` still runs unconditionally — it registers the module
+    // waker every tick — but when nothing is queued every drain inside it
+    // returns early, so it cannot have entered JS.
+    microtasks_dirty |= modules.has_pending_work();
     modules.poll_progress(cx, scope)?;
 
     // 2a. V8 task spawner tasks
@@ -2482,17 +2535,19 @@ impl JsRuntime {
     let timer_ready = Self::dispatch_user_timers(cx, scope, context_state)?;
     did_work |= timer_ready;
     dispatched_ops |= Self::dispatch_event_loop_tick(cx, scope, context_state)?;
+    microtasks_dirty |= dispatched_ops || timer_ready;
     // Microtask checkpoint after timer/op processing, but only when
     // no ticks are scheduled (matching original guard after timers).
-    if !context_state.has_tick_scheduled() {
-      scope.perform_microtask_checkpoint();
+    if microtasks_dirty && !context_state.has_tick_scheduled() {
+      checkpoint!(scope);
+      microtasks_dirty = false;
     }
 
     // 2c. Dispatch "rejectionhandled" events before tick processing.
     // This ensures rejectionhandled fires before unhandledrejection for
     // later promises, since processTicksAndRejections drains unhandled
     // rejections via processPromiseRejections.
-    Self::dispatch_handled_rejections(scope, exception_state);
+    microtasks_dirty |= Self::dispatch_handled_rejections(scope, context_state);
 
     // 2d. nextTick drain + macrotask drain.
     // Only drain if there's actual work (ops dispatched, tick scheduled,
@@ -2502,12 +2557,19 @@ impl JsRuntime {
     dispatched_ops |= has_tick_scheduled;
     if dispatched_ops || did_work || has_tick_scheduled {
       Self::drain_next_tick_and_macrotasks(scope, context_state)?;
+      // `drainTicks` ends in a checkpoint of its own, but a nextTick callback
+      // running after it can queue more, so stay conservative.
+      microtasks_dirty = true;
     }
 
     // 2e. Handle promise rejections (after nextTick/macrotask, since
     // unhandledrejection handlers are run in macrotask callbacks).
-    Self::dispatch_rejections(scope, context_state, exception_state)?;
-    scope.perform_microtask_checkpoint();
+    microtasks_dirty |=
+      Self::dispatch_rejections(scope, context_state, exception_state)?;
+    if microtasks_dirty {
+      checkpoint!(scope);
+      microtasks_dirty = false;
+    }
 
     // ===== Phase 3: Idle / Prepare =====
     // In libuv: idle runs after pending callbacks, prepare runs right
@@ -2518,14 +2580,20 @@ impl JsRuntime {
       Some(ptr) => Some(ptr),
       None => context_state.uv_loop_inner.get(),
     };
-    let has_uv = uv_inner.is_some();
     if let Some(uv_inner_ptr) = uv_inner {
-      unsafe {
-        (*uv_inner_ptr).run_idle();
-        (*uv_inner_ptr).run_prepare();
+      let ran = unsafe {
+        let idle = (*uv_inner_ptr).run_idle();
+        let prepare = (*uv_inner_ptr).run_prepare();
+        idle || prepare
       };
-      // Idle/prepare callbacks may call into JS; flush microtasks.
-      scope.perform_microtask_checkpoint();
+      // Idle/prepare callbacks may call into JS; flush microtasks. With no
+      // active idle/prepare handles neither loop invoked a callback, so
+      // there is nothing to flush.
+      microtasks_dirty |= ran;
+      if microtasks_dirty {
+        checkpoint!(scope);
+        microtasks_dirty = false;
+      }
     }
 
     // ===== Phase 4: I/O =====
@@ -2547,10 +2615,12 @@ impl JsRuntime {
         // Flush microtasks from I/O callbacks, then drain ticks.
         // processTicksAndRejections runs op_run_microtasks internally,
         // so the trailing checkpoint is only needed when no ticks ran.
-        scope.perform_microtask_checkpoint();
+        checkpoint!(scope);
         Self::drain_next_tick_and_macrotasks(scope, context_state)?;
+        microtasks_dirty = true;
         if !context_state.has_tick_scheduled() {
-          scope.perform_microtask_checkpoint();
+          checkpoint!(scope);
+          microtasks_dirty = false;
         }
       }
     }
@@ -2560,7 +2630,7 @@ impl JsRuntime {
     // Immediates fire here, matching Node.js's setImmediate semantics
     // (libuv check phase, after I/O).
     if let Some(uv_inner_ptr) = uv_inner {
-      unsafe { (*uv_inner_ptr).run_check() };
+      microtasks_dirty |= unsafe { (*uv_inner_ptr).run_check() };
     }
     // Drain immediates in the check phase, matching Node.js semantics:
     // - Refed immediates always fire (they keep the event loop alive).
@@ -2577,6 +2647,7 @@ impl JsRuntime {
         && (has_refed || did_work || dispatched_ops || uv_did_io)
       {
         Self::do_js_run_immediate_callbacks(scope, context_state)?;
+        microtasks_dirty = true;
         // Drain ticks queued by immediate callbacks so they don't
         // require an extra full event loop iteration.
         if context_state.has_tick_scheduled() {
@@ -2584,7 +2655,10 @@ impl JsRuntime {
         }
       }
     }
-    scope.perform_microtask_checkpoint();
+    if microtasks_dirty {
+      checkpoint!(scope);
+      microtasks_dirty = false;
+    }
 
     // Drain nextTick queue before close phase, matching Node.js/libuv
     // where process.nextTick fires between each event loop phase.
@@ -2592,16 +2666,17 @@ impl JsRuntime {
     // close callbacks (Phase 6).
     if context_state.has_tick_scheduled() {
       Self::drain_next_tick_and_macrotasks(scope, context_state)?;
+      microtasks_dirty = true;
     }
 
     // ===== Phase 6: Close =====
     exception_state.check_exception_condition(scope)?;
     {
       let mut phases = context_state.event_loop_phases.borrow_mut();
-      phases.run_close_callbacks();
+      microtasks_dirty |= phases.run_close_callbacks();
     }
     if let Some(uv_inner_ptr) = uv_inner {
-      unsafe { (*uv_inner_ptr).run_close() };
+      microtasks_dirty |= unsafe { (*uv_inner_ptr).run_close() };
     }
     // Run V8 close callbacks (JS handle.close() callbacks).
     // These are deferred to Phase 6 to match libuv's uv_close behavior
@@ -2612,19 +2687,14 @@ impl JsRuntime {
         .event_loop_phases
         .borrow_mut()
         .drain_v8_close_callbacks();
+      microtasks_dirty |= !v8_cbs.is_empty();
       for cb in v8_cbs {
         (cb.callback)(scope);
       }
     }
-    // libuv close callbacks may call into JS; flush microtasks if present.
-    if has_uv
-      || !context_state
-        .event_loop_phases
-        .borrow()
-        .v8_close_callbacks
-        .is_empty()
-    {
-      scope.perform_microtask_checkpoint();
+    // Close callbacks may call into JS; flush microtasks if any actually ran.
+    if microtasks_dirty {
+      checkpoint!(scope);
     }
 
     // Evaluate pending state
@@ -2685,40 +2755,38 @@ impl JsRuntime {
     }
 
     // Re-wake logic for next iteration
-    #[allow(
-      clippy::suspicious_else_formatting,
-      clippy::if_same_then_else,
-      reason = "intentional structure for clarity of re-wake conditions"
-    )]
     {
-      if pending_state.has_pending_background_tasks
-        || pending_state.has_tick_scheduled
-        || pending_state.has_outstanding_immediates
+      /// Work that must be revisited on the very next tick.
+      const REWAKE_IMMEDIATELY: u16 = EventLoopPendingState::BACKGROUND_TASKS
+        | EventLoopPendingState::TICK_SCHEDULED
+        | EventLoopPendingState::OUTSTANDING_IMMEDIATES
+        | EventLoopPendingState::PROMISE_EVENTS;
+      /// Module evaluation can only progress if ops were dispatched.
+      const REWAKE_IF_OPS_DISPATCHED: u16 = EventLoopPendingState::MODULE_EVAL
+        | EventLoopPendingState::DYN_MODULE_EVAL;
+
+      if pending_state.has(REWAKE_IMMEDIATELY)
         || context_state.immediate_info[IMM_IDX_REF_COUNT] > 0
-        || pending_state.has_pending_promise_events
         || uv_did_io
-      {
-        self.inner.state.waker.wake();
-      } else
-      // If ops were dispatched we may have progress on pending modules that we should re-check
-      if (pending_state.has_pending_module_evaluation
-        || pending_state.has_pending_dyn_module_evaluation)
-        && dispatched_ops
+        // If ops were dispatched we may have progress on pending modules that
+        // we should re-check
+        || (dispatched_ops && pending_state.has(REWAKE_IF_OPS_DISPATCHED))
       {
         self.inner.state.waker.wake();
       }
     }
 
-    if pending_state.has_pending_module_evaluation {
-      if pending_state.has_pending_ops
-        || pending_state.has_pending_dyn_imports
-        || pending_state.has_pending_dyn_module_evaluation
-        || pending_state.has_pending_background_tasks
-        || pending_state.has_pending_external_ops
-        || pending_state.has_tick_scheduled
-        || pending_state.has_pending_timers
-        || pending_state.has_uv_alive_handles
-      {
+    if pending_state.has(EventLoopPendingState::MODULE_EVAL) {
+      /// Anything that could still drive a stalled top-level await forward.
+      const MAY_UNSTALL: u16 = EventLoopPendingState::PENDING_OPS
+        | EventLoopPendingState::DYN_IMPORTS
+        | EventLoopPendingState::DYN_MODULE_EVAL
+        | EventLoopPendingState::BACKGROUND_TASKS
+        | EventLoopPendingState::EXTERNAL_OPS
+        | EventLoopPendingState::TICK_SCHEDULED
+        | EventLoopPendingState::TIMERS
+        | EventLoopPendingState::UV_ALIVE_HANDLES;
+      if pending_state.has(MAY_UNSTALL) {
         // pass, will be polled again
       } else {
         // Last-resort: try one more microtask checkpoint before reporting
@@ -2767,15 +2835,16 @@ impl JsRuntime {
       }
     }
 
-    if pending_state.has_pending_dyn_module_evaluation {
-      if pending_state.has_pending_ops
-        || pending_state.has_pending_dyn_imports
-        || pending_state.has_pending_background_tasks
-        || pending_state.has_pending_external_ops
-        || pending_state.has_tick_scheduled
-        || pending_state.has_pending_timers
-        || pending_state.has_uv_alive_handles
-      {
+    if pending_state.has(EventLoopPendingState::DYN_MODULE_EVAL) {
+      /// Same as `MAY_UNSTALL` above, minus `DYN_MODULE_EVAL` itself.
+      const MAY_UNSTALL: u16 = EventLoopPendingState::PENDING_OPS
+        | EventLoopPendingState::DYN_IMPORTS
+        | EventLoopPendingState::BACKGROUND_TASKS
+        | EventLoopPendingState::EXTERNAL_OPS
+        | EventLoopPendingState::TICK_SCHEDULED
+        | EventLoopPendingState::TIMERS
+        | EventLoopPendingState::UV_ALIVE_HANDLES;
+      if pending_state.has(MAY_UNSTALL) {
         // pass, will be polled again
       } else if realm.modules_idle() {
         if let Some(js_error) =
@@ -3116,75 +3185,111 @@ pub fn ensure_uv_loop(
   Some(loop_ptr)
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) struct EventLoopPendingState {
-  has_pending_ops: bool,
-  has_pending_refed_ops: bool,
-  has_pending_dyn_imports: bool,
-  has_pending_dyn_module_evaluation: bool,
-  has_pending_module_evaluation: bool,
-  has_pending_background_tasks: bool,
-  has_tick_scheduled: bool,
-  has_pending_promise_events: bool,
-  has_pending_external_ops: bool,
-  has_outstanding_immediates: bool,
-  has_pending_timers: bool,
-  has_uv_alive_handles: bool,
-}
-
 impl EventLoopPendingState {
   /// Collect event loop state from all the sub-states.
+  ///
+  /// Every source below is either a `Cell`/atomic/shared-buffer read (already
+  /// free) or is gated on a [`SchedFlags`] bit so the `RefCell` behind it is
+  /// never borrowed on an idle tick. The gated sources also take the
+  /// opportunity to *clear* their bit once observed empty — the only place in
+  /// the tick where clearing is safe for these queues, because the check and
+  /// the clear happen with no intervening yield to JS.
   pub fn new(
     scope: &mut v8::PinScope<()>,
     state: &ContextState,
     modules: &ModuleMap,
   ) -> Self {
-    let num_unrefed_ops = state.unrefed_ops.borrow().len();
+    let sched = &state.sched;
+    let mut bits = EventLoopPendingBuilder::new();
+
+    // --- op liveness -------------------------------------------------------
+    // `pending_ops.len()` and the task-spawner/external-op flags are a `Cell`
+    // and two atomics respectively; only `unrefed_ops` is a `RefCell`.
     let num_pending_ops = state.pending_ops.len();
+    let num_unrefed_ops = if sched.has(SchedFlags::UNREFED_OPS) {
+      let unrefed = state.unrefed_ops.borrow();
+      sched.clear_if(SchedFlags::UNREFED_OPS, unrefed.is_empty());
+      unrefed.len()
+    } else {
+      0
+    };
     let has_pending_tasks = state.task_spawner_factory.has_pending_tasks();
     // User timers: JS manages these; the timer handle is refed when
     // there are refed timers (timer_info[0] > 0).
     let has_pending_refed_user_timers = state.user_timer.is_refed();
-    let has_pending_dyn_imports = modules.has_pending_dynamic_imports();
-    let has_pending_dyn_module_evaluation =
-      modules.has_pending_dyn_module_evaluation();
-    let has_pending_module_evaluation = modules.has_pending_module_evaluation();
-    let has_pending_promise_events = !state
-      .exception_state
-      .pending_promise_rejections
-      .borrow()
-      .is_empty()
-      || !state
-        .exception_state
-        .pending_handled_promise_rejections
-        .borrow()
-        .is_empty();
     let has_pending_refed_ops = has_pending_tasks
       || has_pending_refed_user_timers
       || num_pending_ops > num_unrefed_ops;
-    let has_outstanding_immediates =
-      state.immediate_info[IMM_IDX_HAS_OUTSTANDING] != 0;
-    let has_pending_timers = !state.active_timers.borrow().is_empty();
-    let has_uv_alive_handles =
-      if let Some(uv_inner_ptr) = state.uv_loop_inner.get() {
-        unsafe { (*uv_inner_ptr).has_alive_handles() }
-      } else {
-        false
-      };
-    EventLoopPendingState {
-      has_pending_ops: has_pending_refed_ops || (num_pending_ops > 0),
+    bits.set_if(
+      EventLoopPendingState::PENDING_REFED_OPS,
       has_pending_refed_ops,
-      has_pending_dyn_imports,
-      has_pending_dyn_module_evaluation,
-      has_pending_module_evaluation,
-      has_pending_background_tasks: scope.has_pending_background_tasks(),
-      has_tick_scheduled: state.has_tick_scheduled(),
+    );
+    bits.set_if(
+      EventLoopPendingState::PENDING_OPS,
+      has_pending_refed_ops || num_pending_ops > 0,
+    );
+    bits.set_if(
+      EventLoopPendingState::EXTERNAL_OPS,
+      state.external_ops_tracker.has_pending_ops(),
+    );
+
+    // --- modules -----------------------------------------------------------
+    // All three are `Cell<bool>` reads on `ModuleMap`.
+    bits.set_if(
+      EventLoopPendingState::DYN_IMPORTS,
+      modules.has_pending_dynamic_imports(),
+    );
+    bits.set_if(
+      EventLoopPendingState::DYN_MODULE_EVAL,
+      modules.has_pending_dyn_module_evaluation(),
+    );
+    bits.set_if(
+      EventLoopPendingState::MODULE_EVAL,
+      modules.has_pending_module_evaluation(),
+    );
+
+    // --- promise rejections ------------------------------------------------
+    let has_pending_promise_events = state.has_pending_rejections();
+    bits.set_if(
+      EventLoopPendingState::PROMISE_EVENTS,
       has_pending_promise_events,
-      has_pending_external_ops: state.external_ops_tracker.has_pending_ops(),
-      has_outstanding_immediates,
-      has_pending_timers,
-      has_uv_alive_handles,
+    );
+
+    // --- JS-side shared buffers (plain array reads) ------------------------
+    bits.set_if(
+      EventLoopPendingState::TICK_SCHEDULED,
+      state.has_tick_scheduled(),
+    );
+    bits.set_if(
+      EventLoopPendingState::OUTSTANDING_IMMEDIATES,
+      state.immediate_info[IMM_IDX_HAS_OUTSTANDING] != 0,
+    );
+
+    // --- timers tracked for the leak sanitizer -----------------------------
+    if sched.has(SchedFlags::ACTIVE_TIMERS) {
+      let active_timers = state.active_timers.borrow();
+      sched.clear_if(SchedFlags::ACTIVE_TIMERS, active_timers.is_empty());
+      bits.set_if(EventLoopPendingState::TIMERS, !active_timers.is_empty());
     }
+
+    // --- libuv compat ------------------------------------------------------
+    // The loop is created lazily, so a runtime that never touched a uv handle
+    // has a null pointer here and skips the C call entirely.
+    if let Some(uv_inner_ptr) = state.uv_loop_inner.get() {
+      // SAFETY: the pointee outlives the `ContextState` (see `uv_loop_inner`).
+      let alive = unsafe { (*uv_inner_ptr).has_alive_handles() };
+      bits.set_if(EventLoopPendingState::UV_ALIVE_HANDLES, alive);
+    }
+
+    // --- V8 ----------------------------------------------------------------
+    // Not flaggable: V8 may start background work (compilation, GC) without
+    // going through any Rust enqueue point.
+    bits.set_if(
+      EventLoopPendingState::BACKGROUND_TASKS,
+      scope.has_pending_background_tasks(),
+    );
+
+    bits.build()
   }
 
   /// Collect event loop state from all the states stored in the scope.
@@ -3192,18 +3297,6 @@ impl EventLoopPendingState {
     let module_map = JsRealm::module_map_from(scope);
     let context_state = JsRealm::state_from_scope(scope);
     Self::new(scope, &context_state, &module_map)
-  }
-
-  pub fn is_pending(&self) -> bool {
-    self.has_pending_refed_ops
-      || self.has_pending_dyn_imports
-      || self.has_pending_dyn_module_evaluation
-      || self.has_pending_module_evaluation
-      || self.has_pending_background_tasks
-      || self.has_tick_scheduled
-      || self.has_pending_promise_events
-      || self.has_pending_external_ops
-      || self.has_uv_alive_handles
   }
 }
 
@@ -3658,8 +3751,12 @@ impl JsRuntime {
       // Both of these are no-ops in the common case: most runtimes never
       // unref an op and leak tracing is off unless a test enables it. The
       // guards avoid a `RefCell` borrow + hash/tree lookup per completion.
-      if !context_state.unrefed_ops.borrow().is_empty() {
-        context_state.unrefed_ops.borrow_mut().remove(&promise_id);
+      if context_state.sched.has(SchedFlags::UNREFED_OPS) {
+        let mut unrefed = context_state.unrefed_ops.borrow_mut();
+        unrefed.remove(&promise_id);
+        context_state
+          .sched
+          .clear_if(SchedFlags::UNREFED_OPS, unrefed.is_empty());
       }
       if context_state.activity_traces.is_enabled() {
         context_state
@@ -3699,10 +3796,19 @@ impl JsRuntime {
   /// reported as unhandled but have since had handlers attached.
   /// This must run before unhandled rejection processing so that
   /// rejectionhandled fires before unhandledrejection for later promises.
+  ///
+  /// Returns `true` if a handler was invoked, i.e. if this entered JS.
   fn dispatch_handled_rejections<'s, 'i>(
     scope: &mut v8::PinScope<'s, 'i>,
-    exception_state: &ExceptionState,
-  ) {
+    context_state: &ContextState,
+  ) -> bool {
+    // Fast path: nothing was ever queued, so skip the `RefCell` borrow and
+    // the `v8::undefined` local this would otherwise allocate every tick.
+    if !context_state.sched.has(SchedFlags::HANDLED_REJECTIONS) {
+      return false;
+    }
+    let mut called = false;
+    let exception_state = &context_state.exception_state;
     let undefined: v8::Local<v8::Value> = v8::undefined(scope).into();
     while let Some((promise, result)) = exception_state
       .pending_handled_promise_rejections
@@ -3719,27 +3825,40 @@ impl JsRuntime {
           v8::Local::new(scope, promise).into(),
           v8::Local::new(scope, result),
         ];
+        called = true;
         function.call(scope, undefined, &args);
       }
     }
+    // The loop above exits only once `pop_front` returns `None`, i.e. with the
+    // queue observed empty. A handler that queued a *new* handled rejection
+    // would have been popped by this same loop, so clearing here cannot drop
+    // work.
+    context_state.sched.clear(SchedFlags::HANDLED_REJECTIONS);
+    called
   }
 
   /// Phase 2c: Handle promise rejections.
+  ///
+  /// Returns `true` if this entered JS (see `dispatch_handled_rejections`).
   fn dispatch_rejections<'s, 'i>(
     scope: &mut v8::PinScope<'s, 'i>,
     context_state: &ContextState,
     exception_state: &ExceptionState,
-  ) -> Result<(), Box<JsError>> {
+  ) -> Result<bool, Box<JsError>> {
     // First handle "handled" rejections
-    Self::dispatch_handled_rejections(scope, exception_state);
+    let called = Self::dispatch_handled_rejections(scope, context_state);
 
     // Then handle unhandled rejections
+    if !context_state.sched.has(SchedFlags::PROMISE_REJECTIONS) {
+      return Ok(called);
+    }
     if exception_state
       .pending_promise_rejections
       .borrow()
       .is_empty()
     {
-      return Ok(());
+      context_state.sched.clear(SchedFlags::PROMISE_REJECTIONS);
+      return Ok(called);
     }
 
     let mut pending_rejections =
@@ -3747,6 +3866,9 @@ impl JsRuntime {
     let mut rejections = VecDeque::default();
     std::mem::swap(&mut *pending_rejections, &mut rejections);
     drop(pending_rejections);
+    // The queue was just swapped out for an empty one. Anything the handler
+    // call below queues re-sets the bit through `track_promise_rejection`.
+    context_state.sched.clear(SchedFlags::PROMISE_REJECTIONS);
 
     let mut args: SmallVec<[v8::Local<v8::Value>; 16]> =
       SmallVec::with_capacity(rejections.len() * 3);
@@ -3768,7 +3890,7 @@ impl JsRuntime {
       return exception_to_err_result(tc_scope, exception, false, true);
     }
 
-    Ok(())
+    Ok(true)
   }
 
   /// Drain nextTick queue and macrotask queue (no op resolution).

--- a/libs/core/runtime/mod.rs
+++ b/libs/core/runtime/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 pub(crate) mod bindings;
+pub(crate) mod event_loop_flags;
 pub(crate) mod exception_state;
 pub mod host_defined_options;
 mod jsrealm;
@@ -20,6 +21,9 @@ pub(crate) mod tests;
 pub const V8_WRAPPER_TYPE_INDEX: i32 = 0;
 pub const V8_WRAPPER_OBJECT_INDEX: i32 = 1;
 
+pub(crate) use event_loop_flags::EventLoopPendingBuilder;
+pub(crate) use event_loop_flags::EventLoopPendingState;
+pub(crate) use event_loop_flags::SchedFlags;
 pub use jsrealm::CONTEXT_STATE_SLOT_INDEX;
 pub use jsrealm::ContextState;
 pub(crate) use jsrealm::JsRealm;

--- a/libs/core/runtime/setup.rs
+++ b/libs/core/runtime/setup.rs
@@ -36,7 +36,54 @@ pub(crate) fn isolate_ptr_to_key(ptr: v8::UnsafeRawIsolatePtr) -> usize {
 /// Thread-safe queue of V8 foreground tasks, shared between the global
 /// isolate registry (written by V8 background threads) and the event
 /// loop (drained on the main thread). Cloning is cheap (Arc).
-pub type ForegroundTaskQueue = std::sync::Arc<Mutex<Vec<v8::Task>>>;
+///
+/// The `has_tasks` flag mirrors the `V8TaskSpawnerFactory` pattern in
+/// `core/tasks.rs`: the event loop drains this queue every tick and it is
+/// almost always empty, so the common case must not pay for a mutex
+/// acquisition. A `false` load guarantees the queue is empty; a `true` load
+/// means it is very likely non-empty (the push and the flag store are not
+/// atomic with respect to each other, so a drain may find nothing — see
+/// `take()`).
+#[derive(Default)]
+pub struct ForegroundTaskQueueInner {
+  tasks: Mutex<Vec<v8::Task>>,
+  has_tasks: AtomicBool,
+}
+
+impl ForegroundTaskQueueInner {
+  /// Push a task, marking the queue non-empty. Called from V8 background
+  /// threads and from tokio timer tasks.
+  pub fn push(&self, task: v8::Task) {
+    self.tasks.lock().unwrap().push(task);
+    // Release: the push above happens-before any acquire load of the flag.
+    self.has_tasks.store(true, Ordering::Release);
+  }
+
+  /// Take every queued task, or `None` when the queue is (almost certainly)
+  /// empty. The empty case costs a single atomic compare-exchange.
+  pub fn take(&self) -> Option<Vec<v8::Task>> {
+    // If the flag is false there are definitely no tasks. Clearing it here
+    // (rather than after the drain) means a task pushed while we run the
+    // drained batch re-sets the flag and is picked up on the next tick,
+    // instead of being silently dropped by a blind post-drain clear.
+    if self
+      .has_tasks
+      .compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire)
+      .is_err()
+    {
+      return None;
+    }
+    let tasks = std::mem::take(&mut *self.tasks.lock().unwrap());
+    if tasks.is_empty() {
+      // Lost an unlikely race: the pusher stored the flag before we cleared
+      // it but has not pushed to the vector yet. It will store `true` again.
+      return None;
+    }
+    Some(tasks)
+  }
+}
+
+pub type ForegroundTaskQueue = std::sync::Arc<ForegroundTaskQueueInner>;
 
 /// Per-isolate state stored in the global registry. Kept minimal: just
 /// enough for platform callbacks (which only have an isolate pointer) to
@@ -80,7 +127,7 @@ pub fn unregister_isolate(isolate_ptr: usize) {
 fn queue_task(key: usize, task: v8::Task) {
   let map = ISOLATE_ENTRIES.lock().unwrap();
   if let Some(entry) = map.get(&key) {
-    entry.tasks.lock().unwrap().push(task);
+    entry.tasks.push(task);
     entry.waker.wake();
   }
 }
@@ -112,7 +159,7 @@ fn spawn_delayed_task(key: usize, task: v8::Task, delay_in_seconds: f64) {
   let waker = entry.waker.clone();
   handle.spawn(async move {
     tokio::time::sleep(Duration::from_secs_f64(delay_in_seconds)).await;
-    tasks.lock().unwrap().push(task);
+    tasks.push(task);
     waker.wake();
   });
 }

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -428,8 +428,13 @@ impl UvLoopInner {
 
   /// ### Safety
   /// All timer handle pointers stored in `timer_handles` must be valid.
-  pub(crate) unsafe fn run_timers(&self) {
+  ///
+  /// Returns `true` if at least one timer callback ran. Callers use this to
+  /// decide whether a microtask checkpoint is needed (a callback may have
+  /// re-entered JS); `false` proves the phase was a no-op.
+  pub(crate) unsafe fn run_timers(&self) -> bool {
     let now = self.now_ms();
+    let mut ran = false;
     let mut expired = Vec::new();
     {
       let timers = self.timers.borrow();
@@ -470,15 +475,20 @@ impl UvLoopInner {
       }
 
       if let Some(cb) = cb {
+        ran = true;
         // SAFETY: handle_ptr is valid; cb was set by the C caller via uv_timer_start.
         unsafe { cb(handle_ptr) };
       }
     }
+    ran
   }
 
   /// ### Safety
   /// All idle handle pointers stored in `idle_handles` must be valid.
-  pub(crate) unsafe fn run_idle(&self) {
+  ///
+  /// Returns `true` if at least one callback ran (see [`Self::run_timers`]).
+  pub(crate) unsafe fn run_idle(&self) -> bool {
+    let mut ran = false;
     let mut i = 0;
     loop {
       let handle_ptr = {
@@ -494,15 +504,20 @@ impl UvLoopInner {
       if handle.flags & UV_HANDLE_ACTIVE != 0
         && let Some(cb) = handle.cb
       {
+        ran = true;
         // SAFETY: Callback set by C caller via uv_idle_start; handle_ptr is valid.
         unsafe { cb(handle_ptr) };
       }
     }
+    ran
   }
 
   /// ### Safety
   /// All prepare handle pointers stored in `prepare_handles` must be valid.
-  pub(crate) unsafe fn run_prepare(&self) {
+  ///
+  /// Returns `true` if at least one callback ran (see [`Self::run_timers`]).
+  pub(crate) unsafe fn run_prepare(&self) -> bool {
+    let mut ran = false;
     let mut i = 0;
     loop {
       let handle_ptr = {
@@ -518,15 +533,20 @@ impl UvLoopInner {
       if handle.flags & UV_HANDLE_ACTIVE != 0
         && let Some(cb) = handle.cb
       {
+        ran = true;
         // SAFETY: Callback set by C caller via uv_prepare_start; handle_ptr is valid.
         unsafe { cb(handle_ptr) };
       }
     }
+    ran
   }
 
   /// ### Safety
   /// All check handle pointers stored in `check_handles` must be valid.
-  pub(crate) unsafe fn run_check(&self) {
+  ///
+  /// Returns `true` if at least one callback ran (see [`Self::run_timers`]).
+  pub(crate) unsafe fn run_check(&self) -> bool {
+    let mut ran = false;
     let mut i = 0;
     loop {
       let handle_ptr = {
@@ -542,24 +562,34 @@ impl UvLoopInner {
       if handle.flags & UV_HANDLE_ACTIVE != 0
         && let Some(cb) = handle.cb
       {
+        ran = true;
         // SAFETY: Callback set by C caller via uv_check_start; handle_ptr is valid.
         unsafe { cb(handle_ptr) };
       }
     }
+    ran
   }
 
   /// ### Safety
   /// All handle pointers in `closing_handles` must be valid.
-  pub(crate) unsafe fn run_close(&self) {
+  ///
+  /// Returns `true` if at least one callback ran (see [`Self::run_timers`]).
+  pub(crate) unsafe fn run_close(&self) -> bool {
     let mut closing = self.closing_handles.borrow_mut();
+    if closing.is_empty() {
+      return false;
+    }
     let snapshot: Vec<_> = closing.drain(..).collect();
     drop(closing);
+    let mut ran = false;
     for (handle_ptr, cb) in snapshot {
       if let Some(cb) = cb {
+        ran = true;
         // SAFETY: handle_ptr is valid; cb was registered by C caller via uv_close.
         unsafe { cb(handle_ptr) };
       }
     }
+    ran
   }
 
   /// Poll all TCP handles for I/O readiness and fire callbacks.


### PR DESCRIPTION
Ported from denoland/deno_core_revamp#22 (rationale in
denoland/deno_core_revamp#9).

**Stacked on #36799** (`up16-lazy-uvloop`, the lazy-`UvLoop` port). The base
branch is set to `up16-lazy-uvloop`, so the diff shown here is only this
change; if that PR lands first this rebases onto `main` cleanly, and if the
base is retargeted the first commit of this branch is #36799's.

`EventLoopPendingState` recomputed twelve booleans from a scatter of
`RefCell`/`Cell`/atomic sources on every tick, and the tick performed four
fixed microtask checkpoints (six once a uv loop existed) whether or not the
intervening phase had done anything. This replaces the recomputation with a
scheduling bitflag maintained at enqueue points, and cuts the idle tick to a
single checkpoint.

## The scheduling word

`SchedFlags` (`libs/core/runtime/event_loop_flags.rs`) is an `Rc<Cell<u16>>`
shared by `OpState`, `ContextState` and `ExceptionState`. Its contract is
one-directional: a set bit over an empty queue costs one cheap wasted check,
whereas a clear bit over a non-empty queue hangs the loop. Bits are therefore
set unconditionally at every enqueue site and cleared only after the backing
container has been observed empty — never blindly at the top of a tick, which
would race with work enqueued mid-tick (the same wrinkle #36799 hit with lazy
uv-loop creation, which it solved by re-reading the pointer before phase 3).
The clear is always taken from an authoritative emptiness check made with no
intervening yield to JS, so a mid-drain enqueue either happens before the
check — which then sees a non-empty container and leaves the bit set — or
after the clear, in which case the enqueue site re-sets it.

Bits were added only where they buy something: the four `RefCell`-backed
sources (`unrefed_ops`, `active_timers`, and the two promise-rejection
queues). The rest were already `Cell`/atomic/typed-array reads, and mirroring
them into a second word would add enqueue sites to keep in sync — i.e. hang
risk — for no measurable gain. Two of them (`TICK_SCHEDULED`,
`OUTSTANDING_IMMEDIATES`) have no Rust enqueue point at all, since JS writes
those shared buffers directly, and `BACKGROUND_TASKS` is not flaggable because
V8 starts background work without passing through any Rust enqueue point.

`EventLoopPendingState` itself is now a `u16` bitfield rather than twelve
`bool`s. `is_pending()` is one mask test instead of nine field loads, and the
three multi-field `||` chains in `poll_event_loop_inner` become named masks
(`REWAKE_IMMEDIATELY`, `REWAKE_IF_OPS_DISPATCHED`, `MAY_UNSTALL`). The
`KEEPS_ALIVE` mask reproduces the old `is_pending()` exactly, including its
deliberate omission of `PENDING_OPS`, `OUTSTANDING_IMMEDIATES` and `TIMERS`.
Beyond the pending-state computation the bits also buy skipping work:
`dispatch_handled_rejections` used to take a `borrow_mut()` and allocate a
`v8::undefined` local on every tick just to find the queue empty; it now
returns immediately on a clear bit.

## Foreground task queue

`ForegroundTaskQueue` was `Arc<Mutex<Vec<v8::Task>>>`, locked and `mem::take`n
every tick. It is now a struct carrying the `has_tasks` `AtomicBool` pattern
from `V8TaskSpawnerFactory`, so the empty case costs one compare-exchange and
never acquires the mutex. As in `poll_inner`, the flag is cleared *before* the
batch runs, so a task pushed by a V8 background thread while the batch
executes re-sets the flag and is picked up next tick rather than being lost to
a blind post-drain clear; the `tasks.is_empty()` re-check handles the
push/store race the same way.

## Checkpoint reduction

A checkpoint after a phase that never entered JS is provably a no-op: the
previous checkpoint drained V8's queue and nothing has run since.
`microtasks_dirty` tracks that. It starts `true` (an embedder can run
arbitrary JS between two polls), is cleared by every checkpoint, and is re-set
by every phase that entered JS. Crucially, phases now *report* whether they
invoked a callback rather than having it inferred from queue state, so the
flag can never be cleared while a phase is midway through calling into JS:
`UvLoopInner::run_{timers,idle,prepare,check,close}` and
`EventLoopPhases::run_close_callbacks` return `bool`, the two rejection
dispatchers return whether a handler was invoked, and
`ModuleMap::has_pending_work()` (four `Cell<bool>` reads covering every queue
`poll_progress` drains) proves the module phase was inert. Everything around
`drain_next_tick_and_macrotasks` conservatively re-sets the flag rather than
reasoning about what `processTicksAndRejections` flushed internally.

Ordering on a busy tick is unchanged: every checkpoint that used to run after
real work still runs, in the same place, under the same guards. The
nextTick-before-`.then` and rejectionhandled-before-unhandledrejection
invariants are untouched — no checkpoint moved, none was added between two
phases that previously had none between them.

Two subtleties worth flagging. The pre-phase checkpoint stays unconditional:
whatever ran between two polls is invisible to the flag, and it is also the
reason the rest can be skipped. And the close-phase checkpoint's old guard
(`has_uv || !v8_close_callbacks.is_empty()`) was effectively just `has_uv`,
because the callbacks are drained a few lines above; under `microtasks_dirty`
there is one narrow case where the new tick performs a checkpoint the old one
did not (no uv loop, and the pre-close nextTick drain ran). That direction is
safe — microtasks flush earlier rather than later, and `drainTicks` has just
flushed them anyway — and it keeps the rule "only skip what is provably
empty". That is the single behavioural delta in either direction.

`JsRuntime::microtask_checkpoint_count()` exists under `debug_assertions`
only, fed by a `checkpoint!` macro wrapping every checkpoint the tick makes,
so a debug run can answer "how many checkpoints does an idle tick make?"
without putting an atomic in the release hot path.

## Deviations from the source PR

`ModuleMap::has_pending_work()` lands in `modules/map/dynamic.rs` next to the
other `has_pending_*` accessors rather than in `modules/map.rs`, because the
`map.rs` split has already landed here. The body is identical.

## Numbers

These come from denoland/deno_core_revamp#22 and #21 and were measured in that
repository (release `loop_probe`, interleaved, 6 rounds, medians of
`cpu_per_iteration_ns`), not on this branch.

| mode | before | after |
|---|---|---|
| `ticks` (idle, no uv) | 213.1 ns | 163.4 ns (-23.3%) |
| `ticks ... uv` | 379.5 ns | 309.2 ns (-18.5%) |
| `ops` (async completion) | 324.1 ns | 318.6 ns (-1.7%, no regression) |

Checkpoints per tick, from the debug-only counter, measured on both sides by
instrumenting the base the same way: idle without uv goes 4.000 -> 1.000, idle
with uv goes 6.000 -> 2.000. The uv idle tick keeps two because the
always-active immediate check handle fires a real callback every tick, so the
phase-5 flush is a genuine callback invocation rather than a spurious
checkpoint.

Stacked on #36799, the combined idle-tick figure claimed by the revamp plan is
about -57% versus the pre-#36799 baseline (362.8 ns -> ~163 ns). Again: those
are the revamp repository's numbers, quoted rather than reproduced here.

## Verification

`cargo test -p deno_core --lib`: 477 passed, 2 ignored — identical to the
counts on #36799's branch, so no test changed behaviour. Note that the source
PR explicitly did *not* land this behind a runtime flag with the old path
retained; the A/B against the full spec-test and WPT suites is exactly what
this repository's CI is for, and is the gate this should be judged on.
