### PR TITLE
fix(task): skip implicit npm install for --cached-only tasks

### DIFF
--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use console_static_text::ansi::strip_ansi_codes;
+use deno_config::deno_json::NodeModulesDirMode;
 use deno_config::workspace::FolderConfigs;
 use deno_config::workspace::TaskDefinition;
 use deno_config::workspace::TaskOrScript;
@@ -728,7 +729,9 @@ impl<'a> TaskRunner<'a> {
       return Ok(0);
     };
 
-    self.maybe_npm_install().await?;
+    if !self.should_skip_npm_install_for_script(command) {
+      self.maybe_npm_install().await?;
+    }
 
     let cwd = match &self.task_flags.cwd {
       Some(path) => canonicalize_path(Path::new(path))
@@ -994,6 +997,21 @@ impl<'a> TaskRunner<'a> {
     }
 
     Ok(exit_code)
+  }
+
+  /// The implicit install before running a task exists to set up npm
+  /// binaries in `node_modules` so the task's shell can invoke them. When no
+  /// node_modules directory is configured there is nothing to set up, so a
+  /// task that explicitly asks to run offline (`--cached-only`) should not
+  /// trigger a fetch of unrelated dependencies.
+  fn should_skip_npm_install_for_script(&self, script: &str) -> bool {
+    if !script_has_cached_only_flag(script) {
+      return false;
+    }
+    matches!(
+      self.cli_options.specified_node_modules_dir(),
+      Ok(None) | Ok(Some(NodeModulesDirMode::None))
+    )
   }
 
   async fn maybe_npm_install(&self) -> Result<(), AnyError> {
@@ -1627,9 +1645,38 @@ impl TaskNameFilter<'_> {
   }
 }
 
+/// Whether a task's command explicitly opts into offline execution via
+/// `--cached-only`. Deliberately a simple whitespace token scan: this only
+/// gates an optimization (skipping the implicit install), so a false
+/// positive on something like `echo --cached-only` is harmless. Known
+/// limits of the scan: a compound script like
+/// `deno run --cached-only a.ts && deno run b.ts` skips the install for the
+/// whole task, and a flag spelled differently (e.g. via a shell variable, or
+/// a future `--cached-only=<bool>` form) is not matched.
+fn script_has_cached_only_flag(script: &str) -> bool {
+  script
+    .split_ascii_whitespace()
+    .any(|t| t == "--cached-only")
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn test_script_has_cached_only_flag() {
+    assert!(script_has_cached_only_flag(
+      "deno run --cached-only main.ts"
+    ));
+    assert!(script_has_cached_only_flag(
+      "deno run -A --cached-only --allow-write='db' api/server.ts"
+    ));
+    assert!(!script_has_cached_only_flag("deno run main.ts"));
+    assert!(!script_has_cached_only_flag(
+      "deno run --cached-onlyx main.ts"
+    ));
+    assert!(!script_has_cached_only_flag("deno run --cached main.ts"));
+  }
 
   #[test]
   fn test_arg_to_task_name_filter() {

--- a/tests/specs/task/cached_only/__test__.jsonc
+++ b/tests/specs/task/cached_only/__test__.jsonc
@@ -1,0 +1,11 @@
+{
+  "tempDir": true,
+  // point npm at an unreachable registry so an actual attempt to install
+  // the uncached `@denotest/esm-basic` dependency fails the task; this
+  // pins the assertion on the implicit install not running at all, rather
+  // than on incidental output text.
+  "envs": { "NPM_CONFIG_REGISTRY": "http://localhost:1/" },
+  "args": "task run-cached",
+  "output": "task.out",
+  "exitCode": 0
+}

--- a/tests/specs/task/cached_only/deno.json
+++ b/tests/specs/task/cached_only/deno.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "run-cached": "deno run --cached-only main.ts"
+  },
+  "imports": {
+    "@denotest/esm-basic": "npm:@denotest/esm-basic@1.0.0"
+  }
+}

--- a/tests/specs/task/cached_only/main.ts
+++ b/tests/specs/task/cached_only/main.ts
@@ -1,0 +1,1 @@
+console.log("hello");

--- a/tests/specs/task/cached_only/task.out
+++ b/tests/specs/task/cached_only/task.out
@@ -1,0 +1,2 @@
+Task run-cached deno run --cached-only main.ts
+hello


### PR DESCRIPTION
`deno task` runs an implicit dependency install before executing a task. With `nodeModulesDir` unset (or `none`), that install downloads every dependency listed in `deno.json`, even when the task's own command is `deno run --cached-only ...` and is meant to run without network access. In production this makes such a task fetch dev-only dependencies it never uses, or fail outright when the registry is unreachable.

This change skips the implicit install only when both hold:

- the task's command contains the `--cached-only` token, and
- no node_modules directory is configured (`nodeModulesDir` unset or `none`), so there are no npm binaries to set up.

With `auto` or `manual` the behaviour is unchanged. The token check is a plain whitespace split; its limits (compound commands, differently spelled flags) are documented on the helper.

Test: `tests/specs/task/cached_only` points npm at an unreachable registry and runs a `--cached-only` task in a project with an uncached npm import. On `main` the task fails trying to fetch the package; with this change it runs and prints `hello`.

Verification: `cargo test --locked -p deno --lib tools::task` (4 passed), `cargo test --locked --test specs task::cached_only` (passes with the change, fails on `main`), `rustfmt --check` and `deno fmt --check` clean on the changed files.

Fixes #30887

AI tools used: no_human (claude-sonnet-5 coder, claude-opus-4-8 reviewer, claude-opus-5 planner).
