### PR TITLE
fix(ext/node): return byte counts as Number from fs write ops

### DIFF
--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -984,7 +984,7 @@ fn write_with_position(
   file: Rc<dyn deno_io::fs::File>,
   buf: &[u8],
   position: i64,
-) -> Result<u32, FsError> {
+) -> Result<usize, FsError> {
   if position >= 0 {
     let mut total = 0usize;
     while total < buf.len() {
@@ -993,25 +993,27 @@ fn write_with_position(
         .write_at_sync(&buf[total..], position as u64 + total as u64)?;
       total += nwritten;
     }
-    Ok(total as u32)
+    Ok(total)
   } else {
     let mut total = 0usize;
     while total < buf.len() {
       let nwritten = file.clone().write_sync(&buf[total..])?;
       total += nwritten;
     }
-    Ok(total as u32)
+    Ok(total)
   }
 }
 
+// Note: the return value is a Number (not an Smi) because a single call can
+// write more than 2^31 bytes, which does not fit in a Smi.
 #[op2(fast)]
-#[smi]
+#[number]
 pub fn op_node_fs_write_sync(
   state: &mut OpState,
   fd: i32,
   #[buffer] buf: &[u8],
   #[number] position: i64,
-) -> Result<u32, FsError> {
+) -> Result<usize, FsError> {
   let file = file_for_fd(state, fd)?;
   write_with_position(file, buf, position)
 }
@@ -1023,13 +1025,13 @@ pub fn op_node_fs_write_sync(
   reason = "async required for deferred op scheduling"
 )]
 #[op2(async(deferred))]
-#[smi]
+#[number]
 pub async fn op_node_fs_write_deferred(
   state: Rc<RefCell<OpState>>,
   fd: i32,
   #[buffer] buf: JsBuffer,
   #[number] position: i64,
-) -> Result<u32, FsError> {
+) -> Result<usize, FsError> {
   let file = file_for_fd(&state.borrow(), fd)?;
   write_with_position(file, &buf, position)
 }

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -169,6 +169,23 @@ Deno.test(
   },
 );
 
+// https://github.com/denoland/deno/issues/36810
+Deno.test(
+  "[node/fs writeFileSync] writes a buffer larger than 2^31 bytes",
+  () => {
+    const size = 2 ** 31 + 1024;
+    const data = new Uint8Array(size);
+    const dir = mkdtempSync(join(tmpdir(), "foo-"));
+    const filename = join(dir, "test.bin");
+    try {
+      writeFileSync(filename, data);
+      assertEquals(Deno.statSync(filename).size, size);
+    } finally {
+      Deno.removeSync(dir, { recursive: true });
+    }
+  },
+);
+
 Deno.test(
   "[node/fs existsSync] path",
   { permissions: { read: true } },


### PR DESCRIPTION
Fixes #36810

## Root cause

`op_node_fs_write_sync` and `op_node_fs_write_deferred` returned the number of bytes written as a V8 Smi (a signed 32-bit value). However, `write_with_position()` loops internally until the *entire* buffer is written, so a single op call can write more than 2^31 bytes. The Smi conversion then bitwise-wraps the count to a negative i32 (e.g. 2147484672 becomes -2147482624).

In `node:fs` `_writeAllSync` this made the remaining-bytes bookkeeping *grow* instead of shrink (`remaining -= bytesWritten` with a negative count), and the subsequent `subarray` with a negative index wraps around from the end of the buffer — so the ~2 GiB buffer was rewritten on every iteration, forever, until the disk filled up. From the caller's side this looked like a hang while the file grew to 1+ TB.

This affected every node:fs sync write path (`writeFileSync`, `writeSync`, `writevSync`, `FileHandle.writeFileSync`, ...), and the async variants silently reported a negative byte count for >2 GiB writes.

## Fix

Return `usize` as a Number (f64, exact up to 2^53) from both write ops instead of an Smi — the same pattern already used by `op_node_fs_seek_sync` (`#[number] -> Result<u64>`). It stays a fast op. This also removes a second, separate wrap at 2^32 from the `total as u32` truncations.

Read ops are deliberately untouched: they return single-syscall counts, which the OS caps well below 2^31.

## Test

Added `[node/fs writeFileSync] writes a buffer larger than 2^31 bytes` to `tests/unit_node/fs_test.ts`, writing a 2^31+1024-byte buffer and asserting the resulting file size (2 GiB allocations have precedent in `tests/unit_node/buffer_test.ts`). Verified locally:

- new test passes (301ms); full `fs_test.ts` suite: 84 passed, 0 failed
- the issue's reproduction now writes exactly the requested size at both 2^31-1024 and 2^31+1024 bytes

---

**AI disclosure (per CONTRIBUTING.md):** this PR was prepared with AI assistance (root-cause analysis and patch). The reproduction, boundary measurements, and test runs above were all executed and verified on a real machine.