### PR TITLE
fix(ext/web): pace identity pipeThrough bypass on the destination writable

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -3308,15 +3308,28 @@ function readableStreamPipeTo(
   // ready promise churn, sink dispatch and reaction) is dead weight.
   // Chunks are enqueued straight into the transform's readable controller
   // via transformStreamDefaultControllerEnqueue, which keeps the
-  // transform's own backpressure and error bookkeeping; pacing comes from
-  // the transform's backpressure signal instead of the writer ready
-  // promise. Any state change (close/abort/error on either side)
-  // permanently disables the route and falls back to the generic writer
-  // path, which surfaces the proper rejection.
+  // transform's own backpressure and error bookkeeping. Because the
+  // writable's queue is skipped, the writable-side pacing the generic loop
+  // gets from the writer ready promise is reproduced with a slot count: a
+  // writable accepts `highWaterMark` writes before applying backpressure,
+  // and each write frees its slot when its transform completes. A
+  // transform with backpressure (the initial state of every
+  // TransformStream) completes its queued writes when the backpressure
+  // next clears, and the sink write algorithm performs those transforms
+  // without a backpressure re-check, so a bypass write occupies a slot
+  // exactly when backpressure holds after its enqueue, and every occupied
+  // slot is freed on the next clear. Without this the pump would stall on
+  // the transform's initial backpressure before ever reading from the
+  // source, deadlocking the pipe until the destination readable is
+  // consumed (#36790). Any state change (close/abort/error on either
+  // side) permanently disables the route and falls back to the generic
+  // writer path, which surfaces the proper rejection.
   const bypassTS = dest[_identityBypassTS];
   let bypassActive = bypassTS !== undefined &&
     dest[_state] === "writable" &&
     bypassTS[_readable][_state] === "readable";
+  const bypassWritableHWM = bypassActive ? dest[_controller][_strategyHWM] : 0;
+  let bypassPendingWrites = 0;
   /** @type {Deferred<void>} */
   const promise = new Deferred();
   /** @type {() => void} */
@@ -3377,6 +3390,13 @@ function readableStreamPipeTo(
     if (bypassActive) {
       try {
         transformStreamDefaultControllerEnqueue(bypassTS[_controller], chunk);
+        if (bypassTS[_backpressure] === true) {
+          // Backpressure holds after the enqueue, so the next transform
+          // would block behind the backpressure change promise: this write
+          // keeps occupying a writable-side slot until the backpressure
+          // clears (see the pacing comment above).
+          bypassPendingWrites++;
+        }
         return;
       } catch {
         // The transform errored or its readable side can no longer accept
@@ -3428,13 +3448,15 @@ function readableStreamPipeTo(
           writableStreamCloseQueuedOrInFlight(dest) === false &&
           readableStreamDefaultControllerCanCloseOrEnqueue(readableController)
         ) {
-          if (bypassTS[_backpressure] === true) {
-            // Pace on the transform's own backpressure flag; resume when the
-            // next readable-side pull clears it. Rejection (transform errored)
-            // is left to the shutdown handlers.
+          if (bypassPendingWrites >= bypassWritableHWM) {
+            // Every writable-side slot is occupied by a write whose
+            // transform is blocked behind the transform's backpressure;
+            // resume when the next readable-side pull clears it (which
+            // frees the slots). Rejection (transform errored) is left to
+            // the shutdown handlers.
             uponPromise(
               bypassTS[_backpressureChangePromise].promise,
-              pump,
+              onBypassBackpressureCleared,
               noopHandler,
             );
             break;
@@ -3458,6 +3480,14 @@ function readableStreamPipeTo(
       readableStreamDefaultReaderRead(reader, readRequest);
     } while (syncAdvance);
     pumping = false;
+  }
+
+  function onBypassBackpressureCleared() {
+    // The backpressure clear completes every transform queued behind it
+    // (the sink write algorithm performs them without a backpressure
+    // re-check), freeing all occupied writable-side slots at once.
+    bypassPendingWrites = 0;
+    pump();
   }
 
   isOrBecomesErrored(

--- a/tests/unit/streams_test.ts
+++ b/tests/unit/streams_test.ts
@@ -1310,3 +1310,36 @@ Deno.test(
     worker.terminate();
   },
 );
+
+// Writing to a TransformStream whose readable side is piped through a second
+// identity TransformStream must resolve without anyone consuming the piped
+// output: the pipe loop paces on the destination writable's desired size
+// (high water mark 1), so it pulls from the source and releases the source
+// transform's initial backpressure
+// (https://github.com/denoland/deno/issues/36790).
+Deno.test(async function pipeThroughWriteResolvesBeforeOutputConsumed() {
+  const a = new TransformStream();
+  const b = new TransformStream();
+  a.readable.pipeThrough(b);
+
+  const writer = a.writable.getWriter();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("write() did not resolve")),
+      1000,
+    );
+  });
+  try {
+    await Promise.race([writer.write(1), timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  // The chunk is buffered in the pipe and flows through once the output is
+  // consumed.
+  const reader = b.readable.getReader();
+  assertEquals(await reader.read(), { value: 1, done: false });
+  await writer.close();
+  assertEquals(await reader.read(), { value: undefined, done: true });
+});


### PR DESCRIPTION
Fixes #36790

## Root cause

The identity `pipeThrough` writable bypass (#35799) paced its pump on the destination TransformStream's `[[backpressure]]` flag. `initializeTransformStream` sets every TransformStream's initial backpressure to `true`, and it only clears on the first pull of the readable side (readable-strategy HWM defaults to 0). So for `a.readable.pipeThrough(b)`:

1. The pump sees `b`'s initial backpressure and waits for `b.readable` to be consumed — never arming a read on `a.readable`.
2. `writer.write(1)` on `a` blocks on `a`'s own initial backpressure, which only that missing read would release — deadlock until someone reads `b.readable`.

The generic pipeTo loop paces on the destination *writable* (`writer[_readyPromise]`, HWM 1 by default), which guarantees the first read — that's why `pipeTo(new WritableStream(...))` and Deno ≤ 2.9.1 (no bypass) work.

## Fix

Reproduce the generic path's writable-side pacing inside the bypass with a slot count, keeping the bypass itself (no per-chunk writable ceremony) intact: count pending bypass writes against the destination writable's strategy HWM, stall when the slots are full, and resume when backpressure clears (a clear completes all queued transforms, since they captured the same change promise). Chunk-count parity with the generic path was traced for HWM combos (0/1, 1/1, 3/1, 0/3); memory stays bounded, and writable HWM 0 stalls in both paths identically (spec-conforming). One accepted approximation: custom writable `sizeAlgorithm`s are counted as size 1 per chunk — it can't hang.

## Tests

Added `pipeThroughWriteResolvesBeforeOutputConsumed` to `tests/unit/streams_test.ts`: the exact issue repro (write before consuming piped output must resolve), then asserts the chunk flows through and close propagates. Verified locally: the issue repro now prints `after write`; full `streams_test.ts`: 68 passed, 0 failed. (WPT was not runnable locally — it requires Python 3.11 — but the pump changes are exercised by the unit suite and CI's WPT run.)

---

**AI disclosure (per CONTRIBUTING.md):** this PR was prepared with AI assistance (root-cause analysis and patch). The reproduction, tests, and verification above were all executed on a real machine.