### PR TITLE
test(core): deflake uv_compat pipe/tty tests

### DIFF
--- a/libs/core/uv_compat/tests.rs
+++ b/libs/core/uv_compat/tests.rs
@@ -2004,6 +2004,19 @@ impl Drop for FdGuard {
 }
 
 #[cfg(unix)]
+// TTY mode operations and handle close both touch process-global termios
+// state. The libtest harness runs tests in this binary in parallel, so every
+// test that owns a TTY handle must share this lock even though each test uses
+// its own PTY.
+static TTY_TEST_LOCK: tokio::sync::Mutex<()> =
+  tokio::sync::Mutex::const_new(());
+
+#[cfg(unix)]
+async fn lock_tty_test() -> tokio::sync::MutexGuard<'static, ()> {
+  TTY_TEST_LOCK.lock().await
+}
+
+#[cfg(unix)]
 unsafe fn set_errno(val: i32) {
   #[cfg(target_os = "macos")]
   unsafe {
@@ -2023,15 +2036,6 @@ fn get_errno() -> i32 {
 }
 
 #[cfg(unix)]
-fn assert_fd_closed(fd: i32) {
-  unsafe {
-    set_errno(0);
-    assert_eq!(libc::fcntl(fd, libc::F_GETFD), -1);
-  }
-  assert_eq!(get_errno(), libc::EBADF);
-}
-
-#[cfg(unix)]
 #[allow(
   clippy::disallowed_methods,
   reason = "uv_compat tests require real Unix socket paths"
@@ -2047,6 +2051,7 @@ fn pipe_test_socket_path(name: &str) -> std::path::PathBuf {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_init_sets_fields() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |_runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
     let _fdm_guard = FdGuard(fdm);
@@ -2098,6 +2103,7 @@ async fn tty_init_rejects_non_tty() {
 #[cfg(target_os = "macos")]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_init_dev_tty_select_fallback() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |runtime, uv_loop| {
     // Open /dev/tty directly — this produces an fd that kqueue rejects.
     let fd = unsafe { libc::open(c"/dev/tty".as_ptr(), libc::O_RDWR) };
@@ -2215,6 +2221,7 @@ async fn tty_init_dev_tty_select_fallback() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_get_winsize() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |_runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
     let _fdm_guard = FdGuard(fdm);
@@ -2251,6 +2258,7 @@ async fn tty_get_winsize() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_set_mode_raw_and_back() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |_runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
     let _fdm_guard = FdGuard(fdm);
@@ -2281,6 +2289,7 @@ async fn tty_set_mode_raw_and_back() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_set_mode_io() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |_runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
     let _fdm_guard = FdGuard(fdm);
@@ -2306,6 +2315,7 @@ async fn tty_set_mode_io() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_write_and_read_through_pty() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
 
@@ -2389,6 +2399,7 @@ async fn tty_write_and_read_through_pty() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_read_from_pty() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
 
@@ -2500,6 +2511,7 @@ async fn tty_read_from_pty() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_close_fires_callback() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
     let _fdm_guard = FdGuard(fdm);
@@ -2534,6 +2546,7 @@ async fn tty_close_fires_callback() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_shutdown_fires_callback() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
     let _fdm_guard = FdGuard(fdm);
@@ -2611,8 +2624,9 @@ fn new_tty_constructor() {
 }
 
 #[cfg(unix)]
-#[test]
-fn tty_reset_mode_when_no_tty_modified() {
+#[tokio::test(flavor = "current_thread")]
+async fn tty_reset_mode_when_no_tty_modified() {
+  let _tty_test_guard = lock_tty_test().await;
   // Should succeed (no-op) when no TTY has entered raw mode.
   assert_ok(uv_tty_reset_mode());
 }
@@ -2620,6 +2634,7 @@ fn tty_reset_mode_when_no_tty_modified() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_reset_mode_restores_termios() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
     let _fdm_guard = FdGuard(fdm);
@@ -2672,6 +2687,7 @@ async fn tty_reset_mode_restores_termios() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_reset_mode_preserves_errno() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
     let _fdm_guard = FdGuard(fdm);
@@ -2709,6 +2725,7 @@ fn tty_guess_handle_negative_fd() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn tty_read_stop() {
+  let _tty_test_guard = lock_tty_test().await;
   run_test(async |runtime, uv_loop| {
     let (fdm, fds) = unsafe { open_pty_pair() };
 
@@ -3071,6 +3088,11 @@ async fn tcp_batch_accept() {
 
 // ========== Pipe handle lifecycle ==========
 
+// Do not verify closure by checking a saved fd number here. Another test in
+// this process can reuse that number as soon as it is closed. Check handle
+// ownership and peer-observable teardown instead; verify filesystem cleanup
+// separately.
+
 // UV_HANDLE_ACTIVE flag value (matches uv_compat.rs private const)
 #[cfg(unix)]
 const UV_HANDLE_ACTIVE: u32 = 1 << 0;
@@ -3078,19 +3100,20 @@ const UV_HANDLE_ACTIVE: u32 = 1 << 0;
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn pipe_open_not_active_until_read_start() {
-  run_test(async |runtime, uv_loop| {
-    // Create an OS pipe pair.
-    let mut pipe_fds = [0i32; 2];
-    assert_eq!(unsafe { libc::pipe(pipe_fds.as_mut_ptr()) }, 0);
-    let read_fd = pipe_fds[0];
-    let write_fd = pipe_fds[1];
-    let _write_guard = FdGuard(write_fd);
+  use std::io::Read;
+  use std::os::unix::io::IntoRawFd;
 
-    // Init and open a uv_pipe_t on the read end.
+  run_test(async |runtime, uv_loop| {
+    let (opened, mut peer) = std::os::unix::net::UnixStream::pair().unwrap();
+    // Keep a leaked owner from making the EOF assertion block indefinitely.
+    peer.set_nonblocking(true).unwrap();
+    let opened_fd = opened.into_raw_fd();
+
+    // Init and open a uv_pipe_t on one end of the socket pair.
     let mut pipe = new_pipe(false);
     unsafe {
       assert_ok(pipe::uv_pipe_init(uv_loop, &mut pipe, 0));
-      assert_ok(pipe::uv_pipe_open(&mut pipe, pipe_fds[0]));
+      assert_ok(pipe::uv_pipe_open(&mut pipe, opened_fd));
     }
 
     // After uv_pipe_open, the handle should NOT be active.
@@ -3156,14 +3179,23 @@ async fn pipe_open_not_active_until_read_start() {
       uv_close(&mut pipe as *mut uv_pipe_t as *mut uv_handle_t, None);
     }
     tick(runtime).await;
-    assert_fd_closed(read_fd);
+    assert!(pipe.internal_fd.is_none());
+    assert!(pipe.internal_async_fd.is_none());
+    let mut byte = [0];
+    assert_eq!(peer.read(&mut byte).unwrap(), 0);
   })
   .await;
 }
 
 #[cfg(unix)]
+#[allow(
+  clippy::disallowed_methods,
+  reason = "uv_compat tests require real Unix socket paths"
+)]
 #[tokio::test(flavor = "current_thread")]
 async fn pipe_listener_transfers_raw_fd_ownership() {
+  use tokio::io::AsyncReadExt;
+
   run_test(async |runtime, uv_loop| {
     let socket_path = pipe_test_socket_path("pipe-owner");
     let socket_path = socket_path.to_string_lossy().into_owned();
@@ -3185,12 +3217,30 @@ async fn pipe_listener_transfers_raw_fd_ownership() {
     );
     assert!(pipe.internal_listener.is_some());
     assert_eq!(pipe.fd(), Some(fd));
+    assert!(std::path::Path::new(&socket_path).exists());
+    // Keep a connection queued so listener teardown is observable separately
+    // from unlinking the socket path.
+    let mut client =
+      tokio::net::UnixStream::connect(&socket_path).await.unwrap();
 
     unsafe {
       uv_close(&mut pipe as *mut uv_pipe_t as *mut uv_handle_t, None);
     }
     tick(runtime).await;
-    assert_fd_closed(fd);
+    assert!(pipe.internal_fd.is_none());
+    assert!(pipe.internal_listener.is_none());
+    assert!(!std::path::Path::new(&socket_path).exists());
+    let mut byte = [0];
+    let read_result = tokio::time::timeout(
+      std::time::Duration::from_secs(1),
+      client.read(&mut byte),
+    )
+    .await
+    .expect("queued client should terminate after listener close");
+    match read_result {
+      Ok(0) | Err(_) => {}
+      Ok(nread) => panic!("queued client unexpectedly read {nread} bytes"),
+    }
   })
   .await;
 }
@@ -3198,11 +3248,14 @@ async fn pipe_listener_transfers_raw_fd_ownership() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn pipe_accept_keeps_only_the_tokio_fd_owner() {
+  use std::io::Read;
   use std::os::unix::io::AsRawFd;
 
   run_test(async |runtime, uv_loop| {
-    let (accepted, peer) = std::os::unix::net::UnixStream::pair().unwrap();
+    let (accepted, mut peer) = std::os::unix::net::UnixStream::pair().unwrap();
     accepted.set_nonblocking(true).unwrap();
+    // Keep a leaked owner from making the EOF assertion block indefinitely.
+    peer.set_nonblocking(true).unwrap();
     let accepted = tokio::net::UnixStream::from_std(accepted).unwrap();
     let fd = accepted.as_raw_fd();
 
@@ -3229,8 +3282,9 @@ async fn pipe_accept_keeps_only_the_tokio_fd_owner() {
       uv_close(&mut server as *mut uv_pipe_t as *mut uv_handle_t, None);
     }
     tick(runtime).await;
-    assert_fd_closed(fd);
-    drop(peer);
+    assert!(client.internal_stream.is_none());
+    let mut byte = [0];
+    assert_eq!(peer.read(&mut byte).unwrap(), 0);
   })
   .await;
 }
@@ -3238,6 +3292,8 @@ async fn pipe_accept_keeps_only_the_tokio_fd_owner() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn pipe_bound_connect_transfers_raw_fd_ownership() {
+  use tokio::io::AsyncReadExt;
+
   run_test(async |runtime, uv_loop| {
     let server_path = pipe_test_socket_path("pipe-connect-server");
     let client_path = pipe_test_socket_path("pipe-connect-client");
@@ -3281,12 +3337,23 @@ async fn pipe_bound_connect_transfers_raw_fd_ownership() {
     );
     assert!(pipe.internal_stream.is_some());
     assert_eq!(pipe.fd(), Some(fd));
+    let (mut peer, _) = listener.accept().await.unwrap();
 
     unsafe {
       uv_close(&mut pipe as *mut uv_pipe_t as *mut uv_handle_t, None);
     }
     tick(runtime).await;
-    assert_fd_closed(fd);
+    assert!(pipe.internal_stream.is_none());
+    // Bound the EOF wait so a leaked owner fails instead of hanging the test.
+    let mut byte = [0];
+    let nread = tokio::time::timeout(
+      std::time::Duration::from_secs(1),
+      peer.read(&mut byte),
+    )
+    .await
+    .expect("peer should reach EOF after pipe close")
+    .unwrap();
+    assert_eq!(nread, 0);
 
     drop(listener);
     #[allow(


### PR DESCRIPTION
Running the Unix `uv_compat` tests with:

```sh
cargo test -p deno_core --lib 'uv_compat::tests::'
```

can fail intermittently because the tests are run concurrently in a single process, sharing the process's file descriptor namespace and `uv_compat`'s process-global TTY reset state.

**These failures do not occur in CI.** The `deno_core` CI job uses `cargo nextest`, which runs individual tests in separate processes.

The changes are confined to `libs/core/uv_compat/tests.rs`; production behavior is unchanged.

## Problem

When the complete `uv_compat` test group runs in parallel, one or more of the following tests often fail, although each passes when run individually:

- `pipe_open_not_active_until_read_start`
- `pipe_listener_transfers_raw_fd_ownership`
- `pipe_accept_keeps_only_the_tokio_fd_owner`
- `pipe_bound_connect_transfers_raw_fd_ownership`
- `tty_reset_mode_restores_termios`
- `tty_reset_mode_preserves_errno`

Other `tty_*` tests can also fail because of the same lack of test isolation, although at a much lower frequency; these failures were observed only after hundreds or thousands of test iterations.

<details>
<summary>Failure outputs</summary>

```text
thread 'uv_compat::tests::pipe_open_not_active_until_read_start' (3793762) panicked at libs/core/uv_compat/tests.rs:2029:5:
assertion `left == right` failed
  left: 0
 right: -1
stack backtrace:
   ...
   4: deno_core::uv_compat::tests::assert_fd_closed
             at ./uv_compat/tests.rs:2029:5
   5: deno_core::uv_compat::tests::pipe_open_not_active_until_read_start::{{closure}}::{{closure}}::{{closure}}
             at ./uv_compat/tests.rs:3159:5
   6: deno_core::uv_compat::tests::run_test::{{closure}}
             at ./uv_compat/tests.rs:26:28
   7: deno_core::uv_compat::tests::pipe_open_not_active_until_read_start::{{closure}}
             at ./uv_compat/tests.rs:3161:4
   ...
```
```text
thread 'uv_compat::tests::pipe_listener_transfers_raw_fd_ownership' (3792369) panicked at libs/core/uv_compat/tests.rs:2029:5:
assertion `left == right` failed
  left: 1
 right: -1
stack backtrace:
   ...
   4: deno_core::uv_compat::tests::assert_fd_closed
             at ./uv_compat/tests.rs:2029:5
   5: deno_core::uv_compat::tests::pipe_listener_transfers_raw_fd_ownership::{{closure}}::{{closure}}::{{closure}}
             at ./uv_compat/tests.rs:3193:5
   6: deno_core::uv_compat::tests::run_test::{{closure}}
             at ./uv_compat/tests.rs:26:28
   7: deno_core::uv_compat::tests::pipe_listener_transfers_raw_fd_ownership::{{closure}}
             at ./uv_compat/tests.rs:3195:4
   ...
```
```text
thread 'uv_compat::tests::pipe_accept_keeps_only_the_tokio_fd_owner' (3790358) panicked at libs/core/uv_compat/tests.rs:2029:5:
assertion `left == right` failed
  left: 1
 right: -1
stack backtrace:
   ...
   4: deno_core::uv_compat::tests::assert_fd_closed
             at ./uv_compat/tests.rs:2029:5
   5: deno_core::uv_compat::tests::pipe_accept_keeps_only_the_tokio_fd_owner::{{closure}}::{{closure}}::{{closure}}
             at ./uv_compat/tests.rs:3232:5
   6: deno_core::uv_compat::tests::run_test::{{closure}}
             at ./uv_compat/tests.rs:26:28
   7: deno_core::uv_compat::tests::pipe_accept_keeps_only_the_tokio_fd_owner::{{closure}}
             at ./uv_compat/tests.rs:3235:4
   ...
```
```text
thread 'uv_compat::tests::pipe_bound_connect_transfers_raw_fd_ownership' (3790706) panicked at libs/core/uv_compat/tests.rs:2029:5:
assertion `left == right` failed
  left: 1
 right: -1
stack backtrace:
   ...
   4: deno_core::uv_compat::tests::assert_fd_closed
             at ./uv_compat/tests.rs:2029:5
   5: deno_core::uv_compat::tests::pipe_bound_connect_transfers_raw_fd_ownership::{{closure}}::{{closure}}::{{closure}}
             at ./uv_compat/tests.rs:3289:5
   6: deno_core::uv_compat::tests::run_test::{{closure}}
             at ./uv_compat/tests.rs:26:28
   7: deno_core::uv_compat::tests::pipe_bound_connect_transfers_raw_fd_ownership::{{closure}}
             at ./uv_compat/tests.rs:3298:4
   ...
```
```text
thread 'uv_compat::tests::tty_reset_mode_restores_termios' (3791866) panicked at libs/core/uv_compat/tests.rs:2654:7:
assertion `left == right` failed: ECHO flag should be restored after reset_mode
  left: 0
 right: 8
stack backtrace:
   ...
   4: deno_core::uv_compat::tests::tty_reset_mode_restores_termios::{{closure}}::{{closure}}::{{closure}}
             at ./uv_compat/tests.rs:2654:7
   5: deno_core::uv_compat::tests::run_test::{{closure}}
             at ./uv_compat/tests.rs:26:28
   6: deno_core::uv_compat::tests::tty_reset_mode_restores_termios::{{closure}}
             at ./uv_compat/tests.rs:2669:4
   ...
```
```text
thread 'uv_compat::tests::tty_reset_mode_preserves_errno' (3891755) panicked at libs/core/uv_compat/tests.rs:18:3:
assertion `left == right` failed
  left: -16
 right: 0
stack backtrace:
   ...
   4: deno_core::uv_compat::tests::assert_ok
             at ./uv_compat/tests.rs:18:3
   5: deno_core::uv_compat::tests::tty_reset_mode_preserves_errno::{{closure}}::{{closure}}::{{closure}}
             at ./uv_compat/tests.rs:2689:7
   6: deno_core::uv_compat::tests::run_test::{{closure}}
             at ./uv_compat/tests.rs:26:28
   7: deno_core::uv_compat::tests::tty_reset_mode_preserves_errno::{{closure}}
             at ./uv_compat/tests.rs:2700:4
   ...
```

----

```text
thread 'uv_compat::tests::tty_get_winsize' (291282) panicked at libs/core/uv_compat/tests.rs:18:3:
assertion `left == right` failed
  left: -5
 right: 0
stack backtrace:
   ...
   4: deno_core::uv_compat::tests::assert_ok
             at ./uv_compat/tests.rs:18:3
   5: deno_core::uv_compat::tests::tty_get_winsize::{{closure}}::{{closure}}::{{closure}}
             at ./uv_compat/tests.rs:2240:7
   6: deno_core::uv_compat::tests::run_test::{{closure}}
             at ./uv_compat/tests.rs:26:28
   7: deno_core::uv_compat::tests::tty_get_winsize::{{closure}}
             at ./uv_compat/tests.rs:2248:4
   ...
```
</details>

## Root causes and fixes

### Pipe descriptor reuse

The pipe tests saved a numeric file descriptor and called `fcntl(fd, F_GETFD)` after `uv_close`, expecting `EBADF`.

Once the original descriptor is closed, another concurrently running test can immediately reuse the same number. The `fcntl` call then examines the new, unrelated descriptor rather than the resource originally owned by the pipe.

The updated tests verify complementary aspects of teardown:

- Cleared internal ownership fields show that the handle released its owned descriptor, stream, or listener.
- EOF or connection termination observed by the peer shows that the underlying OS resource was closed.
- Unix socket-path removal is checked separately because unlinking the path alone does not prove that the listener was closed.

### Process-global TTY state

- https://github.com/denoland/deno/blob/336da420f4343cbb1dcbd5eed9d075ff555ed6ee/libs/core/uv_compat/tty.rs

The Unix implementation keeps a single process-global saved `(fd, termios)` pair. If two tests put different PTYs into a non-normal mode concurrently, only the first PTY is recorded. A reset from the other test can therefore restore the recorded PTY while leaving its own PTY in raw mode.

The global state is protected by a spinlock, and `uv_tty_reset_mode()` tries to acquire that lock without waiting. Every TTY handle close also takes the same lock to restore and clear the saved state.

A reset racing with another test's handle close can return `UV_EBUSY`. If the assertion then panics before cleanup, the global slot can retain a stale file descriptor number, causing later resets to fail with `EIO`.

A shared test-only Tokio mutex now serializes every Unix test that either calls `uv_tty_reset_mode()` or owns a TTY handle. The guard covers the complete handle lifecycle, including deferred close processing. This prevents different PTYs from sharing the saved-state slot and prevents reset operations from overlapping another test's handle closure.

## Verification

The complete parallel `uv_compat` suite passed 10,000 consecutive runs:

```sh
for i in {1..10000}; do RUST_BACKTRACE=1 cargo test -p deno_core --lib uv_compat::tests:: || break; done
```

## AI disclosure

OpenAI Codex was used for the investigation and preparation of this PR. All changes were reviewed and confirmed by the submitter.