### PR TITLE
fix(ext/fs): treat Windows app execution aliases as regular files

### DIFF
--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -984,12 +984,32 @@ fn open_for_stat_windows(
       fallback.custom_flags(reparse_flag);
       fallback.open(path).map_err(|_| err)
     }
+    // `CreateFile` returns `ERROR_CANT_ACCESS_FILE` for reparse points it
+    // cannot resolve on its own, such as the app execution aliases that
+    // Microsoft Store apps install in `%LOCALAPPDATA%\Microsoft\WindowsApps`
+    // (only `CreateProcess` knows how to follow those). Open them without
+    // following the reparse point so they behave like regular files.
+    // See https://github.com/denoland/deno/issues/18598.
+    Err(err)
+      if reparse_flag == 0
+        && err.raw_os_error() == Some(ERROR_CANT_ACCESS_FILE) =>
+    {
+      let mut fallback = fs::OpenOptions::new();
+      fallback.access_mode(0);
+      fallback.custom_flags(
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+      );
+      fallback.open(path).map_err(|_| err)
+    }
     Err(err) => Err(err),
   }
 }
 
 #[cfg(windows)]
 const ERROR_INVALID_FUNCTION: i32 = 1;
+
+#[cfg(windows)]
+const ERROR_CANT_ACCESS_FILE: i32 = 1920;
 
 fn statfs(path: &Path, bigint: bool) -> FsResult<FsStatFs> {
   #[cfg(unix)]
@@ -1127,7 +1147,55 @@ fn exists(path: &Path) -> bool {
 }
 
 fn realpath(path: &Path) -> FsResult<PathBuf> {
-  Ok(deno_path_util::strip_unc_prefix(path.canonicalize()?))
+  #[cfg(windows)]
+  {
+    match path.canonicalize() {
+      Ok(path) => Ok(deno_path_util::strip_unc_prefix(path)),
+      // `canonicalize` follows reparse points, which fails for the ones
+      // `CreateFile` cannot resolve (see `open_for_stat_windows`). Resolve
+      // those to themselves, like any other regular file.
+      Err(err) if err.raw_os_error() == Some(ERROR_CANT_ACCESS_FILE) => {
+        let file = open_for_stat_windows(path, true).map_err(|_| err)?;
+        let path = final_path_of_windows(&file)?;
+        Ok(deno_path_util::strip_unc_prefix(path))
+      }
+      Err(err) => Err(err.into()),
+    }
+  }
+  #[cfg(not(windows))]
+  {
+    Ok(deno_path_util::strip_unc_prefix(path.canonicalize()?))
+  }
+}
+
+/// Gets the canonical path of an already opened file.
+#[cfg(windows)]
+fn final_path_of_windows(file: &fs::File) -> io::Result<PathBuf> {
+  use std::ffi::OsString;
+  use std::os::windows::ffi::OsStringExt;
+  use std::os::windows::io::AsRawHandle;
+
+  use windows_sys::Win32::Storage::FileSystem::GetFinalPathNameByHandleW;
+
+  let handle = file.as_raw_handle();
+  let mut buf = vec![0u16; 512];
+  loop {
+    // SAFETY: `handle` is a valid file handle and `buf` holds `buf.len()`
+    // UTF-16 code units.
+    let len = unsafe {
+      GetFinalPathNameByHandleW(handle, buf.as_mut_ptr(), buf.len() as u32, 0)
+    } as usize;
+    if len == 0 {
+      return Err(io::Error::last_os_error());
+    }
+    // on success the length excludes the NUL terminator, otherwise it is the
+    // required buffer size including it
+    if len < buf.len() {
+      buf.truncate(len);
+      return Ok(PathBuf::from(OsString::from_wide(&buf)));
+    }
+    buf.resize(len, 0);
+  }
 }
 
 fn read_dir(path: &Path) -> FsResult<Vec<FsDirEntry>> {

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -1528,12 +1528,11 @@ pub fn stat_extra(file: &std::fs::File, fsstat: &mut FsStat) -> FsResult<()> {
         &file_info.BasicInformation.ChangeTime,
       ));
 
-      if file_info.BasicInformation.FileAttributes
-        & windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT
-        != 0
-      {
-        fsstat.is_symlink = true;
-      }
+      // note: `is_symlink` is intentionally not set here. Not every reparse
+      // point is a symlink (ex. app execution aliases, cloud file
+      // placeholders, WOF compressed files) and `FsStat::from_std` already
+      // reports the ones that are, by checking the reparse tag instead of
+      // only the attribute.
 
       if file_info.BasicInformation.FileAttributes
         & windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -1528,12 +1528,6 @@ pub fn stat_extra(file: &std::fs::File, fsstat: &mut FsStat) -> FsResult<()> {
         &file_info.BasicInformation.ChangeTime,
       ));
 
-      // note: `is_symlink` is intentionally not set here. Not every reparse
-      // point is a symlink (ex. app execution aliases, cloud file
-      // placeholders, WOF compressed files) and `FsStat::from_std` already
-      // reports the ones that are, by checking the reparse tag instead of
-      // only the attribute.
-
       if file_info.BasicInformation.FileAttributes
         & windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY
         != 0

--- a/tests/unit/stat_test.ts
+++ b/tests/unit/stat_test.ts
@@ -265,6 +265,30 @@ Deno.test(
 
 Deno.test(
   {
+    ignore: Deno.build.os !== "windows",
+    permissions: { ffi: true, read: true, write: true },
+  },
+  function statAppExecLink() {
+    const tempDir = Deno.realPathSync(Deno.makeTempDirSync());
+    const path = `${tempDir}\\app_exec_alias.exe`;
+    Deno.writeFileSync(path, new Uint8Array());
+    createAppExecLink(path, Deno.execPath());
+
+    // an app execution alias is a reparse point that only `CreateProcess`
+    // knows how to follow, so the file system reports it as an empty file and
+    // `stat` does not differ from `lstat`
+    for (const info of [Deno.statSync(path), Deno.lstatSync(path)]) {
+      assert(info.isFile);
+      assert(!info.isDirectory);
+      assert(!info.isSymlink);
+      assertEquals(info.size, 0);
+    }
+    assertEquals(Deno.realPathSync(path), path);
+  },
+);
+
+Deno.test(
+  {
     ignore: Deno.build.os === "windows",
     permissions: { read: true, write: true },
   },
@@ -317,3 +341,89 @@ Deno.test(
     );
   },
 );
+
+/**
+ * Turns the empty file at `path` into a Windows app execution alias pointing
+ * at `target`, the kind of reparse point Microsoft Store apps install into
+ * `%LOCALAPPDATA%\Microsoft\WindowsApps`.
+ */
+function createAppExecLink(path: string, target: string) {
+  const GENERIC_WRITE = 0x40000000;
+  const FILE_SHARE_ALL = 0x00000007;
+  const OPEN_EXISTING = 3;
+  const FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+  const FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
+  const FSCTL_SET_REPARSE_POINT = 0x000900a4;
+  const IO_REPARSE_TAG_APPEXECLINK = 0x8000001b;
+
+  // the tag's data is a version followed by a NUL separated list of strings:
+  // the package family name, the app user model id, the target and the
+  // application type
+  const family = "Deno.Test_8wekyb3d8bbwe";
+  const strings = wideCString(`${family}\0${family}!App\0${target}\0` + "0");
+  const reparseData = new Uint8Array(8 + 4 + strings.byteLength);
+  const view = new DataView(reparseData.buffer);
+  view.setUint32(0, IO_REPARSE_TAG_APPEXECLINK, true);
+  view.setUint16(4, 4 + strings.byteLength, true); // ReparseDataLength
+  view.setUint32(8, 3, true); // Version
+  reparseData.set(strings, 12);
+
+  const kernel32 = Deno.dlopen("kernel32.dll", {
+    CreateFileW: {
+      parameters: ["buffer", "u32", "u32", "pointer", "u32", "u32", "pointer"],
+      result: "pointer",
+    },
+    DeviceIoControl: {
+      parameters: [
+        "pointer",
+        "u32",
+        "buffer",
+        "u32",
+        "pointer",
+        "u32",
+        "buffer",
+        "pointer",
+      ],
+      result: "i32",
+    },
+    CloseHandle: { parameters: ["pointer"], result: "i32" },
+  });
+  try {
+    const file = kernel32.symbols.CreateFileW(
+      wideCString(path),
+      GENERIC_WRITE,
+      FILE_SHARE_ALL,
+      null,
+      OPEN_EXISTING,
+      FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+      null,
+    );
+    try {
+      const result = kernel32.symbols.DeviceIoControl(
+        file,
+        FSCTL_SET_REPARSE_POINT,
+        reparseData,
+        reparseData.byteLength,
+        null,
+        0,
+        new Uint8Array(4),
+        null,
+      );
+      // fails if `CreateFileW` above failed as well, because then `file` is
+      // `INVALID_HANDLE_VALUE`
+      assert(result !== 0, "failed to create the app execution alias");
+    } finally {
+      kernel32.symbols.CloseHandle(file);
+    }
+  } finally {
+    kernel32.close();
+  }
+}
+
+function wideCString(value: string) {
+  const wide = new Uint16Array(value.length + 1);
+  for (let i = 0; i < value.length; i++) {
+    wide[i] = value.charCodeAt(i);
+  }
+  return new Uint8Array(wide.buffer);
+}


### PR DESCRIPTION
## AI PR

App execution aliases are the reparse points Microsoft Store apps install into `%LOCALAPPDATA%\Microsoft\WindowsApps`. Only `CreateProcess` knows how to follow them, so `CreateFile` fails with `ERROR_CANT_ACCESS_FILE` when asked to resolve one:

```
> Deno.statSync(localAppData + "\Microsoft\WindowsApps\winget.exe")
Uncaught Error: The file cannot be accessed by the system. (os error 1920)
> Deno.lstatSync(localAppData + "\Microsoft\WindowsApps\winget.exe")
{ isFile: true, isSymlink: true, size: 0, ... }
```

This opens them without following the reparse point instead, so they report as the empty files that Rust's std, .NET and libuv report them as, and `stat` no longer differs from `lstat`:

| | before | after |
| --- | --- | --- |
| `Deno.stat` | throws os error 1920 | `{ isFile: true, isSymlink: false, size: 0 }` |
| `Deno.lstat` | `{ isFile: true, isSymlink: true }` | `{ isFile: true, isSymlink: false }` |
| `Deno.realPath` | throws os error 1920 | the alias' own path |

`Deno.readLink` still fails, which matches where the ecosystem has landed: libuv is removing its AppExecLink resolution in libuv/libuv#4986 so that these are treated as regular files, PowerShell reverted the same handling in PowerShell/PowerShell#19760, and it was rejected for dotnet/runtime in dotnet/runtime#58233. Rust's std already has this fallback in `fs::stat` and `fs::exists`, but `stat` here opens its own handle (`stat_extra` needs one for `dev`/`ino`/`ctime`) so it never ran.

Three changes:

- `open_for_stat_windows` retries with `FILE_FLAG_OPEN_REPARSE_POINT` on `ERROR_CANT_ACCESS_FILE`. Same shape as the `fs__create_file` wrapper libuv is adding, and since `stat` and `lstat` share this helper they now agree.
- `realpath` gets the matching fallback, resolving through `GetFinalPathNameByHandleW` on a non-following handle. This is the one piece with no upstream precedent — libuv's PR doesn't touch realpath and Node still fails there — but it seemed odd to leave `Deno.realPath` throwing once `stat` works. Happy to drop it.
- `stat_extra` no longer sets `is_symlink` for every `FILE_ATTRIBUTE_REPARSE_POINT`. Only the reparse *tag* distinguishes a symlink (app execution aliases, cloud file placeholders and WOF compressed files are not name surrogates), and `FsStat::from_std` already checks it — hence `Deno.lstat` claiming an alias was both a file and a symlink. All four `stat_extra` callers build from `FsStat::from_std` first, so nothing loses coverage.

The new `statAppExecLink` unit test builds a real AppExecLink reparse point over FFI, which needs no admin rights, so it runs in CI without a Store app installed. It fails on 2.9.6 with the `os error 1920` above.

Verified against a real `winget.exe` alias and a synthetic one, and checked that file symlinks, directory symlinks and junctions produce byte-identical output to 2.9.6.

Ref #18598
