### PR TITLE
fix(ext/node): add receive guard 

### DIFF
--- a/ext/node/ops/http2/session.rs
+++ b/ext/node/ops/http2/session.rs
@@ -50,6 +50,38 @@ thread_local! {
 
   static SETTINGS: UnsafeCell<[u32; SETTINGS_LEN]> =
     const { UnsafeCell::new([0; SETTINGS_LEN]) };
+
+  /// Nesting depth of `nghttp2_session_mem_recv` on this thread. Tracked at
+  /// the FFI call site because a nested `receive_data` is legitimate (it
+  /// queues) and only the second `mem_recv` itself is forbidden.
+  static RECV_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Panics if a `mem_recv` call is already live on this thread.
+///
+/// A function rather than an inline block at the call site so the tests
+/// below can reach it: the real call site is inside a `#[op2]`-generated
+/// `extern "C"` frame, where a panic becomes `panic_cannot_unwind`.
+fn enter_mem_recv() {
+  RECV_DEPTH.with(|depth| {
+    debug_assert_eq!(
+      depth.get(),
+      0,
+      "nghttp2_session_mem_recv re-entered while an outer call is still on the stack"
+    );
+    depth.set(depth.get() + 1);
+  });
+}
+
+/// Release the entry recorded by [`enter_mem_recv`].
+fn exit_mem_recv() {
+  RECV_DEPTH.with(|depth| {
+    debug_assert!(
+      depth.get() > 0,
+      "exit_mem_recv called without a matching enter_mem_recv"
+    );
+    depth.set(depth.get() - 1);
+  });
 }
 
 #[derive(ToV8)]
@@ -2043,6 +2075,16 @@ pub struct Session {
   /// mem_send can close/free streams that mem_recv still references
   /// (double-free). Like Node.js's is_sending() guard.
   pub is_sending: bool,
+  /// True while `receive_data` is inside `nghttp2_session_mem_recv`.
+  ///
+  /// `mem_recv` is not reentrant: it keeps the inbound frame state machine
+  /// and, during GOAWAY processing, the `stream->closed_next` close list
+  /// live for the whole call. `receive` is a `#[reentrant]` op and JS
+  /// reached through `on_stream_close_callback` can hand us more bytes, so
+  /// nested bytes are queued rather than parsed.
+  pub is_receiving: bool,
+  /// Inbound bytes queued while `is_receiving` was set.
+  pub pending_recv: VecDeque<bytes::Bytes>,
   /// Set when destroy() is called while is_sending is true. The TCP
   /// handle close is deferred until send_pending_data can run, allowing
   /// GOAWAY to be sent before the connection closes.
@@ -2713,29 +2755,71 @@ impl Session {
     if self.session.is_null() {
       return;
     }
-    // Block re-entrant send_pending_data calls from JS callbacks during
-    // mem_recv. A single mem_recv can process multiple frames (e.g.
-    // END_STREAM + RST_STREAM). If a callback from frame N triggers
-    // mem_send which closes/frees a stream, frame N+1 (RST_STREAM for
-    // the same stream) would crash with a double-free. Matches Node.js
-    // behavior where sends are deferred until after mem_recv completes.
-    self.is_sending = true;
-    // SAFETY: self.session is valid; data slice pointer and length are valid
-    let ret = unsafe {
-      ffi::nghttp2_session_mem_recv(
-        self.session,
-        data.as_ptr() as _,
-        data.len(),
-      )
-    };
-    self.is_sending = false;
-    if (ret as i64) < 0 {
+
+    // `mem_recv` is not reentrant, and JS reached from it can hand us more
+    // bytes. Queue them and let the loop below drain them once the live
+    // `mem_recv` has unwound.
+    if self.is_receiving {
+      self
+        .pending_recv
+        .push_back(bytes::Bytes::copy_from_slice(data));
+      return;
+    }
+
+    self.is_receiving = true;
+    self
+      .pending_recv
+      .push_back(bytes::Bytes::copy_from_slice(data));
+
+    let mut fatal: Option<i32> = None;
+    while let Some(buf) = self.pending_recv.pop_front() {
+      // `send_pending_data` from the previous iteration can run JS that
+      // tears the session down.
+      if self.session.is_null() {
+        break;
+      }
+      // Block re-entrant send_pending_data calls from JS callbacks during
+      // mem_recv. A single mem_recv can process multiple frames (e.g.
+      // END_STREAM + RST_STREAM). If a callback from frame N triggers
+      // mem_send which closes/frees a stream, frame N+1 (RST_STREAM for
+      // the same stream) would crash with a double-free. Matches Node.js
+      // behavior where sends are deferred until after mem_recv completes.
+      self.is_sending = true;
+      enter_mem_recv();
+      // SAFETY: self.session is valid (checked above); `buf` owns
+      // `buf.len()` readable bytes for the duration of the call.
+      let ret = unsafe {
+        ffi::nghttp2_session_mem_recv(
+          self.session,
+          buf.as_ptr() as _,
+          buf.len(),
+        )
+      };
+      exit_mem_recv();
+      self.is_sending = false;
+
+      if (ret as i64) < 0 {
+        fatal = Some(ret as i32);
+        break;
+      }
+      self.send_pending_data();
+    }
+
+    // Cleared before returning to JS so a receive from the error path is
+    // not left queued behind one that has already finished.
+    self.is_receiving = false;
+
+    // The success path flushed inside the loop; this covers the faulted
+    // path, keeping the original "emit the error, then flush" ordering.
+    if let Some(errno) = fatal {
+      // The session is unusable, so anything still buffered is dropped.
+      self.pending_recv.clear();
       // nghttp2 reported a fatal error processing the inbound frames.
       // Mirrors Node.js HTTP2Session::OnStreamRead: hand the error to JS
       // via onSessionInternalError so it can destroy the session.
-      self.emit_session_internal_error(ret as i32);
+      self.emit_session_internal_error(errno);
+      self.send_pending_data();
     }
-    self.send_pending_data();
   }
 
   /// Invoke `onSessionInternalError(integerCode, customErrorCode)` on the
@@ -2913,6 +2997,8 @@ impl Http2Session {
       graceful_close_initiated: false,
       stream: None,
       is_sending: false,
+      is_receiving: false,
+      pending_recv: VecDeque::new(),
       pending_destroy: false,
       draining_outgoing: false,
       pending_rst_streams: Vec::new(),
@@ -3753,4 +3839,63 @@ pub fn op_http2_error_string(code: i32) -> String {
   unsafe { std::ffi::CStr::from_ptr(p) }
     .to_string_lossy()
     .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// The tripwire rejects a second entry while an outer `mem_recv` is live.
+  #[test]
+  fn enter_mem_recv_rejects_reentry() {
+    assert!(
+      cfg!(debug_assertions),
+      "the tripwire is a debug_assert; running this without debug assertions \
+       on would pass without proving anything"
+    );
+
+    // Silence the expected panic so the run output stays readable.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+
+    enter_mem_recv();
+    let nested =
+      std::panic::catch_unwind(std::panic::AssertUnwindSafe(enter_mem_recv));
+
+    std::panic::set_hook(previous_hook);
+    exit_mem_recv();
+
+    assert!(
+      nested.is_err(),
+      "enter_mem_recv must panic when a call is already live on this thread"
+    );
+    assert_eq!(
+      RECV_DEPTH.with(|depth| depth.get()),
+      0,
+      "depth must be back at 0 after the outer call exits"
+    );
+  }
+
+  #[test]
+  fn enter_mem_recv_allows_the_outer_call() {
+    let outer =
+      std::panic::catch_unwind(std::panic::AssertUnwindSafe(enter_mem_recv));
+
+    assert!(outer.is_ok(), "the first entry must not trip the wire");
+    assert_eq!(RECV_DEPTH.with(|depth| depth.get()), 1);
+
+    exit_mem_recv();
+    assert_eq!(RECV_DEPTH.with(|depth| depth.get()), 0);
+  }
+
+  /// Enter and exit must balance exactly, so a long-lived process cannot
+  /// drift the counter and mask a later violation.
+  #[test]
+  fn enter_and_exit_balance_over_many_cycles() {
+    for _ in 0..1000 {
+      enter_mem_recv();
+      exit_mem_recv();
+    }
+    assert_eq!(RECV_DEPTH.with(|depth| depth.get()), 0);
+  }
 }


### PR DESCRIPTION
We have a vendored version deno-node with this patch running in production. I'm opening this MR to port the fix back to mainstream which we'll move to once the fix is merged in. A Locally running version of qwen3.8-flash-next was used in helping to isolate and write this bug fix. This is my first MR request here so let me know if I missed anything please.

`is_sending` already defers `send_pending_data` while `mem_recv` is running, because a nested `mem_send` can free a stream the outer call still references. The receive side had no equivalent guard, even though the `receive` op is `#[reentrant]` and JS reached from `mem_recv` through `on_stream_close_callback` can hand `receive_data` more bytes.

A second `mem_recv` inside the outer one resumes its inbound frame state machine mid-frame and, during GOAWAY processing, starts a second close-collection over the `stream->closed_next` list the outer walk is still using -- tripping `assert(stream->closed_next == NULL)`, or segfaulting once a listed stream has already been freed. That is the exit 134 / exit 139 split in #36788, and it takes the process down before the session `goaway` event can fire.

Add the matching guard. `is_receiving` plus a `pending_recv` queue: a nested `receive_data` queues its bytes and returns, and the outer call drains the queue after each `mem_recv` unwinds, so bytes are still processed in arrival order rather than nested inside one another.

`enter_mem_recv` / `exit_mem_recv` wrap the FFI call and debug-assert that the depth is zero on entry, so a bypassed guard aborts at the violation instead of corrupting the heap silently.

Closes #36788


<!--
IMPORTANT: If you used AI tools (e.g. Copilot, ChatGPT, Claude, Cursor, etc.)
to help write this PR, you MUST disclose it in the PR description. PRs will be
rejected if there is suspicion of undisclosed AI usage.

Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(ext/net): fix race condition in TCP listener
    - docs(runtime): update permissions API docstrings
    - feat(cli): add --env-file flag to `deno run`
    - refactor(ext/node): simplify Buffer.from() implementation
    - test(ext/fs): add spec tests for symlink resolution

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `./x fmt` passes without changing files.
5. Ensure `./x lint` passes.
6. If you used AI tools to help write this PR, you MUST disclose it below.
   PRs will be rejected if there is suspicion of undisclosed AI usage.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
