### PR TITLE
perf(core): materialize Deno.core.ops lazily via a named-property interceptor

### DIFF
--- a/libs/core/ops_builtin_v8.rs
+++ b/libs/core/ops_builtin_v8.rs
@@ -185,9 +185,6 @@ pub fn op_lazy_load_esm(
   scope: &mut v8::PinScope,
   #[string] module_specifier: String,
 ) -> Result<v8::Global<v8::Value>, CoreError> {
-  // First residual ESM load: run the deferred fast-call op upgrade so this
-  // module's body captures the fast op overloads. No-op after the first call.
-  crate::runtime::bindings::ensure_fast_ops_upgraded(scope);
   let module_map_rc = JsRealm::module_map_from(scope);
   // `synthetic_esm` registrations don't live in `lazy_esm_sources`, so
   // route them through their own sync-load path. `createLazyLoader` calls
@@ -205,9 +202,6 @@ pub fn op_load_ext_script(
   scope: &mut v8::PinScope,
   #[string] specifier: String,
 ) -> Result<v8::Global<v8::Value>, CoreError> {
-  // First residual ext-script load: run the deferred fast-call op upgrade so
-  // this script captures the fast op overloads. No-op after the first call.
-  crate::runtime::bindings::ensure_fast_ops_upgraded(scope);
   let module_map_rc = JsRealm::module_map_from(scope);
   module_map_rc.load_ext_script(scope, &specifier)
 }

--- a/libs/core/runtime/bindings.rs
+++ b/libs/core/runtime/bindings.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+use std::cell::Cell;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;
@@ -39,6 +41,7 @@ use crate::modules::get_requested_module_type_from_attributes;
 use crate::modules::parse_import_attributes;
 use crate::modules::synthetic_module_evaluation_steps;
 use crate::ops::OpCtx;
+use crate::runtime::ContextState;
 use crate::runtime::InitMode;
 use crate::runtime::JsRealm;
 
@@ -51,7 +54,8 @@ pub(crate) fn create_external_references(
 ) -> Vec<v8::ExternalReference> {
   // Overallocate a bit, it's better than having to resize the vector.
   let mut references = Vec::with_capacity(
-    6 + CONTEXT_SETUP_SOURCES.len()
+    6 + 3 // lazy-ops interceptor callbacks
+      + CONTEXT_SETUP_SOURCES.len()
       + BUILTIN_SOURCES.len()
       + (ops.len() * 4)
       + additional_references.len()
@@ -80,6 +84,20 @@ pub(crate) fn create_external_references(
 
   references.push(v8::ExternalReference {
     function: cppgc_template_constructor.map_fn_to(),
+  });
+
+  // The `Deno.core.ops` named-property interceptor (see [`LazyOps`]). Three
+  // entries for the whole runtime, regardless of op count -- the per-op
+  // discriminator is the property name, resolved against the `OpCtx` table at
+  // call time, so this costs nothing per op.
+  references.push(v8::ExternalReference {
+    named_getter: lazy_ops_getter.map_fn_to(),
+  });
+  references.push(v8::ExternalReference {
+    named_query: lazy_ops_query.map_fn_to(),
+  });
+  references.push(v8::ExternalReference {
+    enumerator: lazy_ops_enumerator.map_fn_to(),
   });
 
   // Using v8::OneByteConst and passing external references to it
@@ -347,8 +365,30 @@ pub(crate) fn initialize_deno_core_namespace<'s, 'i>(
 
   let deno_obj = v8::Object::new(scope);
   let deno_core_key = CORE.v8_string(scope).unwrap();
-  // Set up `Deno.core.ops` object
-  let deno_core_ops_obj = v8::Object::new(scope);
+  // Set up the `Deno.core.ops` object. It carries a named-property
+  // interceptor and *no* op properties of its own: op functions are
+  // materialized by [`lazy_ops_getter`] on first access. See [`LazyOps`] for
+  // why, and for the enumeration semantics the query/enumerator callbacks
+  // give us.
+  let deno_core_ops_obj = {
+    let tmpl = v8::ObjectTemplate::new(scope);
+    tmpl.set_named_property_handler(
+      v8::NamedPropertyHandlerConfiguration::new()
+        .getter(lazy_ops_getter)
+        .query(lazy_ops_query)
+        .enumerator(lazy_ops_enumerator)
+        // NON_MASKING: real own properties always win, so anything an
+        // embedder or user assigns to `Deno.core.ops` shadows the op of the
+        // same name exactly as it did when ops were plain data properties.
+        // ONLY_INTERCEPT_STRINGS: op names are strings; symbol lookups skip
+        // the interceptor entirely.
+        .flags(
+          v8::PropertyHandlerFlags::NON_MASKING
+            | v8::PropertyHandlerFlags::ONLY_INTERCEPT_STRINGS,
+        ),
+    );
+    tmpl.new_instance(scope).unwrap()
+  };
   let deno_core_ops_key = OPS.v8_string(scope).unwrap();
 
   let deno_core_obj = v8::Object::new(scope);
@@ -429,13 +469,16 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s, 'i>(
 ) {
   let global = context.global(scope);
 
-  // Set up JavaScript bindings for the defined op - this will insert proper
-  // `v8::Function` into `Deno.core.ops` object. For async ops, there a bit
-  // more machinery involved, see comment below.
+  // Nothing here writes op properties onto `Deno.core.ops` any more: every
+  // entry of that object is materialized on demand by [`lazy_ops_getter`].
+  // What still has to happen eagerly is building the cppgc class *templates*,
+  // because they are registered in the runtime-wide `FunctionTemplateData`
+  // (cppgc wrapping resolves them by type name) and because `inherit()`
+  // requires the parent template to exist by the time the child is built.
+  // The class *functions* are still lazy -- the interceptor pulls them out of
+  // the template store.
   let deno_obj = get(scope, global, DENO, "Deno");
   let deno_core_obj = get(scope, deno_obj, CORE, "Deno.core");
-  let deno_core_ops_obj: v8::Local<v8::Object> =
-    get(scope, deno_core_obj, OPS, "Deno.core.ops");
 
   let set_up_async_stub_fn: v8::Local<v8::Function> = get(
     scope,
@@ -445,7 +488,6 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s, 'i>(
   );
 
   let prototype_key = v8::String::new(scope, "prototype").unwrap();
-  let undefined = v8::undefined(scope);
   let mut index = 0;
 
   for decl in op_method_decls {
@@ -566,201 +608,447 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s, 'i>(
       }
     }
 
-    deno_core_ops_obj.set(scope, key.into(), op_fn.into());
-
     let id = (decl.type_name)().to_string();
     fn_template_store.insert(id, v8::Global::new(scope, tmpl));
   }
+}
 
-  let op_ctxs = &op_ctxs[index..];
-  for op_ctx in op_ctxs {
-    let constructor_behavior = op_ctx_constructor_behavior(op_ctx);
-    let mut op_fn = if will_snapshot && !op_ctx.decl().constructable {
-      op_ctx_plain_function(scope, op_ctx, constructor_behavior)
-    } else {
-      op_ctx_function(scope, op_ctx, constructor_behavior, will_snapshot)
-    };
-    let key = op_ctx.decl().name_fast.v8_string(scope).unwrap();
+// ===========================================================================
+// Lazily materialized `Deno.core.ops`
+// ===========================================================================
 
-    // For async ops we need to set them up, by calling `Deno.core.setUpAsyncStub` -
-    // this call will generate an optimized function that binds to the provided
-    // op, while keeping track of promises and error remapping.
-    if op_ctx.decl().is_async {
-      let result = set_up_async_stub_fn
-        .call(scope, undefined.into(), &[key.into(), op_fn.into()])
-        .unwrap();
-      op_fn = result.try_into().unwrap()
-    }
+/// Longest op name the interceptor will resolve without allocating. Op names
+/// are ASCII identifiers; anything longer than this is definitively not one,
+/// so the interceptor can decline it outright.
+const MAX_OP_NAME_LEN: usize = 96;
 
-    deno_core_ops_obj.set(scope, key.into(), op_fn.into());
+/// Which entry of the op tables a `Deno.core.ops` property name resolves to.
+#[derive(Clone, Copy)]
+enum LazyOpSlot {
+  /// A plain op: index into [`ContextState::op_ctxs`].
+  Op(u32),
+  /// A cppgc class: index into [`ContextState::op_method_decls`], plus the
+  /// index of the first `OpCtx` belonging to that class.
+  Class { decl: u32, ctx: u32 },
+}
+
+struct LazyOpEntry {
+  slot: LazyOpSlot,
+  /// The op's name as a `FastStaticString`, so the enumerator can hand V8 the
+  /// same externalized one-byte string the rest of the runtime uses.
+  name: FastStaticString,
+  /// The materialized function, once something has read this property. Held
+  /// as a strong `Global` (not a weak handle) so identity survives GC:
+  /// `core.ops.op_foo === core.ops.op_foo` must hold forever.
+  func: Option<v8::Global<v8::Function>>,
+}
+
+/// Per-realm state behind the `Deno.core.ops` named-property interceptor.
+///
+/// # Why an interceptor
+///
+/// `Deno.core.ops` used to be an ordinary object carrying one `v8::Function`
+/// property per registered op. In a snapshot-based runtime that costs ~284
+/// bytes of blob and ~0.55 µs of `JsRuntime::new` *per op*, paid by every
+/// runtime and every worker whether or not the op is ever read. Almost all of
+/// it is the function objects themselves, so the fix is to not create them.
+///
+/// The ops object is now built from an `ObjectTemplate` carrying a single
+/// named-property handler and *no* op properties. Nothing about an op reaches
+/// the blob except its `OpCtx` and the four external references it already
+/// contributed (measured at 0.065 B/op). The first read of `core.ops.op_foo`
+/// runs [`lazy_ops_getter`], which builds the function -- with its fast-call
+/// overload, its name and, for async ops, its `setUpAsyncStub` wrapper -- and
+/// memoizes it here.
+///
+/// # Why this also deletes the deferred fast-call upgrade
+///
+/// V8 14.9+ refuses to serialize the `Managed<CFunctionWithSignature>` a
+/// fast-call overload needs, so a snapshot baked the *slow* version of every
+/// op function and a post-deserialization pass
+/// (`upgrade_snapshotted_ops_with_fast_calls`, O(all ops), ~0.9 ms on a real
+/// Deno worker) rebuilt them. Nothing on `core.ops` is baked any more: every
+/// function is built after deserialization, on demand, already fast. The pass
+/// and its `deferred_fast_ops` / `fast_ops_upgraded` plumbing are gone.
+///
+/// # Enumeration semantics
+///
+/// A getter-only interceptor is invisible to `OwnPropertyKeys`, which would
+/// have silently changed `Object.keys(core.ops)` to `[]`. Instead the handler
+/// also carries a query and an enumerator callback, so `Object.keys`,
+/// `for..in`, `in` and `hasOwnProperty` all report the full op set *without*
+/// materializing a single function -- enumeration is served straight from the
+/// name table. `Object.getOwnPropertyDescriptor` does materialize, because it
+/// has to produce a value.
+///
+/// Two behaviours do change, both documented in the module's
+/// breaking-notes and both already accounted for by `createOpsSubset`:
+/// `delete core.ops.op_foo` no longer removes the op (there is no deleter
+/// callback, and the interceptor keeps serving it), and assigning to
+/// `core.ops.op_foo` shadows the op with a real own property rather than
+/// replacing it.
+#[derive(Default)]
+pub(crate) struct LazyOps {
+  /// Name -> slot, built on the first interceptor hit and never rebuilt.
+  /// `None` until then; runtimes that never touch `core.ops` never pay for it.
+  table: RefCell<Option<HashMap<&'static str, LazyOpEntry>>>,
+  /// `Deno.core.setUpAsyncStub`, captured while `Deno.core` is still on the
+  /// global. Async ops materialized after bootstrap (which scrubs `Deno.core`
+  /// from the public `Deno`) cannot read it from there any more.
+  set_up_async_stub: RefCell<Option<v8::Global<v8::Function>>>,
+  /// Build op functions without fast-call overloads (snapshot build only).
+  will_snapshot: Cell<bool>,
+  /// The cppgc class templates came out of a snapshot, so their prototype and
+  /// static methods are the slow variants and need re-attaching when the class
+  /// is first read. False when this runtime built the templates itself.
+  classes_need_fast_call_upgrade: Cell<bool>,
+}
+
+impl LazyOps {
+  /// Record how op functions must be materialized in this realm. Called once,
+  /// from `JsRuntime::new_inner`, while `Deno.core` is still reachable.
+  pub(crate) fn configure(
+    &self,
+    set_up_async_stub: v8::Global<v8::Function>,
+    will_snapshot: bool,
+    classes_need_fast_call_upgrade: bool,
+  ) {
+    *self.set_up_async_stub.borrow_mut() = Some(set_up_async_stub);
+    self.will_snapshot.set(will_snapshot);
+    self
+      .classes_need_fast_call_upgrade
+      .set(classes_need_fast_call_upgrade);
+  }
+
+  /// Drop every V8 handle held here. Used before snapshotting, where the
+  /// materialized functions are already reachable from the `ext:core/ops`
+  /// export cells and this cache must not keep the isolate's handles alive
+  /// past teardown.
+  pub(crate) fn clear(&self) {
+    self.table.borrow_mut().take();
+    self.set_up_async_stub.borrow_mut().take();
   }
 }
 
-/// Re-attach fast-call overloads to snapshotted ops after deserialization.
-///
-/// Fast-call setup creates V8 `Managed<CFunctionWithSignature>` resources,
-/// which the V8 14.9 snapshot serializer rejects (see `op_ctx_template`), so
-/// the snapshot bakes the slow version of every op function. This pass builds
-/// fresh fast-call-equipped functions for each op that declares a `fast_fn`
-/// and overwrites:
-///
-/// 1. the top-level entries in `Deno.core.ops`,
-/// 2. instance methods on each cppgc class prototype,
-/// 3. static methods on each cppgc class function itself.
-///
-/// Accessors stay as-is because they're built with plain
-/// `FunctionTemplate::build` (no `Managed`) and survived the snapshot.
-pub(crate) fn upgrade_snapshotted_ops_with_fast_calls<'s, 'i>(
-  scope: &mut v8::PinScope<'s, 'i>,
-  // `Deno.core.ops` and `Deno.core.setUpAsyncStub`, passed in directly because
-  // `Deno.core` is scrubbed from the public `Deno` after bootstrap and the
-  // deferred caller can no longer read them from the global (see
-  // `snapshotted_fast_op_refs` / `ensure_fast_ops_upgraded`).
-  deno_core_ops_obj: v8::Local<'s, v8::Object>,
-  set_up_async_stub_fn: v8::Local<'s, v8::Function>,
-  op_ctxs: &[OpCtx],
-  op_method_decls: &[OpMethodDecl],
-  methods_ctx_offset: usize,
-) {
-  let prototype_key = v8::String::new(scope, "prototype").unwrap();
-  let undefined = v8::undefined(scope);
-
-  let mut index = 0;
-  for decl in op_method_decls {
-    if index == methods_ctx_offset {
-      break;
-    }
-
-    if decl.constructor.is_some() {
-      index += 1;
-    }
-
-    // Resolve the class function from `Deno.core.ops`; we need it both as the
-    // anchor for prototype methods and to receive static methods.
-    let class_key = decl.name.1.v8_string(scope).unwrap();
-    let class_fn_val = deno_core_ops_obj.get(scope, class_key.into());
-    let class_fn =
-      class_fn_val.and_then(|v| v8::Local::<v8::Function>::try_from(v).ok());
-    let prototype = class_fn.and_then(|f| {
-      let p = f.get(scope, prototype_key.into())?;
-      v8::Local::<v8::Object>::try_from(p).ok()
-    });
-
-    let method_ctxs = &op_ctxs[index..index + decl.methods.len()];
-    for method in method_ctxs {
-      let needs_upgrade =
-        method_needs_fast_call_upgrade(method) && !method.decl().is_accessor();
-      if !needs_upgrade {
-        continue;
-      }
-      let Some(prototype) = prototype else { continue };
-      let method_fn =
-        op_ctx_function(scope, method, v8::ConstructorBehavior::Throw, false);
-      let method_key = name_key(scope, method.decl());
-      if method.decl().is_async {
-        // `setUpAsyncStub` installs the wrapped fn on `class_fn.prototype`
-        // when given the class as the third argument.
-        let Some(class_fn) = class_fn else { continue };
-        let _ = set_up_async_stub_fn.call(
-          scope,
-          undefined.into(),
-          &[method_key.into(), method_fn.into(), class_fn.into()],
-        );
-      } else {
-        prototype.set(scope, method_key.into(), method_fn.into());
-      }
-    }
-    index += decl.methods.len();
-
-    let static_method_ctxs = &op_ctxs[index..index + decl.static_methods.len()];
-    for method in static_method_ctxs {
-      if !method_needs_fast_call_upgrade(method) {
-        continue;
-      }
-      let Some(class_fn) = class_fn else { continue };
-      let method_fn =
-        op_ctx_function(scope, method, v8::ConstructorBehavior::Throw, false);
-      let method_key = name_key(scope, method.decl());
-      class_fn.set(scope, method_key.into(), method_fn.into());
-    }
-    index += decl.static_methods.len();
-  }
-
-  for op_ctx in &op_ctxs[methods_ctx_offset..] {
-    if !method_needs_fast_call_upgrade(op_ctx) {
-      continue;
-    }
-
-    let constructor_behavior = op_ctx_constructor_behavior(op_ctx);
-    let mut op_fn = op_ctx_function(scope, op_ctx, constructor_behavior, false);
-    let key = op_ctx.decl().name_fast.v8_string(scope).unwrap();
-
-    if op_ctx.decl().is_async {
-      let result = set_up_async_stub_fn
-        .call(scope, undefined.into(), &[key.into(), op_fn.into()])
-        .unwrap();
-      op_fn = result.try_into().unwrap();
-    }
-
-    deno_core_ops_obj.set(scope, key.into(), op_fn.into());
-  }
-}
-
-/// Run the deferred fast-call op upgrade exactly once, lazily. Called from the
-/// residual ext-module loaders (`op_lazy_load_esm` / `op_load_ext_script`)
-/// before the loaded module's body captures its op references, so runtime
-/// modules see the fast-call overloads. Programs that never load a residual
-/// module (e.g. `deno run empty.js`) never trigger it, saving the ~0.9ms pass.
-/// No-op during snapshot build / fresh-bind (flag pre-set in `new_inner`).
-/// Read `Deno.core.ops` + `Deno.core.setUpAsyncStub` from the global. Valid
-/// only while `Deno.core` is still present (during `new_inner`, before the
-/// bootstrap scrubs `Deno.core` from the public `Deno`). The deferred upgrade
-/// stashes the result (`ContextState::deferred_fast_ops`) for later use.
-pub(crate) fn snapshotted_fast_op_refs<'s, 'i>(
+/// Capture `Deno.core.setUpAsyncStub` while `Deno.core` is still reachable
+/// from the global. Ops materialized later (bootstrap scrubs `Deno.core` off
+/// the public `Deno`) cannot look it up any more.
+pub(crate) fn capture_set_up_async_stub<'s, 'i>(
   scope: &mut v8::PinScope<'s, 'i>,
   context: v8::Local<'s, v8::Context>,
-) -> (v8::Local<'s, v8::Object>, v8::Local<'s, v8::Function>) {
+) -> v8::Global<v8::Function> {
   let global = context.global(scope);
   let deno_obj = get(scope, global, DENO, "Deno");
   let deno_core_obj = get(scope, deno_obj, CORE, "Deno.core");
-  let deno_core_ops_obj: v8::Local<v8::Object> =
-    get(scope, deno_core_obj, OPS, "Deno.core.ops");
   let set_up_async_stub_fn: v8::Local<v8::Function> = get(
     scope,
     deno_core_obj,
     SET_UP_ASYNC_STUB,
     "Deno.core.setUpAsyncStub",
   );
-  (deno_core_ops_obj, set_up_async_stub_fn)
+  v8::Global::new(scope, set_up_async_stub_fn)
 }
 
-pub(crate) fn ensure_fast_ops_upgraded(scope: &mut v8::PinScope) {
-  let context_state = JsRealm::state_from_scope(scope);
-  if context_state.fast_ops_upgraded.get() {
-    return;
+/// Build the name -> slot table. Mirrors the iteration order of
+/// [`initialize_deno_core_ops_bindings`] exactly, including the
+/// `methods_ctx_offset` cutoff, so the two can never disagree about which
+/// `OpCtx` belongs to which name.
+fn lazy_ops_build_table(
+  state: &ContextState,
+) -> HashMap<&'static str, LazyOpEntry> {
+  let op_ctxs = &state.op_ctxs;
+  let mut table = HashMap::with_capacity(op_ctxs.len());
+  let mut index = 0usize;
+  for (decl_idx, decl) in state.op_method_decls.iter().enumerate() {
+    if index == state.methods_ctx_offset {
+      break;
+    }
+    let ctx = index;
+    if decl.constructor.is_some() {
+      index += 1;
+    }
+    index += decl.methods.len() + decl.static_methods.len();
+    table.insert(
+      decl.name.0,
+      LazyOpEntry {
+        slot: LazyOpSlot::Class {
+          decl: decl_idx as u32,
+          ctx: ctx as u32,
+        },
+        name: decl.name.1,
+        func: None,
+      },
+    );
   }
-  // Set the flag BEFORE running the upgrade so any reentrant residual load
-  // during the upgrade (which calls back into JS via setUpAsyncStub) no-ops.
-  context_state.fast_ops_upgraded.set(true);
-  let refs = context_state.deferred_fast_ops.borrow().clone();
-  let Some((ops_global, stub_global)) = refs else {
-    return;
-  };
-  let deno_core_ops_obj = v8::Local::new(scope, &ops_global);
-  let set_up_async_stub_fn = v8::Local::new(scope, &stub_global);
+  for (offset, op_ctx) in op_ctxs[index..].iter().enumerate() {
+    table.insert(
+      op_ctx.decl().name,
+      LazyOpEntry {
+        slot: LazyOpSlot::Op((index + offset) as u32),
+        name: op_ctx.decl().name_fast,
+        func: None,
+      },
+    );
+  }
+  table
+}
 
-  // NOTE: `capturedCore.ops` (01_core.js) is the *same* object as
-  // `deno_core_ops_obj`, so the `.set`s below are observed by residual ext
-  // modules with no mirroring pass. (It used to be a shallow clone, which had
-  // to be resolved and written through here as well.)
-  upgrade_snapshotted_ops_with_fast_calls(
-    scope,
-    deno_core_ops_obj,
-    set_up_async_stub_fn,
-    &context_state.op_ctxs,
-    &context_state.op_method_decls,
-    context_state.methods_ctx_offset,
-  );
+/// Read a property key into `buf` as a `&str`, or `None` if it cannot be an
+/// op name (non-string key, too long, or not Latin-1). Avoids allocating on
+/// every `core.ops.x` access.
+fn lazy_ops_key_str<'b>(
+  scope: &mut v8::PinScope,
+  key: v8::Local<v8::Name>,
+  buf: &'b mut [u8; MAX_OP_NAME_LEN],
+) -> Option<&'b str> {
+  let key = v8::Local::<v8::String>::try_from(key).ok()?;
+  let len = key.length();
+  if len == 0 || len > MAX_OP_NAME_LEN || !key.contains_only_onebyte() {
+    return None;
+  }
+  key.write_one_byte_v2(scope, 0, &mut buf[..len], v8::WriteFlags::empty());
+  std::str::from_utf8(&buf[..len]).ok()
+}
+
+/// The `Deno.core.ops` getter interceptor: materialize the named op on first
+/// read, then serve the memoized function forever after.
+fn lazy_ops_getter<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  key: v8::Local<'s, v8::Name>,
+  _args: v8::PropertyCallbackArguments<'s>,
+  mut rv: v8::ReturnValue<v8::Value>,
+) -> v8::Intercepted {
+  let mut buf = [0u8; MAX_OP_NAME_LEN];
+  let Some(name) = lazy_ops_key_str(scope, key, &mut buf) else {
+    return v8::Intercepted::kNo;
+  };
+  let state = JsRealm::state_from_scope(scope);
+
+  // Resolve the name and take a *copy* of the cached handle: materialization
+  // below calls back into JS (`setUpAsyncStub`), which can re-enter this
+  // interceptor, so no borrow of `table` may be held across it.
+  let (slot, cached, name) = {
+    let mut table = state.lazy_ops.table.borrow_mut();
+    let table = table.get_or_insert_with(|| lazy_ops_build_table(&state));
+    match table.get_key_value(name) {
+      None => return v8::Intercepted::kNo,
+      Some((name, entry)) => (entry.slot, entry.func.clone(), *name),
+    }
+  };
+  if let Some(func) = cached {
+    rv.set(v8::Local::new(scope, func).into());
+    return v8::Intercepted::kYes;
+  }
+
+  let Some(func) = lazy_ops_materialize(scope, &state, slot) else {
+    // Materialization can only fail if JS threw (a `setUpAsyncStub` failure).
+    // Leave the pending exception alone and report "not intercepted" rather
+    // than handing back a half-built function.
+    return v8::Intercepted::kNo;
+  };
+
+  // Re-entrancy: if materializing this op somehow materialized it again,
+  // keep the first function so identity stays stable.
+  let mut table = state.lazy_ops.table.borrow_mut();
+  let entry = table.as_mut().unwrap().get_mut(name).unwrap();
+  let func = match &entry.func {
+    Some(existing) => v8::Local::new(scope, existing),
+    None => {
+      entry.func = Some(v8::Global::new(scope, func));
+      func
+    }
+  };
+  drop(table);
+  rv.set(func.into());
+  v8::Intercepted::kYes
+}
+
+/// The query interceptor: report an op's attributes without building it.
+/// This is what keeps `Object.keys`, `for..in`, `in` and `hasOwnProperty`
+/// honest under the interceptor while still materializing nothing.
+fn lazy_ops_query<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  key: v8::Local<'s, v8::Name>,
+  _args: v8::PropertyCallbackArguments<'s>,
+  mut rv: v8::ReturnValue<v8::Integer>,
+) -> v8::Intercepted {
+  let mut buf = [0u8; MAX_OP_NAME_LEN];
+  let Some(name) = lazy_ops_key_str(scope, key, &mut buf) else {
+    return v8::Intercepted::kNo;
+  };
+  let state = JsRealm::state_from_scope(scope);
+  let known = {
+    let mut table = state.lazy_ops.table.borrow_mut();
+    let table = table.get_or_insert_with(|| lazy_ops_build_table(&state));
+    table.contains_key(name)
+  };
+  if !known {
+    return v8::Intercepted::kNo;
+  }
+  // Ops are writable, enumerable and configurable, exactly as the data
+  // properties they replaced were.
+  rv.set_uint32(v8::PropertyAttribute::NONE.as_u32());
+  v8::Intercepted::kYes
+}
+
+/// The enumerator interceptor: the names of every op, materializing none of
+/// them.
+fn lazy_ops_enumerator<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  _args: v8::PropertyCallbackArguments<'s>,
+  mut rv: v8::ReturnValue<v8::Array>,
+) {
+  let state = JsRealm::state_from_scope(scope);
+  let names: Vec<FastStaticString> = {
+    let mut table = state.lazy_ops.table.borrow_mut();
+    let table = table.get_or_insert_with(|| lazy_ops_build_table(&state));
+    table.values().map(|entry| entry.name).collect()
+  };
+  let names: Vec<v8::Local<v8::Value>> = names
+    .into_iter()
+    .map(|name| name.v8_string(scope).unwrap().into())
+    .collect();
+  rv.set(v8::Array::new_with_elements(scope, &names));
+}
+
+// Counts op functions actually built by `lazy_ops_materialize`, so tests can
+// assert that enumeration (`Object.keys`, `for..in`, `in`) materializes
+// nothing -- the whole point of giving the interceptor query and enumerator
+// callbacks rather than a getter alone.
+#[cfg(test)]
+thread_local! {
+  static MATERIALIZED_OPS: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Number of op functions built so far on this thread.
+#[cfg(test)]
+pub(crate) fn materialized_op_count() -> usize {
+  MATERIALIZED_OPS.with(|c| c.get())
+}
+
+/// Build the `v8::Function` for one `Deno.core.ops` entry.
+fn lazy_ops_materialize<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  state: &ContextState,
+  slot: LazyOpSlot,
+) -> Option<v8::Local<'s, v8::Function>> {
+  #[cfg(test)]
+  MATERIALIZED_OPS.with(|c| c.set(c.get() + 1));
+  match slot {
+    LazyOpSlot::Op(index) => {
+      let op_ctx = &state.op_ctxs[index as usize];
+      let will_snapshot = state.lazy_ops.will_snapshot.get();
+      let constructor_behavior = op_ctx_constructor_behavior(op_ctx);
+      let mut op_fn = if will_snapshot && !op_ctx.decl().constructable {
+        op_ctx_plain_function(scope, op_ctx, constructor_behavior)
+      } else {
+        op_ctx_function(scope, op_ctx, constructor_behavior, will_snapshot)
+      };
+      if op_ctx.decl().is_async {
+        // Async ops are wrapped by `Deno.core.setUpAsyncStub`, which builds
+        // the promise/error-remapping trampoline around the raw op function.
+        let stub = state.lazy_ops.set_up_async_stub.borrow().clone()?;
+        let stub = v8::Local::new(scope, stub);
+        let key = op_ctx.decl().name_fast.v8_string(scope).unwrap();
+        let undefined = v8::undefined(scope);
+        let result =
+          stub.call(scope, undefined.into(), &[key.into(), op_fn.into()])?;
+        op_fn = result.try_into().ok()?;
+      }
+      Some(op_fn)
+    }
+    LazyOpSlot::Class { decl, ctx } => {
+      lazy_ops_materialize_class(scope, state, decl as usize, ctx as usize)
+    }
+  }
+}
+
+/// Resolve a cppgc class function from the realm's template store, upgrading
+/// its methods to their fast-call variants if the templates came out of a
+/// snapshot.
+///
+/// The template itself is *not* built here: it is created eagerly by
+/// [`initialize_deno_core_ops_bindings`] (or restored from the snapshot),
+/// because cppgc wrapping resolves templates by type name and `inherit()`
+/// needs the parent to exist. Only the class function -- and, from a
+/// snapshot, its fast-call methods -- is deferred.
+fn lazy_ops_materialize_class<'s, 'i>(
+  scope: &mut v8::PinScope<'s, 'i>,
+  state: &ContextState,
+  decl_index: usize,
+  ctx_index: usize,
+) -> Option<v8::Local<'s, v8::Function>> {
+  let decl = &state.op_method_decls[decl_index];
+  let tmpl = state
+    .function_templates
+    .borrow()
+    .get_raw((decl.type_name)())
+    .cloned()?;
+  let tmpl = v8::Local::new(scope, tmpl);
+  let class_fn = tmpl.get_function(scope)?;
+  let class_key = decl.name.1.v8_string(scope).unwrap();
+  class_fn.set_name(class_key);
+
+  if !state.lazy_ops.classes_need_fast_call_upgrade.get() {
+    return Some(class_fn);
+  }
+
+  // Snapshot path: the prototype and static methods baked into the blob are
+  // the slow variants (V8 will not serialize a fast-call overload). Rebuild
+  // the ones that declare a fast function. This is the per-class remnant of
+  // the old `upgrade_snapshotted_ops_with_fast_calls` pass -- but it now runs
+  // only for classes something actually reads.
+  let prototype_key = v8::String::new(scope, "prototype").unwrap();
+  let prototype = class_fn
+    .get(scope, prototype_key.into())
+    .and_then(|p| v8::Local::<v8::Object>::try_from(p).ok());
+  let undefined = v8::undefined(scope);
+  let set_up_async_stub_fn = state.lazy_ops.set_up_async_stub.borrow().clone();
+
+  let mut index = ctx_index;
+  if decl.constructor.is_some() {
+    index += 1;
+  }
+  let method_ctxs = &state.op_ctxs[index..index + decl.methods.len()];
+  for method in method_ctxs {
+    if !method_needs_fast_call_upgrade(method) || method.decl().is_accessor() {
+      continue;
+    }
+    let Some(prototype) = prototype else { continue };
+    let method_fn =
+      op_ctx_function(scope, method, v8::ConstructorBehavior::Throw, false);
+    let method_key = name_key(scope, method.decl());
+    if method.decl().is_async {
+      // `setUpAsyncStub` installs the wrapped fn on `class_fn.prototype` when
+      // given the class as the third argument.
+      let Some(stub) = set_up_async_stub_fn.clone() else {
+        continue;
+      };
+      let stub = v8::Local::new(scope, stub);
+      let _ = stub.call(
+        scope,
+        undefined.into(),
+        &[method_key.into(), method_fn.into(), class_fn.into()],
+      );
+    } else {
+      prototype.set(scope, method_key.into(), method_fn.into());
+    }
+  }
+  index += decl.methods.len();
+
+  let static_method_ctxs =
+    &state.op_ctxs[index..index + decl.static_methods.len()];
+  for method in static_method_ctxs {
+    if !method_needs_fast_call_upgrade(method) {
+      continue;
+    }
+    let method_fn =
+      op_ctx_function(scope, method, v8::ConstructorBehavior::Throw, false);
+    let method_key = name_key(scope, method.decl());
+    class_fn.set(scope, method_key.into(), method_fn.into());
+  }
+
+  Some(class_fn)
 }
 
 fn method_needs_fast_call_upgrade(op_ctx: &OpCtx) -> bool {

--- a/libs/core/runtime/jsrealm.rs
+++ b/libs/core/runtime/jsrealm.rs
@@ -104,20 +104,16 @@ pub struct ContextState {
   pub(crate) op_ctxs: OpCtxs,
   pub(crate) op_method_decls: Vec<OpMethodDecl>,
   pub(crate) methods_ctx_offset: usize,
-  /// Snapshots built against V8 14.9+ bake the *slow* version of each op
-  /// (see `op_ctx_template`); fast-call overloads are re-attached at runtime
-  /// by `upgrade_snapshotted_ops_with_fast_calls`. That pass creates ~1.6k V8
-  /// functions (~0.9ms). It only benefits ops accessed at runtime (baked
-  /// modules captured their slow refs at snapshot eval), so we DEFER it until
-  /// the first residual ext-module load — a program that never loads a
-  /// residual module (e.g. `deno run empty.js`) never pays for it.
-  pub(crate) fast_ops_upgraded: Cell<bool>,
-  /// `(Deno.core.ops, Deno.core.setUpAsyncStub)` captured at `new_inner` time,
-  /// because `Deno.core` is scrubbed from the public `Deno` after bootstrap and
-  /// the deferred upgrade (which runs post-bootstrap) can no longer read them
-  /// from the global. `None` when the upgrade isn't deferred.
-  pub(crate) deferred_fast_ops:
-    RefCell<Option<(v8::Global<v8::Object>, v8::Global<v8::Function>)>>,
+  /// Memoization behind the `Deno.core.ops` named-property interceptor. Op
+  /// functions are not in the snapshot and are not built at startup: they are
+  /// materialized here on first access. See [`crate::runtime::bindings::LazyOps`].
+  /// Boxed to keep `ContextState` -- which is on the hot path of every op
+  /// dispatch -- the same size it was before this state existed. The
+  /// indirection is only ever taken on a first-access miss.
+  pub(crate) lazy_ops: Box<crate::runtime::bindings::LazyOps>,
+  /// The runtime-wide cppgc class template store, needed by the lazy-ops
+  /// interceptor to resolve a class function from its type name.
+  pub(crate) function_templates: Rc<RefCell<FunctionTemplateData>>,
   pub(crate) isolate: Option<v8::UnsafeRawIsolatePtr>,
   pub(crate) exception_state: Rc<ExceptionState>,
   /// Shared tick info buffer exposed to JS as a Uint8Array.
@@ -191,6 +187,11 @@ impl ContextState {
     self.tick_info[1] != 0
   }
 
+  #[allow(
+    clippy::too_many_arguments,
+    reason = "one-shot constructor; every argument is realm state that is \
+              only available at this point in `JsRuntime::new_inner`"
+  )]
   pub(crate) fn new(
     op_driver: Rc<OpDriverImpl>,
     isolate_ptr: v8::UnsafeRawIsolatePtr,
@@ -199,6 +200,7 @@ impl ContextState {
     methods_ctx_offset: usize,
     external_ops_tracker: ExternalOpsTracker,
     unrefed_ops: UnrefedOps,
+    function_templates: Rc<RefCell<FunctionTemplateData>>,
   ) -> Self {
     Self {
       isolate: Some(isolate_ptr),
@@ -217,8 +219,8 @@ impl ContextState {
       op_ctxs,
       op_method_decls,
       methods_ctx_offset,
-      fast_ops_upgraded: Cell::new(false),
-      deferred_fast_ops: RefCell::new(None),
+      lazy_ops: Default::default(),
+      function_templates,
       pending_ops: op_driver,
       task_spawner_factory: Default::default(),
       user_timer: Default::default(),

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -1014,6 +1014,7 @@ impl JsRuntime {
       methods_ctx_offset,
       op_state.borrow().external_ops_tracker.clone(),
       unrefed_ops,
+      state_rc.function_templates.clone(),
     ));
 
     // TODO(bartlomieju): factor out
@@ -1093,35 +1094,28 @@ impl JsRuntime {
           &mut state_rc.function_templates.borrow_mut(),
           will_snapshot,
         );
-      } else if !will_snapshot {
-        // Snapshots built against V8 14.9+ bake the slow version of each op
-        // function (see `op_ctx_template`); the fast-call overloads must be
-        // re-attached at runtime. That pass (~0.9ms, ~1.6k V8 functions) only
-        // helps ops accessed at runtime — baked modules already captured their
-        // slow refs at snapshot eval — so we DEFER it until the first residual
-        // ext-module load (`ensure_fast_ops_upgraded`). A program that loads no
-        // residual module (e.g. an empty script) never pays for it.
-        //
-        // Capture the refs the deferred upgrade needs NOW, while `Deno.core` is
-        // still on the global — it's scrubbed from the public `Deno` after
-        // bootstrap, so the post-bootstrap deferred caller can't read them.
-        let (ops_obj, stub_fn) =
-          bindings::snapshotted_fast_op_refs(scope, context);
-        *context_state.deferred_fast_ops.borrow_mut() = Some((
-          v8::Global::new(scope, ops_obj),
-          v8::Global::new(scope, stub_fn),
-        ));
       }
-      // The deferred upgrade applies ONLY when loading a snapshot at runtime.
-      // In the fresh-bind path the ops were just bound with fast calls, and in
-      // the snapshot-build path we must keep the slow ops (fast-call functions
-      // can't be serialized) and must NOT upgrade even though `op_load_ext_script`
-      // runs during the build. Mark those paths done so `ensure_fast_ops_upgraded`
-      // is a no-op for them.
-      if init_mode.needs_ops_bindings() || will_snapshot {
-        context_state.fast_ops_upgraded.set(true);
-      }
-      startup_phase_end(_phase, "ops_bindings (fast call upgrade)");
+
+      // Arm the `Deno.core.ops` interceptor. Nothing about an op is
+      // materialized until JS reads it; what has to be settled here is *how*
+      // it will be materialized, and that requires reading `Deno.core` while
+      // it is still on the global (bootstrap scrubs it later).
+      //
+      // - `will_snapshot`: build op functions without fast-call overloads,
+      //   because V8 refuses to serialize the `Managed<CFunctionWithSignature>`
+      //   they carry. Every other path materializes with fast calls directly,
+      //   which is what makes the old deferred `upgrade_snapshotted_ops_with_
+      //   fast_calls` pass unnecessary rather than merely deferred.
+      // - cppgc class templates are the one thing still baked into the blob,
+      //   so when we did NOT build them ourselves their methods are the slow
+      //   variants and get re-attached the first time the class is read.
+      let stub_fn = bindings::capture_set_up_async_stub(scope, context);
+      context_state.lazy_ops.configure(
+        stub_fn,
+        will_snapshot,
+        !init_mode.needs_ops_bindings() && !will_snapshot,
+      );
+      startup_phase_end(_phase, "ops_bindings");
 
       // SAFETY: Initialize the context state slot.
       unsafe {
@@ -3015,6 +3009,10 @@ impl JsRuntimeForSnapshot {
         data_store,
       )
     };
+    // The lazily-materialized op functions are reachable from the
+    // `ext:core/ops` export cells that referenced them; this cache must not
+    // outlive the isolate teardown below.
+    realm.0.context_state.lazy_ops.clear();
     drop(realm);
 
     let v8_data = self

--- a/libs/core/runtime/tests/ops.rs
+++ b/libs/core/runtime/tests/ops.rs
@@ -698,3 +698,253 @@ op_async_arg_error Dispatched
 op_async_arg_error Error"#
   );
 }
+
+// ===========================================================================
+// Lazily materialized `Deno.core.ops` (deno_core_revamp#41)
+// ===========================================================================
+
+#[op2(fast)]
+#[smi]
+fn op_lazy_sync_fast(#[smi] a: i32) -> i32 {
+  a + 1
+}
+
+/// No `fast` attribute, so this op only ever has a slow dispatch path -- the
+/// interceptor must handle both shapes.
+#[op2]
+#[string]
+fn op_lazy_sync_slow(#[string] s: String) -> String {
+  format!("{s}!")
+}
+
+#[op2(async(lazy), fast)]
+#[smi]
+async fn op_lazy_async(#[smi] a: i32) -> i32 {
+  a * 2
+}
+
+deno_core::extension!(
+  lazy_ops_test,
+  ops = [op_lazy_sync_fast, op_lazy_sync_slow, op_lazy_async],
+);
+
+fn lazy_ops_runtime() -> JsRuntime {
+  JsRuntime::new(RuntimeOptions {
+    extensions: vec![lazy_ops_test::init()],
+    ..Default::default()
+  })
+}
+
+/// The property is not there until it is read, and once read it is always the
+/// same function object -- including across a GC, which is why the
+/// materialized function is memoized with a strong handle rather than a weak
+/// one.
+#[test]
+fn lazy_ops_identity_is_stable() {
+  let mut runtime = lazy_ops_runtime();
+  runtime
+    .execute_script(
+      "lazy_ops_identity.js",
+      r#"
+      const ops = Deno.core.ops;
+      const a = ops.op_lazy_sync_fast;
+      const b = ops.op_lazy_sync_fast;
+      if (a !== b) throw new Error("identity not stable across reads");
+      if (typeof a !== "function") throw new Error("not a function");
+      if (a.name !== "op_lazy_sync_fast") {
+        throw new Error("wrong name: " + a.name);
+      }
+
+      // Same for an async op, whose materialization runs `setUpAsyncStub`.
+      const c = ops.op_lazy_async;
+      if (c !== ops.op_lazy_async) {
+        throw new Error("async identity not stable");
+      }
+
+      // Churn the heap so anything held weakly would be collected.
+      for (let i = 0; i < 200_000; i++) {
+        ({ i, pad: [i, i, i] });
+      }
+      if (ops.op_lazy_sync_fast !== a) {
+        throw new Error("identity lost after GC pressure");
+      }
+      if (ops.op_lazy_async !== c) {
+        throw new Error("async identity lost after GC pressure");
+      }
+      "#,
+    )
+    .unwrap();
+}
+
+/// End-to-end: ops that were never bound as properties, only ever reached
+/// through the interceptor, dispatch correctly -- fast sync, slow sync, and
+/// async.
+#[tokio::test]
+async fn lazy_ops_call_through_interceptor() {
+  let mut runtime = lazy_ops_runtime();
+  let promise = runtime
+    .execute_script(
+      "lazy_ops_call.js",
+      r#"
+      const { op_lazy_sync_fast, op_lazy_sync_slow, op_lazy_async } =
+        Deno.core.ops;
+      (async () => {
+        if (op_lazy_sync_fast(41) !== 42) throw new Error("fast sync");
+        // Call it enough times to reach the fast-call path.
+        for (let i = 0; i < 10_000; i++) {
+          if (op_lazy_sync_fast(1) !== 2) throw new Error("fast sync loop");
+        }
+        if (op_lazy_sync_slow("hi") !== "hi!") throw new Error("slow sync");
+        if (await op_lazy_async(21) !== 42) throw new Error("async");
+        // Direct property-access call sites keep working too.
+        if (Deno.core.ops.op_lazy_sync_fast(1) !== 2) {
+          throw new Error("direct call");
+        }
+        return "ok";
+      })()
+      "#,
+    )
+    .unwrap();
+  #[allow(deprecated, reason = "test code")]
+  runtime.resolve_value(promise).await.unwrap();
+}
+
+/// Enumeration semantics, which are the part of this design that had to be
+/// chosen rather than derived. The interceptor carries an enumerator and a
+/// query callback, so the full op set is visible to `Object.keys`, `for..in`,
+/// `in` and `hasOwnProperty` -- and observing it materializes nothing.
+///
+/// `getOwnPropertyDescriptor` is the deliberate exception: it has to produce a
+/// value, so it materializes.
+#[test]
+fn lazy_ops_enumeration_does_not_materialize() {
+  use crate::runtime::bindings::materialized_op_count;
+  let mut runtime = lazy_ops_runtime();
+  let before = materialized_op_count();
+  runtime
+    .execute_script(
+      "lazy_ops_enumerate_only.js",
+      r#"
+      {
+      const ops = Deno.core.ops;
+      const keys = Object.keys(ops);
+      if (!keys.includes("op_lazy_sync_fast")) throw new Error("no keys");
+      for (const k in ops) { if (k === "") throw new Error("bad key"); }
+      if (!("op_lazy_async" in ops)) throw new Error("`in` missed an op");
+      if (!Object.prototype.hasOwnProperty.call(ops, "op_lazy_sync_slow")) {
+        throw new Error("hasOwnProperty missed an op");
+      }
+      }
+      "#,
+    )
+    .unwrap();
+  assert_eq!(
+    materialized_op_count(),
+    before,
+    "enumerating `Deno.core.ops` must not materialize any op function"
+  );
+
+  runtime
+    .execute_script(
+      "lazy_ops_enumeration.js",
+      r#"
+      const ops = Deno.core.ops;
+      function assert(cond, msg) {
+        if (!cond) throw new Error(msg);
+      }
+
+      const keys = Object.keys(ops);
+      assert(keys.includes("op_lazy_sync_fast"), "Object.keys missed an op");
+      assert(keys.includes("op_lazy_async"), "Object.keys missed an async op");
+      assert(keys.length > 3, "Object.keys should list the builtin ops too");
+
+      let seen = false;
+      for (const k in ops) {
+        if (k === "op_lazy_sync_slow") seen = true;
+      }
+      assert(seen, "for..in missed an op");
+
+      assert("op_lazy_sync_fast" in ops, "`in` missed an op");
+      assert(
+        Object.prototype.hasOwnProperty.call(ops, "op_lazy_sync_fast"),
+        "hasOwnProperty missed an op",
+      );
+      assert(!("op_nope_not_an_op" in ops), "`in` invented an op");
+      assert(ops.op_nope_not_an_op === undefined, "get invented an op");
+
+      const f = ops.op_lazy_sync_fast;
+      assert(typeof f === "function", "read after enumeration failed");
+      assert(f === ops.op_lazy_sync_fast, "identity broken after enumeration");
+
+      const desc = Object.getOwnPropertyDescriptor(ops, "op_lazy_async");
+      assert(desc !== undefined, "no descriptor for an op");
+      assert(desc.value === ops.op_lazy_async, "descriptor value mismatch");
+      assert(desc.writable && desc.enumerable && desc.configurable,
+        "op should be a plain writable/enumerable/configurable property");
+      "#,
+    )
+    .unwrap();
+}
+
+/// A real own property shadows the interceptor (`NON_MASKING`), so embedder
+/// or user assignment behaves as it did when ops were data properties.
+#[test]
+fn lazy_ops_assignment_shadows_the_interceptor() {
+  let mut runtime = lazy_ops_runtime();
+  runtime
+    .execute_script(
+      "lazy_ops_shadow.js",
+      r#"
+      const ops = Deno.core.ops;
+      const original = ops.op_lazy_sync_fast;
+      ops.op_lazy_sync_fast = () => "shadowed";
+      if (ops.op_lazy_sync_fast() !== "shadowed") {
+        throw new Error("assignment did not take");
+      }
+      if (ops.op_lazy_sync_fast === original) {
+        throw new Error("assignment did not shadow");
+      }
+      "#,
+    )
+    .unwrap();
+}
+
+/// The `__bootstrap` polyfill shape: a hundred ops destructured off
+/// `core.ops` in one statement, each materialized on the way through, each
+/// callable and each stable.
+#[test]
+fn lazy_ops_bulk_destructuring() {
+  let mut runtime = JsRuntime::new(RuntimeOptions::default());
+  runtime
+    .execute_script(
+      "lazy_ops_bulk.js",
+      r#"
+      const names = Object.keys(Deno.core.ops);
+      if (names.length < 50) {
+        throw new Error("expected the builtin op set, got " + names.length);
+      }
+      const first = {};
+      for (const name of names) {
+        const fn = Deno.core.ops[name];
+        if (typeof fn !== "function") {
+          throw new Error(name + " did not materialize");
+        }
+        first[name] = fn;
+      }
+      for (const name of names) {
+        if (Deno.core.ops[name] !== first[name]) {
+          throw new Error(name + " identity changed");
+        }
+      }
+      // And the subset primitive (the supported way to derive a reduced
+      // surface) sees the same functions.
+      const subset = Deno.core.createOpsSubset(names);
+      for (const name of names) {
+        if (subset[name] !== first[name]) {
+          throw new Error(name + " differs in the subset");
+        }
+      }
+      "#,
+    )
+    .unwrap();
+}

--- a/libs/core/runtime/tests/snapshot.rs
+++ b/libs/core/runtime/tests/snapshot.rs
@@ -574,3 +574,88 @@ fn lazy_loaded_esm_not_snapshotted_but_metadata_survives() {
     );
   }
 }
+
+#[op2(fast)]
+#[smi]
+fn op_snap_lazy_add(#[smi] a: i32, #[smi] b: i32) -> i32 {
+  a + b
+}
+
+#[op2]
+#[string]
+fn op_snap_lazy_slow(#[string] s: String) -> String {
+  format!("{s}?")
+}
+
+deno_core::extension!(
+  snap_lazy_ops,
+  ops = [op_snap_lazy_add, op_snap_lazy_slow],
+);
+
+/// Round-trip for the lazily materialized `Deno.core.ops`
+/// (deno_core_revamp#41): op functions are not baked into the blob, so both
+/// directions have to work.
+///
+///  * During snapshot creation the ops must be reachable from JS -- the
+///    interceptor materializes them without fast-call overloads, since V8
+///    will not serialize those.
+///  * After rehydration a runtime that never bound any op property must still
+///    resolve them, with fast calls this time, and with stable identity.
+#[test]
+fn lazy_ops_survive_a_snapshot_round_trip() {
+  let _snapshot_lock = super::snapshot_test_lock();
+  let snapshot = {
+    let mut runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+      extensions: vec![snap_lazy_ops::init()],
+      ..Default::default()
+    });
+    // Reaching an op during snapshot-build JS eval must work.
+    runtime
+      .execute_script(
+        "snapshot_build.js",
+        r#"
+        if (Deno.core.ops.op_snap_lazy_add(1, 2) !== 3) {
+          throw new Error("op not callable at snapshot build time");
+        }
+        globalThis.snapshotTimeSum = Deno.core.ops.op_snap_lazy_add(20, 22);
+        "#,
+      )
+      .unwrap();
+    runtime.snapshot()
+  };
+
+  let snapshot = Box::leak(snapshot);
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![snap_lazy_ops::init()],
+    startup_snapshot: Some(snapshot),
+    skip_op_registration: true,
+    ..Default::default()
+  });
+  runtime
+    .execute_script(
+      "after_rehydration.js",
+      r#"
+      function assert(cond, msg) {
+        if (!cond) throw new Error(msg);
+      }
+      assert(globalThis.snapshotTimeSum === 42, "snapshot state lost");
+
+      const ops = Deno.core.ops;
+      const add = ops.op_snap_lazy_add;
+      assert(typeof add === "function", "op did not materialize");
+      assert(add === ops.op_snap_lazy_add, "identity not stable");
+      assert(add.name === "op_snap_lazy_add", "wrong name: " + add.name);
+      assert(add(1, 2) === 3, "op returned the wrong value");
+      // Warm enough to take the fast-call path, which is the thing the
+      // deleted `upgrade_snapshotted_ops_with_fast_calls` pass used to
+      // restore after deserialization.
+      for (let i = 0; i < 10_000; i++) {
+        assert(add(i, 1) === i + 1, "fast-call path is wrong");
+      }
+      assert(ops.op_snap_lazy_slow("x") === "x?", "slow op is wrong");
+      assert(Object.keys(ops).includes("op_snap_lazy_add"),
+        "op missing from Object.keys after rehydration");
+      "#,
+    )
+    .unwrap();
+}


### PR DESCRIPTION
Ports denoland/deno_core_revamp#45. **Stacked on #36805** -- it targets that
branch and must not land before it; the two halves of the `Deno.core.ops`
contract only work together, for the reason spelled out under "behaviour
changes" below.

`Deno.core.ops` is no longer an object carrying one `v8::Function` property per
registered op. It is built from an `ObjectTemplate` with a single named-property
handler and no op properties at all. The first read of `core.ops.op_foo`
materializes the function -- with its fast-call overload, its name and, for
async ops, its `setUpAsyncStub` wrapper -- and memoizes it in the realm's
`ContextState`.

Two things follow from "every op function is now built after deserialization".
First, the op functions are no longer reachable from the ops object at
snapshot-build time, so nothing about an op has to be in the blob. Second -- and
this is the part that pays off today -- the deferred fast-call upgrade becomes
unnecessary rather than merely deferred. `upgrade_snapshotted_ops_with_fast_calls`
(O(all ops), ~0.9 ms on a real Deno worker), `snapshotted_fast_op_refs`,
`ensure_fast_ops_upgraded`, the `deferred_fast_ops` / `fast_ops_upgraded` realm
state and the two `op_lazy_load_esm` / `op_load_ext_script` call sites that
triggered it are all deleted. cppgc class templates stay eager, because cppgc
wrapping resolves them by type name and `inherit()` needs the parent template to
exist; only the class *function*, and the re-attachment of its fast-call methods
when it came out of a snapshot, is deferred.

The memo lives in `ContextState` as a boxed `LazyOps`: a
`name -> (slot, Option<Global<Function>>)` table built lazily on the first
interceptor hit, plus the `setUpAsyncStub` handle captured during `new_inner`
while `Deno.core` is still on the global. It is realm state rather than a
`thread_local` because handles are isolate-bound and the memo must die with the
realm; it holds strong `Global`s rather than weak handles because
`core.ops.op_foo === core.ops.op_foo` has to hold forever, including across GC;
and it is deliberately *not* written back as an own property on the ops object,
because with a query callback present V8 consults the interceptor while
resolving the store. Boxing keeps `ContextState` -- read on every op dispatch --
the size it was; the indirection is only taken on a first-access miss. Key
lookup reads the V8 string into a stack buffer, so a `core.ops.op_foo(...)` call
site allocates nothing.

On enumeration semantics the revamp PR took the strictly better of the two
options the design issue left open: the handler carries a *query* callback
alongside the enumerator, so `Object.keys`, `for..in`, `in` and
`hasOwnProperty` all see the full op set and none of them build a function.
That is asserted rather than argued -- a `#[cfg(test)]` counter in
`lazy_ops_materialize` is read before and after a script that runs all four over
the whole ops object, and must be unchanged.

Two behaviours do change. **`delete core.ops.op_foo` is now a no-op**: there is
no deleter callback, so the delete succeeds against the (nonexistent) own
property and the interceptor keeps serving the op. This is exactly the failure
mode #36805 called out, and exactly why it has to land first -- deno's
`removeImportedOps()` was an `ObjectKeys` + `delete` sweep that would silently
stop stripping anything under an interceptor, and it has already been replaced
there by an allowlist rebuild through `core.createOpsSubset()`. I grepped
`ext/`, `runtime/`, `cli/`, `libs/` and `tests/` for any other `delete` against
`core.ops` and for any other enumeration of it; after #36805 there are none.
Second, `Object.getOwnPropertyDescriptor(core.ops, "op_foo")` materializes,
because it has to produce a value; a descriptor-based clone of `core.ops` is
therefore not an escape hatch. Assignment is unaffected: the handler is
`NON_MASKING`, so a real own property always wins and `core.ops.op_foo = f`
shadows the op exactly as it did when ops were data properties. Snapshot layout
is otherwise untouched -- the external-reference table keeps its existing
`ops_in_snapshot` partitioning and per-op ordering, and gains exactly three
fixed entries for the interceptor callbacks regardless of op count.

Two adaptations were needed for the monorepo. `ContextState::new` there has one
fewer parameter than in the revamp repo (the scheduler-flags argument from
unlanded Wave 2 work is not present), so adding `function_templates` pushed it
to 8 arguments and tripped `clippy::too_many_arguments`; it carries an `allow`
with a reason string. And the new integration tests were appended rather than
patched in, because the revamp file has a `test_op_metrics_pairing` test above
them that comes from the not-yet-ported metrics-out-of-codegen change. Nothing
in the ported code depends on that change, on the shared async trampoline, or on
anything else from Wave 2 beyond the const op tables that landed in #36696.

The one dependency worth stating explicitly, since the revamp PR flagged it as
an open porting risk: the interceptor API *is* mirrored by the `quickjs`
backend. `deno_v8` re-exports `NamedPropertyHandlerConfiguration` (with its
getter/query/enumerator/flags builders), `PropertyHandlerFlags::{NON_MASKING,
ONLY_INTERCEPT_STRINGS}`, `Intercepted`, `ObjectTemplate::set_named_property_handler`
and the `named_getter` / `named_query` / `enumerator` arms of
`ExternalReference` from both `v8` and `v8x`, so
`cargo check --no-default-features --features quickjs` is not affected.

As measured in denoland/deno_core_revamp#45, the blob barely moves on its own:
269.2 -> 268.1 B/op. The reason retargets the follow-up, and is worth stating
plainly -- the `ext:core/ops` synthetic module exports every registered op and
obtains each export value by reading it off the ops object, which under the
interceptor materializes the function into an export cell that *is* in the blob.
The interceptor removes one of the two references to every op function; the
export list is the other one, and #36807 removes it, at which point the same
probe measures 0.065 B/op. What this PR wins today is the deleted upgrade pass:
`op_scale_probe extra residual` (299 ops, one residual ext script loaded inside
the timed region) 1.080 -> 0.939 ms, -13%, and `bench/run.sh --mem --graph
--startup` per-runtime RSS -5.5% (6.93 -> 6.55 MiB over 4 runtimes). The op call
path is unchanged, which is the thing that had to stay true: `loop_probe ops`
254.2 -> 251.4 ns/iteration, `loop_probe ops_eager` 65.4 -> 65.2 ns/iteration.

New coverage: identity stability across reads and across GC pressure for both a
sync and an async op; end-to-end dispatch of ops reached *only* through the
interceptor (fast sync warmed onto the fast-call path, slow sync, async); bulk
destructuring of the entire op set -- the `__bootstrap` polyfill shape -- with
identity cross-checked against `createOpsSubset`; the enumeration semantics
including the zero-materialization assertion; own-property shadowing; and a
snapshot round trip that reaches ops during the build (where they must
materialize *without* fast calls, since V8 will not serialize those) and again
after rehydration (where they must materialize *with* them). #36805's
`test_lazy_loaded_script_captured_bootstrap_ops` passes unchanged, which is the
regression guard that matters most here.
