### PR TITLE
fix(core): avoid array prototype accessors in callsite cache

### DIFF
--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -1923,8 +1923,6 @@ pub mod callsite_fns {
       .map(|s| serde_v8::to_utf8(s, scope).starts_with("wasm://"))
       .unwrap_or(false);
 
-    let info = v8::Array::new(scope, 3);
-
     // if the types are right, apply the source map (unless wasm), otherwise just take them as is
     if !is_wasm
       && let Some((mapped_file_name, mapped_line_number, mapped_column_number)) =
@@ -1939,9 +1937,14 @@ pub mod callsite_fns {
         convert::Number(mapped_line_number).to_v8(scope);
       let Ok(mapped_column_number) =
         convert::Number(mapped_column_number).to_v8(scope);
-      info.set_index(scope, 0, mapped_file_name.into());
-      info.set_index(scope, 1, mapped_line_number);
-      info.set_index(scope, 2, mapped_column_number);
+      let info = v8::Array::new_with_elements(
+        scope,
+        &[
+          mapped_file_name.into(),
+          mapped_line_number,
+          mapped_column_number,
+        ],
+      );
       callsite.set_private(scope, key, info.into());
       Some(SourceMappedCallsiteInfo::Value {
         file_name: mapped_file_name.into(),
@@ -1954,9 +1957,10 @@ pub mod callsite_fns {
         line_number.unwrap_or_else(|| v8::undefined(scope).into());
       let column_number =
         column_number.unwrap_or_else(|| v8::undefined(scope).into());
-      info.set_index(scope, 0, file_name);
-      info.set_index(scope, 1, line_number);
-      info.set_index(scope, 2, column_number);
+      let info = v8::Array::new_with_elements(
+        scope,
+        &[file_name, line_number, column_number],
+      );
       callsite.set_private(scope, key, info.into());
       Some(SourceMappedCallsiteInfo::Ref(info))
     }

--- a/libs/core/runtime/tests/error.rs
+++ b/libs/core/runtime/tests/error.rs
@@ -4,10 +4,69 @@ use std::future::poll_fn;
 use std::task::Poll;
 
 use deno_error::JsErrorBox;
+use rstest::rstest;
 
 use crate::JsRuntime;
 use crate::RuntimeOptions;
 use crate::op2;
+
+#[rstest]
+fn callsite_cache_ignores_array_prototype(
+  #[values(0, 1, 2)] index: u32,
+  #[values(false, true)] eval: bool,
+) {
+  let mut runtime = JsRuntime::new(Default::default());
+  runtime
+    .execute_script(
+      "setup.js",
+      format!("const index = {index}; const useEval = {eval};"),
+    )
+    .unwrap();
+  runtime
+    .execute_script(
+      "callsite_cache.js",
+      r#"
+const originalPrepareStackTrace = Error.prepareStackTrace;
+Error.prepareStackTrace = (_, frames) => frames;
+function capture() {
+  return useEval ? eval("new Error().stack[0]") : new Error().stack[0];
+}
+const expected = capture();
+const fileName = expected.getFileName();
+const lineNumber = expected.getLineNumber();
+const columnNumber = expected.getColumnNumber();
+if (fileName !== (useEval ? undefined : "callsite_cache.js") ||
+    expected.isEval() !== useEval) {
+  throw new Error("unexpected frame type");
+}
+let accesses = 0;
+function fail() {
+  accesses++;
+  throw new Error("array prototype accessed");
+}
+Object.defineProperty(Array.prototype, index, {
+  get: fail,
+  set: fail,
+  configurable: true,
+});
+try {
+  const actual = capture();
+  for (let i = 0; i < 2; i++) {
+    if (actual.getFileName() !== fileName ||
+        actual.getLineNumber() !== lineNumber ||
+        actual.getColumnNumber() !== columnNumber) {
+      throw new Error("incorrect cached location");
+    }
+  }
+} finally {
+  delete Array.prototype[index];
+  Error.prepareStackTrace = originalPrepareStackTrace;
+}
+if (accesses !== 0) throw new Error("array prototype accessed");
+"#,
+    )
+    .unwrap();
+}
 
 #[tokio::test]
 async fn test_error_builder() {

--- a/tests/specs/run/prepare_stack_trace_array_prototype/__test__.jsonc
+++ b/tests/specs/run/prepare_stack_trace_array_prototype/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run main.ts",
+  "output": "ok\n"
+}

--- a/tests/specs/run/prepare_stack_trace_array_prototype/main.ts
+++ b/tests/specs/run/prepare_stack_trace_array_prototype/main.ts
@@ -1,0 +1,50 @@
+enum Marker {
+  Value,
+}
+
+function capture() {
+  return new Error(String(Marker.Value)).stack;
+}
+
+const originalPrepareStackTrace = Error.prepareStackTrace;
+Error.prepareStackTrace = (_, frames) => frames;
+let accesses = 0;
+function fail() {
+  accesses++;
+  throw new Error("array prototype accessed");
+}
+
+try {
+  for (let index = 0; index < 3; index++) {
+    Object.defineProperty(Array.prototype, index, {
+      get: fail,
+      set: fail,
+      configurable: true,
+    });
+    try {
+      for (const toStringFirst of [false, true]) {
+        const frame = capture()[0];
+        const expected = `capture (${import.meta.filename}:6:10)`;
+        if (toStringFirst && frame.toString() !== expected) {
+          throw new Error("incorrect mapped frame");
+        }
+        for (let repeat = 0; repeat < 2; repeat++) {
+          if (
+            frame.getFileName() !== import.meta.filename ||
+            frame.getLineNumber() !== 6 ||
+            frame.getColumnNumber() !== 10 ||
+            frame.toString() !== expected
+          ) {
+            throw new Error("incorrect mapped location");
+          }
+        }
+      }
+    } finally {
+      delete Array.prototype[index];
+    }
+  }
+} finally {
+  Error.prepareStackTrace = originalPrepareStackTrace;
+}
+if (accesses !== 0) throw new Error("array prototype accessed");
+console.log("ok");


### PR DESCRIPTION
Fixes #36598.

Initialize the private callsite location cache with its elements in place, so indexed Array.prototype accessors cannot interrupt cache population and cause a panic during stack formatting. Add coverage for repeated location reads, eval frames, and TypeScript source mapping.

I used Codex to assist coding and testing. I personally reviewed all work and verified testing.
