### PR TITLE
perf(core): remove the O(total-ops) bootstrap passes over Deno.core.ops

### DIFF
--- a/ext/node/polyfills/_repl_preview.js
+++ b/ext/node/polyfills/_repl_preview.js
@@ -1,11 +1,13 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-// Tiny IIFE-wrapped helper for `node:repl`'s inline preview path. Lives
-// here (rather than in `repl.ts`) because the deno_node ops we need are
-// only reachable from scripts loaded via `core.loadExtScript` -- those
-// see the snapshot-time `__bootstrap.core.ops` capture. ES-module
-// polyfills like `repl.ts` only see the post-`removeImportedOps` view,
-// which doesn't include `op_node_repl_inspector_connect`. See the long
+// Tiny IIFE-wrapped helper for `node:repl`'s inline preview path. Lives here
+// (rather than in `repl.ts`) because the deno_node ops we need used to be
+// reachable only from scripts loaded via `core.loadExtScript`, which read ops
+// through the captured `__bootstrap` view: `removeImportedOps()` stripped the
+// live `core.ops` in place, so an ES-module polyfill like `repl.ts` could not
+// see `op_node_repl_inspector_connect`. `core.ops` is no longer stripped (the
+// reduced, user-visible surface is now built separately with
+// `core.createOpsSubset`), so the split is now only structural. See the long
 // comment around `loadExtScript` / `op_set_captured_bootstrap` in
 // `libs/core/01_core.js`.
 

--- a/ext/node/polyfills/repl.ts
+++ b/ext/node/polyfills/repl.ts
@@ -331,10 +331,12 @@ interface PreviewSession {
   close(): void;
 }
 
-// The actual implementation lives in an IIFE-loaded script so it can
-// see the snapshot-time `core.ops` capture -- ES-module polyfills like
-// this file only see the post-`removeImportedOps` view, which doesn't
-// include `op_node_repl_inspector_connect`. See `_repl_preview.js`.
+// The actual implementation lives in an IIFE-loaded script so it can see
+// `core.ops` through the captured `__bootstrap` view. This used to be load
+// bearing: `removeImportedOps()` stripped the live `core.ops` in place, so
+// an ES-module polyfill like this file could not reach
+// `op_node_repl_inspector_connect` at all. `core.ops` is no longer stripped,
+// so the split is now only structural. See `_repl_preview.js`.
 const { createPreviewSession: _createPreviewSession } = core.loadExtScript(
   "ext:deno_node/_repl_preview.js",
 ) as { createPreviewSession(): PreviewSession | null };

--- a/libs/core/01_core.js
+++ b/libs/core/01_core.js
@@ -968,21 +968,48 @@
 
   const loadedScripts = { __proto__: null };
 
+  // `Deno.core.ops` is the single, canonical ops object. It is referenced (not
+  // copied) by the captured `__bootstrap` view that residual ext scripts are
+  // evaluated against, and -- once ops become lazily materialized properties --
+  // enumerating or copying it would defeat that laziness entirely.
+  //
+  // Embedders that want to expose a *reduced* ops surface to user code (Deno's
+  // `removeImportedOps()` historically did this by `delete`-ing ~940 entries in
+  // place) must therefore build a separate, smaller object instead of mutating
+  // this one. `createOpsSubset` is that blessed primitive: it is O(names), it
+  // never enumerates `ops`, and it is the single place that has to change if
+  // the backing representation of `ops` becomes lazy.
+  //
+  // Names that do not resolve to an op are skipped, so callers can pass a
+  // superset (e.g. ops that only exist in some builds) and get the same result
+  // that a filtering delete-sweep produced.
+  function createOpsSubset(names) {
+    const subset = { __proto__: null };
+    for (let i = 0; i < names.length; i++) {
+      const name = names[i];
+      const op = ops[name];
+      if (op !== undefined) {
+        subset[name] = op;
+      }
+    }
+    return subset;
+  }
+
   // Note: the Rust side of `op_load_ext_script` (in `libs/core/modules/map.rs`)
-  // temporarily reinstalls a captured snapshot-time view of `__bootstrap`
-  // on `globalThis` for the duration of each script evaluation if
-  // `__bootstrap` isn't already on the global. Every `lazy_loaded_js`
-  // polyfill's IIFE preamble destructures `globalThis.__bootstrap` and
-  // `__bootstrap.core.ops`, but at runtime (`runtime/js/99_main.js`) the
-  // harness deletes `globalThis.__bootstrap` and `removeImportedOps()`
-  // strips most entries out of `Deno.core.ops`. The captured view (a
-  // shallow clone of `core.ops` immune to `removeImportedOps`) is
-  // registered via `op_set_captured_bootstrap` at the end of this IIFE.
-  // Doing the install in Rust means the `synthetic_esm` dispatch path
-  // (which calls `load_ext_script` directly without going through this
-  // wrapper) gets the same treatment without leaving `__bootstrap`
-  // permanently on the global (where user code can observe it via
-  // `Object.keys`).
+  // passes a captured snapshot-time view of `__bootstrap` as the argument of
+  // each script's compiled wrapper function. Every `lazy_loaded_js` polyfill's
+  // IIFE preamble destructures `__bootstrap` and `__bootstrap.core.ops`, but at
+  // runtime (`runtime/js/99_main.js`) the harness deletes
+  // `globalThis.__bootstrap`. The captured view is registered via
+  // `op_set_captured_bootstrap` at the end of this IIFE.
+  //
+  // The captured view holds `core.ops` *by reference* -- see the note next to
+  // `createOpsSubset` below for the invariant embedders must uphold to keep
+  // that sound. Passing the value in from Rust means the `synthetic_esm`
+  // dispatch path (which calls `load_ext_script` directly without going
+  // through this wrapper) gets the same treatment without leaving
+  // `__bootstrap` permanently on the global (where user code can observe it
+  // via `Object.keys`).
   function loadExtScript(specifier) {
     if (specifier in loadedScripts) {
       return loadedScripts[specifier];
@@ -1288,6 +1315,7 @@
     propNonEnumerableLazyLoaded,
     defineGlobalProperties,
     createLazyLoader,
+    createOpsSubset,
     loadExtScript,
     createCancelHandle: () => op_cancel_handle(),
     getAsyncContext,
@@ -1303,13 +1331,17 @@
   ObjectFreeze(globalThis.__bootstrap.core);
 
   // Build the snapshot-time view of __bootstrap and hand it off to Rust.
-  // The Rust `load_ext_script` (libs/core/modules/map.rs) temporarily
-  // installs this on `globalThis.__bootstrap` for each script evaluation
-  // when the live `__bootstrap` has already been deleted (i.e. after
-  // runtime bootstrap). See the comment above `loadExtScript` earlier in
-  // this file for context.
+  // The Rust `load_ext_script` (libs/core/modules/map.rs) passes this value
+  // as the `__bootstrap` argument of each script evaluation, for when the
+  // live `__bootstrap` has already been deleted (i.e. after runtime
+  // bootstrap). See the comment above `loadExtScript` earlier in this file
+  // for context.
+  //
+  // `capturedCore.ops` is the *live* ops object, not a copy: copying it here
+  // was O(total ops) on every realm and would force materialization of every
+  // op once ops become lazy properties. Embedders must not strip ops by
+  // mutating `core.ops` -- see `createOpsSubset`.
   const capturedCore = ObjectAssign({ __proto__: null }, core);
-  capturedCore.ops = ObjectAssign({ __proto__: null }, core.ops);
   const capturedBootstrap = {
     __proto__: null,
     primordials: globalThis.__bootstrap.primordials,

--- a/libs/core/core.d.ts
+++ b/libs/core/core.d.ts
@@ -61,8 +61,23 @@ export namespace core {
   /**
    * List of all registered ops, in the form of a map that maps op
    * name to function.
+   *
+   * This object is canonical and must not be mutated: the captured
+   * `__bootstrap` view that residual ext scripts are evaluated against holds
+   * it by reference, and enumerating or copying it is O(total ops) per realm.
+   * To expose a reduced ops surface to user code, build a separate object
+   * with {@linkcode createOpsSubset} instead of deleting entries here.
    */
   const ops: Record<string, (...args: unknown[]) => any>;
+
+  /**
+   * Build a new null-prototype object containing only the named ops, without
+   * enumerating or mutating {@linkcode ops}. Names that don't resolve to an
+   * op are skipped, so a superset may be passed.
+   */
+  function createOpsSubset(
+    names: readonly string[],
+  ): Record<string, (...args: unknown[]) => any>;
 
   /**
    * Retrieve a list of all open resources, in the form of a map that maps

--- a/libs/core/modules/map/ext_script.rs
+++ b/libs/core/modules/map/ext_script.rs
@@ -596,8 +596,8 @@ impl ModuleMap {
     drop(data);
 
     // Each script's IIFE preamble destructures the snapshot-time
-    // `__bootstrap` view (a frozen clone of `core.ops` captured before
-    // `removeImportedOps()` runs). To avoid leaving `__bootstrap` on
+    // `__bootstrap` view (a shallow clone of `core` that references the live,
+    // never-stripped `core.ops` object). To avoid leaving `__bootstrap` on
     // `globalThis` (where user code or `Object.keys` would see it), we
     // compile the source as the body of a function with one named
     // parameter `__bootstrap` and invoke it with the captured value. The
@@ -763,13 +763,6 @@ impl ModuleMap {
   /// it.
   pub(crate) fn set_captured_bootstrap(&self, value: v8::Global<v8::Value>) {
     *self.data.borrow().captured_bootstrap.borrow_mut() = Some(value);
-  }
-
-  /// The snapshot-time `__bootstrap` view stashed by `set_captured_bootstrap`,
-  /// if any. Used by the deferred fast-call upgrade to also update the cloned
-  /// `core.ops` that residual ext modules read through.
-  pub(crate) fn captured_bootstrap(&self) -> Option<v8::Global<v8::Value>> {
-    self.data.borrow().captured_bootstrap.borrow().clone()
   }
 }
 

--- a/libs/core/modules/module_map_data.rs
+++ b/libs/core/modules/module_map_data.rs
@@ -230,7 +230,8 @@ pub(crate) struct ModuleMapData {
     Rc<RefCell<HashMap<ModuleName, ModuleName>>>,
   /// Set of scripts currently being loaded (for circular dep detection).
   pub(crate) lazy_script_loading: Rc<RefCell<HashSet<ModuleName>>>,
-  /// Snapshot-time `__bootstrap` view (frozen clone of `core.ops` etc.)
+  /// Snapshot-time `__bootstrap` view (a shallow clone of `core`, holding the
+  /// live `core.ops` object by reference)
   /// registered from JS via `op_set_captured_bootstrap`. `load_ext_script`
   /// temporarily installs this on `globalThis.__bootstrap` for the duration
   /// of each script evaluation if `__bootstrap` isn't already on the global

--- a/libs/core/modules/testdata/lazy_script_bootstrap_ops.js
+++ b/libs/core/modules/testdata/lazy_script_bootstrap_ops.js
@@ -1,0 +1,15 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+// Mirrors the `__bootstrap` IIFE preamble that ~160 of deno's residual ext
+// polyfills use: destructure the captured bootstrap view and pull ops off
+// `core.ops` at load (module-body) time, long after the runtime bootstrap has
+// deleted `globalThis.__bootstrap` and reduced the user-visible ops surface.
+(function () {
+const core = __bootstrap.core;
+const { op_bootstrap_add } = core.ops;
+return {
+  addIsFunction: typeof op_bootstrap_add === "function",
+  sum: op_bootstrap_add(40, 2),
+  viaOpsObject: core.ops.op_bootstrap_add(1, 2),
+  bootstrapDeleted: typeof globalThis.__bootstrap === "undefined",
+};
+})();

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -828,6 +828,93 @@ fn test_lazy_loaded_script() {
     .unwrap();
 }
 
+/// Regression guard for the captured-`__bootstrap` contract that deno's
+/// residual ext polyfills depend on (deno_core_revamp#39(b)).
+///
+/// `capturedCore.ops` used to be an `ObjectAssign` clone of `core.ops`, made so
+/// that it would survive deno's `removeImportedOps()` deleting ~940 entries out
+/// of the live ops object. It is now the live object itself, so this test pins
+/// down the two halves of the replacement contract:
+///
+///  1. a residual ext script destructuring `__bootstrap.core.ops` at load time
+///     still sees every op, after `globalThis.__bootstrap` is gone, and
+///  2. `core.createOpsSubset()` is the supported way to derive the reduced,
+///     user-visible ops surface -- without enumerating or mutating `core.ops`.
+#[test]
+fn test_lazy_loaded_script_captured_bootstrap_ops() {
+  #[op2(fast)]
+  fn op_bootstrap_add(a: u32, b: u32) -> u32 {
+    a + b
+  }
+
+  deno_core::extension!(
+    test_ext,
+    ops = [op_bootstrap_add],
+    lazy_loaded_js =
+      [dir "modules/testdata", "lazy_script_bootstrap_ops.js"]
+  );
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![test_ext::init()],
+    ..Default::default()
+  });
+
+  runtime
+    .execute_script(
+      "test_captured_bootstrap_ops.js",
+      r#"
+      const core = Deno.core;
+      function assert(cond, msg) {
+        if (!cond) throw new Error(msg);
+      }
+
+      // Derive the reduced user-visible surface the way an embedder now
+      // should: build a subset instead of deleting out of `core.ops`.
+      const userVisibleOps = core.createOpsSubset([
+        "op_add_main_module_handler",
+        "op_op_that_does_not_exist",
+      ]);
+      assert(
+        typeof userVisibleOps.op_add_main_module_handler === "function",
+        "subset should carry ops that exist",
+      );
+      assert(
+        !("op_op_that_does_not_exist" in userVisibleOps),
+        "subset should skip ops that don't exist",
+      );
+      assert(
+        !("op_bootstrap_add" in userVisibleOps),
+        "subset should not carry ops outside the allowlist",
+      );
+      assert(
+        Object.getPrototypeOf(userVisibleOps) === null,
+        "subset should be null-prototype",
+      );
+      // Building the subset must not disturb the canonical ops object.
+      assert(
+        typeof core.ops.op_bootstrap_add === "function",
+        "core.ops must not be mutated by createOpsSubset",
+      );
+
+      // Reproduce the runtime bootstrap teardown.
+      delete globalThis.__bootstrap;
+      assert(
+        typeof globalThis.__bootstrap === "undefined",
+        "__bootstrap should be gone",
+      );
+
+      const mod = core.loadExtScript(
+        "ext:test_ext/lazy_script_bootstrap_ops.js",
+      );
+      assert(mod.bootstrapDeleted, "script saw a global __bootstrap");
+      assert(mod.addIsFunction, "destructured op was not a function");
+      assert(mod.sum === 42, "destructured op returned " + mod.sum);
+      assert(mod.viaOpsObject === 3, "core.ops.op_x() returned " + mod.viaOpsObject);
+      "#,
+    )
+    .unwrap();
+}
+
 #[test]
 fn test_lazy_loaded_script_not_found() {
   deno_core::extension!(test_ext);

--- a/libs/core/runtime/bindings.rs
+++ b/libs/core/runtime/bindings.rs
@@ -617,13 +617,6 @@ pub(crate) fn upgrade_snapshotted_ops_with_fast_calls<'s, 'i>(
   // deferred caller can no longer read them from the global (see
   // `snapshotted_fast_op_refs` / `ensure_fast_ops_upgraded`).
   deno_core_ops_obj: v8::Local<'s, v8::Object>,
-  // The captured-bootstrap clone of `Deno.core.ops` (`capturedCore.ops` in
-  // 01_core.js) that residual ext modules read ops through. The flat-op `.set`s
-  // below replace slots on the ops object, which the shallow clone doesn't see;
-  // mirror them here so residual ext modules get the fast functions too.
-  // (Method/static-method upgrades mutate the shared class objects that the
-  // clone already references, so they need no mirroring.)
-  clone_ops_obj: Option<v8::Local<'s, v8::Object>>,
   set_up_async_stub_fn: v8::Local<'s, v8::Function>,
   op_ctxs: &[OpCtx],
   op_method_decls: &[OpMethodDecl],
@@ -710,9 +703,6 @@ pub(crate) fn upgrade_snapshotted_ops_with_fast_calls<'s, 'i>(
     }
 
     deno_core_ops_obj.set(scope, key.into(), op_fn.into());
-    if let Some(clone_ops_obj) = clone_ops_obj {
-      clone_ops_obj.set(scope, key.into(), op_fn.into());
-    }
   }
 }
 
@@ -759,26 +749,13 @@ pub(crate) fn ensure_fast_ops_upgraded(scope: &mut v8::PinScope) {
   let deno_core_ops_obj = v8::Local::new(scope, &ops_global);
   let set_up_async_stub_fn = v8::Local::new(scope, &stub_global);
 
-  // Residual ext modules read ops through the captured-bootstrap clone of
-  // `core.ops` (`capturedCore.ops` in 01_core.js), a shallow copy that the
-  // flat-op `.set`s below otherwise wouldn't reach. Resolve `<captured>.core
-  // .ops` so the upgrade can mirror the fast functions onto it.
-  let module_map = JsRealm::module_map_from(scope);
-  let clone_ops_obj = module_map.captured_bootstrap().and_then(|g| {
-    let captured = v8::Local::new(scope, &g);
-    let captured = v8::Local::<v8::Object>::try_from(captured).ok()?;
-    let core_key = CORE.v8_string(scope).unwrap();
-    let core = captured.get(scope, core_key.into())?;
-    let core = v8::Local::<v8::Object>::try_from(core).ok()?;
-    let ops_key = OPS.v8_string(scope).unwrap();
-    let ops = core.get(scope, ops_key.into())?;
-    v8::Local::<v8::Object>::try_from(ops).ok()
-  });
-
+  // NOTE: `capturedCore.ops` (01_core.js) is the *same* object as
+  // `deno_core_ops_obj`, so the `.set`s below are observed by residual ext
+  // modules with no mirroring pass. (It used to be a shallow clone, which had
+  // to be resolved and written through here as well.)
   upgrade_snapshotted_ops_with_fast_calls(
     scope,
     deno_core_ops_obj,
-    clone_ops_obj,
     set_up_async_stub_fn,
     &context_state.op_ctxs,
     &context_state.op_method_decls,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -5,7 +5,6 @@ delete Intl.v8BreakIterator;
 
 const internalConsole = core.loadExtScript("ext:deno_web/01_console.js");
 import { core, internals, primordials } from "ext:core/mod.js";
-const ops = core.ops;
 import {
   op_bootstrap_args,
   op_bootstrap_is_from_unconfigured_runtime,
@@ -754,18 +753,47 @@ const WORKER_EXCLUDED_OPS = [
   "op_desktop_write_clipboard_text",
 ];
 
-function removeImportedOps(isWorker = false) {
-  const allOpNames = ObjectKeys(ops);
-  for (let i = 0; i < allOpNames.length; i++) {
-    const opName = allOpNames[i];
-    if (isWorker && ArrayPrototypeIncludes(WORKER_EXCLUDED_OPS, opName)) {
-      delete ops[opName];
-      continue;
-    }
-    if (!ArrayPrototypeIncludes(NOT_IMPORTED_OPS, opName)) {
-      delete ops[opName];
-    }
+// The user-visible ops object, built up from `NOT_IMPORTED_OPS` instead of by
+// deleting the ~940 other entries out of `core.ops`. Three reasons:
+//
+//  * `core.ops` is canonical. deno_core's captured `__bootstrap` view -- the
+//    object every residual ext polyfill is evaluated against -- now holds it
+//    by reference rather than as an `ObjectAssign` clone, so stripping it in
+//    place would strip it for those polyfills too.
+//  * the old sweep was `ObjectKeys` over ~1,005 names x an up-to-64-entry
+//    linear scan plus ~940 `delete`s, which also forced `core.ops` into
+//    dictionary mode. It ran three times per runtime. This is O(64) and runs
+//    at most once, lazily.
+//  * once ops become lazily materialized properties, any enumeration of
+//    `core.ops` forces every op into existence at bootstrap -- and under a
+//    named-property interceptor `ObjectKeys` stops seeing them at all, so a
+//    delete sweep would silently stop stripping anything.
+//
+// `core.createOpsSubset` reads only the listed names and skips the ones this
+// binary/subcommand doesn't register, which is exactly the set the delete
+// sweep left behind. Only the `ObjectKeys` *order* changes: declaration order
+// rather than op-registration order.
+//
+// Deferring the build to first access (rather than doing it while
+// `userVisibleCore` is assembled, which happens at snapshot-build time) keeps
+// two properties of the old code: the entries are the fast-call-upgraded op
+// functions, and nothing is paid by runtimes that never touch
+// `Deno[Deno.internal].core.ops`. It is also what lets the worker exclusions
+// below work: whether this is a worker scope is only known once one of the
+// bootstrap functions has run.
+let isWorkerScope = false;
+let userVisibleOps;
+function getUserVisibleOps() {
+  if (userVisibleOps === undefined) {
+    const names = isWorkerScope
+      ? ArrayPrototypeFilter(
+        NOT_IMPORTED_OPS,
+        (name) => !ArrayPrototypeIncludes(WORKER_EXCLUDED_OPS, name),
+      )
+      : NOT_IMPORTED_OPS;
+    userVisibleOps = core.createOpsSubset(names);
   }
+  return userVisibleOps;
 }
 
 // `Deno[Deno.internal]` is reachable from user code. Preserve its existing
@@ -774,6 +802,13 @@ function removeImportedOps(isWorker = false) {
 const userVisibleCoreDescriptors = getSafeOwnPropertyDescriptors(core);
 delete userVisibleCoreDescriptors.createLazyLoader;
 delete userVisibleCoreDescriptors.loadExtScript;
+userVisibleCoreDescriptors.ops = {
+  __proto__: null,
+  get: getUserVisibleOps,
+  set: undefined,
+  enumerable: true,
+  configurable: false,
+};
 const userVisibleCore = ObjectFreeze(ObjectDefineProperties(
   { __proto__: null },
   userVisibleCoreDescriptors,
@@ -1050,8 +1085,6 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
       });
     }
 
-    removeImportedOps();
-
     performance.setTimeOrigin();
     globalThis_ = globalThis;
 
@@ -1231,7 +1264,8 @@ function bootstrapWorkerRuntime(
 
     closeOnIdle = runtimeOptions[14];
 
-    removeImportedOps(true);
+    // Consulted lazily by `getUserVisibleOps()`; see `WORKER_EXCLUDED_OPS`.
+    isWorkerScope = true;
 
     performance.setTimeOrigin();
     globalThis_ = globalThis;
@@ -1393,8 +1427,6 @@ event.defineEventHandler(globalThis, "unhandledrejection");
 
 // Nothing listens to this, but it warms up the code paths for event dispatch
 (new event.EventTarget()).dispatchEvent(new event.Event("warmup"));
-
-removeImportedOps();
 
 // Run the warmup path through node and runtime/worker bootstrap functions
 bootstrapMainRuntime(undefined, true);

--- a/runtime/ops/desktop.rs
+++ b/runtime/ops/desktop.rs
@@ -1377,7 +1377,7 @@ fn op_desktop_alert(
 }
 
 /// True while an error dialog is on screen. Single-flight at the native
-/// boundary: this op sits on `core.ops` and survives `removeImportedOps()`,
+/// boundary: this op sits on `core.ops` and is in `NOT_IMPORTED_OPS`,
 /// so it is reachable by any code in the runtime, not only the error handler
 /// that respects its own `_exiting` flag. Without a guard here, a loop
 /// calling it directly would park an unbounded number of pool threads, each
@@ -1596,7 +1596,7 @@ fn op_desktop_send_error_report(state: &mut OpState, #[string] body: &str) {
   // The report destination is operator config — it is baked into the app at
   // build time (`error_reporting_url`) and stored in `ERROR_REPORT_CONFIG`.
   // It is deliberately NOT accepted from JS: this op is exposed on
-  // `core.ops` and survives `removeImportedOps()`, so any (untrusted) code
+  // `core.ops` and is in `NOT_IMPORTED_OPS`, so any (untrusted) code
   // in the runtime can call it. Trusting a caller-supplied URL would turn
   // this into an unrestricted file-append (`file://`) or network-POST
   // (`https://`) primitive that bypasses the `--allow-write`/`--allow-net`

--- a/tests/specs/run/desktop_error_report_no_escape/main.js
+++ b/tests/specs/run/desktop_error_report_no_escape/main.js
@@ -1,7 +1,7 @@
 // Regression test for a sandbox-escape via `op_desktop_send_error_report`.
 //
-// The op is exposed on `Deno[Deno.internal].core.ops` and survives
-// `removeImportedOps()` (it's in NOT_IMPORTED_OPS), so untrusted code can
+// The op is exposed on `Deno[Deno.internal].core.ops` because it is listed in
+// `NOT_IMPORTED_OPS` in `99_main.js`, so untrusted code can
 // call it in a plain `deno run`. It used to accept a caller-supplied `url`
 // and, without any permission check, append to that `file://` path (a
 // `--allow-write` bypass) or POST to that `https://` URL (a `--allow-net`


### PR DESCRIPTION
Ports denoland/deno_core_revamp#44, and lands with it the `runtime/js/99_main.js`
half that PR shipped as a verbatim patch rather than as code. Neither half is
correct alone, which is why they are together here.

`01_core.js` built the captured `__bootstrap` view -- the object every residual
ext polyfill is evaluated against -- by copying `core.ops` wholesale with
`ObjectAssign`. The copy existed for exactly one reason: `removeImportedOps()`
deletes ~940 entries out of the live `core.ops` during bootstrap, and the
`__bootstrap`-style polyfills that destructure their ops at load time run after
that, so the clone was the thing that survived the sweep. The captured view now
holds the live ops object by reference, `core.ops` becomes canonical and is
documented as such, and embedders that want a reduced user-visible surface build
a separate object with the new `core.createOpsSubset(names)` -- O(names), never
enumerating `ops`, and the one place that has to change when ops become lazily
materialized properties.

That also deletes the mirroring half of the deferred fast-call upgrade.
`ensure_fast_ops_upgraded` used to resolve `<captured>.core.ops` out of the
module map and write every fast op function twice, once to each object;
`upgrade_snapshotted_ops_with_fast_calls` loses its `clone_ops_obj` parameter and
~1,000 redundant property sets, and `ModuleMap::captured_bootstrap()` is gone.

On the deno side, `removeImportedOps()` is replaced by building the user-visible
surface directly from `NOT_IMPORTED_OPS`, hung off `userVisibleCore` -- which is
the only object through which user code reaches ops, since `globalThis.Deno` is
replaced by `finalDenoNs` and `globalThis.__bootstrap` is deleted. It is O(64)
instead of `ObjectKeys` over ~1,005 names times an up-to-64-entry linear scan
plus ~940 `delete`s, it runs at most once per runtime instead of three times, it
never puts `core.ops` into dictionary mode, and it composes with the interceptor
that follows in the next PR: an allowlist read is exactly what a
deny-list-consulting interceptor wants, whereas `ObjectKeys` + `delete` silently
becomes a no-op under an interceptor and stops stripping anything at all.
Deferring the build to first access preserves two properties of the old code:
the entries are the fast-call-upgraded functions, and runtimes that never touch
`Deno[Deno.internal].core.ops` pay nothing.

One adaptation was needed relative to the revamp patch. Upstream
`removeImportedOps` has since grown an `isWorker` parameter and a
`WORKER_EXCLUDED_OPS` list (the clipboard ops, which must not be reachable from
a plain `new Worker(...)`). Since the subset is now built lazily on first
access, whether this is a worker scope has to be recorded rather than passed:
`bootstrapWorkerRuntime` sets an `isWorkerScope` flag where it used to call
`removeImportedOps(true)`, and `getUserVisibleOps()` filters
`WORKER_EXCLUDED_OPS` out of the allowlist when it is set. Both bootstrap
functions guard their bodies with `if (!warmup)`, so the snapshot-time warmup
passes never reach the flag or the getter and cannot bake a scope decision into
the blob.

The exposed set is unchanged. `createOpsSubset` skips names this
binary/subcommand does not register, which is precisely what the delete sweep
left behind, so `tests/unit/ops_test.ts` (`EXPECTED_OP_COUNT`,
`EXPECTED_WORKER_OP_COUNT`) needed no update -- both assert on length and
membership only. The one observable change is `Object.keys` *order*: declaration
order rather than op-registration order. A few comments in `ext/node/polyfills/`
and `runtime/ops/desktop.rs` described `removeImportedOps` stripping `core.ops`
in place and are corrected; in particular `_repl_preview.js` existed because an
ES-module polyfill could not reach `op_node_repl_inspector_connect` after the
sweep, which is no longer true, so the split there is now only structural.

As measured in denoland/deno_core_revamp#44, this is a blob-size win rather than
a per-runtime one, because `01_core.js` is in `BUILTIN_SOURCES` and
`execute_builtin_sources` is gated on `InitMode::New` -- under a snapshot the
`ObjectAssign` already ran at snapshot-build time and the *result*, a second
~1,005-slot dictionary-mode object, was baked into the blob. Marginal cost there
was 15.24 B per op removed from the snapshot (-1,328 B at 99 ops, -4,376 B at
299 ops), which extrapolates to roughly 15.3 KB of blob at deno's ~1,005 ops,
plus one fewer ~1,005-entry dictionary object to deserialize per realm.
`JsRuntime::new` from a snapshot was unchanged within noise at that scale.

The regression guard that matters is the new
`test_lazy_loaded_script_captured_bootstrap_ops`: a residual ext script that
destructures `__bootstrap.core.ops` at load time -- after
`globalThis.__bootstrap` is deleted -- still resolves and calls its op, and
`createOpsSubset` produces a null-prototype object with the listed ops, skips
unregistered names, excludes everything else, and leaves `core.ops` untouched.

The `op_scale_probe` example the revamp PR also carries is measurement
infrastructure specific to that repo and is not ported.
