### PR TITLE
perf(core): export only the ops something imports from ext:core/ops

### DIFF
--- a/libs/core/runtime/bindings.rs
+++ b/libs/core/runtime/bindings.rs
@@ -44,6 +44,7 @@ use crate::ops::OpCtx;
 use crate::runtime::ContextState;
 use crate::runtime::InitMode;
 use crate::runtime::JsRealm;
+use crate::runtime::ops_exports::OpsExportFilter;
 
 pub(crate) fn create_external_references(
   ops: &[OpCtx],
@@ -2096,12 +2097,16 @@ where
 
 /// This function generates a list of tuples, that are a mapping of `<op_name>`
 /// to a JavaScript function that executes and op.
+///
+/// Only names `filter` allows get an export cell; see
+/// [`crate::runtime::ops_exports`] for how that set is derived.
 pub fn create_exports_for_ops_virtual_module<'s, 'i>(
   op_ctxs: &[OpCtx],
   op_method_decls: &[OpMethodDecl],
   methods_ctx_offset: usize,
   scope: &mut v8::PinScope<'s, 'i>,
   global: v8::Local<'s, v8::Object>,
+  filter: &OpsExportFilter,
 ) -> Vec<(FastStaticString, v8::Local<'s, v8::Value>)> {
   let mut exports = Vec::with_capacity(op_ctxs.len());
 
@@ -2120,15 +2125,25 @@ pub fn create_exports_for_ops_virtual_module<'s, 'i>(
       index += 1;
     }
 
+    index += decl.methods.len() + decl.static_methods.len();
+
+    // Reading the name off `Deno.core.ops` goes through the lazy-ops
+    // interceptor and *materializes* the function -- which is then held alive
+    // by the export cell, and lands in the snapshot blob. Skipping the names
+    // nothing imports is the whole point of this filter.
     let name = decl.name.1;
+    if !filter.allows(decl.name.0) {
+      continue;
+    }
     let op_fn = get(scope, ops_obj, name, "op");
     exports.push((name, op_fn));
-
-    index += decl.methods.len() + decl.static_methods.len();
   }
 
   let op_ctxs = &op_ctxs[index..];
   for op_ctx in op_ctxs {
+    if !filter.allows(op_ctx.decl().name) {
+      continue;
+    }
     let op_fn = get(scope, ops_obj, op_ctx.decl().name_fast, "op");
     exports.push((op_ctx.decl().name_fast, op_fn));
   }

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -71,6 +71,7 @@ use super::bindings::watch_promise;
 use super::exception_state::ExceptionState;
 use super::jsrealm::JsRealmInner;
 use super::op_driver::OpDriver;
+use super::ops_exports;
 use super::setup;
 use super::snapshot;
 use super::stats::RuntimeActivityStatsFactory;
@@ -598,6 +599,28 @@ pub struct RuntimeOptions {
   /// Should op registration be skipped?
   pub skip_op_registration: bool,
 
+  /// Make the `ext:core/ops` synthetic module export **every** registered op,
+  /// the way it did before the export list was shrunk to the set of names that
+  /// extension sources actually import.
+  ///
+  /// By default deno_core scans the extension sources it is given — including
+  /// `lazy_loaded_*` and residual sources — for
+  /// `import { … } from "ext:core/ops"` clauses and exports only those names.
+  /// Anything the scan cannot prove to be a plain named import (a namespace
+  /// import, an `export * from`, a dynamic `import("ext:core/ops")`) already
+  /// switches that runtime back to exporting everything automatically, so this
+  /// flag is only needed when the importing module is **not** among the sources
+  /// deno_core sees — e.g. a module served by the embedder's own
+  /// `ModuleLoader` that imports ops by name.
+  ///
+  /// Turning this on restores the pre-shrink blob cost: one export cell, and
+  /// hence one materialized op function, per registered op (~270 bytes of
+  /// snapshot each). Prefer letting the scanner see the source.
+  ///
+  /// Only meaningful when the runtime builds the module itself, i.e. when there
+  /// is no startup snapshot or the snapshot is being created.
+  pub export_all_ops_from_virtual_module: bool,
+
   /// Isolate creation parameters.
   pub create_params: Option<v8::CreateParams>,
 
@@ -848,6 +871,69 @@ impl JsRuntime {
       },
     )?;
     startup_phase_end(_phase, "into_sources_and_source_maps");
+
+    // Work out which names `ext:core/ops` has to export, before the sources are
+    // externalized. Only the runtime that *builds* the module pays for this;
+    // when the module comes out of a snapshot it is already shaped.
+    let ops_export_filter = if init_mode == InitMode::New {
+      let _phase = startup_phase_begin();
+      let mut scan = ops_exports::OpsImportScan::default();
+      if options.export_all_ops_from_virtual_module {
+        scan.force_export_all();
+      }
+      for source in sources
+        .js
+        .iter()
+        .chain(sources.esm.iter())
+        .chain(sources.lazy_esm.iter())
+        .chain(sources.lazy_js.iter())
+      {
+        scan.add_source(source.code.as_str());
+      }
+      // Residual `lazy_loaded_*` sources are instantiated *after* the snapshot
+      // is deserialized, but they are known here, so their imports go into the
+      // same union rather than exploding at load time.
+      for (_, source) in options
+        .residual_lazy_js_sources
+        .iter()
+        .chain(options.residual_lazy_esm_sources.iter())
+      {
+        scan.add_source(source);
+      }
+      // deno_core's own built-ins are executed after the synthetic module is
+      // created, so they have to be in the union too.
+      for source in CONTEXT_SETUP_SOURCES.iter().chain(BUILTIN_SOURCES.iter()) {
+        scan.add_source(source.source.as_str());
+      }
+      for source in &BUILTIN_ES_MODULES {
+        scan.add_source(source.load()?.as_str());
+      }
+      let filter = scan.finish();
+      startup_phase_end(_phase, "scan_ops_module_imports");
+      if startup_phases_enabled() {
+        #[allow(clippy::print_stderr, reason = "diagnostic")]
+        {
+          // The fail-safe direction of this analysis is "export everything",
+          // which costs the whole win silently. Make it visible next to the
+          // other startup diagnostics.
+          match &filter {
+            ops_exports::OpsExportFilter::All => eprintln!(
+              "[startup] {:>32}  ALL (export-all requested, or a source uses \
+               ext:core/ops in a way the scanner cannot analyse)",
+              "ext:core/ops exports"
+            ),
+            ops_exports::OpsExportFilter::Only(names) => eprintln!(
+              "[startup] {:>32}  {} names",
+              "ext:core/ops exports",
+              names.len()
+            ),
+          }
+        }
+      }
+      filter
+    } else {
+      ops_exports::OpsExportFilter::All
+    };
 
     for loaded_source in sources
       .js
@@ -1257,8 +1343,11 @@ impl JsRuntime {
       // ) {
       if init_mode == InitMode::New {
         let _phase = startup_phase_begin();
-        js_runtime
-          .execute_virtual_ops_module(context_global, module_map.clone());
+        js_runtime.execute_virtual_ops_module(
+          context_global,
+          module_map.clone(),
+          &ops_export_filter,
+        );
         startup_phase_end(_phase, "execute_virtual_ops_module");
       }
 
@@ -1471,6 +1560,7 @@ impl JsRuntime {
     &mut self,
     context_global: &v8::Global<v8::Context>,
     module_map: Rc<ModuleMap>,
+    filter: &ops_exports::OpsExportFilter,
   ) {
     scope!(scope, self);
     let context_local = v8::Local::new(scope, context_global);
@@ -1482,6 +1572,7 @@ impl JsRuntime {
       context_state.methods_ctx_offset,
       scope,
       global,
+      filter,
     );
     let mod_id = module_map.new_synthetic_module(
       scope,

--- a/libs/core/runtime/mod.rs
+++ b/libs/core/runtime/mod.rs
@@ -8,6 +8,7 @@ mod jsruntime;
 pub mod op_driver;
 #[doc(hidden)]
 pub mod ops;
+mod ops_exports;
 pub mod ops_rust_to_v8;
 mod setup;
 mod snapshot;

--- a/libs/core/runtime/ops_exports.rs
+++ b/libs/core/runtime/ops_exports.rs
@@ -1,0 +1,566 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Works out which named exports the `ext:core/ops` synthetic module actually
+//! has to provide.
+//!
+//! `ext:core/ops` used to export one name per registered op. Every export cell
+//! of a synthetic module must hold a value at instantiation time, so with the
+//! lazy-ops interceptor in place (`Deno.core.ops` no longer holds op functions)
+//! the export list became the *only* remaining reference that forces every op
+//! function into the snapshot blob.
+//!
+//! The fix is to export only the names something actually imports. Rather than
+//! making every extension declare its imports (which drifts, silently, in the
+//! direction of "somebody forgot"), the import lists are read straight out of
+//! the extension sources deno_core already holds in memory at snapshot-build
+//! time — see [`OpsExportFilter`].
+//!
+//! The scanner is deliberately **fail-safe**: any use of `ext:core/ops` it
+//! cannot prove to be a plain named import (`import * as ops from ...`, a
+//! dynamic `import("ext:core/ops")`, an `export * from ...`) switches the whole
+//! runtime back to exporting every op. Getting the analysis wrong therefore
+//! costs performance, never correctness. In the other direction — a named
+//! import the scanner somehow failed to see — the failure is a `SyntaxError` at
+//! module instantiation naming the missing export, never a silent `undefined`.
+
+use std::collections::HashSet;
+
+/// Which names `ext:core/ops` should export.
+#[derive(Debug)]
+pub(crate) enum OpsExportFilter {
+  /// Export every registered op. Either an embedder asked for it via
+  /// [`crate::RuntimeOptions::export_all_ops_from_virtual_module`], or the
+  /// scanner saw something it could not analyse.
+  All,
+  /// Export only these names.
+  Only(HashSet<String>),
+}
+
+impl OpsExportFilter {
+  pub(crate) fn allows(&self, name: &str) -> bool {
+    match self {
+      Self::All => true,
+      Self::Only(names) => names.contains(name),
+    }
+  }
+
+  /// Number of names that will be exported, when known.
+  #[cfg(test)]
+  pub(crate) fn len(&self) -> Option<usize> {
+    match self {
+      Self::All => None,
+      Self::Only(names) => Some(names.len()),
+    }
+  }
+}
+
+/// Accumulates the union of `ext:core/ops` named imports across every source
+/// that will ever be instantiated against this runtime's synthetic module.
+#[derive(Debug, Default)]
+pub(crate) struct OpsImportScan {
+  names: HashSet<String>,
+  export_all: bool,
+}
+
+impl OpsImportScan {
+  /// Force "export everything", e.g. because the embedder asked for it.
+  pub(crate) fn force_export_all(&mut self) {
+    self.export_all = true;
+  }
+
+  /// Fold one source file's `ext:core/ops` imports into the union.
+  ///
+  /// Sources that do not mention `ext:core/ops` at all are rejected by a
+  /// substring test before any tokenization happens, so the common case costs a
+  /// memchr sweep.
+  pub(crate) fn add_source(&mut self, source: &str) {
+    if self.export_all || !source.contains(OPS_SPECIFIER) {
+      return;
+    }
+    match scan_source(source) {
+      Some(names) => self.names.extend(names),
+      None => self.export_all = true,
+    }
+  }
+
+  pub(crate) fn finish(self) -> OpsExportFilter {
+    if self.export_all {
+      OpsExportFilter::All
+    } else {
+      OpsExportFilter::Only(self.names)
+    }
+  }
+}
+
+const OPS_SPECIFIER: &str = "ext:core/ops";
+
+/// Returns the set of names imported from `ext:core/ops`, or `None` if the
+/// source uses `ext:core/ops` in a way that needs the full export list.
+fn scan_source(source: &str) -> Option<Vec<String>> {
+  let tokens = tokenize(source);
+  let mut names = Vec::new();
+  // Every occurrence of the specifier as a *string literal in code position*
+  // has to be accounted for by a recognized import form. Anything else is a
+  // bail.
+  let mut accounted = 0usize;
+  let mut occurrences = 0usize;
+
+  for (i, tok) in tokens.iter().enumerate() {
+    if !matches!(tok, Token::Str(s) if s == OPS_SPECIFIER) {
+      continue;
+    }
+    occurrences += 1;
+    if let Some(imported) = named_import_before(&tokens, i) {
+      accounted += 1;
+      names.extend(imported);
+    } else if matches!(
+      tokens.get(i.wrapping_sub(1)),
+      Some(Token::Ident(kw)) if *kw == "import"
+    ) {
+      // Bare side-effect import `import "ext:core/ops";` needs no exports.
+      accounted += 1;
+    }
+  }
+
+  if occurrences == 0 || accounted != occurrences {
+    return None;
+  }
+  Some(names)
+}
+
+/// Given that `tokens[str_idx]` is the specifier string, walk backwards over
+/// `from { a, b as c } import|export` and return the imported names.
+fn named_import_before(
+  tokens: &[Token],
+  str_idx: usize,
+) -> Option<Vec<String>> {
+  // ... from
+  let from = str_idx.checked_sub(1)?;
+  match tokens.get(from)? {
+    Token::Ident(k) if *k == "from" => {}
+    _ => return None,
+  }
+  // ... }
+  let close = from.checked_sub(1)?;
+  match tokens.get(close)? {
+    Token::Punct('}') => {}
+    _ => return None,
+  }
+  // Walk back to the matching `{`. Import clauses cannot nest braces, so the
+  // first `{` going backwards is the opener; anything else in between that is
+  // not an identifier, `,` or `as` means this is not an import clause.
+  let mut open = close;
+  let mut names = Vec::new();
+  let mut expect_name = true;
+  loop {
+    open = open.checked_sub(1)?;
+    match tokens.get(open)? {
+      Token::Punct('{') => break,
+      Token::Punct(',') => expect_name = true,
+      Token::Ident(id) => {
+        // Reading right-to-left, an element is `name` or `name as alias`; the
+        // *last* identifier we see before the `{` or a `,` is the imported
+        // name.
+        if *id == "as" {
+          // The alias we just recorded is not the imported name; the next
+          // identifier to the left is.
+          names.pop();
+          expect_name = true;
+        } else if expect_name {
+          names.push((*id).to_string());
+          expect_name = false;
+        } else {
+          // Two adjacent identifiers with no `as`: not an import clause.
+          return None;
+        }
+      }
+      _ => return None,
+    }
+  }
+  // ... import | export
+  match tokens.get(open.checked_sub(1)?)? {
+    Token::Ident(k) if *k == "import" || *k == "export" => {}
+    // `import defaultName, { ... } from` — a default import of `ext:core/ops`
+    // is meaningless, and we would rather not guess.
+    _ => return None,
+  }
+  // Validate that every name looks like a plain identifier.
+  if names.iter().any(|n| !is_ident(n)) {
+    return None;
+  }
+  Some(names)
+}
+
+fn is_ident(s: &str) -> bool {
+  let mut chars = s.chars();
+  match chars.next() {
+    Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '$' => {}
+    _ => return false,
+  }
+  chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
+/// A very small JS token stream — just enough to find import declarations
+/// without being fooled by comments, strings, template literals or regexes.
+#[derive(Debug, PartialEq)]
+enum Token<'a> {
+  Ident(&'a str),
+  Str(String),
+  Punct(char),
+  /// Numbers, template literals, regexes, and anything else we do not care
+  /// about but must not mistake for one of the above.
+  Other,
+}
+
+fn tokenize(src: &str) -> Vec<Token<'_>> {
+  let b = src.as_bytes();
+  let mut i = 0;
+  let mut out: Vec<Token> = Vec::new();
+  while i < b.len() {
+    let c = b[i];
+    match c {
+      b' ' | b'\t' | b'\r' | b'\n' | 0x0b | 0x0c => i += 1,
+      // Comments. `//` and `/*` are unambiguous: an empty regex `//` and a
+      // regex starting `/*` are both syntax errors, so a `/` followed by `/`
+      // or `*` always begins a comment.
+      b'/' if b.get(i + 1) == Some(&b'/') => {
+        i += 2;
+        while i < b.len() && b[i] != b'\n' {
+          i += 1;
+        }
+      }
+      b'/' if b.get(i + 1) == Some(&b'*') => {
+        i += 2;
+        while i < b.len() && !(b[i] == b'*' && b.get(i + 1) == Some(&b'/')) {
+          i += 1;
+        }
+        i = (i + 2).min(b.len());
+      }
+      b'/' => {
+        // Divide or regex. Use the classic previous-token heuristic; either way
+        // the result is `Token::Other`, so all this decides is how far to skip.
+        if regex_allowed(out.last()) {
+          i = skip_regex(b, i);
+        } else {
+          i += 1;
+        }
+        out.push(Token::Other);
+      }
+      b'"' | b'\'' => {
+        let (s, next) = read_string(b, i);
+        i = next;
+        match s {
+          Some(s) => out.push(Token::Str(s)),
+          None => out.push(Token::Other),
+        }
+      }
+      b'`' => {
+        i = skip_template(b, i);
+        out.push(Token::Other);
+      }
+      b'0'..=b'9' => {
+        i += 1;
+        while i < b.len()
+          && (b[i].is_ascii_alphanumeric() || b[i] == b'.' || b[i] == b'_')
+        {
+          i += 1;
+        }
+        out.push(Token::Other);
+      }
+      _ if is_ident_start(c) => {
+        let start = i;
+        i += 1;
+        while i < b.len() && is_ident_part(b[i]) {
+          i += 1;
+        }
+        out.push(Token::Ident(&src[start..i]));
+      }
+      _ => {
+        out.push(Token::Punct(c as char));
+        i += 1;
+      }
+    }
+  }
+  out
+}
+
+fn is_ident_start(c: u8) -> bool {
+  c.is_ascii_alphabetic() || c == b'_' || c == b'$' || c >= 0x80
+}
+
+fn is_ident_part(c: u8) -> bool {
+  c.is_ascii_alphanumeric() || c == b'_' || c == b'$' || c >= 0x80
+}
+
+/// After which tokens may a `/` start a regex literal?
+fn regex_allowed(prev: Option<&Token>) -> bool {
+  match prev {
+    None => true,
+    Some(Token::Str(_)) | Some(Token::Other) => false,
+    Some(Token::Punct(c)) => !matches!(c, ')' | ']' | '}'),
+    Some(Token::Ident(id)) => matches!(
+      *id,
+      "return"
+        | "typeof"
+        | "instanceof"
+        | "in"
+        | "of"
+        | "new"
+        | "delete"
+        | "void"
+        | "throw"
+        | "case"
+        | "do"
+        | "else"
+        | "yield"
+        | "await"
+    ),
+  }
+}
+
+/// Reads a quoted string starting at `b[i]`. Returns the decoded contents when
+/// the literal contains no escapes (which is all we need — the specifier has
+/// none) and the index just past the closing quote.
+fn read_string(b: &[u8], i: usize) -> (Option<String>, usize) {
+  let quote = b[i];
+  let mut j = i + 1;
+  let start = j;
+  let mut escaped = false;
+  while j < b.len() {
+    match b[j] {
+      b'\\' => {
+        escaped = true;
+        j += 2;
+        continue;
+      }
+      c if c == quote => {
+        let s = if escaped {
+          None
+        } else {
+          std::str::from_utf8(&b[start..j]).ok().map(str::to_string)
+        };
+        return (s, j + 1);
+      }
+      // Unterminated string literal (newline). Give up on this token.
+      b'\n' => return (None, j + 1),
+      _ => j += 1,
+    }
+  }
+  (None, b.len())
+}
+
+fn skip_template(b: &[u8], i: usize) -> usize {
+  // Track `${ ... }` substitutions so a backtick inside one does not terminate
+  // the outer literal early. Nested templates are handled by the depth stack.
+  let mut j = i + 1;
+  let mut brace_depth: Vec<usize> = Vec::new();
+  let mut cur: usize = 0;
+  while j < b.len() {
+    match b[j] {
+      b'\\' => j += 2,
+      b'$' if b.get(j + 1) == Some(&b'{') => {
+        brace_depth.push(cur);
+        cur = 1;
+        j += 2;
+      }
+      b'{' if cur > 0 => {
+        cur += 1;
+        j += 1;
+      }
+      b'}' if cur > 0 => {
+        cur -= 1;
+        if cur == 0 {
+          cur = brace_depth.pop().unwrap_or(0);
+        }
+        j += 1;
+      }
+      b'`' if cur == 0 => return j + 1,
+      _ => j += 1,
+    }
+  }
+  b.len()
+}
+
+fn skip_regex(b: &[u8], i: usize) -> usize {
+  let mut j = i + 1;
+  let mut in_class = false;
+  while j < b.len() {
+    match b[j] {
+      b'\\' => j += 2,
+      b'[' => {
+        in_class = true;
+        j += 1;
+      }
+      b']' => {
+        in_class = false;
+        j += 1;
+      }
+      b'/' if !in_class => {
+        j += 1;
+        while j < b.len() && b[j].is_ascii_alphabetic() {
+          j += 1;
+        }
+        return j;
+      }
+      // A newline means it was not a regex after all; treat the `/` as one
+      // character of punctuation.
+      b'\n' => return i + 1,
+      _ => j += 1,
+    }
+  }
+  i + 1
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn names(src: &str) -> Option<Vec<String>> {
+    let mut v = scan_source(src)?;
+    v.sort();
+    Some(v)
+  }
+
+  #[test]
+  fn single_line_named_import() {
+    assert_eq!(
+      names(r#"import { op_a, op_b } from "ext:core/ops";"#),
+      Some(vec!["op_a".to_string(), "op_b".to_string()])
+    );
+  }
+
+  #[test]
+  fn multiline_named_import() {
+    let src = r#"
+// Copyright.
+import {
+  op_a,
+  op_b,
+  ImageBitmap,
+} from "ext:core/ops";
+import { core } from "ext:core/mod.js";
+"#;
+    assert_eq!(
+      names(src),
+      Some(vec![
+        "ImageBitmap".to_string(),
+        "op_a".to_string(),
+        "op_b".to_string()
+      ])
+    );
+  }
+
+  #[test]
+  fn aliased_import_records_the_exported_name() {
+    assert_eq!(
+      names(r#"import { op_a as a, op_b as b } from "ext:core/ops";"#),
+      Some(vec!["op_a".to_string(), "op_b".to_string()])
+    );
+  }
+
+  #[test]
+  fn single_quotes_and_reexport() {
+    assert_eq!(
+      names("export { op_a } from 'ext:core/ops';"),
+      Some(vec!["op_a".to_string()])
+    );
+  }
+
+  #[test]
+  fn mention_in_a_line_comment_is_not_an_import() {
+    // This exact shape exists in deno's `cli/js/40_test.js`. It must not be
+    // mistaken for an import, and it must not force export-all either.
+    let src = r#"
+// TODO(mmastrac): We cannot import these from "ext:core/ops" yet
+import { op_a } from "ext:core/ops";
+"#;
+    assert_eq!(names(src), Some(vec!["op_a".to_string()]));
+  }
+
+  #[test]
+  fn mention_in_a_block_comment_is_not_an_import() {
+    let src = r#"
+/* import { op_x } from "ext:core/ops"; */
+import { op_a } from "ext:core/ops";
+"#;
+    assert_eq!(names(src), Some(vec!["op_a".to_string()]));
+  }
+
+  #[test]
+  fn namespace_import_forces_export_all() {
+    assert_eq!(names(r#"import * as ops from "ext:core/ops";"#), None);
+  }
+
+  #[test]
+  fn dynamic_import_forces_export_all() {
+    assert_eq!(names(r#"const m = await import("ext:core/ops");"#), None);
+  }
+
+  #[test]
+  fn star_reexport_forces_export_all() {
+    assert_eq!(names(r#"export * from "ext:core/ops";"#), None);
+  }
+
+  #[test]
+  fn default_plus_named_forces_export_all() {
+    assert_eq!(names(r#"import d, { op_a } from "ext:core/ops";"#), None);
+  }
+
+  #[test]
+  fn specifier_inside_a_string_forces_export_all() {
+    // We cannot tell what an embedder does with this, so bail.
+    assert_eq!(names(r#"const s = "ext:core/ops";"#), None);
+  }
+
+  #[test]
+  fn side_effect_import_needs_no_exports() {
+    assert_eq!(names(r#"import "ext:core/ops";"#), Some(vec![]));
+  }
+
+  #[test]
+  fn regex_containing_quotes_does_not_confuse_the_scanner() {
+    let src = r#"
+import { op_a } from "ext:core/ops";
+const re = /["']ext:core\/ops["']/;
+const d = 4 / 2 / 1;
+"#;
+    assert_eq!(names(src), Some(vec!["op_a".to_string()]));
+  }
+
+  #[test]
+  fn template_literal_with_substitution() {
+    let src = r#"
+import { op_a } from "ext:core/ops";
+const t = `a ${ `b ${ 1 } c` } "ext:core/ops" d`;
+"#;
+    assert_eq!(names(src), Some(vec!["op_a".to_string()]));
+  }
+
+  #[test]
+  fn scan_accumulates_and_is_sticky() {
+    let mut scan = OpsImportScan::default();
+    scan.add_source(r#"import { op_a } from "ext:core/ops";"#);
+    scan.add_source(r#"import { op_b } from "ext:core/ops";"#);
+    scan.add_source("const x = 1;");
+    let f = scan.finish();
+    assert_eq!(f.len(), Some(2));
+    assert!(f.allows("op_a"));
+    assert!(f.allows("op_b"));
+    assert!(!f.allows("op_c"));
+
+    let mut scan = OpsImportScan::default();
+    scan.add_source(r#"import { op_a } from "ext:core/ops";"#);
+    scan.add_source(r#"import * as ops from "ext:core/ops";"#);
+    let f = scan.finish();
+    assert_eq!(f.len(), None);
+    assert!(f.allows("anything_at_all"));
+  }
+
+  #[test]
+  fn forced_export_all_short_circuits() {
+    let mut scan = OpsImportScan::default();
+    scan.force_export_all();
+    scan.add_source(r#"import { op_a } from "ext:core/ops";"#);
+    assert_eq!(scan.finish().len(), None);
+  }
+}

--- a/libs/core/runtime/tests/mod.rs
+++ b/libs/core/runtime/tests/mod.rs
@@ -19,6 +19,7 @@ mod error;
 mod jsrealm;
 mod misc;
 mod ops;
+mod ops_exports;
 mod snapshot;
 
 #[derive(Copy, Clone)]

--- a/libs/core/runtime/tests/ops_exports.rs
+++ b/libs/core/runtime/tests/ops_exports.rs
@@ -1,0 +1,263 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! `ext:core/ops` exports only the names extension sources import
+//! (deno_core_revamp#41, final step).
+
+use crate::JsRuntime;
+use crate::JsRuntimeForSnapshot;
+use crate::RuntimeOptions;
+use crate::op2;
+
+#[op2(fast)]
+#[smi]
+fn op_exp_used(#[smi] a: i32) -> i32 {
+  a + 1
+}
+
+#[op2(fast)]
+#[smi]
+fn op_exp_unused(#[smi] a: i32) -> i32 {
+  a + 2
+}
+
+#[op2]
+#[string]
+fn op_exp_aliased(#[string] s: String) -> String {
+  format!("{s}!")
+}
+
+deno_core::extension!(
+  exp_ops,
+  ops = [op_exp_used, op_exp_unused, op_exp_aliased],
+  esm_entry_point = "ext:exp/main.js",
+  esm = ["ext:exp/main.js" = {
+    source = r#"
+        import { op_exp_used, op_exp_aliased as alias } from "ext:core/ops";
+        globalThis.expUsed = op_exp_used(41);
+        globalThis.expAliased = alias("hi");
+      "#
+  },],
+);
+
+/// Reads the export list of the live `ext:core/ops` module by importing a
+/// namespace from a module the scanner never saw. `lazy_load_es_module_with_code`
+/// instantiates against the synthetic module that already exists, so a name
+/// missing from the export list fails here rather than being `undefined`.
+fn try_import(
+  runtime: &mut JsRuntime,
+  specifier: &'static str,
+  code: &'static str,
+) -> Result<(), String> {
+  runtime
+    .lazy_load_es_module_with_code(specifier, code)
+    .map(|_| ())
+    .map_err(|e| e.to_string())
+}
+
+#[test]
+fn exports_only_imported_names() {
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![exp_ops::init()],
+    ..Default::default()
+  });
+
+  // The statically imported op ran at extension-init time.
+  runtime
+    .execute_script(
+      "check.js",
+      r#"
+      if (globalThis.expUsed !== 42) throw new Error("expUsed=" + globalThis.expUsed);
+      if (globalThis.expAliased !== "hi!") throw new Error("expAliased=" + globalThis.expAliased);
+      "#,
+    )
+    .unwrap();
+
+  // Imported names have export cells...
+  try_import(
+    &mut runtime,
+    "ext:exp/probe_ok.js",
+    r#"import { op_exp_used, op_exp_aliased } from "ext:core/ops";
+       if (typeof op_exp_used !== "function") throw new Error("not a fn");
+       if (typeof op_exp_aliased !== "function") throw new Error("not a fn");"#,
+  )
+  .unwrap();
+
+  // ...and a name nothing imports does not. The failure is loud and it names
+  // the op.
+  let err = try_import(
+    &mut runtime,
+    "ext:exp/probe_missing.js",
+    r#"import { op_exp_unused } from "ext:core/ops";"#,
+  )
+  .unwrap_err();
+  assert!(
+    err.contains("op_exp_unused"),
+    "expected the error to name the missing export, got: {err}"
+  );
+  assert!(
+    err.contains("does not provide an export"),
+    "expected a module instantiation SyntaxError, got: {err}"
+  );
+
+  // But the op itself is perfectly callable through the `Deno.core.ops`
+  // interceptor -- shrinking the export list does not disable an op.
+  runtime
+    .execute_script(
+      "call_unused.js",
+      r#"
+      const v = Deno.core.ops.op_exp_unused(40);
+      if (v !== 42) throw new Error("got " + v);
+      "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn export_all_escape_hatch_restores_every_name() {
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![exp_ops::init()],
+    export_all_ops_from_virtual_module: true,
+    ..Default::default()
+  });
+
+  try_import(
+    &mut runtime,
+    "ext:exp/probe_missing.js",
+    r#"import { op_exp_unused } from "ext:core/ops";
+       if (op_exp_unused(40) !== 42) throw new Error("bad");"#,
+  )
+  .unwrap();
+}
+
+deno_core::extension!(
+  exp_ops_namespace,
+  ops = [op_exp_used, op_exp_unused],
+  esm_entry_point = "ext:expns/main.js",
+  esm = ["ext:expns/main.js" = {
+    source = r#"
+        import * as ops from "ext:core/ops";
+        globalThis.expNs = ops.op_exp_used(41);
+      "#
+  },],
+);
+
+/// A namespace import needs every name, and the scanner cannot know which ones
+/// are read off the namespace object. It must fall back to exporting all of
+/// them rather than silently handing back a half-populated namespace.
+#[test]
+fn namespace_import_falls_back_to_exporting_everything() {
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![exp_ops_namespace::init()],
+    ..Default::default()
+  });
+  runtime
+    .execute_script(
+      "check.js",
+      "if (globalThis.expNs !== 42) throw new Error('expNs=' + globalThis.expNs);",
+    )
+    .unwrap();
+  try_import(
+    &mut runtime,
+    "ext:expns/probe.js",
+    r#"import { op_exp_unused } from "ext:core/ops";
+       if (op_exp_unused(40) !== 42) throw new Error("bad");"#,
+  )
+  .unwrap();
+}
+
+deno_core::extension!(
+  exp_ops_lazy,
+  ops = [op_exp_used, op_exp_unused],
+  lazy_loaded_esm = ["ext:exp/lazy.js" = {
+    source = r#"
+        import { op_exp_used } from "ext:core/ops";
+        export const value = op_exp_used(41);
+      "#
+  },],
+);
+
+/// A `lazy_loaded_esm` module instantiates long after the snapshot was built,
+/// against the export list baked into the blob. Its imports have to be in the
+/// union, which is why the scan covers the lazy sources too.
+#[test]
+fn lazy_loaded_esm_imports_survive_a_snapshot() {
+  let _snapshot_lock = super::snapshot_test_lock();
+  let snapshot = {
+    let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+      extensions: vec![exp_ops_lazy::init()],
+      ..Default::default()
+    });
+    runtime.snapshot()
+  };
+  let snapshot = Box::leak(snapshot);
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    startup_snapshot: Some(snapshot),
+    extensions: vec![exp_ops_lazy::init()],
+    ..Default::default()
+  });
+
+  runtime
+    .execute_script(
+      "load_lazy.js",
+      r#"
+      const mod = Deno.core.createLazyLoader("ext:exp/lazy.js")();
+      if (mod.value !== 42) throw new Error("got " + mod.value);
+      "#,
+    )
+    .unwrap();
+}
+
+deno_core::extension!(
+  exp_ops_residual,
+  ops = [op_exp_used, op_exp_unused],
+  lazy_loaded_esm = ["ext:exp/residual.js" = {
+    source = r#"
+        import { op_exp_used } from "ext:core/ops";
+        export const value = op_exp_used(41);
+      "#
+  },],
+);
+
+/// The same module, but reaching the runtime through
+/// `residual_lazy_esm_sources` (the shape a real embedder's build script emits
+/// for lazy files the snapshot did not consume). Those sources are known at
+/// snapshot-build time, so they are scanned there.
+#[test]
+fn residual_lazy_esm_imports_are_in_the_export_set() {
+  let _snapshot_lock = super::snapshot_test_lock();
+  const RESIDUAL: &[(&str, &str)] = &[(
+    "ext:exp/residual.js",
+    r#"
+      import { op_exp_used } from "ext:core/ops";
+      export const value = op_exp_used(41);
+    "#,
+  )];
+
+  let snapshot = {
+    let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+      extensions: vec![exp_ops_residual::init()],
+      residual_lazy_esm_sources: RESIDUAL,
+      ..Default::default()
+    });
+    runtime.snapshot()
+  };
+  let snapshot = Box::leak(snapshot);
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    startup_snapshot: Some(snapshot),
+    extensions: vec![exp_ops_residual::init()],
+    residual_lazy_esm_sources: RESIDUAL,
+    ..Default::default()
+  });
+
+  runtime
+    .execute_script(
+      "load_residual.js",
+      r#"
+      const mod = Deno.core.createLazyLoader("ext:exp/residual.js")();
+      if (mod.value !== 42) throw new Error("got " + mod.value);
+      "#,
+    )
+    .unwrap();
+}

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -666,6 +666,9 @@ impl WebWorker {
         .then(crate::worker::create_permissions_stack_trace_callback),
       extension_code_cache: None,
       skip_op_registration: false,
+      // Every `ext:core/ops` importer in this repo is an extension source, so
+      // the import scan sees them all and the export list can shrink.
+      export_all_ops_from_virtual_module: false,
       v8_platform: None,
       is_main: false,
       worker_id: Some(options.worker_id.0),

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -1286,6 +1286,9 @@ fn common_runtime(opts: CommonRuntimeOptions) -> JsRuntime {
     residual_lazy_esm_sources: opts.residual_lazy_esm_sources,
     create_params: opts.create_params,
     skip_op_registration: opts.skip_op_registration,
+    // Every `ext:core/ops` importer in this repo is an extension source, so
+    // the import scan sees them all and the export list can shrink.
+    export_all_ops_from_virtual_module: false,
     shared_array_buffer_store: opts.shared_array_buffer_store,
     compiled_wasm_module_store: opts.compiled_wasm_module_store,
     extensions: opts.extensions,


### PR DESCRIPTION
Ports denoland/deno_core_revamp#46. **Stacked on #36806**, which is itself
stacked on #36805; it targets the #36806 branch and is only meaningful on top of
it.

#36806 built the lazy-ops interceptor and measured, precisely, why the blob did
not move: `ext:core/ops` exports one name per registered op,
`create_exports_for_ops_virtual_module` obtains each export value by *reading it
off the ops object* -- which under the interceptor materializes the function --
and the export cell then holds it into the blob. The interceptor removed one of
the two references to every op function. This removes the other one.
`ext:core/ops` now exports only the names something actually imports.

The design question was where that list comes from. Requiring `extension!`
invocations to declare their imports was rejected on author burden and drift: at
deno's profile that is 222 distinct names across 36 files that would have to be
restated in ~20 `extension!` invocations and kept in sync by hand forever, when
the import clause five lines away in the same file already *is* the declaration.
A two-pass compile -- compile every real module, harvest
`v8::Module::module_requests()`, then build the synthetic module -- does not
survive the requirement that residual and `lazy_loaded_esm` modules work: those
are deliberately not compiled at snapshot time, yet they instantiate against the
export list baked into the blob, so their imports have to be in the set, and
compiling them to read their import lists gives back exactly the cost the
laziness was buying. So the import clauses are read out of the source text, for
every source the runtime is handed -- `js`, `esm`, `lazy_esm`, `lazy_js`,
`residual_lazy_{js,esm}_sources`, and deno_core's own built-ins -- and the union
is exported.

The obvious objection to text-scanning is that a hand-rolled parser will
eventually be wrong. It is wrong in a safe direction by construction. The
scanner classifies every occurrence of the specifier as a string literal in code
position; if even one of them is not a provably plain named import -- a
namespace import, an `export * from`, a dynamic `import("ext:core/ops")`, a
default-plus-named clause, the specifier appearing inside an ordinary string --
the entire runtime falls back to exporting everything, i.e. to today's
behaviour. Being unable to analyse a source costs performance and nothing else.
In the other direction, an import the scanner somehow failed to see is a
`SyntaxError` at module instantiation that names the missing export; it is never
a silent `undefined`. The scan is comment- and string-aware because it has to
be: `cli/js/40_test.js` contains the line `// TODO(mmastrac): We cannot import
these from "ext:core/ops" yet`, which a naive backwards match would read as an
unanalysable use and would switch export-all on for the whole runtime. Being
token-based also means transpilation and `DENO_SNAPSHOT_MINIFY_SOURCES` are
irrelevant to it.

I checked deno's actual import profile rather than assuming it. There are 40
files mentioning `ext:core/ops`; the two `cli/js` hits are the comment above,
`tests/unit_node/vm_test.ts` only asserts that user code is *refused* the
specifier, and the only namespace import is `libs/core/benches/snapshot/file.js`
-- which the revamp repo also leaves alone deliberately, so that every
`cargo bench -p deno_core --bench snapshot` run exercises the export-all
fallback. Every remaining importer is an extension source, so the fail-safe
never trips for the real runtimes and the full shrink is available. The one
thing that needed checking beyond the file list is the `cli/js` modules that
arrive at runtime through `lazy_load_es_module_with_code` rather than as
extension sources, since the scanner cannot see those: none of them import from
`ext:core/ops`, which is what that TODO is about. The snapshot build in
`runtime/snapshot.rs` registers the same extension set the workers do, and every
extension's `lazy_loaded_*` files are in `sources.lazy_{js,esm}` at scan time
whether or not they are later delivered as residual sources, so the baked export
list covers them.

The monorepo adaptation is small but was a genuine break: `RuntimeOptions` is
constructed with an exhaustive struct literal (no `..Default::default()`) in
`runtime/worker.rs` and `runtime/web_worker.rs`, so the new
`export_all_ops_from_virtual_module` field has to be named in both. It is set to
`false` there, i.e. the shrink is on, with a comment saying why that is safe.
Everything else in the repo that constructs `RuntimeOptions` uses struct-update
syntax and picks up the `Default` value. Nothing here depends on unlanded Wave 2
work.

`export_all_ops_from_virtual_module` defaults to `false` and is documented as
the escape hatch of last resort, with the cost stated in bytes, because reaching
for it gives back the entire win. It is only needed when the importing module is
not among the sources deno_core sees -- e.g. a module served by an embedder's
own `ModuleLoader` -- since an unanalysable *source* already switches export-all
on by itself.

As measured in denoland/deno_core_revamp#46 with `op_scale_probe`: **268.1 ->
0.065 B/op, 99.98% removed**, exactly the figure the five-line experimental
patch in #45 predicted. Absolute blob at 99 / 299 ops goes from 719,150 /
772,763 B to 714,646 / 714,659 B; `JsRuntime::new` per-op cost becomes
indistinguishable from zero. `execute_virtual_ops_module` at 299 ops drops from
~400 us to 16 us, against 20 us for the new scan. `bench/run.sh --mem --graph
--startup` showed per-runtime RSS 6.76 -> 6.60 MiB (-2.4%) and peak footprint
-1.9%. Counting deno's real import profile -- 222 distinct names against ~1,003
export cells -- roughly 780 op function objects stop being reachable from the
blob, which at the 268 B/op measured there is about 205 KB of snapshot and about
0.34 ms off every `JsRuntime::new`, per worker. Both are lower bounds: the
probe's dummy ops carry no cppgc method decls and deno's do. The op call path is
untouched and `loop_probe` says so.

To confirm the shrink is actually on after this lands, `DENO_STARTUP_PHASES=1`
now prints `ext:core/ops exports  N names` right after the scan, or `ALL` with
the reason. If it says `ALL`, some source has acquired an unanalysable use of
the specifier and the win is silently off; that line is how you find out. It is
the only new diagnostic surface, and no new external reference is added -- the
only thing that changes is how many `(name, value)` pairs are handed to
`new_synthetic_module`.

The integration tests are the ones that carry the argument: a static
`import { op_a, op_b as alias } from "ext:core/ops"` in an extension ESM module
keeps working, aliases included; a `lazy_loaded_esm` module that imports an op
still instantiates after a full snapshot round trip; the same for a source
arriving through `residual_lazy_esm_sources`; an op that nothing imports has no
export cell, so importing it from a module deno_core never saw fails with a
`SyntaxError` naming it -- and the very next line calls
`Deno.core.ops.op_exp_unused(40)` successfully, which is the whole design in one
test; an extension whose module uses `import * as ops` gets the full export list
back automatically; and `export_all_ops_from_virtual_module: true` restores it
explicitly. Sixteen unit tests pin the scanner's shapes, including the ones that
must bail.
